### PR TITLE
feat(persisted-metrics): Create persisted event from event

### DIFF
--- a/app/services/persisted_events/create_or_update_service.rb
+++ b/app/services/persisted_events/create_or_update_service.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module PersistedEvents
+  class CreateOrUpdateService < BaseService
+    def initialize(event)
+      @event = event
+
+      super(nil)
+    end
+
+    def call
+      result.persisted_event = case event_operation_type
+                               when :add
+                                 add_metric
+                               when :remove
+                                 remove_metric
+      end
+
+      result
+    end
+
+    def matching_billable_metric?
+      matching_billable_metric&.recurring_count_agg?
+    end
+
+    private
+
+    attr_accessor :event
+
+    delegate :customer, :subscription, :organization, to: :event
+
+    def event_operation_type
+      event.properties['operation_type']&.to_sym
+    end
+
+    def add_metric
+      PersistedEvent.create!(
+        customer: customer,
+        billable_metric: matching_billable_metric,
+        external_subscription_id: subscription.external_id,
+        external_id: event.properties[matching_billable_metric.field_name],
+        added_at: event.timestamp,
+      )
+    end
+
+    def remove_metric
+      metric = PersistedEvent.find_by(
+        customer_id: customer.id,
+        billable_metric_id: matching_billable_metric.id,
+        external_subscription_id: subscription.external_id,
+        external_id: event.properties[matching_billable_metric.field_name],
+      )
+
+      metric.update!(removed_at: event.timestamp)
+      metric
+    end
+
+    def matching_billable_metric
+      @matching_billable_metric ||= organization.billable_metrics.find_by(
+        code: event.code,
+      )
+    end
+  end
+end

--- a/app/services/persisted_events/validate_creation_service.rb
+++ b/app/services/persisted_events/validate_creation_service.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module PersistedEvents
+  class ValidateCreationService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(subscription:, billable_metric:, params:)
+      @subscription = subscription
+      @billable_metric = billable_metric
+      @params = params&.with_indifferent_access
+    end
+
+    def call
+      return 'invalid_operation_type' unless valid_operation_type?
+      return 'recurring_resource_already_added' unless valid_addition?
+      return 'recurring_resource_not_found' unless valid_removal?
+
+      nil
+    end
+
+    private
+
+    attr_accessor :subscription, :billable_metric, :params
+
+    delegate :customer, to: :subscription
+
+    def operation_type
+      @operation_type ||= params.dig('properties', 'operation_type')&.to_sym
+    end
+
+    def external_id
+      @external_id ||= params.dig('properties', billable_metric.field_name)
+    end
+
+    def valid_operation_type?
+      %i[add remove].include?(operation_type)
+    end
+
+    def valid_addition?
+      return true unless operation_type == :add
+
+      # NOTE: Ensure no active persisted metric exists with the same external id
+      PersistedEvent.where(
+        customer_id: customer.id,
+        external_id: external_id,
+        external_subscription_id: subscription.external_id,
+      ).where(removed_at: nil).none?
+    end
+
+    def valid_removal?
+      return true unless operation_type == :remove
+
+      PersistedEvent.where(
+        customer_id: customer.id,
+        external_id: external_id,
+        external_subscription_id: subscription.external_id,
+      ).where(removed_at: nil).exists?
+    end
+  end
+end

--- a/spec/services/persisted_events/create_or_update_service_spec.rb
+++ b/spec/services/persisted_events/create_or_update_service_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersistedEvents::CreateOrUpdateService, type: :service do
+  subject(:create_service) do
+    described_class.new(event)
+  end
+
+  let(:billable_metric) do
+    create(
+      :billable_metric,
+      aggregation_type: 'recurring_count_agg',
+      field_name: 'item_id',
+    )
+  end
+
+  let(:event) do
+    create(
+      :event,
+      properties: properties,
+      organization: billable_metric.organization,
+      code: billable_metric.code,
+    )
+  end
+
+  let(:operation_type) { 'add' }
+  let(:external_id) { 'external_id' }
+  let(:properties) do
+    {
+      'operation_type' => operation_type,
+      billable_metric.field_name => 'ext_12345',
+    }
+  end
+
+  describe '#call' do
+    let(:service_result) { create_service.call }
+
+    context 'with add operation type' do
+      it 'creates a persisted metric' do
+        aggregate_failures do
+          expect { service_result }.to change(PersistedEvent, :count).by(1)
+
+          expect(service_result).to be_success
+
+          persisted_event = service_result.persisted_event
+          expect(persisted_event.customer).to eq(event.customer)
+          expect(persisted_event.external_subscription_id).to eq(event.subscription.external_id)
+          expect(persisted_event.external_id).to eq('ext_12345')
+          expect(persisted_event.added_at.to_s).to eq(event.timestamp.to_s)
+        end
+      end
+    end
+
+    context 'with remove operation type' do
+      let(:persisted_event) do
+        create(
+          :persisted_event,
+          customer: event.customer,
+          billable_metric: billable_metric,
+          external_subscription_id: event.subscription.external_id,
+          external_id: 'ext_12345',
+        )
+      end
+
+      let(:operation_type) { 'remove' }
+
+      before { persisted_event }
+
+      it 'updates the active persisted metric' do
+        aggregate_failures do
+          service_result
+
+          expect(service_result).to be_success
+
+          expect(service_result.persisted_event).to eq(persisted_event)
+          expect(service_result.persisted_event.removed_at.to_s).to eq(event.timestamp.to_s)
+        end
+      end
+    end
+  end
+
+  describe '#matching_billable_metric?' do
+    it { expect(create_service).to be_matching_billable_metric }
+
+    context 'when billable metric is not a recurring count aggregation' do
+      let(:billable_metric) do
+        create(
+          :billable_metric,
+          aggregation_type: 'sum_agg',
+          field_name: 'item_id',
+        )
+      end
+
+      it { expect(create_service).not_to be_matching_billable_metric }
+    end
+  end
+end

