### PR TITLE
feat(segment): Identify user on signup and signin

### DIFF
--- a/app/jobs/segment_identify_job.rb
+++ b/app/jobs/segment_identify_job.rb
@@ -1,0 +1,24 @@
+class SegmentIdentifyJob < ApplicationJob
+  queue_as :default
+
+  def perform(membership_id:)
+    return if ENV['LAGO_DISABLE_SEGMENT'] == 'true'
+    return if membership_id.nil? || membership_id == 'membership/unidentifiable'
+
+    membership = Membership.find(membership_id.sub(/\Amembership\//, ''))
+    traits = { created_at: membership.created_at, hosting_type: hosting_type, version: version }
+    traits.merge!(email: membership.user.email) if hosting_type == 'cloud'
+
+    SEGMENT_CLIENT.identify(user_id: membership_id, traits: traits)
+  end
+
+  private
+
+  def hosting_type
+    @hosting_type ||= ENV['LAGO_CLOUD'] == 'true' ? 'cloud' : 'self'
+  end
+
+  def version
+    Utils::VersionService.new.version.version.number
+  end
+end

--- a/app/services/add_ons/create_service.rb
+++ b/app/services/add_ons/create_service.rb
@@ -13,7 +13,7 @@ module AddOns
       )
 
       result.add_on = add_on
-      track_add_on_create(result.add_on)
+      track_add_on_created(result.add_on)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
@@ -21,10 +21,10 @@ module AddOns
 
     private
 
-    def track_add_on_create(add_on)
+    def track_add_on_created(add_on)
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
-        event: 'add_on_create',
+        event: 'add_on_created',
         properties: {
           addon_code: add_on.code,
           addon_name: add_on.name,

--- a/app/services/applied_add_ons/create_service.rb
+++ b/app/services/applied_add_ons/create_service.rb
@@ -65,7 +65,7 @@ module AppliedAddOns
       )
 
       result.applied_add_on = applied_add_on
-      track_applied_add_on_create(result.applied_add_on)
+      track_applied_add_on_created(result.applied_add_on)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
@@ -83,10 +83,10 @@ module AppliedAddOns
       @active_subscription ||= customer.active_subscription
     end
 
-    def track_applied_add_on_create(applied_add_on)
+    def track_applied_add_on_created(applied_add_on)
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
-        event: 'applied_add_on_create',
+        event: 'applied_add_on_created',
         properties: {
           customer_id: applied_add_on.customer.id,
           addon_code: applied_add_on.add_on.code,

--- a/app/services/applied_coupons/create_service.rb
+++ b/app/services/applied_coupons/create_service.rb
@@ -60,7 +60,7 @@ module AppliedCoupons
       )
 
       result.applied_coupon = applied_coupon
-      track_applied_coupon_create(result.applied_coupon)
+      track_applied_coupon_created(result.applied_coupon)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
@@ -78,10 +78,10 @@ module AppliedCoupons
       customer.active_subscription.plan.amount_currency == currency
     end
 
-    def track_applied_coupon_create(applied_coupon)
+    def track_applied_coupon_created(applied_coupon)
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
-        event: 'applied_coupon_create',
+        event: 'applied_coupon_created',
         properties: {
           customer_id: applied_coupon.customer.id,
           coupon_code: applied_coupon.coupon.code,

--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -13,7 +13,7 @@ module BillableMetrics
       )
 
       result.billable_metric = metric
-      track_billable_metric_create(metric)
+      track_billable_metric_created(metric)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
@@ -21,10 +21,10 @@ module BillableMetrics
 
     private
 
-    def track_billable_metric_create(metric)
+    def track_billable_metric_created(metric)
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
-        event: 'billable_metric_create',
+        event: 'billable_metric_created',
         properties: {
           code: metric.code,
           name: metric.name,

--- a/app/services/coupons/create_service.rb
+++ b/app/services/coupons/create_service.rb
@@ -14,7 +14,7 @@ module Coupons
       )
 
       result.coupon = coupon
-      track_coupon_create(result.coupon)
+      track_coupon_created(result.coupon)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
@@ -22,10 +22,10 @@ module Coupons
 
     private
 
-    def track_coupon_create(coupon)
+    def track_coupon_created(coupon)
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
-        event: 'coupon_create',
+        event: 'coupon_created',
         properties: {
           coupon_code: coupon.code,
           coupon_name: coupon.name,

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -26,7 +26,7 @@ module Customers
       handle_api_billing_configuration(customer, params)
 
       result.customer = customer
-      track_customer_create(customer)
+      track_customer_created(customer)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
@@ -57,7 +57,7 @@ module Customers
       create_billing_configuration(customer, args[:stripe_customer])
 
       result.customer = customer
-      track_customer_create(customer)
+      track_customer_created(customer)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
@@ -109,10 +109,10 @@ module Customers
       create_result.throw_error unless create_result.success?
     end
 
-    def track_customer_create(customer)
+    def track_customer_created(customer)
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
-        event: 'customer_create',
+        event: 'customer_created',
         properties: {
           customer_id: customer.id,
           created_at: customer.created_at,

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -37,7 +37,7 @@ module Invoices
 
       SendWebhookJob.perform_later(:invoice, result.invoice) if should_deliver_webhook?
       create_payment(result.invoice)
-      track_invoice_create(result.invoice)
+      track_invoice_created(result.invoice)
 
       result
     rescue ActiveRecord::RecordInvalid => e
@@ -225,10 +225,10 @@ module Invoices
       end
     end
 
-    def track_invoice_create(invoice)
+    def track_invoice_created(invoice)
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
-        event: 'invoice_create',
+        event: 'invoice_created',
         properties: {
           organization_id: invoice.organization.id,
           invoice_id: invoice.id,

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -31,7 +31,7 @@ module Plans
       end
 
       result.plan = plan
-      track_plan_create(plan)
+      track_plan_created(plan)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
@@ -48,12 +48,12 @@ module Plans
       )
     end
 
-    def track_plan_create(plan)
+    def track_plan_created(plan)
       count_by_charge_model = plan.charges.group(:charge_model).count
 
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
-        event: 'plan_create',
+        event: 'plan_created',
         properties: {
           code: plan.code,
           name: plan.name,

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -43,7 +43,7 @@ module Subscriptions
       return result.fail!('missing_argument', 'plan does not exists') unless current_plan
 
       result.subscription = handle_subscription
-      track_subscription_create(result.subscription)
+      track_subscription_created(result.subscription)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.fail_with_validations!(e.record)
@@ -161,10 +161,10 @@ module Subscriptions
       'create'
     end
 
-    def track_subscription_create(subscription)
+    def track_subscription_created(subscription)
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
-        event: 'subscription_create',
+        event: 'subscription_created',
         properties: {
           created_at: subscription.created_at,
           customer_id: subscription.customer_id,

--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -5,10 +5,7 @@ class UsersService < BaseService
     result.user = User.find_by(email: email)&.authenticate(password)
     result.token = generate_token if result.user
 
-    unless result.user
-      result.fail!('incorrect_login_or_password')
-      return result
-    end
+    return result.fail!('incorrect_login_or_password') unless result.user
 
     # Note: We're tracking the first membership linked to the user.
     SegmentIdentifyJob.perform_later(membership_id: "membership/#{result.user.memberships.first.id}")

--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -39,7 +39,7 @@ class UsersService < BaseService
     end
 
     SegmentIdentifyJob.perform_later(membership_id: "membership/#{result.membership.id}")
-    track_user_register(result.organization, result.membership)
+    track_organization_registered(result.organization, result.membership)
 
     result
   end
@@ -65,10 +65,10 @@ class UsersService < BaseService
     }
   end
 
-  def track_user_register(organization, membership)
+  def track_organization_registered(organization, membership)
     SegmentTrackJob.perform_later(
       membership_id: "membership/#{membership.id}",
-      event: 'user_register',
+      event: 'organization_registered',
       properties: {
         organization_name: organization.name,
         organization_id: organization.id,

--- a/spec/graphql/mutations/login_user_spec.rb
+++ b/spec/graphql/mutations/login_user_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Mutations::LoginUser, type: :graphql do
 
   it 'returns token and user' do
     user = create(:user)
+    create(:membership, user: user)
 
     result = execute_graphql(
       query: mutation,

--- a/spec/jobs/segment_identify_job_spec.rb
+++ b/spec/jobs/segment_identify_job_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+describe SegmentIdentifyJob, job: true do
+  subject { described_class }
+
+  describe '.perform' do
+    let(:membership_id) { "membership/#{membership.id}" }
+    let(:membership) { create(:membership) }
+
+    before do
+      stub_const('ENV', 'LAGO_DISABLE_SEGMENT' => '')
+      allow(CurrentContext).to receive(:membership).and_return(membership_id)
+    end
+
+    it "calls SegmentIdentifyJob's process method" do
+      expect(SEGMENT_CLIENT).to receive(:identify)
+        .with(
+          user_id: membership_id,
+          traits: {
+            created_at: membership.created_at,
+            hosting_type: 'self',
+            version: Utils::VersionService.new.version.version.number
+          }
+        )
+
+      subject.perform_now(membership_id: membership_id)
+    end
+
+    context 'when LAGO_CLOUD is true' do
+      before do
+        stub_const('ENV', 'LAGO_CLOUD' => 'true')
+      end
+
+      it 'includes hosting type equal to cloud' do
+        expect(SEGMENT_CLIENT).to receive(:identify).with(
+          hash_including(traits: hash_including(hosting_type: 'cloud'))
+        )
+
+        subject.perform_now(membership_id: membership_id)
+      end
+
+      it 'includes the email of the membership' do
+        expect(SEGMENT_CLIENT).to receive(:identify).with(
+          hash_including(traits: hash_including(email: membership.user.email))
+        )
+
+        subject.perform_now(membership_id: membership_id)
+      end
+    end
+
+    context 'when membership is nil' do
+      it 'does not send any events' do
+        expect(SEGMENT_CLIENT).not_to receive(:identify)
+
+        subject.perform_now(membership_id: nil)
+      end
+    end
+
+    context 'when membership is unidentifiable' do
+      it 'does not send any events' do
+        expect(SEGMENT_CLIENT).not_to receive(:identify)
+
+        subject.perform_now(membership_id: 'membership/unidentifiable')
+      end
+    end
+
+    context 'when LAGO_DISABLE_SEGMENT is true' do
+      it 'does not call SegmentIdentifyJob' do
+        stub_const('ENV', 'LAGO_DISABLE_SEGMENT' => 'true')
+
+        expect(SEGMENT_CLIENT).not_to receive(:identify)
+        subject.perform_now(membership_id: membership_id)
+      end
+    end
+  end
+end

--- a/spec/services/add_ons/create_service_spec.rb
+++ b/spec/services/add_ons/create_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe AddOns::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'add_on_create',
+        event: 'add_on_created',
         properties: {
           addon_code: add_on.code,
           addon_name: add_on.name,

--- a/spec/services/applied_add_ons/create_service_spec.rb
+++ b/spec/services/applied_add_ons/create_service_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'applied_add_on_create',
+        event: 'applied_add_on_created',
         properties: {
           customer_id: applied_add_on.customer.id,
           addon_code: applied_add_on.add_on.code,
@@ -154,7 +154,7 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'applied_add_on_create',
+        event: 'applied_add_on_created',
         properties: {
           customer_id: applied_add_on.customer.id,
           addon_code: applied_add_on.add_on.code,

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'applied_coupon_create',
+        event: 'applied_coupon_created',
         properties: {
           customer_id: applied_coupon.customer.id,
           coupon_code: applied_coupon.coupon.code,
@@ -171,7 +171,7 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'applied_coupon_create',
+        event: 'applied_coupon_created',
         properties: {
           customer_id: applied_coupon.customer.id,
           coupon_code: applied_coupon.coupon.code,

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'billable_metric_create',
+        event: 'billable_metric_created',
         properties: {
           code: metric.code,
           name: metric.name,

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Coupons::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'coupon_create',
+        event: 'coupon_created',
         properties: {
           coupon_code: coupon.code,
           coupon_name: coupon.name,

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Customers::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'customer_create',
+        event: 'customer_created',
         properties: {
           customer_id: customer.id,
           created_at: customer.created_at,
@@ -258,7 +258,7 @@ RSpec.describe Customers::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'customer_create',
+        event: 'customer_created',
         properties: {
           customer_id: customer.id,
           created_at: customer.created_at,

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Invoices::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'invoice_create',
+        event: 'invoice_created',
         properties: {
           organization_id: invoice.organization.id,
           invoice_id: invoice.id,

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Plans::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'plan_create',
+        event: 'plan_created',
         properties: {
           code: plan.code,
           name: plan.name,

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'subscription_create',
+        event: 'subscription_created',
         properties: {
           created_at: subscription.created_at,
           customer_id: subscription.customer_id,
@@ -362,7 +362,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'subscription_create',
+        event: 'subscription_created',
         properties: {
           created_at: subscription.created_at,
           customer_id: subscription.customer_id,

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe UsersService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: "membership/#{result.membership.id}",
-        event: 'user_register',
+        event: 'organization_registered',
         properties: {
           organization_name: result.organization.name,
           organization_id: result.organization.id

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -6,6 +6,15 @@ RSpec.describe UsersService, type: :service do
   subject { described_class.new }
 
   describe 'register' do
+    it 'calls SegmentIdentifyJob' do
+      allow(SegmentIdentifyJob).to receive(:perform_later)
+      result = subject.register('email', 'password', 'organization_name')
+
+      expect(SegmentIdentifyJob).to have_received(:perform_later).with(
+        membership_id: "membership/#{result.membership.id}"
+      )
+    end
+
     it 'calls SegmentTrackJob' do
       allow(SegmentTrackJob).to receive(:perform_later)
       result = subject.register('email', 'password', 'organization_name')
@@ -17,6 +26,17 @@ RSpec.describe UsersService, type: :service do
           organization_name: result.organization.name,
           organization_id: result.organization.id
         }
+      )
+    end
+  end
+
+  describe 'login' do
+    it 'calls SegmentIdentifyJob' do
+      allow(SegmentIdentifyJob).to receive(:perform_later)
+      result = subject.register('email', 'password', 'organization_name')
+
+      expect(SegmentIdentifyJob).to have_received(:perform_later).with(
+        membership_id: "membership/#{result.user.memberships.first.id}"
       )
     end
   end


### PR DESCRIPTION
### Context

We want to track and measure what our users are doing, both on the self-hosted and fully-hosted sides.
By sending backend events to Segment.com.

### Objective

The goal of this PR is to send an identified event to Segment on:
- when the user signs up
- when the user logs in

### Segment Screenshots

![Capture d’écran 2022-07-27 à 16 00 21](https://user-images.githubusercontent.com/226046/181266483-8264c4f4-01c4-40bf-8794-da355ddc8098.png)
![Capture d’écran 2022-07-27 à 16 00 58](https://user-images.githubusercontent.com/226046/181266486-868a9a32-af02-413c-ac2f-fe7b5a39c6cc.png)

