### PR TITLE
feat: Add wallet transactions

### DIFF
--- a/app/graphql/mutations/wallet_transactions/create.rb
+++ b/app/graphql/mutations/wallet_transactions/create.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Mutations
+  module WalletTransactions
+    class Create < BaseMutation
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      graphql_name 'CreateCustomerWalletTransaction'
+      description 'Creates a new Customer Wallet Transaction'
+
+      argument :wallet_id, ID, required: true
+      argument :paid_credits, String, required: true
+      argument :granted_credits, String, required: true
+
+      type Types::WalletTransactions::Object
+
+      def resolve(**args)
+        validate_organization!
+
+        # TODO
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/wallet_transaction_resolver.rb
+++ b/app/graphql/resolvers/wallet_transaction_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class WalletTransactionResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description 'Query a single wallet transaction'
+
+    argument :id, ID, required: true, description: 'Uniq ID of the wallet transaction'
+
+    type Types::WalletTransactions::SingleObject, null: true
+
+    def resolve(id: nil)
+      validate_organization!
+
+      current_organization.wallet_transactions.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error
+    end
+  end
+end

--- a/app/graphql/resolvers/wallet_transactions_resolver.rb
+++ b/app/graphql/resolvers/wallet_transactions_resolver.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class WalletTransactionsResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description 'Query wallet transactions'
+
+    argument :ids, [ID], required: false, description: 'List of wallet transaction IDs to fetch'
+    argument :wallet_id, ID, required: true, description: 'Uniq ID of the wallet'
+    argument :page, Integer, required: false
+    argument :limit, Integer, required: false
+    argument :transaction_type, Types::WalletTransactions::TransactionTypeEnum, required: false
+    argument :status, Types::WalletTransactions::StatusEnum, required: false
+
+    type Types::WalletTransactions::Object.collection_type, null: false
+
+    def resolve(
+      wallet_id: nil,
+      ids: nil,
+      page: nil,
+      limit: nil,
+      status: nil,
+      transaction_type: nil
+    )
+      validate_organization!
+
+      current_wallet = Wallet.find(wallet_id)
+
+      wallet_transactions = current_wallet
+        .wallet_transactions
+        .page(page)
+        .limit(limit)
+
+      wallet_transactions = wallet_transactions.where(transaction_type: transaction_type) if transaction_type.present?
+      wallet_transactions = wallet_transactions.where(status: status) if status.present?
+      wallet_transactions = wallet_transactions.where(id: ids) if ids.present?
+
+      wallet_transactions
+    rescue ActiveRecord::RecordNotFound
+      not_found_error
+    end
+  end
+end

--- a/app/graphql/resolvers/wallets_resolver.rb
+++ b/app/graphql/resolvers/wallets_resolver.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal
+# frozen_string_literal: true
 
 module Resolvers
   class WalletsResolver < Resolvers::BaseResolver

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -24,5 +24,7 @@ module Types
     field :current_version, resolver: Resolvers::VersionResolver
     field :wallets, resolver: Resolvers::WalletsResolver
     field :wallet, resolver: Resolvers::WalletResolver
+    field :wallet_transactions, resolver: Resolvers::WalletTransactionsResolver
+    field :wallet_transaction, resolver: Resolvers::WalletTransactionResolver
   end
 end

--- a/app/graphql/types/wallet_transactions/object.rb
+++ b/app/graphql/types/wallet_transactions/object.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  module WalletTransactions
+    class Object < Types::BaseObject
+      graphql_name 'WalletTransaction'
+
+      field :id, ID, null: false
+      field :wallet, Types::Wallets::Object
+
+      field :transaction_type, Types::WalletTransactions::TransactionTypeEnum, null: false
+      field :status, Types::Wallets::StatusEnum, null: false
+      field :amount, String, null: false
+      field :credit_amount, String, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :settled_at, GraphQL::Types::ISO8601DateTime, null: true
+    end
+  end
+end

--- a/app/graphql/types/wallet_transactions/single_object.rb
+++ b/app/graphql/types/wallet_transactions/single_object.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Types
+  module WalletTransactions
+    class SingleObject < Types::WalletTransactions::Object
+      graphql_name 'WalletTransactionDetails'
+    end
+  end
+end

