### PR TITLE
fix(multiple_plans): Set customer_id to unique_id

### DIFF
--- a/lib/tasks/subscriptions.rake
+++ b/lib/tasks/subscriptions.rake
@@ -3,8 +3,8 @@
 namespace :subscriptions do
   desc 'Fill missing unique_id'
   task fill_unique_id: :environment do
-    Subscription.where(unique_id: nil).find_each do |sub|
-      sub.update!(unique_id: SecureRandom.uuid)
+    Subscription.includes(:customer).find_each do |subscription|
+      subscription.update!(unique_id: subscription.customer.customer_id)
     end
   end
 end


### PR DESCRIPTION
## Context

After releasing the multiple plans feature, we've seen some issues with subscription creation.
Indeed, retrieving the existing subscription was not possible.

## Description

We've stored the `customer_id` as the default value of `unique_id`.

## Related Task

Related issue on Slack: https://lago-community.slack.com/archives/C03MCH55EL8/p1659957452490519.