### PR TITLE
feat: Add hability to assign stripe customer id with API

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -41,6 +41,7 @@ module Api
           :legal_name,
           :legal_number,
           :vat_rate,
+          billing_configuration: [:payment_provider, :provider_customer_id],
         )
       end
     end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -10,6 +10,9 @@ class Customer < ApplicationRecord
   has_many :coupons, through: :applied_coupons
   has_many :applied_add_ons
   has_many :add_ons, through: :applied_add_ons
+  has_many :payment_provider_customers
+
+  has_one :stripe_customer, class_name: 'PaymentProviderCustomers::StripeCustomer'
 
   validates :customer_id, presence: true, uniqueness: { scope: :organization_id }
   validates :country, country_code: true, if: :country?

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -14,6 +14,10 @@ class Customer < ApplicationRecord
 
   has_one :stripe_customer, class_name: 'PaymentProviderCustomers::StripeCustomer'
 
+  PAYMENT_PROVIDERS = %i[lago stripe].freeze
+
+  enum payment_provider: PAYMENT_PROVIDERS
+
   validates :customer_id, presence: true, uniqueness: { scope: :organization_id }
   validates :country, country_code: true, if: :country?
   validates :vat_rate, numericality: { less_than_or_equal_to: 100, greater_than_or_equal_to: 0 }, allow_nil: true

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -14,12 +14,12 @@ class Customer < ApplicationRecord
 
   has_one :stripe_customer, class_name: 'PaymentProviderCustomers::StripeCustomer'
 
-  PAYMENT_PROVIDERS = %w[external stripe].freeze
+  PAYMENT_PROVIDERS = %w[stripe].freeze
 
   validates :customer_id, presence: true, uniqueness: { scope: :organization_id }
   validates :country, country_code: true, if: :country?
   validates :vat_rate, numericality: { less_than_or_equal_to: 100, greater_than_or_equal_to: 0 }, allow_nil: true
-  validates :payment_provider, inclusion: { in: PAYMENT_PROVIDERS }
+  validates :payment_provider, inclusion: { in: PAYMENT_PROVIDERS }, allow_nil: true
 
   def attached_to_subscriptions?
     subscriptions.exists?

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -14,13 +14,12 @@ class Customer < ApplicationRecord
 
   has_one :stripe_customer, class_name: 'PaymentProviderCustomers::StripeCustomer'
 
-  PAYMENT_PROVIDERS = %i[lago stripe].freeze
-
-  enum payment_provider: PAYMENT_PROVIDERS
+  PAYMENT_PROVIDERS = %w[external stripe].freeze
 
   validates :customer_id, presence: true, uniqueness: { scope: :organization_id }
   validates :country, country_code: true, if: :country?
   validates :vat_rate, numericality: { less_than_or_equal_to: 100, greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :payment_provider, inclusion: { in: PAYMENT_PROVIDERS }
 
   def attached_to_subscriptions?
     subscriptions.exists?

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class BaseCustomer < ApplicationRecord
+    self.table_name = 'payment_provider_customers'
+
+    validates :external_customer_id, presence: true
+
+    def push_to_settings(key:, value:)
+      self.settings ||= {}
+      settings[key] = value
+    end
+
+    def get_from_settings(key)
+      (settings || {})[key]
+    end
+  end
+end

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -4,6 +4,9 @@ module PaymentProviderCustomers
   class BaseCustomer < ApplicationRecord
     self.table_name = 'payment_provider_customers'
 
+    belongs_to :customer
+    belongs_to :payment_provider, optional: true
+
     def push_to_settings(key:, value:)
       self.settings ||= {}
       settings[key] = value

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -4,8 +4,6 @@ module PaymentProviderCustomers
   class BaseCustomer < ApplicationRecord
     self.table_name = 'payment_provider_customers'
 
-    validates :external_customer_id, presence: true
-
     def push_to_settings(key:, value:)
       self.settings ||= {}
       settings[key] = value

--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class StripeCustomer < BaseCustomer
+
+  end
+end

--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -5,6 +5,7 @@ module PaymentProviders
     self.table_name = 'payment_providers'
 
     belongs_to :organization
+    has_many :payment_provider_customers
 
     encrypts :secrets
 

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -32,7 +32,7 @@ module V1
         payment_provider: model.payment_provider,
       }
 
