### PR TITLE
feat(errors): Handle not found error in services API and GraphQL errors

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -58,8 +58,8 @@ module Api
     end
 
     def render_error_response(error_result)
-      if error_result.error_code == 'not_found'
-        not_found_error(message: error_result.error)
+      if error_result.error.is_a?(BaseService::NotFoundFailure)
+        not_found_error(code: error_result.error.code)
       elsif error_result.error_code == 'forbidden'
         forbidden_error(error_result)
       else

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -59,7 +59,7 @@ module Api
 
     def render_error_response(error_result)
       if error_result.error.is_a?(BaseService::NotFoundFailure)
-        not_found_error(code: error_result.error.code)
+        not_found_error(code: error_result.error.error_code)
       elsif error_result.error_code == 'forbidden'
         forbidden_error(error_result)
       else

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -59,7 +59,7 @@ module Api
 
     def render_error_response(error_result)
       if error_result.error.is_a?(BaseService::NotFoundFailure)
-        not_found_error(code: error_result.error.error_code)
+        not_found_error(resource: error_result.error.resource)
       elsif error_result.error_code == 'forbidden'
         forbidden_error(error_result)
       else

--- a/app/controllers/api/v1/add_ons_controller.rb
+++ b/app/controllers/api/v1/add_ons_controller.rb
@@ -53,7 +53,7 @@ module Api
           code: params[:code],
         )
 
-        return not_found_error(code: 'add_on_not_found') unless add_on
+        return not_found_error(resource: 'add_on') unless add_on
 
         render_add_on(add_on)
       end

--- a/app/controllers/api/v1/add_ons_controller.rb
+++ b/app/controllers/api/v1/add_ons_controller.rb
@@ -53,7 +53,7 @@ module Api
           code: params[:code],
         )
 
-        return not_found_error(message: 'add_on_not_found') unless add_on
+        return not_found_error(code: 'add_on_not_found') unless add_on
 
         render_add_on(add_on)
       end

--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -68,7 +68,7 @@ module Api
           code: params[:code],
         )
 
