### PR TITLE
feat(errors): Convert missing_argument to not_found errors

### DIFF
--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -3,10 +3,10 @@
 class ErrorSerializer < ModelSerializer
   def serialize
     {
-      status: 422,
-      error: 'Unprocessable entity',
-      message: model.error,
-      input_params: model.input_params
+      status: model.status,
+      error: model.status == 404 ? 'Not found' : 'Unprocessable entity',
+      message: model.error.to_s,
+      input_params: model.input_params,
     }
   end
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -4,7 +4,7 @@ class ErrorSerializer < ModelSerializer
   def serialize
     {
       status: model.status,
-      error: model.status == 404 ? 'Not found' : 'Unprocessable entity',
+      error: (model.status == 404) ? 'Not found' : 'Unprocessable entity',
       message: model.error.to_s,
       input_params: model.input_params,
     }

--- a/app/services/applied_add_ons/create_service.rb
+++ b/app/services/applied_add_ons/create_service.rb
@@ -41,8 +41,8 @@ module AppliedAddOns
     attr_reader :customer, :add_on
 
     def check_preconditions(amount_currency:)
-      return result.fail!(code: 'missing_argument', message: 'unable_to_find_customer') if customer.blank?
-      return result.fail!(code: 'missing_argument', message: 'add_on_does_not_exist') if add_on.blank?
+      return result.not_found_failure!(resource: 'customer') unless customer
+      return result.not_found_failure!(resource: 'add_on') unless add_on
       return result.fail!(code: 'no_active_subscription') unless active_subscription?
       return result.fail!(code: 'currencies_does_not_match') unless applicable_currency?(amount_currency)
     end

--- a/app/services/applied_coupons/create_service.rb
+++ b/app/services/applied_coupons/create_service.rb
@@ -41,8 +41,8 @@ module AppliedCoupons
     attr_reader :customer, :coupon
 
     def check_preconditions(amount_currency:)
-      return result.fail!(code: 'missing_argument', message: 'unable_to_find_customer') if customer.blank?
-      return result.fail!(code: 'missing_argument', message: 'coupon_does_not_exist') if coupon.blank?
+      return result.not_found_failure!(resource: 'customer') unless customer
+      return result.not_found_failure!(resource: 'coupon') unless coupon
       return result.fail!(code: 'no_active_subscription') unless active_subscription?
       return result.fail!(code: 'coupon_already_applied') if coupon_already_applied?
       return result.fail!(code: 'currencies_does_not_match') unless applicable_currency?(amount_currency)

--- a/app/services/events/validate_creation_service.rb
+++ b/app/services/events/validate_creation_service.rb
@@ -79,7 +79,7 @@ module Events
 
       object = {
         input_params: params,
-        error: result.error,
+        error: result.error.to_s,
         organization_id: organization.id,
       }
 
@@ -91,7 +91,7 @@ module Events
     end
 
     def blank_subscription_error
-      result.fail!(code: 'missing_argument', message: 'subscription does not exist or is not given')
+      result.not_found_failure!(resource: 'subscription')
       send_webhook_notice
     end
 
@@ -101,12 +101,12 @@ module Events
     end
 
     def invalid_code_error
-      result.fail!(code: 'missing_argument', message: 'code does not exist')
+      result.not_found_failure!(resource: 'event')
       send_webhook_notice
     end
 
     def invalid_customer_error
-      result.fail!(code: 'missing_argument', message: 'customer cannot be found')
+      result.not_found_failure!(resource: 'customer')
       send_webhook_notice
     end
 

--- a/app/services/events/validate_creation_service.rb
+++ b/app/services/events/validate_creation_service.rb
@@ -77,9 +77,12 @@ module Events
     def send_webhook_notice
       return unless organization.webhook_url?
 
+      status = result.error.is_a?(BaseService::NotFoundFailure) ? 404 : 422
+
       object = {
         input_params: params,
         error: result.error.to_s,
+        status: status,
         organization_id: organization.id,
       }
 

--- a/app/services/events/validate_creation_service.rb
+++ b/app/services/events/validate_creation_service.rb
@@ -104,7 +104,7 @@ module Events
     end
 
     def invalid_code_error
