### PR TITLE
feat: T-957 Add ChargeModel enum to Charges

### DIFF
--- a/app/graphql/types/charges/charge_model_enum.rb
+++ b/app/graphql/types/charges/charge_model_enum.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module Charges
+    class ChargeModelEnum < Types::BaseEnum
+      Charge::CHARGE_MODELS.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/charges/input.rb
+++ b/app/graphql/types/charges/input.rb
@@ -9,6 +9,7 @@ module Types
       argument :amount_cents, Integer, required: true
       argument :amount_currency, Types::CurrencyEnum, required: true
       argument :frequency, Types::Charges::FrequencyEnum, required: true
+      argument :charge_model, Types::Charges::ChargeModelEnum, required: true
       argument :pro_rata, Boolean, required: true
       argument :vat_rate, Float, required: false
     end

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -10,6 +10,7 @@ module Types
       field :amount_cents, Integer, null: false
       field :amount_currency, Types::CurrencyEnum, null: false
       field :frequency, Types::Charges::FrequencyEnum, null: false
+      field :charge_model, Types::Charges::ChargeModelEnum, null: false
       field :pro_rata, Boolean, null: false
       field :vat_rate, Float
 

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -9,5 +9,10 @@ class Charge < ApplicationRecord
     recurring
   ].freeze
 
+  CHARGE_MODELS = %i[
+    standard
+  ].freeze
+
   enum frequency: FREQUENCIES
+  enum charge_model: CHARGE_MODELS
 end

--- a/app/services/plans_service.rb
+++ b/app/services/plans_service.rb
@@ -96,7 +96,8 @@ class PlansService < BaseService
       amount_currency: args[:amount_currency],
       frequency: args[:frequency].to_sym,
       pro_rata: args[:pro_rata],
-      vat_rate: args[:vat_rate]
+      vat_rate: args[:vat_rate],
+      charge_model: args[:charge_model].to_sym,
     )
   end
 

--- a/db/migrate/20220404080410_add_charge_model_to_charge.rb
+++ b/db/migrate/20220404080410_add_charge_model_to_charge.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddChargeModelToCharge < ActiveRecord::Migration[7.0]
+  def change
+    add_column :charges, :charge_model, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_31_081121) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_04_080410) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_31_081121) do
     t.integer "frequency", null: false
     t.boolean "pro_rata", null: false
     t.float "vat_rate"
+    t.integer "charge_model", default: 0, null: false
     t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"
     t.index ["plan_id"], name: "index_charges_on_plan_id"
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -30,6 +30,7 @@ type Charge {
   amountCents: Int!
   amountCurrency: CurrencyEnum!
   billableMetric: BillableMetric!
+  chargeModel: ChargeModelEnum!
   createdAt: ISO8601DateTime!
   frequency: ChargeFrequency!
   id: ID!
@@ -47,9 +48,14 @@ input ChargeInput {
   amountCents: Int!
   amountCurrency: CurrencyEnum!
   billableMetricId: ID!
+  chargeModel: ChargeModelEnum!
   frequency: ChargeFrequency!
   proRata: Boolean!
   vatRate: Float
+}
+
+enum ChargeModelEnum {
+  standard
 }
 
 type CollectionMetadata {

--- a/schema.json
+++ b/schema.json
@@ -347,6 +347,24 @@
               ]
             },
             {
+              "name": "chargeModel",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ChargeModelEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "createdAt",
               "description": null,
               "type": {
@@ -550,6 +568,22 @@
               "deprecationReason": null
             },
             {
+              "name": "chargeModel",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ChargeModelEnum",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "proRata",
               "description": null,
               "type": {
@@ -579,6 +613,23 @@
             }
           ],
           "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ChargeModelEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "standard",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
         },
         {
           "kind": "OBJECT",

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
               amountCents: 100,
               amountCurrency: 'USD',
               frequency: 'recurring',
-              proRata: false
+              proRata: false,
+              chargeModel: 'standard',
             },
             {
               billableMetricId: billable_metrics.last.id,
@@ -55,11 +56,12 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
               amountCurrency: 'EUR',
               frequency: 'one_time',
               proRata: true,
-              vatRate: 10.5
-            }
-          ]
-        }
-      }
+              vatRate: 10.5,
+              chargeModel: 'standard',
+            },
+          ],
+        },
+      },
     )
 
     result_data = result['data']['createPlan']
