### PR TITLE
refactor: Use named parameters for BaseService::Result#fail!

### DIFF
--- a/app/services/add_ons/destroy_service.rb
+++ b/app/services/add_ons/destroy_service.rb
@@ -4,7 +4,7 @@ module AddOns
   class DestroyService < BaseService
     def destroy(id)
       add_on = result.user.add_ons.find_by(id: id)
-      return result.fail!('not_found') unless add_on
+      return result.fail!(code: 'not_found') unless add_on
 
       add_on.destroy!
 
@@ -14,7 +14,7 @@ module AddOns
 
     def destroy_from_api(organization:, code:)
       add_on = organization.add_ons.find_by(code: code)
-      return result.fail!('not_found', 'add-on does not exist') unless add_on
+      return result.fail!(code: 'not_found', message: 'add-on does not exist') unless add_on
 
       add_on.destroy!
 

--- a/app/services/add_ons/update_service.rb
+++ b/app/services/add_ons/update_service.rb
@@ -4,7 +4,7 @@ module AddOns
   class UpdateService < BaseService
     def update(**args)
       add_on = result.user.add_ons.find_by(id: args[:id])
-      return result.fail!('not_found') unless add_on
+      return result.fail!(code: 'not_found') unless add_on
 
       add_on.name = args[:name]
       add_on.code = args[:code]
@@ -22,7 +22,7 @@ module AddOns
 
     def update_from_api(organization:, code:, params:)
       add_on = organization.add_ons.find_by(code: code)
-      return result.fail!('not_found', 'add-on does not exist') unless add_on
+      return result.fail!(code: 'not_found', message: 'add-on does not exist') unless add_on
 
       add_on.name = params[:name] if params.key?(:name)
       add_on.code = params[:code] if params.key?(:code)

--- a/app/services/applied_add_ons/create_service.rb
+++ b/app/services/applied_add_ons/create_service.rb
@@ -41,10 +41,10 @@ module AppliedAddOns
     attr_reader :customer, :add_on
 
     def check_preconditions(amount_currency:)
-      return result.fail!('missing_argument', 'unable_to_find_customer') if customer.blank?
-      return result.fail!('missing_argument', 'add_on_does_not_exist') if add_on.blank?
-      return result.fail!('no_active_subscription') unless active_subscription?
-      return result.fail!('currencies_does_not_match') unless applicable_currency?(amount_currency)
+      return result.fail!(code: 'missing_argument', message: 'unable_to_find_customer') if customer.blank?
+      return result.fail!(code: 'missing_argument', message: 'add_on_does_not_exist') if add_on.blank?
+      return result.fail!(code: 'no_active_subscription') unless active_subscription?
+      return result.fail!(code: 'currencies_does_not_match') unless applicable_currency?(amount_currency)
     end
 
     def process_creation(amount_cents:, amount_currency:)

--- a/app/services/applied_coupons/create_service.rb
+++ b/app/services/applied_coupons/create_service.rb
@@ -41,11 +41,11 @@ module AppliedCoupons
     attr_reader :customer, :coupon
 
     def check_preconditions(amount_currency:)
-      return result.fail!('missing_argument', 'unable_to_find_customer') if customer.blank?
-      return result.fail!('missing_argument', 'coupon_does_not_exist') if coupon.blank?
-      return result.fail!('no_active_subscription') unless active_subscription?
-      return result.fail!('coupon_already_applied') if coupon_already_applied?
-      return result.fail!('currencies_does_not_match') unless applicable_currency?(amount_currency)
+      return result.fail!(code: 'missing_argument', message: 'unable_to_find_customer') if customer.blank?
+      return result.fail!(code: 'missing_argument', message: 'coupon_does_not_exist') if coupon.blank?
+      return result.fail!(code: 'no_active_subscription') unless active_subscription?
+      return result.fail!(code: 'coupon_already_applied') if coupon_already_applied?
+      return result.fail!(code: 'currencies_does_not_match') unless applicable_currency?(amount_currency)
     end
 
     def process_creation(amount_cents:, amount_currency:)

