### PR TITLE
feat(errors): Turn manualy raised unprocessable_entity errors into ValidationFailure

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -99,7 +99,11 @@ class BaseService
     end
 
     def record_validation_failure!(record:)
-      fail_with_error!(ValidationFailure.new(messages: record.errors.messages))
+      validation_failure!(errors: record.errors.messages)
+    end
+
+    def validation_failure!(errors:)
+      fail_with_error!(ValidationFailure.new(messages: errors))
     end
 
     def throw_error

--- a/app/services/base_validator.rb
+++ b/app/services/base_validator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class BaseValidator
+  def initialize(result, **args)
+    @result = result
+    @args = args
+
+    @errors = {}
+  end
+
+  protected
+
+  attr_reader :result, :args, :errors
+
+  def add_error(field:, error_code:)
+    errors[field.to_sym] ||= []
+    errors[field.to_sym] << error_code
+
+    false
+  end
+
+  def errors?
+    errors.present?
+  end
+end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -63,11 +63,7 @@ module Subscriptions
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     rescue ArgumentError
-      result.fail!(
-        code: 'unprocessable_entity',
-        message: 'Validation error on the record',
-        details: { billing_time: ['value_is_invalid'] },
-      )
+      result.validation_failure!(errors: { billing_time: ['value_is_invalid'] })
     end
 
     def handle_subscription

--- a/spec/services/invites/create_service_spec.rb
+++ b/spec/services/invites/create_service_spec.rb
@@ -38,8 +38,11 @@ RSpec.describe Invites::CreateService, type: :service do
         create(:invite, organization: create_args[:current_organization], email: create_args[:email])
         result = create_service.call(**create_args)
 
-        expect(result).not_to be_success
-        expect(result.error_code).to eq('unprocessable_entity')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to eq([:invite])
+        end
       end
     end
 
@@ -51,8 +54,11 @@ RSpec.describe Invites::CreateService, type: :service do
 
         result = create_service.call(**create_args)
 
-        expect(result).not_to be_success
-        expect(result.error_code).to eq('unprocessable_entity')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to eq([:email])
+        end
       end
     end
   end

--- a/spec/services/invites/validate_service_spec.rb
+++ b/spec/services/invites/validate_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Invites::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error_details[:invite]).to eq(['invite_already_exists'])
+        expect(result.error.messages[:invite]).to eq(['invite_already_exists'])
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe Invites::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error_details[:email]).to eq(['email_already_used'])
+        expect(result.error.messages[:email]).to eq(['email_already_used'])
       end
     end
   end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -207,9 +207,8 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error).to eq('Validation error on the record')
-          expect(result.error_code).to eq('unprocessable_entity')
-          expect(result.error_details.keys).to eq([:billing_time])
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to eq([:billing_time])
         end
       end
     end
@@ -553,9 +552,8 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error).to eq('Validation error on the record')
-          expect(result.error_code).to eq('unprocessable_entity')
-          expect(result.error_details.keys).to eq([:billing_time])
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to eq([:billing_time])
         end
       end
     end

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
         result = create_service.create(**create_args)
 
         expect(result).not_to be_success
-        expect(result.error_details.first).to eq('invalid_paid_credits')
+        expect(result.error.messages[:paid_credits]).to eq(['invalid_paid_credits'])
       end
     end
   end

--- a/spec/services/wallet_transactions/validate_service_spec.rb
+++ b/spec/services/wallet_transactions/validate_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error_details.first).to eq('wallet_not_found')
+        expect(result.error.messages[:wallet_id]).to eq(['wallet_not_found'])
       end
     end
 
@@ -45,7 +45,7 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error_details.first).to eq('invalid_paid_credits')
+        expect(result.error.messages[:paid_credits]).to eq(['invalid_paid_credits'])
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error_details.first).to eq('invalid_granted_credits')
+        expect(result.error.messages[:granted_credits]).to eq(['invalid_granted_credits'])
       end
     end
   end

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Wallets::CreateService, type: :service do
         result = create_service.create(**create_args)
 
         expect(result).not_to be_success
-        expect(result.error_details.first).to eq('invalid_paid_credits')
+        expect(result.error.messages[:paid_credits]).to eq(['invalid_paid_credits'])
       end
     end
   end

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error_details.first).to eq('customer_not_found')
+        expect(result.error.messages[:customer]).to eq(['customer_not_found'])
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error_details.first).to eq('no_active_subscription')
+        expect(result.error.messages[:customer]).to eq(['no_active_subscription'])
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error_details.first).to eq('wallet_already_exists')
+        expect(result.error.messages[:customer]).to eq(['wallet_already_exists'])
       end
     end
 
@@ -68,7 +68,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error_details.first).to eq('invalid_paid_credits')
+        expect(result.error.messages[:paid_credits]).to eq(['invalid_paid_credits'])
       end
     end
 
@@ -77,7 +77,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error_details.first).to eq('invalid_granted_credits')
+        expect(result.error.messages[:granted_credits]).to eq(['invalid_granted_credits'])
       end
     end
   end


### PR DESCRIPTION
## Context

Error handling in services and the way it's rendered in API and GraphQL needs a complete refactoring.

## Description

The objective of this pull request is to normalize the way services return data validation errors.

When a service action cannot be performed because the custom pre-conditions are not met, the service keeps returning a failed error as it was doing before. But instead of a list of error codes and custom "unprocessable entity we are now building a `BaseService::ValidationFailure` with a list of error messages for each fields (or base if not for a specific field) and we attach it as the error field of the result object.

This new behavior is now used in the custom service validators

**NOTE:** The result of wallet validators changed a bit, it as an impact on the front end and should be fixed before the merge