### PR TITLE
feat(persisted-metrics): Add persisted metric breakdown on the invoice

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -98,6 +98,22 @@ class Invoice < ApplicationRecord
     invoice_subscription(subscription_id).fees
   end
 
+  def recurring_fees(subscription_id)
+    subscription_fees(subscription_id).joins(charge: :billable_metric)
+      .merge(BillableMetric.recurring_count_agg)
+  end
+
+  def recurring_breakdown(fee)
+    result = BillableMetrics::Aggregations::RecurringCountService.new(
+      billable_metric: fee.charge.billable_metric,
+      subscription: fee.subscription,
+    ).breakdown(
+      from_date: Date.parse(fee.properties['charges_from_date']),
+      to_date: Date.parse(fee.properties['charges_to_date']),
+    )
+    result.breakdown
+  end
+
   private
 
   def ensure_number

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -178,7 +178,7 @@ module BillableMetrics
         added_and_removed_list.map do |aggregation|
           OpenStruct.new(
             date: aggregation.first.to_date,
-            action: 'add',
+            action: 'add_and_removed',
             count: aggregation.last,
             duration: (aggregation.second.to_date + 1.day - aggregation.first.to_date).to_i,
             total_duration: period_duration,

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -11,6 +11,19 @@ module BillableMetrics
         result
       end
 
+      def breakdown(from_date:, to_date:)
+        @from_date = from_date.to_date
+        @to_date = to_date.to_date
+
+        breakdown = persisted_breakdown
+        breakdown += added_breakdown
+        breakdown += removed_breadown
+        breakdown += added_and_removed_breakdown
+
+        result.breakdown = breakdown.sort_by(&:date)
+        result
+      end
+
       private
 
       attr_reader :from_date, :to_date
@@ -77,11 +90,45 @@ module BillableMetrics
           .where('persisted_events.removed_at IS NULL OR DATE(persisted_events.removed_at) > ?', to_date)
       end
 
+      def persisted_breakdown
+        persisted_count = persisted.count
+        return [] if persisted_count.zero?
+
+        [
+          OpenStruct.new(
+            date: from_date,
+            action: 'add',
+            count: persisted_count,
+            duration: (to_date - from_date + 1).to_i,
+            total_duration: period_duration,
+          ),
+        ]
+      end
+
       def added
         base_scope
           .where('DATE(persisted_events.added_at) >= ?', from_date)
           .where('DATE(persisted_events.added_at) <= ?', to_date)
           .where('persisted_events.removed_at IS NULL OR DATE(persisted_events.removed_at) > ?', to_date)
+      end
+
+      def added_breakdown
+        added_list = added.group('DATE(persisted_events.added_at)')
+          .order('DATE(persisted_events.added_at) ASC')
+          .pluck([
+            'DATE(persisted_events.added_at) as date',
+            'COUNT(persisted_events.id) as metric_count',
+          ].join(', '))
+
+        added_list.map do |aggregation|
+          OpenStruct.new(
+            date: aggregation.first.to_date,
+            action: 'add',
+            count: aggregation.last,
+            duration: (to_date + 1.day - aggregation.first).to_i,
+            total_duration: period_duration,
+          )
+        end
       end
 
       def removed
@@ -91,12 +138,52 @@ module BillableMetrics
           .where('DATE(persisted_events.removed_at) <= ?', to_date)
       end
 
+      def removed_breadown
+        removed_list = removed.group('DATE(persisted_events.removed_at)')
+          .order('DATE(persisted_events.removed_at) ASC')
+          .pluck([
+            'DATE(persisted_events.removed_at) as date',
+            'COUNT(persisted_events.id) as metric_count',
+          ].join(', '))
+
+        removed_list.map do |aggregation|
+          OpenStruct.new(
+            date: aggregation.first.to_date,
+            action: 'remove',
+            count: aggregation.last,
+            duration: (aggregation.first + 1.day - from_date).to_i,
+            total_duration: period_duration,
+          )
+        end
+      end
+
       def added_and_removed
         base_scope
           .where('DATE(persisted_events.added_at) >= ?', from_date)
           .where('DATE(persisted_events.added_at) <= ?', to_date)
           .where('DATE(persisted_events.removed_at) >= ?', from_date)
           .where('DATE(persisted_events.removed_at) <= ?', to_date)
+      end
+
+      def added_and_removed_breakdown
+        added_and_removed_list = added_and_removed.group(
+          'DATE(persisted_events.added_at), DATE(persisted_events.removed_at)',
+        ).order('DATE(persisted_events.added_at) ASC, DATE(persisted_events.removed_at) ASC')
+          .pluck([
+            'DATE(persisted_events.added_at) as added_at',
+            'DATE(persisted_events.removed_at) as removed_at',
+            'COUNT(persisted_events.id) as metric_count',
+          ].join(', '))
+
+        added_and_removed_list.map do |aggregation|
+          OpenStruct.new(
+            date: aggregation.first.to_date,
+            action: 'add',
+            count: aggregation.last,
+            duration: (aggregation.second.to_date + 1.day - aggregation.first.to_date).to_i,
+            total_duration: period_duration,
+          )
+        end
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -74,7 +74,7 @@ module BillableMetrics
       #       or start on non-anniversary day into account
       def period_duration
         @period_duration ||= Subscriptions::DatesService.new_instance(subscription, to_date + 1.day)
-          .duration_in_days
+          .charges_duration_in_days
       end
 
       # NOTE: when subscription is terminated or upgraded,

--- a/app/services/subscriptions/dates/monthly_service.rb
+++ b/app/services/subscriptions/dates/monthly_service.rb
@@ -28,6 +28,15 @@ module Subscriptions
         compute_to_date(compute_charges_from_date)
       end
 
+      def compute_duration(from_date:)
+        return Time.days_in_month(from_date.month, from_date.year) if calendar?
+
+        next_month_date = compute_to_date(from_date)
+        (next_month_date.to_date + 1.day - from_date.to_date).to_i
+      end
+
+      alias compute_charges_duration compute_duration
+
       private
 
       def compute_base_date
@@ -89,13 +98,6 @@ module Subscriptions
         end
 
         build_date(year, month, day)
-      end
-
-      def compute_duration(from_date:)
-        return Time.days_in_month(from_date.month, from_date.year) if calendar?
-
-        next_month_date = compute_to_date(from_date)
-        (next_month_date.to_date + 1.day - from_date.to_date).to_i
       end
     end
   end

--- a/app/services/subscriptions/dates/weekly_service.rb
+++ b/app/services/subscriptions/dates/weekly_service.rb
@@ -70,6 +70,8 @@ module Subscriptions
       def compute_duration(*)
         WEEK_DURATION
       end
+
+      alias compute_charges_duration compute_duration
     end
   end
 end

--- a/app/services/subscriptions/dates/weekly_service.rb
+++ b/app/services/subscriptions/dates/weekly_service.rb
@@ -32,8 +32,9 @@ module Subscriptions
         end
 
         return compute_from_date if plan.pay_in_arrear?
+        return base_date.beginning_of_week if calendar?
 
-        compute_from_date - 1.week
+        previous_anniversary_day(base_date)
       end
 
       def compute_charges_to_date

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -94,6 +94,12 @@ module Subscriptions
 
         Time.days_in_year(year)
       end
+
+      def compute_charges_duration(from_date:)
+        return monthly_service.compute_charges_duration(from_date: from_date) if plan.bill_charges_monthly
+
+        compute_duration(from_date: from_date)
+      end
     end
   end
 end

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -80,7 +80,7 @@ module Subscriptions
     end
 
     def charges_duration_in_days
-      compute_duration(from_date: compute_charges_from_date)
+      compute_charges_duration(from_date: compute_charges_from_date)
     end
 
     private

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -11,7 +11,7 @@ module Subscriptions
               when :yearly
                 Subscriptions::Dates::YearlyService
               else
-                raise NotImplementedError
+                raise(NotImplementedError)
       end
 
       klass.new(subscription, billing_date, current_usage)
@@ -79,8 +79,8 @@ module Subscriptions
       plan.amount_cents.fdiv(duration.to_i)
     end
 
-    def duration_in_days
-      compute_duration(from_date: compute_from_date)
+    def charges_duration_in_days
+      compute_duration(from_date: compute_charges_from_date)
     end
 
     private
@@ -112,27 +112,27 @@ module Subscriptions
     end
 
     def compute_base_date
-      raise NotImplementedError
+      raise(NotImplementedError)
     end
 
     def compute_from_date
-      raise NotImplementedError
+      raise(NotImplementedError)
     end
 
     def compute_to_date
-      raise NotImplementedError
+      raise(NotImplementedError)
     end
 
     def compute_charges_from_date
-      raise NotImplementedError
+      raise(NotImplementedError)
     end
 
     def compute_charges_to_date
-      raise NotImplementedError
+      raise(NotImplementedError)
     end
 
     def compute_next_end_of_period(date)
-      raise NotImplementedError
+      raise(NotImplementedError)
     end
 
     def first_month_in_yearly_period?
@@ -140,7 +140,7 @@ module Subscriptions
     end
 
     def compute_duration(from_date:)
-      raise NotImplementedError
+      raise(NotImplementedError)
     end
   end
 end

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -309,6 +309,20 @@ html
         text-align: right;
       }
 
