### PR TITLE
feat(customers): Add currency field

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -2,6 +2,7 @@
 
 class Customer < ApplicationRecord
   include Sequenced
+  include Currencies
 
   before_save :ensure_slug
 
@@ -31,6 +32,7 @@ class Customer < ApplicationRecord
   validates :country, country_code: true, unless: -> { country.nil? }
   validates :vat_rate, numericality: { less_than_or_equal_to: 100, greater_than_or_equal_to: 0 }, allow_nil: true
   validates :payment_provider, inclusion: { in: PAYMENT_PROVIDERS }, allow_nil: true
+  validates :currency, inclusion: { in: currency_list }, allow_nil: true
 
   def attached_to_subscriptions?
     subscriptions.exists?

--- a/db/migrate/20220915092730_add_currency_to_customers.rb
+++ b/db/migrate/20220915092730_add_currency_to_customers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCurrencyToCustomers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :customers, :currency, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_06_130714) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_15_092730) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -157,6 +157,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_06_130714) do
     t.string "payment_provider"
     t.string "slug"
     t.bigint "sequential_id"
+    t.string "currency"
     t.index ["external_id"], name: "index_customers_on_external_id"
     t.index ["organization_id"], name: "index_customers_on_organization_id"
   end


### PR DESCRIPTION
## Context

Currently, we cannot apply a coupon, an add-on or even prepaid-credits if a customer has no active subscription. This problem happen because customer object does not hold the currency directly, but via the currency of the plan of it’s first active subscription.

It’s a problem when a plan is invoiced `in-advance` because it can then take up to 1 year to apply the mentioned objects on the first generated invoice.

## Description

This PR is the first one of the feature, it simply add the new `currency` field to the customer model
