### PR TITLE
feat(free-units): Calculate running total on sum aggregation

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -9,7 +9,7 @@ module BillableMetrics
         @subscription = subscription
       end
 
-      def aggregate(from_date:, to_date:)
+      def aggregate(from_date:, to_date:, free_units_count: 0)
         raise NotImplementedError
       end
 

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -3,7 +3,7 @@
 module BillableMetrics
   module Aggregations
     class CountService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:)
+      def aggregate(from_date:, to_date:, free_units_count: 0)
         result.aggregation = events_scope(from_date: from_date, to_date: to_date).count
         result
       end

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -3,12 +3,12 @@
 module BillableMetrics
   module Aggregations
     class MaxService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:)
-        max = events_scope(from_date: from_date, to_date: to_date)
+      def aggregate(from_date:, to_date:, free_units_count: 0)
+        events = events_scope(from_date: from_date, to_date: to_date)
           .where("#{sanitized_field_name} IS NOT NULL")
-          .maximum("(#{sanitized_field_name})::numeric")
 
-        result.aggregation = max || 0
+        result.aggregation = events.maximum("(#{sanitized_field_name})::numeric") || 0
+        result.count = events.count
         result
       rescue ActiveRecord::StatementInvalid => e
         result.fail!(code: 'aggregation_failure', message: e.message)

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -4,10 +4,11 @@ module BillableMetrics
   module Aggregations
     class SumService < BillableMetrics::Aggregations::BaseService
       def aggregate(from_date:, to_date:)
-        result.aggregation = events_scope(from_date: from_date, to_date: to_date)
+        events = events_scope(from_date: from_date, to_date: to_date)
           .where("#{sanitized_field_name} IS NOT NULL")
-          .sum("(#{sanitized_field_name})::numeric")
 
+        result.aggregation = events.sum("(#{sanitized_field_name})::numeric")
+        result.options = { running_total: running_total(events) }
         result
       rescue ActiveRecord::StatementInvalid => e
         result.fail!(code: 'aggregation_failure', message: e.message)
@@ -22,6 +23,15 @@ module BillableMetrics
             billable_metric.field_name,
           ],
         )
+      end
+
+      # NOTES: Return cumulative sum of field_name
+      def running_total(events)
+        total = 0.0
+
+        events.order(created_at: :asc)
+          .pluck(Arel.sql("(#{sanitized_field_name})::numeric"))
+          .map { |x| total += x }
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -3,10 +3,12 @@
 module BillableMetrics
   module Aggregations
     class UniqueCountService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:)
-        result.aggregation = events_scope(from_date: from_date, to_date: to_date)
+      def aggregate(from_date:, to_date:, free_units_count: 0)
+         events = events_scope(from_date: from_date, to_date: to_date)
           .where("#{sanitized_field_name} IS NOT NULL")
-          .count("DISTINCT (#{sanitized_field_name})")
+
+        result.aggregation = events.count("DISTINCT (#{sanitized_field_name})")
+        result.count = events.count
         result
       end
 

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -61,7 +61,11 @@ module Fees
     end
 
     def compute_amount
-      aggregated_events = aggregator.aggregate(from_date: charges_from_date, to_date: boundaries.to_date)
+      aggregated_events = aggregator.aggregate(
+        from_date: charges_from_date,
+        to_date: boundaries.to_date,
+        free_units_count: charge.properties.is_a?(Hash) ? charge.properties['free_units_per_events'].to_i : 0,
+      )
       return aggregated_events unless aggregated_events.success?
 
       charge_model.apply(value: aggregated_events.aggregation)

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     result = max_service.aggregate(from_date: from_date, to_date: to_date)
 
     expect(result.aggregation).to eq(12)
+    expect(result.count).to eq(5)
   end
 
   context 'when events are out of bounds' do
@@ -61,6 +62,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       result = max_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
     end
   end
 
@@ -73,6 +75,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       result = max_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
     end
   end
 

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -38,10 +38,11 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
   end
 
   it 'aggregates the events' do
-    result = sum_service.aggregate(from_date: from_date, to_date: to_date)
+    result = sum_service.aggregate(from_date: from_date, to_date: to_date, free_units_count: 2)
 
     expect(result.aggregation).to eq(48)
-    expect(result.options).to eq({ running_total: [12, 24, 36, 48]})
+    expect(result.count).to eq(4)
+    expect(result.options).to eq({ running_total: [12, 24]})
   end
 
   context 'when events are out of bounds' do
@@ -51,6 +52,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
       expect(result.options).to eq({ running_total: [] })
     end
   end
@@ -64,6 +66,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
       expect(result.options).to eq({ running_total: [] })
     end
   end

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     result = sum_service.aggregate(from_date: from_date, to_date: to_date)
 
     expect(result.aggregation).to eq(48)
+    expect(result.options).to eq({ running_total: [12, 24, 36, 48]})
   end
 
   context 'when events are out of bounds' do
@@ -50,6 +51,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.options).to eq({ running_total: [] })
     end
   end
 
@@ -62,6 +64,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.options).to eq({ running_total: [] })
     end
   end
 

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
     result = count_service.aggregate(from_date: from_date, to_date: to_date)
 
     expect(result.aggregation).to eq(1)
+    expect(result.count).to eq(4)
   end
 
   context 'when events are out of bounds' do
@@ -50,6 +51,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       result = count_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
     end
   end
 
@@ -62,6 +64,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       result = count_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
## Context

We want to add the ability to:
- Apply a fixed fee per `distinct transaction`
- Apply free units on the `number of distinct transactions` or on `the monetary total amount`

## Description

This is the first step of the feature, the goal of this PR is to calculate running total from sum aggregator service.

The running total of the events is the cumulative sum of the event’s `properties.field_name`.

## Related Task

https://github.com/getlago/lago/issues/92

## How Has This Been Tested?

A full QA will be performed when the feature will be 100% implemented.
