### PR TITLE
misc: Add external_customer_id on wallet serializer

### DIFF
--- a/app/serializers/v1/wallet_serializer.rb
+++ b/app/serializers/v1/wallet_serializer.rb
@@ -6,6 +6,7 @@ module V1
       {
         lago_id: model.id,
         lago_customer_id: model.customer_id,
+        external_customer_id: model.customer.customer_id,
         status: model.status,
         currency: model.currency,
         name: model.name,

--- a/spec/requests/api/v1/wallets_spec.rb
+++ b/spec/requests/api/v1/wallets_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
       result = JSON.parse(response.body, symbolize_names: true)[:wallet]
       expect(result[:lago_id]).to be_present
       expect(result[:name]).to eq(create_params[:name])
+      expect(result[:external_customer_id]).to eq(customer.customer_id)
     end
   end
 


### PR DESCRIPTION
## Context

We want to clarify the difference between lago ids and external ids.

## Description

The goal of this PR is to:
- return `external_customer_id` on wallet serializer
