### PR TITLE
feat(api): Handle 500 and 404 global errors

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -45,16 +45,6 @@ module Api
       )
     end
 
-    def not_found_error
-      render(
-        json: {
-          status: 404,
-          error: 'Not Found',
-        },
-        status: :not_found
-      )
-    end
-
     def forbidden_error(error_result)
       render(
         json: {
@@ -63,7 +53,7 @@ module Api
           message: error_result.error,
           error_details: error_result.error_details,
         },
-        status: :forbidden
+        status: :forbidden,
       )
     end
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -59,7 +59,7 @@ module Api
 
     def render_error_response(error_result)
       if error_result.error_code == 'not_found'
-        not_found_error
+        not_found_error(message: error_result.error)
       elsif error_result.error_code == 'forbidden'
         forbidden_error(error_result)
       else

--- a/app/controllers/api/v1/add_ons_controller.rb
+++ b/app/controllers/api/v1/add_ons_controller.rb
@@ -9,7 +9,7 @@ module Api
           **input_params
             .merge(organization_id: current_organization.id)
             .to_h
-            .symbolize_keys
+            .symbolize_keys,
         )
 
         if result.success?
@@ -38,7 +38,7 @@ module Api
         service = AddOns::DestroyService.new
         result = service.destroy_from_api(
           organization: current_organization,
-          code: params[:code]
+          code: params[:code],
         )
 
         if result.success?
@@ -50,27 +50,27 @@ module Api
 
       def show
         add_on = current_organization.add_ons.find_by(
-          code: params[:code]
+          code: params[:code],
         )
 
-        return not_found_error unless add_on
+        return not_found_error(message: 'add_on_not_found') unless add_on
 
         render_add_on(add_on)
       end
 
       def index
         add_ons = current_organization.add_ons
-                                      .order(created_at: :desc)
-                                      .page(params[:page])
-                                      .per(params[:per_page] || PER_PAGE)
+          .order(created_at: :desc)
+          .page(params[:page])
+          .per(params[:per_page] || PER_PAGE)
 
         render(
           json: ::CollectionSerializer.new(
             add_ons,
             ::V1::AddOnSerializer,
             collection_name: 'add_ons',
-            meta: pagination_metadata(add_ons)
-          )
+            meta: pagination_metadata(add_ons),
+          ),
         )
       end
 

--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -9,7 +9,7 @@ module Api
           **input_params
             .merge(organization_id: current_organization.id)
             .to_h
-            .symbolize_keys
+            .symbolize_keys,
         )
 
         if result.success?
@@ -48,7 +48,7 @@ module Api
         service = BillableMetrics::DestroyService.new
         result = service.destroy_from_api(
           organization: current_organization,
-          code: params[:code]
+          code: params[:code],
         )
 
         if result.success?
@@ -65,32 +65,32 @@ module Api
 
       def show
         metric = current_organization.billable_metrics.find_by(
-          code: params[:code]
+          code: params[:code],
         )
 
-        return not_found_error unless metric
+        return not_found_error(message: 'billable_metric_not_found') unless metric
 
         render(
           json: ::V1::BillableMetricSerializer.new(
             metric,
             root_name: 'billable_metric',
-          )
+          ),
         )
       end
 
       def index
         metrics = current_organization.billable_metrics
-                                      .order(created_at: :desc)
-                                      .page(params[:page])
-                                      .per(params[:per_page] || PER_PAGE)
+          .order(created_at: :desc)
+          .page(params[:page])
+          .per(params[:per_page] || PER_PAGE)
 
         render(
           json: ::CollectionSerializer.new(
             metrics,
             ::V1::BillableMetricSerializer,
             collection_name: 'billable_metrics',
-            meta: pagination_metadata(metrics)
-          )
+            meta: pagination_metadata(metrics),
+          ),
         )
       end
 

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -9,7 +9,7 @@ module Api
           **input_params
             .merge(organization_id: current_organization.id)
             .to_h
-            .symbolize_keys
+            .symbolize_keys,
         )
 
         if result.success?
@@ -38,7 +38,7 @@ module Api
         service = Coupons::DestroyService.new
         result = service.destroy_from_api(
           organization: current_organization,
-          code: params[:code]
+          code: params[:code],
         )
 
         if result.success?