-        return not_found_error(code: 'billable_metric_not_found') unless metric
+        return not_found_error(resource: 'billable_metric') unless metric
 
         render(
           json: ::V1::BillableMetricSerializer.new(

--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -68,7 +68,7 @@ module Api
           code: params[:code],
         )
 
-        return not_found_error(message: 'billable_metric_not_found') unless metric
+        return not_found_error(code: 'billable_metric_not_found') unless metric
 
         render(
           json: ::V1::BillableMetricSerializer.new(

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -53,7 +53,7 @@ module Api
           code: params[:code],
         )
 
-        return not_found_error(message: 'coupon_not_found') unless coupon
+        return not_found_error(code: 'coupon_not_found') unless coupon
 
         render_coupon(coupon)
       end

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -53,7 +53,7 @@ module Api
           code: params[:code],
         )
 
-        return not_found_error(code: 'coupon_not_found') unless coupon
+        return not_found_error(resource: 'coupon') unless coupon
 
         render_coupon(coupon)
       end

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -63,7 +63,7 @@ module Api
       def show
         customer = current_organization.customers.find_by(external_id: params[:external_id])
 
-        return not_found_error(code: 'customer_not_found') unless customer
+        return not_found_error(resource: 'customer') unless customer
 
         render(
           json: ::V1::CustomerSerializer.new(

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -63,7 +63,7 @@ module Api
       def show
         customer = current_organization.customers.find_by(external_id: params[:external_id])
 
-        return not_found_error(message: 'customer_not_found') unless customer
+        return not_found_error(code: 'customer_not_found') unless customer
 
         render(
           json: ::V1::CustomerSerializer.new(

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -37,7 +37,7 @@ module Api
           transaction_id: params[:id],
         )
 
-        return not_found_error(message: 'event_not_found') unless event
+        return not_found_error(code: 'event_not_found') unless event
 
         render(
           json: ::V1::EventSerializer.new(

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -37,7 +37,7 @@ module Api
           transaction_id: params[:id],
         )
 
-        return not_found_error(code: 'event_not_found') unless event
+        return not_found_error(resource: 'event') unless event
 
         render(
           json: ::V1::EventSerializer.new(

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -20,7 +20,7 @@ module Api
       def show
         invoice = current_organization.invoices.find_by(id: params[:id])
 
-        return not_found_error(code: 'invoice_not_found') unless invoice
+        return not_found_error(resource: 'invoice') unless invoice
 
         render_invoice(invoice)
       end
@@ -46,7 +46,7 @@ module Api
       def download
         invoice = current_organization.invoices.find_by(id: params[:id])
 
-        return not_found_error(code: 'invoice_not_found') unless invoice
+        return not_found_error(resource: 'invoice') unless invoice
 
         if invoice.file.present?
           return render(

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -20,7 +20,7 @@ module Api
       def show
         invoice = current_organization.invoices.find_by(id: params[:id])
 
-        return not_found_error(message: 'invoice_not_found') unless invoice
+        return not_found_error(code: 'invoice_not_found') unless invoice
 
         render_invoice(invoice)
       end
@@ -46,7 +46,7 @@ module Api
       def download
         invoice = current_organization.invoices.find_by(id: params[:id])
 
-        return not_found_error(message: 'invoice_not_found') unless invoice
+        return not_found_error(code: 'invoice_not_found') unless invoice
 
         if invoice.file.present?
           return render(

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -53,7 +53,7 @@ module Api
           code: params[:code],
         )
 
-        return not_found_error(code: 'plan_not_found') unless plan
+        return not_found_error(resource: 'plan') unless plan
 
         render_plan(plan)
       end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -53,7 +53,7 @@ module Api
           code: params[:code],
         )
 
-        return not_found_error(message: 'plan_not_found') unless plan
+        return not_found_error(code: 'plan_not_found') unless plan
 
         render_plan(plan)
       end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -66,7 +66,7 @@ module Api
       def index
         customer = current_organization.customers.find_by(external_id: params[:external_customer_id])
 
-        return not_found_error(code: 'customer_not_found') unless customer
+        return not_found_error(resource: 'customer') unless customer
 
         subscriptions = customer.active_subscriptions
           .page(params[:page])

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -66,7 +66,7 @@ module Api
       def index
         customer = current_organization.customers.find_by(external_id: params[:external_customer_id])
 
-        return not_found_error(message: 'customer_not_found') unless customer
+        return not_found_error(code: 'customer_not_found') unless customer
 
         subscriptions = customer.active_subscriptions
           .page(params[:page])

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -51,7 +51,7 @@ module Api
           id: params[:id],
         )
 
-        return not_found_error(message: 'wallet_not_found') unless wallet
+        return not_found_error(code: 'wallet_not_found') unless wallet
 
         render_wallet(wallet)
       end
@@ -59,7 +59,7 @@ module Api
       def index
         customer = Customer.find_by(external_id: params[:external_customer_id])
 
-        return not_found_error(message: 'customer_not_found') unless customer
+        return not_found_error(code: 'customer_not_found') unless customer
 
         wallets = customer.wallets
           .page(params[:page])

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -51,7 +51,7 @@ module Api
           id: params[:id],
         )
 
-        return not_found_error(code: 'wallet_not_found') unless wallet
+        return not_found_error(resource: 'wallet') unless wallet
 
         render_wallet(wallet)
       end
@@ -59,7 +59,7 @@ module Api
       def index
         customer = Customer.find_by(external_id: params[:external_customer_id])
 
-        return not_found_error(code: 'customer_not_found') unless customer
+        return not_found_error(resource: 'customer') unless customer
 
         wallets = customer.wallets
           .page(params[:page])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,6 @@ class ApplicationController < ActionController::API
   end
 
   def not_found
-    not_found_error(code: 'resource_not_found')
+    not_found_error(resource: 'resource')
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,6 @@ class ApplicationController < ActionController::API
   end
 
   def not_found
-    not_found_error(message: 'Resource not found')
+    not_found_error(code: 'resource_not_found')
   end
 end

--- a/app/controllers/concerns/api_responses.rb
+++ b/app/controllers/concerns/api_responses.rb
@@ -7,12 +7,12 @@ module ApiResponses
     before_action :set_json_format
   end
 
-  def not_found_error(message:)
+  def not_found_error(code:)
     render(
       json: {
         status: 404,
         error: 'Not Found',
-        message: message,
+        code: code,
       },
       status: :not_found,
     )

--- a/app/controllers/concerns/api_responses.rb
+++ b/app/controllers/concerns/api_responses.rb
@@ -7,12 +7,12 @@ module ApiResponses
     before_action :set_json_format
   end
 
-  def not_found_error(code:)
+  def not_found_error(resource:)
     render(
       json: {
         status: 404,
         error: 'Not Found',
-        code: code,
+        code: "#{resource}_not_found",
       },
       status: :not_found,
     )

--- a/app/graphql/concerns/execution_error_responder.rb
+++ b/app/graphql/concerns/execution_error_responder.rb
@@ -21,17 +21,17 @@ module ExecutionErrorResponder
     GraphQL::ExecutionError.new(error, extensions: payload)
   end
 
-  def not_found_error(code:)
+  def not_found_error(resource:)
     execution_error(
       error: 'Resource not found',
       status: 404,
-      code: code,
+      code: "#{resource}_not_found",
     )
   end
 
   def result_error(service_result)
     if service_result.error.is_a?(BaseService::NotFoundFailure)
-      return not_found_error(code: service_result.error.error_code)
+      return not_found_error(resource: service_result.error.resource)
     end
 
     execution_error(

--- a/app/graphql/concerns/execution_error_responder.rb
+++ b/app/graphql/concerns/execution_error_responder.rb
@@ -6,7 +6,7 @@ module ExecutionErrorResponder
 
   private
 
-  def execution_error(message: 'Internal Error', status: 422, code: 'internal_error', details: nil)
+  def execution_error(error: 'Internal Error', status: 422, code: 'internal_error', details: nil)
     payload = {
       status: status,
       code: code,
@@ -18,21 +18,23 @@ module ExecutionErrorResponder
       end
     end
 
-    GraphQL::ExecutionError.new(message, extensions: payload)
+    GraphQL::ExecutionError.new(error, extensions: payload)
   end
 
-  def not_found_error
+  def not_found_error(code:)
     execution_error(
-      message: 'Resource not found',
+      error: 'Resource not found',
       status: 404,
-      code: 'not_found',
+      code: code,
     )
   end
 
   def result_error(service_result)
+    return not_found_error(code: service_result.error.code) if service_result.error.is_a?(BaseService::NotFoundFailure)
+
     execution_error(
       code: service_result.error_code,
-      message: service_result.error,
+      error: service_result.error,
       details: service_result.error_details,
     )
   end

--- a/app/graphql/concerns/execution_error_responder.rb
+++ b/app/graphql/concerns/execution_error_responder.rb
@@ -30,7 +30,9 @@ module ExecutionErrorResponder
   end
 
   def result_error(service_result)
-    return not_found_error(code: service_result.error.code) if service_result.error.is_a?(BaseService::NotFoundFailure)
+    if service_result.error.is_a?(BaseService::NotFoundFailure)
+      return not_found_error(code: service_result.error.error_code)
+    end
 
     execution_error(
       code: service_result.error_code,

--- a/app/graphql/resolvers/add_on_resolver.rb
+++ b/app/graphql/resolvers/add_on_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.add_ons.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error
+      not_found_error(code: 'add_on_not_found')
     end
   end
 end

--- a/app/graphql/resolvers/add_on_resolver.rb
+++ b/app/graphql/resolvers/add_on_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.add_ons.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error(code: 'add_on_not_found')
+      not_found_error(resource: 'add_on')
     end
   end
 end

--- a/app/graphql/resolvers/billable_metric_resolver.rb
+++ b/app/graphql/resolvers/billable_metric_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.billable_metrics.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error
+      not_found_error(code: 'billable_metric_not_found')
     end
   end
 end

--- a/app/graphql/resolvers/billable_metric_resolver.rb
+++ b/app/graphql/resolvers/billable_metric_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.billable_metrics.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error(code: 'billable_metric_not_found')
+      not_found_error(resource: 'billable_metric')
     end
   end
 end

--- a/app/graphql/resolvers/coupon_resolver.rb
+++ b/app/graphql/resolvers/coupon_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.coupons.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error
+      not_found_error(code: 'coupon_not_found')
     end
   end
 end

--- a/app/graphql/resolvers/coupon_resolver.rb
+++ b/app/graphql/resolvers/coupon_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.coupons.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error(code: 'coupon_not_found')
+      not_found_error(resource: 'coupon')
     end
   end
 end

--- a/app/graphql/resolvers/customer_resolver.rb
+++ b/app/graphql/resolvers/customer_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.customers.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error(code: 'customer_not_found')
+      not_found_error(resource: 'customer')
     end
   end
 end

--- a/app/graphql/resolvers/customer_resolver.rb
+++ b/app/graphql/resolvers/customer_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.customers.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error
+      not_found_error(code: 'customer_not_found')
     end
   end
 end

--- a/app/graphql/resolvers/invite_resolver.rb
+++ b/app/graphql/resolvers/invite_resolver.rb
@@ -14,7 +14,7 @@ module Resolvers
         status: 'pending',
       )
 
-      return not_found_error unless invite
+      return not_found_error(resource: 'invite') unless invite
 
       invite
     end

--- a/app/graphql/resolvers/plan_resolver.rb
+++ b/app/graphql/resolvers/plan_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.plans.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error(code: 'plan_not_found')
+      not_found_error(resource: 'plan')
     end
   end
 end

--- a/app/graphql/resolvers/plan_resolver.rb
+++ b/app/graphql/resolvers/plan_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.plans.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error
+      not_found_error(code: 'plan_not_found')
     end
   end
 end

--- a/app/graphql/resolvers/wallet_resolver.rb
+++ b/app/graphql/resolvers/wallet_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       Wallet.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error
+      not_found_error(code: 'wallet_not_found')
     end
   end
 end

--- a/app/graphql/resolvers/wallet_resolver.rb
+++ b/app/graphql/resolvers/wallet_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       Wallet.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error(code: 'wallet_not_found')
+      not_found_error(resource: 'wallet')
     end
   end
 end

--- a/app/graphql/resolvers/wallet_transaction_resolver.rb
+++ b/app/graphql/resolvers/wallet_transaction_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.wallet_transactions.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error
+      not_found_error(code: 'wallet_transaction_not_found')
     end
   end
 end

--- a/app/graphql/resolvers/wallet_transaction_resolver.rb
+++ b/app/graphql/resolvers/wallet_transaction_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
 
       current_organization.wallet_transactions.find(id)
     rescue ActiveRecord::RecordNotFound
-      not_found_error(code: 'wallet_transaction_not_found')
+      not_found_error(resource: 'wallet_transaction')
     end
   end
 end

--- a/app/graphql/resolvers/wallet_transactions_resolver.rb
+++ b/app/graphql/resolvers/wallet_transactions_resolver.rb
@@ -40,7 +40,7 @@ module Resolvers
 
       wallet_transactions
     rescue ActiveRecord::RecordNotFound
-      not_found_error(code: 'wallet_not_found')
+      not_found_error(resource: 'wallet')
     end
   end
 end

--- a/app/graphql/resolvers/wallet_transactions_resolver.rb
+++ b/app/graphql/resolvers/wallet_transactions_resolver.rb
@@ -40,7 +40,7 @@ module Resolvers
 
       wallet_transactions
     rescue ActiveRecord::RecordNotFound
-      not_found_error
+      not_found_error(code: 'wallet_not_found')
     end
   end
 end

--- a/app/graphql/resolvers/wallets_resolver.rb
+++ b/app/graphql/resolvers/wallets_resolver.rb
@@ -30,7 +30,7 @@ module Resolvers
 
       wallets.order(status: :asc, created_at: :desc)
     rescue ActiveRecord::RecordNotFound
-      not_found_error(code: 'customer_not_found')
+      not_found_error(resource: 'customer')
     end
   end
 end

--- a/app/graphql/resolvers/wallets_resolver.rb
+++ b/app/graphql/resolvers/wallets_resolver.rb
@@ -30,7 +30,7 @@ module Resolvers
 
       wallets.order(status: :asc, created_at: :desc)
     rescue ActiveRecord::RecordNotFound
-      not_found_error
+      not_found_error(code: 'customer_not_found')
     end
   end
 end

--- a/app/services/add_ons/destroy_service.rb
+++ b/app/services/add_ons/destroy_service.rb
@@ -4,7 +4,7 @@ module AddOns
   class DestroyService < BaseService
     def destroy(id)
       add_on = result.user.add_ons.find_by(id: id)
-      return result.fail!(code: 'not_found') unless add_on
+      return result.not_found_failure!(code: 'add_on_not_found') unless add_on
 
       add_on.destroy!
 
@@ -14,7 +14,7 @@ module AddOns
 
     def destroy_from_api(organization:, code:)
       add_on = organization.add_ons.find_by(code: code)
-      return result.fail!(code: 'not_found', message: 'add-on does not exist') unless add_on
+      return result.not_found_failure!(code: 'add_on_not_found') unless add_on
 
       add_on.destroy!
 

--- a/app/services/add_ons/destroy_service.rb
+++ b/app/services/add_ons/destroy_service.rb
@@ -4,7 +4,7 @@ module AddOns
   class DestroyService < BaseService
     def destroy(id)
       add_on = result.user.add_ons.find_by(id: id)
-      return result.not_found_failure!(code: 'add_on_not_found') unless add_on
+      return result.not_found_failure!(resource: 'add_on') unless add_on
 
       add_on.destroy!
 
@@ -14,7 +14,7 @@ module AddOns
 
     def destroy_from_api(organization:, code:)
       add_on = organization.add_ons.find_by(code: code)
-      return result.not_found_failure!(code: 'add_on_not_found') unless add_on
+      return result.not_found_failure!(resource: 'add_on') unless add_on
 
       add_on.destroy!
 

--- a/app/services/add_ons/update_service.rb
+++ b/app/services/add_ons/update_service.rb
@@ -4,7 +4,7 @@ module AddOns
   class UpdateService < BaseService
     def update(**args)
       add_on = result.user.add_ons.find_by(id: args[:id])
-      return result.fail!(code: 'not_found') unless add_on
+      return result.not_found_failure!(code: 'add_on_not_found') unless add_on
 
       add_on.name = args[:name]
       add_on.code = args[:code]
@@ -22,7 +22,7 @@ module AddOns
 
     def update_from_api(organization:, code:, params:)
       add_on = organization.add_ons.find_by(code: code)
-      return result.fail!(code: 'not_found', message: 'add-on does not exist') unless add_on
+      return result.not_found_failure!(code: 'add_on_not_found') unless add_on
 
       add_on.name = params[:name] if params.key?(:name)
       add_on.code = params[:code] if params.key?(:code)

--- a/app/services/add_ons/update_service.rb
+++ b/app/services/add_ons/update_service.rb
@@ -4,7 +4,7 @@ module AddOns
   class UpdateService < BaseService
     def update(**args)
       add_on = result.user.add_ons.find_by(id: args[:id])
-      return result.not_found_failure!(code: 'add_on_not_found') unless add_on
+      return result.not_found_failure!(resource: 'add_on') unless add_on
 
       add_on.name = args[:name]
       add_on.code = args[:code]
@@ -22,7 +22,7 @@ module AddOns
 
     def update_from_api(organization:, code:, params:)
       add_on = organization.add_ons.find_by(code: code)
-      return result.not_found_failure!(code: 'add_on_not_found') unless add_on
+      return result.not_found_failure!(resource: 'add_on') unless add_on
 
       add_on.name = params[:name] if params.key?(:name)
       add_on.code = params[:code] if params.key?(:code)

--- a/app/services/applied_coupons/terminate_service.rb
+++ b/app/services/applied_coupons/terminate_service.rb
@@ -8,7 +8,7 @@ module AppliedCoupons
         .where(organizations: { id: result.user.organization_ids })
         .find_by(id: id)
 
-      return result.fail!(code: 'not_found') unless applied_coupon
+      return result.not_found_failure!(code: 'applied_coupon_not_found') unless applied_coupon
 
       applied_coupon.mark_as_terminated! unless applied_coupon.terminated?
 

--- a/app/services/applied_coupons/terminate_service.rb
+++ b/app/services/applied_coupons/terminate_service.rb
@@ -8,7 +8,7 @@ module AppliedCoupons
         .where(organizations: { id: result.user.organization_ids })
         .find_by(id: id)
 
-      return result.not_found_failure!(code: 'applied_coupon_not_found') unless applied_coupon
+      return result.not_found_failure!(resource: 'applied_coupon') unless applied_coupon
 
       applied_coupon.mark_as_terminated! unless applied_coupon.terminated?
 

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -17,12 +17,16 @@ class BaseService
   end
 
   class NotFoundFailure < FailedResult
-    attr_reader :code
+    attr_reader :resource
 
-    def initialize(code:)
-      @code = code
+    def initialize(resource:)
+      @resource = resource
 
-      super(code)
+      super(error_code)
+    end
+
+    def error_code
+      "#{resource}_not_found"
     end
   end
 
@@ -68,8 +72,8 @@ class BaseService
       self
     end
 
-    def not_found_failure!(code:)
-      fail_with_error!(NotFoundFailure.new(code: code))
+    def not_found_failure!(resource:)
+      fail_with_error!(NotFoundFailure.new(resource: resource))
     end
 
     def throw_error

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -15,6 +15,16 @@ class BaseService
     end
   end
 
+  class NotFoundFailure < StandardError
+    attr_reader :code
+
+    def initialize(code:)
+      @code = code
+
+      super(code)
+    end
+  end
+
   class Result < OpenStruct
     attr_reader :error, :error_code, :error_details
 
@@ -46,14 +56,25 @@ class BaseService
       fail!(
         code: 'unprocessable_entity',
         message: 'Validation error on the record',
-        details: record.errors.messages
+        details: record.errors.messages,
       )
+    end
+
+    def fail_with_error!(error)
+      @failure = true
+      @error = error
+
+      self
+    end
+
+    def not_found_failure!(code:)
+      fail_with_error!(NotFoundFailure.new(code: code))
     end
 
     def throw_error
       return if success?
 
-      raise FailedResult, self
+      raise(FailedResult, self)
     end
 
     private

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -9,13 +9,14 @@ class BaseService
     private
 
     def format_message(result)
+      return result if result.is_a?(String)
       return result.error unless result.error_details
 
       "#{result.error}: #{[result.error_details].flatten.join(', ')}"
     end
   end
 
-  class NotFoundFailure < StandardError
+  class NotFoundFailure < FailedResult
     attr_reader :code
 
     def initialize(code:)
@@ -73,6 +74,8 @@ class BaseService
 
     def throw_error
       return if success?
+
+      raise(error) if error.is_a?(FailedResult)
 
       raise(FailedResult, self)
     end

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -4,7 +4,7 @@ module BillableMetrics
   class DestroyService < BaseService
     def destroy(id)
       metric = result.user.billable_metrics.find_by(id: id)
-      return result.fail!(code: 'not_found') unless metric
+      return result.not_found_failure!(code: 'billable_metric_not_found') unless metric
 
       unless metric.deletable?
         return result.fail!(
@@ -21,13 +21,13 @@ module BillableMetrics
 
     def destroy_from_api(organization:, code:)
       metric = organization.billable_metrics.find_by(code: code)
-      return result.fail!(code: 'not_found', message: 'billable metric does not exist') unless metric
+      return result.not_found_failure!(code: 'billable_metric_not_found') unless metric
 
       unless metric.deletable?
         return result.fail!(
           code: 'forbidden',
           message: 'billable metric is attached to an active subscriptions',
-          )
+        )
       end
 
       metric.destroy!

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -4,7 +4,7 @@ module BillableMetrics
   class DestroyService < BaseService
     def destroy(id)
       metric = result.user.billable_metrics.find_by(id: id)
-      return result.not_found_failure!(code: 'billable_metric_not_found') unless metric
+      return result.not_found_failure!(resource: 'billable_metric') unless metric
 
       unless metric.deletable?
         return result.fail!(
@@ -21,7 +21,7 @@ module BillableMetrics
 
     def destroy_from_api(organization:, code:)
       metric = organization.billable_metrics.find_by(code: code)
-      return result.not_found_failure!(code: 'billable_metric_not_found') unless metric
+      return result.not_found_failure!(resource: 'billable_metric') unless metric
 
       unless metric.deletable?
         return result.fail!(

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -4,7 +4,7 @@ module BillableMetrics
   class UpdateService < BaseService
     def update(**args)
       metric = result.user.billable_metrics.find_by(id: args[:id])
-      return result.fail!(code: 'not_found') unless metric
+      return result.not_found_failure!(code: 'billable_metric_not_found') unless metric
 
       metric.name = args[:name]
       metric.description = args[:description] if args[:description]
@@ -27,7 +27,7 @@ module BillableMetrics
 
     def update_from_api(organization:, code:, params:)
       metric = organization.billable_metrics.find_by(code: code)
-      return result.fail!(code: 'not_found', message: 'billable metric does not exist') unless metric
+      return result.not_found_failure!(code: 'billable_metric_not_found') unless metric
 
       metric.name = params[:name] if params.key?(:name)
       metric.description = params[:description] if params.key?(:description)

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -4,7 +4,7 @@ module BillableMetrics
   class UpdateService < BaseService
     def update(**args)
       metric = result.user.billable_metrics.find_by(id: args[:id])
-      return result.not_found_failure!(code: 'billable_metric_not_found') unless metric
+      return result.not_found_failure!(resource: 'billable_metric') unless metric
 
       metric.name = args[:name]
       metric.description = args[:description] if args[:description]
@@ -27,7 +27,7 @@ module BillableMetrics
 
     def update_from_api(organization:, code:, params:)
       metric = organization.billable_metrics.find_by(code: code)
-      return result.not_found_failure!(code: 'billable_metric_not_found') unless metric
+      return result.not_found_failure!(resource: 'billable_metric') unless metric
 
       metric.name = params[:name] if params.key?(:name)
       metric.description = params[:description] if params.key?(:description)

--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -4,7 +4,7 @@ module Coupons
   class DestroyService < BaseService
     def destroy(id)
       coupon = result.user.coupons.find_by(id: id)
-      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
+      return result.not_found_failure!(resource: 'coupon') unless coupon
 
       unless coupon.deletable?
         return result.fail!(
@@ -21,7 +21,7 @@ module Coupons
 
     def destroy_from_api(organization:, code:)
       coupon = organization.coupons.find_by(code: code)
-      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
+      return result.not_found_failure!(resource: 'coupon') unless coupon
 
       unless coupon.deletable?
         return result.fail!(
@@ -38,7 +38,7 @@ module Coupons
 
     def terminate(id)
       coupon = result.user.coupons.find_by(id: id)
-      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
+      return result.not_found_failure!(resource: 'coupon') unless coupon
 
       coupon.mark_as_terminated! unless coupon.terminated?
 

--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -4,7 +4,7 @@ module Coupons
   class DestroyService < BaseService
     def destroy(id)
       coupon = result.user.coupons.find_by(id: id)
-      return result.fail!(code: 'not_found') unless coupon
+      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
 
       unless coupon.deletable?
         return result.fail!(
@@ -21,7 +21,7 @@ module Coupons
 
     def destroy_from_api(organization:, code:)
       coupon = organization.coupons.find_by(code: code)
-      return result.fail!(code: 'not_found', message: 'coupon does not exist') unless coupon
+      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
 
       unless coupon.deletable?
         return result.fail!(
@@ -38,7 +38,7 @@ module Coupons
 
     def terminate(id)
       coupon = result.user.coupons.find_by(id: id)
-      return result.fail!(code: 'not_found') unless coupon
+      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
 
       coupon.mark_as_terminated! unless coupon.terminated?
 

--- a/app/services/coupons/terminate_service.rb
+++ b/app/services/coupons/terminate_service.rb
@@ -4,7 +4,7 @@ module Coupons
   class TerminateService < BaseService
     def terminate(id)
       coupon = result.user.coupons.find_by(id: id)
-      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
+      return result.not_found_failure!(resource: 'coupon') unless coupon
 
       coupon.mark_as_terminated! unless coupon.terminated?
 

--- a/app/services/coupons/terminate_service.rb
+++ b/app/services/coupons/terminate_service.rb
@@ -4,7 +4,7 @@ module Coupons
   class TerminateService < BaseService
     def terminate(id)
       coupon = result.user.coupons.find_by(id: id)
-      return result.fail!(code: 'not_found') unless coupon
+      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
 
       coupon.mark_as_terminated! unless coupon.terminated?
 
@@ -15,7 +15,7 @@ module Coupons
     end
 
     def terminate_all_expired
-      coupons = Coupon
+      Coupon
         .active
         .time_limit
         .expired

--- a/app/services/coupons/update_service.rb
+++ b/app/services/coupons/update_service.rb
@@ -4,7 +4,7 @@ module Coupons
   class UpdateService < BaseService
     def update(**args)
       coupon = result.user.coupons.find_by(id: args[:id])
-      return result.fail!(code: 'not_found') unless coupon
+      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
 
       coupon.name = args[:name]
 
@@ -26,7 +26,7 @@ module Coupons
 
     def update_from_api(organization:, code:, params:)
       coupon = organization.coupons.find_by(code: code)
-      return result.fail!(code: 'not_found', message: 'coupon does not exist') unless coupon
+      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
 
       coupon.name = params[:name] if params.key?(:name)
 

--- a/app/services/coupons/update_service.rb
+++ b/app/services/coupons/update_service.rb
@@ -4,7 +4,7 @@ module Coupons
   class UpdateService < BaseService
     def update(**args)
       coupon = result.user.coupons.find_by(id: args[:id])
-      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
+      return result.not_found_failure!(resource: 'coupon') unless coupon
 
       coupon.name = args[:name]
 
@@ -26,7 +26,7 @@ module Coupons
 
     def update_from_api(organization:, code:, params:)
       coupon = organization.coupons.find_by(code: code)
-      return result.not_found_failure!(code: 'coupon_not_found') unless coupon
+      return result.not_found_failure!(resource: 'coupon') unless coupon
 
       coupon.name = params[:name] if params.key?(:name)
 

--- a/app/services/customers/destroy_service.rb
+++ b/app/services/customers/destroy_service.rb
@@ -4,7 +4,7 @@ module Customers
   class DestroyService < BaseService
     def destroy(id:)
       customer = result.user.customers.find_by(id: id)
-      return result.fail!(code: 'not_found') unless customer
+      return result.not_found_failure!(code: 'customer_not_found') unless customer
 
       unless customer.deletable?
         return result.fail!(

--- a/app/services/customers/destroy_service.rb
+++ b/app/services/customers/destroy_service.rb
@@ -4,7 +4,7 @@ module Customers
   class DestroyService < BaseService
     def destroy(id:)
       customer = result.user.customers.find_by(id: id)
-      return result.not_found_failure!(code: 'customer_not_found') unless customer
+      return result.not_found_failure!(resource: 'customer') unless customer
 
       unless customer.deletable?
         return result.fail!(

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -4,7 +4,7 @@ module Customers
   class UpdateService < BaseService
     def update(**args)
       customer = result.user.customers.find_by(id: args[:id])
-      return result.not_found_failure!(code: 'customer_not_found') unless customer
+      return result.not_found_failure!(resource: 'customer') unless customer
 
       customer.name = args[:name] if args.key?(:name)
       customer.country = args[:country]&.upcase if args.key?(:country)

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -4,7 +4,7 @@ module Customers
   class UpdateService < BaseService
     def update(**args)
       customer = result.user.customers.find_by(id: args[:id])
-      return result.fail!(code: 'not_found') unless customer
+      return result.not_found_failure!(code: 'customer_not_found') unless customer
 
       customer.name = args[:name] if args.key?(:name)
       customer.country = args[:country]&.upcase if args.key?(:country)
@@ -23,9 +23,7 @@ module Customers
       customer.payment_provider = args[:payment_provider] if args.key?(:payment_provider)
 
       # NOTE: external_id is not editable if customer is attached to subscriptions
-      if !customer.attached_to_subscriptions? && args.key?(:external_id)
-        customer.external_id = args[:external_id]
-      end
+      customer.external_id = args[:external_id] if !customer.attached_to_subscriptions? && args.key?(:external_id)
 
       customer.save!
 

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -16,11 +16,11 @@ module Invoices
         @subscription = @customer&.active_subscriptions&.find_by(id: subscription_id)
       end
     rescue ActiveRecord::RecordNotFound
-      result.not_found_failure!(code: 'customer_not_found')
+      result.not_found_failure!(resource: 'customer')
     end
 
     def usage
-      return result.not_found_failure!(code: 'customer_not_found') unless @customer
+      return result.not_found_failure!(resource: 'customer') unless @customer
       return result.fail!(code: 'no_active_subscription') if subscription.blank?
 
       result.usage = JSON.parse(compute_usage, object_class: OpenStruct)

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -16,11 +16,11 @@ module Invoices
         @subscription = @customer&.active_subscriptions&.find_by(id: subscription_id)
       end
     rescue ActiveRecord::RecordNotFound
-      result.fail!(code: 'not_found')
+      result.not_found_failure!(code: 'customer_not_found')
     end
 
     def usage
-      return result.fail!(code: 'not_found') unless @customer
+      return result.not_found_failure!(code: 'customer_not_found') unless @customer
       return result.fail!(code: 'no_active_subscription') if subscription.blank?
 
       result.usage = JSON.parse(compute_usage, object_class: OpenStruct)

--- a/app/services/invoices/generate_service.rb
+++ b/app/services/invoices/generate_service.rb
@@ -12,7 +12,7 @@ module Invoices
 
     def generate(invoice_id:)
       invoice = Invoice.find_by(id: invoice_id)
-      return result.not_found_failure!(code: 'invoice_not_found') if invoice.blank?
+      return result.not_found_failure!(resource: 'invoice') if invoice.blank?
 
       generate_pdf(invoice) if invoice.file.blank?
 

--- a/app/services/invoices/generate_service.rb
+++ b/app/services/invoices/generate_service.rb
@@ -12,8 +12,7 @@ module Invoices
 
     def generate(invoice_id:)
       invoice = Invoice.find_by(id: invoice_id)
-
-      return result.fail!(code: 'not_found') if invoice.blank?
+      return result.not_found_failure!(code: 'invoice_not_found') if invoice.blank?
 
       generate_pdf(invoice) if invoice.file.blank?
 

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -4,7 +4,7 @@ class Invoices::UpdateService < BaseService
   def update_from_api(invoice_id:, params:)
     invoice = Invoice.find_by(id: invoice_id)
 
-    return result.not_found_failure!(code: 'invoice_not_found') if invoice.blank?
+    return result.not_found_failure!(resource: 'invoice') if invoice.blank?
     return result.fail!(code: 'invalid_status') unless valid_status?(params[:status])
 
     invoice.status = params[:status] if params.key?(:status)

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -4,7 +4,7 @@ class Invoices::UpdateService < BaseService
   def update_from_api(invoice_id:, params:)
     invoice = Invoice.find_by(id: invoice_id)
 
-    return result.fail!(code: 'not_found') if invoice.blank?
+    return result.not_found_failure!(code: 'invoice_not_found') if invoice.blank?
     return result.fail!(code: 'invalid_status') unless valid_status?(params[:status])
 
     invoice.status = params[:status] if params.key?(:status)
@@ -22,7 +22,7 @@ class Invoices::UpdateService < BaseService
   private
 
   def valid_status?(status)
-    Invoice::STATUS.include? status&.to_sym
+    Invoice::STATUS.include?(status&.to_sym)
   end
 
   def track_payment_status_changed(invoice)
@@ -32,8 +32,8 @@ class Invoices::UpdateService < BaseService
       properties: {
         organization_id: invoice.organization.id,
         invoice_id: invoice.id,
-        payment_status: invoice.status
-      }
+        payment_status: invoice.status,
+      },
     )
   end
 

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -29,7 +29,7 @@ module PaymentProviderCustomers
         .joins(:customer)
         .where(customers: { organization_id: organization_id })
         .find_by(provider_customer_id: stripe_customer_id)
-      return result.not_found_failure!(code: 'stripe_customer_not_found') unless stripe_customer
+      return result.not_found_failure!(resource: 'stripe_customer') unless stripe_customer
 
       stripe_customer.payment_method_id = payment_method_id
       stripe_customer.save!
@@ -47,7 +47,7 @@ module PaymentProviderCustomers
         .joins(:customer)
         .where(customers: { organization_id: organization_id })
         .find_by(provider_customer_id: stripe_customer_id)
-      return result.not_found_failure!(code: 'stripe_customer_not_found') unless stripe_customer
+      return result.not_found_failure!(resource: 'stripe_customer') unless stripe_customer
 
       # NOTE: check if payment_method was the default one
       stripe_customer.payment_method_id = nil if stripe_customer.payment_method_id == payment_method_id

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -29,7 +29,7 @@ module PaymentProviderCustomers
         .joins(:customer)
         .where(customers: { organization_id: organization_id })
         .find_by(provider_customer_id: stripe_customer_id)
-      return result.fail!(code: 'not_found') unless stripe_customer
+      return result.not_found_failure!(code: 'stripe_customer_not_found') unless stripe_customer
 
       stripe_customer.payment_method_id = payment_method_id
       stripe_customer.save!
@@ -47,7 +47,7 @@ module PaymentProviderCustomers
         .joins(:customer)
         .where(customers: { organization_id: organization_id })
         .find_by(provider_customer_id: stripe_customer_id)
-      return result.fail!(code: 'not_found') unless stripe_customer
+      return result.not_found_failure!(code: 'stripe_customer_not_found') unless stripe_customer
 
       # NOTE: check if payment_method was the default one
       stripe_customer.payment_method_id = nil if stripe_customer.payment_method_id == payment_method_id

--- a/app/services/payment_providers/destroy_service.rb
+++ b/app/services/payment_providers/destroy_service.rb
@@ -7,7 +7,7 @@ module PaymentProviders
         id: id,
         organization_id: result.user.organization_ids,
       )
-      return result.not_found_failure!(code: 'payment_provider_not_found') unless payment_provider
+      return result.not_found_failure!(resource: 'payment_provider') unless payment_provider
 
       payment_provider.destroy!
 

--- a/app/services/payment_providers/destroy_service.rb
+++ b/app/services/payment_providers/destroy_service.rb
@@ -7,7 +7,7 @@ module PaymentProviders
         id: id,
         organization_id: result.user.organization_ids,
       )
-      return result.fail!(code: 'not_found') unless payment_provider
+      return result.not_found_failure!(code: 'payment_provider_not_found') unless payment_provider
 
       payment_provider.destroy!
 

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -20,7 +20,7 @@ module Plans
       if args[:charges].present?
         metric_ids = args[:charges].map { |c| c[:billable_metric_id] }.uniq
         if metric_ids.present? && plan.organization.billable_metrics.where(id: metric_ids).count != metric_ids.count
-          return result.not_found_failure!(code: 'billable_metrics_not_found')
+          return result.not_found_failure!(resource: 'billable_metrics')
         end
       end
 
@@ -66,8 +66,8 @@ module Plans
           nb_percentage_charges: count_by_charge_model['percentage'] || 0,
           nb_graduated_charges: count_by_charge_model['graduated'] || 0,
           nb_package_charges: count_by_charge_model['package'] || 0,
-          organization_id: plan.organization_id
-        }
+          organization_id: plan.organization_id,
+        },
       )
     end
   end

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -20,7 +20,7 @@ module Plans
       if args[:charges].present?
         metric_ids = args[:charges].map { |c| c[:billable_metric_id] }.uniq
         if metric_ids.present? && plan.organization.billable_metrics.where(id: metric_ids).count != metric_ids.count
-          return result.fail!(code: 'not_found', message: 'Billable metrics does not exists')
+          return result.not_found_failure!(code: 'billable_metrics_not_found')
         end
       end
 

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -4,7 +4,7 @@ module Plans
   class DestroyService < BaseService
     def destroy(id)
       plan = result.user.plans.find_by(id: id)
-      return result.not_found_failure!(code: 'plan_not_found') unless plan
+      return result.not_found_failure!(resource: 'plan') unless plan
 
       unless plan.deletable?
         return result.fail!(
@@ -21,7 +21,7 @@ module Plans
 
     def destroy_from_api(organization:, code:)
       plan = organization.plans.find_by(code: code)
-      return result.not_found_failure!(code: 'plan_not_found') unless plan
+      return result.not_found_failure!(resource: 'plan') unless plan
 
       unless plan.deletable?
         return result.fail!(

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -4,7 +4,7 @@ module Plans
   class DestroyService < BaseService
     def destroy(id)
       plan = result.user.plans.find_by(id: id)
-      return result.fail!(code: 'not_found') unless plan
+      return result.not_found_failure!(code: 'plan_not_found') unless plan
 
       unless plan.deletable?
         return result.fail!(
@@ -21,13 +21,13 @@ module Plans
 
     def destroy_from_api(organization:, code:)
       plan = organization.plans.find_by(code: code)
-      return result.fail!(code: 'not_found', message: 'plan does not exist') unless plan
+      return result.not_found_failure!(code: 'plan_not_found') unless plan
 
       unless plan.deletable?
         return result.fail!(
           code: 'forbidden',
           message: 'plan is attached to an active subscriptions',
-          )
+        )
       end
 
       plan.destroy!

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -4,7 +4,7 @@ module Plans
   class UpdateService < BaseService
     def update(**args)
       plan = result.user.plans.find_by(id: args[:id])
-      return result.fail!(code: 'not_found') unless plan
+      return result.not_found_failure!(code: 'plan_not_found') unless plan
 
       plan.name = args[:name]
       plan.description = args[:description]
@@ -23,7 +23,7 @@ module Plans
 
       metric_ids = args[:charges].map { |c| c[:billable_metric_id] }.uniq
       if metric_ids.present? && plan.organization.billable_metrics.where(id: metric_ids).count != metric_ids.count
-        return result.fail!(code: 'not_found', message: 'Billable metrics does not exists')
+        return result.not_found_failure!(code: 'billable_metrics_not_found')
       end
 
       ActiveRecord::Base.transaction do
@@ -40,7 +40,7 @@ module Plans
 
     def update_from_api(organization:, code:, params:)
       plan = organization.plans.find_by(code: code)
-      return result.fail!(code: 'not_found', message: 'plan does not exist') unless plan
+      return result.not_found_failure!(code: 'plan_not_found') unless plan
 
       plan.name = params[:name] if params.key?(:name)
       plan.description = params[:description] if params.key?(:description)
@@ -55,10 +55,10 @@ module Plans
         plan.bill_charges_monthly = params[:interval]&.to_sym == :yearly ? params[:bill_charges_monthly] || false : nil
       end
 
-      unless params[:charges].blank?
+      if params[:charges].present?
         metric_ids = params[:charges].map { |c| c[:billable_metric_id] }.uniq
         if metric_ids.present? && plan.organization.billable_metrics.where(id: metric_ids).count != metric_ids.count
-          return result.fail!(code: 'not_found', message: 'plan does not exists')
+          return result.not_found_failure!(code: 'plan_not_found')
         end
       end
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -4,7 +4,7 @@ module Plans
   class UpdateService < BaseService
     def update(**args)
       plan = result.user.plans.find_by(id: args[:id])
-      return result.not_found_failure!(code: 'plan_not_found') unless plan
+      return result.not_found_failure!(resource: 'plan') unless plan
 
       plan.name = args[:name]
       plan.description = args[:description]
@@ -23,7 +23,7 @@ module Plans
 
       metric_ids = args[:charges].map { |c| c[:billable_metric_id] }.uniq
       if metric_ids.present? && plan.organization.billable_metrics.where(id: metric_ids).count != metric_ids.count
-        return result.not_found_failure!(code: 'billable_metrics_not_found')
+        return result.not_found_failure!(resource: 'billable_metrics')
       end
 
       ActiveRecord::Base.transaction do
@@ -40,7 +40,7 @@ module Plans
 
     def update_from_api(organization:, code:, params:)
       plan = organization.plans.find_by(code: code)
-      return result.not_found_failure!(code: 'plan_not_found') unless plan
+      return result.not_found_failure!(resource: 'plan') unless plan
 
       plan.name = params[:name] if params.key?(:name)
       plan.description = params[:description] if params.key?(:description)
@@ -58,7 +58,7 @@ module Plans
       if params[:charges].present?
         metric_ids = params[:charges].map { |c| c[:billable_metric_id] }.uniq
         if metric_ids.present? && plan.organization.billable_metrics.where(id: metric_ids).count != metric_ids.count
-          return result.not_found_failure!(code: 'plan_not_found')
+          return result.not_found_failure!(resource: 'plan')
         end
       end
 

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -4,14 +4,14 @@ module Subscriptions
   class TerminateService < BaseService
     def terminate(subscription_id)
       subscription = Subscription.find_by(id: subscription_id)
-      return result.not_found_failure!(code: 'subscription_not_found') if subscription.blank?
+      return result.not_found_failure!(resource: 'subscription') if subscription.blank?
 
       process_terminate(subscription)
     end
 
     def terminate_from_api(organization:, external_id:)
       subscription = organization.subscriptions.find_by(external_id: external_id)
-      return result.not_found_failure!(code: 'subscription_not_found') if subscription.blank?
+      return result.not_found_failure!(resource: 'subscription') if subscription.blank?
 
       process_terminate(subscription)
     end

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -4,14 +4,14 @@ module Subscriptions
   class TerminateService < BaseService
     def terminate(subscription_id)
       subscription = Subscription.find_by(id: subscription_id)
-      return result.fail!(code: 'not_found') if subscription.blank?
+      return result.not_found_failure!(code: 'subscription_not_found') if subscription.blank?
 
       process_terminate(subscription)
     end
 
     def terminate_from_api(organization:, external_id:)
       subscription = organization.subscriptions.find_by(external_id: external_id)
-      return result.fail!(code: 'not_found', message: 'subscription is not found') if subscription.blank?
+      return result.not_found_failure!(code: 'subscription_not_found') if subscription.blank?
 
       process_terminate(subscription)
     end

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -4,7 +4,7 @@ module Subscriptions
   class UpdateService < BaseService
     def update(**args)
       subscription = Subscription.find_by(id: args[:id])
-      return result.fail!(code: 'not_found') unless subscription
+      return result.not_found_failure!(code: 'subscription_not_found') unless subscription
 
       subscription.name = args[:name] if args.key?(:name)
 
@@ -18,7 +18,7 @@ module Subscriptions
 
     def update_from_api(organization:, external_id:, params:)
       subscription = organization.subscriptions.find_by(external_id: external_id)
-      return result.fail!(code: 'not_found', message: 'subscription is not found') unless subscription
+      return result.not_found_failure!(code: 'subscription_not_found') unless subscription
 
       subscription.name = params[:name] if params.key?(:name)
 

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -4,7 +4,7 @@ module Subscriptions
   class UpdateService < BaseService
     def update(**args)
       subscription = Subscription.find_by(id: args[:id])
-      return result.not_found_failure!(code: 'subscription_not_found') unless subscription
+      return result.not_found_failure!(resource: 'subscription') unless subscription
 
       subscription.name = args[:name] if args.key?(:name)
 
@@ -18,7 +18,7 @@ module Subscriptions
 
     def update_from_api(organization:, external_id:, params:)
       subscription = organization.subscriptions.find_by(external_id: external_id)
-      return result.not_found_failure!(code: 'subscription_not_found') unless subscription
+      return result.not_found_failure!(resource: 'subscription') unless subscription
 
       subscription.name = params[:name] if params.key?(:name)
 

--- a/app/services/wallets/terminate_service.rb
+++ b/app/services/wallets/terminate_service.rb
@@ -4,8 +4,7 @@ module Wallets
   class TerminateService < BaseService
     def terminate(id)
       wallet = Wallet.find_by(id: id)
-
-      return result.fail!(code: 'not_found') unless wallet
+      return result.not_found_failure!(code: 'wallet_not_found') unless wallet
 
       wallet.mark_as_terminated! if wallet.active?
 

--- a/app/services/wallets/terminate_service.rb
+++ b/app/services/wallets/terminate_service.rb
@@ -4,7 +4,7 @@ module Wallets
   class TerminateService < BaseService
     def terminate(id)
       wallet = Wallet.find_by(id: id)
-      return result.not_found_failure!(code: 'wallet_not_found') unless wallet
+      return result.not_found_failure!(resource: 'wallet') unless wallet
 
       wallet.mark_as_terminated! if wallet.active?
 

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -4,7 +4,7 @@ module Wallets
   class UpdateService < BaseService
     def update(**args)
       wallet = Wallet.find_by(id: args[:id])
-      return result.not_found_failure!(code: 'wallet_not_found') unless wallet
+      return result.not_found_failure!(resource: 'wallet') unless wallet
 
       wallet.name = args[:name] if args.key?(:name)
       wallet.expiration_date = args[:expiration_date] if args.key?(:expiration_date)

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -4,7 +4,7 @@ module Wallets
   class UpdateService < BaseService
     def update(**args)
       wallet = Wallet.find_by(id: args[:id])
-      return result.fail!(code: 'not_found') unless wallet
+      return result.not_found_failure!(code: 'wallet_not_found') unless wallet
 
       wallet.name = args[:name] if args.key?(:name)
       wallet.expiration_date = args[:expiration_date] if args.key?(:expiration_date)

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ApplicationController, type: :request do
         json = JSON.parse(response.body)
         expect(json['status']).to eq(404)
         expect(json['error']).to eq('Not Found')
-        expect(json['message']).to eq('Resource not found')
+        expect(json['code']).to eq('resource_not_found')
       end
     end
   end

--- a/spec/services/add_ons/destroy_service_spec.rb
+++ b/spec/services/add_ons/destroy_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe AddOns::DestroyService, type: :service do
         result = destroy_service.destroy(nil)
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('add_on_not_found')
+        expect(result.error.error_code).to eq('add_on_not_found')
       end
     end
   end
@@ -43,7 +43,7 @@ RSpec.describe AddOns::DestroyService, type: :service do
         result = destroy_service.destroy_from_api(organization: organization, code: 'invalid12345')
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('add_on_not_found')
+        expect(result.error.error_code).to eq('add_on_not_found')
       end
     end
   end

--- a/spec/services/add_ons/destroy_service_spec.rb
+++ b/spec/services/add_ons/destroy_service_spec.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require 'rails_helper'
@@ -24,7 +23,7 @@ RSpec.describe AddOns::DestroyService, type: :service do
         result = destroy_service.destroy(nil)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('not_found')
+        expect(result.error.code).to eq('add_on_not_found')
       end
     end
   end
@@ -44,7 +43,7 @@ RSpec.describe AddOns::DestroyService, type: :service do
         result = destroy_service.destroy_from_api(organization: organization, code: 'invalid12345')
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result.error.code).to eq('add_on_not_found')
       end
     end
   end

--- a/spec/services/add_ons/update_service_spec.rb
+++ b/spec/services/add_ons/update_service_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe AddOns::UpdateService, type: :service do
         )
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('add_on_not_found')
+        expect(result.error.error_code).to eq('add_on_not_found')
       end
     end
   end

--- a/spec/services/add_ons/update_service_spec.rb
+++ b/spec/services/add_ons/update_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AddOns::UpdateService, type: :service do
         code: 'code',
         description: 'desc',
         amount_cents: 100,
-        amount_currency: 'EUR'
+        amount_currency: 'EUR',
       }
     end
 
@@ -44,14 +44,14 @@ RSpec.describe AddOns::UpdateService, type: :service do
           name: nil,
           code: 'code',
           amount_cents: 100,
-          amount_currency: 'EUR'
+          amount_currency: 'EUR',
         }
       end
 
       it 'returns an error' do
         result = update_service.update(**update_args)
 
-        expect(result).to_not be_success
+        expect(result).not_to be_success
         expect(result.error_code).to eq('unprocessable_entity')
       end
     end
@@ -66,7 +66,7 @@ RSpec.describe AddOns::UpdateService, type: :service do
         code: 'code',
         description: 'desc',
         amount_cents: 100,
-        amount_currency: 'EUR'
+        amount_currency: 'EUR',
       }
     end
 
@@ -74,7 +74,7 @@ RSpec.describe AddOns::UpdateService, type: :service do
       result = subject.update_from_api(
         organization: organization,
         code: add_on.code,
-        params: update_args
+        params: update_args,
       )
 
       aggregate_failures do
@@ -95,10 +95,10 @@ RSpec.describe AddOns::UpdateService, type: :service do
         result = subject.update_from_api(
           organization: organization,
           code: add_on.code,
-          params: update_args
+          params: update_args,
         )
 
-        expect(result).to_not be_success
+        expect(result).not_to be_success
         expect(result.error_code).to eq('unprocessable_entity')
       end
     end
@@ -108,11 +108,11 @@ RSpec.describe AddOns::UpdateService, type: :service do
         result = subject.update_from_api(
           organization: organization,
           code: 'fake_code12345',
-          params: update_args
+          params: update_args,
         )
 
-        expect(result).to_not be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result).not_to be_success
+        expect(result.error.code).to eq('add_on_not_found')
       end
     end
   end

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
         result = destroy_service.destroy(nil)
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('billable_metric_not_found')
+        expect(result.error.error_code).to eq('billable_metric_not_found')
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
         result = destroy_service.destroy_from_api(organization: organization, code: 'invalid12345')
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('billable_metric_not_found')
+        expect(result.error.error_code).to eq('billable_metric_not_found')
       end
     end
 

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
         result = destroy_service.destroy(nil)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('not_found')
+        expect(result.error.code).to eq('billable_metric_not_found')
       end
     end
 
@@ -58,7 +58,7 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
         result = destroy_service.destroy_from_api(organization: organization, code: 'invalid12345')
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result.error.code).to eq('billable_metric_not_found')
       end
     end
 

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
         result = subject.update(**update_args)
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('billable_metric_not_found')
+        expect(result.error.error_code).to eq('billable_metric_not_found')
       end
     end
   end
@@ -120,7 +120,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
         )
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('billable_metric_not_found')
+        expect(result.error.error_code).to eq('billable_metric_not_found')
       end
     end
   end

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
         name: 'New Metric',
         code: 'new_metric',
         description: 'New metric description',
-        aggregation_type: 'count_agg'
+        aggregation_type: 'count_agg',
       }
     end
 
@@ -41,14 +41,14 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
           name: nil,
           code: 'new_metric',
           description: 'New metric description',
-          aggregation_type: 'count_agg'
+          aggregation_type: 'count_agg',
         }
       end
 
       it 'returns an error' do
         result = subject.update(**update_args)
 
