### PR TITLE
Remove plan charge currency

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -9,7 +9,7 @@ module Api
           **input_params
             .merge(organization_id: current_organization.id)
             .to_h
-            .deep_symbolize_keys
+            .deep_symbolize_keys,
         )
 
         if result.success?
@@ -38,7 +38,7 @@ module Api
         service = Plans::DestroyService.new
         result = service.destroy_from_api(
           organization: current_organization,
-          code: params[:code]
+          code: params[:code],
         )
 
         if result.success?
@@ -50,7 +50,7 @@ module Api
 
       def show
         plan = current_organization.plans.find_by(
-          code: params[:code]
+          code: params[:code],
         )
 
         return not_found_error unless plan
@@ -60,9 +60,9 @@ module Api
 
       def index
         plans = current_organization.plans
-                                    .order(created_at: :desc)
-                                    .page(params[:page])
-                                    .per(params[:per_page] || PER_PAGE)
+          .order(created_at: :desc)
+          .page(params[:page])
+          .per(params[:per_page] || PER_PAGE)
 
         render(
           json: ::CollectionSerializer.new(
@@ -71,7 +71,7 @@ module Api
             collection_name: 'plans',
             meta: pagination_metadata(plans),
             includes: %i[charges],
-          )
+          ),
         )
       end
 
@@ -88,7 +88,7 @@ module Api
           :trial_period,
           :pay_in_advance,
           :bill_charges_monthly,
-          charges: [:id, :billable_metric_id, :amount_currency, :charge_model],
+          charges: [:id, :billable_metric_id, :charge_model],
         ).tap do |permitted_params|
           # NOTE: Charges properties can have 2 differents formats
           # - An array if the charge model need many ranges (ie: graduated)

--- a/app/graphql/types/charges/input.rb
+++ b/app/graphql/types/charges/input.rb
@@ -8,7 +8,6 @@ module Types
       argument :id, ID, required: false
       argument :billable_metric_id, ID, required: true
       argument :charge_model, Types::Charges::ChargeModelEnum, required: true
-      argument :amount_currency, Types::CurrencyEnum, required: true
 
       # NOTE: Standard and Package charge model
       argument :amount, String, required: false

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -8,7 +8,6 @@ module Types
       field :id, ID, null: false
       field :billable_metric, Types::BillableMetrics::Object, null: false
       field :charge_model, Types::Charges::ChargeModelEnum, null: false
-      field :amount_currency, Types::CurrencyEnum, null: true
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/charges/usage.rb
+++ b/app/graphql/types/charges/usage.rb
@@ -7,7 +7,6 @@ module Types
 
       field :units, GraphQL::Types::Float, null: false
       field :amount_cents, GraphQL::Types::BigInt, null: false
-      field :amount_currency, Types::CurrencyEnum, null: false
 
       field :charge, Types::Charges::Object, null: false
       field :billable_metric, Types::BillableMetrics::Object, null: false

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -18,7 +18,6 @@ class Charge < ApplicationRecord
 
   enum charge_model: CHARGE_MODELS
 
-  validates :amount_currency, inclusion: { in: currency_list }
   validate :validate_amount, if: :standard?
   validate :validate_graduated_range, if: :graduated?
   validate :validate_package, if: :package?

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 module V1
   class ChargeSerializer < ModelSerializer
     def serialize
@@ -7,7 +7,6 @@ module V1
         lago_id: model.id,
         lago_billable_metric_id: model.billable_metric_id,
         created_at: model.created_at.iso8601,
-        amount_currency: model.amount_currency,
         charge_model: model.charge_model,
         properties: model.properties,
       }

--- a/app/serializers/v1/charge_usage_serializer.rb
+++ b/app/serializers/v1/charge_usage_serializer.rb
@@ -16,7 +16,7 @@ module V1
           name: model.billable_metric.name,
           code: model.billable_metric.code,
           aggregation_type: model.billable_metric.aggregation_type,
