### PR TITLE
fix: Add Segment write key into Dockerfile

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,32 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version
+        required: true
+jobs:
+  build-image:
+    name: Build Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Log In to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Add version into docker image
+        run: echo ${{ github.event.inputs.version }} > LAGO_VERSION
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: getlago/api:${{ github.event.inputs.version }}
+          build-args: |
+            SEGMENT_WRITE_KEY=${{ secrets.SEGMENT_WRITE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,6 @@ jobs:
           context: .
           push: true
           tags: getlago/api:${{ github.event.client_payload.version }}
+          build-args: |
+            SEGMENT_WRITE_KEY=${{ secrets.SEGMENT_WRITE_KEY }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,10 @@ RUN apk add --no-cache \
   postgresql-dev \
   tzdata
 
+ARG SEGMENT_WRITE_KEY
+
+ENV SEGMENT_WRITE_KEY $SEGMENT_WRITE_KEY
+
 COPY --from=build /usr/local/bundle/ /usr/local/bundle
 
 CMD ["./scripts/start.sh"]


### PR DESCRIPTION
## Context

We have some errors trying to start api's docker image because `SEGMENT_WRITE_KEY` is not packaged into the image

## Description

- Add `SEGMENT_WRITE_KEY` as Docker build arg
- Add support of Build Args for release actions
- Add a manual release action