### PR TITLE
feat(persisted-metrics): Add new type of aggregation

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -16,6 +16,7 @@ class BillableMetric < ApplicationRecord
     sum_agg
     max_agg
     unique_count_agg
+    recurring_count_agg
   ].freeze
 
   enum billable_period: BILLABLE_PERIODS

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module BillableMetrics
+  module Aggregations
+    class RecurringCountService < BillableMetrics::Aggregations::BaseService
+      def aggregate(from_date:, to_date:, options: {})
+        # TODO: implement aggregation logic
+        result.aggregation = 0
+        result.count = 0
+        result
+      end
+    end
+  end
+end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -101,6 +101,8 @@ module Fees
                              BillableMetrics::Aggregations::SumService
                            when :unique_count_agg
                              BillableMetrics::Aggregations::UniqueCountService
+                           when :recurring_count_agg
+                             BillableMetrics::Aggregations::RecurringCountService
                            else
                              raise NotImplementedError
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -62,6 +62,7 @@ input AddStripePaymentProviderInput {
 enum AggregationTypeEnum {
   count_agg
   max_agg
+  recurring_count_agg
   sum_agg
   unique_count_agg
 }

--- a/schema.json
+++ b/schema.json
@@ -551,6 +551,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "recurring_count_agg",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a system of persistent billable metrics that do not resume to 0 at the end of a billing period.

## Description

This pull request adds the new `recurring_count_agg` aggregation type and exposes it for creation, update and display in API and GraphQL.

It does not implment yet the aggregation logic, it will come in a following pull request.

## Related Task

- New `PersistedMetric` model: https://github.com/getlago/lago-api/pull/414
