### PR TITLE
feat: Bill anniversary subscriptions

### DIFF
--- a/app/services/billing_service.rb
+++ b/app/services/billing_service.rb
@@ -28,10 +28,10 @@ class BillingService
   private
 
   def today
-    @today ||= Time.zone.now
+    @today ||= Time.current
   end
 
-  # NOTE: Retrieve list of subscription that should be billed today
+  # NOTE: Retrieve list of subscriptions that should be billed today
   def billable_subscriptions
     sql = []
 

--- a/app/services/billing_service.rb
+++ b/app/services/billing_service.rb
@@ -27,41 +27,115 @@ class BillingService
 
   private
 
-  # Retrieve list of subscription that should be billed today
+  def today
+    @today ||= Time.zone.now
+  end
+
+  # NOTE: Retrieve list of subscription that should be billed today
   def billable_subscriptions
     sql = []
-    today = Time.zone.now
 
-    return Subscription.none unless (today.day == 1 || today.monday?)
+    # NOTE: Calendar subscriptions
 
-    # For weekly interval we send invoices on Monday
-    if today.monday?
-      sql << Subscription.active.joins(:plan)
-        .merge(Plan.weekly)
-        .select(:id).to_sql
-    end
+    # NOTE: For weekly interval we send invoices on Monday
+    sql << weekly_calendar if today.monday?
 
     if today.day == 1
-      # Billed monthly
-      sql << Subscription.active.joins(:plan)
-        .merge(Plan.monthly)
-        .select(:id).to_sql
+      # NOTE: Billed monthly
+      sql << monthly_calendar
 
-      # Bill charges monthly for yearly plans
-      sql << Subscription.active.joins(:plan)
-        .merge(Plan.yearly)
-        .merge(Plan.where(bill_charges_monthly: true))
-        .select(:id).to_sql
+      # NOTE: Bill charges monthly for yearly plans
+      sql << yearly_with_monthly_charges_calendar
 
-      # We are on the first day of the year
-      if today.month == 1
-        # Billed yearly
-        sql << Subscription.active.joins(:plan)
-          .merge(Plan.yearly)
-          .select(:id).to_sql
-      end
+      # NOTE: Billed yearly and we are on the first day of the year
+      sql << yearly_calendar if today.month == 1
     end
 
+    # NOTE: Anniversary subscriptions
+    sql << weekly_anniversary
+    sql << monthly_anniversary
+    sql << yearly_with_monthly_charges_anniversary
+    sql << yearly_anniversary
+
     Subscription.where("id in (#{sql.join(' UNION ')})")
+  end
+
+  def weekly_calendar
+    Subscription.active.joins(:plan)
+      .calendar
+      .merge(Plan.weekly)
+      .select(:id).to_sql
+  end
+
+  def monthly_calendar
+    Subscription.active.joins(:plan)
+      .calendar
+      .merge(Plan.monthly)
+      .select(:id).to_sql
+  end
+
+  def yearly_with_monthly_charges_calendar
+    Subscription.active.joins(:plan)
+      .calendar
+      .merge(Plan.yearly.where(bill_charges_monthly: true))
+      .select(:id).to_sql
+  end
+
+  def yearly_calendar
+    Subscription.active.joins(:plan)
+      .calendar
+      .merge(Plan.yearly)
+      .select(:id).to_sql
+  end
+
+  def weekly_anniversary
+    Subscription.active.joins(:plan)
+      .anniversary
+      .merge(Plan.weekly)
+      .where('EXTRACT(ISODOW FROM subscriptions.subscription_date) = ?', today.wday)
+      .select(:id).to_sql
+  end
+
+  def monthly_anniversary
+    days = [today.day]
+
+    # If today is the last day of the month and month count less than 31 days,
+    # we need to take all days up to 31 into account
+    ((today.day + 1)..31).each { |day| days << day } if today.day == today.end_of_month.day
+
+    Subscription.active.joins(:plan)
+      .anniversary
+      .merge(Plan.monthly)
+      .where('DATE_PART(\'day\', subscriptions.subscription_date) IN (?)', days)
+      .select(:id).to_sql
+  end
+
+  def yearly_anniversary
+    # Billed yearly
+    days = [today.day]
+
+    # If we are not in leap year and we are on 28/02 take 29/02 into account
+    days << 29 if !Date.leap?(today.year) && today.day == 28 && today.month == 2
+
+    Subscription.active.joins(:plan)
+      .anniversary
+      .merge(Plan.yearly)
+      .where('DATE_PART(\'month\', subscriptions.subscription_date) = ?', today.month)
+      .where('DATE_PART(\'day\', subscriptions.subscription_date) IN (?)', days)
+      .select(:id).to_sql
+  end
+
+  def yearly_with_monthly_charges_anniversary
+    days = [today.day]
+
+    # If today is the last day of the month and month count less than 31 days,
+    # we need to take all days up to 31 into account
+    ((today.day + 1)..31).each { |day| days << day } if today.day == today.end_of_month.day
+
+    Subscription.active.joins(:plan)
+      .anniversary
+      .merge(Plan.yearly.where(bill_charges_monthly: true))
+      .where('DATE_PART(\'day\', subscriptions.subscription_date) IN (?)', days)
+      .select(:id).to_sql
   end
 end

