### PR TITLE
feat: Improve event API

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -4,7 +4,11 @@ module Api
   module V1
     class EventsController < Api::BaseController
       def create
-        CreateEventJob.perform_later(current_organization, create_params)
+        CreateEventJob.perform_later(
+          current_organization,
+          create_params,
+          Time.zone.now.to_i,
+        )
 
         head(:ok)
       end
@@ -18,7 +22,7 @@ module Api
             :customer_id,
             :code,
             :timestamp,
-            properties: [],
+            properties: {},
           )
       end
     end

--- a/app/jobs/create_event_job.rb
+++ b/app/jobs/create_event_job.rb
@@ -3,10 +3,11 @@
 class CreateEventJob < ApplicationJob
   queue_as :default
 
-  def perform(organization, params)
+  def perform(organization, params, timestamp)
     result = EventsService.new.create(
       organization: organization,
       params: params,
+      timestamp: timestamp,
     )
 
     raise result.throw_error unless result.success?

--- a/app/services/events_service.rb
+++ b/app/services/events_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class EventsService < BaseService
-  def create(organization:, params:)
+  def create(organization:, params:, timestamp:)
     event = organization.events.find_by(id: params[:transaction_id])
 
     if event
@@ -20,6 +20,7 @@ class EventsService < BaseService
     event.properties = params[:properties]
 
     event.timestamp = Time.zone.at(params[:timestamp]) if params[:timestamp]
+    event.timestamp ||= timestamp
 
     event.save!
 

--- a/spec/jobs/create_event_job_spec.rb
+++ b/spec/jobs/create_event_job_spec.rb
@@ -7,14 +7,15 @@ RSpec.describe CreateEventJob, type: :job do
   let(:params) { {} }
   let(:event_service) { instance_double(EventsService) }
   let(:result) { BaseService::Result.new }
+  let(:timestamp) { Time.zone.now.to_i }
 
   it 'calls the event service' do
     allow(EventsService).to receive(:new).and_return(event_service)
     allow(event_service).to receive(:create)
-      .with(organization: organization, params: params)
+      .with(organization: organization, params: params, timestamp: timestamp)
       .and_return(result)
 
-    described_class.perform_now(organization, params)
+    described_class.perform_now(organization, params, timestamp)
 
     expect(EventsService).to have_received(:new)
     expect(event_service).to have_received(:create)
@@ -28,11 +29,11 @@ RSpec.describe CreateEventJob, type: :job do
     it 'raises an error' do
       allow(EventsService).to receive(:new).and_return(event_service)
       allow(event_service).to receive(:create)
-        .with(organization: organization, params: params)
+        .with(organization: organization, params: params, timestamp: timestamp)
         .and_return(result)
 
       expect do
-        described_class.perform_now(organization, params)
+        described_class.perform_now(organization, params, timestamp)
       end.to raise_error(BaseService::FailedResult)
 
       expect(EventsService).to have_received(:new)

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
       post_with_token(
         organization,
         '/api/v1/events',
-        {
+        event: {
           code: 'event_code',
           transaction_id: SecureRandom.uuid,
           timestamp: Time.zone.now.to_i,

--- a/spec/services/events_service_spec.rb
+++ b/spec/services/events_service_spec.rb
@@ -18,11 +18,13 @@ RSpec.describe EventsService, type: :service do
         timestamp: Time.zone.now.to_i,
       }
     end
+    let(:timestamp) { Time.zone.now.to_i }
 
     it 'creates a new event' do
       result = event_service.create(
         organization: organization,
         params: create_args,
+        timestamp: timestamp,
       )
 
       expect(result).to be_success
@@ -49,6 +51,7 @@ RSpec.describe EventsService, type: :service do
           event_service.create(
             organization: organization,
             params: create_args,
+            timestamp: timestamp,
           )
         end.not_to change { organization.events.count }
       end
@@ -69,6 +72,7 @@ RSpec.describe EventsService, type: :service do
         result = event_service.create(
           organization: organization,
           params: create_args,
+          timestamp: timestamp,
         )
 
         expect(result).not_to be_success


### PR DESCRIPTION
Small improvements on the event public API:
- Fill the optional `Event#timestamp` attribute with the current date if it is not provided
- Ensure the optional `properties` parameter of the `POST /events` request is stored in DB