--- a/app/services/applied_coupons/terminate_service.rb
+++ b/app/services/applied_coupons/terminate_service.rb
@@ -8,7 +8,7 @@ module AppliedCoupons
         .where(organizations: { id: result.user.organization_ids })
         .find_by(id: id)
 
-      return result.fail!('not_found') unless applied_coupon
+      return result.fail!(code: 'not_found') unless applied_coupon
 
       applied_coupon.mark_as_terminated! unless applied_coupon.terminated?
 

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -29,7 +29,7 @@ class BaseService
       !failure
     end
 
-    def fail!(code, message = nil, details = nil)
+    def fail!(code:, message: nil, details: nil)
       @failure = true
       @error_code = code
       @error = message || code
@@ -37,16 +37,16 @@ class BaseService
 
       # Return self to return result immediately in case of failure:
       # ```
-      # return result.fail!('not_found')
+      # return result.fail!(code: 'not_found')
       # ```
       self
     end
 
     def fail_with_validations!(record)
       fail!(
-        'unprocessable_entity',
-        'Validation error on the record',
-        record.errors.messages,
+        code: 'unprocessable_entity',
+        message: 'Validation error on the record',
+        details: record.errors.messages
       )
     end
 

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -11,7 +11,7 @@ module BillableMetrics
         result.aggregation = max || 0
         result
       rescue ActiveRecord::StatementInvalid => e
-        result.fail!('aggregation_failure', e.message)
+        result.fail!(code: 'aggregation_failure', message: e.message)
       end
 
       private

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -10,7 +10,7 @@ module BillableMetrics
 
         result
       rescue ActiveRecord::StatementInvalid => e
-        result.fail!('aggregation_failure', e.message)
+        result.fail!(code: 'aggregation_failure', message: e.message)
       end
 
       private

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -4,12 +4,12 @@ module BillableMetrics
   class DestroyService < BaseService
     def destroy(id)
       metric = result.user.billable_metrics.find_by(id: id)
-      return result.fail!('not_found') unless metric
+      return result.fail!(code: 'not_found') unless metric
 
       unless metric.deletable?
         return result.fail!(
-          'forbidden',
-          'Billable metric is attached to an active subscriptions',
+          code: 'forbidden',
+          message: 'Billable metric is attached to an active subscriptions',
         )
       end
 
@@ -21,12 +21,12 @@ module BillableMetrics
 
     def destroy_from_api(organization:, code:)
       metric = organization.billable_metrics.find_by(code: code)
-      return result.fail!('not_found', 'billable metric does not exist') unless metric
+      return result.fail!(code: 'not_found', message: 'billable metric does not exist') unless metric
 
       unless metric.deletable?
         return result.fail!(
-          'forbidden',
-          'billable metric is attached to an active subscriptions',
+          code: 'forbidden',
+          message: 'billable metric is attached to an active subscriptions',
           )
       end
 

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -4,7 +4,7 @@ module BillableMetrics
   class UpdateService < BaseService
     def update(**args)
       metric = result.user.billable_metrics.find_by(id: args[:id])
-      return result.fail!('not_found') unless metric
+      return result.fail!(code: 'not_found') unless metric
 
       metric.name = args[:name]
       metric.description = args[:description] if args[:description]
@@ -27,7 +27,7 @@ module BillableMetrics
 
     def update_from_api(organization:, code:, params:)
       metric = organization.billable_metrics.find_by(code: code)
-      return result.fail!('not_found', 'billable metric does not exist') unless metric
+      return result.fail!(code: 'not_found', message: 'billable metric does not exist') unless metric
 
       metric.name = params[:name] if params.key?(:name)
       metric.description = params[:description] if params.key?(:description)

--- a/app/services/charges/validators/graduated_service.rb
+++ b/app/services/charges/validators/graduated_service.rb
@@ -8,7 +8,7 @@ module Charges
 
         if ranges.blank?
           errors << :missing_graduated_range
