### PR TITLE
misc: Add Docker Compose file for CI purposes

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -30,6 +30,8 @@ services:
     image: getlago/api:ci
     container_name: lago-api
     restart: unless-stopped
+    depends_on: 
+      - "db"
     environment:
       RAILS_ENV: production
       DATABASE_URL: postgres://lago:lago@db:5432/lago

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -27,3 +27,5 @@ services:
       SECRET_KEY_BASE: secret-key
       LAGO_RSA_PRIVATE_KEY: ${LAGO_RSA_PRIVATE_KEY}
       LAGO_DISABLE_SEGMENT: "true"
+    ports:
+      - 3000:3000

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -3,9 +3,6 @@
 
 version: "3.8"
 
-volumes:
-  lago_api_data:
-
 services:
   db:
     image: postgres:14.0-alpine
@@ -15,9 +12,6 @@ services:
       POSTGRES_DB: lago
       POSTGRES_USER: lago
       POSTGRES_PASSWORD: lago
-      PGDATA: /data/postgres
-    volumes:
-      - lago_postgres_data:/data/postgres
     ports:
       - 5432:5432
   

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -37,4 +37,4 @@ services:
       DATABASE_URL: postgres://lago:lago@db:5432/lago
       SECRET_KEY_BASE: secret-key
       LAGO_RSA_PRIVATE_KEY: ${LAGO_RSA_PRIVATE_KEY}
-      LAGO_DISABLE_SEGMENT: true
+      LAGO_DISABLE_SEGMENT: "true"

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,38 @@
+# This Docker Compose file is to use for CI purposes only
+# At Lago we use it to run ours integrations tests
+
+version: "3.8"
+
+volumes:
+  lago_api_data:
+
+services:
+  db:
+    image: postgres:14.0-alpine
+    container_name: lago-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: lago
+      POSTGRES_USER: lago
+      POSTGRES_PASSWORD: lago
+      PGDATA: /data/postgres
+    volumes:
+      - lago_postgres_data:/data/postgres
+    ports:
+      - 5432:5432
+    options: >-
+      --health-cmd pg_isready
+      --health-interval 10s
+      --health-timeout 5s
+      --health-retries 5
+  
+  api:
+    image: getlago/api:ci
+    container_name: lago-api
+    restart: unless-stopped
+    environment:
+      RAILS_ENV: production
+      DATABASE_URL: postgres://lago:lago@db:5432/lago
+      SECRET_KEY_BASE: secret-key
+      LAGO_RSA_PRIVATE_KEY: ${LAGO_RSA_PRIVATE_KEY}
+      LAGO_DISABLE_SEGMENT: true

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -20,11 +20,6 @@ services:
       - lago_postgres_data:/data/postgres
     ports:
       - 5432:5432
-    options: >-
-      --health-cmd pg_isready
-      --health-interval 10s
-      --health-timeout 5s
-      --health-retries 5
   
   api:
     image: getlago/api:ci


### PR DESCRIPTION
## Context

We want to add some E2E/Integration tests to Lago, we need to run an API with Github action.
The best way to to it is to work with Docker Compose.

## Description

- Create a `docker-compose.ci.yml` file for CI purposes