### PR TITLE
feat: Allow alternate S3 compatible storages

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,7 +26,11 @@ Rails.application.configure do
   end
 
   config.active_storage.service = if ENV['LAGO_USE_AWS_S3'].present?
-    :amazon
+    if ENV['LAGO_AWS_S3_ENDPOINT'].present?
+      :amazon_compatible_endpoint
+    else
+      :amazon
+    end
   else
     :local
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,7 +9,11 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   config.active_storage.service = if ENV['LAGO_USE_AWS_S3'].present?
-    :amazon
+    if ENV['LAGO_AWS_S3_ENDPOINT'].present?
+      :amazon_compatible_endpoint
+    else
+      :amazon
+    end
   else
     :local
   end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -14,7 +14,11 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   config.active_storage.service = if ENV['LAGO_USE_AWS_S3'].present?
-    :amazon
+    if ENV['LAGO_AWS_S3_ENDPOINT'].present?
+      :amazon_compatible_endpoint
+    else
+      :amazon
+    end
   else
     :local
   end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,21 +13,8 @@ amazon:
   region: <%= ENV['LAGO_AWS_S3_REGION'] %>
   bucket: <%= ENV['LAGO_AWS_S3_BUCKET'] %>
 
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket-<%= Rails.env %>
-
-# Use bin/rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
-# microsoft:
-#   service: AzureStorage
-#   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name-<%= Rails.env %>
-
-# mirror:
-#   service: Mirror
-#   primary: local
-#   mirrors: [ amazon, google, microsoft ]
+amazon_compatible_endpoint:
+  service: S3
+  access_key_id: <%= ENV['LAGO_AWS_S3_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['LAGO_AWS_S3_SECRET_ACCESS_KEY'] %>
+  endpoint: <%= ENV['LAGO_AWS_S3_ENDPOINT'] %>


### PR DESCRIPTION
## Context

The `aws-s3-sdk` gem that we are using to manage document storage (for invoice) allows the usage of S3 compatible services.

This feature has been requested multiple https://github.com/getlago/lago/issues/90 and we already tried to address it (https://github.com/getlago/lago-api/pull/355) but it ended on some trouble on our cloud environment and the change was reverted.

## Description

This PR is a new attempt to address the feature by adding an alternate s3 configuration when `LAGO_AWS_S3_ENDPOINT` the environment variable is present in the configuration.

## How Has This Been Tested?

A full QA will be performed on a staging environment
