### PR TITLE
fix(persisted-metrics): Add relation between billable metric and persisted events

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -5,6 +5,7 @@ class BillableMetric < ApplicationRecord
 
   has_many :charges, dependent: :destroy
   has_many :plans, through: :charges
+  has_many :persisted_events
 
   BILLABLE_PERIODS = %i[
     one_shot

--- a/app/models/persisted_event.rb
+++ b/app/models/persisted_event.rb
@@ -2,6 +2,7 @@
 
 class PersistedEvent < ApplicationRecord
   belongs_to :customer
+  belongs_to :billable_metric
 
   validates :external_id, presence: true
   validates :added_at, presence: true

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -52,6 +52,7 @@ module BillableMetrics
 
       def base_scope
         PersistedEvent
+          .where(billable_metric_id: billable_metric.id)
           .where(customer_id: subscription.customer_id)
           .where(external_subscription_id: subscription.unique_id)
       end

--- a/db/migrate/20220905142834_add_billable_metric_id_to_persisted_events.rb
+++ b/db/migrate/20220905142834_add_billable_metric_id_to_persisted_events.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddBillableMetricIdToPersistedEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :persisted_events, :billable_metric, type: :uuid
+
+    remove_index :persisted_events, name: :index_search_persisted_events
+    add_index :persisted_events,
+              [:customer_id, :external_subscription_id, :billable_metric_id],
+              name: :index_search_persisted_events
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_05_095529) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_05_142834) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -310,7 +310,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_05_095529) do
     t.datetime "removed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["customer_id", "external_subscription_id"], name: "index_search_persisted_events"
+    t.uuid "billable_metric_id"
+    t.index ["billable_metric_id"], name: "index_persisted_events_on_billable_metric_id"
+    t.index ["customer_id", "external_subscription_id", "billable_metric_id"], name: "index_search_persisted_events"
     t.index ["customer_id"], name: "index_persisted_events_on_customer_id"
     t.index ["external_id"], name: "index_persisted_events_on_external_id"
   end

--- a/spec/factories/persisted_events.rb
+++ b/spec/factories/persisted_events.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :persisted_event do
     customer
+    billable_metric
 
     external_id { SecureRandom.uuid }
     added_at { Time.current - 10.days }

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       added_at: added_at,
       removed_at: removed_at,
       external_subscription_id: subscription.unique_id,
+      billable_metric: billable_metric,
     )
   end
 


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a system of persistent billable metrics that do not resume to 0 at the end of a billing period.

## Description

This PR is a fix to add a foreign key on the persisted event table to point to a billable metric. Without this relation, all metrics are taken into account for all billable metrics, leading to an inconsistent billing...
