### PR TITLE
Force setting RAILS_ENV to test in rails_helper

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,8 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
+ENV['RAILS_ENV'] = 'test'
+require_relative '../config/environment'
 
+require 'spec_helper'
 require 'simplecov'
 
 SimpleCov.start do
@@ -17,8 +19,6 @@ SimpleCov.start do
   add_group 'GraphQL', 'app/graphql'
 end
 
-ENV['RAILS_ENV'] ||= 'test'
-require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'


### PR DESCRIPTION
### Objective

The goal is to enforce `RAILS_ENV` to be equal to `test` when running specs.
So that running `bundle exec rspec` without passing `RAILS_ENV` is loading the correct environment (not `development`).