+      .breakdown-details table {
+        border-collapse: collapse;
+      }
+      .breakdown-details-table tr td {
+        padding-bottom: 12px;
+      }
+      .breakdown-details-table tr td:last-child {
+        text-align: right;
+      }
+      .breakdown-details-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+
       .powered-by {
         width: 100%;
         text-align: right;
@@ -321,6 +335,15 @@ html
         height: 11px;
         vertical-align: middle;
         margin-top: 2px;
+      }
+      .alert {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        padding: 16px;
+        gap: 16px;
+        background: #F3F4F6;
+        border-radius: 12px;
       }
 
     .wrapper
@@ -485,7 +508,9 @@ html
                     td width="70%"
                       .body-1 = fee.billable_metric.name
                       .body-3
-                        - if fee.charge.percentage?
+                        - if fee.charge.billable_metric.recurring_count_agg?
+                          | See breakdown for total unit
+                        - elsif fee.charge.percentage?
                           | Total unit: #{fee.events_count} events for #{fee.units}
                         - else
                           | Total unit: #{fee.units}
@@ -499,3 +524,25 @@ html
                 tr
                   td.body-2 width="70%" Total
                   td.body-1 width="30%" = invoice_subscription(subscription.id).total_amount.format
+
+            - recurring_fees(subscription.id).each do |fee|
+              - if subscription.name.present?
+                h2.invoice-details-title.title-2.mb-24 #{subscription.name} details
+              - else
+                h2.invoice-details-title.title-2.mb-24 #{subscription.plan.name} details
+
+              .body-1.mb-24 Breackdown of #{fee.item_name}
+              .breakdown-details.mb-24
+                table.breakdown-details-table width="100%"
+                  - recurring_breakdown(fee).each do |breakdown|
+                    tr
+                      td.body-3 width="15%" = breakdown.date.strftime('%b %d, %Y')
+                      td.body-1 width="65%"
+                        - if breakdown.action.to_sym == :add
+                          | +#{breakdown.count} #{fee.item_name}
+                        - else
+                          | -#{breakdown.count} #{fee.item_name}
+                      td.body-3 width="20%"
+                        | #{breakdown.duration} of #{breakdown.total_duration} days
+              .alert.body-3
+                | For example, if a unit is added with 15 days left in your monthly plan, we multiply the price by 15/31 (days remaining divided by the total number of days in your plan) to calculate the prorated price. Same logic when removing a unit used during 10 days, we multiply the price by 10/31.

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -540,8 +540,10 @@ html
                       td.body-1 width="65%"
                         - if breakdown.action.to_sym == :add
                           | +#{breakdown.count} #{fee.item_name}
