### PR TITLE
feat(errors): Handle not allowed error in services API and GraphQL errors

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -45,23 +45,23 @@ module Api
       )
     end
 
-    def forbidden_error(error_result)
+    def method_not_allowed_error(code:)
       render(
         json: {
-          status: 403,
-          error: 'Forbidden',
-          message: error_result.error,
-          error_details: error_result.error_details,
+          status: 405,
+          error: 'Method Not Allowed',
+          code: code,
         },
-        status: :forbidden,
+        status: :method_not_allowed,
       )
     end
 
     def render_error_response(error_result)
-      if error_result.error.is_a?(BaseService::NotFoundFailure)
+      case error_result.error
+      when BaseService::NotFoundFailure
         not_found_error(resource: error_result.error.resource)
-      elsif error_result.error_code == 'forbidden'
-        forbidden_error(error_result)
+      when BaseService::MethodNotAllowedFailure
+        method_not_allowed_error(code: error_result.error.code)
       else
         validation_errors(error_result)
       end

--- a/app/graphql/concerns/execution_error_responder.rb
+++ b/app/graphql/concerns/execution_error_responder.rb
@@ -29,9 +29,20 @@ module ExecutionErrorResponder
     )
   end
 
+  def not_allowed_error(code:)
+    execution_error(
+      message: 'Method Not Allowed',
+      status: 405,
+      code: code,
+    )
+  end
+
   def result_error(service_result)
-    if service_result.error.is_a?(BaseService::NotFoundFailure)
+    case service_result.error.class
+    when BaseService::NotFoundFailure
       return not_found_error(resource: service_result.error.resource)
+    when BaseService::MethodNotAllowedFailure
+      return not_allowed_error(code: service_result.error.code)
     end
 
     execution_error(

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -30,6 +30,16 @@ class BaseService
     end
   end
 
+  class MethodNotAllowedFailure < FailedResult
+    attr_reader :code
+
+    def initialize(code:)
+      @code = code
+
+      super(code)
+    end
+  end
+
   class Result < OpenStruct
     attr_reader :error, :error_code, :error_details
 
@@ -74,6 +84,10 @@ class BaseService
 
     def not_found_failure!(resource:)
       fail_with_error!(NotFoundFailure.new(resource: resource))
+    end
+
+    def not_allowed_failure!(code:)
+      fail_with_error!(MethodNotAllowedFailure.new(code: code))
     end
 
     def throw_error

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -5,13 +5,7 @@ module BillableMetrics
     def destroy(id)
       metric = result.user.billable_metrics.find_by(id: id)
       return result.not_found_failure!(resource: 'billable_metric') unless metric
-
-      unless metric.deletable?
-        return result.fail!(
-          code: 'forbidden',
-          message: 'Billable metric is attached to an active subscriptions',
-        )
-      end
+      return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless metric.deletable?
 
       metric.destroy!
 
@@ -22,13 +16,7 @@ module BillableMetrics
     def destroy_from_api(organization:, code:)
       metric = organization.billable_metrics.find_by(code: code)
       return result.not_found_failure!(resource: 'billable_metric') unless metric
-
-      unless metric.deletable?
-        return result.fail!(
-          code: 'forbidden',
-          message: 'billable metric is attached to an active subscriptions',
-        )
-      end
+      return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless metric.deletable?
 
       metric.destroy!
 

--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -5,13 +5,7 @@ module Coupons
     def destroy(id)
       coupon = result.user.coupons.find_by(id: id)
       return result.not_found_failure!(resource: 'coupon') unless coupon
-
-      unless coupon.deletable?
-        return result.fail!(
-          code: 'forbidden',
-          message: 'Coupon is attached to an active customer',
-        )
-      end
+      return result.not_allowed_failure!(code: 'attached_to_an_active_customer') unless coupon.deletable?
 
       coupon.destroy!
 
@@ -22,13 +16,7 @@ module Coupons
     def destroy_from_api(organization:, code:)
       coupon = organization.coupons.find_by(code: code)
       return result.not_found_failure!(resource: 'coupon') unless coupon
-
-      unless coupon.deletable?
-        return result.fail!(
-          code: 'forbidden',
-          message: 'coupon is attached to an active customer',
-        )
-      end
+      return result.not_allowed_failure!(code: 'attached_to_an_active_customer') unless coupon.deletable?
 
       coupon.destroy!
 

--- a/app/services/customers/destroy_service.rb
+++ b/app/services/customers/destroy_service.rb
@@ -5,13 +5,7 @@ module Customers
     def destroy(id:)
       customer = result.user.customers.find_by(id: id)
       return result.not_found_failure!(resource: 'customer') unless customer
-
-      unless customer.deletable?
-        return result.fail!(
-          code: 'forbidden',
-          message: 'Customer is attached to an active subscription',
-        )
-      end
+      return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless customer.deletable?
 
       customer.destroy!
 

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -5,13 +5,7 @@ module Plans
     def destroy(id)
       plan = result.user.plans.find_by(id: id)
       return result.not_found_failure!(resource: 'plan') unless plan
-
-      unless plan.deletable?
-        return result.fail!(
-          code: 'forbidden',
-          message: 'Plan is attached to active subscriptions',
-        )
-      end
+      return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless plan.deletable?
 
       plan.destroy!
 
@@ -22,13 +16,7 @@ module Plans
     def destroy_from_api(organization:, code:)
       plan = organization.plans.find_by(code: code)
       return result.not_found_failure!(resource: 'plan') unless plan
-
-      unless plan.deletable?
-        return result.fail!(
-          code: 'forbidden',
-          message: 'plan is attached to an active subscriptions',
-        )
-      end
+      return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless plan.deletable?
 
       plan.destroy!
 

--- a/spec/requests/api/v1/billable_metrics_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
         code: 'BM1_code',
         description: 'description',
         aggregation_type: 'sum_agg',
-        field_name: 'amount_sum'
+        field_name: 'amount_sum',
       }
     end
 
