### PR TITLE
feat: Implement volume pricing charge model logic

### DIFF
--- a/app/services/charges/charge_models/volume_service.rb
+++ b/app/services/charges/charge_models/volume_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Charges
+  module ChargeModels
+    class VolumeService < Charges::ChargeModels::BaseService
+      protected
+
+      def ranges
+        charge.properties['ranges']&.map(&:with_indifferent_access)
+      end
+
+      def compute_amount
+        return 0 if units.zero?
+
+        flat_amount = BigDecimal(matching_range[:flat_amount])
+        per_unit_amount = BigDecimal(matching_range[:per_unit_amount])
+
+        units * per_unit_amount + flat_amount
+      end
+
+      def matching_range
+        @matching_range ||= ranges.find do |range|
+          range[:from_value] <= units && (!range[:to_value] || units <= range[:to_value])
+        end
+      end
+    end
+  end
+end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -111,6 +111,8 @@ module Fees
                         Charges::ChargeModels::PackageService
                       when :percentage
                         Charges::ChargeModels::PercentageService
+                      when :volume
+                        Charges::ChargeModels::VolumeService
                       else
                         raise NotImplementedError
       end

--- a/spec/factories/charge_factory.rb
+++ b/spec/factories/charge_factory.rb
@@ -45,8 +45,8 @@ FactoryBot.define do
       properties do
         {
           ranges: [
-            { from_value: 0, to_value: 100, per_unit_amount: 2 },
-            { from_value: 120, to_value: nil, per_unit_amount: 1 },
+            { from_value: 0, to_value: 100, per_unit_amount: '2', flat_amount: '1' },
+            { from_value: 101, to_value: nil, per_unit_amount: '1', flat_amount: '0' },
           ],
         }
       end

--- a/spec/services/charges/charge_models/volume_service_spec.rb
+++ b/spec/services/charges/charge_models/volume_service_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
+  subject(:apply_volume_service) do
+    described_class.apply(charge: charge, aggregation_result: aggregation_result)
+  end
+
+  before do
+    aggregation_result.aggregation = aggregation
+  end
+
+  let(:aggregation_result) { BaseService::Result.new }
+
+  let(:charge) do
+    create(
+      :volume_charge,
+      properties: {
+        ranges: [
+          { from_value: 0, to_value: 100, per_unit_amount: '2', flat_amount: '10' },
+          { from_value: 101, to_value: 200, per_unit_amount: '1', flat_amount: '0' },
+          { from_value: 201, to_value: nil, per_unit_amount: '0.5', flat_amount: '50' },
+        ],
+      },
+    )
+  end
+
+  context 'when aggregation is 0' do
+    let(:aggregation) { 0 }
+
+    it 'does not apply the flat amount' do
+      expect(apply_volume_service.amount).to eq(0)
+    end
+  end
+
+  context 'when aggregation is 1' do
+    let(:aggregation) { 1 }
+
+    it 'applies a unit amount for 1 and the flat amount' do
+      expect(apply_volume_service.amount).to eq(12)
+    end
+  end
+
+  context 'when aggregation is the limit of the first range' do
+    let(:aggregation) { 100 }
+
+    it 'applies unit amount for the first range and the flat amount' do
+      expect(apply_volume_service.amount).to eq(210)
+    end
+  end
+
+  context 'when aggregation is the lower limit of the second range' do
+    let(:aggregation) { 101 }
+
+    it 'applies unit amount the second range and no flat amount' do
+      expect(apply_volume_service.amount).to eq(101)
+    end
+  end
+
+  context 'when aggregation is the uper limit of the second range' do
+    let(:aggregation) { 200 }
+
+    it 'applies unit amount the second range and no flat amount' do
+      expect(apply_volume_service.amount).to eq(200)
+    end
+  end
+
+  context 'when aggregation is the above the lower limit of the last range' do
+    let(:aggregation) { 300 }
+
+    it 'applies unit amount the second range and no flat amount' do
+      expect(apply_volume_service.amount).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to introduce a new charge model to charge users based on a consumed volume.

The existing graduated pricing does not fit this need because it creates tier, and each tier has its own price.
The volume price works differently, it creates tiers, but the whole number of units is multiplied by the current tier. Then, the number of units consumed determine the total price for each unit.

## Description

This PR adds the core charge model logic.

## Related Task

This PR follows https://github.com/getlago/lago-api/pull/394