-                        - else
+                        - elsif breakdown.action.to_sym == :remove
                           | -#{breakdown.count} #{fee.item_name}
+                        - else
+                          | +/-#{breakdown.count} #{fee.item_name}
                       td.body-3 width="20%"
                         | #{breakdown.duration} of #{breakdown.total_duration} days
               .alert.body-3

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_05_142834) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_06_065059) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -239,6 +239,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_05_142834) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "role", default: 0, null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "revoked_at"
     t.index ["organization_id"], name: "index_memberships_on_organization_id"
     t.index ["user_id"], name: "index_memberships_on_user_id"
   end

--- a/spec/factories/billable_metric_factory.rb
+++ b/spec/factories/billable_metric_factory.rb
@@ -9,4 +9,9 @@ FactoryBot.define do
     aggregation_type { 'count_agg' }
     properties { {} }
   end
+
+  factory :recurring_billable_metric, parent: :billable_metric do
+    aggregation_type { 'recurring_count_agg' }
+    field_name { 'item_id' }
+  end
 end

--- a/spec/factories/fee_factory.rb
+++ b/spec/factories/fee_factory.rb
@@ -17,4 +17,20 @@ FactoryBot.define do
     vat_amount_cents { 2 }
     vat_amount_currency { 'EUR' }
   end
