### PR TITLE
feat: Terminate a subscription only via customer_id

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -23,15 +23,19 @@ module Api
       end
 
       # NOTE: We can't destroy a subscription, it will terminate it
-      def destroy
-        result = Subscriptions::TerminateService.new(params[:id]).terminate
+      def terminate
+        result = Subscriptions::TerminateService.new
+          .terminate_from_api(
+            organization: current_organization,
+            customer_id: params[:customer_id],
+          )
 
         if result.success?
           render(
             json: ::V1::SubscriptionSerializer.new(
               result.subscription,
               root_name: 'subscription',
-            )
+            ),
           )
         else
           validation_errors(result.error)

--- a/app/graphql/mutations/subscriptions/terminate.rb
+++ b/app/graphql/mutations/subscriptions/terminate.rb
@@ -16,7 +16,7 @@ module Mutations
       def resolve(**args)
         validate_organization!
 
-        result = ::Subscriptions::TerminateService.new(args[:id]).terminate
+        result = ::Subscriptions::TerminateService.new.terminate(args[:id])
 
         result.success? ? result.subscription : result_error(result)
       end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -17,4 +17,8 @@ class Customer < ApplicationRecord
   def deletable?
     !attached_to_subscriptions?
   end
+
+  def active_subscription
+    subscriptions.active.order(started_at: :desc).first
+  end
 end

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -2,14 +2,26 @@
 
 module Subscriptions
   class TerminateService < BaseService
-    def initialize(subscription_id)
-      super(nil)
-      @subscription = Subscription.find_by(id: subscription_id)
-    end
-
-    def terminate
+    def terminate(subscription_id)
+      subscription = Subscription.find_by(id: subscription_id)
       return result.fail!('not_found') if subscription.blank?
 
+      process_terminate(subscription)
+    end
+
+    def terminate_from_api(organization:, customer_id:)
+      customer = organization.customers.find_by(customer_id: customer_id)
+      return result.fail!('not_found') if customer.blank?
+
+      subscription = customer.active_subscription
+      return result.fail!('no_active_subscription') if subscription.blank?
+
+      process_terminate(subscription)
+    end
+
+    private
+
+    def process_terminate(subscription)
       unless subscription.terminated?
         subscription.mark_as_terminated!
 
@@ -20,9 +32,5 @@ module Subscriptions
       result.subscription = subscription
       result
     end
-
-    private
-
-    attr_reader :subscription
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :customers, only: %i[create]
-      resources :subscriptions, only: %i[create destroy]
+      resources :subscriptions, only: %i[create] do
+        delete :terminate, on: :collection
+      end
       resources :events, only: %i[create]
     end
   end

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -45,15 +45,15 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
     end
   end
 
-  describe 'DELETE /subscriptions/:id' do
+  describe 'DELETE /subscriptions/terminate' do
     let(:subscription) { create(:subscription, customer: customer, plan: plan) }
 
     before { subscription }
 
     it 'terminates a subscription' do
-      delete_with_token(organization, "/api/v1/subscriptions/#{subscription.id}")
+      delete_with_token(organization, "/api/v1/subscriptions/terminate?customer_id=#{customer.customer_id}")
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:success)
 
       result = JSON.parse(response.body, symbolize_names: true)[:subscription]
 
@@ -64,9 +64,9 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
 
     context 'with not existing subscription' do
       it 'returns an unprocessable entity error' do
-        delete_with_token(organization, '/api/v1/subscriptions/123456')
+        delete_with_token(organization, '/api/v1/subscriptions/terminate?customer_id=123456')
 
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe Subscriptions::TerminateService do
-  subject(:terminate_service) { described_class.new(subscription.id) }
+  subject(:terminate_service) { described_class.new }
 
   describe '.terminate' do
     let(:subscription) { create(:subscription) }
 
     it 'terminates a subscription' do
-      result = terminate_service.terminate
+      result = terminate_service.terminate(subscription.id)
 
       aggregate_failures do
         expect(result.subscription).to be_present
@@ -20,7 +20,7 @@ RSpec.describe Subscriptions::TerminateService do
 
     it 'enqueues a BillSubscriptionJob' do
       expect do
-        terminate_service.terminate
+        terminate_service.terminate(subscription.id)
       end.to have_enqueued_job(BillSubscriptionJob)
     end
 
@@ -28,7 +28,7 @@ RSpec.describe Subscriptions::TerminateService do
       let(:subscription) { OpenStruct.new(id: '123456') }
 
       it 'returns an error' do
-        result = terminate_service.terminate
+        result = terminate_service.terminate(subscription.id)
 
         expect(result.error).to eq('not_found')
       end


### PR DESCRIPTION
Replace API route `DELETE /api/v1/subscriptions/:id` with `DELETE /api/v1/subscriptions?customer_id=:customer_id`

It allows user to destroy the subscription of a customer without having to know the subscription id (and so without having to store the subscription id on their side)