### PR TITLE
Prefer LAGO_RSA_PRIVATE_KEY

### DIFF
--- a/config/initializers/rsa_keys.rb
+++ b/config/initializers/rsa_keys.rb
@@ -3,7 +3,7 @@
 private_key_string = if Rails.env.development? || Rails.env.test?
   File.read(Rails.root.join('.rsa_private.pem'))
 else
-  Base64.decode64(ENV['RSA_PRIVATE_KEY'])
+  Base64.decode64(ENV['LAGO_RSA_PRIVATE_KEY'])
 end
 
 RsaPrivateKey = OpenSSL::PKey::RSA.new(private_key_string)


### PR DESCRIPTION
Prefer the documented variable name `LAGO_RSA_PRIVATE_KEY` and allow the previous variable name `RSA_PRIVATE_KEY` for backwards-compatability

Fixes part two of #296