+
+  factory :charge_fee, parent: :fee do
+    invoice
+    charge
+    fee_type { 'charge' }
+
+    invoiceable_type { 'Charge' }
+    invoiceable_id { charge.id }
+
+    properties do
+      {
+        'charges_from_date' => Date.parse('2022-08-01'),
+        'charges_to_date' => Date.parse('2022-08-30'),
+      }
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -190,28 +190,26 @@ RSpec.describe Invoice, type: :model do
 
   describe '#recurring_fees' do
     let(:invoice_subscription) { create(:invoice_subscription) }
+    let(:invoice) { invoice_subscription.invoice }
+    let(:subscription) { invoice_subscription.subscription }
+    let(:billable_metric) { create(:recurring_billable_metric, organization: subscription.organization) }
+    let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric: billable_metric) }
+    let(:fee) { create(:charge_fee, subscription: subscription, invoice: invoice, charge: charge) }
 
     it 'returns the fees of the corresponding invoice_subscription' do
-      invoice = invoice_subscription.invoice
-      subscription = invoice_subscription.subscription
-      billable_metric = create(:recurring_billable_metric, organization: subscription.organization)
-      charge = create(:standard_charge, plan: subscription.plan, billable_metric: billable_metric)
-      fee = create(:charge_fee, subscription: subscription, invoice: invoice, charge: charge)
-
       expect(invoice.recurring_fees(subscription.id)).to eq([fee])
     end
   end
 
   describe '#recurring_breakdown' do
     let(:invoice_subscription) { create(:invoice_subscription) }
+    let(:invoice) { invoice_subscription.invoice }
+    let(:subscription) { invoice_subscription.subscription }
+    let(:billable_metric) { create(:recurring_billable_metric, organization: subscription.organization) }
+    let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric: billable_metric) }
+    let(:fee) { create(:charge_fee, subscription: subscription, invoice: invoice, charge: charge) }
 
     it 'returns the fees of the corresponding invoice_subscription' do
-      invoice = invoice_subscription.invoice
-      subscription = invoice_subscription.subscription
-      billable_metric = create(:recurring_billable_metric, organization: subscription.organization)
-      charge = create(:standard_charge, plan: subscription.plan, billable_metric: billable_metric)
-      fee = create(:charge_fee, subscription: subscription, invoice: invoice, charge: charge)
-
       expect(invoice.recurring_breakdown(fee)).to eq([])
     end
   end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -187,4 +187,32 @@ RSpec.describe Invoice, type: :model do
       expect(invoice.subscription_fees(subscription.id)).to eq([fee])
     end
   end
