### PR TITLE
Integrate Ruby library for Segment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.0.1'
 
+gem 'analytics-ruby', '~> 2.4.0', require: 'segment/analytics'
 gem 'bcrypt'
 gem 'bootsnap', require: false
 gem 'clockwork', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    analytics-ruby (2.4.0)
     aws-eventstream (1.2.0)
     aws-partitions (1.605.0)
     aws-sdk-core (3.131.2)
@@ -329,6 +330,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  analytics-ruby (~> 2.4.0)
   aws-sdk-s3
   bcrypt
   bootsnap

--- a/config/initializers/analytics_ruby.rb
+++ b/config/initializers/analytics_ruby.rb
@@ -1,0 +1,8 @@
+require 'segment/analytics'
+
+if ENV['SEGMENT_WRITE_KEY'] && ENV['LAGO_DISABLE_SEGMENT'] != 'true'
+  Analytics = Segment::Analytics.new({
+    write_key: ENV['SEGMENT_WRITE_KEY'],
+    on_error: Proc.new { |status, msg| print msg }
+  })
+end


### PR DESCRIPTION
## Context

We want to track and measure what our users are doing, both on the self-hosted and fully-hosted sides.
By sending backend events to Segment.com.

### Changes

This PR is integrating the Ruby library for Segment.
And using the `SEGMENT_WRITE_KEY` based on the environment.
