### PR TITLE
feat(segment): Add some tracking on Segment

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -28,6 +28,7 @@ jobs:
       ENCRYPTION_KEY_DERIVATION_SALT: q3pkMw34ZkRPFSf2LmtWe705yw532Pf7
       LAGO_API_URL: https://api.lago.dev
       LAGO_PDF_URL: https://pdf.lago.dev
+      SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/app/jobs/segment_track_job.rb
+++ b/app/jobs/segment_track_job.rb
@@ -1,0 +1,11 @@
+class SegmentTrackJob < ApplicationJob
+  queue_as :default
+
+  def perform(membership_id:, event:, properties:)
+    SEGMENT_CLIENT.track(
+      membership_id: membership_id,
+      event: event,
+      properties: properties
+    )
+  end
+end

--- a/app/jobs/segment_track_job.rb
+++ b/app/jobs/segment_track_job.rb
@@ -1,11 +1,21 @@
 class SegmentTrackJob < ApplicationJob
   queue_as :default
 
-  def perform(membership_id:, event:, properties:)
+  def perform(event:, properties:)
     SEGMENT_CLIENT.track(
-      membership_id: membership_id,
+      user_id: CurrentContext.membership,
       event: event,
-      properties: properties
+      properties: properties.merge(hosting_type, version)
     )
+  end
+
+  private
+
+  def hosting_type
+    { hosting_type: ENV['HOSTING_TYPE'] }
+  end
+
+  def version
+    { version: Utils::VersionService.new.version.version.number }
   end
 end

--- a/app/jobs/segment_track_job.rb
+++ b/app/jobs/segment_track_job.rb
@@ -1,9 +1,9 @@
 class SegmentTrackJob < ApplicationJob
   queue_as :default
 
-  def perform(event:, properties:)
+  def perform(membership_id:, event:, properties:)
     SEGMENT_CLIENT.track(
-      user_id: CurrentContext.membership,
+      user_id: membership_id,
       event: event,
       properties: properties.merge(hosting_type, version)
     )
@@ -12,7 +12,7 @@ class SegmentTrackJob < ApplicationJob
   private
 
   def hosting_type
-    { hosting_type: ENV['HOSTING_TYPE'] }
+    { hosting_type: ENV['LAGO_CLOUD'] == 'true' ? 'cloud' : 'self' }
   end
 
   def version

--- a/app/jobs/segment_track_job.rb
+++ b/app/jobs/segment_track_job.rb
@@ -2,6 +2,8 @@ class SegmentTrackJob < ApplicationJob
   queue_as :default
 
   def perform(membership_id:, event:, properties:)
+    return if ENV['LAGO_DISABLE_SEGMENT'] == 'true'
+
     SEGMENT_CLIENT.track(
       user_id: membership_id,
       event: event,

--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -31,7 +31,7 @@ class UsersService < BaseService
       )
     end
 
-    track_user_register(result.organization)
+    track_user_register(result.organization, result.membership)
 
     result
   end
@@ -57,9 +57,9 @@ class UsersService < BaseService
     }
   end
 