-          return result.fail!(:invalid_properties, errors)
+          return result.fail!(code: :invalid_properties, message: errors)
         end
 
         next_from_value = 0
@@ -19,7 +19,7 @@ module Charges
           next_from_value = (range[:to_value] || 0) + 1
         end
 
-        return result.fail!(:invalid_properties, errors) if errors.present?
+        return result.fail!(code: :invalid_properties, message: errors) if errors.present?
 
         result
       end

--- a/app/services/charges/validators/package_service.rb
+++ b/app/services/charges/validators/package_service.rb
@@ -9,7 +9,7 @@ module Charges
         errors << :invalid_free_units unless valid_free_units?
         errors << :invalid_package_size unless valid_package_size?
 
-        return result.fail!(:invalid_properties, errors) if errors.present?
+        return result.fail!(code: :invalid_properties, message: errors) if errors.present?
 
         result
       end

--- a/app/services/charges/validators/percentage_service.rb
+++ b/app/services/charges/validators/percentage_service.rb
@@ -9,7 +9,7 @@ module Charges
         errors << :invalid_fixed_amount unless valid_fixed_amount?
         errors << :invalid_fixed_amount_target unless valid_fixed_amount_target?
 
-        return result.fail!(:invalid_properties, errors) if errors.present?
+        return result.fail!(code: :invalid_properties, message: errors) if errors.present?
 
         result
       end

--- a/app/services/charges/validators/standard_service.rb
+++ b/app/services/charges/validators/standard_service.rb
@@ -7,7 +7,7 @@ module Charges
         errors = []
         errors << :invalid_amount unless valid_amount?
 
-        return result.fail!(:invalid_properties, errors) if errors.present?
+        return result.fail!(code: :invalid_properties, message: errors) if errors.present?
 
         result
       end

--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -4,12 +4,12 @@ module Coupons
   class DestroyService < BaseService
     def destroy(id)
       coupon = result.user.coupons.find_by(id: id)
-      return result.fail!('not_found') unless coupon
+      return result.fail!(code: 'not_found') unless coupon
 
       unless coupon.deletable?
         return result.fail!(
-          'forbidden',
-          'Coupon is attached to an active customer',
+          code: 'forbidden',
+          message: 'Coupon is attached to an active customer',
         )
       end
 
@@ -21,12 +21,12 @@ module Coupons
 
     def destroy_from_api(organization:, code:)
       coupon = organization.coupons.find_by(code: code)
-      return result.fail!('not_found', 'coupon does not exist') unless coupon
+      return result.fail!(code: 'not_found', message: 'coupon does not exist') unless coupon
 
       unless coupon.deletable?
         return result.fail!(
-          'forbidden',
-          'coupon is attached to an active customer',
+          code: 'forbidden',
+          message: 'coupon is attached to an active customer',
         )
       end
 
@@ -38,7 +38,7 @@ module Coupons
 
     def terminate(id)
       coupon = result.user.coupons.find_by(id: id)
-      return result.fail!('not_found') unless coupon
+      return result.fail!(code: 'not_found') unless coupon
 
       coupon.mark_as_terminated! unless coupon.terminated?
 

--- a/app/services/coupons/terminate_service.rb
+++ b/app/services/coupons/terminate_service.rb
@@ -4,7 +4,7 @@ module Coupons
   class TerminateService < BaseService
     def terminate(id)
       coupon = result.user.coupons.find_by(id: id)
-      return result.fail!('not_found') unless coupon
+      return result.fail!(code: 'not_found') unless coupon
 
       coupon.mark_as_terminated! unless coupon.terminated?
 

--- a/app/services/coupons/update_service.rb
+++ b/app/services/coupons/update_service.rb
@@ -4,7 +4,7 @@ module Coupons
   class UpdateService < BaseService
     def update(**args)
       coupon = result.user.coupons.find_by(id: args[:id])
