### PR TITLE
Membership - return object instead of relation id

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
       - name: Setup pronto
-        run: gem install pronto pronto-rubocop
+        run: gem install pronto pronto-rubocop rubocop rubocop-rspec rubocop-performance rubocop-rails rubocop-thread_safety
       - name: Run Pronto
         run: PRONTO_PULL_REQUEST_ID="${{ github.event.pull_request.number }}" PRONTO_GITHUB_ACCESS_TOKEN="${{ secrets.GH_TOKEN }}" pronto run -f github_status github_pr -c origin/${{ github.base_ref }}

--- a/app/graphql/types/membership_type.rb
+++ b/app/graphql/types/membership_type.rb
@@ -3,8 +3,8 @@
 module Types
   class MembershipType < Types::BaseObject
     field :id, ID, null: false
-    field :organization_id, Integer, null: false
-    field :user_id, Integer, null: false
+    field :organization, Types::OrganizationType, null: false
+    field :user, Types::UserType, null: false
     field :status, Types::Memberships::StatusEnum, null: false
     field :role, String, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -2751,12 +2751,12 @@ input LoginUserInput {
 type Membership {
   createdAt: ISO8601DateTime!
   id: ID!
-  organizationId: Int!
+  organization: Organization!
   revokedAt: ISO8601DateTime!
   role: String
   status: MembershipStatus!
   updatedAt: ISO8601DateTime!
-  userId: Int!
+  user: User!
 }
 
 type MembershipCollection {

--- a/schema.json
+++ b/schema.json
@@ -9064,14 +9064,14 @@
               ]
             },
             {
-              "name": "organizationId",
+              "name": "organization",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
+                  "kind": "OBJECT",
+                  "name": "Organization",
                   "ofType": null
                 }
               },
@@ -9150,14 +9150,14 @@
               ]
             },
             {
-              "name": "userId",
+              "name": "user",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
+                  "kind": "OBJECT",
+                  "name": "User",
                   "ofType": null
                 }
               },


### PR DESCRIPTION
This PR aims to udpate the membership type definition.

--

The membership has 2 `belongs_to` relationships with `user` and `organization`.

In the type definition we were defining the fields to return those relations' ids.

Now it's defining the Objects themself so they can be properly used and query using graphQL (so `memberhip.user` will now work on client side.)
