### PR TITLE
feat(persisted-metrics): Rename PersistedMetric into PersistedEvent

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -19,7 +19,7 @@ class Customer < ApplicationRecord
   has_many :payment_provider_customers,
            class_name: 'PaymentProviderCustomers::BaseCustomer',
            dependent: :destroy
-  has_many :persisted_metrics
+  has_many :persisted_events
 
   has_one :stripe_customer, class_name: 'PaymentProviderCustomers::StripeCustomer'
 

--- a/app/models/persisted_event.rb
+++ b/app/models/persisted_event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PersistedMetric < ApplicationRecord
+class PersistedEvent < ApplicationRecord
   belongs_to :customer
 
   validates :external_id, presence: true

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -29,21 +29,21 @@ module BillableMetrics
           # NOTE: Added during the period
           added
             .select(
-              "SUM(('#{to_date}'::date - DATE(persisted_metrics.added_at) + 1)::numeric / #{period_duration})::numeric",
+              "SUM(('#{to_date}'::date - DATE(persisted_events.added_at) + 1)::numeric / #{period_duration})::numeric",
             )
             .to_sql,
 
           # NOTE: removed during the period
           removed
             .select(
-              "SUM((DATE(persisted_metrics.removed_at) - '#{from_date}'::date + 1)::numeric / #{period_duration})::numeric",
+              "SUM((DATE(persisted_events.removed_at) - '#{from_date}'::date + 1)::numeric / #{period_duration})::numeric",
             )
             .to_sql,
 
           # # NOTE: Added and then removed during the period
           added_and_removed
             .select(
-              "SUM((DATE(persisted_metrics.removed_at) - DATE(persisted_metrics.added_at) + 1)::numeric / #{period_duration})::numeric",
+              "SUM((DATE(persisted_events.removed_at) - DATE(persisted_events.added_at) + 1)::numeric / #{period_duration})::numeric",
             ).to_sql,
         ]
 
@@ -51,7 +51,7 @@ module BillableMetrics
       end
 
       def base_scope
-        PersistedMetric
+        PersistedEvent
           .where(customer_id: subscription.customer_id)
           .where(external_subscription_id: subscription.unique_id)
       end
@@ -72,30 +72,30 @@ module BillableMetrics
 
       def persisted
         base_scope
-          .where('DATE(persisted_metrics.added_at) < ?', from_date)
-          .where('persisted_metrics.removed_at IS NULL OR DATE(persisted_metrics.removed_at) > ?', to_date)
+          .where('DATE(persisted_events.added_at) < ?', from_date)
+          .where('persisted_events.removed_at IS NULL OR DATE(persisted_events.removed_at) > ?', to_date)
       end
 
       def added
         base_scope
-          .where('DATE(persisted_metrics.added_at) >= ?', from_date)
-          .where('DATE(persisted_metrics.added_at) <= ?', to_date)
-          .where('persisted_metrics.removed_at IS NULL OR DATE(persisted_metrics.removed_at) > ?', to_date)
+          .where('DATE(persisted_events.added_at) >= ?', from_date)
+          .where('DATE(persisted_events.added_at) <= ?', to_date)
+          .where('persisted_events.removed_at IS NULL OR DATE(persisted_events.removed_at) > ?', to_date)
       end
 
       def removed
         base_scope
-          .where('DATE(persisted_metrics.added_at) < ?', from_date)
-          .where('DATE(persisted_metrics.removed_at) >= ?', from_date)
-          .where('DATE(persisted_metrics.removed_at) <= ?', to_date)
+          .where('DATE(persisted_events.added_at) < ?', from_date)
+          .where('DATE(persisted_events.removed_at) >= ?', from_date)
+          .where('DATE(persisted_events.removed_at) <= ?', to_date)
       end
 
       def added_and_removed
         base_scope
-          .where('DATE(persisted_metrics.added_at) >= ?', from_date)
-          .where('DATE(persisted_metrics.added_at) <= ?', to_date)
-          .where('DATE(persisted_metrics.removed_at) >= ?', from_date)
-          .where('DATE(persisted_metrics.removed_at) <= ?', to_date)
+          .where('DATE(persisted_events.added_at) >= ?', from_date)
+          .where('DATE(persisted_events.added_at) <= ?', to_date)
+          .where('DATE(persisted_events.removed_at) >= ?', from_date)
+          .where('DATE(persisted_events.removed_at) <= ?', to_date)
       end
     end
   end

--- a/db/migrate/20220905095529_rename_persisted_metrics_into_persisted_events.rb
+++ b/db/migrate/20220905095529_rename_persisted_metrics_into_persisted_events.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RenamePersistedMetricsIntoPersistedEvents < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :persisted_metrics, :persisted_events
+    rename_index :persisted_events, :index_search_persisted_metrics, :index_search_persisted_events
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_31_113537) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_05_095529) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -302,7 +302,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_31_113537) do
     t.index ["payment_provider_id"], name: "index_payments_on_payment_provider_id"
   end
 
-  create_table "persisted_metrics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "persisted_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "customer_id", null: false
     t.string "external_subscription_id", null: false
     t.string "external_id", null: false
@@ -310,9 +310,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_31_113537) do
     t.datetime "removed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["customer_id", "external_subscription_id"], name: "index_search_persisted_metrics"
-    t.index ["customer_id"], name: "index_persisted_metrics_on_customer_id"
-    t.index ["external_id"], name: "index_persisted_metrics_on_external_id"
+    t.index ["customer_id", "external_subscription_id"], name: "index_search_persisted_events"
+    t.index ["customer_id"], name: "index_persisted_events_on_customer_id"
+    t.index ["external_id"], name: "index_persisted_events_on_external_id"
   end
 
   create_table "plans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -418,7 +418,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_31_113537) do
   add_foreign_key "payment_providers", "organizations"
   add_foreign_key "payments", "invoices"
   add_foreign_key "payments", "payment_providers"
-  add_foreign_key "persisted_metrics", "customers"
+  add_foreign_key "persisted_events", "customers"
   add_foreign_key "plans", "organizations"
   add_foreign_key "subscriptions", "customers"
   add_foreign_key "subscriptions", "plans"

--- a/spec/factories/persisted_events.rb
+++ b/spec/factories/persisted_events.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :persisted_metric do
+  factory :persisted_event do
     customer
 
     external_id { SecureRandom.uuid }

--- a/spec/models/persisted_event_spec.rb
+++ b/spec/models/persisted_event_spec.rb
@@ -2,6 +2,5 @@
 
 require 'rails_helper'
 
-RSpec.describe PersistedMetric, type: :model do
-
+RSpec.describe PersistedEvent, type: :model do
 end

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
 
   let(:added_at) { from_date - 1.month }
   let(:removed_at) { nil }
-  let(:persisted_metric) do
+  let(:persisted_event) do
     create(
-      :persisted_metric,
+      :persisted_event,
       customer: customer,
       added_at: added_at,
       removed_at: removed_at,
@@ -47,7 +47,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
     )
   end
 
-  before { persisted_metric }
+  before { persisted_event }
 
   context 'with persisted metric on full period' do
     it 'returns the number of persisted metric' do


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a system of persistent billable metrics that do not resume to 0 at the end of a billing period.

## Description

This PR rename the previously added `PersistedMetrics` into `PersistedEvents` to make it more obvious it's related to events and not a new kind of metric definition
