### PR TITLE
fix(stripe): ensure payment method is up to date

### DIFF
--- a/app/jobs/payment_providers/stripe/refresh_webhook_job.rb
+++ b/app/jobs/payment_providers/stripe/refresh_webhook_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    class RefreshWebhookJob < ApplicationJob
+      queue_as 'providers'
+
+      def perform(stripe_provider)
+        result = PaymentProviders::StripeService.new.refresh_webhook(
+          stripe_provider: stripe_provider,
+        )
+        result.throw_error
+      end
+    end
+  end
+end

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -123,7 +123,7 @@ module Invoices
             idempotency_key: invoice.id,
           },
         )
-      rescue Stripe::CardError => e
+      rescue Stripe::CardError, Stripe::InvalidRequestError => e
         deliver_error_webhook(e)
         update_invoice_status(:failed)
 

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -90,9 +90,16 @@ module Invoices
       end
 
       def stripe_payment_method
-        payment_method = customer.stripe_customer.payment_method_id
-        return payment_method if payment_method.present?
+        payment_method_id = customer.stripe_customer.payment_method_id
 
+        if payment_method_id
+          # NOTE: Check if payment method still exists
+          customer_service = PaymentProviderCustomers::StripeService.new(customer.stripe_customer)
+          customer_service_result = customer_service.check_payment_method(payment_method_id)
+          return customer_service_result.payment_method.id if customer_service_result.success?
+        end
+
+        # NOTE: Retrieve list of existing payment_methods
         payment_method = Stripe::PaymentMethod.list(
           {
             customer: customer.stripe_customer.provider_customer_id,

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -42,6 +42,22 @@ module PaymentProviderCustomers
       result.fail_with_validations!(e.record)
     end
 
+    def delete_payment_method(organization_id:, stripe_customer_id:, payment_method_id:)
+      stripe_customer = PaymentProviderCustomers::StripeCustomer
+        .joins(:customer)
+        .where(customers: { organization_id: organization_id })
+        .find_by(provider_customer_id: stripe_customer_id)
+      return result.fail!(code: 'not_found') unless stripe_customer
+
+      # NOTE: check if payment_method was the default one
+      stripe_customer.payment_method_id = nil if stripe_customer.payment_method_id == payment_method_id
+
+      result.stripe_customer = stripe_customer
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.fail_with_validations!(e.record)
+    end
+
     private
 
     attr_accessor :stripe_customer

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -58,6 +58,19 @@ module PaymentProviderCustomers
       result.fail_with_validations!(e.record)
     end
 
+    def check_payment_method(payment_method_id)
+      payment_method = Stripe::Customer.new(id: stripe_customer.provider_customer_id)
+        .retrieve_payment_method(payment_method_id, {}, { api_key: api_key })
+
+      result.payment_method = payment_method
+      result
+    rescue Stripe::InvalidRequestError
+      # NOTE: The payment method is no longer valid
+      stripe_customer.update!(payment_method_id: nil)
+
+      result.fail!(code: 'invalid_payment_method')
+    end
+
     private
 
     attr_accessor :stripe_customer

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -62,6 +62,11 @@ module PaymentProviders
       result.fail_with_validations!(e.record)
     end
 
+    def refresh_webhook(stripe_provider:)
+      unregister_webhook(stripe_provider, stripe_provider.secret_key)
+      register_webhook(stripe_provider)
+    end
+
     def handle_incoming_webhook(organization_id:, params:, signature:)
       organization = Organization.find_by(id: organization_id)
 

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -7,6 +7,7 @@ module PaymentProviders
       'setup_intent.succeeded',
       'payment_intent.payment_failed',
       'payment_intent.succeeded',
+      'payment_method.detached',
     ].freeze
 
     def create_or_update(**args)
@@ -105,6 +106,15 @@ module PaymentProviders
             provider_payment_id: event.data.object.id,
             status: status,
           )
+      when 'payment_method.detached'
+        result = PaymentProviderCustomers::StripeService
+          .new
+          .delete_payment_method(
+            organization_id: organization.id,
+            stripe_customer_id: event.data.object.customer,
+            payment_method_id: event.data.object.id,
+          )
+        result.throw_error || result
       end
     end
 

--- a/db/migrate/20220811155332_refresh_stripe_webhooks.rb
+++ b/db/migrate/20220811155332_refresh_stripe_webhooks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RefreshStripeWebhooks < ActiveRecord::Migration[7.0]
+  def change
+    LagoApi::Application.load_tasks
+    Rake::Task['stripe:refresh_registered_webhooks'].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_09_083243) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_11_155332) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/lib/tasks/stripe.rake
+++ b/lib/tasks/stripe.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :stripe do
+  desc 'Refresh stripe webhooks to add or remove an event type'
+  task refresh_registered_webhooks: :environment do
+    PaymentProviders::StripeProvider.find_each do |stripe_provider|
+      next unless stripe_provider.secret_key
+
+      PaymentProviders::Stripe::RefreshWebhookJob.perform_later(stripe_provider)
+    end
+  end
+end