-      if model.payment_provider.to_sym == :stripe
+      if model.payment_provider&.to_sym == :stripe
         configuration[:provider_customer_id] = model.stripe_customer&.provider_customer_id
         configuration.merge!(model.stripe_customer.settings || {})
       end

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -21,7 +21,23 @@ module V1
         logo_url: model.logo_url,
         legal_name: model.legal_name,
         legal_number: model.legal_number,
+        billing_configuration: billing_configuration,
       }
+    end
+
+    private
+
+    def billing_configuration
+      configuration = {
+        payment_provider: model.payment_provider,
+      }
+
+      if model.payment_provider.to_sym == :stripe
+        configuration[:provider_customer_id] = model.stripe_customer&.provider_customer_id
+        configuration.merge!(model.stripe_customer.settings || {})
+      end
+
+      configuration
     end
   end
 end

--- a/app/services/customers_service.rb
+++ b/app/services/customers_service.rb
@@ -116,6 +116,7 @@ class CustomersService < BaseService
 
       create_result = PaymentProviderCustomers::CreateService.new(customer).create(
         customer_class: PaymentProviderCustomers::StripeCustomer,
+        payment_provider_id: customer.organization.stripe_payment_provider&.id,
         params: billing_configuration,
       )
       create_result.throw_error unless create_result.success?

--- a/app/services/customers_service.rb
+++ b/app/services/customers_service.rb
@@ -18,7 +18,10 @@ class CustomersService < BaseService
     customer.legal_name = params[:legal_name] if params.key?(:legal_name)
     customer.legal_number = params[:legal_number] if params.key?(:legal_number)
     customer.vat_rate = params[:vat_rate] if params.key?(:vat_rate)
+
     customer.save!
+
+    assign_billing_configuration(customer, params)
 
     result.customer = customer
     result
@@ -99,5 +102,24 @@ class CustomersService < BaseService
 
     result.customer = customer
     result
+  end
+
+  private
+
+  def assign_billing_configuration(customer, params)
+    return unless params.key?(:billing_configuration)
+
+    billing_configuration = params[:billing_configuration]
+
+    if billing_configuration[:payment_provider] == 'stripe'
+      customer.update!(payment_provider: 'stripe')
+
+      create_result = PaymentProviderCustomers::CreateService.new(customer).create(
+        params: billing_configuration,
+      )
+      create_result.throw_error unless create_result.success?
+    else
+      customer.update!(payment_provider: 'external')
+    end
   end
 end

--- a/app/services/customers_service.rb
+++ b/app/services/customers_service.rb
@@ -111,17 +111,18 @@ class CustomersService < BaseService
 
     billing_configuration = params[:billing_configuration]
 
-    if billing_configuration[:payment_provider] == 'stripe'
-      customer.update!(payment_provider: 'stripe')
-
-      create_result = PaymentProviderCustomers::CreateService.new(customer).create(
-        customer_class: PaymentProviderCustomers::StripeCustomer,
-        payment_provider_id: customer.organization.stripe_payment_provider&.id,
-        params: billing_configuration,
-      )
-      create_result.throw_error unless create_result.success?
-    else
-      customer.update!(payment_provider: 'external')
+    unless billing_configuration[:payment_provider] == 'stripe'
+      customer.update!(payment_provider: nil)
+      return
     end
+
+    customer.update!(payment_provider: 'stripe')
+
+    create_result = PaymentProviderCustomers::CreateService.new(customer).create(
+      customer_class: PaymentProviderCustomers::StripeCustomer,
+      payment_provider_id: customer.organization.stripe_payment_provider&.id,
+      params: billing_configuration,
+    )
+    create_result.throw_error unless create_result.success?
   end
 end

--- a/app/services/customers_service.rb
+++ b/app/services/customers_service.rb
@@ -115,6 +115,7 @@ class CustomersService < BaseService
       customer.update!(payment_provider: 'stripe')
 
       create_result = PaymentProviderCustomers::CreateService.new(customer).create(
+        customer_class: PaymentProviderCustomers::StripeCustomer,
         params: billing_configuration,
       )
       create_result.throw_error unless create_result.success?

--- a/app/services/payment_provider_customers/create_service.rb
+++ b/app/services/payment_provider_customers/create_service.rb
@@ -8,8 +8,8 @@ module PaymentProviderCustomers
       super(nil)
     end
 
