### PR TITLE
misc: Update default per page from 10 to 100

### DIFF
--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -3,7 +3,7 @@ module Pagination
 
   private
 
-  PER_PAGE = 10.freeze
+  PER_PAGE = 100
 
   def pagination_metadata(records)
     if records.present?


### PR DESCRIPTION
## Context

We want to increase the default pagination on API from `10` to `100`.
For GraphQL, it remains the same value, `25`.