### PR TITLE
fix: Ability to filter invoices by external customer id

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -27,7 +27,9 @@ module Api
 
       def index
         invoices = current_organization.invoices
-        invoices = invoices.where(customer_id: params[:customer_id]) if params[:customer_id]
+        if params[:external_customer_id]
+          invoices = invoices.joins(:customer).where(customers: { external_id: params[:external_customer_id] })
+        end
         invoices = invoices.where(date_from_criteria) if valid_date?(params[:issuing_date_from])
         invoices = invoices.where(date_to_criteria) if valid_date?(params[:issuing_date_to])
         invoices = invoices.order(created_at: :desc)

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -113,12 +113,12 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       end
     end
 
-    context 'with customer_id params' do
+    context 'with external_customer_id params' do
       it 'returns invoices of the customer' do
         second_customer = create(:customer, organization: organization)
         invoice = create(:invoice, customer: second_customer)
 
-        get_with_token(organization, "/api/v1/invoices?customer_id=#{second_customer.id}")
+        get_with_token(organization, "/api/v1/invoices?external_customer_id=#{second_customer.external_id}")
 
         expect(response).to have_http_status(:success)
         expect(json[:invoices].count).to eq(1)


### PR DESCRIPTION
The goal of this PR is to be able to filter invoices by `external_customer_id` instead of `customer_id`.