--- a/spec/services/billing_service_spec.rb
+++ b/spec/services/billing_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe BillingService, type: :service do
       let(:interval) { :weekly }
       let(:billing_time) { :calendar }
 
-      it 'enqueue a job on billing day' do
+      it 'enqueues a job on billing day' do
         current_date = DateTime.parse('20 Jun 2022')
 
         travel_to(current_date) do
@@ -87,7 +87,7 @@ RSpec.describe BillingService, type: :service do
       let(:interval) { :monthly }
       let(:billing_time) { :calendar }
 
-      it 'enqueue a job on billing day' do
+      it 'enqueues a job on billing day' do
         current_date = DateTime.parse('01 Feb 2022')
 
         travel_to(current_date) do
@@ -111,7 +111,7 @@ RSpec.describe BillingService, type: :service do
       let(:interval) { :yearly }
       let(:billing_time) { :calendar }
 
-      it 'enqueue a job on billing day' do
+      it 'enqueues a job on billing day' do
         current_date = DateTime.parse('01 Jan 2022')
 
         travel_to(current_date) do
@@ -154,7 +154,7 @@ RSpec.describe BillingService, type: :service do
 
       let(:current_date) { DateTime.parse('20 Jun 2022').prev_occurring(subscription_date.strftime('%A').downcase.to_sym) }
 
-      it 'enqueue a job on billing day' do
+      it 'enqueues a job on billing day' do
         travel_to(current_date) do
           billing_service.call
 
@@ -175,7 +175,7 @@ RSpec.describe BillingService, type: :service do
       let(:billing_time) { :anniversary }
       let(:current_date) { subscription_date.next_month }
 
-      it 'enqueue a job on billing day' do
+      it 'enqueues a job on billing day' do
         travel_to(current_date) do
           billing_service.call
 
@@ -194,7 +194,7 @@ RSpec.describe BillingService, type: :service do
         let(:subscription_date) { DateTime.parse('31 Mar 2021') }
         let(:current_date) { DateTime.parse('28 Feb 2022') }
 
-        it 'enqueue a job if the month count less than 31 days' do
+        it 'enqueues a job if the month count less than 31 days' do
           travel_to(current_date) do
             billing_service.call
 
@@ -211,7 +211,7 @@ RSpec.describe BillingService, type: :service do
 
       let(:current_date) { subscription_date.next_year }
 
-      it 'enqueue a job on billing day' do
+      it 'enqueues a job on billing day' do
         travel_to(current_date) do
           billing_service.call
 
@@ -230,7 +230,7 @@ RSpec.describe BillingService, type: :service do
         let(:subscription_date) { DateTime.parse('29 Feb 2020') }
         let(:current_date) { DateTime.parse('28 Feb 2022') }
 
-        it 'enqueue a job on 28th of february when year is not a leap year' do
+        it 'enqueues a job on 28th of february when year is not a leap year' do
           travel_to(current_date) do
             billing_service.call
 
@@ -257,7 +257,7 @@ RSpec.describe BillingService, type: :service do
           let(:subscription_date) { DateTime.parse('31 Mar 2021') }
           let(:current_date) { DateTime.parse('28 Feb 2022') }
 
-          it 'enqueue a job if the month count less than 31 days' do
+          it 'enqueues a job if the month count less than 31 days' do
             travel_to(current_date) do
               billing_service.call
 
