### PR TITLE
fix: Subscription anniversary date with trial amount

### DIFF
--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -195,8 +195,7 @@ module Fees
         #       for this case, we should not apply the full period amount
         #       but the prorata between the trial end date end the invoice to_date
         if (subscription.trial_end_date > from_date) && (subscription.trial_end_date < to_date)
-          from_date = subscription.trial_end_date
-          number_of_day_to_bill = (to_date + 1.day - from_date).to_i
+          number_of_day_to_bill = (to_date + 1.day - subscription.trial_end_date).to_i
 
           return number_of_day_to_bill * single_day_price(subscription, optional_from_date: from_date)
         end


### PR DESCRIPTION
## Context

- When using a trial period with a pay in advance plan, with an anniversary subscription, the daily price is wrong.

## Description

- Use the correct date for daily price calculating.

We QAed it and it's all good now!