-      result.not_found_failure!(resource: 'event')
+      result.not_found_failure!(resource: 'billable_metric')
       send_webhook_notice
     end
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -50,8 +50,8 @@ module Subscriptions
     private
 
     def process_create
-      return result.fail!(code: 'missing_argument', message: 'unable to find customer') unless current_customer
-      return result.fail!(code: 'missing_argument', message: 'plan does not exists') unless current_plan
+      return result.not_found_failure!(resource: 'customer') unless current_customer
+      return result.not_found_failure!(resource: 'plan') unless current_plan
 
       if currency_missmatch?(current_customer&.active_subscription&.plan, current_plan)
         return result.fail!(code: 'currencies_does_not_match', message: 'currencies does not match')

--- a/spec/requests/api/v1/applied_add_ons_spec.rb
+++ b/spec/requests/api/v1/applied_add_ons_spec.rb
@@ -39,15 +39,15 @@ RSpec.describe Api::V1::AppliedAddOnsController, type: :request do
       end
     end
 
-    context 'with invalid params' do
+    context 'with invalid name' do
       let(:params) do
         { name: 'Foo Bar' }
       end
 
-      it 'returns an unprocessable_entity' do
+      it 'returns an not_found error' do
         post_with_token(organization, '/api/v1/applied_add_ons', { applied_add_on: params })
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/api/v1/applied_coupons_spec.rb
+++ b/spec/requests/api/v1/applied_coupons_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
       it 'returns an unprocessable_entity' do
         post_with_token(organization, '/api/v1/applied_coupons', { applied_coupon: params })
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -37,15 +37,15 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       expect(json[:subscription][:downgrade_plan_date]).to be_nil
     end
 
-    context 'with invalid params' do
+    context 'with invalid plan code' do
       let(:params) do
         { plan_code: plan.code }
       end
 
-      it 'returns an unprocessable_entity error' do
+      it 'returns a not_found error' do
         post_with_token(organization, '/api/v1/subscriptions', { subscription: params })
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/serializers/error_serializer_spec.rb
+++ b/spec/serializers/error_serializer_spec.rb
@@ -9,22 +9,23 @@ RSpec.describe ErrorSerializer do
       input_params: {
         customer_id: 'customer',
         transaction_id: transaction_id,
-        code: 'code'
+        code: 'code',
       },
-      error: 'Code does not exist',
-      organization_id: 'testtest'
+      error: 'Event not found',
+      status: 404,
+      organization_id: 'testtest',
     }
   end
   let(:json_response_hash) do
     {
       'event_error' => {
-        'status' => 422,
-        'error' => 'Unprocessable entity',
-        'message' => 'Code does not exist',
+        'status' => 404,
+        'error' => 'Not found',
+        'message' => 'Event not found',
         'input_params' => {
           'customer_id' => 'customer',
           'transaction_id' => transaction_id,
-          'code' => 'code'
+          'code' => 'code',
         }
       }
     }

--- a/spec/services/applied_add_ons/create_service_spec.rb
+++ b/spec/services/applied_add_ons/create_service_spec.rb
@@ -84,17 +84,25 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
       let(:customer) { nil }
       let(:customer_id) { 'foo' }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error_code).to eq('missing_argument') }
-      it { expect(create_result.error).to eq('unable_to_find_customer') }
+      it 'returns a not found error' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(create_result.error.message).to eq('customer_not_found')
+        end
+      end
     end
 
     context 'when add-on is not found' do
       let(:add_on_id) { 'foo' }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error_code).to eq('missing_argument') }
-      it { expect(create_result.error).to eq('add_on_does_not_exist') }
+      it 'returns a not found error' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(create_result.error.message).to eq('add_on_not_found')
+        end
+      end
     end
 
     context 'when customer does not have a subscription' do
@@ -158,8 +166,8 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
         properties: {
           customer_id: applied_add_on.customer.id,
           addon_code: applied_add_on.add_on.code,
-          addon_name: applied_add_on.add_on.name
-        }
+          addon_name: applied_add_on.add_on.name,
+        },
       )
     end
 
