### PR TITLE
fix: Fix cache expiration result for customer current usage

### DIFF
--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -120,7 +120,10 @@ module Invoices
 
     def cache_expiration
       expiration = (boundaries[:charges_to_date] - Time.zone.today).to_i + 1
-      expiration > 4 ? 4 : expiration
+      return 1 if expiration < 1
+      return 4 if expiration > 4
+
+      expiration
     end
 
     def format_usage


### PR DESCRIPTION
## Context

We have received few errors lately with the cache expiration computation for customer usage

These errors are raised by Redis (`Redis::CommandError - ERR invalid expire time in 'set' command`) when trying to write down the usage into the cache with the expiration key.

## Description

The goal of this PR is to make sure that the expiration duration is never 0 or negative to prevent Redis from raising the error

