### PR TITLE
feat(customers): Add or update customer currency via API

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -92,7 +92,12 @@ module Api
           :legal_name,
           :legal_number,
           :vat_rate,
-          billing_configuration: [:payment_provider, :provider_customer_id, :sync],
+          :currency,
+          billing_configuration: [
+            :payment_provider,
+            :provider_customer_id,
+            :sync,
+          ],
         )
       end
     end

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -23,6 +23,7 @@ module V1
         logo_url: model.logo_url,
         legal_name: model.legal_name,
         legal_number: model.legal_number,
+        currency: model.currency,
         billing_configuration: billing_configuration,
       }
     end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -106,7 +106,7 @@ class BaseService
       fail_with_error!(ValidationFailure.new(messages: errors))
     end
 
-    def single_validation_failure!(field:, error_code:)
+    def single_validation_failure!(error_code:, field: :base)
       validation_failure!(errors: { field.to_sym => [error_code] })
     end
 

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       {
         external_id: SecureRandom.uuid,
         name: 'Foo Bar',
+        currency: 'EUR',
       }
     end
 
@@ -20,6 +21,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       expect(json[:customer][:external_id]).to eq(create_params[:external_id])
       expect(json[:customer][:name]).to eq(create_params[:name])
       expect(json[:customer][:created_at]).to be_present
+      expect(json[:customer][:currency]).to eq(create_params[:currency])
     end
 
     context 'with billing configuration' do
@@ -50,7 +52,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
 
     context 'with invalid params' do
       let(:create_params) do
-        { name: 'Foo Bar' }
+        { name: 'Foo Bar', currency: 'invalid' }
       end
 
       it 'returns an unprocessable_entity' do


### PR DESCRIPTION
## Context

Currently, we cannot apply a coupon, an add-on or even prepaid-credits if a customer has no active subscription. This problem happen because customer object does not hold the currency directly, but via the currency of the plan of it’s first active subscription.

It’s a problem when a plan is invoiced in-advance because it can then take up to 1 year to apply the mentioned objects on the first generated invoice.

## Description

This PR allows API users to assign customer currency at customer creation or update time via a `POST` on `/api/v1/customers`

It also exposes this currency in the `response` type

In the update scenario, if the customer is attached to an `active subscription`, an `add_on`, a `coupon` or a `wallet`, the call will render an HTTP 422 error, with the error code `currencies_does_not_match` attached to the `currency` field in the error detail