@@ -290,7 +290,7 @@ RSpec.describe BillingService, type: :service do
 
       before { subscription }
 
-      it 'enqueue a job on billing day' do
+      it 'enqueues a job on billing day' do
         current_date = DateTime.parse('01 Feb 2022')
 
         travel_to(current_date) do

--- a/spec/services/billing_service_spec.rb
+++ b/spec/services/billing_service_spec.rb
@@ -21,44 +21,46 @@ RSpec.describe BillingService, type: :service do
       )
     end
 
-    let(:subscription1) do
-      create(
-        :subscription,
-        customer: customer,
-        plan: plan,
-        subscription_date: subscription_date,
-        started_at: Time.zone.now,
-      )
-    end
-    let(:subscription2) do
-      create(
-        :subscription,
-        customer: customer,
-        plan: plan,
-        subscription_date: subscription_date,
-        started_at: Time.zone.now,
-      )
-    end
-    let(:subscription3) do
-      create(
-        :subscription,
-        plan: plan,
-        subscription_date: subscription_date,
-        started_at: Time.zone.now,
-      )
-    end
-
     before { subscription }
 
     context 'when billed weekly with calendar billing time' do
+      let(:interval) { :weekly }
+      let(:billing_time) { :calendar }
+
+      let(:subscription1) do
+        create(
+          :subscription,
+          customer: customer,
+          plan: plan,
+          subscription_date: subscription_date,
+          started_at: Time.zone.now,
+        )
+      end
+
+      let(:subscription2) do
+        create(
+          :subscription,
+          customer: customer,
+          plan: plan,
+          subscription_date: subscription_date,
+          started_at: Time.zone.now,
+        )
+      end
+
+      let(:subscription3) do
+        create(
+          :subscription,
+          plan: plan,
+          subscription_date: subscription_date,
+          started_at: Time.zone.now,
+        )
+      end
+
       before do
         subscription1
         subscription2
         subscription3
       end
-
-      let(:interval) { :weekly }
-      let(:billing_time) { :calendar }
 
       it 'enqueues a job on billing day' do
         current_date = DateTime.parse('20 Jun 2022')
@@ -159,7 +161,7 @@ RSpec.describe BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with(subscription, current_date.to_i)
+            .with([subscription], current_date.to_i)
         end
       end
 
@@ -180,7 +182,7 @@ RSpec.describe BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with(subscription, current_date.to_i)
+            .with([subscription], current_date.to_i)
         end
       end
 
@@ -199,7 +201,7 @@ RSpec.describe BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with(subscription, current_date.to_i)
+              .with([subscription], current_date.to_i)
           end
         end
       end
@@ -216,7 +218,7 @@ RSpec.describe BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with(subscription, current_date.to_i)
+            .with([subscription], current_date.to_i)
         end
       end
 
@@ -235,7 +237,7 @@ RSpec.describe BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with(subscription, current_date.to_i)
+              .with([subscription], current_date.to_i)
           end
         end
       end
@@ -249,7 +251,7 @@ RSpec.describe BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with(subscription, current_date.next_month.to_i)
+              .with([subscription], current_date.next_month.to_i)
           end
         end
 
@@ -262,7 +264,7 @@ RSpec.describe BillingService, type: :service do
               billing_service.call
 
               expect(BillSubscriptionJob).to have_been_enqueued
-                .with(subscription, current_date.to_i)
+                .with([subscription], current_date.to_i)
             end
           end
         end

--- a/spec/services/billing_service_spec.rb
+++ b/spec/services/billing_service_spec.rb
@@ -6,44 +6,59 @@ RSpec.describe BillingService, type: :service do
   subject(:billing_service) { described_class.new }
 
   describe '.call' do
-    let(:start_date) { DateTime.parse('20 Feb 2021') }
+    let(:plan) { create(:plan, interval: interval, bill_charges_monthly: bill_charges_monthly) }
+    let(:bill_charges_monthly) { false }
+    let(:subscription_date) { DateTime.parse('20 Feb 2021') }
+    let(:customer) { create(:customer) }
 