-        expect(result).to_not be_success
+        expect(result).not_to be_success
         expect(result.error_code).to eq('unprocessable_entity')
       end
     end
@@ -59,8 +59,8 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       it 'returns an error' do
         result = subject.update(**update_args)
 
-        expect(result).to_not be_success
-        expect(result.error).to eq('not_found')
+        expect(result).not_to be_success
+        expect(result.error.code).to eq('billable_metric_not_found')
       end
     end
   end
@@ -74,7 +74,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
         code: 'new_metric',
         description: 'New metric description',
         aggregation_type: 'count_agg',
-        field_name: 'amount_sum'
+        field_name: 'amount_sum',
       }
     end
 
@@ -82,7 +82,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       result = subject.update_from_api(
         organization: organization,
         code: billable_metric.code,
-        params: update_args
+        params: update_args,
       )
 
       aggregate_failures do
@@ -103,10 +103,10 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
         result = subject.update_from_api(
           organization: organization,
           code: billable_metric.code,
-          params: update_args
+          params: update_args,
         )
 
-        expect(result).to_not be_success
+        expect(result).not_to be_success
         expect(result.error_code).to eq('unprocessable_entity')
       end
     end
@@ -116,11 +116,11 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
         result = subject.update_from_api(
           organization: organization,
           code: 'fake_code12345',
-          params: update_args
+          params: update_args,
         )
 
