### PR TITLE
feat: Use date service for invoice bounds

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -18,9 +18,6 @@ module Types
       field :status, Types::Invoices::StatusTypeEnum, null: false
       field :file_url, String, null: true
 
-      field :from_date, GraphQL::Types::ISO8601Date, null: false
-      field :to_date, GraphQL::Types::ISO8601Date, null: false
-      field :charges_from_date, GraphQL::Types::ISO8601Date, null: true
       field :issuing_date, GraphQL::Types::ISO8601Date, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -37,7 +37,7 @@ module Types
         return unless object.next_subscription
         return unless object.next_subscription.pending?
 
-        Subscriptions::DatesService.new_instance(object, Time.zone.today)
+        ::Subscriptions::DatesService.new_instance(object, Time.zone.today)
           .next_end_of_period(Time.zone.today)
       end
     end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -19,7 +19,6 @@ module Types
       field :canceled_at, GraphQL::Types::ISO8601DateTime
       field :terminated_at, GraphQL::Types::ISO8601DateTime
       field :started_at, GraphQL::Types::ISO8601DateTime
-      field :pending_start_date, GraphQL::Types::ISO8601Date
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
@@ -32,6 +31,14 @@ module Types
 
       def next_name
         object.next_subscription&.name
+      end
+
+      def next_pending_start_date
+        return unless object.next_subscription
+        return unless object.next_subscription.pending?
+
+        Subscriptions::DatesService.new_instance(object, Time.zone.today)
+          .next_end_of_period(Time.zone.today)
       end
     end
   end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -38,7 +38,7 @@ module Types
         return unless object.next_subscription.pending?
 
         ::Subscriptions::DatesService.new_instance(object, Time.zone.today)
-          .next_end_of_period(Time.zone.today)
+          .next_end_of_period(Time.zone.today) + 1.day
       end
     end
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -53,6 +53,10 @@ class Invoice < ApplicationRecord
     fees.subscription_kind.sum(:amount_cents)
   end
 
+  def subscription_amount_currency
+    amount_currency
+  end
+
   def credit_amount_cents
     credits.sum(:amount_cents)
   end

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class InvoiceSubscription < ApplicationRecord
   belongs_to :invoice
   belongs_to :subscription
@@ -10,7 +12,7 @@ class InvoiceSubscription < ApplicationRecord
   def fees
     @fees ||= Fee.where(
       subscription_id: subscription.id,
-      invoice_id: invoice.id
+      invoice_id: invoice.id,
     )
   end
 
@@ -26,6 +28,18 @@ class InvoiceSubscription < ApplicationRecord
     fees.first.properties['to_date']&.to_date
   end
 
+  def charges_from_date
+    return if fees.empty?
+
+    fees.first.properties['charges_from_date']&.to_date
+  end
+
+  def charges_to_date
+    return if fees.empty?
+
+    fees.first.properties['charges_to_date']&.to_date
+  end
+
   def charge_amount_cents
     fees.charge_kind.sum(:amount_cents)
   end
@@ -37,4 +51,11 @@ class InvoiceSubscription < ApplicationRecord
   def total_amount_cents
     charge_amount_cents + subscription_amount_cents
   end
+
+  def total_amount_currency
+    subscription.plan.amount_currency
+  end
+
+  alias charge_amount_currency total_amount_currency
+  alias subscription_amount_currency total_amount_currency
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -67,36 +67,8 @@ class Subscription < ApplicationRecord
     next_subscriptions.not_canceled.order(created_at: :desc).first
   end
 
-  def pending_start_date
-    return unless pending?
-
-    (created_at.end_of_month + 1.day).to_date
-  end
-
-  def next_pending_start_date
-    following_subscription = next_subscription
-
-    return unless following_subscription
-    return unless following_subscription.pending?
-
-    last_interval_date
-  end
-
   def already_billed?
     fees.subscription_kind.any?
-  end
-
-  def last_interval_date
-    case plan.interval.to_sym
-    when :weekly
-      (created_at.end_of_week + 1.day).to_date
-    when :monthly
-      (created_at.end_of_month + 1.day).to_date
-    when :yearly
-      (created_at.end_of_year + 1.day).to_date
-    else
-      raise NotImplementedError
-    end
   end
 
   def validate_unique_id

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -63,8 +63,8 @@ module Fees
 
     def compute_amount
       aggregation_result = aggregator.aggregate(
-        from_date: charges_from_date,
-        to_date: boundaries.to_date,
+        from_date: boundaries.charges_from_date,
+        to_date: boundaries.charges_to_date,
         free_units_count: charge.properties.is_a?(Hash) ? charge.properties['free_units_per_events'].to_i : 0,
       )
       return aggregation_result unless aggregation_result.success?
@@ -116,31 +116,6 @@ module Fees
       end
 
       @charge_model = model_service.apply(charge: charge, aggregation_result: aggregation_result)
-    end
-
-    def charges_from_date
-      return boundaries.charges_from_date unless subscription.previous_subscription
-
-      if subscription.previous_subscription.upgraded?
-        date = case plan.interval.to_sym
-               when :weekly
-                 boundaries.charges_from_date.beginning_of_week
-               when :monthly
-                 boundaries.charges_from_date.beginning_of_month
-               when :yearly
-                 if subscription.previous_subscription.plan.bill_charges_monthly
-                   boundaries.charges_from_date.beginning_of_month
-                 else
-                   boundaries.charges_from_date.beginning_of_year
-                 end
-               else
-                 raise NotImplementedError
-        end
-
-        return date
-      end
-
-      boundaries.charges_from_date
     end
   end
 end

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -226,7 +226,7 @@ module Fees
 
     def compute_from_date(target_subscription)
       date_service(target_subscription).previous_beginning_of_period(
-        use_billing_date: target_subscription.plan.pay_in_advance? && subscription.plan.pay_in_advance?,
+        current_period: target_subscription.plan.pay_in_advance? && subscription.plan.pay_in_advance?,
       )
     end
   end

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -72,7 +72,7 @@ module Fees
 
     def should_compute_upgraded_amount?
       return false unless subscription.previous_subscription_id?
-      return false if subscription.invoices.count > 1 # TODO: check is still applies
+      return false if subscription.invoices.count > 1 # TODO: check if it still applies
 
       subscription.previous_subscription.upgraded?
     end
@@ -136,7 +136,7 @@ module Fees
       from_date = boundaries.from_date
       to_date = boundaries.to_date
 
-      # NOTE: to_date for previous plan might be different than to_date
+      # NOTE: to_date for previous plan might be different from to_date
       #       if plan interval is not the same
       old_to_date = compute_to_date(previous_subscription, boundaries.to_date)
 

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -2,8 +2,6 @@
 
 module Fees
   class SubscriptionService < BaseService
-    WEEK_DURATION = 7.freeze
-
     def initialize(invoice, subscription, boundaries)
       @invoice = invoice
       @subscription = subscription
@@ -24,7 +22,7 @@ module Fees
         amount_currency: plan.amount_currency,
         vat_rate: customer.applicable_vat_rate,
         units: 1,
-        properties: boundaries.to_h
+        properties: boundaries.to_h,
       )
 
       new_fee.compute_vat
