### PR TITLE
feat(error): Turn more service errors into not found or not allowed

### DIFF
--- a/app/graphql/concerns/execution_error_responder.rb
+++ b/app/graphql/concerns/execution_error_responder.rb
@@ -31,14 +31,14 @@ module ExecutionErrorResponder
 
   def not_allowed_error(code:)
     execution_error(
-      message: 'Method Not Allowed',
+      error: 'Method Not Allowed',
       status: 405,
       code: code,
     )
   end
 
   def result_error(service_result)
-    case service_result.error.class
+    case service_result.error
     when BaseService::NotFoundFailure
       return not_found_error(resource: service_result.error.resource)
     when BaseService::MethodNotAllowedFailure

--- a/app/services/invites/revoke_service.rb
+++ b/app/services/invites/revoke_service.rb
@@ -4,7 +4,7 @@ module Invites
   class RevokeService < BaseService
     def call(**args)
       invite = args[:current_organization].invites.pending.find_by(id: args[:id], status: :pending)
-      return result.fail!(code: 'invite_not_found') unless invite
+      return result.not_found_failure!(resource: 'invite') unless invite
 
       invite.mark_as_revoked!
 

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -43,7 +43,7 @@ module Invoices
 
       def update_status(provider_payment_id:, status:)
         payment = Payment.find_by(provider_payment_id: provider_payment_id)
-        return result.fail!(code: 'stripe_payment_not_found') unless payment
+        return result.not_found_failure!(resource: 'stripe_payment') unless payment
 
         result.payment = payment
         result.invoice = payment.invoice
@@ -185,8 +185,8 @@ module Invoices
           properties: {
             organization_id: invoice.organization.id,
             invoice_id: invoice.id,
-            payment_status: invoice.status
-          }
+            payment_status: invoice.status,
+          },
         )
       end
     end

--- a/app/services/memberships/revoke_service.rb
+++ b/app/services/memberships/revoke_service.rb
@@ -4,14 +4,8 @@ module Memberships
   class RevokeService < BaseService
     def call(id)
       membership = Membership.find_by(id: id)
-      return result.fail!(code: 'membership_not_found') unless membership
-
-      if result.user.id == membership.user.id
-        return result.fail!(
-          code: 'unprocessable_entity',
-          message: 'Cannot revoke own membership',
-        )
-      end
+      return result.not_found_failure!(resource: 'membership') unless membership
+      return result.not_allowed_failure!(code: 'cannot_revoke_own_membership') if result.user.id == membership.user.id
 
       membership.mark_as_revoked!
 

--- a/spec/graphql/mutations/invites/revoke_spec.rb
+++ b/spec/graphql/mutations/invites/revoke_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Mutations::Invites::Revoke, type: :graphql do
     GQL
   end
 
-  describe 'Invite revoke mutation' do 
+  describe 'Invite revoke mutation' do
     context 'with an existing invite' do
       let(:invite) { create(:invite, organization: organization) }
 
@@ -53,7 +53,10 @@ RSpec.describe Mutations::Invites::Revoke, type: :graphql do
           },
         )
 
-        expect(result['errors'].first['message']).to eq('invite_not_found')
+        aggregate_failures do
+          expect(result['errors'].first['message']).to eq('Resource not found')
+          expect(result['errors'].first['extensions']['code']).to eq('invite_not_found')
+        end
       end
     end
   end

--- a/spec/graphql/mutations/memberships/revoke_spec.rb
+++ b/spec/graphql/mutations/memberships/revoke_spec.rb
@@ -43,7 +43,10 @@ RSpec.describe Mutations::Memberships::Revoke, type: :graphql do
       },
     )
 
-    expect(result['errors'].first['message']).to eq('Cannot revoke own membership')
-    expect(result['errors'].first['extensions']['status']).to eq(422)
+    aggregate_failures do
+      expect(result['errors'].first['message']).to eq('Method Not Allowed')
+      expect(result['errors'].first['extensions']['code']).to eq('cannot_revoke_own_membership')
+      expect(result['errors'].first['extensions']['status']).to eq(405)
+    end
   end
 end

--- a/spec/services/invites/revoke_service_spec.rb
+++ b/spec/services/invites/revoke_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Invites::RevokeService, type: :service do
         result = revoke_service.call(**revoke_args)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('invite_not_found')
+        expect(result.error.error_code).to eq('invite_not_found')
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe Invites::RevokeService, type: :service do
         result = revoke_service.call(**revoke_args)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('invite_not_found')
+        expect(result.error.error_code).to eq('invite_not_found')
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe Invites::RevokeService, type: :service do
         result = revoke_service.call(**revoke_args)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('invite_not_found')
+        expect(result.error.error_code).to eq('invite_not_found')
       end
     end
 

--- a/spec/services/memberships/revoke_service_spec.rb
+++ b/spec/services/memberships/revoke_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Memberships::RevokeService, type: :service do
         result = revoke_service.call(membership.id)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('Cannot revoke own membership')
+        expect(result.error.code).to eq('cannot_revoke_own_membership')
       end
     end
 
@@ -22,7 +22,7 @@ RSpec.describe Memberships::RevokeService, type: :service do
         result = revoke_service.call(nil)
 
         expect(result).not_to be_success
-        expect(result.error).to eq('membership_not_found')
+        expect(result.error.error_code).to eq('membership_not_found')
       end
     end
 


### PR DESCRIPTION
## Context

Error handling in services and the way it's rendered in API and GraphQL needs a complete refactoring.

## Description

Following previous PR https://github.com/getlago/lago-api/pull/442 and https://github.com/getlago/lago-api/pull/444, this one aims to turn more simple `fail!` service errors into typed errors