### PR TITLE
Revert "feat: active storage: make non-aws users happy"

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -12,7 +12,6 @@ amazon:
   secret_access_key: <%= ENV['LAGO_AWS_S3_SECRET_ACCESS_KEY'] %>
   region: <%= ENV['LAGO_AWS_S3_REGION'] %>
   bucket: <%= ENV['LAGO_AWS_S3_BUCKET'] %>
-  endpoint: <%= ENV['LAGO_AWS_S3_ENDPOINT'] %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
Reverts getlago/lago-api#355

@namehorn Sorry but we have to revert it for now since `ActiveStorage` do want a value for `endpoint` if you define it.
We have some work to do to make it optional on our side and not break the AWS S3 support (since with a private S3 Bucket you don't have any endpoint on AWS!)