### PR TITLE
feat(free-units): Calculate percentage based on fixed amount and free units

### DIFF
--- a/app/services/charges/charge_models/base_service.rb
+++ b/app/services/charges/charge_models/base_service.rb
@@ -23,6 +23,8 @@ module Charges
 
       attr_accessor :charge, :aggregation_result
 
+      delegate :units, to: :result
+
       def compute_amount(value)
         raise NotImplementedError
       end

--- a/app/services/charges/charge_models/base_service.rb
+++ b/app/services/charges/charge_models/base_service.rb
@@ -3,20 +3,25 @@
 module Charges
   module ChargeModels
     class BaseService < ::BaseService
-      def initialize(charge:)
-        super(nil)
-        @charge = charge
+      def self.apply(...)
+        new(...).apply
       end
 
-      def apply(value:)
-        result.units = value
-        result.amount = compute_amount(value)
+      def initialize(charge:, aggregation_result:)
+        super(nil)
+        @charge = charge
+        @aggregation_result = aggregation_result
+      end
+
+      def apply
+        result.units = aggregation_result.aggregation
+        result.amount = compute_amount
         result
       end
 
       protected
 
-      attr_accessor :charge
+      attr_accessor :charge, :aggregation_result
 
       def compute_amount(value)
         raise NotImplementedError

--- a/app/services/charges/charge_models/graduated_service.rb
+++ b/app/services/charges/charge_models/graduated_service.rb
@@ -9,7 +9,7 @@ module Charges
         charge.properties.map(&:with_indifferent_access)
       end
 
-      def compute_amount(value)
+      def compute_amount
         ranges.reduce(0) do |result_amount, range|
           flat_amount = BigDecimal(range[:flat_amount])
           per_unit_amount = BigDecimal(range[:per_unit_amount])
@@ -17,10 +17,10 @@ module Charges
           # NOTE: Add flat amount to the total
           result_amount += flat_amount unless value.zero?
 
-          units = compute_range_units(range[:from_value], range[:to_value], value)
+          units = compute_range_units(range[:from_value], range[:to_value])
           result_amount += units * per_unit_amount
 
-          # NOTE: value is between the bounds of the current range,
+          # NOTE: aggregation_result.aggregation is between the bounds of the current range,
           #       we must stop the loop
           break result_amount if range[:to_value].nil? || range[:to_value] >= value
 
@@ -29,7 +29,7 @@ module Charges
       end
 
       # NOTE: compute how many units to bill in the range
-      def compute_range_units(from_value, to_value, value)
+      def compute_range_units(from_value, to_value)
         # NOTE: value is higher than the to_value of the range
         if to_value && value >= to_value
           return to_value - (from_value.zero? ? 1 : from_value) + 1
@@ -40,6 +40,10 @@ module Charges
 
         # NOTE: value is in the range
         value - from_value + 1
+      end
+
+      def value
+        aggregation_result.aggregation
       end
     end
   end

--- a/app/services/charges/charge_models/graduated_service.rb
+++ b/app/services/charges/charge_models/graduated_service.rb
@@ -15,14 +15,14 @@ module Charges
           per_unit_amount = BigDecimal(range[:per_unit_amount])
 
           # NOTE: Add flat amount to the total
-          result_amount += flat_amount unless value.zero?
+          result_amount += flat_amount unless units.zero?
 
-          units = compute_range_units(range[:from_value], range[:to_value])
-          result_amount += units * per_unit_amount
+          range_units = compute_range_units(range[:from_value], range[:to_value])
+          result_amount += range_units * per_unit_amount
 
           # NOTE: aggregation_result.aggregation is between the bounds of the current range,
           #       we must stop the loop
-          break result_amount if range[:to_value].nil? || range[:to_value] >= value
+          break result_amount if range[:to_value].nil? || range[:to_value] >= units
 
           result_amount
         end
@@ -30,20 +30,16 @@ module Charges
 
       # NOTE: compute how many units to bill in the range
       def compute_range_units(from_value, to_value)
-        # NOTE: value is higher than the to_value of the range
-        if to_value && value >= to_value
+        # NOTE: units is higher than the to_value of the range
+        if to_value && units >= to_value
           return to_value - (from_value.zero? ? 1 : from_value) + 1
         end
 
-        return to_value - from_value if to_value && value >= to_value
-        return value if from_value.zero?
+        return to_value - from_value if to_value && units >= to_value
+        return units if from_value.zero?
 