-      return result.fail!('not_found') unless coupon
+      return result.fail!(code: 'not_found') unless coupon
 
       coupon.name = args[:name]
 
@@ -26,7 +26,7 @@ module Coupons
 
     def update_from_api(organization:, code:, params:)
       coupon = organization.coupons.find_by(code: code)
-      return result.fail!('not_found', 'coupon does not exist') unless coupon
+      return result.fail!(code: 'not_found', message: 'coupon does not exist') unless coupon
 
       coupon.name = params[:name] if params.key?(:name)
 

--- a/app/services/customers/destroy_service.rb
+++ b/app/services/customers/destroy_service.rb
@@ -4,12 +4,12 @@ module Customers
   class DestroyService < BaseService
     def destroy(id:)
       customer = result.user.customers.find_by(id: id)
-      return result.fail!('not_found') unless customer
+      return result.fail!(code: 'not_found') unless customer
 
       unless customer.deletable?
         return result.fail!(
-          'forbidden',
-          'Customer is attached to an active subscription',
+          code: 'forbidden',
+          message: 'Customer is attached to an active subscription',
         )
       end
 

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -4,7 +4,7 @@ module Customers
   class UpdateService < BaseService
     def update(**args)
       customer = result.user.customers.find_by(id: args[:id])
-      return result.fail!('not_found') unless customer
+      return result.fail!(code: 'not_found') unless customer
 
       customer.name = args[:name] if args.key?(:name)
       customer.country = args[:country]&.upcase if args.key?(:country)

--- a/app/services/events_service.rb
+++ b/app/services/events_service.rb
@@ -9,7 +9,7 @@ class EventsService < BaseService
     missing_subscription_arguments = mandatory_subscription_arguments.select { |arg| params[arg].blank? }
     return result if missing_arguments.blank? && missing_subscription_arguments.count <= 1
 
-    result.fail!('missing_mandatory_param', nil, missing_arguments + missing_subscription_arguments)
+    result.fail!(code: 'missing_mandatory_param', details: missing_arguments + missing_subscription_arguments)
   end
 
   def validate_batch_params(params:)
@@ -18,7 +18,7 @@ class EventsService < BaseService
     missing_arguments = mandatory_arguments.select { |arg| params[arg].blank? }
     return result if missing_arguments.blank?
 
-    result.fail!('missing_mandatory_param', nil, missing_arguments)
+    result.fail!(code: 'missing_mandatory_param', details: missing_arguments)
   end
 
   def create(organization:, params:, timestamp:, metadata:)
@@ -166,22 +166,22 @@ class EventsService < BaseService
   end
 
   def blank_subscription_error(organization, params)
-    result.fail!('missing_argument', 'subscription does not exist or is not given')
+    result.fail!(code: 'missing_argument', message: 'subscription does not exist or is not given')
     send_webhook_notice(organization, params)
   end
 
   def invalid_subscription_error(organization, params)
-    result.fail!('invalid_argument', 'subscription_id is invalid')
+    result.fail!(code: 'invalid_argument', message: 'subscription_id is invalid')
     send_webhook_notice(organization, params)
   end
 
   def invalid_code_error(organization, params)
-    result.fail!('missing_argument', 'code does not exist')
+    result.fail!(code: 'missing_argument', message: 'code does not exist')
     send_webhook_notice(organization, params)
   end
 
   def invalid_customer_error(organization, params)
-    result.fail!('missing_argument', 'customer cannot be found')
+    result.fail!(code: 'missing_argument', message: 'customer cannot be found')
     send_webhook_notice(organization, params)
   end
 end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -33,7 +33,7 @@ module Fees
 
     def init_fee
       amount_result = compute_amount
-      return result.fail!(amount_result.error_code, amount_result.error) unless amount_result.success?
+      return result.fail!(code: amount_result.error_code, message: amount_result.error) unless amount_result.success?
 
       # NOTE: amount_result should be a BigDecimal, we need to round it
       # to the currency decimals and transform it into currency cents

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -19,8 +19,8 @@ module Invoices
     end
 
     def usage