+
+  describe '#recurring_fees' do
+    let(:invoice_subscription) { create(:invoice_subscription) }
+
+    it 'returns the fees of the corresponding invoice_subscription' do
+      invoice = invoice_subscription.invoice
+      subscription = invoice_subscription.subscription
+      billable_metric = create(:recurring_billable_metric, organization: subscription.organization)
+      charge = create(:standard_charge, plan: subscription.plan, billable_metric: billable_metric)
+      fee = create(:charge_fee, subscription: subscription, invoice: invoice, charge: charge)
+
+      expect(invoice.recurring_fees(subscription.id)).to eq([fee])
+    end
+  end
+
+  describe '#recurring_breakdown' do
+    let(:invoice_subscription) { create(:invoice_subscription) }
+
+    it 'returns the fees of the corresponding invoice_subscription' do
+      invoice = invoice_subscription.invoice
+      subscription = invoice_subscription.subscription
+      billable_metric = create(:recurring_billable_metric, organization: subscription.organization)
+      charge = create(:standard_charge, plan: subscription.plan, billable_metric: billable_metric)
+      fee = create(:charge_fee, subscription: subscription, invoice: invoice, charge: charge)
+
+      expect(invoice.recurring_breakdown(fee)).to eq([])
+    end
+  end
 end

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -110,6 +110,16 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
           expect(result.aggregation).to eq(8.fdiv(31).ceil(5))
         end
       end
+
+      context 'when plan is pay in advance' do
+        before do
+          subscription.plan.update!(pay_in_advance: true)
+        end
+
+        it 'returns the number of persisted metric' do
+          expect(result.aggregation).to eq(1)
+        end
+      end
     end
 
     context 'with persisted metrics added in the period' do

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -33,8 +33,6 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
   let(:from_date) { Date.parse('2022-07-09') }
   let(:to_date) { Date.parse('2022-08-08') }
 
-  let(:result) { recurring_service.aggregate(from_date: from_date, to_date: to_date) }
-
   let(:added_at) { from_date - 1.month }
   let(:removed_at) { nil }
   let(:persisted_event) do
@@ -50,113 +48,322 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
 
   before { persisted_event }
 
-  context 'with persisted metric on full period' do
-    it 'returns the number of persisted metric' do
-      expect(result.aggregation).to eq(1)
+  describe '#aggregate' do
+    let(:result) { recurring_service.aggregate(from_date: from_date, to_date: to_date) }
+
+    context 'with persisted metric on full period' do
+      it 'returns the number of persisted metric' do
+        expect(result.aggregation).to eq(1)
+      end
+
+      context 'when subscription was terminated in the period' do
+        let(:subscription) do
+          create(
+            :subscription,
+            started_at: started_at,
+            subscription_date: subscription_date,
+            billing_time: :anniversary,
+            terminated_at: to_date,
+            status: :terminated,
+          )
+        end
+        let(:to_date) { Date.parse('2022-07-24') }
+
+        it 'returns the prorata of the full duration' do
+          expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
+        end
+      end
+
+      context 'when subscription was upgraded in the period' do
+        let(:subscription) do
+          create(
+            :subscription,
+            started_at: started_at,
+            subscription_date: subscription_date,
+            billing_time: :anniversary,
+            terminated_at: to_date,
+            status: :terminated,
+          )
+        end
+        let(:to_date) { Date.parse('2022-07-24') }
+
+        before do
+          create(
+            :subscription,
+            previous_subscription: subscription,
+            organization: organization,
+            customer: customer,
+            started_at: to_date,
+          )
+        end
+
+        it 'returns the prorata of the full duration' do
+          expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
+        end
+      end
+
+      context 'when subscription was started in the period' do
+        let(:started_at) { Date.parse('2022-08-01') }
+        let(:from_date) { started_at }
+
+        it 'returns the prorata of the full duration' do
+          expect(result.aggregation).to eq(8.fdiv(31).ceil(5))
+        end
+      end
     end
 