-        # NOTE: value is in the range
-        value - from_value + 1
-      end
-
-      def value
-        aggregation_result.aggregation
+        # NOTE: units is in the range
+        units - from_value + 1
       end
     end
   end

--- a/app/services/charges/charge_models/package_service.rb
+++ b/app/services/charges/charge_models/package_service.rb
@@ -7,7 +7,7 @@ module Charges
 
       def compute_amount
         # NOTE: exclude free units from the count
-        billed_units = aggregation_result.aggregation - free_units
+        billed_units = units - free_units
         return 0 if billed_units.negative?
 
         # NOTE: Check how many packages (groups of units) are consumed

--- a/app/services/charges/charge_models/package_service.rb
+++ b/app/services/charges/charge_models/package_service.rb
@@ -5,9 +5,9 @@ module Charges
     class PackageService < Charges::ChargeModels::BaseService
       protected
 
-      def compute_amount(value)
+      def compute_amount
         # NOTE: exclude free units from the count
-        billed_units = value - free_units
+        billed_units = aggregation_result.aggregation - free_units
         return 0 if billed_units.negative?
 
         # NOTE: Check how many packages (groups of units) are consumed

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -5,22 +5,48 @@ module Charges
     class PercentageService < Charges::ChargeModels::BaseService
       protected
 
-      def compute_amount(value)
-        compute_percentage_amount(value) + compute_fixed_amount(value)
+      def compute_amount
+        compute_percentage_amount + compute_fixed_amount
       end
 
-      def compute_percentage_amount(value)
-        value * (rate.fdiv(100))
+      def compute_percentage_amount
+        return 0 if free_units_value > aggregation_result.aggregation
+
+        (aggregation_result.aggregation - free_units_value) * rate.fdiv(100)
       end
 
-      def compute_fixed_amount(value)
-        return 0 if value.zero?
+      def compute_fixed_amount
+        return 0 if aggregation_result.aggregation.zero?
         return 0 if fixed_amount.nil?
 
-        value * fixed_amount
+        (aggregation_result.count - free_units_count) * fixed_amount
       end
 
-      # NOTE: FE divides percentage rate with 100 and sends to BE
+      def free_units_value
+        return last_running_total unless last_running_total > free_units_per_total_aggregation
+
+        free_units_per_total_aggregation.to_i
+      end
+
+      def free_units_count
+        return free_units_per_events unless last_running_total > free_units_per_total_aggregation
+
+        aggregation_result.options[:running_total].count { |e| e < free_units_per_total_aggregation }
+      end
+
+      def last_running_total
+        @last_running_total ||= aggregation_result.options[:running_total].last
+      end
+
+      def free_units_per_total_aggregation
+        @free_units_per_total_aggregation ||= BigDecimal(charge.properties['free_units_per_total_aggregation'] || 0)
+      end
+
+      def free_units_per_events
+        @free_units_per_events ||= charge.properties['free_units_per_events'].to_i
+      end
+
+      # NOTE: FE divides percentage rate with 100 and sends to BE.
       def rate
         BigDecimal(charge.properties['rate'])
       end

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -10,13 +10,13 @@ module Charges
       end
 
       def compute_percentage_amount
-        return 0 if free_units_value > aggregation_result.aggregation
+        return 0 if free_units_value > units
 
-        (aggregation_result.aggregation - free_units_value) * rate.fdiv(100)
+        (units - free_units_value) * rate.fdiv(100)
       end
 
       def compute_fixed_amount
-        return 0 if aggregation_result.aggregation.zero?
+        return 0 if units.zero?
         return 0 if fixed_amount.nil?
 
         (aggregation_result.count - free_units_count) * fixed_amount

--- a/app/services/charges/charge_models/standard_service.rb
+++ b/app/services/charges/charge_models/standard_service.rb
@@ -6,7 +6,7 @@ module Charges
       protected
 
       def compute_amount
-        (aggregation_result.aggregation * BigDecimal(charge.properties['amount']))
+        (units * BigDecimal(charge.properties['amount']))
       end
     end
   end

--- a/app/services/charges/charge_models/standard_service.rb
+++ b/app/services/charges/charge_models/standard_service.rb
@@ -5,8 +5,8 @@ module Charges
     class StandardService < Charges::ChargeModels::BaseService
       protected
 
-      def compute_amount(value)
-        (value * BigDecimal(charge.properties['amount']))
+      def compute_amount
+        (aggregation_result.aggregation * BigDecimal(charge.properties['amount']))
       end
     end
   end

