### PR TITLE
fix: Fix cors issue for production environment

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -6,7 +6,7 @@ Rails.application.config.middleware.insert_before(0, Rack::Cors) do
   allow do
     if Rails.env.development?
       origins 'app.lago.dev'
-    else
+    elsif ENV['LAGO_FRONT_URL']
       origins URI(ENV['LAGO_FRONT_URL']).host
     end
 


### PR DESCRIPTION
Fixes https://github.com/getlago/lago/issues/18

Whitelist front in CORS config using `LAGO_FRONT_URL` env variable