### PR TITLE
feat: Enable add charge if subscription

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -3,7 +3,7 @@
 class Charge < ApplicationRecord
   include Currencies
 
-  belongs_to :plan
+  belongs_to :plan, touch: true
   belongs_to :billable_metric
 
   has_many :fees

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -163,11 +163,11 @@ module Invoices
       expire_cache(last_events[1]) if last_events.count > 1
       last_created_at = last_events.first || customer.created_at
 
-      @cache_key = "current_usage/#{customer.id}-#{last_created_at.iso8601}"
+      @cache_key = "current_usage/#{customer.id}-#{last_created_at.iso8601}/#{plan.updated_at.iso8601}"
     end
 
     def expire_cache(date)
-      Rails.cache.delete("current_usage/#{customer.id}-#{date.iso8601}")
+      Rails.cache.delete("current_usage/#{customer.id}-#{date.iso8601}/#{plan.updated_at.iso8601}")
     end
 
     def cache_expiration

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -86,15 +86,17 @@ module Plans
     end
 
     def process_charges(plan, params_charges)
-      return if plan.attached_to_subscriptions?
-
       created_charges_ids = []
 
       hash_charges = params_charges.map { |c| c.to_h.deep_symbolize_keys }
       hash_charges.each do |payload_charge|
         charge = Charge.find_by(id: payload_charge[:id])
 
-        next charge.update(payload_charge) if charge
+        if charge
+          # NOTE: charges cannot be edited if plan is attached to a subscription
+          charge.update(payload_charge) unless plan.attached_to_subscriptions?
+          next
+        end
 
         created_charge = create_charge(plan, payload_charge)
         created_charges_ids.push(created_charge.id)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -210,11 +210,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_05_155228) do
     t.string "vat_amount_currency"
     t.bigint "total_amount_cents", default: 0, null: false
     t.string "total_amount_currency"
-    t.integer "invoice_type", default: 0, null: false
     t.date "charges_from_date"
+    t.integer "invoice_type", default: 0, null: false
     t.integer "status", default: 0, null: false
     t.string "number", default: "", null: false
     t.integer "sequential_id"
+    t.string "file"
     t.index ["subscription_id"], name: "index_invoices_on_subscription_id"
   end
 


### PR DESCRIPTION
Allow addition of new charge to a plan even if subscriptions are using the plan