@@ -38,14 +38,15 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
         code: code,
         description: 'description',
         aggregation_type: 'sum_agg',
-        field_name: 'amount_sum'
+        field_name: 'amount_sum',
       }
     end
 
     it 'updates a billable_metric' do
-      put_with_token(organization,
-                     "/api/v1/billable_metrics/#{billable_metric.code}",
-                     { billable_metric: update_params }
+      put_with_token(
+        organization,
+        "/api/v1/billable_metrics/#{billable_metric.code}",
+        { billable_metric: update_params },
       )
 
       expect(response).to have_http_status(:success)
@@ -71,9 +72,10 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
       before { billable_metric2 }
 
       it 'returns unprocessable_entity error' do
-        put_with_token(organization,
-                       "/api/v1/billable_metrics/#{billable_metric.code}",
-                       { billable_metric: update_params }
+        put_with_token(
+          organization,
+          "/api/v1/billable_metrics/#{billable_metric.code}",
+          { billable_metric: update_params },
         )
 
         expect(response).to have_http_status(:unprocessable_entity)
@@ -87,7 +89,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
     it 'returns a billable metric' do
       get_with_token(
         organization,
-        "/api/v1/billable_metrics/#{billable_metric.code}"
+        "/api/v1/billable_metrics/#{billable_metric.code}",
       )
 
       expect(response).to have_http_status(:success)
@@ -102,7 +104,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
       it 'returns not found' do
         get_with_token(
           organization,
-          "/api/v1/billable_metrics/555"
+          '/api/v1/billable_metrics/555',
         )
 
         expect(response).to have_http_status(:not_found)
@@ -152,7 +154,14 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
       it 'returns forbidden error' do
         delete_with_token(organization, "/api/v1/billable_metrics/#{billable_metric.code}")
 
-        expect(response).to have_http_status(:forbidden)
+        aggregate_failures do
+          expect(response).to have_http_status(:method_not_allowed)
+
+          result = JSON.parse(response.body, symbolize_names: true)
+          expect(result[:status]).to eq(405)
+          expect(result[:error]).to eq('Method Not Allowed')
+          expect(result[:code]).to eq('attached_to_an_active_subscription')
+        end
       end
     end
   end

--- a/spec/requests/api/v1/coupons_spec.rb
+++ b/spec/requests/api/v1/coupons_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::V1::CouponsController, type: :request do
         amount_cents: 123,
         amount_currency: 'EUR',
         expiration: 'time_limit',
-        expiration_duration: 15
+        expiration_duration: 15,
       }
     end
 
@@ -40,14 +40,15 @@ RSpec.describe Api::V1::CouponsController, type: :request do
         amount_cents: 123,
         amount_currency: 'EUR',
         expiration: 'time_limit',
-        expiration_duration: 15
+        expiration_duration: 15,
       }
     end
 
     it 'updates a coupon' do
