### PR TITLE
misc: Bump rubocop config to latest version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -174,7 +174,7 @@ Style/BlockDelimiters:
                 Prefer {...} over do...end for single-line blocks.
   Enabled: true
   EnforcedStyle: line_count_based
-  IgnoredMethods:
+  AllowedMethods:
     - lambda
     - proc
     - it
@@ -200,7 +200,7 @@ Style/MethodCallWithArgsParentheses:
   Description: 'Use parentheses for method calls with arguments.'
   Enabled: true
   IgnoreMacros: true
-  IgnoredMethods:
+  AllowedMethods:
     - require_relative
     - require
     - load


### PR DESCRIPTION
## Context

We're using Rubocop as our code analyzer and code formatter.

## Description

With the latest version of Rubocop (1.35.0), `IgnoredMethods` has been renamed to `AllowedMethods`.
The goal of this PR is to not have any warning message due to this change.