@@ -91,18 +89,7 @@ module Fees
       # NOTE: When pay in advance, first invoice has from_date = to_date
       #       To get the number of days to bill, we must
       #       jump to the end of the billing period
-      if plan.pay_in_advance?
-        case plan.interval.to_sym
-        when :weekly
-          to_date = boundaries.to_date.end_of_week
-        when :monthly
-          to_date = boundaries.to_date.end_of_month
-        when :yearly
-          to_date = boundaries.to_date.end_of_year
-        else
-          raise NotImplementedError
-        end
-      end
+      to_date = compute_to_date(subscription, boundaries.to_date) if plan.pay_in_advance?
 
       if plan.has_trial?
         # NOTE: amount is 0 if trial cover the full period
@@ -117,7 +104,7 @@ module Fees
       # NOTE: Number of days of the first period since subscription creation
       days_to_bill = (to_date + 1.day - from_date).to_i
 
-      days_to_bill * single_day_price(plan)
+      days_to_bill * single_day_price(subscription)
     end
 
     # NOTE: When terminating a pay in arrerar subscription, we need to
@@ -144,13 +131,13 @@ module Fees
       # NOTE: number of days between beginning of the period and the termination date
       number_of_day_to_bill = (to_date + 1.day - from_date).to_i
 
-      number_of_day_to_bill * single_day_price(plan)
+      number_of_day_to_bill * single_day_price(subscription)
     end
 
     def upgraded_amount
       from_date = boundaries.from_date
-      to_date = compute_to_date(boundaries.to_date, plan)
-      old_to_date = compute_to_date(boundaries.to_date, previous_subscription.plan)
+      to_date = compute_to_date(subscription, boundaries.to_date)
+      old_to_date = compute_to_date(previous_subscription, boundaries.to_date)
 
       if plan.has_trial?
         from_date = to_date + 1.day if subscription.trial_end_date >= to_date
@@ -174,9 +161,9 @@ module Fees
         #       **old_day_price** = (old plan amount_cents / full period duration)
         #       **new_day_price** = (new plan amount_cents / full period duration)
         #       amount_to_bill = nb_day * (new_day_price - old_day_price)
-        old_day_price = single_day_price(previous_subscription.plan)
+        old_day_price = single_day_price(previous_subscription)
 
-        amount = new_number_of_day_to_bill * single_day_price(plan) - old_number_of_day_to_bill * old_day_price
+        amount = new_number_of_day_to_bill * single_day_price(subscription) - old_number_of_day_to_bill * old_day_price
 
         return 0 if amount.negative?
 
@@ -189,7 +176,7 @@ module Fees
         #       **nb_day** = number of days between upgrade and the end of the period
         #       **day_cost** = (plan amount_cents / full period duration)
         #       amount_to_bill = (nb_day * day_cost)
-        new_number_of_day_to_bill * single_day_price(plan)
+        new_number_of_day_to_bill * single_day_price(subscription)
       end
     end
 
@@ -204,17 +191,7 @@ module Fees
         #       jump to the end of the billing period
         if plan.pay_in_advance?
           from_date = boundaries.to_date + 1.day
-
-          case plan.interval.to_sym
-          when :weekly
-            to_date = from_date.end_of_week
-          when :monthly
-            to_date = from_date.end_of_month
-          when :yearly
-            to_date = from_date.end_of_year
-          else
-            raise NotImplementedError
-          end
+          to_date = compute_to_date(subscription, boundaries.to_date)
         end
 
         # NOTE: amount is 0 if trial cover the full period
@@ -227,20 +204,31 @@ module Fees
           from_date = subscription.trial_end_date
           number_of_day_to_bill = (to_date + 1.day - from_date).to_i
 
-          return number_of_day_to_bill * single_day_price(plan, from_date)
+          return number_of_day_to_bill * single_day_price(subscription, from_date)
         end
       end
 
       plan.amount_cents
     end
 
+    def date_service(subscription)
+      Subscriptions::DatesService.new_instance(subscription, Time.zone.at(boundaries.timestamp).to_date)
+    end
+
     # NOTE: cost of a single day in a period
-    def single_day_price(target_plan, optional_from_date = nil)
+    # def single_day_price(target_subscription, optional_from_date = nil)
+    #   date_service(target_subscription).single_day_price(
+    #     optional_from_date: optional_from_date,
+    #   )
+    # end
+
+    WEEK_DURATION = 7
+    def single_day_price(target_subscription, optional_from_date = nil)
       from_date = optional_from_date || boundaries.from_date
 
       # NOTE: Duration in days of full billed period (without termination)
       #       WARNING: the method only handles beginning of period logic
-      duration = case target_plan.interval.to_sym
+      duration = case target_subscription.plan.interval.to_sym
                  when :weekly
                    WEEK_DURATION
                  when :monthly
@@ -251,24 +239,15 @@ module Fees
                    raise NotImplementedError
       end
 
-      target_plan.amount_cents.fdiv(duration.to_i)
+      target_subscription.plan.amount_cents.fdiv(duration.to_i)
     end
 
-    def compute_to_date(base_date, plan)
+    def compute_to_date(target_subscription, base_date)
       return base_date if plan.pay_in_arrear?
 
-      # NOTE: when plan is pay in advance, the to date should be the
-      # end of the actual period
-      case plan.interval.to_sym
-      when :weekly
-        boundaries.to_date.end_of_week
-      when :monthly
-        boundaries.to_date.end_of_month
-      when :yearly
-        boundaries.to_date.end_of_year
-      else
-        raise NotImplementedError
-      end
+      # NOTE: when plan is pay in advance, the_to date should be the
+      #       end of the actual period
+      date_service(target_subscription).next_end_of_period(base_date)
     end
   end
 end

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -72,7 +72,7 @@ module Fees
 
     def should_compute_upgraded_amount?
       return false unless subscription.previous_subscription_id?
-      return false if subscription.invoices.count > 1 # TODO: check if it still applies
+      return false if subscription.invoices.count > 1
 
       subscription.previous_subscription.upgraded?
     end

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -168,6 +168,7 @@ module Invoices
         from_date: date_service.from_date,
         to_date: date_service.to_date,
         charges_from_date: date_service.charges_from_date,
+        timestamp: timestamp,
       }
     end
   end

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -13,10 +13,9 @@ module Invoices
 
     def create
       ActiveRecord::Base.transaction do
-        # NOTE: potential issue with issuing_date when creation date is equal to termination date.
         invoice = Invoice.create!(
           customer: customer,
-          issuing_date: (Time.zone.at(timestamp) - 1.day).to_date,
+          issuing_date: Time.zone.at(timestamp).to_date,
           invoice_type: :subscription,
         )
 

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -54,65 +54,8 @@ module Invoices
 
     attr_accessor :subscriptions, :timestamp, :customer, :currency
 
