### PR TITLE
feat(persisted-metrics): Aggregation logic implementation

### DIFF
--- a/app/models/persisted_metric.rb
+++ b/app/models/persisted_metric.rb
@@ -5,4 +5,5 @@ class PersistedMetric < ApplicationRecord
 
   validates :external_id, presence: true
   validates :added_at, presence: true
+  validates :external_subscription_id, presence: true
 end

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -4,10 +4,98 @@ module BillableMetrics
   module Aggregations
     class RecurringCountService < BillableMetrics::Aggregations::BaseService
       def aggregate(from_date:, to_date:, options: {})
-        # TODO: implement aggregation logic
-        result.aggregation = 0
-        result.count = 0
+        @from_date = from_date
+        @to_date = to_date
+
+        result.aggregation = compute_aggregation.ceil(5)
         result
+      end
+
+      private
+
+      attr_reader :from_date, :to_date
+
+      def compute_aggregation
+        ActiveRecord::Base.connection
+          .execute(aggregation_query)
+          .first['aggregation_result']
+      end
+
+      def aggregation_query
+        queries = [
+          # NOTE: Billed on the full period
+          persisted.select("SUM(#{persisted_pro_rata}::numeric)").to_sql,
+
+          # NOTE: Added during the period
+          added
+            .select(
+              "SUM(('#{to_date}'::date - DATE(persisted_metrics.added_at) + 1)::numeric / #{period_duration})::numeric",
+            )
+            .to_sql,
+
+          # NOTE: removed during the period
+          removed
+            .select(
+              "SUM((DATE(persisted_metrics.removed_at) - '#{from_date}'::date + 1)::numeric / #{period_duration})::numeric",
+            )
+            .to_sql,
+
+          # # NOTE: Added and then removed during the period
+          added_and_removed
+            .select(
+              "SUM((DATE(persisted_metrics.removed_at) - DATE(persisted_metrics.added_at) + 1)::numeric / #{period_duration})::numeric",
+            ).to_sql,
+        ]
+
+        "SELECT (#{queries.map { |q| "COALESCE((#{q}), 0)" }.join(' + ')}) AS aggregation_result"
+      end
+
+      def base_scope
+        PersistedMetric
+          .where(customer_id: subscription.customer_id)
+          .where(external_subscription_id: subscription.unique_id)
+      end
+
+      # NOTE: Full period duration to take upgrade, terminate
+      #       or start on non-anniversary day into account
+      def period_duration
+        @period_duration ||= Subscriptions::DatesService.new_instance(subscription, to_date + 1.day)
+          .duration_in_days
+      end
+
+      # NOTE: when subscription is terminated or upgraded,
+      #       we want to bill the persisted metrics at prorata of the full period duration.
+      #       ie: the number of day of the terminated period divided by number of days without termination
+      def persisted_pro_rata
+        (to_date - from_date + 1).to_i.fdiv(period_duration)
+      end
+
+      def persisted
+        base_scope
+          .where('DATE(persisted_metrics.added_at) < ?', from_date)
+          .where('persisted_metrics.removed_at IS NULL OR DATE(persisted_metrics.removed_at) > ?', to_date)
+      end
+
+      def added
+        base_scope
+          .where('DATE(persisted_metrics.added_at) >= ?', from_date)
+          .where('DATE(persisted_metrics.added_at) <= ?', to_date)
+          .where('persisted_metrics.removed_at IS NULL OR DATE(persisted_metrics.removed_at) > ?', to_date)
+      end
+
+      def removed
+        base_scope
+          .where('DATE(persisted_metrics.added_at) < ?', from_date)
+          .where('DATE(persisted_metrics.removed_at) >= ?', from_date)
+          .where('DATE(persisted_metrics.removed_at) <= ?', to_date)
+      end
+
+      def added_and_removed
+        base_scope
+          .where('DATE(persisted_metrics.added_at) >= ?', from_date)
+          .where('DATE(persisted_metrics.added_at) <= ?', to_date)
+          .where('DATE(persisted_metrics.removed_at) >= ?', from_date)
+          .where('DATE(persisted_metrics.removed_at) <= ?', to_date)
       end
     end
   end

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -79,6 +79,10 @@ module Subscriptions
       plan.amount_cents.fdiv(duration.to_i)
     end
 
+    def duration_in_days
+      compute_duration(from_date: compute_from_date)
+    end
+
     private
 
     attr_accessor :subscription, :billing_date, :current_usage

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :service do
+  subject(:recurring_service) do
+    described_class.new(billable_metric: billable_metric, subscription: subscription)
+  end
+
+  let(:subscription) do
+    create(
+      :subscription,
+      started_at: started_at,
+      subscription_date: subscription_date,
+      billing_time: :anniversary,
+    )
+  end
+
+  let(:subscription_date) { DateTime.parse('2022-06-09') }
+  let(:started_at) { subscription_date }
+  let(:organization) { subscription.organization }
+  let(:customer) { subscription.customer }
+
+  let(:billable_metric) do
+    create(
+      :billable_metric,
+      organization: organization,
+      aggregation_type: 'recurring_count_agg',
+      field_name: 'unique_id',
+    )
+  end
+
+  let(:from_date) { Date.parse('2022-07-09') }
+  let(:to_date) { Date.parse('2022-08-08') }
+
+  let(:result) { recurring_service.aggregate(from_date: from_date, to_date: to_date) }
+
+  let(:added_at) { from_date - 1.month }
+  let(:removed_at) { nil }
+  let(:persisted_metric) do
+    create(
+      :persisted_metric,
+      customer: customer,
+      added_at: added_at,
+      removed_at: removed_at,
+      external_subscription_id: subscription.unique_id,
+    )
+  end
+
+  before { persisted_metric }
+
+  context 'with persisted metric on full period' do
+    it 'returns the number of persisted metric' do
+      expect(result.aggregation).to eq(1)
+    end
+
+    context 'when subscription was terminated in the period' do
+      let(:subscription) do
+        create(
+          :subscription,
+          started_at: started_at,
+          subscription_date: subscription_date,
+          billing_time: :anniversary,
+          terminated_at: to_date,
+          status: :terminated,
+        )
+      end
+      let(:to_date) { Date.parse('2022-07-24') }
+
+      it 'returns the prorata of the full duration' do
+        expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
+      end
+    end
+
+    context 'when subscription was upgraded in the period' do
+      let(:subscription) do
+        create(
+          :subscription,
+          started_at: started_at,
+          subscription_date: subscription_date,
+          billing_time: :anniversary,
+          terminated_at: to_date,
+          status: :terminated,
+        )
+      end
+      let(:to_date) { Date.parse('2022-07-24') }
+
+      before do
+        create(
+          :subscription,
+          previous_subscription: subscription,
+          organization: organization,
+          customer: customer,
+          started_at: to_date,
+        )
+      end
+
+      it 'returns the prorata of the full duration' do
+        expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
+      end
+    end
+
+    context 'when subscription was started in the period' do
+      let(:started_at) { Date.parse('2022-08-01') }
+      let(:from_date) { started_at }
+
+      it 'returns the prorata of the full duration' do
+        expect(result.aggregation).to eq(8.fdiv(31).ceil(5))
+      end
+    end
+  end
+
+  context 'with persisted metrics added in the period' do
+    let(:added_at) { from_date + 15.days }
+
+    it 'returns the prorata of the full duration' do
+      expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
+    end
+
+    context 'when added on the first day of the period' do
+      let(:added_at) { from_date }
+
+      it 'returns the full duration' do
+        expect(result.aggregation).to eq(1)
+      end
+    end
+  end
+
+  context 'with persisted metrics terminated in the period' do
+    let(:removed_at) { to_date - 15.days }
+
+    it 'returns the prorata of the full duration' do
+      expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
+    end
+
+    context 'when removed on the last day of the period' do
+      let(:removed_at) { to_date }
+
+      it 'returns the full duration' do
+        expect(result.aggregation).to eq(1)
+      end
+    end
+  end
+
+  context 'with persisted metrics added and terminated in the period' do
+    let(:added_at) { from_date + 1.day }
+    let(:removed_at) { to_date - 1.day }
+
+    it 'returns the prorata of the full duration' do
+      expect(result.aggregation).to eq(29.fdiv(31).ceil(5))
+    end
+
+    context 'when added and removed the same day' do
+      let(:added_at) { from_date + 1.day }
+      let(:removed_at) { added_at }
+
+      it 'returns a 1 day duration' do
+        expect(result.aggregation).to eq(1.fdiv(31).ceil(5))
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -434,4 +434,42 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
     end
   end
+
+  describe 'duration_in_days' do
+    let(:result) { date_service.duration_in_days }
+
+    context 'when billing_time is calendar' do
+      let(:billing_time) { :calendar }
+
+      it 'returns the month duration' do
+        expect(result).to eq(28)
+      end
+
+      context 'when on a leap year' do
+        let(:subscription_date) { DateTime.parse('28 Feb 2019') }
+        let(:billing_date) { DateTime.parse('01 Mar 2020') }
+
+        it 'returns the month duration' do
+          expect(result).to eq(29)
+        end
+      end
+    end
+
+    context 'when billing_time is anniversary' do
+      let(:billing_time) { :anniversary }
+
+      it 'returns the month duration' do
+        expect(result).to eq(28)
+      end
+
+      context 'when on a leap year' do
+        let(:subscription_date) { DateTime.parse('02 Feb 2019') }
+        let(:billing_date) { DateTime.parse('08 Mar 2020') }
+
+        it 'returns the month duration' do
+          expect(result).to eq(29)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -358,4 +358,14 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       expect(result).to eq(plan.amount_cents.fdiv(7))
     end
   end
+
+  describe 'duration_in_days' do
+    let(:billing_time) { :anniversary }
+    let(:billing_date) { DateTime.parse('08 Mar 2022') }
+    let(:result) { date_service.duration_in_days }
+
+    it 'returns the duration of the period' do
+      expect(result).to eq(7)
+    end
+  end
 end

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -483,4 +483,42 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
     end
   end
+
+  describe 'duration_in_days' do
+    let(:result) { date_service.duration_in_days }
+
+    context 'when billing_time is calendar' do
+      let(:billing_time) { :calendar }
+
+      it 'returns the year duration' do
+        expect(result).to eq(365)
+      end
+
+      context 'when on a leap year' do
+        let(:subscription_date) { DateTime.parse('28 Feb 2019') }
+        let(:billing_date) { DateTime.parse('01 Jan 2021') }
+
+        it 'returns the year duration' do
+          expect(result).to eq(366)
+        end
+      end
+    end
+
+    context 'when billing_time is anniversary' do
+      let(:billing_time) { :anniversary }
+
+      it 'returns the year duration' do
+        expect(result).to eq(365)
+      end
+
+      context 'when on a leap year' do
+        let(:subscription_date) { DateTime.parse('02 Feb 2019') }
+        let(:billing_date) { DateTime.parse('08 Mar 2021') }
+
+        it 'returns the year duration' do
+          expect(result).to eq(366)
+        end
+      end
+    end
+  end
 end

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -106,4 +106,11 @@ RSpec.describe Subscriptions::DatesService, type: :service do
         .to raise_error(NotImplementedError)
     end
   end
+
+  describe 'duration_in_days' do
+    it 'raises a not implemented error' do
+      expect { date_service.duration_in_days }
+        .to raise_error(NotImplementedError)
+    end
+  end
 end


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a system of persistent billable metrics that do not resume to 0 at the end of a billing period.

## Description

This PR is adding the aggregation logic. It uses the previously introduced `PersistedMetric`.

The logic takes into account:
- persisted metrics added before the period and not terminated or terminated after the period
- persisted metrics added during the period
- persisted metrics removed during the period
- persisted metrics added and removed during the period
- subscription terminated (or upgraded) before the end of the period
- subscription started before the beginning

## Related Task

- PersistedMetric model: https://github.com/getlago/lago-api/pull/414
- New aggregation type: https://github.com/getlago/lago-api/pull/415