-    context 'when subscription was terminated in the period' do
-      let(:subscription) do
-        create(
-          :subscription,
-          started_at: started_at,
-          subscription_date: subscription_date,
-          billing_time: :anniversary,
-          terminated_at: to_date,
-          status: :terminated,
-        )
-      end
-      let(:to_date) { Date.parse('2022-07-24') }
+    context 'with persisted metrics added in the period' do
+      let(:added_at) { from_date + 15.days }
 
       it 'returns the prorata of the full duration' do
         expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
       end
+
+      context 'when added on the first day of the period' do
+        let(:added_at) { from_date }
+
+        it 'returns the full duration' do
+          expect(result.aggregation).to eq(1)
+        end
+      end
     end
 
-    context 'when subscription was upgraded in the period' do
-      let(:subscription) do
-        create(
-          :subscription,
-          started_at: started_at,
-          subscription_date: subscription_date,
-          billing_time: :anniversary,
-          terminated_at: to_date,
-          status: :terminated,
-        )
-      end
-      let(:to_date) { Date.parse('2022-07-24') }
-
-      before do
-        create(
-          :subscription,
-          previous_subscription: subscription,
-          organization: organization,
-          customer: customer,
-          started_at: to_date,
-        )
-      end
+    context 'with persisted metrics terminated in the period' do
+      let(:removed_at) { to_date - 15.days }
 
       it 'returns the prorata of the full duration' do
         expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
       end
-    end
 
-    context 'when subscription was started in the period' do
-      let(:started_at) { Date.parse('2022-08-01') }
-      let(:from_date) { started_at }
+      context 'when removed on the last day of the period' do
+        let(:removed_at) { to_date }
 
-      it 'returns the prorata of the full duration' do
-        expect(result.aggregation).to eq(8.fdiv(31).ceil(5))
+        it 'returns the full duration' do
+          expect(result.aggregation).to eq(1)
+        end
       end
     end
-  end
 
-  context 'with persisted metrics added in the period' do
-    let(:added_at) { from_date + 15.days }
-
-    it 'returns the prorata of the full duration' do
-      expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
-    end
-
-    context 'when added on the first day of the period' do
-      let(:added_at) { from_date }
-
-      it 'returns the full duration' do
-        expect(result.aggregation).to eq(1)
-      end
-    end
-  end
-
-  context 'with persisted metrics terminated in the period' do
-    let(:removed_at) { to_date - 15.days }
-
-    it 'returns the prorata of the full duration' do
-      expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
-    end
-
-    context 'when removed on the last day of the period' do
-      let(:removed_at) { to_date }
-
-      it 'returns the full duration' do
-        expect(result.aggregation).to eq(1)
-      end
-    end
-  end
-
-  context 'with persisted metrics added and terminated in the period' do
-    let(:added_at) { from_date + 1.day }
-    let(:removed_at) { to_date - 1.day }
-
-    it 'returns the prorata of the full duration' do
-      expect(result.aggregation).to eq(29.fdiv(31).ceil(5))
-    end
-
-    context 'when added and removed the same day' do
+    context 'with persisted metrics added and terminated in the period' do
       let(:added_at) { from_date + 1.day }
-      let(:removed_at) { added_at }
+      let(:removed_at) { to_date - 1.day }
 