--- a/spec/services/charges/charge_models/graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/graduated_service_spec.rb
@@ -3,7 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
-  subject(:graduated_service) { described_class.new(charge: charge) }
+  subject(:apply_graduated_service) do
+    described_class.apply(charge: charge, aggregation_result: aggregation_result)
+  end
+
+  before do
+    aggregation_result.aggregation = aggregation
+  end
+
+  let(:aggregation_result) { BaseService::Result.new }
 
   let(:charge) do
     create(
@@ -31,27 +39,51 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
     )
   end
 
-  it 'does not apply the flat amount for 0' do
-    expect(graduated_service.apply(value: 0).amount).to eq(0)
+  context 'when aggregation is 0' do
+    let(:aggregation) { 0 }
+
+    it 'does not apply the flat amount' do
+      expect(apply_graduated_service.amount).to eq(0)
+    end
   end
 
-  it 'applies a unit amount for 1 and the flat rate for 1' do
-    expect(graduated_service.apply(value: 1).amount).to eq(12)
+  context 'when aggregation is 1' do
+    let(:aggregation) { 1 }
+
+    it 'applies a unit amount for 1 and the flat rate for 1' do
+      expect(apply_graduated_service.amount).to eq(12)
+    end
   end
 
-  it 'applies all unit amount for top bound' do
-    expect(graduated_service.apply(value: 10).amount).to eq(102)
+  context 'when aggregation is 10' do
+    let(:aggregation) { 10 }
+
+    it 'applies all unit amount for top bound' do
+      expect(apply_graduated_service.amount).to eq(102)
+    end
   end
 
-  it 'applies next range flat amount for the next step' do
-    expect(graduated_service.apply(value: 11).amount).to eq(110)
+  context 'when aggregation is 11' do
+    let(:aggregation) { 11 }
+
+    it 'applies next range flat amount for the next step' do
+      expect(apply_graduated_service.amount).to eq(110)
+    end
   end
 
-  it 'applies next unit amount for more unit in next step' do
-    expect(graduated_service.apply(value: 12).amount).to eq(115)
+  context 'when aggregation is 12' do
+    let(:aggregation) { 12 }
+
+    it 'applies next unit amount for more unit in next step' do
+      expect(apply_graduated_service.amount).to eq(115)
+    end
   end
 
-  it 'applies last unit amount for more unit in last step' do
-    expect(graduated_service.apply(value: 21).amount).to eq(163)
+  context 'when aggregation is 21' do
+    let(:aggregation) { 21 }
+
+    it 'applies last unit amount for more unit in last step' do
+      expect(apply_graduated_service.amount).to eq(163)
+    end
   end
 end

