### PR TITLE
fix(current_usage): Fix customer current usage in API when not found

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -28,7 +28,7 @@ module Api
             nil,
             customer_id: params[:customer_id],
             subscription_id: params[:subscription_id],
-            organization_id: current_organization.id
+            organization_id: current_organization.id,
           )
         result = service.usage
 

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -7,7 +7,7 @@ module Invoices
 
       if organization_id.present?
         @organization_id = organization_id
-        @customer = Customer.find_by(
+        @customer = Customer.find_by!(
           customer_id: customer_id,
           organization_id: organization_id,
         )
@@ -16,6 +16,8 @@ module Invoices
       end
 
       @subscription = find_subscription(subscription_id)
+    rescue ActiveRecord::RecordNotFound
+      result.fail!(code: 'not_found')
     end
 
     def usage

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     end
   end
 
-  describe '.current_usage' do
+  describe 'GET /customers/:id/current_usage' do
     let(:customer) { create(:customer, organization: organization) }
     let(:organization) { create(:organization) }
     let(:subscription) do
@@ -139,6 +139,19 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         expect(charge_usage[:units]).to eq('4.0')
         expect(charge_usage[:amount_cents]).to eq(5)
         expect(charge_usage[:amount_currency]).to eq('EUR')
+      end
+    end
+
+    context 'when customer does not belongs to the organization' do
+      let(:customer) { create(:customer) }
+
+      it 'returns not found' do
+        get_with_token(
+          organization,
+          "/api/v1/customers/#{customer.customer_id}/current_usage?subscription_id=#{subscription.id}",
+        )
+
+        expect(response).to have_http_status(:not_found)
       end
     end
   end


### PR DESCRIPTION
## Context

With the introduction of the multiple plan feature, a regression has been identified in customer current usage on the customer API.

## Description

If the provider `customer_id` is not found or does not belongs to the organization, an error is raised in the `Invoices::CustomerUsageService` when trying to find the subscription.

Details of the error:
```
NoMethodError
undefined method `organization_ids' for nil:NilClass
```

To fix the issue, we should render a not found error as soon as possible instead of going further in the service.

## Related Task

Sentry issue: https://sentry.io/organizations/lago/issues/3487652425/?project=6370067 (external link)