### PR TITLE
fix(errors): Fix error details for GraphQL mutations

### DIFF
--- a/app/graphql/concerns/execution_error_responder.rb
+++ b/app/graphql/concerns/execution_error_responder.rb
@@ -12,7 +12,7 @@ module ExecutionErrorResponder
       code: code,
     }
 
-    if code == 'unprocessable_entity' && payload[:details].is_a?(Hash)
+    if code == 'unprocessable_entity' && details.is_a?(Hash)
       payload[:details] = details&.transform_keys do |key|
         key.to_s.camelize(:lower)
       end


### PR DESCRIPTION
## Context

Details for `unprocessable_entity` error was lost recently with the introduction of the wallet feature.

As a result, it was not possible anymore for the front end to display validation errors.

## Description

This PR fixes the regression and adds a test case for this scenario.