-    def from_date(subscription)
-      return @from_date if @from_date.present?
-
-      @from_date = case subscription.plan.interval.to_sym
-                   when :weekly
-                     (Time.zone.at(timestamp) - 1.week).to_date
-                   when :monthly
-                     (Time.zone.at(timestamp) - 1.month).to_date
-                   when :yearly
-                     (Time.zone.at(timestamp) - 1.year).to_date
-                   else
-                     raise NotImplementedError
-                   end
-
-      # NOTE: In case of termination or upgrade when we are terminating old plan(paying in arrear),
-      # we should move to the beginning of the billing period
-      if subscription.terminated? && subscription.plan.pay_in_arrear? && !subscription.downgraded?
-        @from_date = compute_termination_from_date(subscription)
-      end
-
-      # NOTE: On first billing period, subscription might start after the computed start of period
-      #       ei: if we bill on beginning of period, and user registered on the 15th, the invoice should
-      #       start on the 15th (subscription date) and not on the 1st
-      @from_date = subscription.started_at.to_date if @from_date < subscription.started_at
-
-      @from_date
-    end
-
-    def charges_from_date(subscription)
-      return @charges_from_date if @charges_from_date.present?
-
-      @charges_from_date = if subscription.plan.yearly? && subscription.plan.bill_charges_monthly
-        (Time.zone.at(timestamp) - 1.month).to_date
-      else
-        from_date(subscription)
-      end
-
-      @charges_from_date = subscription.started_at.to_date if @charges_from_date < subscription.started_at
-
-      @charges_from_date
-    end
-
-    def to_date(subscription)
-      return @to_date if @to_date.present?
-
-      @to_date = (Time.zone.at(timestamp) - 1.day).to_date
-
-      if subscription.terminated? && @to_date > subscription.terminated_at
-        # NOTE: When subscription is terminated, we cannot generate an invoice for a period after the termination
-        # TODO: from_date / to_date of invoices should be timestamps so that to_date = subscription.terminated_at
-        @to_date = subscription.terminated_at.to_date - 1.day
-      end
-
-      # NOTE: When price plan is configured as `pay_in_advance`, subscription creation will be
-      #       billed immediatly. An invoice must be generated for it with only the subscription fee.
-      #       The invoicing period will be only one day: the subscription day
-      @to_date = subscription.started_at.to_date if @to_date < subscription.started_at
-
-      @to_date
+    def date_service(subscription)
+      Subscriptions::DatesService.new_instance(subscription, Time.zone.at(timestamp).to_date)
     end
 
     def compute_amounts(invoice)
@@ -152,9 +95,10 @@ module Invoices
       # NOTE: we do not want to create a subscription fee for plans with bill_charges_monthly activated
       # But we want to keep the subscription charge when it has to proceed
       # Cases when we want to charge a subscription:
-      #   - Plan is pay in advance, we're at the beginning of the period (month 1) or subscription has never been billed
-      #   - Plan is pay in arrear and we're at the beginning of the period (month 1)
-      Time.zone.at(timestamp).to_date.month == 1 || (subscription.plan.pay_in_advance && !subscription.already_billed?)
+      # - Plan is pay in advance, we're at the beginning of the period or subscription has never been billed
+      # - Plan is pay in arrear and we're at the beginning of the period
+      date_service(subscription).first_month_in_yearly_period? ||
+        subscription.plan.pay_in_advance && !subscription.already_billed?
     end
 
     def should_create_charge_fees?(invoice, subscription)
@@ -198,19 +142,6 @@ module Invoices
       invoice.vat_amount_cents = (invoice.amount_cents * customer.applicable_vat_rate).fdiv(100).ceil
     end
 
-    def compute_termination_from_date(subscription)
-      case subscription.plan.interval.to_sym
-      when :weekly
-        Time.zone.at(timestamp).to_date.beginning_of_week
-      when :monthly
-        Time.zone.at(timestamp).to_date.beginning_of_month
-      when :yearly
-        Time.zone.at(timestamp).to_date.beginning_of_year
-      else
-        raise NotImplementedError
-      end
-    end
-
     def create_payment(invoice)
       case customer.payment_provider&.to_sym
       when :stripe
@@ -225,16 +156,18 @@ module Invoices
         properties: {
           organization_id: invoice.organization.id,
           invoice_id: invoice.id,
-          invoice_type: invoice.invoice_type
-        }
+          invoice_type: invoice.invoice_type,
+        },
       )
     end
 
     def calculate_boundaries(subscription)
+      date_service = date_service(subscription)
+
       {
-        from_date: from_date(subscription),
-        to_date: to_date(subscription),
-        charges_from_date: charges_from_date(subscription)
+        from_date: date_service.from_date,
+        to_date: date_service.to_date,
+        charges_from_date: date_service.charges_from_date,
       }
     end
   end

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -68,7 +68,8 @@ module Invoices
     end
 
     def create_subscription_fee(invoice, subscription, boundaries)
-      fee_result = Fees::SubscriptionService.new(invoice, subscription, boundaries).create
+      fee_result = Fees::SubscriptionService
+        .new(invoice: invoice, subscription: subscription, boundaries: boundaries).create
       fee_result.throw_error unless fee_result.success?
     end
 
@@ -168,6 +169,7 @@ module Invoices
         from_date: date_service.from_date,
         to_date: date_service.to_date,
         charges_from_date: date_service.charges_from_date,
+        charges_to_date: date_service.charges_to_date,
         timestamp: timestamp,
       }
     end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -33,7 +33,6 @@ module Invoices
     #       - The cache expiration is at most, the end date of the billing period
     #         + 1 day to handle cache generated on the last billing period
     #       - The cache key includes the customer id and the creation date of the last customer event
-    # TODO: Refresh cache automatically when receiving an new event
     def compute_usage
       Rails.cache.fetch(cache_key, expires_in: cache_expiration.days) do
         @invoice = Invoice.new(

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -38,7 +38,7 @@ module Invoices
       Rails.cache.fetch(cache_key, expires_in: cache_expiration.days) do
         @invoice = Invoice.new(
           customer: subscription.customer,
-          issuing_date: issuing_date,
+          issuing_date: boundaries[:issuing_date],
         )
 
         add_charge_fee
@@ -65,73 +65,6 @@ module Invoices
       customer&.active_subscriptions&.find_by(id: subscription_id)
     end
 
-    def from_date
-      return @from_date if @from_date.present?
-
-      @from_date = case subscription.plan.interval.to_sym
-                   when :weekly
-                     Time.zone.today.beginning_of_week
-                   when :monthly
-                     Time.zone.today.beginning_of_month
-                   when :yearly
-                     Time.zone.today.beginning_of_year
-                   else
-                     raise NotImplementedError
-      end
-
-      # NOTE: On first billing period, subscription might start after the computed start of period
-      #       ie: if we bill on beginning of period, and user registered on the 15th, the usage should
-      #       start on the 15th (subscription date) and not on the 1st
-      @from_date = subscription.started_at.to_date if @from_date < subscription.started_at
-
-      @from_date
-    end
-
-    def charges_from_date
-      return @charges_from_date if @charges_from_date.present?
-
-      @charges_from_date = if subscription.plan.yearly? && subscription.plan.bill_charges_monthly
-        Time.zone.today.beginning_of_month
-      else
-        from_date
-      end
-
-      @charges_from_date = subscription.started_at.to_date if @charges_from_date < subscription.started_at
-
-      @charges_from_date
-    end
-
-    def to_date
-      return @to_date if @to_date.present?
-
-      @to_date = case subscription.plan.interval.to_sym
-                 when :weekly
-                   Time.zone.today.end_of_week
-                 when :monthly
-                   Time.zone.today.end_of_month
-                 when :yearly
-                   if subscription.plan.bill_charges_monthly
-                     Time.zone.today.end_of_month
-                   else
-                     Time.zone.today.end_of_year
-                   end
-                 else
-                   raise NotImplementedError
-      end
-
-      @to_date
-    end
-
-    def issuing_date
-      return @issuing_date if @issuing_date.present?
-
-      # NOTE: When price plan is configured as `pay_in_advance`, we issue the invoice for the first day of
-      #       the period, it's on the last day otherwise
-      @issuing_date = to_date
-      @issuing_date = to_date + 1.day if subscription.plan.pay_in_advance?
-      @issuing_date
-    end
-
     def add_charge_fee
       query = subscription.plan.charges.joins(:billable_metric)
         .order(Arel.sql('lower(unaccent(billable_metrics.name)) ASC'))
@@ -141,7 +74,7 @@ module Invoices
           invoice: invoice,
           charge: charge,
           subscription: subscription,
-          boundaries: boundaries
+          boundaries: boundaries,
         ).current_usage
 
         fee_result.throw_error unless fee_result.success?
