### PR TITLE
feat: Format date as iso8601 in API

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -13,7 +13,7 @@ module Api
 
       api_key = auth_header.split(' ').second
 
-      return unauthorized unless api_key
+      return unauthorized_error unless api_key
       return unauthorized_error unless current_organization(api_key)
 
       true

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -7,7 +7,7 @@ module V1
         lago_id: model.id,
         customer_id: model.customer_id,
         name: model.name,
-        created_at: model.created_at
+        created_at: model.created_at.iso8601,
       }
     end
   end

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -6,9 +6,9 @@ module V1
       payload = {
         lago_id: model.id,
         sequential_id: model.sequential_id,
-        from_date: model.from_date,
-        to_date: model.to_date,
-        issuing_date: model.issuing_date,
+        from_date: model.from_date.iso8601,
+        to_date: model.to_date.iso8601,
+        issuing_date: model.issuing_date.iso8601,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,
         vat_amount_cents: model.vat_amount_cents,

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -9,10 +9,10 @@ module V1
         customer_id: model.customer.customer_id,
         plan_code: model.plan.code,
         status: model.status,
-        started_at: model.started_at,
-        terminated_at: model.terminated_at,
-        canceled_at: model.canceled_at,
-        created_at: model.created_at,
+        started_at: model.started_at&.iso8601,
+        terminated_at: model.terminated_at&.iso8601,
+        canceled_at: model.canceled_at&.iso8601,
+        created_at: model.created_at.iso8601,
       }
     end
   end


### PR DESCRIPTION
In API, date should be exported as iso8601 as it is a standard format for date in APIs