-        }
+        },
       }
     end
   end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -49,7 +49,7 @@ module Fees
         subscription: subscription,
         charge: charge,
         amount_cents: amount_cents,
-        amount_currency: charge.amount_currency,
+        amount_currency: currency,
         vat_rate: customer.applicable_vat_rate,
         units: amount_result.units,
         properties: boundaries.to_h,

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -42,7 +42,6 @@ module Plans
     def create_charge(plan, args)
       plan.charges.create!(
         billable_metric_id: args[:billable_metric_id],
-        amount_currency: args[:amount_currency],
         charge_model: args[:charge_model]&.to_sym,
         properties: args[:properties] || {},
       )

--- a/db/migrate/20220818151052_remove_amount_currency_null_constraint_from_charges.rb
+++ b/db/migrate/20220818151052_remove_amount_currency_null_constraint_from_charges.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveAmountCurrencyNullConstraintFromCharges < ActiveRecord::Migration[7.0]
+  def up
+    change_column :charges, :amount_currency, :string, null: true
+  end
+
+  def down
+    change_column :charges, :amount_currency, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_18_141616) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_18_151052) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -101,7 +101,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_18_141616) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "plan_id"
-    t.string "amount_currency", null: false
+    t.string "amount_currency"
     t.integer "charge_model", default: 0, null: false
     t.jsonb "properties", default: "{}", null: false
     t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -135,7 +135,6 @@ enum BillingTimeEnum {
 
 type Charge {
   amount: String
-  amountCurrency: CurrencyEnum
   billableMetric: BillableMetric!
   chargeModel: ChargeModelEnum!
   createdAt: ISO8601DateTime!
@@ -152,7 +151,6 @@ type Charge {
 
 input ChargeInput {
   amount: String
-  amountCurrency: CurrencyEnum!
   billableMetricId: ID!
   chargeModel: ChargeModelEnum!
   fixedAmount: String
@@ -175,7 +173,6 @@ enum ChargeModelEnum {
 
 type ChargeUsage {
   amountCents: BigInt!
-  amountCurrency: CurrencyEnum!
   billableMetric: BillableMetric!
   charge: Charge!
   units: Float!

--- a/schema.json
+++ b/schema.json
@@ -1264,20 +1264,6 @@
               ]
             },
             {
-              "name": "amountCurrency",
-              "description": null,
-              "type": {
-                "kind": "ENUM",
-                "name": "CurrencyEnum",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "billableMetric",
               "description": null,
               "type": {
@@ -1530,22 +1516,6 @@
               "deprecationReason": null
             },
             {
-              "name": "amountCurrency",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "CurrencyEnum",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "amount",
               "description": null,
               "type": {
@@ -1711,24 +1681,6 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "amountCurrency",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "CurrencyEnum",
                   "ofType": null
                 }
               },

--- a/spec/factories/charge_factory.rb
+++ b/spec/factories/charge_factory.rb
@@ -5,8 +5,6 @@ FactoryBot.define do
     billable_metric
     plan
 
-    amount_currency { 'EUR' }
-
     factory :standard_charge do
       charge_model { 'standard' }
       properties do

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -47,12 +47,10 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
             {
               billableMetricId: billable_metrics.first.id,
               amount: '100.00',
-              amountCurrency: 'USD',
               chargeModel: 'standard',
             },
             {
               billableMetricId: billable_metrics.second.id,
-              amountCurrency: 'EUR',
               chargeModel: 'package',
               amount: '300.00',
               freeUnits: 10,
@@ -60,7 +58,6 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
             },
             {
               billableMetricId: billable_metrics.third.id,
-              amountCurrency: 'EUR',
               chargeModel: 'percentage',
               rate: '0.25',
               fixedAmount: '2',
@@ -69,7 +66,6 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
             },
             {
               billableMetricId: billable_metrics.last.id,
-              amountCurrency: 'EUR',
               chargeModel: 'graduated',
               graduatedRanges: [
                 {

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -48,12 +48,10 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
             {
               billableMetricId: billable_metrics.first.id,
               amount: '100',
-              amountCurrency: 'USD',
               chargeModel: 'standard',
             },
             {
               billableMetricId: billable_metrics.second.id,
-              amountCurrency: 'EUR',
               chargeModel: 'package',
               amount: '300',
               freeUnits: 10,
@@ -61,7 +59,6 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
             },
             {
               billableMetricId: billable_metrics.third.id,
-              amountCurrency: 'EUR',
               chargeModel: 'percentage',
               rate: '0.25',
               fixedAmount: '2',
@@ -70,7 +67,6 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
             },
             {
               billableMetricId: billable_metrics.last.id,
-              amountCurrency: 'EUR',
               chargeModel: 'graduated',
               graduatedRanges: [
                 {

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -105,7 +105,6 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
       expect(charge_usage['charge']['chargeModel']).to eq('graduated')
       expect(charge_usage['units']).to eq(4.0)
       expect(charge_usage['amountCents']).to eq('5')
-      expect(charge_usage['amountCurrency']).to eq('EUR')
     end
   end
 end

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
             charge { chargeModel }
             units
             amountCents
-            amountCurrency
           }
         }
       }
@@ -82,7 +81,7 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
       query: query,
       variables: {
         customerId: customer.id,
-        subscriptionId: subscription.id
+        subscriptionId: subscription.id,
       },
     )
 

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -21,12 +21,11 @@ RSpec.describe Api::V1::PlansController, type: :request do
           {
             billable_metric_id: billable_metric.id,
             charge_model: 'standard',
-            amount_currency: 'EUR',
             properties: {
-              amount: '0.22'
-            }
-          }
-        ]
+              amount: '0.22',
+            },
+          },
+        ],
       }
     end
 
@@ -58,7 +57,6 @@ RSpec.describe Api::V1::PlansController, type: :request do
             {
               billable_metric_id: billable_metric.id,
               charge_model: 'graduated',
-              amount_currency: 'EUR',
               properties: [
                 {
                   to_value: 1,
@@ -77,12 +75,12 @@ RSpec.describe Api::V1::PlansController, type: :request do
           ],
         }
       end
-    
+
       it 'creates a plan' do
         post_with_token(organization, '/api/v1/plans', { plan: create_params })
-    
+
         expect(response).to have_http_status(:success)
-    
+
         result = JSON.parse(response.body, symbolize_names: true)[:plan]
         expect(result[:lago_id]).to be_present
         expect(result[:code]).to eq(create_params[:code])
@@ -110,19 +108,19 @@ RSpec.describe Api::V1::PlansController, type: :request do
           {
             billable_metric_id: billable_metric.id,
             charge_model: 'standard',
-            amount_currency: 'EUR',
             properties: {
-              amount: '0.22'
-            }
-          }
-        ]
+              amount: '0.22',
+            },
+          },
+        ],
       }
     end
 
     it 'updates a plan' do