@@ -151,10 +84,20 @@ module Invoices
     end
 
     def boundaries
+      return @boundaries if @boundaries.present?
+
+      date_service = Subscriptions::DatesService.new_instance(
+        subscription,
+        Time.zone.now.to_date,
+        current_usage: true,
+      )
+
       {
-        from_date: from_date,
-        to_date: to_date,
-        charges_from_date: charges_from_date
+        from_date: date_service.from_date,
+        to_date: date_service.to_date,
+        charges_from_date: date_service.charges_from_date,
+        charges_to_date: date_service.charges_to_date,
+        issuing_date: date_service.next_end_of_period(Time.zone.now),
       }
     end
 
@@ -182,14 +125,14 @@ module Invoices
     end
 
     def cache_expiration
-      expiration = (to_date - Time.zone.today).to_i + 1
+      expiration = (boundaries[:charges_to_date] - Time.zone.today).to_i + 1
       expiration > 4 ? 4 : expiration
     end
 
     def format_usage
       {
-        from_date: charges_from_date.iso8601,
-        to_date: to_date.iso8601,
+        from_date: boundaries[:charges_from_date].iso8601,
+        to_date: boundaries[:charges_to_date].iso8601,
         issuing_date: invoice.issuing_date.iso8601,
         amount_cents: invoice.amount_cents,
         amount_currency: invoice.amount_currency,

--- a/app/services/subscriptions/dates/monthly_service.rb
+++ b/app/services/subscriptions/dates/monthly_service.rb
@@ -80,7 +80,7 @@ module Subscriptions
         month = nil
         day = subscription_date.day
 
-        if date.day <= day
+        if date.day < day
           year = date.month == 1 ? date.year - 1 : date.year
           month = date.month == 1 ? 12 : date.month - 1
         else

--- a/app/services/subscriptions/dates/monthly_service.rb
+++ b/app/services/subscriptions/dates/monthly_service.rb
@@ -94,7 +94,7 @@ module Subscriptions
       def compute_duration(from_date:)
         return Time.days_in_month(from_date.month, from_date.year) if calendar?
 
-        next_month_date = compute_to_date
+        next_month_date = compute_to_date(from_date)
         (next_month_date.to_date + 1.day - from_date.to_date).to_i
       end
     end

--- a/app/services/subscriptions/dates/weekly_service.rb
+++ b/app/services/subscriptions/dates/weekly_service.rb
@@ -57,6 +57,8 @@ module Subscriptions
       end
 
       def previous_anniversary_day(date)
+        return date if date.wday == subscription_date.wday
+
         date.prev_occurring(subscription_day_name)
       end
 

--- a/app/services/subscriptions/dates/weekly_service.rb
+++ b/app/services/subscriptions/dates/weekly_service.rb
@@ -19,24 +19,27 @@ module Subscriptions
         subscription.anniversary? ? previous_anniversary_day(base_date) : base_date.beginning_of_week
       end
 
-      def compute_to_date
+      def compute_to_date(from_date = compute_from_date)
         return from_date.end_of_week if calendar?
 
         from_date + 6.days
       end
 
       def compute_charges_from_date
-        return from_date if plan.pay_in_arrear?
+        # NOTE: when subscription is terminated, we must bill on the current period
+        if terminated?
+          return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_week
+        end
 
-        from_date - 1.week
+        return compute_from_date if plan.pay_in_arrear?
+
+        compute_from_date - 1.week
       end
 
       def compute_charges_to_date
-        return to_date if plan.pay_in_arrear?
+        return compute_charges_from_date.end_of_week if calendar?
 
-        # NOTE: In pay in advance scenario, from_date will be the begining of the new period.
-        #       To get the end of the previous one, we just have to take the day before
-        from_date - 1.day
+        compute_charges_from_date + 6.days
       end
 
       def compute_next_end_of_period(date)

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -6,7 +6,7 @@ module Subscriptions
       def first_month_in_yearly_period?
         return billing_date.month == 1 if calendar?
 
-        monthly_service.compute_from_date(billing_date - 1.month).month == subscription_date.month
+        monthly_service.compute_from_date(billing_date).month == subscription_date.month
       end
 
       private

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -27,7 +27,7 @@ module Subscriptions
         subscription.anniversary? ? previous_anniversary_day(base_date) : base_date.beginning_of_year
       end
 
-      def compute_to_date
+      def compute_to_date(from_date = compute_from_date)
         return from_date.end_of_year if subscription.calendar? || subscription_date.yday == 1
 
         year = from_date.year + 1
@@ -39,6 +39,11 @@ module Subscriptions
 
       def compute_charges_from_date
         return monthly_service.compute_charges_from_date if plan.bill_charges_monthly
+
+        if terminated?
+          return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_year
+        end
+
         return from_date if plan.pay_in_arrear?
         return base_date.beginning_of_year if calendar?
 
@@ -46,13 +51,10 @@ module Subscriptions
       end
 
       def compute_charges_to_date
-        return to_date if plan.pay_in_arrear?
+        return monthly_service.compute_charges_to_date if plan.bill_charges_monthly
+        return compute_charges_from_date.end_of_year if calendar?
 
-        # NOTE: In pay in advance scenario, from_date will be the begining of the new period.
-        #       To get the end of the previous one, we just have to take the day before
-        return from_date - 1.day unless plan.bill_charges_monthly
-
-        monthly_service.compute_charges_to_date
+        compute_to_date(compute_charges_from_date)
       end
 
       def compute_next_end_of_period(date)

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -95,6 +95,10 @@ module Subscriptions
       subscription.terminated? && plan.pay_in_arrear? && !subscription.downgraded?
     end
 
+    def terminated?
+      subscription.terminated? && !subscription.next_subscription
+    end
+
     # NOTE: Handle leap years and anniversary date > 28
     def build_date(year, month, day)
       days_count_in_month = Time.days_in_month(month, year)

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -307,7 +307,7 @@ html
         - if subscription? && subscription_fees(subscription.id).charge_kind.any?
           .body-1 Charges
           .mb-24.body-3
-            | List of charges used from #{invoice_subscription(subscription.id).from_date&.strftime('%b %d, %Y')} to #{invoice_subscription(subscription.id).to_date&.strftime('%b %d, %Y')}
+            | List of charges used from #{invoice_subscription(subscription.id).charges_from_date&.strftime('%b %d, %Y')} to #{invoice_subscription(subscription.id).charges_to_date&.strftime('%b %d, %Y')}
           .charge-details.mb-24
             table.charge-details-table width="100%"
               - subscription_fees(subscription.id).charge_kind.each do |fee|

--- a/schema.graphql
+++ b/schema.graphql
@@ -2663,10 +2663,8 @@ scalar ISO8601DateTime
 type Invoice {
   amountCents: Int!
   amountCurrency: CurrencyEnum!
-  chargesFromDate: ISO8601Date
   createdAt: ISO8601DateTime!
   fileUrl: String
-  fromDate: ISO8601Date!
   id: ID!
   invoiceType: InvoiceTypeEnum!
   issuingDate: ISO8601Date!
@@ -2675,7 +2673,6 @@ type Invoice {
   sequentialId: ID!
   status: InvoiceStatusTypeEnum!
   subscription: Subscription
-  toDate: ISO8601Date!
   totalAmountCents: Int!
   totalAmountCurrency: CurrencyEnum!
   updatedAt: ISO8601DateTime!
@@ -3400,7 +3397,6 @@ type Subscription {
   nextName: String
   nextPendingStartDate: ISO8601Date
   nextPlan: Plan
-  pendingStartDate: ISO8601Date
   plan: Plan!
   startedAt: ISO8601DateTime
   status: StatusTypeEnum

--- a/schema.json
+++ b/schema.json
@@ -8289,20 +8289,6 @@
               ]
             },
             {
-              "name": "chargesFromDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "createdAt",
               "description": null,
               "type": {
@@ -8327,24 +8313,6 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "fromDate",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601Date",
-                  "ofType": null
-                }
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -8481,24 +8449,6 @@
                 "kind": "OBJECT",
                 "name": "Subscription",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "toDate",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601Date",
-                  "ofType": null
-                }
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -12189,20 +12139,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Plan",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "pendingStartDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/models/invoice_subscription_spec.rb
+++ b/spec/models/invoice_subscription_spec.rb
@@ -55,6 +55,44 @@ RSpec.describe InvoiceSubscription, type: :model do
     end
   end
 
+  describe '#charges_from_date' do
+    it 'returns first fee charges_from_date' do
+      create(
+        :fee,
+        subscription_id: subscription.id,
+        invoice_id: invoice.id,
+        properties: { charges_from_date: '2022-01-01' },
+      )
+
+      expect(invoice_subscription.charges_from_date).to eq(Date.parse('2022-01-01'))
+    end
+
+    context 'when fees are empty' do
+      it 'returns nil' do
+        expect(invoice_subscription.charges_from_date).to be_nil
+      end
+    end
+  end
+
+  describe '#charges_to_date' do
+    it 'returns first fee charges_to_date' do
+      create(
+        :fee,
+        subscription_id: subscription.id,
+        invoice_id: invoice.id,
+        properties: { charges_to_date: '2022-01-31' },
+      )
+
+      expect(invoice_subscription.charges_to_date).to eq(Date.parse('2022-01-31'))
+    end
+
+    context 'when fees are empty' do
+      it 'returns nil' do
+        expect(invoice_subscription.charges_to_date).to be_nil
+      end
+    end
+  end
+
   describe '#charge_amount_cents' do
     it 'returns the sum of the related charge fees' do
       charge = create(:standard_charge)
@@ -133,6 +171,24 @@ RSpec.describe InvoiceSubscription, type: :model do
       )
 
       expect(invoice_subscription.total_amount_cents).to eq(350)
+    end
+  end
+
+  describe '#total_amount_currency' do
+    it 'returns the currency of the total amount' do
+      expect(invoice_subscription.total_amount_currency).to eq(subscription.plan.amount_currency)
+    end
+  end
+
+  describe '#charge_amount_currency' do
+    it 'returns the currency of the charge amount' do
+      expect(invoice_subscription.charge_amount_currency).to eq(subscription.plan.amount_currency)
+    end
+  end
+
+  describe '#subscription_amount_currency' do
+    it 'returns the currency of the subscription amount' do
+      expect(invoice_subscription.subscription_amount_currency).to eq(subscription.plan.amount_currency)
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe Subscription, type: :model do
 
       it { expect(previous_subscription).to be_upgraded }
 
-      it { expect(previous_subscription.next_pending_start_date).to be nil }
-
       context 'when previous plan was more expensive' do
         let(:previous_plan) do
           create(:plan, amount_cents: plan.amount_cents + 10)
@@ -46,14 +44,6 @@ RSpec.describe Subscription, type: :model do
         end
 
         it { expect(previous_subscription).not_to be_upgraded }
-      end
-
-      context 'when next subscription is pending' do
-        before do
-          subscription.update!(status: :pending)
-        end
-
-        it { expect(previous_subscription.next_pending_start_date).not_to be nil }
       end
     end
   end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Fees::ChargeService do
       from_date: subscription.started_at.to_date,
       to_date: subscription.started_at.end_of_month.to_date,
       charges_from_date: subscription.started_at.to_date,
+      charges_to_date: subscription.started_at.end_of_month.to_date,
     }
   end
 
