### PR TITLE
feat: prefer LAGO_FRONT_URL and enable urls with non-standard ports

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -4,10 +4,18 @@
 
 Rails.application.config.middleware.insert_before(0, Rack::Cors) do
   allow do
-    if Rails.env.development?
+    if ENV.key?('LAGO_FRONT_URL')
+      uri = URI(ENV['LAGO_FRONT_URL'])
+
+      frontend_origin = if uri.port.in?([80, 443])
+        uri.host
+      else
+        [uri.host, uri.port].join(':')
+      end
+
+      origins frontend_origin
+    elsif Rails.env.development?
       origins 'app.lago.dev', 'api'
-    elsif ENV['LAGO_FRONT_URL']
-      origins URI(ENV['LAGO_FRONT_URL']).host
     end
 
     resource '*',


### PR DESCRIPTION
Before this change you had to manually edit this file in order to run
the api and front-end on a non-standard port in development. Now
LAGO_FRONT_URL will be preferred if it exists in the environment and it
will allow non-standard ports instead of just using the configured
hostname.
