### PR TITLE
fix: Hotfix subscription index

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -64,7 +64,7 @@ module Api
       end
 
       def index
-        customer = Customer.find_by(customer_id: params[:customer_id])
+        customer = current_organization.customers.find_by(customer_id: params[:customer_id])
 
         return not_found_error unless customer
 


### PR DESCRIPTION
## Context

The subscription index is not scoped to the organization.

## Description

- Scope the subscription index to the `current_organization`