### PR TITLE
misc: Rename customer_id to external_customer_id on wallets

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -57,7 +57,7 @@ module Api
       end
 
       def index
-        customer = Customer.find_by(customer_id: params[:customer_id])
+        customer = Customer.find_by(customer_id: params[:external_customer_id])
 
         return not_found_error unless customer
 
@@ -88,7 +88,7 @@ module Api
       end
 
       def customer_params
-        params.require(:wallet).permit(:customer_id)
+        params.require(:wallet).permit(:external_customer_id)
       end
 
       def update_params
@@ -99,7 +99,7 @@ module Api
       end
 
       def customer
-        Customer.find_by(customer_id: customer_params[:customer_id], organization_id: current_organization.id)
+        Customer.find_by(customer_id: customer_params[:external_customer_id], organization_id: current_organization.id)
       end
 
       def render_wallet(wallet)

--- a/spec/requests/api/v1/wallets_spec.rb
+++ b/spec/requests/api/v1/wallets_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
   describe 'create' do
     let(:create_params) do
       {
-        customer_id: customer.customer_id,
+        external_customer_id: customer.customer_id,
         rate_amount: '1',
         name: 'Wallet1',
         paid_credits: '10',
@@ -134,7 +134,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
     before { wallet }
 
     it 'returns wallets' do
-      get_with_token(organization, "/api/v1/wallets?customer_id=#{customer.customer_id}")
+      get_with_token(organization, "/api/v1/wallets?external_customer_id=#{customer.customer_id}")
 
       expect(response).to have_http_status(:success)
 
@@ -151,7 +151,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
       before { wallet2 }
 
       it 'returns wallets with correct meta data' do
-        get_with_token(organization, "/api/v1/wallets?customer_id=#{customer.customer_id}&page=1&per_page=1")
+        get_with_token(organization, "/api/v1/wallets?external_customer_id=#{customer.customer_id}&page=1&per_page=1")
 
         expect(response).to have_http_status(:success)
 


### PR DESCRIPTION
## Context

We want to clarify the difference between lago ids and external ids.

## Description

The goal of this PR is to:
- rename `customer_id` to `external_customer_id` on wallets
