### PR TITLE
feat(free-units): Add events_count on Fee and update invoice

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -19,6 +19,7 @@ class Fee < ApplicationRecord
   validates :amount_currency, inclusion: { in: currency_list }
   validates :vat_amount_currency, inclusion: { in: currency_list }
   validates :units, numericality: { greated_than_or_equal_to: 0 }
+  validates :events_count, numericality: { greated_than_or_equal_to: 0 }, allow_nil: true
 
   scope :subscription_kind, -> { where(charge_id: nil, applied_add_on_id: nil) }
   scope :charge_kind, -> { where.not(charge_id: nil) }

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -14,6 +14,7 @@ module V1
         vat_amount_cents: model.vat_amount_cents,
         vat_amount_currency: model.vat_amount_currency,
         units: model.units,
+        events_count: model.events_count,
       }
     end
   end

--- a/app/services/charges/charge_models/base_service.rb
+++ b/app/services/charges/charge_models/base_service.rb
@@ -15,6 +15,7 @@ module Charges
 
       def apply
         result.units = aggregation_result.aggregation
+        result.count = aggregation_result.count
         result.amount = compute_amount
         result
       end

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -23,19 +23,22 @@ module Charges
       end
 
       def free_units_value
+        return last_running_total if free_units_per_total_aggregation.zero?
+        return free_units_per_total_aggregation if last_running_total.zero?
         return last_running_total unless last_running_total > free_units_per_total_aggregation
 
-        free_units_per_total_aggregation.to_i
+        free_units_per_total_aggregation
       end
 
       def free_units_count
+        return free_units_per_events if free_units_per_total_aggregation.zero?
         return free_units_per_events unless last_running_total > free_units_per_total_aggregation
 
         aggregation_result.options[:running_total].count { |e| e < free_units_per_total_aggregation }
       end
 
       def last_running_total
-        @last_running_total ||= aggregation_result.options[:running_total].last
+        @last_running_total ||= aggregation_result.options[:running_total].last || 0
       end
 
       def free_units_per_total_aggregation

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -52,7 +52,8 @@ module Fees
         amount_currency: charge.amount_currency,
         vat_rate: customer.applicable_vat_rate,
         units: amount_result.units,
-        properties: boundaries.to_h
+        properties: boundaries.to_h,
+        events_count: amount_result.count,
       )
 
       new_fee.compute_vat

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -315,7 +315,10 @@ html
                   td width="70%"
                     .body-1 = fee.billable_metric.name
                     .body-3
-                      | Total unit: #{fee.units}
+                      - if fee.charge.percentage?
+                        | Total unit: #{fee.events_count} events for #{fee.units}
+                      - else
+                        | Total unit: #{fee.units}
                   td.body-1 width="30%" = fee.amount.format
 
             table.total-table width="100%"

--- a/db/migrate/20220818141616_add_events_count_to_fees.rb
+++ b/db/migrate/20220818141616_add_events_count_to_fees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEventsCountToFees < ActiveRecord::Migration[7.0]
+  def change
+    add_column :fees, :events_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_16_120137) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_18_141616) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -194,6 +194,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_16_120137) do
     t.decimal "units", default: "0.0", null: false
     t.uuid "applied_add_on_id"
     t.jsonb "properties", default: {}, null: false
+    t.integer "events_count"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -10,9 +10,10 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
   before do
     aggregation_result.aggregation = aggregation
     aggregation_result.count = 4
-    aggregation_result.options = { running_total: [50, 150, 400] }
+    aggregation_result.options = { running_total: running_total }
   end
 
+  let(:running_total) { [50, 150, 400] }
   let(:aggregation_result) { BaseService::Result.new }
   let(:fixed_amount) { '2.0' }
   let(:aggregation) { 800 }
@@ -43,6 +44,47 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
   end
 
   context 'when fixed amount value is 0' do
+    it 'returns expected percentage amount' do
+      expect(apply_percentage_service.amount).to eq(
+        (expected_percentage_amount + expected_fixed_amount)
+      )
+    end
+  end
+
+  context 'when free_units_per_events is nil' do
+    let(:free_units_per_events) { nil }
+    let(:running_total) { [] }
+
+    let(:expected_percentage_amount) { (800 - 250) * (1.3 / 100) }
+    let(:expected_fixed_amount) { (4 - 0) * 2.0 }
+
+    it 'returns expected percentage amount' do
+      expect(apply_percentage_service.amount).to eq(
+        (expected_percentage_amount + expected_fixed_amount)
+      )
+    end
+  end
+
+  context 'when free_units_per_total_aggregation is nil' do
+    let(:free_units_per_total_aggregation) { nil }
+    let(:expected_percentage_amount) { (800 - 400) * (1.3 / 100) }
+    let(:expected_fixed_amount) { (4 - 3) * 2.0 }
+
+    it 'returns expected percentage amount' do
+      expect(apply_percentage_service.amount).to eq(
+        (expected_percentage_amount + expected_fixed_amount)
+      )
+    end
+  end
+
+  context 'when free units are not set' do
+    let(:free_units_per_total_aggregation) { nil }
+    let(:free_units_per_events) { nil }
+    let(:running_total) { [] }
+
+    let(:expected_percentage_amount) { 800 * (1.3 / 100) }
+    let(:expected_fixed_amount) { 4 * 2.0 }
+
     it 'returns expected percentage amount' do
       expect(apply_percentage_service.amount).to eq(
         (expected_percentage_amount + expected_fixed_amount)

--- a/spec/services/fees/add_on_service_spec.rb
+++ b/spec/services/fees/add_on_service_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Fees::AddOnService do
         expect(created_fee.vat_amount_cents).to eq(40)
         expect(created_fee.vat_rate).to eq(20.0)
         expect(created_fee.units).to eq(1)
+        expect(created_fee.events_count).to be_nil
       end
     end
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Fees::ChargeService do
         expect(created_fee.vat_amount_cents).to eq(0)
         expect(created_fee.vat_rate).to eq(20.0)
         expect(created_fee.units).to eq(0)
+        expect(created_fee.events_count).to be_nil
       end
     end
 

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Fees::SubscriptionService do
         expect(created_fee.vat_amount_cents).to eq(20)
         expect(created_fee.vat_rate).to eq(20.0)
         expect(created_fee.units).to eq(1)
+        expect(created_fee.events_count).to be_nil
       end
     end
 


### PR DESCRIPTION
## Context

We want to add the ability to:
- Apply a fixed fee per `distinct transaction`
- Apply free units on the `number of distinct transactions` or on `the monetary total amount`

## Description

This is the last step of adding fixed amount and free units to the percentage charge.
The goal of this PR is to update the invoice to display the number of events for a percentage charge.

## Related Task

https://github.com/getlago/lago/issues/92

## How Has This Been Tested?

A full QA will be performed when the feature will be 100% implemented.