-        expect(result).to_not be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result).not_to be_success
+        expect(result.error.code).to eq('billable_metric_not_found')
       end
     end
   end

--- a/spec/services/coupons/destroy_service_spec.rb
+++ b/spec/services/coupons/destroy_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Coupons::DestroyService, type: :service do
         result = destroy_service.destroy(nil)
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('coupon_not_found')
+        expect(result.error.error_code).to eq('coupon_not_found')
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Coupons::DestroyService, type: :service do
         result = destroy_service.destroy_from_api(organization: organization, code: 'invalid12345')
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('coupon_not_found')
+        expect(result.error.error_code).to eq('coupon_not_found')
       end
     end
 

--- a/spec/services/coupons/destroy_service_spec.rb
+++ b/spec/services/coupons/destroy_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Coupons::DestroyService, type: :service do
         result = destroy_service.destroy(nil)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('not_found')
+        expect(result.error.code).to eq('coupon_not_found')
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Coupons::DestroyService, type: :service do
         result = destroy_service.destroy_from_api(organization: organization, code: 'invalid12345')
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result.error.code).to eq('coupon_not_found')
       end
     end
 

--- a/spec/services/coupons/update_service_spec.rb
+++ b/spec/services/coupons/update_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
       it 'returns an error' do
         result = update_service.update(**update_args)
 
