### PR TITLE
fix: Add missing object type field in webhooks

### DIFF
--- a/app/services/webhooks/add_on_service.rb
+++ b/app/services/webhooks/add_on_service.rb
@@ -19,5 +19,9 @@ module Webhooks
     def webhook_type
       'invoice.add_on_added'
     end
+
+    def object_type
+      'invoice'
+    end
   end
 end

--- a/app/services/webhooks/base_service.rb
+++ b/app/services/webhooks/base_service.rb
@@ -13,7 +13,10 @@ module Webhooks
       return unless current_organization&.webhook_url?
 
       payload = object_serializer.serialize
-      payload = payload.merge(webhook_type: webhook_type)
+      payload = payload.merge(
+        webhook_type: webhook_type,
+        object_type: object_type,
+      )
 
       http_client = LagoHttpClient::Client.new(current_organization.webhook_url)
       headers = generate_headers(payload)
@@ -33,6 +36,10 @@ module Webhooks
     end
 
     def webhook_type
+      # Empty
+    end
+
+    def object_type
       # Empty
     end
 

--- a/app/services/webhooks/invoices_service.rb
+++ b/app/services/webhooks/invoices_service.rb
@@ -19,5 +19,9 @@ module Webhooks
     def webhook_type
       'invoice.created'
     end
+
+    def object_type
+      'invoice'
+    end
   end
 end

--- a/spec/services/webhooks/add_on_service_spec.rb
+++ b/spec/services/webhooks/add_on_service_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe Webhooks::AddOnService do
       expect(LagoHttpClient::Client).to have_received(:new)
         .with(organization.webhook_url)
       expect(lago_client).to have_received(:post) do |payload|
-        expect(payload[:webhook_type]).to eq 'invoice.add_on_added'
+        expect(payload[:webhook_type]).to eq('invoice.add_on_added')
+        expect(payload[:object_type]).to eq('invoice')
       end
     end
 

--- a/spec/services/webhooks/invoices_service_spec.rb
+++ b/spec/services/webhooks/invoices_service_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe Webhooks::InvoicesService do
       expect(LagoHttpClient::Client).to have_received(:new)
         .with(organization.webhook_url)
       expect(lago_client).to have_received(:post) do |payload|
-        expect(payload[:webhook_type]).to eq 'invoice.created'
+        expect(payload[:webhook_type]).to eq('invoice.created')
+        expect(payload[:object_type]).to eq('invoice')
       end
     end
 


### PR DESCRIPTION
Fixes #243 