### PR TITLE
feat(segment): Add some tracking on Segment (part 3)

### DIFF
--- a/app/jobs/segment_track_job.rb
+++ b/app/jobs/segment_track_job.rb
@@ -5,7 +5,7 @@ class SegmentTrackJob < ApplicationJob
     return if ENV['LAGO_DISABLE_SEGMENT'] == 'true'
 
     SEGMENT_CLIENT.track(
-      user_id: membership_id,
+      user_id: membership_id || 'membership/unidentifiable',
       event: event,
       properties: properties.merge(hosting_type, version)
     )


### PR DESCRIPTION
### Context

We want to track and measure what our users are doing, both on the self-hosted and fully-hosted sides.
By sending backend events to Segment.com.

### Objective

The goal of this PR is to send a tracking event to Segment on:
- Invoice creation
- Payment status change on invoice update
- Payment status change on stripe service

And use `membership/unidentifiable` as Segment user id when membership is not found (for instance when doing an action from the rails console).

### Segment Screenshots

![Capture d’écran 2022-07-27 à 11 34 16](https://user-images.githubusercontent.com/226046/181219389-42b494da-f6c1-409f-a1fe-b831a58aa46e.png)

![Capture d’écran 2022-07-27 à 11 51 13](https://user-images.githubusercontent.com/226046/181219394-e6508143-b763-4aa1-bfa2-38edd08db9a3.png)
