### PR TITLE
feat: Forecast for customer usage

### DIFF
--- a/app/graphql/resolvers/customers/forecast_resolver.rb
+++ b/app/graphql/resolvers/customers/forecast_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module Customers
+    class ForecastResolver < Resolvers::BaseResolver
+      include AuthenticableApiUser
+
+      description 'Query the forecast of customer usage'
+
+      argument :customer_id, type: ID, required: false
+
+      type Types::Invoices::Forecast, null: false
+
+      def resolve(customer_id:)
+        result = Invoices::ForecastService.new(context[:current_user])
+          .forecast(customer_id: customer_id)
+
+        result.success? ? result.invoice : result_error(result)
+      end
+    end
+  end
+end

--- a/app/graphql/types/invoices/forecast.rb
+++ b/app/graphql/types/invoices/forecast.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Types
+  module Invoices
+    class Forecast < Types::BaseObject
+      graphql_name 'Forecast'
+
+      field :from_date, GraphQL::Types::ISO8601Date, null: false
+      field :to_date, GraphQL::Types::ISO8601Date, null: false
+      field :issuing_date, GraphQL::Types::ISO8601Date, null: false
+
+      field :amount_cents, Integer, null: false
+      field :amount_currency, Types::CurrencyEnum, null: false
+      field :total_amount_cents, Integer, null: false
+      field :total_amount_currency, Types::CurrencyEnum, null: false
+      field :vat_amount_cents, Integer, null: false
+      field :vat_amount_currency, Types::CurrencyEnum, null: false
+
+      field :fees, [Types::Invoices::ForecastedFee], null: true
+    end
+  end
+end

--- a/app/graphql/types/invoices/forecasted_fee.rb
+++ b/app/graphql/types/invoices/forecasted_fee.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Types
+  module Invoices
+    class ForecastedFee < Types::BaseObject
+      graphql_name 'ForecastedFee'
+
+      field :billable_metric_name, String, null: false
+      field :billable_metric_code, String, null: false
+      field :aggregation_type, Types::BillableMetrics::AggregationTypeEnum, null: false
+      field :charge_model, Types::Charges::ChargeModelEnum, null: false
+
+      field :units, Integer, null: false
+      field :amount_cents, Integer, null: false
+      field :amount_currency, Types::CurrencyEnum, null: false
+      field :vat_amount_cents, Integer, null: false
+      field :vat_amount_currency, Types::CurrencyEnum, null: false
+
+      def billable_metric_name
+        object.billable_metric.name
+      end
+
+      def billable_metric_code
+        object.billable_metric.code
+      end
+
+      def aggregation_type
+        object.billable_metric.aggregation_type
+      end
+
+      def charge_model
+        object.charge.charge_model
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -18,6 +18,7 @@ module Types
     field :customers, resolver: Resolvers::CustomersResolver
     field :customer, resolver: Resolvers::CustomerResolver
     field :events, resolver: Resolvers::EventsResolver
+    field :forecast, resolver: Resolvers::Customers::ForecastResolver
     field :plans, resolver: Resolvers::PlansResolver
     field :plan, resolver: Resolvers::PlanResolver
   end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -11,6 +11,29 @@ module Fees
     def create
       return result if already_billed?
 
+      init_fee
+      return result unless result.success?
+
+      result.fee.save!
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.fail_with_validations!(e.record)
+    end
+
+    def forecast
+      @forecast_mode = true
+
+      init_fee
+    end
+
+    private
+
+    attr_accessor :invoice, :charge, :forecast_mode
+
+    delegate :customer, :plan, :subscription, to: :invoice
+    delegate :billable_metric, to: :charge
+
+    def init_fee
       amount_result = compute_amount
       return result.fail!(amount_result.error_code, amount_result.error) unless amount_result.success?
 
@@ -31,20 +54,9 @@ module Fees
       )
 
       new_fee.compute_vat
-      new_fee.save!
-
       result.fee = new_fee
       result
-    rescue ActiveRecord::RecordInvalid => e
-      result.fail_with_validations!(e.record)
     end
-
-    private
-
-    attr_accessor :invoice, :charge
-
-    delegate :customer, :plan, :subscription, to: :invoice
-    delegate :billable_metric, to: :charge
 
     def compute_amount
       aggregated_events = aggregator.aggregate(from_date: from_date, to_date: invoice.to_date)
@@ -98,7 +110,7 @@ module Fees
     end
 
     def from_date