-      it 'returns a 1 day duration' do
-        expect(result.aggregation).to eq(1.fdiv(31).ceil(5))
+      it 'returns the prorata of the full duration' do
+        expect(result.aggregation).to eq(29.fdiv(31).ceil(5))
+      end
+
+      context 'when added and removed the same day' do
+        let(:added_at) { from_date + 1.day }
+        let(:removed_at) { added_at }
+
+        it 'returns a 1 day duration' do
+          expect(result.aggregation).to eq(1.fdiv(31).ceil(5))
+        end
+      end
+    end
+  end
+
+  describe '#breakdown' do
+    let(:result) { recurring_service.breakdown(from_date: from_date, to_date: to_date).breakdown }
+
+    context 'with persisted metric on full period' do
+      it 'returns the detail the persisted metrics' do
+        aggregate_failures do
+          expect(result.count).to eq(1)
+
+          item = result.first
+          expect(item.date.to_s).to eq(from_date.to_s)
+          expect(item.action).to eq('add')
+          expect(item.count).to eq(1)
+          expect(item.duration).to eq(31)
+          expect(item.total_duration).to eq(31)
+        end
+      end
+
+      context 'when subscription was terminated in the period' do
+        let(:subscription) do
+          create(
+            :subscription,
+            started_at: started_at,
+            subscription_date: subscription_date,
+            billing_time: :anniversary,
+            terminated_at: to_date,
+            status: :terminated,
+          )
+        end
+        let(:to_date) { Date.parse('2022-07-24') }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(from_date.to_s)
+            expect(item.action).to eq('add')
+            expect(item.count).to eq(1)
+            expect(item.duration).to eq(16)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+
+      context 'when subscription was upgraded in the period' do
+        let(:subscription) do
+          create(
+            :subscription,
+            started_at: started_at,
+            subscription_date: subscription_date,
+            billing_time: :anniversary,
+            terminated_at: to_date,
+            status: :terminated,
+          )
+        end
+        let(:to_date) { Date.parse('2022-07-24') }
+
+        before do
+          create(
+            :subscription,
+            previous_subscription: subscription,
+            organization: organization,
+            customer: customer,
+            started_at: to_date,
+          )
+        end
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(from_date.to_s)
+            expect(item.action).to eq('add')
+            expect(item.count).to eq(1)
+            expect(item.duration).to eq(16)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+
+      context 'when subscription was started in the period' do
+        let(:started_at) { Date.parse('2022-08-01') }
+        let(:from_date) { started_at }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(from_date.to_s)
+            expect(item.action).to eq('add')
+            expect(item.count).to eq(1)
+            expect(item.duration).to eq(8)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+    end
+
+    context 'with persisted metrics added in the period' do
+      let(:added_at) { from_date + 15.days }
+
+      it 'returns the detail the persisted metrics' do
+        aggregate_failures do
+          expect(result.count).to eq(1)
+
+          item = result.first
+          expect(item.date.to_s).to eq(added_at.to_s)
+          expect(item.action).to eq('add')
+          expect(item.count).to eq(1)
+          expect(item.duration).to eq(16)
+          expect(item.total_duration).to eq(31)
+        end
+      end
+
+      context 'when added on the first day of the period' do
+        let(:added_at) { from_date }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(from_date.to_s)
+            expect(item.action).to eq('add')
+            expect(item.count).to eq(1)
+            expect(item.duration).to eq(31)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+    end
+
+    context 'with persisted metrics terminated in the period' do
+      let(:removed_at) { to_date - 15.days }
+
+      it 'returns the detail the persisted metrics' do
+        aggregate_failures do
+          expect(result.count).to eq(1)
+
+          item = result.first
+          expect(item.date.to_s).to eq(removed_at.to_s)
+          expect(item.action).to eq('remove')
+          expect(item.count).to eq(1)
+          expect(item.duration).to eq(16)
+          expect(item.total_duration).to eq(31)
+        end
+      end
+
+      context 'when removed on the last day of the period' do
+        let(:removed_at) { to_date }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(to_date.to_s)
+            expect(item.action).to eq('remove')
+            expect(item.count).to eq(1)
+            expect(item.duration).to eq(31)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+    end
+
+    context 'with persisted metrics added and terminated in the period' do
+      let(:added_at) { from_date + 1.day }
+      let(:removed_at) { to_date - 1.day }
+
+      it 'returns the detail the persisted metrics' do
+        aggregate_failures do
+          expect(result.count).to eq(1)
+
+          item = result.first
+          expect(item.date.to_s).to eq(added_at.to_s)
+          expect(item.action).to eq('add')
+          expect(item.count).to eq(1)
+          expect(item.duration).to eq(29)
+          expect(item.total_duration).to eq(31)
+        end
+      end
+
+      context 'when added and removed the same day' do
+        let(:added_at) { from_date + 1.day }
+        let(:removed_at) { added_at }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(added_at.to_s)
+            expect(item.action).to eq('add')
+            expect(item.count).to eq(1)
+            expect(item.duration).to eq(1)
+            expect(item.total_duration).to eq(31)
+          end
+        end
       end
     end
   end

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
 
           item = result.first
           expect(item.date.to_s).to eq(added_at.to_s)