@@ -148,6 +149,7 @@ RSpec.describe Fees::ChargeService do
           from_date: Time.zone.parse('15 Apr 2022 00:01:00').to_date,
           to_date: Time.zone.parse('30 Apr 2022 00:01:00').to_date,
           charges_from_date: subscription.started_at.to_date,
+          charges_to_date: Time.zone.parse('30 Apr 2022 00:01:00').to_date,
         }
       end
 

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -408,7 +408,7 @@ RSpec.describe Invoices::CreateService, type: :service do
       let(:timestamp) { Time.zone.now.beginning_of_month - 1.day }
       let(:started_at) { Time.zone.today - 3.months }
       let(:terminated_at) { timestamp - 2.days }
-      let(:previous_plan) { create(:plan, amount_cents: 10000, interval: :yearly, pay_in_advance: true) }
+      let(:previous_plan) { create(:plan, amount_cents: 10_000, interval: :yearly, pay_in_advance: true) }
 
       let(:previous_subscription) do
         create(
@@ -438,9 +438,9 @@ RSpec.describe Invoices::CreateService, type: :service do
 
         aggregate_failures do
           expect(result.invoice.fees.first.properties['to_date'])
-            .to eq (subscription.started_at.to_date.to_s).to_s
+            .to eq(subscription.started_at.to_date.end_of_month.to_s)
           expect(result.invoice.fees.first.properties['from_date'])
-            .to eq (subscription.started_at.to_date.to_s).to_s
+            .to eq(subscription.started_at.to_date.to_s)
           expect(result.invoice.total_amount_cents).to eq(0)
           expect(result.invoice.status).to eq('succeeded')
           expect(result.invoice.fees.charge_kind.count).to eq(0)

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -21,9 +21,8 @@ RSpec.describe Invoices::CreateService, type: :service do
     let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
     let(:timestamp) { Time.zone.now.beginning_of_month }
 
-    let(:plan) do
-      create(:plan, interval: 'monthly')
-    end
+    let(:plan) { create(:plan, interval: 'monthly', pay_in_advance: pay_in_advance) }
+    let(:pay_in_advance) { false }
 
     before do
       create(:standard_charge, plan: subscription.plan, charge_model: 'standard')
@@ -92,6 +91,74 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect do
             invoice_service.create
           end.to have_enqueued_job(Invoices::Payments::StripeCreateJob)
+        end
+      end
+
+      context 'when subscription is billed on anniversary date' do
+        let(:timestamp) { DateTime.parse('07 Mar 2022') }
+        let(:started_at) { DateTime.parse('06 Jun 2021').to_date }
+        let(:subscription_date) { started_at }
+
+        let(:subscription) do
+          create(
+            :subscription,
+            plan: plan,
+            subscription_date: subscription_date,
+            started_at: started_at,
+            billing_time: :anniversary,
+          )
+        end
+
+        it 'creates an invoice' do
+          result = invoice_service.create
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(result.invoice.fees.first.properties['to_date']).to eq('2022-03-05')
+            expect(result.invoice.fees.first.properties['from_date']).to eq('2022-02-06')
+            expect(result.invoice.subscriptions.first).to eq(subscription)
+            expect(result.invoice.issuing_date.to_date).to eq(timestamp)
+            expect(result.invoice.invoice_type).to eq('subscription')
+            expect(result.invoice.status).to eq('pending')
+            expect(result.invoice.fees.subscription_kind.count).to eq(1)
+            expect(result.invoice.fees.charge_kind.count).to eq(1)
+
+            expect(result.invoice.amount_cents).to eq(100)
+            expect(result.invoice.amount_currency).to eq('EUR')
+            expect(result.invoice.vat_amount_cents).to eq(20)
+            expect(result.invoice.vat_amount_currency).to eq('EUR')
+            expect(result.invoice.total_amount_cents).to eq(120)
+            expect(result.invoice.total_amount_currency).to eq('EUR')
+          end
+        end
+
+        context 'when plan is pay in advance' do
+          let(:pay_in_advance) { true }
+
+          it 'creates an invoice' do
+            result = invoice_service.create
+
+            aggregate_failures do
+              expect(result).to be_success
+
+              expect(result.invoice.fees.first.properties['to_date']).to eq('2022-04-05')
+              expect(result.invoice.fees.first.properties['from_date']).to eq('2022-03-06')
+              expect(result.invoice.subscriptions.first).to eq(subscription)
+              expect(result.invoice.issuing_date.to_date).to eq(timestamp)
+              expect(result.invoice.invoice_type).to eq('subscription')
+              expect(result.invoice.status).to eq('pending')
+              expect(result.invoice.fees.subscription_kind.count).to eq(1)
+              expect(result.invoice.fees.charge_kind.count).to eq(0)
+
+              expect(result.invoice.amount_cents).to eq(100)
+              expect(result.invoice.amount_currency).to eq('EUR')
+              expect(result.invoice.vat_amount_cents).to eq(20)
+              expect(result.invoice.vat_amount_currency).to eq('EUR')
+              expect(result.invoice.total_amount_cents).to eq(120)
+              expect(result.invoice.total_amount_currency).to eq('EUR')
+            end
+          end
         end
       end
     end
@@ -175,7 +242,7 @@ RSpec.describe Invoices::CreateService, type: :service do
       let(:timestamp) { Time.zone.now.beginning_of_week }
 
       let(:plan) do
-        create(:plan, interval: 'weekly')
+        create(:plan, interval: 'weekly', pay_in_advance: pay_in_advance)
       end
 
       it 'creates an invoice' do
@@ -190,6 +257,56 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
+        end
+      end
+
+      context 'when subscription is billed on anniversary date' do
+        let(:timestamp) { DateTime.parse('07 Mar 2022') }
+        let(:started_at) { DateTime.parse('06 Jun 2021').to_date }
+        let(:subscription_date) { started_at }
+
+        let(:subscription) do
+          create(
+            :subscription,
+            plan: plan,
+            subscription_date: subscription_date,
+            started_at: started_at,
+            billing_time: :anniversary,
+          )
+        end
+
+        it 'creates an invoice' do
+          result = invoice_service.create
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(result.invoice.fees.first.properties['to_date']).to eq('2022-03-05')
+            expect(result.invoice.fees.first.properties['from_date']).to eq('2022-02-27')
+            subscription.subscription_date
+            expect(result.invoice.subscriptions.first).to eq(subscription)
+            expect(result.invoice.fees.subscription_kind.count).to eq(1)
+            expect(result.invoice.fees.charge_kind.count).to eq(1)
+          end
+        end
+
+        context 'when plan is pay in advance' do
+          let(:pay_in_advance) { true }
+
+          it 'creates an invoice' do
+            result = invoice_service.create
+
+            aggregate_failures do
+              expect(result).to be_success
+
+              expect(result.invoice.fees.first.properties['to_date']).to eq('2022-03-12')
+              expect(result.invoice.fees.first.properties['from_date']).to eq('2022-03-06')
+              subscription.subscription_date
+              expect(result.invoice.subscriptions.first).to eq(subscription)
+              expect(result.invoice.fees.subscription_kind.count).to eq(1)
+              expect(result.invoice.fees.charge_kind.count).to eq(0)
+            end
+          end
         end
       end
     end
@@ -230,7 +347,7 @@ RSpec.describe Invoices::CreateService, type: :service do
       let(:timestamp) { Time.zone.now.beginning_of_year }
 
       let(:plan) do
-        create(:plan, interval: 'yearly')
+        create(:plan, interval: 'yearly', pay_in_advance: pay_in_advance)
       end
 
       it 'creates an invoice' do
@@ -268,6 +385,56 @@ RSpec.describe Invoices::CreateService, type: :service do
               expect(result.invoice.fees.charge_kind.count).to eq(1)
               expect(result.invoice.fees.first.properties['charges_from_date'])
                 .to eq (Time.zone.at(timestamp).to_date - 1.month).to_s
+            end
+          end
+        end
+      end
+
+      context 'when subscription is billed on anniversary date' do
+        let(:timestamp) { DateTime.parse('07 Jun 2022') }
+        let(:started_at) { DateTime.parse('06 Jun 2020').to_date }
+        let(:subscription_date) { started_at }
+
+        let(:subscription) do
+          create(
+            :subscription,
+            plan: plan,
+            subscription_date: subscription_date,
+            started_at: started_at,
+            billing_time: :anniversary,
+          )
+        end
+
+        it 'creates an invoice' do
+          result = invoice_service.create
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(result.invoice.fees.first.properties['to_date']).to eq('2022-06-05')
+            expect(result.invoice.fees.first.properties['from_date']).to eq('2021-06-06')
+            subscription.subscription_date
+            expect(result.invoice.subscriptions.first).to eq(subscription)
+            expect(result.invoice.fees.subscription_kind.count).to eq(1)
+            expect(result.invoice.fees.charge_kind.count).to eq(1)
+          end
+        end
+
+        context 'when plan is pay in advance' do
+          let(:pay_in_advance) { true }
+
+          it 'creates an invoice' do
+            result = invoice_service.create
+
+            aggregate_failures do
+              expect(result).to be_success
+
+              expect(result.invoice.fees.first.properties['to_date']).to eq('2023-06-05')
+              expect(result.invoice.fees.first.properties['from_date']).to eq('2022-06-06')
+              subscription.subscription_date
+              expect(result.invoice.subscriptions.first).to eq(subscription)
+              expect(result.invoice.fees.subscription_kind.count).to eq(1)
+              expect(result.invoice.fees.charge_kind.count).to eq(0)
             end
           end
         end
@@ -358,6 +525,36 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.fees.first.properties['from_date'])
             .to eq(terminated_at.to_date.beginning_of_month.to_s)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