-      put_with_token(organization,
-                     "/api/v1/plans/#{plan.code}",
-                     { plan: update_params }
+      put_with_token(
+        organization,
+        "/api/v1/plans/#{plan.code}",
+        { plan: update_params },
       )
 
       expect(response).to have_http_status(:success)
@@ -148,9 +146,10 @@ RSpec.describe Api::V1::PlansController, type: :request do
       before { plan2 }
 
       it 'returns unprocessable_entity error' do
-        put_with_token(organization,
-                       "/api/v1/plans/#{plan.code}",
-                       { plan: update_params }
+        put_with_token(
+          organization,
+          "/api/v1/plans/#{plan.code}",
+          { plan: update_params },
         )
 
         expect(response).to have_http_status(:unprocessable_entity)
@@ -164,7 +163,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
     it 'returns a plan' do
       get_with_token(
         organization,
-        "/api/v1/plans/#{plan.code}"
+        "/api/v1/plans/#{plan.code}",
       )
 
       expect(response).to have_http_status(:success)
@@ -179,7 +178,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
       it 'returns not found' do
         get_with_token(
           organization,
-          "/api/v1/plans/555"
+          "/api/v1/plans/555",
         )
 
         expect(response).to have_http_status(:not_found)

--- a/spec/serializers/v1/charge_serializer_spec.rb
+++ b/spec/serializers/v1/charge_serializer_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe ::V1::ChargeSerializer do
       expect(result['charge']['lago_id']).to eq(charge.id)
       expect(result['charge']['lago_billable_metric_id']).to eq(charge.billable_metric_id)
       expect(result['charge']['created_at']).to eq(charge.created_at.iso8601)
-      expect(result['charge']['amount_currency']).to eq(charge.amount_currency)
       expect(result['charge']['charge_model']).to eq(charge.charge_model)
       expect(result['charge']['properties']).to eq(charge.properties)
     end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Plans::CreateService, type: :service do
         charges: [
           {
             billable_metric_id: billable_metrics.first.id,
-            amount_currency: 'USD',
             charge_model: 'standard',
             properties: {
               amount: '100',
@@ -32,7 +31,6 @@ RSpec.describe Plans::CreateService, type: :service do
           },
           {
             billable_metric_id: billable_metrics.last.id,
-            amount_currency: 'EUR',
             charge_model: 'graduated',
             properties: [
               {
@@ -85,8 +83,8 @@ RSpec.describe Plans::CreateService, type: :service do
           nb_percentage_charges: 0,
           nb_graduated_charges: 1,
           nb_package_charges: 0,
-          organization_id: plan.organization_id
-        }
+          organization_id: plan.organization_id,
+        },
       )
     end
 

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Plans::UpdateService, type: :service do
       charges: [
         {
           billable_metric_id: billable_metrics.first.id,
-          amount_currency: 'USD',
           charge_model: 'standard',
           properties: {
             amount: '100',
@@ -32,7 +31,6 @@ RSpec.describe Plans::UpdateService, type: :service do
         },
         {
           billable_metric_id: billable_metrics.last.id,
-          amount_currency: 'EUR',
           charge_model: 'graduated',
           properties: [
             {
@@ -112,7 +110,6 @@ RSpec.describe Plans::UpdateService, type: :service do
             {
               id: existing_charge.id,
               billable_metric_id: billable_metrics.first.id,
-              amount_currency: 'USD',
               charge_model: 'standard',
               properties: {
                 amount: '100',
@@ -120,11 +117,10 @@ RSpec.describe Plans::UpdateService, type: :service do
             },
             {
               billable_metric_id: billable_metrics.last.id,
-              amount_currency: 'EUR',
               charge_model: 'standard',
               properties: {
                 amount: '300',
-              }
+              },
             },
           ],
         }
@@ -137,12 +133,11 @@ RSpec.describe Plans::UpdateService, type: :service do
     end
 
     context 'with charge to delete' do
-      let!(:charge) do
+      let(:charge) do
         create(
           :standard_charge,
           plan_id: plan.id,
           billable_metric_id: billable_metrics.first.id,
-          amount_currency: 'USD',
           properties: {
             amount: '300',
           },
@@ -162,6 +157,8 @@ RSpec.describe Plans::UpdateService, type: :service do
         }
       end
 
+      before { charge }
+
       it 'destroys the unattached charge' do
         expect { plans_service.update(**update_args) }
           .to change { plan.charges.count }.by(-1)
@@ -174,7 +171,6 @@ RSpec.describe Plans::UpdateService, type: :service do
           :standard_charge,
           plan_id: plan.id,
           billable_metric_id: billable_metrics.first.id,
-          amount_currency: 'USD',
           properties: {
             amount: '300',
           },
@@ -194,7 +190,6 @@ RSpec.describe Plans::UpdateService, type: :service do
             {
               id: existing_charge.id,
               billable_metric_id: billable_metrics.first.id,
-              amount_currency: 'USD',
               charge_model: 'standard',
               properties: {
                 amount: '100',
@@ -202,11 +197,10 @@ RSpec.describe Plans::UpdateService, type: :service do
             },
             {
               billable_metric_id: billable_metrics.last.id,
-              amount_currency: 'EUR',
               charge_model: 'standard',
               properties: {
                 amount: '300',
-              }
+              },
             },
           ],
         }
@@ -233,7 +227,7 @@ RSpec.describe Plans::UpdateService, type: :service do
       result = plans_service.update_from_api(
         organization: organization,
         code: plan.code,
-        params: update_args
+        params: update_args,
       )
 
       aggregate_failures do
@@ -254,10 +248,10 @@ RSpec.describe Plans::UpdateService, type: :service do
         result = plans_service.update_from_api(
           organization: organization,
           code: plan.code,
-          params: update_args
+          params: update_args,
         )
 
-        expect(result).to_not be_success
+        expect(result).not_to be_success
         expect(result.error_code).to eq('unprocessable_entity')
       end
     end
@@ -269,7 +263,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         result = plans_service.update_from_api(
           organization: organization,
           code: plan.code,
-          params: update_args
+          params: update_args,
         )
 
         expect(result).not_to be_success
@@ -282,10 +276,10 @@ RSpec.describe Plans::UpdateService, type: :service do
         result = plans_service.update_from_api(
           organization: organization,
           code: 'fake_code12345',
-          params: update_args
+          params: update_args,
         )
 
-        expect(result).to_not be_success
+        expect(result).not_to be_success
         expect(result.error_code).to eq('not_found')
       end
     end
@@ -297,7 +291,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         result = plans_service.update_from_api(
           organization: organization,
           code: plan.code,
-          params: update_args
+          params: update_args,
         )
 
         plan_result = result.plan
@@ -316,9 +310,8 @@ RSpec.describe Plans::UpdateService, type: :service do
           :standard_charge,
           plan_id: plan.id,
           billable_metric_id: billable_metrics.first.id,
-          amount_currency: 'USD',
           properties: {
-            amount: '300'
+            amount: '300',
           },
         )
       end
@@ -335,7 +328,6 @@ RSpec.describe Plans::UpdateService, type: :service do
             {
               id: existing_charge.id,
               billable_metric_id: billable_metrics.first.id,
-              amount_currency: 'USD',
               charge_model: 'standard',
               properties: {
                 amount: '100',
@@ -343,7 +335,6 @@ RSpec.describe Plans::UpdateService, type: :service do
             },
             {
               billable_metric_id: billable_metrics.last.id,
-              amount_currency: 'EUR',
               charge_model: 'standard',
               properties: {
                 amount: '300',
@@ -360,7 +351,7 @@ RSpec.describe Plans::UpdateService, type: :service do
           plans_service.update_from_api(
             organization: organization,
             code: plan.code,
-            params: update_args
+            params: update_args,
           )
         end.to change(Charge, :count).by(1)
       end
@@ -372,7 +363,6 @@ RSpec.describe Plans::UpdateService, type: :service do
           :standard_charge,
           plan_id: plan.id,
           billable_metric_id: billable_metrics.first.id,
-          amount_currency: 'USD',
           properties: {
             amount: '300',
           },
@@ -398,7 +388,7 @@ RSpec.describe Plans::UpdateService, type: :service do
           plans_service.update_from_api(
             organization: organization,
             code: plan.code,
-            params: update_args
+            params: update_args,
           )
         end.to change { plan.charges.count }.by(-1)
       end


### PR DESCRIPTION
**Context**

`amount_currency` on `Charges` is misleading and not used, it should always be the same as the plan's currency.

**Description**

- Remove the `amount_currency` for `charges` in payload
- Make `amount_currency` nullable on `charges` before removing it later