@@ -182,17 +190,25 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
       let(:customer) { nil }
       let(:external_customer_id) { 'foo' }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error_code).to eq('missing_argument') }
-      it { expect(create_result.error).to eq('unable_to_find_customer') }
+      it 'returns a not found error' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(create_result.error.message).to eq('customer_not_found')
+        end
+      end
     end
 
     context 'when add-on is not found' do
       let(:add_on_code) { 'foo' }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error_code).to eq('missing_argument') }
-      it { expect(create_result.error).to eq('add_on_does_not_exist') }
+      it 'returns a not found error' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(create_result.error.message).to eq('add_on_not_found')
+        end
+      end
     end
 
     context 'when customer does not have a subscription' do

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -81,25 +81,37 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       let(:customer) { nil }
       let(:customer_id) { 'foo' }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error_code).to eq('missing_argument') }
-      it { expect(create_result.error).to eq('unable_to_find_customer') }
+      it 'returns a not found error' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(create_result.error.message).to eq('customer_not_found')
+        end
+      end
     end
 
     context 'when coupon is not found' do
       let(:coupon_id) { 'foo' }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error_code).to eq('missing_argument') }
-      it { expect(create_result.error).to eq('coupon_does_not_exist') }
+      it 'returns a not found error' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(create_result.error.message).to eq('coupon_not_found')
+        end
+      end
     end
 
     context 'when coupon is inactive' do
       before { coupon.terminated! }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error_code).to eq('missing_argument') }
-      it { expect(create_result.error).to eq('coupon_does_not_exist') }
+      it 'returns a not found error' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(create_result.error.message).to eq('coupon_not_found')
+        end
+      end
     end
 
     context 'when customer does not have a subscription' do
@@ -176,8 +188,8 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
           customer_id: applied_coupon.customer.id,
           coupon_code: applied_coupon.coupon.code,
           coupon_name: applied_coupon.coupon.name,
-          organization_id: applied_coupon.coupon.organization_id
-        }
+          organization_id: applied_coupon.coupon.organization_id,
+        },
       )
     end
 
@@ -200,25 +212,37 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       let(:customer) { nil }
       let(:external_customer_id) { 'foo' }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error_code).to eq('missing_argument') }
-      it { expect(create_result.error).to eq('unable_to_find_customer') }
+      it 'returns a not found error' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(create_result.error.message).to eq('customer_not_found')
+        end
+      end
     end
 
     context 'when coupon is not found' do
       let(:coupon_code) { 'foo' }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error_code).to eq('missing_argument') }
-      it { expect(create_result.error).to eq('coupon_does_not_exist') }
+      it 'returns a not found error' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(create_result.error.message).to eq('coupon_not_found')
+        end
+      end
     end
 
     context 'when coupon is inactive' do
       before { coupon.terminated! }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error_code).to eq('missing_argument') }
-      it { expect(create_result.error).to eq('coupon_does_not_exist') }
+      it 'returns a not found error' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::NotFoundFailure)
+          expect(create_result.error.message).to eq('coupon_not_found')
+        end
+      end
     end
 
     context 'when customer does not have a subscription' do

--- a/spec/services/events/validate_creation_service_spec.rb
+++ b/spec/services/events/validate_creation_service_spec.rb
@@ -72,11 +72,14 @@ RSpec.describe Events::ValidateCreationService, type: :service do
           )
         end
 
-        it 'returns customer cannot be found error' do
+        it 'returns a customer_not_found error' do
           validate_event
 
-          expect(result).not_to be_success
-          expect(result.error).to eq('customer cannot be found')
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq('customer_not_found')
+          end
         end
 
         it 'enqueues a SendWebhookJob' do
@@ -89,11 +92,14 @@ RSpec.describe Events::ValidateCreationService, type: :service do
           create(:active_subscription, customer: customer, organization: organization)
         end
 
-        it 'returns subscription is not given error' do
+        it 'returns a subscription_not_found error' do
           validate_event
 
-          expect(result).not_to be_success
-          expect(result.error).to eq('subscription does not exist or is not given')
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq('subscription_not_found')
+          end
         end
 
         it 'enqueues a SendWebhookJob' do
