### PR TITLE
feat(customers): Add index and show on API

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -61,7 +61,7 @@ module Api
       end
 
       def show
-        customer = current_organization.customers.find_by(customer_id: params[:customer_id])
+        customer = current_organization.customers.find_by(external_id: params[:external_id])
 
         return not_found_error unless customer
 

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -45,6 +45,34 @@ module Api
         end
       end
 
+      def index
+        customers = current_organization.customers
+          .page(params[:page])
+          .per(params[:per_page] || PER_PAGE)
+
+        render(
+          json: ::CollectionSerializer.new(
+            customers,
+            ::V1::CustomerSerializer,
+            collection_name: 'customers',
+            meta: pagination_metadata(customers),
+          ),
+        )
+      end
+
+      def show
+        customer = current_organization.customers.find_by(customer_id: params[:customer_id])
+
+        return not_found_error unless customer
+
+        render(
+          json: ::V1::CustomerSerializer.new(
+            customer,
+            root_name: 'customer',
+          ),
+        )
+      end
+
       private
 
       def create_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :customers, param: :external_id, only: %i[create] do
+      resources :customers, param: :external_id, only: %i[create index show] do
         get :current_usage
       end
 

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     context 'with invalid params' do
       let(:create_params) do
         {
-          name: 'Foo Bar'
+          name: 'Foo Bar',
         }
       end
 
@@ -66,7 +66,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     end
   end
 
-  describe 'GET /customers/:id/current_usage' do
+  describe 'GET /customers/:customer_id/current_usage' do
     let(:customer) { create(:customer, organization: organization) }
     let(:organization) { create(:organization) }
     let(:subscription) do
@@ -113,8 +113,9 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     end
 
     it 'returns the usage for the customer' do
-      get_with_token(organization,
-        "/api/v1/customers/#{customer.external_id}/current_usage?external_subscription_id=#{subscription.external_id}"
+      get_with_token(
+        organization,
+        "/api/v1/customers/#{customer.external_id}/current_usage?external_subscription_id=#{subscription.external_id}",
       )
 
       aggregate_failures do
@@ -149,6 +150,60 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         get_with_token(
           organization,
           "/api/v1/customers/#{customer.external_id}/current_usage?external_subscription_id=#{subscription.external_id}",
+        )
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'GET /customers' do
+    let(:organization) { create(:organization) }
+
+    before do
+      create_list(:customer, 2, organization: organization)
+    end
+
+    it 'returns all customers from organization' do
+      get_with_token(
+        organization,
+        '/api/v1/customers',
+      )
+
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+      aggregate_failures do
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response[:meta][:total_count]).to eq(2)
+      end
+    end
+  end
+
+  describe 'GET /customers/:customer_id' do
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization: organization) }
+
+    before do
+      customer
+    end
+
+    it 'returns the customer' do
+      get_with_token(
+        organization,
+        "/api/v1/customers/#{customer.customer_id}",
+      )
+
+      parsed_response = JSON.parse(response.body, symbolize_names: true)
+      aggregate_failures do
+        expect(response).to have_http_status(:ok)
+        expect(parsed_response[:customer][:lago_id]).to eq(customer.id)
+      end
+    end
+
+    context 'with not existing customer_id' do
+      it 'returns a not found error' do
+        get_with_token(
+          organization,
+          '/api/v1/customers/foobar',
         )
 
         expect(response).to have_http_status(:not_found)

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     it 'returns the customer' do
       get_with_token(
         organization,
-        "/api/v1/customers/#{customer.customer_id}",
+        "/api/v1/customers/#{customer.external_id}",
       )
 
       parsed_response = JSON.parse(response.body, symbolize_names: true)
@@ -199,7 +199,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       end
     end
 
-    context 'with not existing customer_id' do
+    context 'with not existing external_id' do
       it 'returns a not found error' do
         get_with_token(
           organization,


### PR DESCRIPTION
## Context

We do not have any endpoints to list organization's customer or search for a customer on the API.

## Description

- Add the `/customers` index endpoint
- Add the `/customers/:customer_id` show endpoint