-      return result.fail!('not_found') unless @customer
-      return result.fail!('no_active_subscription') if subscription.blank?
+      return result.fail!(code: 'not_found') unless @customer
+      return result.fail!(code: 'no_active_subscription') if subscription.blank?
 
       result.usage = JSON.parse(compute_usage, object_class: OpenStruct)
       result

--- a/app/services/invoices/generate_service.rb
+++ b/app/services/invoices/generate_service.rb
@@ -13,7 +13,7 @@ module Invoices
     def generate(invoice_id:)
       invoice = Invoice.find_by(id: invoice_id)
 
-      return result.fail!('not_found') if invoice.blank?
+      return result.fail!(code: 'not_found') if invoice.blank?
 
       generate_pdf(invoice) if invoice.file.blank?
 

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -42,7 +42,7 @@ module Invoices
 
       def update_status(provider_payment_id:, status:)
         payment = Payment.find_by(provider_payment_id: provider_payment_id)
-        return result.fail!('stripe_payment_not_found') unless payment
+        return result.fail!(code: 'stripe_payment_not_found') unless payment
 
         result.payment = payment
         result.invoice = payment.invoice
@@ -54,7 +54,7 @@ module Invoices
 
         result
       rescue ArgumentError
-        result.fail!('invalid_invoice_status')
+        result.fail!(code: 'invalid_invoice_status')
       end
 
       private

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -4,8 +4,8 @@ class Invoices::UpdateService < BaseService
   def update_from_api(invoice_id:, params:)
     invoice = Invoice.find_by(id: invoice_id)
 
-    return result.fail!('not_found') if invoice.blank?
-    return result.fail!('invalid_status') unless valid_status?(params[:status])
+    return result.fail!(code: 'not_found') if invoice.blank?
+    return result.fail!(code: 'invalid_status') unless valid_status?(params[:status])
 
     invoice.status = params[:status] if params.key?(:status)
     invoice.save!

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -29,7 +29,7 @@ module PaymentProviderCustomers
         .joins(:customer)
         .where(customers: { organization_id: organization_id })
         .find_by(provider_customer_id: stripe_customer_id)
-      return result.fail!('not_found') unless stripe_customer
+      return result.fail!(code: 'not_found') unless stripe_customer
 
       stripe_customer.payment_method_id = payment_method_id
       stripe_customer.save!

--- a/app/services/payment_providers/destroy_service.rb
+++ b/app/services/payment_providers/destroy_service.rb
@@ -7,7 +7,7 @@ module PaymentProviders
         id: id,
         organization_id: result.user.organization_ids,
       )
-      return result.fail!('not_found') unless payment_provider
+      return result.fail!(code: 'not_found') unless payment_provider
 
       payment_provider.destroy!
 

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -78,14 +78,14 @@ module PaymentProviders
       result.event = event
       result
     rescue JSON::ParserError
-      result.fail!('webhook_error', 'Invalid payload')
+      result.fail!(code: 'webhook_error', message: 'Invalid payload')
     rescue ::Stripe::SignatureVerificationError
-      result.fail!('webhook_error', 'Invalid signature')
+      result.fail!(code: 'webhook_error', message: 'Invalid signature')
     end
 
     def handle_event(organization:, event_json:)
       event = ::Stripe::Event.construct_from(JSON.parse(event_json))
-      return result.fail!('invalid_stripe_event_type') unless WEBHOOKS_EVENTS.include?(event.type)
+      return result.fail!(code: 'invalid_stripe_event_type') unless WEBHOOKS_EVENTS.include?(event.type)
 
       case event.type
       when 'setup_intent.succeeded'

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -20,7 +20,7 @@ module Plans
       if args[:charges].present?
         metric_ids = args[:charges].map { |c| c[:billable_metric_id] }.uniq
         if metric_ids.present? && plan.organization.billable_metrics.where(id: metric_ids).count != metric_ids.count