@@ -131,11 +137,14 @@ RSpec.describe Events::ValidateCreationService, type: :service do
           { external_customer_id: customer.external_id, code: 'event_code' }
         end
 
-        it 'returns code does not exist error' do
+        it 'returns an event_not_found error' do
           validate_event
 
-          expect(result).not_to be_success
-          expect(result.error).to eq('code does not exist')
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq('event_not_found')
+          end
         end
 
         it 'enqueues a SendWebhookJob' do
@@ -208,11 +217,14 @@ RSpec.describe Events::ValidateCreationService, type: :service do
           { external_subscription_ids: [] }
         end
 
-        it 'returns subscription is not given error' do
+        it 'returns a subscription_not_found error' do
           validate_event
 
-          expect(result).not_to be_success
-          expect(result.error).to eq('subscription does not exist or is not given')
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq('subscription_not_found')
+          end
         end
 
         it 'enqueues a SendWebhookJob' do
@@ -235,11 +247,14 @@ RSpec.describe Events::ValidateCreationService, type: :service do
           )
         end
 
-        it 'returns customer cannot be found error' do
+        it 'returns a customer_not_found error' do
           validate_event
 
-          expect(result).not_to be_success
-          expect(result.error).to eq('customer cannot be found')
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq('customer_not_found')
+          end
         end
 
         it 'enqueues a SendWebhookJob' do
@@ -281,11 +296,14 @@ RSpec.describe Events::ValidateCreationService, type: :service do
           }
         end
 
-        it 'returns code does not exist error' do
+        it 'returns an event_not_found error' do
           validate_event
 
-          expect(result).not_to be_success
-          expect(result.error).to eq('code does not exist')
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq('event_not_found')
+          end
         end
 
         it 'enqueues a SendWebhookJob' do

--- a/spec/services/events/validate_creation_service_spec.rb
+++ b/spec/services/events/validate_creation_service_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Events::ValidateCreationService, type: :service do
           aggregate_failures do
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq('event_not_found')
+            expect(result.error.message).to eq('billable_metric_not_found')
           end
         end
 
@@ -302,7 +302,7 @@ RSpec.describe Events::ValidateCreationService, type: :service do
           aggregate_failures do
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq('event_not_found')
+            expect(result.error.message).to eq('billable_metric_not_found')
           end
         end
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -158,14 +158,17 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         }
       end
 
-      it 'fails' do
+      it 'returns a customer_not_found error' do
         result = create_service.create_from_api(
           organization: organization,
           params: params,
         )
 
-        expect(result).not_to be_success
-        expect(result.error).to eq('unable to find customer')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('customer_not_found')
+        end
       end
     end
 
@@ -178,14 +181,17 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         }
       end
 
-      it 'fails' do
+      it 'returns a plan_not_found error' do
         result = create_service.create_from_api(
           organization: organization,
           params: params,
         )
 
-        expect(result).not_to be_success
-        expect(result.error).to eq('plan does not exists')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('plan_not_found')
+        end
       end
     end
 
@@ -508,12 +514,13 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         }
       end
 
-      it 'fails' do
+      it 'returns a customer_not_found error' do
         result = create_service.create(**params)
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error).to eq('unable to find customer')
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('customer_not_found')
         end
       end
     end
@@ -527,12 +534,13 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         }
       end
 
-      it 'fails' do
+      it 'returns a plan_not_found error' do
         result = create_service.create(**params)
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error).to eq('plan does not exists')
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('plan_not_found')
         end
       end
     end


### PR DESCRIPTION
**Context**

Error handling in services and the way it's rendered in API and GraphQL needs a complete refactoring.

**Description**

The objective of this PR is to return `404 not_found` errors for existing `422 missing_argument` failures.

Concerning GraphQL, it impacts `CreateAppliedAddOn` (when customer or add_on not found), `CreateAppliedCoupon` (when customer or coupon not found) and `CreateSubscription` (when customer or plan not found).

It has been validated that this change does not require updating the frontend, as it only triggers a generic error.

**WIP**
Need to update `ErrorSerializer` to render 404 Not Found for webhooks instead of 422.