### PR TITLE
feat: Lago internal id should be prefixed by lago

### DIFF
--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -4,7 +4,7 @@ module V1
   class CustomerSerializer < ModelSerializer
     def serialize
       {
-        id: model.id,
+        lago_id: model.id,
         customer_id: model.customer_id,
         name: model.name,
         created_at: model.created_at

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       expect(response).to have_http_status(:success)
 
       result = JSON.parse(response.body, symbolize_names: true)[:customer]
-      expect(result[:id]).to be_present
+      expect(result[:lago_id]).to be_present
       expect(result[:customer_id]).to eq(create_params[:customer_id])
       expect(result[:name]).to eq(create_params[:name])
       expect(result[:created_at]).to be_present


### PR DESCRIPTION
Lago resource ID exposed in customer API should be prefixed by `lago_` to discriminate them from the customer ids.

At this point, it impacts `customers` and `subscriptions`