### PR TITLE
fix(invoice): add on invoice should not show subscription page

### DIFF
--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -451,7 +451,7 @@ html
             clipPath id="c"
               path fill="#fff" d="M0 0h9.25v9.263H0z"
 
-      - if invoice.subscription?
+      - if subscription?
         - subscriptions.each do |subscription|
           - if subscription.name.present?
             h2.invoice-details-title.title-2.mb-24 #{subscription.name} details


### PR DESCRIPTION
## Context

Add on invoice actually show the subscription page, it's empty and it does not have to be on this invoice.

## Description

Remove the subscription page on others invoice than subscription ones
