### PR TITLE
feat: Add validation logic for the volume charge model

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -13,6 +13,7 @@ class Charge < ApplicationRecord
     graduated
     package
     percentage
+    volume
   ].freeze
 
   enum charge_model: CHARGE_MODELS
@@ -22,32 +23,32 @@ class Charge < ApplicationRecord
   validate :validate_graduated_range, if: :graduated?
   validate :validate_package, if: :package?
   validate :validate_percentage, if: :percentage?
+  validate :validate_volume, if: :volume?
 
   private
 
   def validate_amount
-    validation_result = Charges::Validators::StandardService.new(charge: self).validate
-    return if validation_result.success?
-
-    validation_result.error.each { |error| errors.add(:properties, error) }
+    validate_charge_model(Charges::Validators::StandardService)
   end
 
   def validate_graduated_range
-    validation_result = Charges::Validators::GraduatedService.new(charge: self).validate
-    return if validation_result.success?
-
-    validation_result.error.each { |error| errors.add(:properties, error) }
+    validate_charge_model(Charges::Validators::GraduatedService)
   end
 
   def validate_package
-    validation_result = Charges::Validators::PackageService.new(charge: self).validate
-    return if validation_result.success?
-
-    validation_result.error.each { |error| errors.add(:properties, error) }
+    validate_charge_model(Charges::Validators::PackageService)
   end
 
   def validate_percentage
-    validation_result = Charges::Validators::PercentageService.new(charge: self).validate
+    validate_charge_model(Charges::Validators::PercentageService)
+  end
+
+  def validate_volume
+    validate_charge_model(Charges::Validators::VolumeService)
+  end
+
+  def validate_charge_model(validator)
+    validation_result = validator.new(charge: self).validate
     return if validation_result.success?
 
     validation_result.error.each { |error| errors.add(:properties, error) }

--- a/app/services/charges/validators/volume_service.rb
+++ b/app/services/charges/validators/volume_service.rb
@@ -13,7 +13,8 @@ module Charges
 
         next_from_value = 0
         ranges.each_with_index do |range, index|
-          errors << :invalid_amount unless valid_amounts?(range)
+          errors << :invalid_per_unit_amount unless valid_amount?(range[:per_unit_amount])
+          errors << :invalid_flat_amount unless valid_amount?(range[:flat_amount])
           errors << :invalid_ranges unless valid_bounds?(range, index, next_from_value)
 
           next_from_value = (range[:to_value] || 0) + 1
@@ -30,9 +31,8 @@ module Charges
         charge.properties['ranges']&.map(&:with_indifferent_access)
       end
 
-      def valid_amounts?(range)
-        ::Validators::DecimalAmountService.new(range[:per_unit_amount]).valid_amount? &&
-          ::Validators::DecimalAmountService.new(range[:flat_amount]).valid_amount?
+      def valid_amount?(amount)
+        ::Validators::DecimalAmountService.new(amount).valid_amount?
       end
 
       def valid_bounds?(range, index, next_from_value)

--- a/app/services/charges/validators/volume_service.rb
+++ b/app/services/charges/validators/volume_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Charges
+  module Validators
+    class VolumeService < Charges::Validators::BaseService
+      def validate
+        errors = []
+
+        if ranges.blank?
+          errors << :missing_ranges
+          return result.fail!(code: :invalid_properties, message: errors)
+        end
+
+        next_from_value = 0
+        ranges.each_with_index do |range, index|
+          errors << :invalid_amount unless valid_amounts?(range)
+          errors << :invalid_ranges unless valid_bounds?(range, index, next_from_value)
+
+          next_from_value = (range[:to_value] || 0) + 1
+        end
+
+        return result.fail!(code: :invalid_properties, message: errors) if errors.present?
+
+        result
+      end
+
+      private
+
+      def ranges
+        charge.properties['ranges']&.map(&:with_indifferent_access)
+      end
+
+      def valid_amounts?(range)
+        ::Validators::DecimalAmountService.new(range[:per_unit_amount]).valid_amount? &&
+          ::Validators::DecimalAmountService.new(range[:flat_amount]).valid_amount?
+      end
+
+      def valid_bounds?(range, index, next_from_value)
+        range[:from_value] == (next_from_value) && (
+          index == (ranges.size - 1) && range[:to_value].nil? ||
+          index < (ranges.size - 1) && (range[:to_value] || 0) > range[:from_value]
+        )
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,6 +14,8 @@ en:
         greater_than: value_is_out_of_range
         missing_graduated_range: missing_graduated_range
         invalid_amount: invalid_amount
