### PR TITLE
fix: canceled next subscription when terminating a downgraded one

### DIFF
--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -63,6 +63,9 @@ module Subscriptions
           .perform_later(subscription, subscription.terminated_at)
       end
 
+      # NOTE: Pending next subscription should be canceled as well
+      subscription.next_subscription&.mark_as_canceled!
+
       result.subscription = subscription
       result
     end

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Subscriptions::TerminateService do
 
       before { next_subscription }
 
-      it 'canceled the next subscription' do
+      it 'cancels the next subscription' do
         result = terminate_service.terminate(subscription.id)
 
         aggregate_failures do

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -33,6 +33,28 @@ RSpec.describe Subscriptions::TerminateService do
         expect(result.error).to eq('not_found')
       end
     end
+
+    context 'when pending next subscription' do
+      let(:subscription) { create(:subscription) }
+      let(:next_subscription) do
+        create(
+          :subscription,
+          previous_subscription: subscription,
+          status: :pending,
+        )
+      end
+
+      before { next_subscription }
+
+      it 'canceled the next subscription' do
+        result = terminate_service.terminate(subscription.id)
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(next_subscription.reload).to be_canceled
+        end
+      end
+    end
   end
 
   describe '.terminate_and_start_next' do


### PR DESCRIPTION
### Context

1. When customer got an active plan A and we decide to downgrade this plan B, a new line appears and the plan B is in `pending` status.
2. If we terminate the active plan A, the plan B is still in pending in the base and will be active on the next billable period

### Expected behavior

Terminating the active plan A should also cancel the pending plan B

### Changes

Check for presence of pending next subscription when terminating and canceled it