### PR TITLE
fix: make Segment optional

### DIFF
--- a/config/initializers/analytics_ruby.rb
+++ b/config/initializers/analytics_ruby.rb
@@ -1,15 +1,17 @@
-class SegmentError < StandardError
-  attr_reader :status, :error_message, :message
+unless ENV['LAGO_DISABLE_SEGMENT'] == 'true'
+  class SegmentError < StandardError
+    attr_reader :status, :error_message, :message
 
-  def initialize(status, error_message)
-    @status = status
-    @error_message = error_message
-    @message = "Status: #{status}, Message: #{error_message}"
+    def initialize(status, error_message)
+      @status = status
+      @error_message = error_message
+      @message = "Status: #{status}, Message: #{error_message}"
+    end
   end
-end
 
-SEGMENT_CLIENT = Segment::Analytics.new({
-  write_key: ENV['SEGMENT_WRITE_KEY'],
-  on_error: proc { |status, msg| Sentry.capture_exception(SegmentError.new(status, msg)) },
-  stub: Rails.env.development? || Rails.env.test?
-})
+  SEGMENT_CLIENT = Segment::Analytics.new({
+    write_key: ENV['SEGMENT_WRITE_KEY'],
+    on_error: proc { |status, msg| Sentry.capture_exception(SegmentError.new(status, msg)) },
+    stub: Rails.env.development? || Rails.env.test?
+  })
+end


### PR DESCRIPTION
Before this change Rails would not boot if `SEGMENT_WRITE_KEY` was not
set in the environment. Now we re-use the `LAGO_DISABLE_SEGMENT`
environment variable that was already being checked in the Segment jobs
to disable this initializer if it's set.