-        expect(result).to_not be_success
+        expect(result).not_to be_success
         expect(result.error_code).to eq('unprocessable_entity')
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
         amount_cents: 123,
         amount_currency: 'EUR',
         expiration: 'time_limit',
-        expiration_duration: 15
+        expiration_duration: 15,
       }
     end
 
@@ -77,7 +77,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
       result = subject.update_from_api(
         organization: organization,
         code: coupon.code,
-        params: update_args
+        params: update_args,
       )
 
       aggregate_failures do
@@ -98,10 +98,10 @@ RSpec.describe Coupons::UpdateService, type: :service do
         result = subject.update_from_api(
           organization: organization,
           code: coupon.code,
-          params: update_args
+          params: update_args,
         )
 
-        expect(result).to_not be_success
+        expect(result).not_to be_success
         expect(result.error_code).to eq('unprocessable_entity')
       end
     end
@@ -111,11 +111,11 @@ RSpec.describe Coupons::UpdateService, type: :service do
         result = subject.update_from_api(
           organization: organization,
           code: 'fake_code12345',
-          params: update_args
+          params: update_args,
         )
 
-        expect(result).to_not be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result).not_to be_success
+        expect(result.error.code).to eq('coupon_not_found')
       end
     end
   end

--- a/spec/services/coupons/update_service_spec.rb
+++ b/spec/services/coupons/update_service_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
         )
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('coupon_not_found')
+        expect(result.error.error_code).to eq('coupon_not_found')
       end
     end
   end