+        end
+      end
+
+      context 'when subscription is billed on anniversary date' do
+        let(:timestamp) { DateTime.parse('07 Mar 2022') }
+        let(:started_at) { DateTime.parse('06 Jun 2021').to_date }
+        let(:subscription_date) { started_at }
+
+        let(:subscription) do
+          create(
+            :subscription,
+            plan: plan,
+            subscription_date: subscription_date,
+            started_at: started_at,
+            status: :terminated,
+            billing_time: :anniversary,
+            terminated_at: terminated_at,
+          )
+        end
+
+        it 'creates an invoice with subscription fee' do
+          result = invoice_service.create
+
+          aggregate_failures do
+            expect(result.invoice.fees.first.properties['to_date'])
+              .to eq(terminated_at.to_date.to_s)
+            expect(result.invoice.fees.first.properties['from_date'])
+              .to eq('2022-03-06')
+            expect(result.invoice.fees.subscription_kind.count).to eq(1)
+          end
         end
       end
     end

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
           expect(result.invoice.fees.first.properties['from_date']).to eq (timestamp - 1.month).to_date.to_s
           expect(result.invoice.subscriptions.first).to eq(subscription)
-          expect(result.invoice.issuing_date.to_date).to eq(timestamp - 1.day)
+          expect(result.invoice.issuing_date.to_date).to eq(timestamp)
           expect(result.invoice.invoice_type).to eq('subscription')
           expect(result.invoice.status).to eq('pending')
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
@@ -117,7 +117,7 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
           expect(result.invoice.fees.first.properties['from_date']).to eq (timestamp - 1.month).to_date.to_s
           expect(result.invoice.subscriptions).to eq(subscriptions)