+        invalid_flat_amount: invalid_flat_amount
+        invalid_per_unit_amount: invalid_per_unit_amount
         invalid_graduated_ranges: invalid_graduated_ranges
         invalid_ranges: invalid_ranges
         invalid_free_units: invalid_free_units

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
         missing_graduated_range: missing_graduated_range
         invalid_amount: invalid_amount
         invalid_graduated_ranges: invalid_graduated_ranges
+        invalid_ranges: invalid_ranges
         invalid_free_units: invalid_free_units
         invalid_package_size: invalid_package_size
         invalid_rate: invalid_rate

--- a/schema.graphql
+++ b/schema.graphql
@@ -165,6 +165,7 @@ enum ChargeModelEnum {
   package
   percentage
   standard
+  volume
 }
 
 type ChargeUsage {

--- a/schema.json
+++ b/schema.json
@@ -1661,6 +1661,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "volume",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/factories/charge_factory.rb
+++ b/spec/factories/charge_factory.rb
@@ -43,7 +43,12 @@ FactoryBot.define do
     factory :volume_charge do
       charge_model { 'volume' }
       properties do
-        { ranges: [] }
+        {
+          ranges: [
+            { from_value: 0, to_value: 100, per_unit_amount: 2 },
+            { from_value: 120, to_value: nil, per_unit_amount: 1 },
+          ],
+        }
       end
     end
   end

--- a/spec/factories/charge_factory.rb
+++ b/spec/factories/charge_factory.rb
@@ -39,5 +39,12 @@ FactoryBot.define do
         }
       end
     end
+
+    factory :volume_charge do
+      charge_model { 'volume' }
+      properties do
+        { ranges: [] }
+      end
+    end
   end
 end

--- a/spec/services/charges/validators/volume_service_spec.rb
+++ b/spec/services/charges/validators/volume_service_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
         [{ from_value: 0, to_value: nil, per_unit_amount: nil, flat_amount: '0' }]
       end
 
-      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+      it { expect(volume_service.validate.error).to include(:invalid_per_unit_amount) }
     end
 
     context 'with invalid range per unit amount cents' do
@@ -69,7 +69,7 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
         [{ from_value: 0, to_value: nil, per_unit_amount: 'foo', flat_amount: '0' }]
       end
 
-      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+      it { expect(volume_service.validate.error).to include(:invalid_per_unit_amount) }
     end
 
     context 'with negative range per unit amount cents' do
@@ -77,7 +77,7 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
         [{ from_value: 0, to_value: nil, per_unit_amount: '-2', flat_amount: 0 }]
       end
 
-      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+      it { expect(volume_service.validate.error).to include(:invalid_per_unit_amount) }
     end
 
     context 'with no range flat amount cents' do
@@ -85,7 +85,7 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
         [{ from_value: 0, to_value: nil, per_unit_amount: '0', flat_amount: nil }]
       end
 
-      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+      it { expect(volume_service.validate.error).to include(:invalid_flat_amount) }
     end
 
     context 'with invalid range flat amount cents' do
@@ -93,7 +93,7 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
         [{ from_value: 0, to_value: nil, per_unit_amount: '0', flat_amount: 'foo' }]
       end
 
-      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+      it { expect(volume_service.validate.error).to include(:invalid_flat_amount) }
     end
 
     context 'with negative range flat amount cents' do
@@ -101,7 +101,7 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
         [{ from_value: 0, to_value: nil, per_unit_amount: '0', flat_amount: '-2' }]
       end
 