--- a/app/graphql/types/wallet_transactions/status_enum.rb
+++ b/app/graphql/types/wallet_transactions/status_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module WalletTransactions
+    class StatusEnum < Types::BaseEnum
+      graphql_name 'WalletTransactionStatusEnum'
+
+      WalletTransaction::STATUSES.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/wallet_transactions/transaction_type_enum.rb
+++ b/app/graphql/types/wallet_transactions/transaction_type_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module WalletTransactions
+    class TransactionTypeEnum < Types::BaseEnum
+      graphql_name 'WalletTransactionTransactionTypeEnum'
+
+      WalletTransaction::TRANSACTION_TYPES.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -15,6 +15,7 @@ class Customer < ApplicationRecord
   has_many :applied_add_ons
   has_many :add_ons, through: :applied_add_ons
   has_many :wallets
+  has_many :wallet_transactions, through: :wallets
   has_many :payment_provider_customers,
            class_name: 'PaymentProviderCustomers::BaseCustomer',
            dependent: :destroy

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,6 +12,8 @@ class Organization < ApplicationRecord
   has_many :coupons
   has_many :add_ons
   has_many :payment_providers
+  has_many :wallets, through: :customers
+  has_many :wallet_transactions, through: :wallets
 
   has_one :stripe_payment_provider, class_name: 'PaymentProviders::StripeProvider'
 

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -5,6 +5,8 @@ class Wallet < ApplicationRecord
 
   has_one :organization, through: :customer
 
+  has_many :wallet_transactions
+
   STATUSES = [
     :active,
     :terminated,

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class WalletTransaction < ApplicationRecord
+  belongs_to :wallet
+
+  STATUSES = [
+    :pending,
+    :settled,
+  ].freeze
+
+  TRANSACTION_TYPES = [
+    :inbound,
+    :outbound,
+  ].freeze
+
+  enum status: STATUSES
+  enum transaction_type: TRANSACTION_TYPES
+end

--- a/db/migrate/20220721150658_create_wallet_transactions.rb
+++ b/db/migrate/20220721150658_create_wallet_transactions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateWalletTransactions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :wallet_transactions, id: :uuid do |t|
+      t.references :wallet, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.integer :transaction_type, null: false
+      t.integer :status, null: false
+
+      t.decimal :amount, null: false, default: 0, precision: 5
+      t.decimal :credit_amount, null: false, default: 0, precision: 5
+
+      t.timestamp :settled_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -340,20 +340,21 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_21_150658) do
   end
 
   create_table "wallets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "customers_id", null: false
+    t.uuid "customer_id", null: false
     t.integer "status", null: false
     t.string "currency", null: false
     t.string "name"
     t.string "rate_amount", null: false
     t.string "credits_balance", default: "0.00", null: false
-    t.string "balance", null: false
+    t.string "balance", default: "0.00", null: false
     t.string "consumed_credits", default: "0.00", null: false
     t.datetime "expiration_date", precision: nil
     t.datetime "last_balance_sync_at", precision: nil
     t.datetime "last_consumed_credit_at", precision: nil
+    t.datetime "terminated_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["customers_id"], name: "index_wallets_on_customers_id"
+    t.index ["customer_id"], name: "index_wallets_on_customer_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
@@ -385,5 +386,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_21_150658) do
   add_foreign_key "subscriptions", "customers"
   add_foreign_key "subscriptions", "plans"
   add_foreign_key "wallet_transactions", "wallets"
-  add_foreign_key "wallets", "customers", column: "customers_id"
+  add_foreign_key "wallets", "customers"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_18_083657) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_21_150658) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -327,22 +327,33 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_083657) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "wallet_transactions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "wallet_id", null: false
+    t.integer "transaction_type", null: false
+    t.integer "status", null: false
+    t.decimal "amount", precision: 5, default: "0", null: false
+    t.decimal "credit_amount", precision: 5, default: "0", null: false
+    t.datetime "settled_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
+  end
+
   create_table "wallets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "customer_id", null: false
+    t.uuid "customers_id", null: false
     t.integer "status", null: false
     t.string "currency", null: false
     t.string "name"
     t.string "rate_amount", null: false
     t.string "credits_balance", default: "0.00", null: false
-    t.string "balance", default: "0.00", null: false
+    t.string "balance", null: false
     t.string "consumed_credits", default: "0.00", null: false
     t.datetime "expiration_date", precision: nil
     t.datetime "last_balance_sync_at", precision: nil
     t.datetime "last_consumed_credit_at", precision: nil