--- a/spec/services/charges/charge_models/package_service_spec.rb
+++ b/spec/services/charges/charge_models/package_service_spec.rb
@@ -3,7 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe Charges::ChargeModels::PackageService, type: :service do
-  subject(:package_service) { described_class.new(charge: charge) }
+  subject(:apply_package_service) do
+    described_class.apply(charge: charge, aggregation_result: aggregation_result)
+  end
+
+  before do
+    aggregation_result.aggregation = aggregation
+  end
+
+  let(:aggregation_result) { BaseService::Result.new }
+  let(:aggregation) { 121 }
 
   let(:charge) do
     create(
@@ -17,20 +26,20 @@ RSpec.describe Charges::ChargeModels::PackageService, type: :service do
   end
 
   it 'applies the package size to the value' do
-    expect(package_service.apply(value: 121).amount).to eq(1300)
+    expect(apply_package_service.amount).to eq(1300)
   end
 
   context 'with free_units' do
     before { charge.properties['free_units'] = 10 }
 
     it 'substracts the free units from the value' do
-      expect(package_service.apply(value: 121).amount).to eq(1200)
+      expect(apply_package_service.amount).to eq(1200)
     end
 
     context 'when free units is higher than the value' do
       before { charge.properties['free_units'] = 200 }
 
-      it { expect(package_service.apply(value: 121).amount).to eq(0) }
+      it { expect(apply_package_service.amount).to eq(0) }
     end
   end
 end

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -3,53 +3,62 @@
 require 'rails_helper'
 
 RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
-  subject(:percentage_service) { described_class.new(charge: charge) }
+  subject(:apply_percentage_service) do
+    described_class.apply(charge: charge, aggregation_result: aggregation_result)
+  end
+
+  before do
+    aggregation_result.aggregation = aggregation
+    aggregation_result.count = 4
+    aggregation_result.options = { running_total: [50, 150, 400] }
+  end
+
+  let(:aggregation_result) { BaseService::Result.new }
+  let(:fixed_amount) { '2.0' }
+  let(:aggregation) { 800 }
+  let(:free_units_per_events) { 3 }
+  let(:free_units_per_total_aggregation) { '250.0' }
+
+  let(:expected_percentage_amount) { (800 - 250) * (1.3 / 100) }
+  let(:expected_fixed_amount) { (4 - 2) * 2.0 }
 
   let(:charge) do
     create(
       :percentage_charge,
       properties: {
-        rate: '5.55',
-        fixed_amount: '0',
+        rate: '1.3',
+        fixed_amount: fixed_amount,
+        free_units_per_events: free_units_per_events,
+        free_units_per_total_aggregation: free_units_per_total_aggregation,
       },
     )
   end
 
-  context 'when fixed amount value is zero' do
-    it 'applies the percentage rate to the value' do
-      expect(percentage_service.apply(value: 100).amount).to eq(5.55)
+  context 'when aggregation value is 0' do
+    let(:aggregation) { 0 }
+
+    it 'returns 0' do
+      expect(apply_percentage_service.amount).to eq(0)
     end
   end
 
-  context 'when fixed amount value is nil and fixed amount target is nil' do
-    let(:charge) do
-      create(
-        :percentage_charge,
-        properties: {
-          rate: '5.55',
-          fixed_amount: nil,
-        },
+  context 'when fixed amount value is 0' do
+    it 'returns expected percentage amount' do
+      expect(apply_percentage_service.amount).to eq(
+        (expected_percentage_amount + expected_fixed_amount)
       )
-    end
-
-    it 'applies the percentage rate to the value' do
-      expect(percentage_service.apply(value: 100).amount).to eq(5.55)
     end
   end
 
-  context 'when fixed amount value is NOT zero' do
-    let(:charge) do
-      create(
-        :percentage_charge,
-        properties: {
-          rate: '5.55',
-          fixed_amount: '2',
-        },
-      )
-    end
+  context 'when free_units_per_total_aggregation > last running total' do
+    let(:free_units_per_total_aggregation) { '500.0' }
+    let(:expected_percentage_amount) { (800 - 400) * (1.3 / 100) }
+    let(:expected_fixed_amount) { (4 - 3) * 2.0 }
 
-    it 'applies the percentage rate and the additional charge on each unit' do
-      expect(percentage_service.apply(value: 100).amount).to eq(205.55)
+    it 'returns expected percentage amount based on last running total' do
+      expect(apply_percentage_service.amount).to eq(
+        (expected_percentage_amount + expected_fixed_amount)
+      )
     end
   end
 end

--- a/spec/services/charges/charge_models/standard_service_spec.rb
+++ b/spec/services/charges/charge_models/standard_service_spec.rb
@@ -3,7 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe Charges::ChargeModels::StandardService, type: :service do
-  subject(:standard_service) { described_class.new(charge: charge) }
+  subject(:apply_standard_service) do
+    described_class.apply(charge: charge, aggregation_result: aggregation_result)
+  end
+
+  before do
+    aggregation_result.aggregation = aggregation
+  end
+
+  let(:aggregation_result) { BaseService::Result.new }
+  let(:aggregation) { 10 }
 
   let(:charge) do
     create(
@@ -15,7 +24,7 @@ RSpec.describe Charges::ChargeModels::StandardService, type: :service do
     )
   end
 
-  it 'apply the charge model to the value' do
-    expect(standard_service.apply(value: 10).amount).to eq(5000)
+  it 'applies the charge model to the value' do
+    expect(apply_standard_service.amount).to eq(5000)
   end
 end


### PR DESCRIPTION
## Context

We want to add the ability to:
- Apply a fixed fee per distinct transaction
- Apply free units on the number of distinct transactions or on the monetary total amount

## Description

This is the third step of adding fixed amount and free units to the percentage charge.

The goal of this PR is to:
- Calculate percentage charge based on fixed amount
- Calculate percentage charge based on free units (per aggregation or per events)

## Related Task

https://github.com/getlago/lago/issues/92

## How Has This Been Tested?

A full QA will be performed when the feature will be 100% implemented.