--- a/spec/fixtures/stripe/payment_method_detached_event.json
+++ b/spec/fixtures/stripe/payment_method_detached_event.json
@@ -1,0 +1,62 @@
+{
+  "id": "evt_1LVXQRH4tiDZlIUa2kOODfxl",
+  "object": "event",
+  "api_version": "2020-08-27",
+  "created": 1660209095,
+  "data": {
+      "object": {
+          "id": "card_1LVXJrH4tiDZlIUaDiJElAN9",
+          "object": "payment_method",
+          "billing_details": {
+              "address": {
+                  "city": null,
+                  "country": null,
+                  "line1": null,
+                  "line2": null,
+                  "postal_code": null,
+                  "state": null
+              },
+              "email": null,
+              "name": null,
+              "phone": null
+          },
+          "card": {
+              "brand": "visa",
+              "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": "pass"
+              },
+              "country": "US",
+              "exp_month": 12,
+              "exp_year": 2023,
+              "fingerprint": "ek9QuolF5FxYiTDH",
+              "funding": "debit",
+              "generated_from": null,
+              "last4": "5556",
+              "networks": {
+                  "available": [
+                      "visa"
+                  ],
+                  "preferred": null
+              },
+              "three_d_secure_usage": {
+                  "supported": true
+              },
+              "wallet": null
+          },
+          "created": 1660208687,
+          "customer": "cus_LxpUP3kyHRmiwV",
+          "livemode": false,
+          "metadata": {},
+          "type": "card"
+      }
+  },
+  "livemode": false,
+  "pending_webhooks": 3,
+  "request": {
+      "id": "req_fs39TluTwjkndU",
+      "idempotency_key": "c41958b3-5ab4-49d2-8791-a7871635765d"
+  },
+  "type": "payment_method.detached"
+}

--- a/spec/jobs/payment_providers/stripe/refresh_webhook_job_spec.rb
+++ b/spec/jobs/payment_providers/stripe/refresh_webhook_job_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentProviders::Stripe::RefreshWebhookJob, type: :job do
+  let(:stripe_service) { instance_double(PaymentProviders::StripeService) }
+  let(:result) { BaseService::Result.new }
+
+  let(:stripe_provider) { create(:stripe_provider) }
+
+  before do
+    allow(PaymentProviders::StripeService).to receive(:new)
+      .and_return(stripe_service)
+    allow(stripe_service).to receive(:refresh_webhook)
+      .and_return(result)
+  end
+
+  it 'calls the register webhook service' do
+    described_class.perform_now(stripe_provider)
+
+    expect(PaymentProviders::StripeService).to have_received(:new)
+    expect(stripe_service).to have_received(:refresh_webhook)
+  end
+end

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -120,4 +120,45 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
       end
     end
   end
+
+  describe '.delete_payment_method' do
+    let(:payment_method_id) { 'card_12345' }
+
+    let(:stripe_customer) do
+      create(
+        :stripe_customer,
+        customer: customer,
+        provider_customer_id: 'cus_123456',
+        payment_method_id: payment_method_id,
+      )
+    end
+
+    it 'removes the customer payment method' do
+      result = stripe_service.delete_payment_method(
+        organization_id: organization.id,
+        stripe_customer_id: stripe_customer.provider_customer_id,
+        payment_method_id: payment_method_id,
+      )
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.stripe_customer.payment_method_id).to be_nil
+      end
+    end
+
+    context 'when customer payment method is not the deleted one' do
+      it 'does not remove the customer payment method' do
+        result = stripe_service.delete_payment_method(
+          organization_id: organization.id,
+          stripe_customer_id: stripe_customer.provider_customer_id,
+          payment_method_id: 'other_payment_method_id',
+        )
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.stripe_customer.payment_method_id).to eq(payment_method_id)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -161,4 +161,61 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
       end
     end
   end
+
+  describe '.check_payment_method' do
+    let(:payment_method_id) { 'card_12345' }
+
+    let(:stripe_customer) do
+      create(
+        :stripe_customer,
+        customer: customer,
+        provider_customer_id: 'cus_123456',
+        payment_method_id: payment_method_id,
+      )
+    end
+
+    let(:payment_method) { Stripe::PaymentMethod.new(id: payment_method_id) }
+
+    let(:stripe_api_customer) { instance_double(Stripe::Customer) }
+
+    before do
+      allow(Stripe::Customer).to receive(:new)
+        .and_return(stripe_api_customer)
+    end
+
+    it 'checks for the existance of the payment method' do
+      allow(stripe_api_customer)
+        .to receive(:retrieve_payment_method)
+        .and_return(payment_method)
+
+      result = stripe_service.check_payment_method(payment_method_id)
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.payment_method.id).to eq(payment_method_id)
+
+        expect(Stripe::Customer).to have_received(:new)
+        expect(stripe_api_customer).to have_received(:retrieve_payment_method)
+      end
+    end
+
+    context 'when payment method is not found on stripe' do
+      before do
+        allow(stripe_api_customer)
+          .to receive(:retrieve_payment_method)
+          .and_raise(Stripe::InvalidRequestError.new('error', {}))
+      end
+
+      it 'returns a failed result' do
+        result = stripe_service.check_payment_method(payment_method_id)
+
+        aggregate_failures do
+          expect(result).not_to be_success
+
+          expect(Stripe::Customer).to have_received(:new)
+          expect(stripe_api_customer).to have_received(:retrieve_payment_method)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Stripe integration is missing the payment method cleanup webhook and does not checks for the validity of the registered payment   method

## Description

If a payment method is removed from a customer on stripe dashboard, or via an API call, Lago application does not know about it and will try to use it for future payment.

This PR includes two fixes:
- handle `payment_method.detached` Stripe webhook to cleanup `PaymentProviderCustomers::StripeCustomer payment_method_id field` when a payment method is removed on Stripe side
- Check if a registered payment method still exists before processing a payment

## How Has This Been Tested?

A Complete QA will be performed both locally and on a staging branch
