### PR TITLE
feat(customers): Assign customer currency via add_on application

### DIFF
--- a/app/jobs/bill_add_on_job.rb
+++ b/app/jobs/bill_add_on_job.rb
@@ -5,13 +5,12 @@ class BillAddOnJob < ApplicationJob
 
   retry_on Sequenced::SequenceError
 
-  def perform(subscription, applied_add_on, date)
+  def perform(applied_add_on, date)
     result = Invoices::AddOnService.new(
-      subscription: subscription,
       applied_add_on: applied_add_on,
       date: date,
     ).create
 
-    raise result.throw_error unless result.success?
+    raise(result.throw_error) unless result.success?
   end
 end

--- a/app/services/applied_add_ons/create_service.rb
+++ b/app/services/applied_add_ons/create_service.rb
@@ -40,26 +40,33 @@ module AppliedAddOns
 
     attr_reader :customer, :add_on
 
-    def check_preconditions(amount_currency:)
+    def check_preconditions
       return result.not_found_failure!(resource: 'customer') unless customer
       return result.not_found_failure!(resource: 'add_on') unless add_on
-      return result.fail!(code: 'no_active_subscription') unless active_subscription?
-      return result.fail!(code: 'currencies_does_not_match') unless applicable_currency?(amount_currency)
     end
 
     def process_creation(amount_cents:, amount_currency:)
-      check_preconditions(amount_currency: amount_currency)
+      check_preconditions
       return result if result.error
 
-      applied_add_on = AppliedAddOn.create!(
+      applied_add_on = AppliedAddOn.new(
         customer: customer,
         add_on: add_on,
         amount_cents: amount_cents,
         amount_currency: amount_currency,
       )
 
+      ActiveRecord::Base.transaction do
+        currency_result = Customers::UpdateService.new(nil).update_currency(
+          customer: customer,
+          currency: amount_currency,
+        )
+        return currency_result unless currency_result.success?
+
+        applied_add_on.save!
+      end
+
       BillAddOnJob.perform_later(
-        active_subscription,
         applied_add_on,
         Time.zone.now.to_date,
       )
@@ -69,18 +76,6 @@ module AppliedAddOns
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    end
-
-    def active_subscription?
-      active_subscription.present?
-    end
-
-    def applicable_currency?(currency)
-      active_subscription.plan.amount_currency == currency
-    end
-
-    def active_subscription
-      @active_subscription ||= customer.active_subscription
     end
 
     def track_applied_add_on_created(applied_add_on)

--- a/app/services/fees/add_on_service.rb
+++ b/app/services/fees/add_on_service.rb
@@ -2,9 +2,8 @@
 
 module Fees
   class AddOnService < BaseService
-    def initialize(invoice:, applied_add_on:, subscription:)
+    def initialize(invoice:, applied_add_on:)
       @invoice = invoice
-      @subscription = subscription
       @applied_add_on = applied_add_on
       super(nil)
     end
@@ -14,10 +13,9 @@ module Fees
 
       new_fee = Fee.new(
         invoice: invoice,
-        subscription: subscription,
         applied_add_on: applied_add_on,
         amount_cents: applied_add_on.amount_cents,
-        amount_currency: plan.amount_currency,
+        amount_currency: applied_add_on.amount_currency,
         fee_type: :add_on,
         invoiceable_type: 'AppliedAddOn',
         invoiceable: applied_add_on,
@@ -36,10 +34,9 @@ module Fees
 
     private
 
-    attr_reader :invoice, :applied_add_on, :subscription
+    attr_reader :invoice, :applied_add_on
 
     delegate :customer, to: :invoice
-    delegate :plan, to: :subscription
 
     def already_billed?
       existing_fee = invoice.fees.find_by(applied_add_on_id: applied_add_on.id)

--- a/spec/jobs/bill_add_on_job_spec.rb
+++ b/spec/jobs/bill_add_on_job_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe BillAddOnJob, type: :job do
-  let(:subscription) { create(:subscription) }
   let(:applied_add_on) { create(:applied_add_on) }
   let(:date) { Time.zone.now.to_date }
 
@@ -12,14 +11,14 @@ RSpec.describe BillAddOnJob, type: :job do
 
   before do
     allow(Invoices::AddOnService).to receive(:new)
-      .with(subscription: subscription, applied_add_on: applied_add_on, date: date)
+      .with(applied_add_on: applied_add_on, date: date)
       .and_return(invoice_service)
     allow(invoice_service).to receive(:create)
       .and_return(result)
   end
 
   it 'calls the add on create service' do
-    described_class.perform_now(subscription, applied_add_on, date)
+    described_class.perform_now(applied_add_on, date)
 
     expect(Invoices::AddOnService).to have_received(:new)
     expect(invoice_service).to have_received(:create)
@@ -32,7 +31,7 @@ RSpec.describe BillAddOnJob, type: :job do
 
     it 'raises an error' do
       expect do
-        described_class.perform_now(subscription, applied_add_on, date)
+        described_class.perform_now(applied_add_on, date)
       end.to raise_error(BaseService::FailedResult)
 
       expect(Invoices::AddOnService).to have_received(:new)

--- a/spec/services/fees/add_on_service_spec.rb
+++ b/spec/services/fees/add_on_service_spec.rb
@@ -4,10 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Fees::AddOnService do
   subject(:add_on_service) do
-    described_class.new(invoice: invoice, applied_add_on: applied_add_on, subscription: subscription)
+    described_class.new(invoice: invoice, applied_add_on: applied_add_on)
   end
 
-  let(:subscription) { create(:subscription) }
   let(:invoice) { create(:invoice) }
   let(:applied_add_on) { create(:applied_add_on) }
 
@@ -37,7 +36,6 @@ RSpec.describe Fees::AddOnService do
         create(
           :fee,
           applied_add_on: applied_add_on,
-          subscription: subscription,
           invoice: invoice,
         )
       end


### PR DESCRIPTION
## Context

Currently, we cannot apply a coupon, an add-on or even prepaid-credits if a customer has no active subscription. This problem happen because customer object does not hold the currency directly, but via the currency of the plan of it’s first active subscription.

It’s a problem when a plan is invoiced in-advance because it can then take up to 1 year to apply the mentioned objects on the first generated invoice.

## Description

The role of this PR is to assign the customer currency when applying an add-on to a customer with no currency

It also impacts the way add-ons are billed in order to remove the needs for a subscription attached to the add_on fee, and so allows add_on to be created without a pre-existing subscription.