--- a/spec/services/persisted_events/validate_creation_service_spec.rb
+++ b/spec/services/persisted_events/validate_creation_service_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PersistedEvents::ValidateCreationService, type: :service do
+  subject(:validate_result) do
+    described_class.call(
+      subscription: subscription,
+      billable_metric: billable_metric,
+      params: params,
+    )
+  end
+
+  let(:subscription) { create(:subscription) }
+  let(:customer) { subscription.customer }
+
+  let(:billable_metric) do
+    create(
+      :billable_metric,
+      aggregation_type: 'recurring_count_agg',
+      organization: customer.organization,
+      field_name: 'item_id',
+    )
+  end
+
+  let(:params) do
+    {
+      code: billable_metric.code,
+      properties: {
+        'item_id' => external_id,
+        'operation_type' => operation_type,
+      },
+    }.with_indifferent_access
+  end
+
+  let(:external_id) { 'ext_12345' }
+  let(:operation_type) { 'add' }
+
+  context 'without operation type' do
+    let(:operation_type) { nil }
+
+    it { expect(validate_result).to eq('invalid_operation_type') }
+  end
+
+  context 'with invalid operation type' do
+    let(:operation_type) { 'invalid' }
+
+    it { expect(validate_result).to eq('invalid_operation_type') }
+  end
+
+  context 'when operation type is add' do
+    it { expect(validate_result).to be_nil }
+
+    context 'with an active persisted metric' do
+      before do
+        create(
+          :persisted_event,
+          customer: customer,
+          external_id: external_id,
+          external_subscription_id: subscription.external_id,
+        )
+      end
+
+      it { expect(validate_result).to eq('recurring_resource_already_added') }
+    end
+
+    context 'with removed persisted metric' do
+      before do
+        create(
+          :persisted_event,
+          customer: customer,
+          external_id: external_id,
+          external_subscription_id: subscription.external_id,
+          removed_at: Time.current - 3.days,
+        )
+      end
+
+      it { expect(validate_result).to be_nil }
+    end
+  end
+
+  context 'when operation type is remove' do
+    let(:operation_type) { 'remove' }
+
+    context 'without persisted metric' do
+      it { expect(validate_result).to eq('recurring_resource_not_found') }
+    end
+
+    context 'with an active persisted metric' do
+      before do
+        create(
+          :persisted_event,
+          customer: customer,
+          external_id: external_id,
+          external_subscription_id: subscription.external_id,
+        )
+      end
+
+      it { expect(validate_result).to be_nil }
+    end
+
+    context 'with a removed persisted metric' do
+      before do
+        create(
+          :persisted_event,
+          customer: customer,
+          external_id: external_id,
+          external_subscription_id: subscription.external_id,
+          removed_at: Time.current - 3.days,
+        )
+      end
+
+      it { expect(validate_result).to eq('recurring_resource_not_found') }
+    end
+  end
+end

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization: organization) }
   let(:subscription) { create(:subscription, customer: customer) }
-  let(:customer_id) { customer.customer_id }
+  let(:customer_id) { customer.external_id }
   let(:paid_credits) { '1.00' }
   let(:granted_credits) { '0.00' }
   let(:args) do


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a system of persistent billable metrics that do not resume to 0 at the end of a billing period.

## Description

This PR updates the event creation logic to manage as well the persistent metrics:
- Create a persistent metric when receiving an `add` operation
- Remove an existing persistent metric when receiving a `remove` operation
- Validate the persisted metrics requirements before processing the event

**NOTE: We should wait for the merge of https://github.com/getlago/lago-api/pull/419 since `Subscription#unique_id` will be renamed into `Subscription#external_id`**

## Related Task

Aggregation logic: https://github.com/getlago/lago-api/pull/421