-    t.datetime "terminated_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["customer_id"], name: "index_wallets_on_customer_id"
+    t.index ["customers_id"], name: "index_wallets_on_customers_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
@@ -373,5 +384,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_18_083657) do
   add_foreign_key "plans", "organizations"
   add_foreign_key "subscriptions", "customers"
   add_foreign_key "subscriptions", "plans"
-  add_foreign_key "wallets", "customers"
+  add_foreign_key "wallet_transactions", "wallets"
+  add_foreign_key "wallets", "customers", column: "customers_id"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -131,6 +131,41 @@ Charge.create_with(
   end
 end
 
+first_customer = organization.customers.first
+
+wallet = Wallet.create!(
+  customer: first_customer,
+  name: 'My Active Wallet',
+  status: :active,
+  rate_amount: BigDecimal('1.00'),
+  balance: BigDecimal('100.00'),
+  credits_balance: BigDecimal('100.00'),
+  currency: 'EUR',
+)
+
+Wallet.create!(
+  customer: first_customer,
+  name: 'My Terminated Wallet',
+  status: :terminated,
+  terminated_at: Time.zone.now - 3.days,
+  rate_amount: BigDecimal('1.00'),
+  balance: BigDecimal('86.00'),
+  credits_balance: BigDecimal('86.00'),
+  consumed_credits: BigDecimal('114.00'),
+  currency: 'EUR',
+)
+
+3.times do
+  WalletTransaction.create!(
+    wallet: wallet,
+    transaction_type: :outbound,
+    status: :settled,
+    amount: BigDecimal('10.00'),
+    credit_amount: BigDecimal('10.00'),
+    settled_at: Time.zone.now,
+  )
+end
+
 # NOTE: Regenerate events for the customers
 organization.customers.find_each do |customer|
   5.times do

--- a/schema.graphql
+++ b/schema.graphql
@@ -3242,6 +3242,35 @@ type Query {
   ): WalletDetails
 
   """
+  Query a single wallet transaction
+  """
+  walletTransaction(
+    """
+    Uniq ID of the wallet transaction
+    """
+    id: ID!
+  ): WalletTransactionDetails
+
+  """
+  Query wallet transactions
+  """
+  walletTransactions(
+    """
+    List of wallet transaction IDs to fetch
+    """
+    ids: [ID!]
+    limit: Int
+    page: Int
+    status: WalletTransactionStatusEnum
+    transactionType: WalletTransactionTransactionTypeEnum
+
+    """
+    Uniq ID of the wallet
+    """
+    walletId: ID!
+  ): WalletTransactionCollection!
+
+  """
   Query wallets
   """
   wallets(
@@ -3565,4 +3594,43 @@ type WalletDetails {
 enum WalletStatusEnum {
   active
   terminated
+}
+
+type WalletTransaction {
+  amount: String!
+  createdAt: ISO8601DateTime!
+  creditAmount: String!
+  id: ID!
+  settledAt: ISO8601DateTime
+  status: WalletStatusEnum!
+  transactionType: WalletTransactionTransactionTypeEnum!
+  updatedAt: ISO8601DateTime!
+  wallet: Wallet
+}
+
+type WalletTransactionCollection {
+  collection: [WalletTransaction!]!
+  metadata: CollectionMetadata!
+}
+
+type WalletTransactionDetails {
+  amount: String!
+  createdAt: ISO8601DateTime!
+  creditAmount: String!
+  id: ID!
+  settledAt: ISO8601DateTime
+  status: WalletStatusEnum!
+  transactionType: WalletTransactionTransactionTypeEnum!
+  updatedAt: ISO8601DateTime!
+  wallet: Wallet
+}
+
+enum WalletTransactionStatusEnum {
+  pending
+  settled
+}
+
+enum WalletTransactionTransactionTypeEnum {
+  inbound
+  outbound
 }

--- a/schema.json
+++ b/schema.json
@@ -11185,6 +11185,136 @@
               ]
             },
             {
+              "name": "walletTransaction",
+              "description": "Query a single wallet transaction",
+              "type": {
+                "kind": "OBJECT",
+                "name": "WalletTransactionDetails",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the wallet transaction",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "walletTransactions",
+              "description": "Query wallet transactions",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "WalletTransactionCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "ids",
+                  "description": "List of wallet transaction IDs to fetch",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "walletId",
+                  "description": "Uniq ID of the wallet",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "transactionType",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "WalletTransactionTransactionTypeEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "status",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "WalletTransactionStatusEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "wallets",
               "description": "Query wallets",
               "type": {
@@ -13769,6 +13899,443 @@
             },
             {
               "name": "terminated",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WalletTransaction",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditAmount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "settledAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "status",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WalletStatusEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "transactionType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WalletTransactionTransactionTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "wallet",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Wallet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WalletTransactionCollection",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "WalletTransaction",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "WalletTransactionDetails",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditAmount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "settledAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "status",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WalletStatusEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "transactionType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WalletTransactionTransactionTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "wallet",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Wallet",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "WalletTransactionStatusEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "pending",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "settled",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "WalletTransactionTransactionTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "inbound",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "outbound",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/factories/wallet_transaction_factory.rb
+++ b/spec/factories/wallet_transaction_factory.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :wallet_transaction do
+    wallet
+    transaction_type { 'inbound' }
+    status { 'settled' }
+    amount { '1.00' }
+    credit_amount { '1.00' }
+    settled_at { Time.zone.now }
+  end
+end

--- a/spec/graphql/resolvers/wallet_transaction_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_transaction_resolver_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::WalletTransactionResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($walletTransactionId: ID!) {
+        walletTransaction(id: $walletTransactionId) {
+          id, amount, creditAmount
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer, organization: membership.organization) }
+  let(:wallet) { create(:wallet, customer: customer) }
+  let(:wallet_transaction) { create(:wallet_transaction, wallet: wallet) }
+
+  before { wallet_transaction }
+
+  it 'returns a single wallet transaction' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: membership.organization,
+      query: query,
+      variables: {
+        walletTransactionId: wallet_transaction.id,
+      },
+    )
+    
+    wallet_transaction_response = result['data']['walletTransaction']
+
+    aggregate_failures do
+      expect(wallet_transaction_response['id']).to eq(wallet_transaction.id)
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query: query,
+        variables: {
+          walletTransactionId: wallet_transaction.id,
+        },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Missing organization id',
+      )
+    end
+  end
+
+  context 'when wallet transaction is not found' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        query: query,
+        variables: {
+          walletTransactionId: 'foo',
+        },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Resource not found',
+      )
+    end
+  end
+end

--- a/spec/graphql/resolvers/wallet_transactions_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_transactions_resolver_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::WalletsResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($walletId: ID!) {
+        walletTransactions(walletId: $walletId, limit: 5, status: settled) {
+          collection { id }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:wallet) { create(:wallet, customer: customer) }
+  let(:wallet_transaction) { create(:wallet_transaction, wallet: wallet) }
+
+  before do
+    wallet_transaction
+  end
+
+  it 'returns a list of wallet transactions' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query: query,
+      variables: {
+        walletId: wallet.id,
+      },
+    )
+
+    wallet_transactions_response = result['data']['walletTransactions']
+
+    aggregate_failures do
+      expect(wallet_transactions_response['collection'].count).to eq(wallet.wallet_transactions.count)
+      expect(wallet_transactions_response['collection'].first['id']).to eq(wallet_transaction.id)
+
+      expect(wallet_transactions_response['metadata']['currentPage']).to eq(1)
+      expect(wallet_transactions_response['metadata']['totalCount']).to eq(1)
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query: query,
+        variables: {
+          walletId: wallet.id,
+        },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Missing organization id',
+      )
+    end
+  end
+
+  context 'when not member of the organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: create(:organization),
+        query: query,
+        variables: {
+          walletId: wallet.id,
+        },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Not in organization',
+      )
+    end
+  end
+
+  context 'when wallet does not exists' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query: query,
+        variables: {
+          walletId: '123456',
+        },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Resource not found',
+      )
+    end
+  end
+end


### PR DESCRIPTION
**Context**

As we added `wallets` linked to a customer, we now need to prepare the logic behind the prepaid credits feature.
For this we need to add `wallet_transactions` that will represent what happen in the wallet and keep a trace of all credits movements.

**Changes**

- Add `WalletTransactions` migration
- Add GraphQL Resolvers for `walletTransactions`