--- a/spec/services/customers/destroy_service_spec.rb
+++ b/spec/services/customers/destroy_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Customers::DestroyService, type: :service do
         )
 
         expect(result).not_to be_success
-        expect(result.error).to eq('not_found')
+        expect(result.error.code).to eq('customer_not_found')
       end
     end
 

--- a/spec/services/customers/destroy_service_spec.rb
+++ b/spec/services/customers/destroy_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Customers::DestroyService, type: :service do
         )
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('customer_not_found')
+        expect(result.error.error_code).to eq('customer_not_found')
       end
     end
 

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
     it 'uses the Rails cache' do
       key = "current_usage/#{subscription.id}-#{subscription.created_at.iso8601}/#{subscription.plan.updated_at.iso8601}"
 
-      expect {
+      expect do
         invoice_service.usage
-      }.to change { cache.exist?(key) }.from(false).to(true)
+      end.to change { cache.exist?(key) }.from(false).to(true)
     end
 
     context 'when billed monthly' do
@@ -262,7 +262,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
         result = invoice_service.usage
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result.error.code).to eq('customer_not_found')
       end
     end
 

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -262,7 +262,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
         result = invoice_service.usage
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('customer_not_found')
+        expect(result.error.error_code).to eq('customer_not_found')
       end
     end
 

