### PR TITLE
fix(multiple_plans): Force filling customer id to invoices

### DIFF
--- a/db/migrate/20220727161448_add_customer_to_invoices.rb
+++ b/db/migrate/20220727161448_add_customer_to_invoices.rb
@@ -1,8 +1,5 @@
 class AddCustomerToInvoices < ActiveRecord::Migration[7.0]
   def change
     add_reference :invoices, :customer, type: :uuid, foreign_key: true, index: true
-
-    LagoApi::Application.load_tasks
-    Rake::Task['invoices:fill_customer'].invoke
   end
 end

--- a/db/migrate/20220809083243_fill_customer_id_on_invoices.rb
+++ b/db/migrate/20220809083243_fill_customer_id_on_invoices.rb
@@ -1,0 +1,6 @@
+class FillCustomerIdOnInvoices < ActiveRecord::Migration[7.0]
+  def change
+    LagoApi::Application.load_tasks
+    Rake::Task['invoices:fill_customer'].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_01_101144) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_09_083243) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -19,9 +19,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_01_101144) do
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.uuid "record_id"
     t.uuid "blob_id", null: false
     t.datetime "created_at", null: false
+    t.uuid "record_id"
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
   end
 
@@ -356,10 +356,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_01_101144) do
     t.integer "status", null: false
     t.string "currency", null: false
     t.string "name"
-    t.string "rate_amount", null: false
-    t.string "credits_balance", default: "0.00", null: false
-    t.string "balance", default: "0.00", null: false
-    t.string "consumed_credits", default: "0.00", null: false
+    t.decimal "rate_amount", precision: 5, default: "0", null: false
+    t.decimal "credits_balance", precision: 5, default: "0", null: false
+    t.decimal "balance", precision: 5, default: "0", null: false
+    t.decimal "consumed_credits", precision: 5, default: "0", null: false
     t.datetime "expiration_date", precision: nil
     t.datetime "last_balance_sync_at", precision: nil
     t.datetime "last_consumed_credit_at", precision: nil


### PR DESCRIPTION
## Context

We've seen some issues where `customer_id` is not filled on `invoices`.
This, because we're calling the rake task in the same migration we're adding the column.

## Description

The goal of this PR is to call the rake task inside a new migration, so that we ensure `customer_id` is correctly populated.