-          return result.fail!('not_found', 'Billable metrics does not exists')
+          return result.fail!(code: 'not_found', message: 'Billable metrics does not exists')
         end
       end
 

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -4,12 +4,12 @@ module Plans
   class DestroyService < BaseService
     def destroy(id)
       plan = result.user.plans.find_by(id: id)
-      return result.fail!('not_found') unless plan
+      return result.fail!(code: 'not_found') unless plan
 
       unless plan.deletable?
         return result.fail!(
-          'forbidden',
-          'Plan is attached to active subscriptions',
+          code: 'forbidden',
+          message: 'Plan is attached to active subscriptions',
         )
       end
 
@@ -21,12 +21,12 @@ module Plans
 
     def destroy_from_api(organization:, code:)
       plan = organization.plans.find_by(code: code)
-      return result.fail!('not_found', 'plan does not exist') unless plan
+      return result.fail!(code: 'not_found', message: 'plan does not exist') unless plan
 
       unless plan.deletable?
         return result.fail!(
-          'forbidden',
-          'plan is attached to an active subscriptions',
+          code: 'forbidden',
+          message: 'plan is attached to an active subscriptions',
           )
       end
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -4,7 +4,7 @@ module Plans
   class UpdateService < BaseService
     def update(**args)
       plan = result.user.plans.find_by(id: args[:id])
-      return result.fail!('not_found') unless plan
+      return result.fail!(code: 'not_found') unless plan
 
       plan.name = args[:name]
       plan.description = args[:description]
@@ -23,7 +23,7 @@ module Plans
 
       metric_ids = args[:charges].map { |c| c[:billable_metric_id] }.uniq
       if metric_ids.present? && plan.organization.billable_metrics.where(id: metric_ids).count != metric_ids.count
-        return result.fail!('not_found', 'Billable metrics does not exists')
+        return result.fail!(code: 'not_found', message: 'Billable metrics does not exists')
       end
 
       ActiveRecord::Base.transaction do
@@ -40,7 +40,7 @@ module Plans
 
     def update_from_api(organization:, code:, params:)
       plan = organization.plans.find_by(code: code)
-      return result.fail!('not_found', 'plan does not exist') unless plan
+      return result.fail!(code: 'not_found', message: 'plan does not exist') unless plan
 
       plan.name = params[:name] if params.key?(:name)
       plan.description = params[:description] if params.key?(:description)
@@ -58,7 +58,7 @@ module Plans
       unless params[:charges].blank?
         metric_ids = params[:charges].map { |c| c[:billable_metric_id] }.uniq
         if metric_ids.present? && plan.organization.billable_metrics.where(id: metric_ids).count != metric_ids.count
-          return result.fail!('not_found', 'plan does not exists')
+          return result.fail!(code: 'not_found', message: 'plan does not exists')
         end
       end
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -45,11 +45,11 @@ module Subscriptions
     private
 
     def process_create
-      return result.fail!('missing_argument', 'unable to find customer') unless current_customer
-      return result.fail!('missing_argument', 'plan does not exists') unless current_plan
+      return result.fail!(code: 'missing_argument', message: 'unable to find customer') unless current_customer
+      return result.fail!(code: 'missing_argument', message: 'plan does not exists') unless current_plan
 
       if currency_missmatch?(current_customer&.active_subscription&.plan, current_plan)
-        return result.fail!('currencies_does_not_match', 'currencies does not match')
+        return result.fail!(code: 'currencies_does_not_match',message: 'currencies does not match')
       end
 
 

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -4,14 +4,14 @@ module Subscriptions
   class TerminateService < BaseService
     def terminate(subscription_id)
       subscription = Subscription.find_by(id: subscription_id)
-      return result.fail!('not_found') if subscription.blank?
+      return result.fail!(code: 'not_found') if subscription.blank?
 
       process_terminate(subscription)
     end
 
     def terminate_from_api(organization:, subscription_id:)
       subscription = organization.subscriptions.find_by(id: subscription_id)