--- a/spec/services/invoices/generate_service_spec.rb
+++ b/spec/services/invoices/generate_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Invoices::GenerateService, type: :service do
         result = invoice_generate_service.generate(invoice_id: '123456')
 
         expect(result.success).to be_falsey
-        expect(result.error).to eq('not_found')
+        expect(result.error.code).to eq('invoice_not_found')
       end
     end
 

--- a/spec/services/invoices/generate_service_spec.rb
+++ b/spec/services/invoices/generate_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Invoices::GenerateService, type: :service do
         result = invoice_generate_service.generate(invoice_id: '123456')
 
         expect(result.success).to be_falsey
-        expect(result.error.code).to eq('invoice_not_found')
+        expect(result.error.error_code).to eq('invoice_not_found')
       end
     end
 

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Invoices::UpdateService do
         )
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('invoice_not_found')
+        expect(result.error.error_code).to eq('invoice_not_found')
       end
     end
 

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe Invoices::UpdateService do
         properties: {
           organization_id: invoice.organization.id,
           invoice_id: invoice.id,
-          payment_status: invoice.status
-        }
+          payment_status: invoice.status,
+        },
       )
     end
 
@@ -57,11 +57,12 @@ RSpec.describe Invoices::UpdateService do
         create(:wallet_transaction, wallet: wallet, amount: 15.0, credit_amount: 15.0, status: 'pending')
       end
       let(:fee) do
-        create(:fee,
+        create(
+          :fee,
           fee_type: 'credit',
           invoiceable_type: 'WalletTransaction',
           invoiceable_id: wallet_transaction.id,
-          invoice: invoice
+          invoice: invoice,
         )
       end
 
@@ -92,7 +93,7 @@ RSpec.describe Invoices::UpdateService do
         )
 
         expect(result).not_to be_success
-        expect(result.error).to eq('not_found')
+        expect(result.error.code).to eq('invoice_not_found')
       end
     end
 