-    def create(params:)
-      provider_customer = PaymentProviderCustomers::StripeCustomer.find_or_initialize_by(
+    def create(customer_class:, params:)
+      provider_customer = customer_class.find_or_initialize_by(
         customer_id: customer.id,
         # TODO: attache payment provider of the organization
       )

--- a/app/services/payment_provider_customers/create_service.rb
+++ b/app/services/payment_provider_customers/create_service.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class CreateService < BaseService
+    def initialize(customer)
+      @customer = customer
+
+      super(nil)
+    end
+
+    def create(params:)
+      provider_customer = PaymentProviderCustomers::StripeCustomer.find_or_initialize_by(
+        customer_id: customer.id,
+        # TODO: attache payment provider of the organization
+      )
+      provider_customer.provider_customer_id = params[:provider_customer_id]
+      # TODO: Handle settings and create customer on stripe if no customer id
+
+      provider_customer.save!
+
+      result.provider_customer = provider_customer
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.fail_with_validations!(e.record)
+    end
+
+    private
+
+    attr_accessor :customer
+  end
+end

--- a/app/services/payment_provider_customers/create_service.rb
+++ b/app/services/payment_provider_customers/create_service.rb
@@ -8,10 +8,10 @@ module PaymentProviderCustomers
       super(nil)
     end
 
-    def create(customer_class:, params:)
+    def create(customer_class:, payment_provider_id:, params:)
       provider_customer = customer_class.find_or_initialize_by(
         customer_id: customer.id,
-        # TODO: attache payment provider of the organization
+        payment_provider_id: payment_provider_id,
       )
       provider_customer.provider_customer_id = params[:provider_customer_id]
       # TODO: Handle settings and create customer on stripe if no customer id
@@ -27,5 +27,7 @@ module PaymentProviderCustomers
     private
 
     attr_accessor :customer
+
+    delegate :organization, to: :customer
   end
 end

--- a/db/migrate/20220610134535_create_payment_provider_customers.rb
+++ b/db/migrate/20220610134535_create_payment_provider_customers.rb
@@ -4,6 +4,7 @@ class CreatePaymentProviderCustomers < ActiveRecord::Migration[7.0]
   def change
     create_table :payment_provider_customers, id: :uuid do |t|
       t.references :customer, type: :uuid, index: true, null: false, foreign_key: true
+      t.references :payment_provider, type: :uuid, index: true, null: true, foreign_key: true, dependent: :nullify
       t.string :type, null: false
       t.string :provider_customer_id, index: true
       t.jsonb :settings, null: false, default: {}

--- a/db/migrate/20220610134535_create_payment_provider_customers.rb
+++ b/db/migrate/20220610134535_create_payment_provider_customers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreatePaymentProviderCustomers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :payment_provider_customers, id: :uuid do |t|
+      t.references :customer, type: :uuid, index: true, null: false, foreign_key: true
+      t.string :type, null: false
+      t.string :external_customer_id, null: false, index: true
+      t.jsonb :settings, null: false, default: {}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220610134535_create_payment_provider_customers.rb
+++ b/db/migrate/20220610134535_create_payment_provider_customers.rb
@@ -5,7 +5,7 @@ class CreatePaymentProviderCustomers < ActiveRecord::Migration[7.0]
     create_table :payment_provider_customers, id: :uuid do |t|
       t.references :customer, type: :uuid, index: true, null: false, foreign_key: true
       t.string :type, null: false
-      t.string :external_customer_id, null: false, index: true
+      t.string :provider_customer_id, index: true
       t.jsonb :settings, null: false, default: {}
 
       t.timestamps

--- a/db/migrate/20220610143942_add_payment_provider_to_customers.rb
+++ b/db/migrate/20220610143942_add_payment_provider_to_customers.rb
@@ -2,6 +2,6 @@
 
 class AddPaymentProviderToCustomers < ActiveRecord::Migration[7.0]
   def change
-    add_column :customers, :payment_provider, :string, default: 'lago'
+    add_column :customers, :payment_provider, :string, default: 'external'
   end
 end

--- a/db/migrate/20220610143942_add_payment_provider_to_customers.rb
+++ b/db/migrate/20220610143942_add_payment_provider_to_customers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPaymentProviderToCustomers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :customers, :payment_provider, :string, default: 'lago'
+  end
+end

--- a/db/migrate/20220610143942_add_payment_provider_to_customers.rb
+++ b/db/migrate/20220610143942_add_payment_provider_to_customers.rb
@@ -2,6 +2,6 @@
 
 class AddPaymentProviderToCustomers < ActiveRecord::Migration[7.0]
   def change
-    add_column :customers, :payment_provider, :string, default: 'external'
+    add_column :customers, :payment_provider, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -126,7 +126,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_13_130634) do
     t.string "legal_name"
     t.string "legal_number"
     t.float "vat_rate"
