### PR TITLE
misc: Add activejob-traceable to have context on active jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.0.1'
 
+gem 'activejob-traceable'
 gem 'analytics-ruby', '~> 2.4.0', require: 'segment/analytics'
 gem 'bcrypt'
 gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,9 @@ GEM
     activejob (7.0.3.1)
       activesupport (= 7.0.3.1)
       globalid (>= 0.3.6)
+    activejob-traceable (0.3.5)
+      activejob
+      activesupport
     activemodel (7.0.3.1)
       activesupport (= 7.0.3.1)
     activerecord (7.0.3.1)
@@ -330,6 +333,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activejob-traceable
   analytics-ruby (~> 2.4.0)
   aws-sdk-s3
   bcrypt

--- a/config/initializers/activejob_traceable.rb
+++ b/config/initializers/activejob_traceable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'current_context'
+
+ActiveJob::Traceable.tracing_info_getter = lambda do
+  {
+    membership: CurrentContext.membership,
+  }
+end
+
+ActiveJob::Traceable.tracing_info_setter = lambda do |attributes|
+  return unless attributes
+
+  CurrentContext.membership = attributes[:membership]
+end


### PR DESCRIPTION
## Context

We want to keep tracing information on active jobs.

## Description

The goal of this PR is to include [activejob-traceable](https://github.com/qonto/activejob-traceable) so that `CurrentContext.membership` is also available in background jobs. 
