### PR TITLE
fix: remove result raises error on result not success

### DIFF
--- a/app/jobs/events/create_job.rb
+++ b/app/jobs/events/create_job.rb
@@ -5,14 +5,12 @@ module Events
     queue_as :default
 
     def perform(organization, params, timestamp, metadata)
-      result = Events::CreateService.new.call(
+      Events::CreateService.new.call(
         organization: organization,
         params: params,
         timestamp: Time.zone.at(timestamp),
         metadata: metadata,
       )
-
-      result.throw_error unless result.success?
     end
   end
 end

--- a/spec/jobs/events/create_job_spec.rb
+++ b/spec/jobs/events/create_job_spec.rb
@@ -21,24 +21,4 @@ RSpec.describe Events::CreateJob, type: :job do
     expect(Events::CreateService).to have_received(:new)
     expect(create_service).to have_received(:call)
   end
-
-  context 'when result is a failure' do
-    let(:result) do
-      BaseService::Result.new.fail!(code: 'Invalid customer id')
-    end
-
-    it 'raises an error' do
-      allow(Events::CreateService).to receive(:new).and_return(create_service)
-      allow(create_service).to receive(:call)
-        .with(organization: organization, params: params, timestamp: Time.zone.at(timestamp), metadata: metadata)
-        .and_return(result)
-
-      expect do
-        described_class.perform_now(organization, params, timestamp, metadata)
-      end.to raise_error(BaseService::FailedResult)
-
-      expect(Events::CreateService).to have_received(:new)
-      expect(create_service).to have_received(:call)
-    end
-  end
 end


### PR DESCRIPTION
**Context**

Event job is raising validation errors linked to the Service Result. We do not want to keep dead jobs about validation errors

**Changes**

Do not raise service result errors