### PR TITLE
feat(persisted-metrics): Add Persisted metric model

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -19,6 +19,7 @@ class Customer < ApplicationRecord
   has_many :payment_provider_customers,
            class_name: 'PaymentProviderCustomers::BaseCustomer',
            dependent: :destroy
+  has_many :persisted_metrics
 
   has_one :stripe_customer, class_name: 'PaymentProviderCustomers::StripeCustomer'
 

--- a/app/models/persisted_metric.rb
+++ b/app/models/persisted_metric.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class PersistedMetric < ApplicationRecord
+  belongs_to :customer
+
+  validates :external_id, presence: true
+  validates :added_at, presence: true
+end

--- a/db/migrate/20220829094054_create_persisted_metrics.rb
+++ b/db/migrate/20220829094054_create_persisted_metrics.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreatePersistedMetrics < ActiveRecord::Migration[7.0]
+  def change
+    create_table :persisted_metrics, id: :uuid do |t|
+      t.references :customer, type: :uuid, foreign_key: true, null: false
+
+      t.string :external_subscription_id, null: false
+      t.string :external_id, null: false, index: true
+      t.datetime :added_at, null: false
+      t.datetime :removed_at
+
+      t.timestamps
+
+      t.index [:customer_id, :external_subscription_id], name: :index_search_persisted_metrics
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -302,6 +302,19 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_31_113537) do
     t.index ["payment_provider_id"], name: "index_payments_on_payment_provider_id"
   end
 
+  create_table "persisted_metrics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "customer_id", null: false
+    t.string "external_subscription_id", null: false
+    t.string "external_id", null: false
+    t.datetime "added_at", null: false
+    t.datetime "removed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id", "external_subscription_id"], name: "index_search_persisted_metrics"
+    t.index ["customer_id"], name: "index_persisted_metrics_on_customer_id"
+    t.index ["external_id"], name: "index_persisted_metrics_on_external_id"
+  end
+
   create_table "plans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "organization_id", null: false
     t.string "name", null: false
@@ -405,6 +418,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_31_113537) do
   add_foreign_key "payment_providers", "organizations"
   add_foreign_key "payments", "invoices"
   add_foreign_key "payments", "payment_providers"
+  add_foreign_key "persisted_metrics", "customers"
   add_foreign_key "plans", "organizations"
   add_foreign_key "subscriptions", "customers"
   add_foreign_key "subscriptions", "plans"

--- a/spec/factories/persisted_metrics.rb
+++ b/spec/factories/persisted_metrics.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :persisted_metric do
+    customer
+
+    external_id { SecureRandom.uuid }
+    added_at { Time.current - 10.days }
+    external_subscription_id { SecureRandom.uuid }
+  end
+end

--- a/spec/models/persisted_metric_spec.rb
+++ b/spec/models/persisted_metric_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersistedMetric, type: :model do
+
+end


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a system of persistent billable metrics that do not resume to 0 at the end of a billing period.

## Description

This pull request is the first for this topic. Its objective is to introduce the new PersistedMetric model that will be used later by the recurring_count aggregation.
