### PR TITLE
misc: Add CORS origin env var for CI docker compose

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -24,6 +24,7 @@ services:
     environment:
       RAILS_ENV: production
       DATABASE_URL: postgres://lago:lago@db:5432/lago
+      LAGO_FRONT_URL: http://localhost
       SECRET_KEY_BASE: secret-key
       LAGO_RSA_PRIVATE_KEY: ${LAGO_RSA_PRIVATE_KEY}
       LAGO_DISABLE_SEGMENT: "true"


### PR DESCRIPTION
## Context

We have to support the CORS policy on CI environment

## Description

- Add the `LAGO_FRONT_URL` for the CI `docker-compose.ci.yml` file