-      return result.fail!('not_found', 'subscription is not found') if subscription.blank?
+      return result.fail!(code: 'not_found', message: 'subscription is not found') if subscription.blank?
 
       process_terminate(subscription)
     end

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -4,7 +4,7 @@ module Subscriptions
   class UpdateService < BaseService
     def update(**args)
       subscription = Subscription.find_by(id: args[:id])
-      return result.fail!('not_found') unless subscription
+      return result.fail!(code: 'not_found') unless subscription
 
       subscription.name = args[:name] if args.key?(:name)
 
@@ -18,7 +18,7 @@ module Subscriptions
 
     def update_from_api(organization:, id:, params:)
       subscription = organization.subscriptions.find_by(id: id)
-      return result.fail!('not_found', 'subscription is not found') unless subscription
+      return result.fail!(code: 'not_found', message: 'subscription is not found') unless subscription
 
       subscription.name = params[:name] if params.key?(:name)
 

--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -5,7 +5,7 @@ class UsersService < BaseService
     result.user = User.find_by(email: email)&.authenticate(password)
     result.token = generate_token if result.user
 
-    return result.fail!('incorrect_login_or_password') unless result.user
+    return result.fail!(code: 'incorrect_login_or_password') unless result.user
 
     # Note: We're tracking the first membership linked to the user.
     SegmentIdentifyJob.perform_later(membership_id: "membership/#{result.user.memberships.first.id}")
@@ -17,7 +17,7 @@ class UsersService < BaseService
     result.user = User.find_or_initialize_by(email: email)
 
     if result.user.id
-      result.fail!('user_already_exists')
+      result.fail!(code: 'user_already_exists')
 
       return result
     end
@@ -52,7 +52,7 @@ class UsersService < BaseService
   def generate_token
     JWT.encode(payload, ENV['SECRET_KEY_BASE'], 'HS256')
   rescue StandardError => e
-    result.fail!('token_encoding_error', e.message)
+    result.fail!(code: 'token_encoding_error', message: e.message)
   end
 
   def payload

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -8,14 +8,14 @@ module Wallets
         organization_id: args[:organization_id],
       )
 
-      return result.fail!('missing_argument', 'unable to find customer') unless current_customer
+      return result.fail!(code: 'missing_argument', message: 'unable to find customer') unless current_customer
 
       if current_customer.wallets.active.any?
-        return result.fail!('wallet_already_exists', 'a wallet already exists for this customer')
+        return result.fail!(code: 'wallet_already_exists', message: 'a wallet already exists for this customer')
       end
 
       unless current_customer.subscriptions.active.any?
