### PR TITLE
Use the documented variable LAGO_RSA_PRIVATE_KEY

### DIFF
--- a/config/initializers/rsa_keys.rb
+++ b/config/initializers/rsa_keys.rb
@@ -3,7 +3,7 @@
 private_key_string = if Rails.env.development? || Rails.env.test?
   File.read(Rails.root.join('.rsa_private.pem'))
 else
-  Base64.decode64(ENV['RSA_PRIVATE_KEY'])
+  Base64.decode64(ENV['LAGO_RSA_PRIVATE_KEY'])
 end
 
 RsaPrivateKey = OpenSSL::PKey::RSA.new(private_key_string)


### PR DESCRIPTION
Fixes part two of https://github.com/getlago/lago-api/issues/296 and replaces #297 