-    context 'when billed weekly' do
-      let(:plan) { create(:plan, interval: :weekly) }
-      let(:customer) { create(:customer) }
+    let(:subscription) do
+      create(
+        :subscription,
+        plan: plan,
+        subscription_date: subscription_date,
+        started_at: Time.zone.now,
+        billing_time: billing_time,
+      )
+    end
 
-      let(:subscription1) do
-        create(
-          :subscription,
-          customer: customer,
-          plan: plan,
-          subscription_date: start_date,
-          started_at: Time.zone.now,
-        )
-      end
-      let(:subscription2) do
-        create(
-          :subscription,
-          customer: customer,
-          plan: plan,
-          subscription_date: start_date,
-          started_at: Time.zone.now,
-        )
-      end
-      let(:subscription3) do
-        create(
-          :subscription,
-          plan: plan,
-          subscription_date: start_date,
-          started_at: Time.zone.now,
-        )
-      end
+    let(:subscription1) do
+      create(
+        :subscription,
+        customer: customer,
+        plan: plan,
+        subscription_date: subscription_date,
+        started_at: Time.zone.now,
+      )
+    end
+    let(:subscription2) do
+      create(
+        :subscription,
+        customer: customer,
+        plan: plan,
+        subscription_date: subscription_date,
+        started_at: Time.zone.now,
+      )
+    end
+    let(:subscription3) do
+      create(
+        :subscription,
+        plan: plan,
+        subscription_date: subscription_date,
+        started_at: Time.zone.now,
+      )
+    end
 
+    before { subscription }
+
+    context 'when billed weekly with calendar billing time' do
       before do
         subscription1
         subscription2
         subscription3
       end
+
+      let(:interval) { :weekly }
+      let(:billing_time) { :calendar }
 
       it 'enqueue a job on billing day' do
         current_date = DateTime.parse('20 Jun 2022')
@@ -68,19 +83,9 @@ RSpec.describe BillingService, type: :service do
       end
     end
 
-    context 'when billed monthly' do
-      let(:plan) { create(:plan, interval: :monthly) }
-
-      let(:subscription) do
-        create(
-          :subscription,
-          plan: plan,
-          subscription_date: start_date,
-          started_at: Time.zone.now,
-        )
-      end
-
-      before { subscription }
+    context 'when billed monthly with calendar billing time' do
+      let(:interval) { :monthly }
+      let(:billing_time) { :calendar }
 
       it 'enqueue a job on billing day' do
         current_date = DateTime.parse('01 Feb 2022')
@@ -102,19 +107,9 @@ RSpec.describe BillingService, type: :service do
       end
     end
 
-    context 'when billed yearly' do
-      let(:plan) { create(:plan, interval: :yearly) }
-
-      let(:subscription) do
-        create(
-          :subscription,
-          plan: plan,
-          subscription_date: start_date,
-          started_at: Time.zone.now,
-        )
-      end
-
-      before { subscription }
+    context 'when billed yearly with calendar billing time' do
+      let(:interval) { :yearly }
+      let(:billing_time) { :calendar }
 
       it 'enqueue a job on billing day' do
         current_date = DateTime.parse('01 Jan 2022')
@@ -136,7 +131,7 @@ RSpec.describe BillingService, type: :service do
       end
 
       context 'when charges are billed monthly' do
-        before { plan.update(bill_charges_monthly: true) }
+        let(:bill_charges_monthly) { true }
 
         it 'enqueues a job on billing day' do
           current_date = DateTime.parse('01 Feb 2022')
@@ -151,11 +146,134 @@ RSpec.describe BillingService, type: :service do
       end
     end
 
