### PR TITLE
misc: Add email for segment identify on self hosted

### DIFF
--- a/app/jobs/segment_identify_job.rb
+++ b/app/jobs/segment_identify_job.rb
@@ -13,8 +13,8 @@ class SegmentIdentifyJob < ApplicationJob
       hosting_type: hosting_type,
       version: version,
       organization_name: membership.organization.name,
+      email: membership.user.email,
     }
-    traits[:email] = membership.user.email if hosting_type == 'cloud'
 
     SEGMENT_CLIENT.identify(user_id: membership_id, traits: traits)
   end

--- a/spec/jobs/segment_identify_job_spec.rb
+++ b/spec/jobs/segment_identify_job_spec.rb
@@ -23,6 +23,7 @@ describe SegmentIdentifyJob, job: true do
             hosting_type: 'self',
             version: Utils::VersionService.new.version.version.number,
             organization_name: membership.organization.name,
+            email: membership.user.email,
           }
         )
 

--- a/spec/jobs/segment_identify_job_spec.rb
+++ b/spec/jobs/segment_identify_job_spec.rb
@@ -42,14 +42,6 @@ describe SegmentIdentifyJob, job: true do
 
         subject.perform_now(membership_id: membership_id)
       end
-
-      it 'includes the email of the membership' do
-        expect(SEGMENT_CLIENT).to receive(:identify).with(
-          hash_including(traits: hash_including(email: membership.user.email))
-        )
-
-        subject.perform_now(membership_id: membership_id)
-      end
     end
 
     context 'when membership is nil' do


### PR DESCRIPTION
## Context

We need the membership email on Self Hosted for tracking purpose.
NOTE: This is included in our Privacy Policy.

## Description

Add the membership's email on Segment tracking for self hosted
