### PR TITLE
feat(segment): Add some tracking on Segment (part 2)

### DIFF
--- a/app/services/add_ons/create_service.rb
+++ b/app/services/add_ons/create_service.rb
@@ -13,9 +13,24 @@ module AddOns
       )
 
       result.add_on = add_on
+      track_add_on_create(result.add_on)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
+    end
+
+    private
+
+    def track_add_on_create(add_on)
+      SegmentTrackJob.perform_later(
+        membership_id: CurrentContext.membership,
+        event: 'add_on_create',
+        properties: {
+          addon_code: add_on.code,
+          addon_name: add_on.name,
+          organization_id: add_on.organization_id
+        }
+      )
     end
   end
 end

--- a/app/services/applied_add_ons/create_service.rb
+++ b/app/services/applied_add_ons/create_service.rb
@@ -65,6 +65,7 @@ module AppliedAddOns
       )
 
       result.applied_add_on = applied_add_on
+      track_applied_add_on_create(result.applied_add_on)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
@@ -80,6 +81,18 @@ module AppliedAddOns
 
     def active_subscription
       @active_subscription ||= customer.active_subscription
+    end
+
+    def track_applied_add_on_create(applied_add_on)
+      SegmentTrackJob.perform_later(
+        membership_id: CurrentContext.membership,
+        event: 'applied_add_on_create',
+        properties: {
+          customer_id: applied_add_on.customer.id,
+          addon_code: applied_add_on.add_on.code,
+          addon_name: applied_add_on.add_on.name
+        }
+      )
     end
   end
 end

--- a/app/services/coupons/create_service.rb
+++ b/app/services/coupons/create_service.rb
@@ -14,9 +14,24 @@ module Coupons
       )
 
       result.coupon = coupon
+      track_coupon_create(result.coupon)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
+    end
+
+    private
+
+    def track_coupon_create(coupon)
+      SegmentTrackJob.perform_later(
+        membership_id: CurrentContext.membership,
+        event: 'coupon_create',
+        properties: {
+          coupon_code: coupon.code,
+          coupon_name: coupon.name,
+          organization_id: coupon.organization_id
+        }
+      )
     end
   end
 end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -157,6 +157,7 @@ module Subscriptions
     def subscription_type
       return 'downgrade' if downgrade?
       return 'upgrade' if upgrade?
+
       'create'
     end
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -43,6 +43,7 @@ module Subscriptions
       return result.fail!('missing_argument', 'plan does not exists') unless current_plan
 
       result.subscription = handle_subscription
+      track_subscription_create(result.subscription)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
@@ -151,6 +152,27 @@ module Subscriptions
 
     def cancel_pending_subscription
       current_subscription.next_subscription.mark_as_canceled!
+    end
+
+    def subscription_type
+      return 'downgrade' if downgrade?
+      return 'upgrade' if upgrade?
+      'create'
+    end
+
+    def track_subscription_create(subscription)
+      SegmentTrackJob.perform_later(
+        membership_id: CurrentContext.membership,
+        event: 'subscription_create',
+        properties: {
+          created_at: subscription.created_at,
+          customer_id: subscription.customer_id,
+          plan_code: subscription.plan.code,
+          plan_name: subscription.plan.name,
+          subscription_type: subscription_type,
+          organization_id: subscription.organization.id
+        }
+      )
     end
   end
 end

--- a/spec/services/applied_add_ons/create_service_spec.rb
+++ b/spec/services/applied_add_ons/create_service_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
 
     let(:create_result) { create_service.create(**create_args) }
 
+    before do
+      allow(SegmentTrackJob).to receive(:perform_later)
+    end
+
     it 'applied the add-on to the customer' do
       expect { create_result }.to change(AppliedAddOn, :count).by(1)
 
@@ -45,6 +49,20 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
 
     it 'enqueues a job to bill the add-on' do
       expect { create_result }.to have_enqueued_job(BillAddOnJob)
+    end
+
+    it 'calls SegmentTrackJob' do
+      applied_add_on = create_result.applied_add_on
+
+      expect(SegmentTrackJob).to have_received(:perform_later).with(
+        membership_id: CurrentContext.membership,
+        event: 'applied_add_on_create',
+        properties: {
+          customer_id: applied_add_on.customer.id,
+          addon_code: applied_add_on.add_on.code,
+          addon_name: applied_add_on.add_on.name
+        }
+      )
     end
 
     context 'with overridden amount and currency' do
@@ -114,6 +132,10 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
       )
     end
 
+    before do
+      allow(SegmentTrackJob).to receive(:perform_later)
+    end
+
     it 'applied the add-on to the customer' do
       expect { create_result }.to change(AppliedAddOn, :count).by(1)
 
@@ -125,6 +147,20 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
 
     it 'enqueues a job to bill the add-on' do
       expect { create_result }.to have_enqueued_job(BillAddOnJob)
+    end
+
+    it 'calls SegmentTrackJob' do
+      applied_add_on = create_result.applied_add_on
+
+      expect(SegmentTrackJob).to have_received(:perform_later).with(
+        membership_id: CurrentContext.membership,
+        event: 'applied_add_on_create',
+        properties: {
+          customer_id: applied_add_on.customer.id,
+          addon_code: applied_add_on.add_on.code,
+          addon_name: applied_add_on.add_on.name
+        }
+      )
     end
 
     context 'with overridden amount' do


### PR DESCRIPTION
### Context

We want to track and measure what our users are doing, both on the self-hosted and fully-hosted sides.
By sending backend events to Segment.com.

### Objective

The goal of this PR is to send a tracking event to Segment on:
- Customer creation
- Subscription creation
- Coupon creation
- Coupon assignment
- Addon creation
- Addon assignment

### Segment Screenshots

<img width="470" alt="Capture d’écran 2022-07-26 à 15 07 35" src="https://user-images.githubusercontent.com/226046/181017322-49c8c059-f47f-49a8-a481-ab74a9bcda24.png">
<img width="467" alt="Capture d’écran 2022-07-26 à 15 09 35" src="https://user-images.githubusercontent.com/226046/181017326-595a09e0-529c-4e31-87cf-484529ff6111.png">
<img width="462" alt="Capture d’écran 2022-07-26 à 15 12 00" src="https://user-images.githubusercontent.com/226046/181017328-80072353-28fd-4fb2-91a4-d8bef8a43487.png">
<img width="458" alt="Capture d’écran 2022-07-26 à 15 23 16" src="https://user-images.githubusercontent.com/226046/181017331-12e259d4-cc11-4e35-ade0-98a83b27ffbb.png">
<img width="460" alt="Capture d’écran 2022-07-26 à 15 24 19" src="https://user-images.githubusercontent.com/226046/181017337-201aca4b-d4cc-40ad-a007-e7340b7409f3.png">
<img width="465" alt="Capture d’écran 2022-07-26 à 15 24 46" src="https://user-images.githubusercontent.com/226046/181017341-0ee62d35-d47c-43a4-abf7-7c62d72a67fa.png">