-    t.string "payment_provider", default: "external"
+    t.string "payment_provider"
     t.index ["customer_id"], name: "index_customers_on_customer_id"
     t.index ["organization_id"], name: "index_customers_on_organization_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -126,6 +126,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_13_130634) do
     t.string "legal_name"
     t.string "legal_number"
     t.float "vat_rate"
+    t.string "payment_provider", default: "external"
     t.index ["customer_id"], name: "index_customers_on_customer_id"
     t.index ["organization_id"], name: "index_customers_on_organization_id"
   end
@@ -205,6 +206,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_13_130634) do
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
   end
 
+  create_table "payment_provider_customers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "customer_id", null: false
+    t.string "type", null: false
+    t.string "provider_customer_id"
+    t.jsonb "settings", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_payment_provider_customers_on_customer_id"
+    t.index ["provider_customer_id"], name: "index_payment_provider_customers_on_provider_customer_id"
+  end
+
   create_table "payment_providers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "organization_id", null: false
     t.string "type", null: false
@@ -272,6 +284,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_13_130634) do
   add_foreign_key "invoices", "subscriptions"
   add_foreign_key "memberships", "organizations"
   add_foreign_key "memberships", "users"
+  add_foreign_key "payment_provider_customers", "customers"
   add_foreign_key "payment_providers", "organizations"
   add_foreign_key "plans", "organizations"
   add_foreign_key "subscriptions", "customers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -208,12 +208,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_13_130634) do
 
   create_table "payment_provider_customers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "customer_id", null: false
+    t.uuid "payment_provider_id"
     t.string "type", null: false
     t.string "provider_customer_id"
     t.jsonb "settings", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["customer_id"], name: "index_payment_provider_customers_on_customer_id"
+    t.index ["payment_provider_id"], name: "index_payment_provider_customers_on_payment_provider_id"
     t.index ["provider_customer_id"], name: "index_payment_provider_customers_on_provider_customer_id"
   end
 
@@ -285,6 +287,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_13_130634) do
   add_foreign_key "memberships", "organizations"
   add_foreign_key "memberships", "users"
   add_foreign_key "payment_provider_customers", "customers"
+  add_foreign_key "payment_provider_customers", "payment_providers"
   add_foreign_key "payment_providers", "organizations"
   add_foreign_key "plans", "organizations"
   add_foreign_key "subscriptions", "customers"

--- a/spec/factories/payment_provider_customers_factory.rb
+++ b/spec/factories/payment_provider_customers_factory.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :payment_provider_customer do
+    customer
+
+    external_customer_id { SecureRandom.uuid }
+  end
+end

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -24,6 +24,33 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       expect(result[:created_at]).to be_present
     end
 