-      put_with_token(organization,
-                     "/api/v1/coupons/#{coupon.code}",
-                     { coupon: update_params }
+      put_with_token(
+        organization,
+        "/api/v1/coupons/#{coupon.code}",
+        { coupon: update_params },
       )
 
       expect(response).to have_http_status(:success)
@@ -73,9 +74,10 @@ RSpec.describe Api::V1::CouponsController, type: :request do
       before { coupon2 }
 
       it 'returns unprocessable_entity error' do
-        put_with_token(organization,
-                       "/api/v1/coupons/#{coupon.code}",
-                       { coupon: update_params }
+        put_with_token(
+          organization,
+          "/api/v1/coupons/#{coupon.code}",
+          { coupon: update_params },
         )
 
         expect(response).to have_http_status(:unprocessable_entity)
@@ -89,7 +91,7 @@ RSpec.describe Api::V1::CouponsController, type: :request do
     it 'returns a coupon' do
       get_with_token(
         organization,
-        "/api/v1/coupons/#{coupon.code}"
+        "/api/v1/coupons/#{coupon.code}",
       )
 
       expect(response).to have_http_status(:success)
@@ -104,7 +106,7 @@ RSpec.describe Api::V1::CouponsController, type: :request do
       it 'returns not found' do
         get_with_token(
           organization,
-          "/api/v1/coupons/555"
+          '/api/v1/coupons/555',
         )
 
         expect(response).to have_http_status(:not_found)
@@ -149,7 +151,14 @@ RSpec.describe Api::V1::CouponsController, type: :request do
       it 'returns forbidden error' do
         delete_with_token(organization, "/api/v1/coupons/#{coupon.code}")
 
-        expect(response).to have_http_status(:forbidden)
+        aggregate_failures do
+          expect(response).to have_http_status(:method_not_allowed)
+
+          result = JSON.parse(response.body, symbolize_names: true)
+          expect(result[:status]).to eq(405)
+          expect(result[:error]).to eq('Method Not Allowed')
+          expect(result[:code]).to eq('attached_to_an_active_customer')
+        end
       end
     end
   end

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
       it 'returns not found' do
         get_with_token(
           organization,
-          "/api/v1/plans/555",
+          '/api/v1/plans/555',
         )
 
         expect(response).to have_http_status(:not_found)
@@ -252,7 +252,14 @@ RSpec.describe Api::V1::PlansController, type: :request do
       it 'returns forbidden error' do
         delete_with_token(organization, "/api/v1/plans/#{plan.code}")
 
-        expect(response).to have_http_status(:forbidden)
+        aggregate_failures do
+          expect(response).to have_http_status(:method_not_allowed)
+
+          result = JSON.parse(response.body, symbolize_names: true)
+          expect(result[:status]).to eq(405)
+          expect(result[:error]).to eq('Method Not Allowed')
+          expect(result[:code]).to eq('attached_to_an_active_subscription')
+        end
       end
     end
   end

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
         result = destroy_service.destroy(billable_metric.id)
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('forbidden')
+        expect(result.error.code).to eq('attached_to_an_active_subscription')
       end
     end
   end
@@ -71,7 +71,7 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
         result = destroy_service.destroy_from_api(organization: organization, code: billable_metric.code)
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('forbidden')
+        expect(result.error.code).to eq('attached_to_an_active_subscription')
       end
     end
   end

--- a/spec/services/coupons/destroy_service_spec.rb
+++ b/spec/services/coupons/destroy_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Coupons::DestroyService, type: :service do
         result = destroy_service.destroy(coupon.id)
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('forbidden')
+        expect(result.error.code).to eq('attached_to_an_active_customer')
       end
     end
   end
@@ -69,7 +69,7 @@ RSpec.describe Coupons::DestroyService, type: :service do
         result = destroy_service.destroy_from_api(organization: organization, code: coupon.code)
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('forbidden')
+        expect(result.error.code).to eq('attached_to_an_active_customer')
       end
     end
   end

--- a/spec/services/customers/destroy_service_spec.rb
+++ b/spec/services/customers/destroy_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Customers::DestroyService, type: :service do
         )
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('forbidden')
+        expect(result.error.code).to eq('attached_to_an_active_subscription')
       end
     end
   end

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Plans::DestroyService, type: :service do
         result = plans_service.destroy(plan.id)
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('forbidden')
+        expect(result.error.code).to eq('attached_to_an_active_subscription')
       end
     end
   end
@@ -69,7 +69,7 @@ RSpec.describe Plans::DestroyService, type: :service do
         result = plans_service.destroy_from_api(organization: organization, code: plan.code)
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('forbidden')
+        expect(result.error.code).to eq('attached_to_an_active_subscription')
       end
     end
   end


### PR DESCRIPTION
## Context

Error handling in services and the way it's rendered in API and GraphQL needs a complete refactoring.

## Description

The objective of this pull request is to normalize the way services return method not allowed errors.

When a service action cannot be performed because the status is invalid or the pre-conditions are not met, the service keeps returning a failed as it was doing before. But instead of a code and a message attached to the result, we now build a `BaseService::MethodNotAllowedFailure` with a code attribute and we attach it as the error field of the result object.

- At API controller level, when a service result has a `BaseService::MethodNotAllowedFailure`, it will format an HTTP 405 response with the error code in the payload
- At GraphQL level, it formats a `GraphQL::ExecutionError`, with the error code attached in the `extensions` payload

The current list error codes is:
- `attached_to_an_active_subscription`
- `attached_to_an_active_customer`