-  def track_user_register(organization)
+  def track_user_register(organization, membership)
     SegmentTrackJob.perform_later(
-      membership_id: CurrentContext.membership,
+      membership_id: "membership/#{membership.id}",
       event: 'user_register',
       properties: {
         organization_name: organization.name,

--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -59,6 +59,7 @@ class UsersService < BaseService
 
   def track_user_register(organization)
     SegmentTrackJob.perform_later(
+      membership_id: CurrentContext.membership,
       event: 'user_register',
       properties: {
         organization_name: organization.name,

--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -31,6 +31,8 @@ class UsersService < BaseService
       )
     end
 
+    track_user_register(result.organization)
+
     result
   end
 
@@ -53,5 +55,15 @@ class UsersService < BaseService
       sub: result.user.id,
       exp: Time.now.to_i + 8640 # 6 hours expiration
     }
+  end
+
+  def track_user_register(organization)
+    SegmentTrackJob.perform_later(
+      event: 'user_register',
+      properties: {
+        organization_name: organization.name,
+        organization_id: organization.id,
+      }
+    )
   end
 end

--- a/config/initializers/analytics_ruby.rb
+++ b/config/initializers/analytics_ruby.rb
@@ -1,8 +1,15 @@
-require 'segment/analytics'
+class SegmentError < StandardError
+  attr_reader :status, :error_message, :message
 
-if ENV['SEGMENT_WRITE_KEY'] && ENV['LAGO_DISABLE_SEGMENT'] != 'true'
-  Analytics = Segment::Analytics.new({
-    write_key: ENV['SEGMENT_WRITE_KEY'],
-    on_error: Proc.new { |status, msg| print msg }
-  })
+  def initialize(status, error_message)
+    @status = status
+    @error_message = error_message
+    @message = "Status: #{status}, Message: #{error_message}"
+  end
 end
+
+SEGMENT_CLIENT = Segment::Analytics.new({
+  write_key: ENV['SEGMENT_WRITE_KEY'],
+  on_error: proc { |status, msg| Sentry.capture_exception(SegmentError.new(status, msg)) },
+  stub: Rails.env.development? || Rails.env.test?
+})

--- a/spec/jobs/segment_track_job_spec.rb
+++ b/spec/jobs/segment_track_job_spec.rb
@@ -4,6 +4,7 @@ describe SegmentTrackJob, job: true do
   subject { described_class }
 
   describe '.perform' do
+    let(:membership_id) { CurrentContext.membership }
     let(:event) { 'event' }
     let(:properties) do
       { method: 1 }
@@ -12,16 +13,28 @@ describe SegmentTrackJob, job: true do
     it "calls SegmentTrackJob's process method" do
       expect(SEGMENT_CLIENT).to receive(:track)
         .with(
-          user_id: CurrentContext.membership,
+          user_id: membership_id,
           event: event,
           properties: {
             method: 1,
-            hosting_type: ENV['HOSTING_TYPE'],
+            hosting_type: 'self',
             version: Utils::VersionService.new.version.version.number
           }
         )
 
-      subject.perform_now(event: event, properties: properties)
+      subject.perform_now(membership_id: membership_id, event: event, properties: properties)
+    end
+
+    context 'when LAGO_CLOUD is true' do
+      it 'includes hosting type equal to cloud' do
+        stub_const('ENV', 'LAGO_CLOUD' => 'true')
+
+        expect(SEGMENT_CLIENT).to receive(:track).with(
+          hash_including(properties: hash_including(hosting_type: 'cloud'))
+        )
+
+        subject.perform_now(membership_id: membership_id, event: event, properties: properties)
+      end
     end
   end
 end

--- a/spec/jobs/segment_track_job_spec.rb
+++ b/spec/jobs/segment_track_job_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe SegmentTrackJob, job: true do
+  subject { described_class }
+
+  describe '.perform' do
+    let(:membership_id) { SecureRandom.uuid }
+    let(:event) { 'event' }
+    let(:properties) do
+      {
+        method: 1
+      }
+    end
+
+    it "calls SegmentTrackJob's process method" do
+      expect(SEGMENT_CLIENT).to receive(:track)
+        .with(
+          membership_id: membership_id,
+          event: event,
+          properties: properties
+        )
+
+      subject.perform_now(membership_id: membership_id, event: event, properties: properties)
+    end
+  end
+end

--- a/spec/jobs/segment_track_job_spec.rb
+++ b/spec/jobs/segment_track_job_spec.rb
@@ -4,23 +4,24 @@ describe SegmentTrackJob, job: true do
   subject { described_class }
 
   describe '.perform' do
-    let(:membership_id) { SecureRandom.uuid }
     let(:event) { 'event' }
     let(:properties) do
-      {
-        method: 1
-      }
+      { method: 1 }
     end
 
     it "calls SegmentTrackJob's process method" do
       expect(SEGMENT_CLIENT).to receive(:track)
         .with(
-          membership_id: membership_id,
+          user_id: CurrentContext.membership,
           event: event,
-          properties: properties
+          properties: {
+            method: 1,
+            hosting_type: ENV['HOSTING_TYPE'],
+            version: Utils::VersionService.new.version.version.number
+          }
         )
 
-      subject.perform_now(membership_id: membership_id, event: event, properties: properties)
+      subject.perform_now(event: event, properties: properties)
     end
   end
 end

--- a/spec/jobs/segment_track_job_spec.rb
+++ b/spec/jobs/segment_track_job_spec.rb
@@ -10,6 +10,10 @@ describe SegmentTrackJob, job: true do
       { method: 1 }
     end
 
+    before do
+      stub_const('ENV', 'LAGO_DISABLE_SEGMENT' => '')
+    end
+
     it "calls SegmentTrackJob's process method" do
       expect(SEGMENT_CLIENT).to receive(:track)
         .with(
@@ -33,6 +37,15 @@ describe SegmentTrackJob, job: true do
           hash_including(properties: hash_including(hosting_type: 'cloud'))
         )
 
+        subject.perform_now(membership_id: membership_id, event: event, properties: properties)
+      end
+    end
+
+    context 'when LAGO_DISABLE_SEGMENT is true' do
+      it 'does not call SegmentTrackJob' do
+        stub_const('ENV', 'LAGO_DISABLE_SEGMENT' => 'true')
+
+        expect(SEGMENT_CLIENT).not_to receive(:track)
         subject.perform_now(membership_id: membership_id, event: event, properties: properties)
       end
     end

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -5,6 +5,21 @@ require 'rails_helper'
 RSpec.describe UsersService, type: :service do
   subject { described_class.new }
 
+  describe 'register' do
+    it 'calls SegmentTrackJob' do
+      allow(SegmentTrackJob).to receive(:perform_later)
+      result = subject.register('email', 'password', 'organization_name')
+
+      expect(SegmentTrackJob).to have_received(:perform_later).with(
+        event: 'user_register',
+        properties: {
+          organization_name: result.organization.name,
+          organization_id: result.organization.id
+        }
+      )
+    end
+  end
+
   describe 'new_token' do
     let(:user) { create(:user) }
 

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe UsersService, type: :service do
       result = subject.register('email', 'password', 'organization_name')
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
+        membership_id: CurrentContext.membership,
         event: 'user_register',
         properties: {
           organization_name: result.organization.name,

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UsersService, type: :service do
       result = subject.register('email', 'password', 'organization_name')
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
-        membership_id: CurrentContext.membership,
+        membership_id: "membership/#{result.membership.id}",
         event: 'user_register',
         properties: {
           organization_name: result.organization.name,


### PR DESCRIPTION
### Context

We want to track and measure what our users are doing, both on the self-hosted and fully-hosted sides.
By sending backend events to Segment.com.

### Objective

The goal of this PR is to send a tracking event to Segment on:
- User registration
- Billable metric creation
- Plan creation

### Segment Screenshots

<img width="465" alt="Capture d’écran 2022-07-26 à 10 25 00" src="https://user-images.githubusercontent.com/226046/180960008-990a5447-b4e4-4977-87ee-2a0ac74e92fa.png">

<img width="464" alt="Capture d’écran 2022-07-26 à 10 25 08" src="https://user-images.githubusercontent.com/226046/180960013-ce810872-e0b2-4c69-a468-6dc6fea3eb8a.png">

<img width="462" alt="Capture d’écran 2022-07-26 à 10 29 49" src="https://user-images.githubusercontent.com/226046/180960954-eadb1a81-0ae8-4744-b689-7d456be3a6a2.png">