-        return result.fail!('no_active_subscription', 'customer does not have any active subscription')
+        return result.fail!(code: 'no_active_subscription', message: 'customer does not have any active subscription')
       end
 
       wallet = current_customer.wallets.create!(

--- a/app/services/wallets/terminate_service.rb
+++ b/app/services/wallets/terminate_service.rb
@@ -5,7 +5,7 @@ module Wallets
     def terminate(id)
       wallet = Wallet.find_by(id: id)
 
-      return result.fail!('not_found') unless wallet
+      return result.fail!(code: 'not_found') unless wallet
 
       wallet.mark_as_terminated! if wallet.active?
 

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -4,7 +4,7 @@ module Wallets
   class UpdateService < BaseService
     def update(**args)
       wallet = Wallet.find_by(id: args[:id])
-      return result.fail!('not_found') unless wallet
+      return result.fail!(code: 'not_found') unless wallet
 
       wallet.name = args[:name]
       wallet.expiration_date = args[:expiration_date]

--- a/spec/jobs/bill_add_on_job_spec.rb
+++ b/spec/jobs/bill_add_on_job_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe BillAddOnJob, type: :job do
 
   context 'when result is a failure' do
     let(:result) do
-      BaseService::Result.new.fail!('error')
+      BaseService::Result.new.fail!(code: 'error')
     end
 
     it 'raises an error' do

--- a/spec/jobs/bill_subscription_job_spec.rb
+++ b/spec/jobs/bill_subscription_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe BillSubscriptionJob, type: :job do
 
   context 'when result is a failure' do
     let(:result) do
-      BaseService::Result.new.fail!('error')
+      BaseService::Result.new.fail!(code: 'error')
     end
 
     it 'raises an error' do

--- a/spec/jobs/events/create_job_spec.rb
+++ b/spec/jobs/events/create_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Events::CreateJob, type: :job do
 
   context 'when result is a failure' do
     let(:result) do
-      BaseService::Result.new.fail!('Invalid customer id')
+      BaseService::Result.new.fail!(code: 'Invalid customer id')
     end
 
     it 'raises an error' do

--- a/spec/jobs/subscriptions/terminate_job_spec.rb
+++ b/spec/jobs/subscriptions/terminate_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Subscriptions::TerminateJob, type: :job do
 
   context 'when result is a failure' do
     let(:result) do
-      BaseService::Result.new.fail!('error')
+      BaseService::Result.new.fail!(code: 'error')
     end
 
     it 'raises an error' do

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Charge, type: :model do
 
     let(:service_response) do
       BaseService::Result.new.fail!(
-        :invalid_properties,
-        [
+        code: :invalid_properties,
+        message: [
           :invalid_amount,
           :invalid_graduated_ranges,
         ],
@@ -66,8 +66,8 @@ RSpec.describe Charge, type: :model do
 
     let(:service_response) do
       BaseService::Result.new.fail!(
-        :invalid_properties,
-        [:invalid_amount],
+        code: :invalid_properties,
+        message: [:invalid_amount],
       )
     end
 
@@ -115,8 +115,8 @@ RSpec.describe Charge, type: :model do
 
     let(:service_response) do
       BaseService::Result.new.fail!(
-        :invalid_properties,
-        [
+        code: :invalid_properties,
+        message: [
           :invalid_amount,
           :invalid_free_units,
           :invalid_package_size,
@@ -168,8 +168,8 @@ RSpec.describe Charge, type: :model do
 
     let(:service_response) do
       BaseService::Result.new.fail!(
-        :invalid_properties,
-        [
+        code: :invalid_properties,
+        message: [
           :invalid_rate,
           :invalid_fixed_amount,
           :invalid_fixed_amount_target,

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe WebhooksController, type: :request do
 
     context 'when failing to handle stripe event' do
       let(:result) do
-        BaseService::Result.new.fail!('webhook_error', 'Invalid payload')
+        BaseService::Result.new.fail!(code: 'webhook_error', message: 'Invalid payload')
       end
 
       it 'returns a bad request' do

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Fees::ChargeService do
         )
       end
       let(:aggregator_service) { instance_double(BillableMetrics::Aggregations::MaxService) }
-      let(:error_result) { BaseService::Result.new.fail!('aggregation_failure') }
+      let(:error_result) { BaseService::Result.new.fail!(code: 'aggregation_failure') }
 
       it 'returns an error' do
         allow(BillableMetrics::Aggregations::MaxService).to receive(:new)
@@ -317,7 +317,7 @@ RSpec.describe Fees::ChargeService do
         )
       end
       let(:aggregator_service) { instance_double(BillableMetrics::Aggregations::MaxService) }
-      let(:error_result) { BaseService::Result.new.fail!('aggregation_failure') }
+      let(:error_result) { BaseService::Result.new.fail!(code: 'aggregation_failure') }
 
       it 'returns an error' do
         allow(BillableMetrics::Aggregations::MaxService).to receive(:new)


### PR DESCRIPTION
### Changes

The goal of this PR is to add named parameters to the `BaseService::Result#fail!` method.

So that we can have:
`result.fail!(code: 'missing_mandatory_param', details: arguments)`
Instead of
`result.fail!('missing_mandatory_param', nil, arguments)`