### PR TITLE
feat: Return downgrade plan date instead of next and previous external id

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -35,11 +35,7 @@ module Types
       end
 
       def next_pending_start_date
-        return unless object.next_subscription
-        return unless object.next_subscription.pending?
-
-        ::Subscriptions::DatesService.new_instance(object, Time.zone.today)
-          .next_end_of_period(Time.zone.today) + 1.day
+        object.downgrade_plan_date
       end
     end
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -78,4 +78,12 @@ class Subscription < ApplicationRecord
     used_ids = organization.subscriptions.active.pluck(:external_id)
     errors.add(:external_id, :value_already_exists) if used_ids&.include?(external_id)
   end
+
+  def downgrade_plan_date
+    return unless next_subscription
+    return unless next_subscription.pending?
+
+    ::Subscriptions::DatesService.new_instance(self, Time.zone.today)
+      .next_end_of_period(Time.zone.today) + 1.day
+  end
 end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -19,8 +19,7 @@ module V1
         created_at: model.created_at.iso8601,
         previous_plan_code: model.previous_subscription&.plan&.code,
         next_plan_code: model.next_subscription&.plan&.code,
-        previous_external_id: model.previous_subscription&.external_id,
-        next_external_id: model.next_subscription&.external_id,
+        downgrade_plan_date: model.downgrade_plan_date&.iso8601,
       }
     end
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -153,4 +153,30 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe '#downgrade_plan_date' do
+    let(:subscription) { create(:subscription) }
+
+    context 'without next subscription' do
+      it 'returns nil' do
+        expect(subscription.downgrade_plan_date).to be_nil
+      end
+    end
+
+    context 'without pending next subscription' do
+      it 'returns nil' do
+        create(:subscription, previous_subscription: subscription, status: :active)
+        expect(subscription.downgrade_plan_date).to be_nil
+      end
+    end
+
+    it 'returns the date when the plan will be downgraded' do
+      current_date = DateTime.parse('20 Jun 2022')
+      create(:subscription, previous_subscription: subscription, status: :pending)
+
+      travel_to(current_date) do
+        expect(subscription.downgrade_plan_date).to eq(Date.parse('1 Jul 2022'))
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       expect(json[:subscription][:billing_time]).to eq('anniversary')
       expect(json[:subscription][:previous_plan_code]).to be_nil
       expect(json[:subscription][:next_plan_code]).to be_nil
-      expect(json[:subscription][:previous_external_id]).to be_nil
-      expect(json[:subscription][:next_external_id]).to be_nil
+      expect(json[:subscription][:downgrade_plan_date]).to be_nil
     end
 
     context 'with invalid params' do
@@ -141,12 +140,15 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
         expect(subscription[:next_plan_code]).to eq(next_subscription.plan.code)
       end
 
-      it 'returns next and previous external ids' do
-        get_with_token(organization, "/api/v1/subscriptions?external_customer_id=#{customer.external_id}")
+      it 'returns the downgrade plan date' do
+        current_date = DateTime.parse('20 Jun 2022')
 
-        subscription = json[:subscriptions].first
-        expect(subscription[:previous_external_id]).to eq(previous_subscription.external_id)
-        expect(subscription[:next_external_id]).to eq(next_subscription.external_id)
+        travel_to(current_date) do
+          get_with_token(organization, "/api/v1/subscriptions?external_customer_id=#{customer.external_id}")
+
+          subscription = json[:subscriptions].first
+          expect(subscription[:downgrade_plan_date]).to eq('2022-07-01')
+        end
       end
     end
 


### PR DESCRIPTION
When a downgrade is made, `external_id` is copied from the original to the new subscription.
Instead of returning `external_id`, we want to return the downgrade plan date of the subscription in the API.