### PR TITLE
feat(customers): Add or update customer currency via GraphQL

### DIFF
--- a/app/graphql/mutations/customers/create.rb
+++ b/app/graphql/mutations/customers/create.rb
@@ -24,6 +24,7 @@ module Mutations
       argument :legal_name, String, required: false
       argument :legal_number, String, required: false
       argument :vat_rate, Float, required: false
+      argument :currency, Types::CurrencyEnum, required: false
 
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
       argument :stripe_customer, Types::PaymentProviderCustomers::StripeInput, required: false

--- a/app/graphql/mutations/customers/update.rb
+++ b/app/graphql/mutations/customers/update.rb
@@ -24,8 +24,9 @@ module Mutations
       argument :legal_name, String, required: false
       argument :legal_number, String, required: false
       argument :vat_rate, Float, required: false
-      argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
+      argument :currency, Types::CurrencyEnum, required: false
 
+      argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
       argument :stripe_customer, Types::PaymentProviderCustomers::StripeInput, required: false
 
       type Types::Customers::Object

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -25,6 +25,7 @@ module Types
       field :legal_name, String, null: true
       field :legal_number, String, null: true
       field :vat_rate, Float, null: true
+      field :currency, Types::CurrencyEnum, null: true
       field :payment_provider, Types::PaymentProviders::ProviderTypeEnum, null: true
 
       field :stripe_customer, Types::PaymentProviderCustomers::Stripe, null: true

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -57,7 +57,7 @@ class Customer < ApplicationRecord
   end
 
   def default_currency
-    active_subscription&.plan&.amount_currency
+    currency || active_subscription&.plan&.amount_currency
   end
 
   private

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -106,6 +106,10 @@ class BaseService
       fail_with_error!(ValidationFailure.new(messages: errors))
     end
 
+    def single_validation_failure!(field:, error_code:)
+      validation_failure!(errors: { field.to_sym => [error_code] })
+    end
+
     def throw_error
       return if success?
 

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -51,6 +51,7 @@ module Customers
         legal_number: args[:legal_number],
         vat_rate: args[:vat_rate],
         payment_provider: args[:payment_provider],
+        currency: args[:currency],
       )
 
       # NOTE: handle configuration for configured payment providers

--- a/schema.graphql
+++ b/schema.graphql
@@ -1611,6 +1611,7 @@ input CreateCustomerInput {
   """
   clientMutationId: String
   country: CountryCode
+  currency: CurrencyEnum
   email: String
   externalId: String!
   legalName: String
@@ -2405,6 +2406,7 @@ type Customer {
   city: String
   country: CountryCode
   createdAt: ISO8601DateTime!
+  currency: CurrencyEnum
   email: String
   externalId: String!
 
@@ -3661,6 +3663,7 @@ input UpdateCustomerInput {
   """
   clientMutationId: String
   country: CountryCode
+  currency: CurrencyEnum
   email: String
   externalId: String!
   id: ID!

--- a/schema.json
+++ b/schema.json
@@ -4762,6 +4762,18 @@
               "deprecationReason": null
             },
             {
+              "name": "currency",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "CurrencyEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "paymentProvider",
               "description": null,
               "type": {
@@ -6271,6 +6283,20 @@
                   "name": "ISO8601DateTime",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "currency",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "CurrencyEnum",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -13786,6 +13812,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currency",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "CurrencyEnum",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           country
           paymentProvider
           stripeCustomer { id, providerCustomerId }
+          currency
         }
       }
     GQL
@@ -37,6 +38,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           city: 'London',
           country: 'GB',
           paymentProvider: 'stripe',
+          currency: 'EUR',
           stripeCustomer: {
             providerCustomerId: 'cu_12345',
           },
@@ -52,6 +54,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
       expect(result_data['externalId']).to eq('john_doe_2')
       expect(result_data['city']).to eq('London')
       expect(result_data['country']).to eq('GB')
+      expect(result_data['currency']).to eq('EUR')
       expect(result_data['paymentProvider']).to eq('stripe')
       expect(result_data['stripeCustomer']['id']).to be_present
       expect(result_data['stripeCustomer']['providerCustomerId']).to eq('cu_12345')

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           name,
           externalId
           paymentProvider
+          currency
           stripeCustomer { id, providerCustomerId }
         }
       }
@@ -35,6 +36,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           name: 'Updated customer',
           externalId: external_id,
           paymentProvider: 'stripe',
+          currency: 'EUR',
           stripeCustomer: {
             providerCustomerId: 'cu_12345',
           },
@@ -49,6 +51,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       expect(result_data['name']).to eq('Updated customer')
       expect(result_data['externalId']).to eq(external_id)
       expect(result_data['paymentProvider']).to eq('stripe')
+      expect(result_data['currency']).to eq('EUR')
       expect(result_data['stripeCustomer']['id']).to be_present
       expect(result_data['stripeCustomer']['providerCustomerId']).to eq('cu_12345')
     end

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Customers::CreateService, type: :service do
           customer_id: customer.id,
           created_at: customer.created_at,
           payment_provider: customer.payment_provider,
-          organization_id: customer.organization_id
-        }
+          organization_id: customer.organization_id,
+        },
       )
     end
 
@@ -232,6 +232,7 @@ RSpec.describe Customers::CreateService, type: :service do
         external_id: SecureRandom.uuid,
         name: 'Foo Bar',
         organization_id: organization.id,
+        currency: 'EUR',
       }
     end
 
@@ -250,6 +251,7 @@ RSpec.describe Customers::CreateService, type: :service do
         expect(customer.organization_id).to eq(organization.id)
         expect(customer.external_id).to eq(create_args[:external_id])
         expect(customer.name).to eq(create_args[:name])
+        expect(customer.currency).to eq('EUR')
       end
     end
 
@@ -263,8 +265,8 @@ RSpec.describe Customers::CreateService, type: :service do
           customer_id: customer.id,
           created_at: customer.created_at,
           payment_provider: customer.payment_provider,
-          organization_id: customer.organization_id
-        }
+          organization_id: customer.organization_id,
+        },
       )
     end
 

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -60,6 +60,26 @@ RSpec.describe Customers::UpdateService, type: :service do
           expect(updated_customer.external_id).to eq(customer.external_id)
         end
       end
+
+      context 'when updating the currency' do
+        let(:update_args) do
+          {
+            id: customer.id,
+            currency: 'CAD',
+          }
+        end
+
+        it 'fails' do
+          result = customers_service.update(**update_args)
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages.keys).to include(:currency)
+            expect(result.error.messages[:currency]).to include('currencies_does_not_match')
+          end
+        end
+      end
     end
 
     context 'when updating payment provider' do


### PR DESCRIPTION
## Context

Currently, we cannot apply a coupon, an add-on or even prepaid-credits if a customer has no active subscription. This problem happen because customer object does not hold the currency directly, but via the currency of the plan of it’s first active subscription.

It’s a problem when a plan is invoiced in-advance because it can then take up to 1 year to apply the mentioned objects on the first generated invoice.

## Description

This PR allows front end to assign customer currency:
- At customer creation time via the `createCustomer` mutation
- At customer edition via the `updateCustomer` mutation

It also exposes this currency in the `Customer` type

In the update scenario, if the customer is attached to an `active subscription`, an `add_on`, a `coupon` or a `wallet`, the action will raise an `unprocessable_entity` error, with the error code `currencies_does_not_match` attached to the `currency` field