-          expect(result.invoice.issuing_date.to_date).to eq(timestamp - 1.day)
+          expect(result.invoice.issuing_date.to_date).to eq(timestamp)
           expect(result.invoice.invoice_type).to eq('subscription')
           expect(result.invoice.status).to eq('pending')
           expect(result.invoice.fees.subscription_kind.count).to eq(2)
@@ -325,7 +325,7 @@ RSpec.describe Invoices::CreateService, type: :service do
         result = invoice_service.create
 
         aggregate_failures do
-          expect(result.invoice.issuing_date).to eq(timestamp - 1.day)
+          expect(result.invoice.issuing_date).to eq(timestamp)
         end
       end
     end
@@ -474,7 +474,7 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
           expect(result.invoice.fees.first.properties['from_date']).to eq (timestamp - 1.month).to_date.to_s
           expect(result.invoice.subscriptions.first).to eq(subscription)
-          expect(result.invoice.issuing_date.to_date).to eq(timestamp - 1.day)
+          expect(result.invoice.issuing_date.to_date).to eq(timestamp)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
 

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -354,9 +354,9 @@ RSpec.describe Invoices::CreateService, type: :service do
 
         aggregate_failures do
           expect(result.invoice.fees.first.properties['to_date'])
-            .to eq (terminated_at.to_date - 1.day).to_s
+            .to eq(terminated_at.to_date.to_s)
           expect(result.invoice.fees.first.properties['from_date'])
-            .to eq (terminated_at.to_date.beginning_of_month).to_s
+            .to eq(terminated_at.to_date.beginning_of_month.to_s)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
         end
       end
@@ -392,9 +392,9 @@ RSpec.describe Invoices::CreateService, type: :service do
 
         aggregate_failures do
           expect(result.invoice.fees.first.properties['to_date'])
-            .to eq (terminated_at.to_date - 1.day).to_s
+            .to eq(terminated_at.to_date.to_s)
           expect(result.invoice.fees.first.properties['from_date'])
-            .to eq (terminated_at.to_date.beginning_of_month).to_s
+            .to eq(terminated_at.to_date.beginning_of_month.to_s)
           expect(result.invoice.fees.charge_kind.count).to eq(0)
         end
       end

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -83,6 +83,111 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
           end
         end
       end
+
+      context 'when subscription is billed on anniversary date' do
+        let(:current_date) { DateTime.parse('2022-06-22') }
+        let(:started_at) { DateTime.parse('2022-03-07') }
+        let(:subscription_date) { started_at }
+
+        let(:subscription) do
+          create(
+            :subscription,
+            plan: plan,
+            customer: customer,
+            subscription_date: subscription_date,
+            started_at: started_at,
+            billing_time: :anniversary,
+          )
+        end
+
+        it 'initialize an invoice' do
+          travel_to(current_date) do
+            result = invoice_service.usage
+
+            aggregate_failures do
+              expect(result).to be_success
+
+              expect(result.usage.id).to be_nil
+              expect(result.usage.from_date.to_date.to_s).to eq('2022-06-07')
+              expect(result.usage.to_date.to_date.to_s).to eq('2022-07-06')
+              expect(result.usage.issuing_date).to eq('2022-07-06')
+              expect(result.usage.fees.size).to eq(1)
+
+              expect(result.usage.amount_cents).to eq(0)
+              expect(result.usage.amount_currency).to eq('EUR')
+              expect(result.usage.vat_amount_cents).to eq(0)
+              expect(result.usage.vat_amount_currency).to eq('EUR')
+              expect(result.usage.total_amount_cents).to eq(0)
+              expect(result.usage.total_amount_currency).to eq('EUR')
+            end
+          end
+        end
+      end
+    end
+
+    context 'when billed weekly' do
+      let(:plan) { create(:plan, interval: 'weekly') }
+
+      it 'intialize an invoice' do
+        result = invoice_service.usage
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.usage.id).to be_nil
+          expect(result.usage.from_date).to eq(Time.zone.today.beginning_of_week.iso8601)
+          expect(result.usage.to_date).to eq(Time.zone.today.end_of_week.iso8601)
+          expect(result.usage.issuing_date).to eq(Time.zone.today.end_of_week.iso8601)
+          expect(result.usage.fees.size).to eq(1)
+
+          expect(result.usage.amount_cents).to eq(0)
+          expect(result.usage.amount_currency).to eq('EUR')
+          expect(result.usage.vat_amount_cents).to eq(0)
+          expect(result.usage.vat_amount_currency).to eq('EUR')
+          expect(result.usage.total_amount_cents).to eq(0)
+          expect(result.usage.total_amount_currency).to eq('EUR')
+        end
+      end
+
+      context 'when subscription is billed on anniversary date' do
+        let(:current_date) { DateTime.parse('2022-06-22') }
+        let(:started_at) { DateTime.parse('2022-03-07') }
+        let(:subscription_date) { started_at }
+
+        let(:subscription) do
+          create(
+            :subscription,
+            plan: plan,
+            customer: customer,
+            subscription_date: subscription_date,
+            started_at: started_at,
+            billing_time: :anniversary,
+          )
+        end
+
+        it 'initialize an invoice' do
+          travel_to(current_date) do
+            result = invoice_service.usage
+
+            aggregate_failures do
+              expect(result).to be_success
+
+              expect(result.usage.id).to be_nil
+              expect(result.usage.from_date.to_date.to_s).to eq('2022-06-20')
+              expect(result.usage.to_date.to_date.to_s).to eq('2022-06-26')
+              expect(result.usage.issuing_date).to eq('2022-06-26')
+              expect(result.usage.fees.size).to eq(1)
+
+              expect(result.usage.amount_cents).to eq(0)
+              expect(result.usage.amount_currency).to eq('EUR')
+              expect(result.usage.vat_amount_cents).to eq(0)
+              expect(result.usage.vat_amount_currency).to eq('EUR')
+              expect(result.usage.total_amount_cents).to eq(0)
+              expect(result.usage.total_amount_currency).to eq('EUR')
+            end
+          end
+        end
+      end
     end
 
     context 'when billed yearly' do
