### PR TITLE
Update start.sh for IPv6

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,4 +7,4 @@ fi
 
 rm -f ./tmp/pids/server.pid
 bundle exec rake db:migrate
-bundle exec rails s -b 0.0.0.0
+bundle exec rails s -b ::


### PR DESCRIPTION
Update start.sh so that the API will run in both an IPv4 and IPv6 environment. Fly.io is an example of an IPv6 env.

## Context

I'm attempting to run Lago using Fly.io, but Fly's private networking is IPv6 only. As such, I'm not able to use Lago till rails listens on both IPv4 and IPv6.

## Description

Changed the listening address from `0.0.0.0`, which is IPv4 only, to `::`, which is both IPv4 and IPv6.
