### PR TITLE
fix: Avoid catching ActiveStorage routes with catch_all

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,5 +48,9 @@ Rails.application.routes.draw do
     post 'stripe/:organization_id', to: 'webhooks#stripe', on: :collection, as: :stripe
   end
 
-  match '*unmatched' => 'application#not_found', via: %i[get post put delete patch]
+  match '*unmatched' => 'application#not_found',
+        via: %i[get post put delete patch],
+        constraints: lambda { |req|
+          req.path.exclude?('rails/active_storage')
+        }
 end


### PR DESCRIPTION
Hotfix to avoid catching inner ActiveStorage routes with the "Catch all" route added to render json 404