@@ -50,27 +50,27 @@ module Api
 
       def show
         coupon = current_organization.coupons.find_by(
-          code: params[:code]
+          code: params[:code],
         )
 
-        return not_found_error unless coupon
+        return not_found_error(message: 'coupon_not_found') unless coupon
 
         render_coupon(coupon)
       end
 
       def index
         coupons = current_organization.coupons
-                                      .order(created_at: :desc)
-                                      .page(params[:page])
-                                      .per(params[:per_page] || PER_PAGE)
+          .order(created_at: :desc)
+          .page(params[:page])
+          .per(params[:per_page] || PER_PAGE)
 
         render(
           json: ::CollectionSerializer.new(
             coupons,
             ::V1::CouponSerializer,
             collection_name: 'coupons',
-            meta: pagination_metadata(coupons)
-          )
+            meta: pagination_metadata(coupons),
+          ),
         )
       end
 

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -63,7 +63,7 @@ module Api
       def show
         customer = current_organization.customers.find_by(external_id: params[:external_id])
 
-        return not_found_error unless customer
+        return not_found_error(message: 'customer_not_found') unless customer
 
         render(
           json: ::V1::CustomerSerializer.new(

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -34,16 +34,16 @@ module Api
       def show
         event = Event.find_by(
           organization: current_organization,
-          transaction_id: params[:id]
+          transaction_id: params[:id],
         )
 
-        return not_found_error unless event
+        return not_found_error(message: 'event_not_found') unless event
 
         render(
           json: ::V1::EventSerializer.new(
             event,
             root_name: 'event',
-          )
+          ),
         )
       end
 

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -20,7 +20,7 @@ module Api
       def show
         invoice = current_organization.invoices.find_by(id: params[:id])
 
-        return not_found_error unless invoice
+        return not_found_error(message: 'invoice_not_found') unless invoice
 
         render_invoice(invoice)
       end
@@ -30,8 +30,8 @@ module Api
         invoices = invoices.where(date_from_criteria) if valid_date?(params[:issuing_date_from])
         invoices = invoices.where(date_to_criteria) if valid_date?(params[:issuing_date_to])
         invoices = invoices.order(created_at: :desc)
-                           .page(params[:page])
-                           .per(params[:per_page] || PER_PAGE)
+          .page(params[:page])
+          .per(params[:per_page] || PER_PAGE)
 
         render(
           json: ::CollectionSerializer.new(
@@ -46,7 +46,7 @@ module Api
       def download
         invoice = current_organization.invoices.find_by(id: params[:id])
 
-        return not_found_error unless invoice
+        return not_found_error(message: 'invoice_not_found') unless invoice
 
         if invoice.file.present?
           return render(
@@ -79,11 +79,11 @@ module Api
       end
 
       def date_from_criteria
-        {issuing_date: Date.strptime(params[:issuing_date_from])..}
+        { issuing_date: Date.strptime(params[:issuing_date_from]).. }
       end
 
       def date_to_criteria
-        {issuing_date: ..Date.strptime(params[:issuing_date_to])}
+        { issuing_date: ..Date.strptime(params[:issuing_date_to]) }
       end
     end
   end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -53,7 +53,7 @@ module Api
           code: params[:code],
         )
 
-        return not_found_error unless plan
+        return not_found_error(message: 'plan_not_found') unless plan
 
         render_plan(plan)
       end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -27,7 +27,7 @@ module Api
         result = Subscriptions::TerminateService.new
           .terminate_from_api(
             organization: current_organization,
-            external_id: params[:external_id]
+            external_id: params[:external_id],
           )
 
         if result.success?
@@ -48,7 +48,7 @@ module Api
         result = service.update_from_api(
           organization: current_organization,
           external_id: params[:external_id],
-          params: update_params
+          params: update_params,
         )
 
         if result.success?
@@ -66,11 +66,11 @@ module Api
       def index
         customer = current_organization.customers.find_by(external_id: params[:external_customer_id])
 
-        return not_found_error unless customer
+        return not_found_error(message: 'customer_not_found') unless customer
 
         subscriptions = customer.active_subscriptions
-                                .page(params[:page])
-                                .per(params[:per_page] || PER_PAGE)
+          .page(params[:page])
+          .per(params[:per_page] || PER_PAGE)
 
         render(
           json: ::CollectionSerializer.new(

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -10,7 +10,7 @@ module Api
             .merge(organization_id: current_organization.id)
             .merge(customer: customer)
             .to_h
-            .symbolize_keys
+            .symbolize_keys,
         )
 
         if result.success?
@@ -25,7 +25,7 @@ module Api
         result = service.update(
           **update_params.merge(id: params[:id])
             .to_h
-            .symbolize_keys
+            .symbolize_keys,
         )
 
         if result.success?
@@ -48,10 +48,10 @@ module Api
 
       def show
         wallet = current_organization.wallets.find_by(
-          id: params[:id]
+          id: params[:id],
         )
 
-        return not_found_error unless wallet
+        return not_found_error(message: 'wallet_not_found') unless wallet
 
         render_wallet(wallet)
       end
@@ -59,11 +59,11 @@ module Api
       def index
         customer = Customer.find_by(external_id: params[:external_customer_id])
 
-        return not_found_error unless customer
+        return not_found_error(message: 'customer_not_found') unless customer
 
         wallets = customer.wallets
-                          .page(params[:page])
-                          .per(params[:per_page] || PER_PAGE)
+          .page(params[:page])
+          .per(params[:per_page] || PER_PAGE)
 
         render(
           json: ::CollectionSerializer.new(
@@ -94,7 +94,7 @@ module Api
       def update_params
         params.require(:wallet).permit(
           :name,
-          :expiration_date
+          :expiration_date,
         )
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  include ApiResponses
+
+  rescue_from ActionController::RoutingError, with: :not_found
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+
   def health
     result = Utils::VersionService.new.version
 
@@ -12,5 +17,9 @@ class ApplicationController < ActionController::API
       },
       status: :ok,
     )
+  end
+
+  def not_found
+    not_found_error(message: 'Resource not found')
   end
 end

--- a/app/controllers/concerns/api_responses.rb
+++ b/app/controllers/concerns/api_responses.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ApiResponses
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_json_format
+  end
+
+  def not_found_error(message:)
+    render(
+      json: {
+        status: 404,
+        error: 'Not Found',
+        message: message,
+      },
+      status: :not_found,
+    )
+  end
+
+  protected
+
+  def set_json_format
+    request.format = :json
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,7 @@ require 'sidekiq/web'
 Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq' if ENV['LAGO_SIDEKIQ_WEB']
 
-  if Rails.env.development?
-    mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql'
-  end
+  mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql' if Rails.env.development?
 
   post '/graphql', to: 'graphql#execute'
 
@@ -49,4 +47,6 @@ Rails.application.routes.draw do
   resources :webhooks, only: [] do
     post 'stripe/:organization_id', to: 'webhooks#stripe', on: :collection, as: :stripe
   end
+
+  match '*unmatched' => 'application#not_found', via: %i[get post put delete patch]
 end

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :request do
+  describe 'GET /health' do
+    it 'returns the application health check' do
+      get '/health'
+
+      aggregate_failures do
+        expect(response.status).to be(200)
+
+        json = JSON.parse(response.body)
+        expect(json['message']).to eq('Success')
+        expect(json['version']).to be_present
+        expect(json['github_url']).to be_present
+      end
+    end
+  end
+
+  describe 'Missing resources' do
+    it 'returns a 404 response' do
+      get '/not_found'
+
+      aggregate_failures do
+        expect(response.status).to be(404)
+
+        json = JSON.parse(response.body)
+        expect(json['status']).to eq(404)
+        expect(json['error']).to eq('Not Found')
+        expect(json['message']).to eq('Resource not found')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Current Rails configuration is missing a proper handling of HTTP 500 and 404 errors.

Both where not sending empty responses.

## Description

This PR :
- Adds 404 error handling for:
  - ActionController::RoutingError
  - ActiveRecord::RecordNotFound
- Force request to JSON format, in order for Rails to use built-in 500 response
- Add a "catch all" route to respond 404 when users tries to access