### PR TITLE
fix: Fix boundaries for full period payed in advance

### DIFF
--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -198,6 +198,10 @@ module Fees
       to_date = boundaries.to_date
 
       if plan.has_trial?
+        # NOTE: When pay in advance, boundaries are on the previous period
+        #       but subscription duration have to be computed on the comming one.
+        #       To get the number of days to bill, we must
+        #       jump to the end of the billing period
         if plan.pay_in_advance?
           from_date = boundaries.to_date + 1.day
 

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -199,8 +199,18 @@ module Fees
 
       if plan.has_trial?
         if plan.pay_in_advance?
-          from_date = invoice.issuing_date
-          to_date = invoice.issuing_date.end_of_month
+          from_date = boundaries.to_date + 1.day
+
+          case plan.interval.to_sym
+          when :weekly
+            to_date = from_date.end_of_week
+          when :monthly
+            to_date = from_date.end_of_month
+          when :yearly
+            to_date = from_date.end_of_year
+          else
+            raise NotImplementedError
+          end
         end
 
         # NOTE: amount is 0 if trial cover the full period


### PR DESCRIPTION
## Context

With the new multiple plans feature,  the issuing date of the invoice have been updated to be the previous day of the invoice generation.

## Description

Before the change, in the case of a plan payed in advance, the issuing date was the invoice creation date and so the first day of the new invoice period. 

The issuing date field was used to recompute bounds of the invoice in the case of a trial period.

Before:
```ruby
issuing_date = DateTime.parse('2022-03-01')
invoiced_from_date = issuing_date // 2022-03-01
invoiced_to_date = issuing_date.end_of_month // 2022-03-31
```

After:
```ruby
issuing_date = DateTime.parse('2022-28-02')
invoiced_from_date = issuing_date // 2022-02-28
invoiced_to_date = issuing_date.end_of_month // 2022-02-28
```

Also, the code was not taking the plan interval into account, it was only working with monthly interval... :lady_beetle: 

**Note**: the bounds computation will be delegated to a proper date service with the coming anniversary date feature

## How Has This Been Tested?

QA have been performed locally
