### PR TITLE
fix: Delivered webhooks with empty response bodies should not fail

### DIFF
--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -25,7 +25,7 @@ module LagoHttpClient
 
       raise_error(response) unless RESPONSE_SUCCESS_CODES.include?(response.code.to_i)
 
-      JSON.parse(response.body)
+      JSON.parse(response.body&.presence || '{}')
     end
 
     private

--- a/spec/lib/lago_http_client/client_spec.rb
+++ b/spec/lib/lago_http_client/client_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe LagoHttpClient::Client do
   subject(:client) { described_class.new(url) }
+
   let(:url) { 'http://example.com/api/v1/example' }
 
   describe '#post' do
@@ -25,6 +26,16 @@ RSpec.describe LagoHttpClient::Client do
 
         expect(response['status']).to eq 200
         expect(response['message']).to eq 'Success'
+      end
+
+      context 'when response body is blank' do
+        let(:response) { '' }
+
+        it 'returns an empty response' do
+          response = client.post('', {})
+
+          expect(response).to eq({})
+        end
       end
     end
 


### PR DESCRIPTION
Today, if we successfully deliver a webhook (HTTP 200 response code), if the response body is empty, the job fails with a `JSON::ParserError`.

The webhook has been delivered, so the job should not failed