-      return invoice.from_date unless subscription.previous_subscription
+      return invoice.from_date if forecast_mode || !subscription.previous_subscription
 
       if subscription.previous_subscription.upgraded?
         date = case plan.interval.to_sym

--- a/app/services/invoices/forecast_service.rb
+++ b/app/services/invoices/forecast_service.rb
@@ -89,11 +89,6 @@ module Invoices
       @issuing_date
     end
 
-    def add_subscription_fee
-      fee_result = Fees::SubscriptionService.new(invoice).forecast
-      fee_result.throw_error unless fee_result.success?
-    end
-
     def add_charge_fee
       subscription.plan.charges.each do |charge|
         fee_result = Fees::ChargeService.new(
@@ -108,11 +103,9 @@ module Invoices
     end
 
     def compute_amounts
-      fee_amounts = invoice.fees.select(:amount_cents, :vat_amount_cents)
-
-      invoice.amount_cents = fee_amounts.sum(&:amount_cents)
+      invoice.amount_cents = invoice.fees.sum(&:amount_cents)
       invoice.amount_currency = plan.amount_currency
-      invoice.vat_amount_cents = fee_amounts.sum(&:vat_amount_cents)
+      invoice.vat_amount_cents = invoice.fees.sum(&:vat_amount_cents)
       invoice.vat_amount_currency = plan.amount_currency
       invoice.total_amount_cents = invoice.amount_cents + invoice.vat_amount_cents
       invoice.total_amount_currency = plan.amount_currency

--- a/app/services/invoices/forecast_service.rb
+++ b/app/services/invoices/forecast_service.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module Invoices
+  class ForecastService < BaseService
+    def forecast(customer_id:)
+      return result.fail!('not_found') unless customer(customer_id: customer_id)
+      return result.fail!('no_active_subscription') if subscription.blank?
+
+      invoice = Invoice.new(
+        subscription: subscription,
+        from_date: from_date,
+        to_date: to_date,
+        issuing_date: issuing_date,
+      )
+
+      result.invoice = invoice
+
+      add_charge_fee
+      compute_amounts
+
+      result
+    end
+
+    private
+
+    delegate :invoice, to: :result
+    delegate :plan, to: :subscription
+
+    def customer(customer_id: nil)
+      @customer ||= Customer.find_by(
+        id: customer_id,
+        organization_id: result.user.organization_ids,
+      )
+    end
+
+    def subscription
+      @subscription ||= customer.active_subscription
+    end
+
+    def previous_invoice
+      @previous_invoice ||= @subscription.invoices.order(issuing_date: :asc).first
+    end
+
+    def from_date
+      return @from_date if @from_date.present?
+
+      # NOTE: If a previous invoice exists, the forecast should start on the next day
+      return @from_date = previous_invoice.to_date + 1.day if previous_invoice.present?
+
+      @from_date = case subscription.plan.interval.to_sym
+                   when :monthly
+                     Time.zone.today.beginning_of_month
+                   when :yearly
+                     Time.zone.today.beginning_of_year
+                   else
+                     raise NotImplementedError
+      end
+
+      # NOTE: On first billing period, subscription might start after the computed start of period
+      #       ei: if we bill on beginning of period, and user registered on the 15th, the forecast should
+      #       start on the 15th (subscription date) and not on the 1st
+      @from_date = subscription.started_at.to_date if @from_date < subscription.started_at
+
+      @from_date
+    end
+
+    def to_date
+      return @to_date if @to_date.present?
+
+      @to_date = case subscription.plan.interval.to_sym
+                 when :monthly
+                   Time.zone.today.end_of_month
+                 when :yearly
+                   Time.zone.today.end_of_year
+                 else
+                   raise NotImplementedError
+      end
+
+      @to_date
+    end
+
+    def issuing_date
+      return @issuing_date if @issuing_date.present?
+
+      # NOTE: When price plan is configured as `pay_in_advance`, we issue the invoice for the first day of
+      #       the period, it's on the last day otherwise
+      @issuing_date = to_date
+      @issuing_date = to_date + 1.day if subscription.plan.pay_in_advance?
+      @issuing_date
+    end
+
+    def add_subscription_fee
+      fee_result = Fees::SubscriptionService.new(invoice).forecast
+      fee_result.throw_error unless fee_result.success?
+    end
+
+    def add_charge_fee
+      subscription.plan.charges.each do |charge|
+        fee_result = Fees::ChargeService.new(
+          invoice: invoice,
+          charge: charge,
+        ).forecast
+
+        fee_result.throw_error unless fee_result.success?
+
+        invoice.fees << fee_result.fee
+      end
+    end
+
+    def compute_amounts
+      fee_amounts = invoice.fees.select(:amount_cents, :vat_amount_cents)
+
+      invoice.amount_cents = fee_amounts.sum(&:amount_cents)
+      invoice.amount_currency = plan.amount_currency
+      invoice.vat_amount_cents = fee_amounts.sum(&:vat_amount_cents)
+      invoice.vat_amount_currency = plan.amount_currency
+      invoice.total_amount_cents = invoice.amount_cents + invoice.vat_amount_cents
+      invoice.total_amount_currency = plan.amount_currency
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1831,6 +1831,31 @@ type EventCollection {
   metadata: CollectionMetadata!
 }
 
+type Forecast {
+  amountCents: Int!
+  amountCurrency: CurrencyEnum!
+  fees: [ForecastedFee!]
+  fromDate: ISO8601Date!
+  issuingDate: ISO8601Date!
+  toDate: ISO8601Date!
+  totalAmountCents: Int!
+  totalAmountCurrency: CurrencyEnum!
+  vatAmountCents: Int!
+  vatAmountCurrency: CurrencyEnum!
+}
+
+type ForecastedFee {
+  aggregationType: AggregationTypeEnum!
+  amountCents: Int!
+  amountCurrency: CurrencyEnum!
+  billableMetricCode: String!
+  billableMetricName: String!
+  chargeModel: ChargeModelEnum!
+  units: Int!
+  vatAmountCents: Int!
+  vatAmountCurrency: CurrencyEnum!
+}
+
 type GraduatedRange {
   flatAmount: String!
   fromValue: Int!
@@ -2338,6 +2363,11 @@ type Query {
   Query events of an organization
   """
   events(limit: Int, page: Int): EventCollection
+
+  """
+  Query the forecast of customer usage
+  """
+  forecast(customerId: ID): Forecast!
 
   """
   Query a single plan of an organization

--- a/schema.json
+++ b/schema.json
@@ -6129,6 +6129,378 @@
         },
         {
           "kind": "OBJECT",
+          "name": "Forecast",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fees",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ForecastedFee",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fromDate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "issuingDate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "toDate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "totalAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "totalAmountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "vatAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "vatAmountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ForecastedFee",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "aggregationType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AggregationTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "billableMetricCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "billableMetricName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "chargeModel",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ChargeModelEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "units",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "vatAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "vatAmountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "GraduatedRange",
           "description": null,
           "interfaces": [
@@ -8798,6 +9170,35 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "forecast",
+              "description": "Query the forecast of customer usage",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Forecast",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "customerId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/spec/graphql/resolvers/customers/forecast_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/forecast_resolver_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::Customers::ForecastResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($customerId: ID!) {
+        forecast(customerId: $customerId) {
+          fromDate,
+          toDate,
+          issuingDate,
+          amountCents,
+          amountCurrency,
+          totalAmountCents,
+          totalAmountCurrency,
+          vatAmountCents,
+          vatAmountCurrency,
+          fees {
+            billableMetricName,
+            billableMetricCode,
+            aggregationType,
+            chargeModel,
+            units,
+            amountCents,
+            amountCurrency,
+            vatAmountCents,
+            vatAmountCurrency
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+
+  let(:customer) { create(:customer, organization: organization) }
+  let(:subscription) do
+    create(
+      :subscription,
+      plan: plan,
+      customer: customer,
+      started_at: Time.zone.now - 2.years,
+    )
+  end
+  let(:plan) { create(:plan, interval: 'monthly') }
+
+  let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
+  let(:charge) do
+    create(
+      :graduated_charge,
+      plan: subscription.plan,
+      charge_model: 'graduated',
+      billable_metric: billable_metric,
+      properties: [
+        {
+          from_value: 0,
+          to_value: nil,
+          per_unit_amount: '0.01',
+          flat_amount: '0.01',
+        },
+      ],
+    )
+  end
+
+  before do
+    subscription
+    charge
+
+    create_list(
+      :event,
+      4,
+      organization: organization,
+      customer: customer,
+      code: billable_metric.code,
+      timestamp: Time.zone.now,
+    )
+  end
+
+  it 'returns the forecast for the customer' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query: query,
+      variables: {
+        customerId: customer.id,
+      },
+    )
+
+    forecast_response = result['data']['forecast']
+
+    aggregate_failures do
+      expect(forecast_response['fromDate']).to eq(Time.zone.today.beginning_of_month.iso8601)
+      expect(forecast_response['toDate']).to eq(Time.zone.today.end_of_month.iso8601)
+      expect(forecast_response['issuingDate']).to eq(Time.zone.today.end_of_month.iso8601)
+      expect(forecast_response['amountCents']).to eq(5)
+      expect(forecast_response['amountCurrency']).to eq('EUR')
+      expect(forecast_response['totalAmountCents']).to eq(6)
+      expect(forecast_response['totalAmountCurrency']).to eq('EUR')
+      expect(forecast_response['vatAmountCents']).to eq(1)
+      expect(forecast_response['vatAmountCurrency']).to eq('EUR')
+
+      fee_response = forecast_response['fees'].first
+      expect(fee_response['billableMetricName']).to eq(billable_metric.name)
+      expect(fee_response['billableMetricCode']).to eq(billable_metric.code)
+      expect(fee_response['aggregationType']).to eq('count_agg')
+      expect(fee_response['chargeModel']).to eq('graduated')
+      expect(fee_response['units']).to eq(4)
+      expect(fee_response['amountCents']).to eq(5)
+      expect(fee_response['amountCurrency']).to eq('EUR')
+      expect(fee_response['vatAmountCents']).to eq(1)
+      expect(fee_response['vatAmountCurrency']).to eq('EUR')
+    end
+  end
+end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -223,4 +223,112 @@ RSpec.describe Fees::ChargeService do
       end
     end
   end
+
+  describe '.forecast' do
+    context 'with all types of aggregation' do
+      BillableMetric::AGGREGATION_TYPES.each do |aggregation_type|
+        before do
+          billable_metric.update!(
+            aggregation_type: aggregation_type,
+            field_name: 'foo_bar',
+          )
+        end
+
+        it 'initializes fees' do
+          result = charge_subscription_service.forecast
+
+          expect(result).to be_success
+
+          forecasted_fee = result.fee
+
+          aggregate_failures do
+            expect(forecasted_fee.id).to be_nil
+            expect(forecasted_fee.invoice_id).to eq(invoice.id)
+            expect(forecasted_fee.charge_id).to eq(charge.id)
+            expect(forecasted_fee.amount_cents).to eq(0)
+            expect(forecasted_fee.amount_currency).to eq('EUR')
+            expect(forecasted_fee.vat_amount_cents).to eq(0)
+            expect(forecasted_fee.vat_rate).to eq(20.0)
+            expect(forecasted_fee.units).to eq(0)
+          end
+        end
+      end
+    end
+
+    context 'with graduated charge model' do
+      let(:charge) do
+        create(
+          :graduated_charge,
+          plan: subscription.plan,
+          charge_model: 'graduated',
+          billable_metric: billable_metric,
+          properties: [
+            {
+              from_value: 0,
+              to_value: nil,
+              per_unit_amount: '0.01',
+              flat_amount: '0.01',
+            },
+          ],
+        )
+      end
+
+      before do
+        create_list(
+          :event,
+          4,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+        )
+      end
+
+      it 'initialize a fee' do
+        result = charge_subscription_service.forecast
+
+        expect(result).to be_success
+
+        forecasted_fee = result.fee
+
+        aggregate_failures do
+          expect(forecasted_fee.id).to be_nil
+          expect(forecasted_fee.invoice_id).to eq(invoice.id)
+          expect(forecasted_fee.charge_id).to eq(charge.id)
+          expect(forecasted_fee.amount_cents).to eq(5)
+          expect(forecasted_fee.amount_currency).to eq('EUR')
+          expect(forecasted_fee.vat_amount_cents).to eq(1)
+          expect(forecasted_fee.vat_rate).to eq(20.0)
+          expect(forecasted_fee.units.to_s).to eq('4.0')
+        end
+      end
+    end
+
+    context 'with aggregation error' do
+      let(:billable_metric) do
+        create(
+          :billable_metric,
+          aggregation_type: 'max_agg',
+          field_name: 'foo_bar',
+        )
+      end
+      let(:aggregator_service) { instance_double(BillableMetrics::Aggregations::MaxService) }
+      let(:error_result) { BaseService::Result.new.fail!('aggregation_failure') }
+
+      it 'returns an error' do
+        allow(BillableMetrics::Aggregations::MaxService).to receive(:new)
+          .and_return(aggregator_service)
+        allow(aggregator_service).to receive(:aggregate)
+          .and_return(error_result)
+
+        result = charge_subscription_service.forecast
+
+        expect(result).not_to be_success
+        expect(result.error_code).to eq('aggregation_failure')
+
+        expect(BillableMetrics::Aggregations::MaxService).to have_received(:new)
+        expect(aggregator_service).to have_received(:aggregate)
+      end
+    end
+  end
 end

--- a/spec/services/invoices/forecast_service_spec.rb
+++ b/spec/services/invoices/forecast_service_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::ForecastService, type: :service do
+  subject(:invoice_service) do
+    described_class.new(membership.user)
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+
+  describe '.forecast' do
+    let(:billable_metric) do
+      create(:billable_metric, aggregation_type: 'count_agg')
+    end
+
+    let(:customer) { create(:customer, organization: organization) }
+    let(:subscription) do
+      create(
+        :subscription,
+        plan: plan,
+        customer: customer,
+        started_at: Time.zone.now - 2.years,
+      )
+    end
+    let(:plan) { create(:plan, interval: 'monthly') }
+
+    before do
+      subscription
+      create(:standard_charge, plan: plan, charge_model: 'standard')
+    end
+
+    context 'when billed monthly' do
+      it 'intialize an invoice' do
+        result = invoice_service.forecast(customer_id: customer.id)
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.invoice.id).to be_nil
+          expect(result.invoice.from_date).to eq(Time.zone.today.beginning_of_month)
+          expect(result.invoice.to_date).to eq(Time.zone.today.end_of_month)
+          expect(result.invoice.subscription).to eq(subscription)
+          expect(result.invoice.issuing_date.to_date).to eq(Time.zone.today.end_of_month)
+          expect(result.invoice.fees.size).to eq(1)
+
+          expect(result.invoice.amount_cents).to eq(0)
+          expect(result.invoice.amount_currency).to eq('EUR')
+          expect(result.invoice.vat_amount_cents).to eq(0)
+          expect(result.invoice.vat_amount_currency).to eq('EUR')
+          expect(result.invoice.total_amount_cents).to eq(0)
+          expect(result.invoice.total_amount_currency).to eq('EUR')
+        end
+      end
+
+      context 'with subscription started in current billing period' do
+        before { subscription.update!(started_at: Time.zone.today) }
+
+        it 'changes the from date of the invoice' do
+          result = invoice_service.forecast(customer_id: customer.id)
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(result.invoice.id).to be_nil
+            expect(result.invoice.from_date).to eq(subscription.started_at)
+          end
+        end
+      end
+    end
+
+    context 'when billed yearly' do
+      let(:plan) { create(:plan, interval: 'yearly') }
+
+      it 'intialize an invoice' do
+        result = invoice_service.forecast(customer_id: customer.id)
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.invoice.id).to be_nil
+          expect(result.invoice.from_date).to eq(Time.zone.today.beginning_of_year)
+          expect(result.invoice.to_date).to eq(Time.zone.today.end_of_year)
+          expect(result.invoice.subscription).to eq(subscription)
+          expect(result.invoice.issuing_date.to_date).to eq(Time.zone.today.end_of_year)
+          expect(result.invoice.fees.size).to eq(1)
+
+          expect(result.invoice.amount_cents).to eq(0)
+          expect(result.invoice.amount_currency).to eq('EUR')
+          expect(result.invoice.vat_amount_cents).to eq(0)
+          expect(result.invoice.vat_amount_currency).to eq('EUR')
+          expect(result.invoice.total_amount_cents).to eq(0)
+          expect(result.invoice.total_amount_currency).to eq('EUR')
+        end
+      end
+    end
+
+    context 'when customer is not found' do
+      it 'returns an error' do
+        result = invoice_service.forecast(customer_id: 'foo')
+
+        expect(result).not_to be_success
+        expect(result.error_code).to eq('not_found')
+      end
+    end
+
+    context 'when no_active_subscription' do
+      let(:subscription) { nil }
+
+      it 'returns an error' do
+        result = invoice_service.forecast(customer_id: customer.id)
+
+        expect(result).not_to be_success
+        expect(result.error_code).to eq('no_active_subscription')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add `forecast` GraphQL query to retrieve next invoice estimate for a customer

Note: For now, forecast does not take into account coupons and subscription fees

Closes #216 