### PR TITLE
fix: Add validation for Plan and Charges currencies

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -22,7 +22,7 @@ class Charge < ApplicationRecord
 
   enum charge_model: CHARGE_MODELS
 
-  validates :amount_currency, inclusion: { in: currency_list }
+  validate :validate_currency
   validate :validate_amount, if: :standard?
   validate :validate_graduated_range, if: :graduated?
   validate :validate_package, if: :package?
@@ -56,5 +56,11 @@ class Charge < ApplicationRecord
     return if validation_result.success?
 
     validation_result.error.each { |error| errors.add(:properties, error) }
+  end
+
+  def validate_currency
+    return if plan.amount_currency == amount_currency
+
+    errors.add(:amount_currency, :plan_has_different_currency)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,3 +23,4 @@ en:
         invalid_content_type: invalid_content_type
         invalid_size: invalid_size
         value_already_exists: value_already_exists
+        plan_has_different_currency: plan_has_different_currency

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
             {
               billableMetricId: billable_metrics.first.id,
               amount: '100.00',
-              amountCurrency: 'USD',
+              amountCurrency: 'EUR',
               chargeModel: 'standard',
             },
             {

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
             {
               billableMetricId: billable_metrics.first.id,
               amount: '100',
-              amountCurrency: 'USD',
+              amountCurrency: 'EUR',
               chargeModel: 'standard',
             },
             {

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Plans::UpdateService, type: :service do
       charges: [
         {
           billable_metric_id: billable_metrics.first.id,
-          amount_currency: 'USD',
+          amount_currency: 'EUR',
           charge_model: 'standard',
           properties: {
             amount: '100',
@@ -87,12 +87,12 @@ RSpec.describe Plans::UpdateService, type: :service do
     end
 
     context 'with existing charges' do
-      let!(:existing_charge) do
+      let(:existing_charge) do
         create(
           :standard_charge,
           plan_id: plan.id,
           billable_metric_id: billable_metrics.first.id,
-          amount_currency: 'USD',
+          amount_currency: 'EUR',
           properties: {
             amount: '300',
           },
@@ -112,7 +112,7 @@ RSpec.describe Plans::UpdateService, type: :service do
             {
               id: existing_charge.id,
               billable_metric_id: billable_metrics.first.id,
-              amount_currency: 'USD',
+              amount_currency: 'EUR',
               charge_model: 'standard',
               properties: {
                 amount: '100',
@@ -124,11 +124,13 @@ RSpec.describe Plans::UpdateService, type: :service do
               charge_model: 'standard',
               properties: {
                 amount: '300',
-              }
+              },
             },
           ],
         }
       end
+
+      before { existing_charge }
 
       it 'updates existing charge and creates an other one' do
         expect { plans_service.update(**update_args) }
@@ -137,12 +139,12 @@ RSpec.describe Plans::UpdateService, type: :service do
     end
 
     context 'with charge to delete' do
-      let!(:charge) do
+      let(:charge) do
         create(
           :standard_charge,
           plan_id: plan.id,
           billable_metric_id: billable_metrics.first.id,
-          amount_currency: 'USD',
+          amount_currency: 'EUR',
           properties: {
             amount: '300',
           },
@@ -162,6 +164,8 @@ RSpec.describe Plans::UpdateService, type: :service do
         }
       end
 
+      before { charge }
+
       it 'destroys the unattached charge' do
         expect { plans_service.update(**update_args) }
           .to change { plan.charges.count }.by(-1)
@@ -174,7 +178,7 @@ RSpec.describe Plans::UpdateService, type: :service do
           :standard_charge,
           plan_id: plan.id,
           billable_metric_id: billable_metrics.first.id,
-          amount_currency: 'USD',
+          amount_currency: 'EUR',
           properties: {
             amount: '300',
           },
@@ -194,7 +198,7 @@ RSpec.describe Plans::UpdateService, type: :service do
             {
               id: existing_charge.id,
               billable_metric_id: billable_metrics.first.id,
-              amount_currency: 'USD',
+              amount_currency: 'EUR',
               charge_model: 'standard',
               properties: {
                 amount: '100',
@@ -206,7 +210,7 @@ RSpec.describe Plans::UpdateService, type: :service do
               charge_model: 'standard',
               properties: {
                 amount: '300',
-              }
+              },
             },
           ],
         }
@@ -233,7 +237,7 @@ RSpec.describe Plans::UpdateService, type: :service do
       result = plans_service.update_from_api(
         organization: organization,
         code: plan.code,
-        params: update_args
+        params: update_args,
       )
 
       aggregate_failures do
@@ -254,10 +258,10 @@ RSpec.describe Plans::UpdateService, type: :service do
         result = plans_service.update_from_api(
           organization: organization,
           code: plan.code,
-          params: update_args
+          params: update_args,
         )
 
-        expect(result).to_not be_success
+        expect(result).not_to be_success
         expect(result.error_code).to eq('unprocessable_entity')
       end
     end
@@ -269,7 +273,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         result = plans_service.update_from_api(
           organization: organization,
           code: plan.code,
-          params: update_args
+          params: update_args,
         )
 
         expect(result).not_to be_success
@@ -282,10 +286,10 @@ RSpec.describe Plans::UpdateService, type: :service do
         result = plans_service.update_from_api(
           organization: organization,
           code: 'fake_code12345',
-          params: update_args
+          params: update_args,
         )
 
-        expect(result).to_not be_success
+        expect(result).not_to be_success
         expect(result.error_code).to eq('not_found')
       end
     end
@@ -297,7 +301,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         result = plans_service.update_from_api(
           organization: organization,
           code: plan.code,
-          params: update_args
+          params: update_args,
         )
 
         plan_result = result.plan
@@ -316,9 +320,9 @@ RSpec.describe Plans::UpdateService, type: :service do
           :standard_charge,
           plan_id: plan.id,
           billable_metric_id: billable_metrics.first.id,
-          amount_currency: 'USD',
+          amount_currency: 'EUR',
           properties: {
-            amount: '300'
+            amount: '300',
           },
         )
       end
@@ -335,7 +339,7 @@ RSpec.describe Plans::UpdateService, type: :service do
             {
               id: existing_charge.id,
               billable_metric_id: billable_metrics.first.id,
-              amount_currency: 'USD',
+              amount_currency: 'EUR',
               charge_model: 'standard',
               properties: {
                 amount: '100',
@@ -347,7 +351,7 @@ RSpec.describe Plans::UpdateService, type: :service do
               charge_model: 'standard',
               properties: {
                 amount: '300',
-              }
+              },
             },
           ],
         }
@@ -360,7 +364,7 @@ RSpec.describe Plans::UpdateService, type: :service do
           plans_service.update_from_api(
             organization: organization,
             code: plan.code,
-            params: update_args
+            params: update_args,
           )
         end.to change(Charge, :count).by(1)
       end
@@ -372,7 +376,7 @@ RSpec.describe Plans::UpdateService, type: :service do
           :standard_charge,
           plan_id: plan.id,
           billable_metric_id: billable_metrics.first.id,
-          amount_currency: 'USD',
+          amount_currency: 'EUR',
           properties: {
             amount: '300',
           },
@@ -398,7 +402,7 @@ RSpec.describe Plans::UpdateService, type: :service do
           plans_service.update_from_api(
             organization: organization,
             code: plan.code,
-            params: update_args
+            params: update_args,
           )
         end.to change { plan.charges.count }.by(-1)
       end


### PR DESCRIPTION
## Context

We can create a Plan with somes charges that have a different currency from the Plan, it's not correct and can leads to errors

## Description

- Add a validation on charges to check that the currency is the same as the linked plan


## How Has This Been Tested?

- Added some unit tests