### PR TITLE
Set membership context on each request

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -6,6 +6,7 @@ module Api
     include Common
 
     before_action :authenticate
+    include Trackable
 
     private
 

--- a/app/controllers/concerns/trackable.rb
+++ b/app/controllers/concerns/trackable.rb
@@ -1,0 +1,25 @@
+module Trackable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_tracing_information
+  end
+
+  def set_tracing_information
+    CurrentContext.membership = "membership/#{membership_id || 'unidentifiable'}"
+  end
+
+  def membership_id
+    return nil unless current_organization
+
+    # NOTE: When doing requests from the API, we haven't the current user information.
+    # In that case, we add tracing information on the first created membership of the organization.
+    return first_membership_id unless (defined?(current_user) && current_user)
+
+    current_organization.memberships.find_by(user_id: current_user.id).id
+  end
+
+  def first_membership_id
+    @first_membership_id ||= current_organization.memberships.order(:created_at).first&.id
+  end
+end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -3,6 +3,7 @@
 class GraphqlController < ApplicationController
   include AuthenticableUser
   include OrganizationHeader
+  include Trackable
 
   rescue_from JWT::ExpiredSignature do
     render_graphql_error(code: 'expired_jwt_token', status: 401)

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,10 @@ Bundler.require(*Rails.groups)
 module LagoApi
   class Application < Rails::Application
     config.load_defaults(7.0)
-    config.eager_load_paths << Rails.root.join('lib/lago_http_client')
+    config.eager_load_paths += %W[
+      #{config.root}/lib
+      #{config.root}/lib/lago_http_client
+    ]
     config.api_only = true
     config.active_job.queue_adapter = :sidekiq
 

--- a/lib/current_context.rb
+++ b/lib/current_context.rb
@@ -1,0 +1,3 @@
+module CurrentContext
+  thread_mattr_accessor :membership
+end

--- a/spec/controllers/concerns/trackable_spec.rb
+++ b/spec/controllers/concerns/trackable_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe Trackable do
+  describe '#set_tracing_information' do
+    let(:membership) { create(:membership) }
+
+    it 'sets the membership identifier to context' do
+      build_dummy(current_user: membership.user).set_tracing_information
+
+      expect(CurrentContext.membership).to eq "membership/#{membership.id}"
+    end
+
+    context 'when current organization is not present' do
+      it 'sets an "unidentifiable" membership identifier to context' do
+        build_dummy(current_organization: nil).set_tracing_information
+
+        expect(CurrentContext.membership).to eq 'membership/unidentifiable'
+      end
+    end
+
+    context 'when current user is nil' do
+      it 'sets the first created membership to context' do
+        build_dummy(current_user: nil).set_tracing_information
+
+        expect(CurrentContext.membership).to eq "membership/#{membership.id}"
+      end
+    end
+  end
+
+  def dummy_class
+    Class.new do
+      def self.before_action(*)
+      end
+
+      include Trackable
+
+      def initialize(options = {})
+        self.current_user = options.fetch(:current_user) if options[:current_user]
+        self.current_organization = options.fetch(:current_organization)
+      end
+
+      private
+
+      attr_accessor :current_user
+      attr_accessor :current_organization
+    end
+  end
+
+  def build_dummy(attrs = {})
+    base_attrs = {current_organization: membership.organization}
+    stub_const('DummyClass', dummy_class)
+    DummyClass.new(base_attrs.merge(attrs))
+  end
+end


### PR DESCRIPTION
## Context

We want to track and measure what our users are doing, both on the self-hosted and fully-hosted sides.
By sending backend events to Segment.com.

We decided to track memberships and not users on [Segment.com](http://segment.com/) for now, as they should be authenticated to perform the actions.
Concerning the API, we only have the information about the organization, we’ll put tracking on the first created membership.

### Changes

Each time a request is made (cloud or self-hosted), the membership id is now added to the current context.
This information is mandatory for sending tracking events to Segment.
