### PR TITLE
bug: prevent assignation of multiple coupon to customers

### DIFF
--- a/app/services/applied_coupons/create_service.rb
+++ b/app/services/applied_coupons/create_service.rb
@@ -70,7 +70,7 @@ module AppliedCoupons
     end
 
     def coupon_already_applied?
-      customer.applied_coupons.active.where(coupon_id: coupon.id).exists?
+      customer.applied_coupons.active.exists?
     end
 
     def applicable_currency?(currency)

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       it { expect(create_result.error).to eq('coupon_already_applied') }
     end
 
+    context 'when an other coupon is already applied to the customer' do
+      let(:other_coupon) { create(:coupon, status: 'active', organization: organization) }
+
+      before { create(:applied_coupon, customer: customer, coupon: other_coupon) }
+
+      it { expect(create_result).not_to be_success }
+      it { expect(create_result.error).to eq('coupon_already_applied') }
+    end
+
     context 'when currency of coupon does not match customer currency' do
       let(:coupon) { create(:coupon, status: 'active', organization: organization, amount_currency: 'NOK') }
 


### PR DESCRIPTION
Closes #227 

Ensure customer can have only one active coupon at the same time