@@ -106,6 +211,46 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
           expect(result.usage.vat_amount_currency).to eq('EUR')
           expect(result.usage.total_amount_cents).to eq(0)
           expect(result.usage.total_amount_currency).to eq('EUR')
+        end
+      end
+
+      context 'when subscription is billed on anniversary date' do
+        let(:current_date) { DateTime.parse('2022-06-22') }
+        let(:started_at) { DateTime.parse('2021-03-07') }
+        let(:subscription_date) { started_at }
+
+        let(:subscription) do
+          create(
+            :subscription,
+            plan: plan,
+            customer: customer,
+            subscription_date: subscription_date,
+            started_at: started_at,
+            billing_time: :anniversary,
+          )
+        end
+
+        it 'initialize an invoice' do
+          travel_to(current_date) do
+            result = invoice_service.usage
+
+            aggregate_failures do
+              expect(result).to be_success
+
+              expect(result.usage.id).to be_nil
+              expect(result.usage.from_date.to_date.to_s).to eq('2022-03-07')
+              expect(result.usage.to_date.to_date.to_s).to eq('2023-03-06')
+              expect(result.usage.issuing_date).to eq('2023-03-06')
+              expect(result.usage.fees.size).to eq(1)
+
+              expect(result.usage.amount_cents).to eq(0)
+              expect(result.usage.amount_currency).to eq('EUR')
+              expect(result.usage.vat_amount_cents).to eq(0)
+              expect(result.usage.vat_amount_currency).to eq('EUR')
+              expect(result.usage.total_amount_cents).to eq(0)
+              expect(result.usage.total_amount_currency).to eq('EUR')
+            end
+          end
         end
       end
     end

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('03 Mar 2022') }
+      let(:billing_date) { DateTime.parse('02 Mar 2022') }
 
       it 'returns the day in the previous month day' do
         expect(result).to eq('2022-02-02')
@@ -151,7 +151,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('04 Mar 2022') }
+      let(:billing_date) { DateTime.parse('02 Mar 2022') }
 
       it 'returns the day in the previous month' do
         expect(result).to eq('2022-03-01')
@@ -239,7 +239,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('03 Mar 2022') }
+      let(:billing_date) { DateTime.parse('02 Mar 2022') }
 
       it 'returns from_date' do
         expect(result).to eq(date_service.from_date.to_s)
@@ -297,7 +297,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('10 Mar 2022') }
+      let(:billing_date) { DateTime.parse('02 Mar 2022') }
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_date.to_s)
@@ -359,7 +359,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
     end
   end
 
-  describe 'compute_previous_beginning_of_period' do
+  describe 'previous_beginning_of_period' do
     let(:result) { date_service.previous_beginning_of_period(current_period: current_period).to_s }
 
     let(:current_period) { false }

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('10 Mar 2022') }
+      let(:billing_date) { DateTime.parse('09 Mar 2022') }
 
       it 'returns the previous week week day' do
         expect(result).to eq('2022-03-01')
@@ -139,7 +139,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('10 Mar 2022') }
+      let(:billing_date) { DateTime.parse('09 Mar 2022') }
 
       it 'returns the previous week week day' do
         expect(result).to eq('2022-03-07')
@@ -197,7 +197,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('10 Mar 2022') }
+      let(:billing_date) { DateTime.parse('09 Mar 2022') }
 
       it 'returns from_date' do
         expect(result).to eq(date_service.from_date.to_s)
@@ -254,7 +254,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('10 Mar 2022') }
+      let(:billing_date) { DateTime.parse('09 Mar 2022') }
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_date.to_s)

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('03 Feb 2022') }
+      let(:billing_date) { DateTime.parse('02 Feb 2022') }
 
       it 'returns the previous year day and month' do
         expect(result).to eq('2021-02-02')
@@ -94,7 +94,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
         context 'when subscription date on 29/02 of a leap year' do
           let(:subscription_date) { DateTime.parse('29 Feb 2020') }
-          let(:billing_date) { DateTime.parse('01 Mar 2022') }
+          let(:billing_date) { DateTime.parse('28 Mar 2022') }
 
           it 'returns the previous month last day' do
             expect(result).to eq('2022-02-28')
@@ -150,7 +150,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('03 Feb 2022') }
+      let(:billing_date) { DateTime.parse('02 Feb 2022') }
 
       it 'returns the previous year day and month' do
         expect(result).to eq('2022-02-01')
@@ -245,7 +245,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('03 Feb 2022') }
+      let(:billing_date) { DateTime.parse('02 Feb 2022') }
 
       it 'returns from_date' do
         expect(result).to eq(date_service.from_date.to_s)
@@ -352,7 +352,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('10 Mar 2022') }
+      let(:billing_date) { DateTime.parse('02 Feb 2022') }
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_date.to_s)

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -317,6 +317,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when billing charge monthly' do
+        let(:billing_date) { DateTime.parse('01 Jan 2022') }
+
         before { plan.update!(bill_charges_monthly: true) }
 
         it 'returns to_date' do
@@ -325,6 +327,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
         context 'when subscription terminated in the middle of a period' do
           let(:terminated_at) { DateTime.parse('10 Mar 2022') }
+          let(:billing_date) { DateTime.parse('07 Mar 2022') }
 
           before do
             subscription.update!(status: :terminated, terminated_at: terminated_at)
@@ -338,6 +341,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         context 'when plan is pay in advance' do
           let(:pay_in_advance) { true }
           let(:subscription_date) { DateTime.parse('02 Feb 2020') }
+          let(:billing_date) { DateTime.parse('07 Mar 2022') }
 
           it 'returns the end of the current period' do
             expect(result).to eq('2022-02-28')


### PR DESCRIPTION
## Context

We want to add the ability to choose to bill users at subscription date anniversary and not only on a calendar basis.

## Description

This pull request is the last one for this feature.
It uses the previously introduce `Subscriptions::DatesService` into the invoice and fees creation logic in order to make it easier to understand and to allow the usage of the `anniversary` billing time.

All date management is removed from `Invoices::CreateService`, `Fees::SubscriptionService`, `Fees::ChargeService` and `Invoices::CustomerUsageService` and delegated to the `Subscriptions::DatesService` and its subclasses

## Related Task

It should be merged before https://github.com/getlago/lago-api/pull/365 and https://github.com/getlago/lago-api/pull/364

## How Has This Been Tested?

A huge QA will be performed on a staging branch before merging this branch