### PR TITLE
fix(subscriptions): Apply charge fees on subscription upgrade

### DIFF
--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -103,10 +103,6 @@ module Invoices
     end
 
     def should_create_charge_fees?(invoice, subscription)
-      # NOTE: When a subscription is upgraded, the charges will be billed at the end of the period
-      #       using the new subscription
-      return false if subscription.terminated? && subscription.upgraded?
-
       # NOTE: Charges should not be billed in advance when we are just upgrading to a new
       #       pay_in_advance subscription
       return false if subscription.plan.pay_in_advance? && subscription.invoices.where.not(id: invoice.id).count.zero?

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -559,44 +559,6 @@ RSpec.describe Invoices::CreateService, type: :service do
       end
     end
 
-    context 'when subscription is terminated and upgraded' do
-      let(:plan) do
-        create(:plan, interval: 'monthly', pay_in_advance: false)
-      end
-
-      let(:timestamp) { Time.zone.now.beginning_of_month - 1.day }
-      let(:started_at) { Time.zone.today - 3.months }
-      let(:terminated_at) { timestamp - 2.days }
-      let(:subscription) do
-        create(
-          :subscription,
-          plan: plan,
-          subscription_date: started_at.to_date,
-          started_at: started_at,
-          status: :terminated,
-          terminated_at: terminated_at,
-        )
-      end
-      let(:next_plan) { create(:plan, amount_cents: plan.amount_cents + 20) }
-      let(:next_subscription) do
-        create(:subscription, plan: next_plan, previous_subscription: subscription)
-      end
-
-      before { next_subscription }
-
-      it 'creates an invoice without charge fee' do
-        result = invoice_service.create
-
-        aggregate_failures do
-          expect(result.invoice.fees.first.properties['to_date'])
-            .to eq(terminated_at.to_date.to_s)
-          expect(result.invoice.fees.first.properties['from_date'])
-            .to eq(terminated_at.to_date.beginning_of_month.to_s)
-          expect(result.invoice.fees.charge_kind.count).to eq(0)
-        end
-      end
-    end
-
     context 'when subscription is pay in advance and is an upgrade' do
       let(:plan) do
         create(:plan, interval: :monthly, pay_in_advance: true, amount_cents: 1000)


### PR DESCRIPTION
## Context

With we introduce the anniversary date subscription billing, we made a change in the way we bill charges. 

## Description

Before the feature, the charges were not billed on the terminated subscription, but only at the end of the upgraded subscription period.
We decided to get rid of this behavior because it was a mess for the billing period computation and was kind of a weird behavior, that's why 

Unfortunately, we forgot to remove one condition in the `Invoices::CreateService` to check if charge fees should be generated.
This PR is here to fix this mistake