### PR TITLE
fix(customer): Fix removal of stripe customer id

### DIFF
--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -51,7 +51,10 @@ module Customers
         payment_provider_id: customer.organization.stripe_payment_provider&.id,
         params: billing_configuration,
       )
-      create_result.throw_error unless create_result.success?
+      return create_result.throw_error unless create_result.success?
+
+      # NOTE: Create service is modifying an other instance of the provider customer
+      customer.stripe_customer&.reload
     end
   end
 end

--- a/app/services/payment_provider_customers/create_service.rb
+++ b/app/services/payment_provider_customers/create_service.rb
@@ -15,7 +15,7 @@ module PaymentProviderCustomers
       )
 
       if (params || {}).key?(:provider_customer_id)
-        provider_customer.provider_customer_id = params[:provider_customer_id]
+        provider_customer.provider_customer_id = params[:provider_customer_id].presence
       end
 
       provider_customer.save!

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -133,7 +133,6 @@ RSpec.describe Customers::UpdateService, type: :service do
               expect(customer.id).to eq(customer.id)
               expect(customer.payment_provider).to be_nil
 
-              customer.stripe_customer.reload
               expect(customer.stripe_customer).to eq(stripe_customer)
               expect(customer.stripe_customer.provider_customer_id).to be_nil
             end


### PR DESCRIPTION
## Context

When a customer has a default_payment_provider & payment_provider_customer_ID filled , if we want to remove it from the edit customer dialog, the payment_provider_customer_id remains

## Description

The issue is related to the way we are treating payment provider customers with the "create customers" option checked.

The customer related logic is performed in the `PaymentProviderCustomers::CreateService` called from the `Customers::UpdateService`.
As both services are working with two distinct instance of the same `PaymentProviderCustomers::StripeCustomer`, the response from the update service is returning the wrong value.

The fix is only to reload the provider customer