### PR TITLE
fix: organization logo validations

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -25,7 +25,7 @@ class Organization < ApplicationRecord
   validates :country, country_code: true, if: :country?
   validates :invoice_footer, length: { maximum: 600 }
   validates :email, email: true, if: :email?
-  validates :logo, image: { authorized_content_type: %w[image/png image/jpg], max_size: 800.kilobytes }, if: :logo?
+  validates :logo, image: { authorized_content_type: %w[image/png image/jpg image/jpeg], max_size: 800.kilobytes }, if: :logo?
 
   def logo_url
     return if logo.blank?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,3 +20,5 @@ en:
         invalid_rate: invalid_rate
         invalid_fixed_amount: invalid_fixed_amount
         invalid_fixed_amount_target: invalid_fixed_amount_target
+        invalid_content_type: invalid_content_type
+        invalid_size: invalid_size


### PR DESCRIPTION
- Add locales for `invalid_content_type` and `invalid_size`
- Add support of `image/jpeg` type