### PR TITLE
fix(invoices): Fix permissions for invoices show and download on API

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -18,7 +18,7 @@ module Api
       end
 
       def show
-        invoice = Invoice.find_by(id: params[:id])
+        invoice = current_organization.invoices.find_by(id: params[:id])
 
         return not_found_error unless invoice
 
@@ -44,7 +44,7 @@ module Api
       end
 
       def download
-        invoice = Invoice.find_by(id: params[:id])
+        invoice = current_organization.invoices.find_by(id: params[:id])
 
         return not_found_error unless invoice
 

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::InvoicesController, type: :request do
   let(:organization) { create(:organization) }
-  let(:invoice) { create(:invoice) }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:invoice) { create(:invoice, customer: customer) }
 
   describe 'UPDATE /invoices' do
     let(:update_params) do
@@ -33,13 +34,11 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
   end
 
-  describe 'show' do
-    let(:invoice) { create(:invoice) }
-
+  describe 'GET /invoices/:id' do
     it 'returns a invoice' do
       get_with_token(
         organization,
-        "/api/v1/invoices/#{invoice.id}"
+        "/api/v1/invoices/#{invoice.id}",
       )
 
       expect(response).to have_http_status(:success)
@@ -54,7 +53,20 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       it 'returns not found' do
         get_with_token(
           organization,
-          "/api/v1/invoices/555"
+          '/api/v1/invoices/555',
+        )
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when invoices belongs to an other organization' do
+      let(:invoice) { create(:invoice) }
+
+      it 'returns not found' do
+        get_with_token(
+          organization,
+          "/api/v1/invoices/#{invoice.id}",
         )
 
         expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
## Context

`GET /api/v1/invoices/:id` and `POST /api/v1/invoices/:id/download` does not apply permissions when looking for the invoice. It should be fixed as it is a potential security hole.

## Changes

Invoices search should be scoped to the current organization