-          expect(item.action).to eq('add')
+          expect(item.action).to eq('add_and_removed')
           expect(item.count).to eq(1)
           expect(item.duration).to eq(29)
           expect(item.total_duration).to eq(31)
@@ -368,7 +368,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
 
             item = result.first
             expect(item.date.to_s).to eq(added_at.to_s)
-            expect(item.action).to eq('add')
+            expect(item.action).to eq('add_and_removed')
             expect(item.count).to eq(1)
             expect(item.duration).to eq(1)
             expect(item.total_duration).to eq(31)

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -435,8 +435,8 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
     end
   end
 
-  describe 'duration_in_days' do
-    let(:result) { date_service.duration_in_days }
+  describe 'charges_duration_in_days' do
+    let(:result) { date_service.charges_duration_in_days }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -359,10 +359,10 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
     end
   end
 
-  describe 'duration_in_days' do
+  describe 'charges_duration_in_days' do
     let(:billing_time) { :anniversary }
     let(:billing_date) { DateTime.parse('08 Mar 2022') }
-    let(:result) { date_service.duration_in_days }
+    let(:result) { date_service.charges_duration_in_days }
 
     it 'returns the duration of the period' do
       expect(result).to eq(7)

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -502,6 +502,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
           expect(result).to eq(366)
         end
       end
+
+      context 'when billing charge monthly' do
+        before { plan.update!(bill_charges_monthly: true) }
+
+        it 'returns the month duration' do
+          expect(result).to eq(28)
+        end
+      end
     end
 
     context 'when billing_time is anniversary' do
@@ -517,6 +525,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
         it 'returns the year duration' do
           expect(result).to eq(366)
+        end
+      end
+
+      context 'when billing charge monthly' do
+        before { plan.update!(bill_charges_monthly: true) }
+
+        it 'returns the month duration' do
+          expect(result).to eq(28)
         end
       end
     end

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -484,8 +484,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
     end
   end
 
-  describe 'duration_in_days' do
-    let(:result) { date_service.duration_in_days }
+  describe 'charges_duration_in_days' do
+    let(:result) { date_service.charges_duration_in_days }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -107,9 +107,9 @@ RSpec.describe Subscriptions::DatesService, type: :service do
     end
   end
 
-  describe 'duration_in_days' do
+  describe 'charges_duration_in_days' do
     it 'raises a not implemented error' do
-      expect { date_service.duration_in_days }
+      expect { date_service.charges_duration_in_days }
         .to raise_error(NotImplementedError)
     end
   end


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a system of persistent billable metrics that do not resume to 0 at the end of a billing period.

## Description

The objective of this pull request is to update the PDF invoice in order to render the breakdown of the persisted metrics:
- Items billed on the full period
- Items added during the period
- Items remove during the period
- Items added and then remove during the same period

## Related Task

- Event ingestion logic: https://github.com/getlago/lago-api/pull/429
- Aggregation logic for the recurring persisted metrics: https://github.com/getlago/lago-api/pull/421