+    context 'with billing configuration' do
+      let(:create_params) do
+        {
+          customer_id: SecureRandom.uuid,
+          name: 'Foo Bar',
+          billing_configuration: {
+            payment_provider: 'stripe',
+            provider_customer_id: 'stripe_id',
+          },
+        }
+      end
+
+      it 'returns a success' do
+        post_with_token(organization, '/api/v1/customers', { customer: create_params })
+
+        expect(response).to have_http_status(:success)
+
+        result = JSON.parse(response.body, symbolize_names: true)[:customer]
+        expect(result[:lago_id]).to be_present
+        expect(result[:customer_id]).to eq(create_params[:customer_id])
+
+        expect(result[:billing_configuration]).to be_present
+        expect(result[:billing_configuration][:payment_provider]).to eq('stripe')
+        expect(result[:billing_configuration][:provider_customer_id]).to eq('stripe_id')
+      end
+    end
+
     context 'with invalid params' do
       let(:create_params) do
         {

--- a/spec/services/customers_service_spec.rb
+++ b/spec/services/customers_service_spec.rb
@@ -144,8 +144,7 @@ RSpec.describe CustomersService, type: :service do
         aggregate_failures do
           customer = result.customer
           expect(customer.id).to be_present
-          expect(customer.payment_provider).to eq('external')
-
+          expect(customer.payment_provider).to be_nil
           expect(customer.stripe_customer).to be_nil
         end
       end

--- a/spec/services/customers_service_spec.rb
+++ b/spec/services/customers_service_spec.rb
@@ -87,6 +87,69 @@ RSpec.describe CustomersService, type: :service do
         expect(result).not_to be_success
       end
     end
+
+    context 'with stripe configuration' do
+      let(:create_args) do
+        {
+          customer_id: SecureRandom.uuid,
+          name: 'Foo Bar',
+          billing_configuration: {
+            payment_provider: 'stripe',
+            provider_customer_id: 'stripe_id',
+          },
+        }
+      end
+
+      it 'creates a stripe customer' do
+        result = customers_service.create_from_api(
+          organization: organization,
+          params: create_args,
+        )
+
+        expect(result).to be_success
+
+        aggregate_failures do
+          customer = result.customer
+          expect(customer.id).to be_present
+          expect(customer.payment_provider).to eq('stripe')
+
+          expect(customer.stripe_customer).to be_present
+
+          stripe_customer = customer.stripe_customer
+          expect(stripe_customer.id).to be_present
+          expect(stripe_customer.provider_customer_id).to eq('stripe_id')
+        end
+      end
+    end
+
+    context 'with unknown payment provider' do
+      let(:create_args) do
+        {
+          customer_id: SecureRandom.uuid,
+          name: 'Foo Bar',
+          billing_configuration: {
+            payment_provider: 'foo',
+          },
+        }
+      end
+
+      it 'does not create a payment provider customer' do
+        result = customers_service.create_from_api(
+          organization: organization,
+          params: create_args,
+        )
+
+        expect(result).to be_success
+
+        aggregate_failures do
+          customer = result.customer
+          expect(customer.id).to be_present
+          expect(customer.payment_provider).to eq('external')
+
+          expect(customer.stripe_customer).to be_nil
+        end
+      end
+    end
   end
 
   describe 'create' do

--- a/spec/services/payment_provider_customers/create_service_spec.rb
+++ b/spec/services/payment_provider_customers/create_service_spec.rb
@@ -11,10 +11,13 @@ RSpec.describe PaymentProviderCustomers::CreateService, type: :service do
     { provider_customer_id: 'stripe_id' }
   end
 
+  let(:stripe_provider) { create(:stripe_provider, organization: customer.organization) }
+
   describe '.create' do
     it 'creates a payment_provider_customer' do
       result = create_service.create(
         customer_class: PaymentProviderCustomers::StripeCustomer,
+        payment_provider_id: stripe_provider.id,
         params: create_params,
       )
 

--- a/spec/services/payment_provider_customers/create_service_spec.rb
+++ b/spec/services/payment_provider_customers/create_service_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentProviderCustomers::CreateService, type: :service do
+  let(:create_service) { described_class.new(customer) }
+
+  let(:customer) { create(:customer) }
+
+  let(:create_params) do
+    { provider_customer_id: 'stripe_id' }
+  end
+
+  describe '.create' do
+    it 'creates a payment_provider_customer' do
+      result = create_service.create(params: create_params)
+
+      expect(result).to be_success
+      expect(result.provider_customer).to be_present
+      expect(result.provider_customer.provider_customer_id).to eq('stripe_id')
+    end
+  end
+end

--- a/spec/services/payment_provider_customers/create_service_spec.rb
+++ b/spec/services/payment_provider_customers/create_service_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe PaymentProviderCustomers::CreateService, type: :service do
 
   describe '.create' do
     it 'creates a payment_provider_customer' do
-      result = create_service.create(params: create_params)
+      result = create_service.create(
+        customer_class: PaymentProviderCustomers::StripeCustomer,
+        params: create_params,
+      )
 
       expect(result).to be_success
       expect(result.provider_customer).to be_present


### PR DESCRIPTION
Related to https://github.com/getlago/lago-api/issues/257

Changes:
- Add a new table `payment_provider_customers` to store customer config for payment providers.
- Update `POST api/v1/customers` API end-point to allow update of payment provider and customer_id on external payment provider (stripe)
- Send back these fields to the customer payload in API