-      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+      it { expect(volume_service.validate.error).to include(:invalid_flat_amount) }
     end
 
     context 'with applicable ranges' do

--- a/spec/services/charges/validators/volume_service_spec.rb
+++ b/spec/services/charges/validators/volume_service_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::Validators::VolumeService, type: :service do
+  subject(:volume_service) { described_class.new(charge: charge) }
+
+  let(:charge) { build(:volume_charge, properties: { ranges: ranges }) }
+
+  let(:ranges) do
+    []
+  end
+
+  describe '.validate' do
+    it 'ensures the presence of ranges' do
+      result = volume_service.validate
+
+      expect(result.error).to include(:missing_ranges)
+    end
+
+    context 'when ranges does not starts at 0' do
+      let(:ranges) do
+        [{ from_value: -1, to_value: 100 }]
+      end
+
+      it { expect(volume_service.validate.error).to include(:invalid_ranges) }
+    end
+
+    context 'when ranges does not ends at infinity' do
+      let(:ranges) do
+        [{ from_value: 0, to_value: 100 }]
+      end
+
+      it { expect(volume_service.validate.error).to include(:invalid_ranges) }
+    end
+
+    context 'when ranges have holes' do
+      let(:ranges) do
+        [
+          { from_value: 0, to_value: 100 },
+          { from_value: 120, to_value: 100 },
+        ]
+      end
+
+      it { expect(volume_service.validate.error).to include(:invalid_ranges) }
+    end
+
+    context 'when ranges are overlapping' do
+      let(:ranges) do
+        [
+          { from_value: 0, to_value: 100 },
+          { from_value: 90, to_value: 100 },
+        ]
+      end
+
+      it { expect(volume_service.validate.error).to include(:invalid_ranges) }
+    end
+
+    context 'with no range per unit amount cents' do
+      let(:ranges) do
+        [{ from_value: 0, to_value: nil, per_unit_amount: nil, flat_amount: '0' }]
+      end
+
+      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+    end
+
+    context 'with invalid range per unit amount cents' do
+      let(:ranges) do
+        [{ from_value: 0, to_value: nil, per_unit_amount: 'foo', flat_amount: '0' }]
+      end
+
+      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+    end
+
+    context 'with negative range per unit amount cents' do
+      let(:ranges) do
+        [{ from_value: 0, to_value: nil, per_unit_amount: '-2', flat_amount: 0 }]
+      end
+
+      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+    end
+
+    context 'with no range flat amount cents' do
+      let(:ranges) do
+        [{ from_value: 0, to_value: nil, per_unit_amount: '0', flat_amount: nil }]
+      end
+
+      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+    end
+
+    context 'with invalid range flat amount cents' do
+      let(:ranges) do
+        [{ from_value: 0, to_value: nil, per_unit_amount: '0', flat_amount: 'foo' }]
+      end
+
+      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+    end
+
+    context 'with negative range flat amount cents' do
+      let(:ranges) do
+        [{ from_value: 0, to_value: nil, per_unit_amount: '0', flat_amount: '-2' }]
+      end
+
+      it { expect(volume_service.validate.error).to include(:invalid_amount) }
+    end
+
+    context 'with applicable ranges' do
+      let(:ranges) do
+        [
+          {
+            from_value: 0,
+            to_value: 10,
+            per_unit_amount: '0',
+            flat_amount: '0',
+          },
+          {
+            from_value: 11,
+            to_value: 20,
+            per_unit_amount: '10',
+            flat_amount: '20',
+          },
+          {
+            from_value: 21,
+            to_value: nil,
+            per_unit_amount: '15',
+            flat_amount: '30',
+          },
+        ]
+      end
+
+      it { expect(volume_service.validate).to be_success }
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to introduce a new charge model to charge users based on a consumed volume.

The existing graduated pricing does not fit this need because it creates tier, and each tier has its own price.
The volume price works differently, it creates tiers, but the whole number of units is multiplied by the current tier. Then, **the number of units consumed determine the total price for each unit.**

## Description

This pull request is the first step of the volume pricing charge model.
It adds the logic to validate a charge with a `volume` charge model.
