### PR TITLE
fix(charge): Prevent issue with plan create/update and empty charges

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -93,7 +93,7 @@ module Api
           # NOTE: Charges properties can have 2 differents formats
           # - An array if the charge model need many ranges (ie: graduated)
           # - A hash if other cases (ie: standard)
-          permitted_params[:charges].each_with_index do |permitted_charge, idx|
+          (permitted_params[:charges] || []).each_with_index do |permitted_charge, idx|
             permitted_charge[:properties] = if params[:plan][:charges][idx][:properties].is_a?(Array)
               params[:plan][:charges][idx][:properties].map(&:permit!)
             else

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -89,6 +89,34 @@ RSpec.describe Api::V1::PlansController, type: :request do
         expect(result[:charges].first[:lago_id]).to be_present
       end
     end
+
+    context 'without charges' do
+      let(:create_params) do
+        {
+          name: 'P1',
+          code: 'plan_code',
+          interval: 'weekly',
+          description: 'description',
+          amount_cents: 100,
+          amount_currency: 'EUR',
+          trial_period: 1,
+          pay_in_advance: false,
+        }
+      end
+
+      it 'creates a plan' do
+        post_with_token(organization, '/api/v1/plans', { plan: create_params })
+
+        expect(response).to have_http_status(:success)
+
+        result = JSON.parse(response.body, symbolize_names: true)[:plan]
+        expect(result[:lago_id]).to be_present
+        expect(result[:code]).to eq(create_params[:code])
+        expect(result[:name]).to eq(create_params[:name])
+        expect(result[:created_at]).to be_present
+        expect(result[:charges].count).to eq(0)
+      end
+    end
   end
 
   describe 'update' do


### PR DESCRIPTION
## Description

The objective of this PR is to ensure that a call to `POST /api/v1/plans` or `PUT /api/v1/plans/:id` without a charges attribute in the plan payload does not result in a server error (`HTTP 500`)