+    context 'when billed weekly with anniversary billing time' do
+      let(:interval) { :weekly }
+      let(:billing_time) { :anniversary }
+
+      let(:subscription_date) { DateTime.now.prev_occurring(DateTime.now.strftime('%A').downcase.to_sym) }
+
+      let(:current_date) { DateTime.parse('20 Jun 2022').prev_occurring(subscription_date.strftime('%A').downcase.to_sym) }
+
+      it 'enqueue a job on billing day' do
+        travel_to(current_date) do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with(subscription, current_date.to_i)
+        end
+      end
+
+      it 'does not enqueue a job on other day' do
+        travel_to(current_date + 1.day) do
+          expect { billing_service.call }.not_to have_enqueued_job
+        end
+      end
+    end
+
+    context 'when billed monthly with anniversary billing time' do
+      let(:interval) { :monthly }
+      let(:billing_time) { :anniversary }
+      let(:current_date) { subscription_date.next_month }
+
+      it 'enqueue a job on billing day' do
+        travel_to(current_date) do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with(subscription, current_date.to_i)
+        end
+      end
+
+      it 'does not enqueue a job on other day' do
+        travel_to(current_date + 1.day) do
+          expect { billing_service.call }.not_to have_enqueued_job
+        end
+      end
+
+      context 'when subscription anniversary is on a 31st' do
+        let(:subscription_date) { DateTime.parse('31 Mar 2021') }
+        let(:current_date) { DateTime.parse('28 Feb 2022') }
+
+        it 'enqueue a job if the month count less than 31 days' do
+          travel_to(current_date) do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with(subscription, current_date.to_i)
+          end
+        end
+      end
+    end
+
+    context 'when billed yearly with anniversary billing time' do
+      let(:interval) { :yearly }
+      let(:billing_time) { :anniversary }
+
+      let(:current_date) { subscription_date.next_year }
+
+      it 'enqueue a job on billing day' do
+        travel_to(current_date) do
+          billing_service.call
+
+          expect(BillSubscriptionJob).to have_been_enqueued
+            .with(subscription, current_date.to_i)
+        end
+      end
+
+      it 'does not enqueue a job on other day' do
+        travel_to(current_date + 1.day) do
+          expect { billing_service.call }.not_to have_enqueued_job
+        end
+      end
+
+      context 'when subscription anniversary is on 29th of february' do
+        let(:subscription_date) { DateTime.parse('29 Feb 2020') }
+        let(:current_date) { DateTime.parse('28 Feb 2022') }
+
+        it 'enqueue a job on 28th of february when year is not a leap year' do
+          travel_to(current_date) do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with(subscription, current_date.to_i)
+          end
+        end
+      end
+
+      context 'when charges are billed monthly' do
+        let(:bill_charges_monthly) { true }
+        let(:current_date) { subscription_date.next_month }
+
+        it 'enqueues a job on billing day' do
+          travel_to(current_date.next_month) do
+            billing_service.call
+
+            expect(BillSubscriptionJob).to have_been_enqueued
+              .with(subscription, current_date.next_month.to_i)
+          end
+        end
+
+        context 'when subscription anniversary is on a 31st' do
+          let(:subscription_date) { DateTime.parse('31 Mar 2021') }
+          let(:current_date) { DateTime.parse('28 Feb 2022') }
+
+          it 'enqueue a job if the month count less than 31 days' do
+            travel_to(current_date) do
+              billing_service.call
+
+              expect(BillSubscriptionJob).to have_been_enqueued
+                .with(subscription, current_date.to_i)
+            end
+          end
+        end
+      end
+    end
+
     context 'when downgraded' do
       let(:subscription) do
         create(
           :subscription,
-          subscription_date: start_date,
+          subscription_date: subscription_date,
           started_at: Time.zone.now,
           previous_subscription: previous_subscription,
           status: :pending,
@@ -165,7 +283,7 @@ RSpec.describe BillingService, type: :service do
       let(:previous_subscription) do
         create(
           :subscription,
-          subscription_date: start_date,
+          subscription_date: subscription_date,
           started_at: Time.zone.now,
         )
       end


### PR DESCRIPTION
## Context

We want to add the ability to choose to bill users at subscription date anniversary and not only on a calendar basis.

## Changes

The objective of this pull request is to take anniversary subscriptions into account in the `BillingService`

It will:
- Bill weekly subscriptions on their weekly anniversary day
- Bill monthly subscriptions on their monthly anniversary day, taking into account month duration for subscription day > 28
- Bill yearly subscriptions on their yearly anniversary day, taking into account year duration for subscription = February 29th when year is not a leap year
- Bill fees for yearly subscriptions with monthly fee billing on their monthly anniversary taking into account month duration for subscription day > 28

## Related resources

This PR follows:
- https://github.com/getlago/lago-api/pull/352 to update the subscription data model.
- https://github.com/getlago/lago-api/pull/360 to add a new date service for invoice bounds
- https://github.com/getlago/lago-api/pull/364 to expose billing time into GraphQL
- https://github.com/getlago/lago-api/pull/365 to expose billing time into API