### PR TITLE
feat: enable configuration for webhook attempts

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -5,7 +5,8 @@ require Rails.root.join('lib/lago_http_client/lago_http_client')
 class SendWebhookJob < ApplicationJob
   queue_as 'webhook'
 
-  retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
+  retry_on LagoHttpClient::HttpError, wait: :exponentially_longer,
+    attempts: ENV.fetch('LAGO_WEBHOOK_ATTEMPTS', 3).to_i
 
   def perform(webhook_type, object)
     case webhook_type


### PR DESCRIPTION
This change introduces the `LAGO_WEBHOOK_ATTEMPTS` environment variable,
which will be used instead of the default of 3 when attempting to
deliver webhooks.