@@ -115,7 +116,7 @@ RSpec.describe Invoices::UpdateService do
     end
 
     context 'when invoice status is not present' do
-      let(:update_args) {{}}
+      let(:update_args) { {} }
 
       it 'returns an error' do
         result = invoice_service.update_from_api(

--- a/spec/services/payment_providers/destroy_service_spec.rb
+++ b/spec/services/payment_providers/destroy_service_spec.rb
@@ -18,23 +18,23 @@ RSpec.describe PaymentProviders::DestroyService, type: :service do
         .to change(PaymentProviders::BaseProvider, :count).by(-1)
     end
 
-    context 'when coupon is not found' do
+    context 'when payment provider is not found' do
       it 'returns an error' do
         result = destroy_service.destroy(id: nil)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('not_found')
+        expect(result.error.code).to eq('payment_provider_not_found')
       end
     end
 
-    context 'when coupon is not attached to the organization' do
+    context 'when payment provider is not attached to the organization' do
       let(:payment_provider) { create(:stripe_provider) }
 
       it 'returns an error' do
         result = destroy_service.destroy(id: payment_provider.id)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('not_found')
+        expect(result.error.code).to eq('payment_provider_not_found')
       end
     end
   end

--- a/spec/services/payment_providers/destroy_service_spec.rb
+++ b/spec/services/payment_providers/destroy_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe PaymentProviders::DestroyService, type: :service do
         result = destroy_service.destroy(id: nil)
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('payment_provider_not_found')
+        expect(result.error.error_code).to eq('payment_provider_not_found')
       end
     end
 
@@ -34,7 +34,7 @@ RSpec.describe PaymentProviders::DestroyService, type: :service do
         result = destroy_service.destroy(id: payment_provider.id)
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('payment_provider_not_found')
+        expect(result.error.error_code).to eq('payment_provider_not_found')
       end
     end
   end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Plans::CreateService, type: :service do
         result = plans_service.create(**create_args)
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('billable_metrics_not_found')
+        expect(result.error.error_code).to eq('billable_metrics_not_found')
       end
     end
   end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Plans::CreateService, type: :service do
         result = plans_service.create(**create_args)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('Billable metrics does not exists')
+        expect(result.error.code).to eq('billable_metrics_not_found')
       end
     end
   end

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Plans::DestroyService, type: :service do
         result = plans_service.destroy(nil)
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('plan_not_found')
+        expect(result.error.error_code).to eq('plan_not_found')
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Plans::DestroyService, type: :service do
         result = plans_service.destroy_from_api(organization: organization, code: 'invalid12345')
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('plan_not_found')
+        expect(result.error.error_code).to eq('plan_not_found')
       end
     end
 

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Plans::DestroyService, type: :service do
         result = plans_service.destroy(nil)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('not_found')
+        expect(result.error.code).to eq('plan_not_found')
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Plans::DestroyService, type: :service do
         result = plans_service.destroy_from_api(organization: organization, code: 'invalid12345')
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result.error.code).to eq('plan_not_found')
       end
     end
 

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         result = plans_service.update(**update_args)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('Billable metrics does not exists')
+        expect(result.error.code).to eq('billable_metrics_not_found')
       end
     end
 
@@ -267,7 +267,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         )
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result.error.code).to eq('plan_not_found')
       end
     end
 
@@ -280,7 +280,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         )
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result.error.code).to eq('plan_not_found')
       end
     end
 
@@ -338,7 +338,7 @@ RSpec.describe Plans::UpdateService, type: :service do
               charge_model: 'standard',
               properties: {
                 amount: '300',
-              }
+              },
             },
           ],
         }

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         result = plans_service.update(**update_args)
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('billable_metrics_not_found')
+        expect(result.error.error_code).to eq('billable_metrics_not_found')
       end
     end
 
@@ -267,7 +267,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         )
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('plan_not_found')
+        expect(result.error.error_code).to eq('plan_not_found')
       end
     end
 
@@ -280,7 +280,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         )
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('plan_not_found')
+        expect(result.error.error_code).to eq('plan_not_found')
       end
     end
 

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Subscriptions::TerminateService do
       it 'returns an error' do
         result = terminate_service.terminate(subscription.id)
 
-        expect(result.error.code).to eq('subscription_not_found')
+        expect(result.error.error_code).to eq('subscription_not_found')
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe Subscriptions::TerminateService do
           external_id: subscription.external_id + '123',
         )
 
-        expect(result.error.code).to eq('subscription_not_found')
+        expect(result.error.error_code).to eq('subscription_not_found')
       end
     end
   end

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Subscriptions::TerminateService do
       it 'returns an error' do
         result = terminate_service.terminate(subscription.id)
 
-        expect(result.error).to eq('not_found')
+        expect(result.error.code).to eq('subscription_not_found')
       end
     end
 
@@ -66,7 +66,7 @@ RSpec.describe Subscriptions::TerminateService do
     it 'terminates a subscription' do
       result = terminate_service.terminate_from_api(
         organization: organization,
-        external_id: subscription.external_id
+        external_id: subscription.external_id,
       )
 
       aggregate_failures do
@@ -80,7 +80,7 @@ RSpec.describe Subscriptions::TerminateService do
       expect do
         terminate_service.terminate_from_api(
           organization: organization,
-          external_id: subscription.external_id
+          external_id: subscription.external_id,
         )
       end.to have_enqueued_job(BillSubscriptionJob)
     end
@@ -89,10 +89,10 @@ RSpec.describe Subscriptions::TerminateService do
       it 'returns an error' do
         result = terminate_service.terminate_from_api(
           organization: organization,
-          external_id: subscription.external_id + '123'
+          external_id: subscription.external_id + '123',
         )
 
-        expect(result.error_code).to eq('not_found')
+        expect(result.error.code).to eq('subscription_not_found')
       end
     end
   end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
         result = update_service.update(**update_args)
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('subscription_not_found')
+        expect(result.error.error_code).to eq('subscription_not_found')
       end
     end
   end
@@ -80,7 +80,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
         )
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('subscription_not_found')
+        expect(result.error.error_code).to eq('subscription_not_found')
       end
     end
   end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
     let(:update_args) do
       {
         id: subscription.id,
-        name: 'new name'
+        name: 'new name',
       }
     end
 
@@ -32,37 +32,36 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
       let(:update_args) do
         {
           id: subscription.id + '123',
-          name: 'new name'
+          name: 'new name',
         }
       end
 
       it 'returns an error' do
         result = update_service.update(**update_args)
 
-        expect(result).to_not be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result).not_to be_success
+        expect(result.error.code).to eq('subscription_not_found')
       end
     end
   end
 
   describe 'update_from_api' do
     let(:organization) { membership.organization }
+    let(:update_args) do
+      {
+        name: 'new name',
+      }
+    end
     let(:customer) { create(:customer, organization: organization) }
     let(:subscription) { create(:subscription, customer: customer) }
 
     before { subscription }
 
-    let(:update_args) do
-      {
-        name: 'new name'
-      }
-    end
-
     it 'updates the subscription' do
       result = update_service.update_from_api(
         organization: organization,
         external_id: subscription.external_id,
-        params: update_args
+        params: update_args,
       )
 
       expect(result).to be_success
@@ -77,11 +76,11 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
         result = update_service.update_from_api(
           organization: organization,
           external_id: subscription.external_id + '123',
-          params: update_args
+          params: update_args,
         )
 
-        expect(result).to_not be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result).not_to be_success
+        expect(result.error.code).to eq('subscription_not_found')
       end
     end
   end

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
         result = update_service.update(**update_args)
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('not_found')
+        expect(result.error.code).to eq('wallet_not_found')
       end
     end
   end

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
         result = update_service.update(**update_args)
 
         expect(result).not_to be_success
-        expect(result.error.code).to eq('wallet_not_found')
+        expect(result.error.error_code).to eq('wallet_not_found')
       end
     end
   end


### PR DESCRIPTION
## Context

Error handling in services and the way it's rendered in API and GraphQL needs a complete refactoring.

## Description

The objective of this pull request is to normalize the way service return not found errors.

When a required resource is not found, the services now returns a failed result as it was doing before. Instead of a code and a message, attached to the result, we now build a `BaseService::NotFoundFailure` with a `code` attribute and we attach it as the `error` field of the result object.

- At API controller level, when a service result has a `BaseService::NotFoundFailure`, it will format an HTTP 404 response with the error code in the payload
- At GraphQL level, it formats a `GraphQL::ExecutionError`, with the error code attached in the `extensions` payload

The current list of not found error codes is:
- `add_on_not_found`
- `applied_coupon_not_found`
- `billable_metric_not_found`
- `billable_metrics_not_found`
- `coupon_not_found`
- `customer_not_found`
- `event_not_found`
- `invoice_not_found`
- `payment_provider_not_found`
- `plan_not_found`
- `resource_not_found`
- `stripe_customer_not_found`
- `subscription_not_found`
- `wallet_not_found`
- `wallet_transaction_not_found`