@@ -91,9 +93,9 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
             proRata: false,
             amountCents: 200,
             amountCurrency: 'EUR',
-            charges: []
-          }
-        }
+            charges: [],
+          },
+        },
       )
 
       expect_unauthorized_error(result)
@@ -114,9 +116,9 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
             proRata: false,
             amountCents: 200,
             amountCurrency: 'EUR',
-            charges: []
-          }
-        }
+            charges: [],
+          },
+        },
       )
 
       expect_forbidden_error(result)

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
               amountCents: 100,
               amountCurrency: 'USD',
               frequency: 'recurring',
-              proRata: false
+              proRata: false,
+              chargeModel: 'standard',
             },
             {
               billableMetricId: billable_metrics.last.id,
@@ -56,11 +57,12 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
               amountCurrency: 'EUR',
               frequency: 'one_time',
               proRata: true,
-              vatRate: 10.5
-            }
-          ]
-        }
-      }
+              vatRate: 10.5,
+              chargeModel: 'standard',
+            },
+          ],
+        },
+      },
     )
 
     result_data = result['data']['updatePlan']
@@ -92,9 +94,9 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
             proRata: false,
             amountCents: 200,
             amountCurrency: 'EUR',
-            charges: []
-          }
-        }
+            charges: [],
+          },
+        },
       )
 
       expect_unauthorized_error(result)

--- a/spec/services/plans_service_spec.rb
+++ b/spec/services/plans_service_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe PlansService, type: :service do
             amount_currency: 'USD',
             frequency: 'recurring',
             pro_rata: false,
+            charge_model: 'standard',
           },
           {
             billable_metric_id: billable_metrics.last.id,
@@ -36,7 +37,8 @@ RSpec.describe PlansService, type: :service do
             amount_currency: 'EUR',
             frequency: 'one_time',
             pro_rata: true,
-            vat_rate: 10.5
+            vat_rate: 10.5,
+            charge_model: 'standard',
           }
         ]
       }
@@ -97,7 +99,8 @@ RSpec.describe PlansService, type: :service do
             amount_cents: 100,
             amount_currency: 'USD',
             frequency: 'recurring',
-            pro_rata: false
+            pro_rata: false,
+            charge_model: 'standard',
           },
           {
             billable_metric_id: billable_metrics.last.id,
@@ -105,7 +108,8 @@ RSpec.describe PlansService, type: :service do
             amount_currency: 'EUR',
             frequency: 'one_time',
             pro_rata: true,
-            vat_rate: 10.5
+            vat_rate: 10.5,
+            charge_model: 'standard',
           }
         ]
       }
@@ -152,7 +156,8 @@ RSpec.describe PlansService, type: :service do
           amount_cents: 300,
           amount_currency: 'USD',
           frequency: 'recurring',
-          pro_rata: false
+          pro_rata: false,
+          charge_model: 'standard',
         )
       end
 
@@ -173,7 +178,8 @@ RSpec.describe PlansService, type: :service do
               amount_cents: 100,
               amount_currency: 'USD',
               frequency: 'recurring',
-              pro_rata: false
+              pro_rata: false,
+              charge_model: 'standard',
             },
             {
               billable_metric_id: billable_metrics.last.id,
@@ -181,7 +187,8 @@ RSpec.describe PlansService, type: :service do
               amount_currency: 'EUR',
               frequency: 'one_time',
               pro_rata: true,
-              vat_rate: 10.5
+              vat_rate: 10.5,
+              charge_model: 'standard',
             }
           ]
         }
@@ -202,7 +209,8 @@ RSpec.describe PlansService, type: :service do
           amount_cents: 300,
           amount_currency: 'USD',
           frequency: 'recurring',
-          pro_rata: false
+          pro_rata: false,
+          charge_model: 'standard',
         )
       end
 
@@ -216,7 +224,7 @@ RSpec.describe PlansService, type: :service do
           pro_rata: false,
           amount_cents: 200,
           amount_currency: 'EUR',
-          charges: []
+          charges: [],
         }
       end
 


### PR DESCRIPTION
Add `charge_model` field to the `Charge` model and expose it in GraphQL mutations and queries