### PR TITLE
feat: Attach plan and subscription to Invoice GraphQL object

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -19,7 +19,9 @@ module Types
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      field :subscription, Types::Subscriptions::Object
+      field :plan, Types::Plans::Object
     end
   end
 end
-

--- a/schema.graphql
+++ b/schema.graphql
@@ -224,6 +224,8 @@ type Invoice {
   fromDate: ISO8601Date!
   id: ID!
   issuingDate: ISO8601Date!
+  plan: Plan
+  subscription: Subscription
   toDate: ISO8601Date!
   totalAmountCents: Int!
   totalAmountCurrency: CurrencyEnum!

--- a/schema.json
+++ b/schema.json
@@ -1796,6 +1796,34 @@
               ]
             },
             {
+              "name": "plan",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Plan",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "subscription",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Subscription",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "toDate",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
   let(:customer) do
     create(:customer, organization: organization)
   end
+  let(:subscription) { create(:subscription, customer: customer) }
+
+  before do
+    create_list(:invoice, 2, subscription: subscription)
+  end
 
   it 'returns a single of customer' do
     result = execute_graphql(
@@ -35,8 +40,8 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
 
     aggregate_failures do
       expect(customer_response['id']).to eq(customer.id)
-      expect(customer_response['subscriptions'].count).to eq(0)
-      expect(customer_response['invoices'].count).to eq(0)
+      expect(customer_response['subscriptions'].count).to eq(1)
+      expect(customer_response['invoices'].count).to eq(2)
     end
   end
 


### PR DESCRIPTION
Add `plan` and `subscription` to `invoice` GraphQL object so that the front is allowed to retrieve plan name