### PR TITLE
fix(free-units): Includes all the events in running total

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -9,7 +9,7 @@ module BillableMetrics
         @subscription = subscription
       end
 
-      def aggregate(from_date:, to_date:, free_units_count: 0)
+      def aggregate(from_date:, to_date:, options: {})
         raise NotImplementedError
       end
 

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -3,7 +3,7 @@
 module BillableMetrics
   module Aggregations
     class CountService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:, free_units_count: 0)
+      def aggregate(from_date:, to_date:, options: {})
         result.aggregation = events_scope(from_date: from_date, to_date: to_date).count
         result
       end

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -3,7 +3,7 @@
 module BillableMetrics
   module Aggregations
     class MaxService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:, free_units_count: 0)
+      def aggregate(from_date:, to_date:, options: {})
         events = events_scope(from_date: from_date, to_date: to_date)
           .where("#{sanitized_field_name} IS NOT NULL")
 

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -3,13 +3,13 @@
 module BillableMetrics
   module Aggregations
     class SumService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:, free_units_count: 0)
+      def aggregate(from_date:, to_date:, options: {})
         events = events_scope(from_date: from_date, to_date: to_date)
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.sum("(#{sanitized_field_name})::numeric")
         result.count = events.count
-        result.options = { running_total: running_total(events, free_units_count) }
+        result.options = { running_total: running_total(events, options) }
         result
       rescue ActiveRecord::StatementInvalid => e
         result.fail!(code: 'aggregation_failure', message: e.message)
@@ -26,14 +26,38 @@ module BillableMetrics
         )
       end
 
-      # NOTES: Return cumulative sum of field_name based on the number of free units.
-      def running_total(events, free_units_count)
-        total = 0.0
-        events = events.order(created_at: :asc)
-        events = events.limit(free_units_count) unless free_units_count.zero?
+      # NOTE: Return cumulative sum of field_name based on the number of free units (per_events or per_total_aggregation).
+      def running_total(events, options)
+        free_units_per_events = options[:free_units_per_events].to_i
+        free_units_per_total_aggregation = BigDecimal(options[:free_units_per_total_aggregation] || 0)
 
-        events.pluck(Arel.sql("(#{sanitized_field_name})::numeric"))
+        return [] if free_units_per_events.zero? && free_units_per_total_aggregation.zero?
+
+        events = events.order(created_at: :asc)
+        return running_total_per_events(events, free_units_per_events) unless free_units_per_events.zero?
+
+        running_total_per_aggregation(events, free_units_per_total_aggregation)
+      end
+
+      def running_total_per_events(events, limit)
+        total = 0.0
+
+        events
+          .limit(limit)
+          .pluck(Arel.sql("(#{sanitized_field_name})::numeric"))
           .map { |x| total += x }
+      end
+
+      def running_total_per_aggregation(events, aggregation)
+        total = 0.0
+
+        events
+          .pluck(Arel.sql("(#{sanitized_field_name})::numeric"))
+          .each_with_object([]) do |val, accumulator|
+            break accumulator if aggregation < total
+
+            accumulator << total += val
+          end
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -28,12 +28,11 @@ module BillableMetrics
 
       # NOTES: Return cumulative sum of field_name based on the number of free units.
       def running_total(events, free_units_count)
-        return [] if free_units_count.zero?
-
         total = 0.0
-        events.order(created_at: :asc)
-          .limit(free_units_count)
-          .pluck(Arel.sql("(#{sanitized_field_name})::numeric"))
+        events = events.order(created_at: :asc)
+        events = events.limit(free_units_count) unless free_units_count.zero?
+
+        events.pluck(Arel.sql("(#{sanitized_field_name})::numeric"))
           .map { |x| total += x }
       end
     end

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -3,8 +3,8 @@
 module BillableMetrics
   module Aggregations
     class UniqueCountService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:, free_units_count: 0)
-         events = events_scope(from_date: from_date, to_date: to_date)
+      def aggregate(from_date:, to_date:, options: {})
+        events = events_scope(from_date: from_date, to_date: to_date)
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.count("DISTINCT (#{sanitized_field_name})")

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -23,18 +23,21 @@ module Charges
       end
 
       def free_units_value
+        return 0 if last_running_total.zero?
         return last_running_total if free_units_per_total_aggregation.zero?
-        return free_units_per_total_aggregation if last_running_total.zero?
-        return last_running_total unless last_running_total > free_units_per_total_aggregation
+        return last_running_total if last_running_total <= free_units_per_total_aggregation
 
         free_units_per_total_aggregation
       end
 
       def free_units_count
         return free_units_per_events if free_units_per_total_aggregation.zero?
-        return free_units_per_events unless last_running_total > free_units_per_total_aggregation
 
-        aggregation_result.options[:running_total].count { |e| e < free_units_per_total_aggregation }
+        if !last_running_total.zero? && last_running_total <= free_units_per_total_aggregation
+          free_units_per_events
+        else
+          aggregation_result.options[:running_total].count { |e| e < free_units_per_total_aggregation }
+        end
       end
 
       def last_running_total

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -65,11 +65,20 @@ module Fees
       aggregation_result = aggregator.aggregate(
         from_date: boundaries.charges_from_date,
         to_date: boundaries.charges_to_date,
-        free_units_count: charge.properties.is_a?(Hash) ? charge.properties['free_units_per_events'].to_i : 0,
+        options: options,
       )
       return aggregation_result unless aggregation_result.success?
 
       apply_charge_model_service(aggregation_result)
+    end
+
+    def options
+      return {} unless charge.properties.is_a?(Hash)
+
+      {
+        free_units_per_events: charge.properties['free_units_per_events'].to_i,
+        free_units_per_total_aggregation: BigDecimal(charge.properties['free_units_per_total_aggregation'] || 0),
+      }
     end
 
     def already_billed?

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     expect(result.options).to eq({ running_total: [12, 24]})
   end
 
+  context 'without free_units_count' do
+    it 'includes all the events in running total' do
+      result = sum_service.aggregate(from_date: from_date, to_date: to_date)
+
+      expect(result.options).to eq({ running_total: [12, 24, 36, 48]})
+    end
+  end
+
   context 'when events are out of bounds' do
     let(:to_date) { Time.zone.now - 2.days }
 

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -53,10 +53,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
 
   context 'when free_units_per_events is nil' do
     let(:free_units_per_events) { nil }
-    let(:running_total) { [] }
-
     let(:expected_percentage_amount) { (800 - 250) * (1.3 / 100) }
-    let(:expected_fixed_amount) { (4 - 0) * 2.0 }
+    let(:expected_fixed_amount) { (4 - 2) * 2.0 }
 
     it 'returns expected percentage amount' do
       expect(apply_percentage_service.amount).to eq(


### PR DESCRIPTION
## Context

We've added the ability to:
- Apply a fixed fee per `distinct transaction`
- Apply free units on the `number of distinct transactions` or on `the monetary total amount`

## Description

But when a user does not set any free units on events, only for total aggregation, an issue is present when calculating the running total.

The goal of this PR is to includes all the events in running total, even without free units per events.

## Related Task

https://github.com/getlago/lago/issues/92
