### PR TITLE
feat(customers): Apply customer currency when applying coupon

### DIFF
--- a/app/services/applied_coupons/create_service.rb
+++ b/app/services/applied_coupons/create_service.rb
@@ -40,24 +40,32 @@ module AppliedCoupons
 
     attr_reader :customer, :coupon
 
-    def check_preconditions(amount_currency:)
+    def check_preconditions
       return result.not_found_failure!(resource: 'customer') unless customer
       return result.not_found_failure!(resource: 'coupon') unless coupon
-      return result.fail!(code: 'no_active_subscription') unless active_subscription?
       return result.fail!(code: 'coupon_already_applied') if coupon_already_applied?
-      return result.fail!(code: 'currencies_does_not_match') unless applicable_currency?(amount_currency)
     end
 
     def process_creation(amount_cents:, amount_currency:)
-      check_preconditions(amount_currency: amount_currency)
+      check_preconditions
       return result if result.error
 
-      applied_coupon = AppliedCoupon.create!(
+      applied_coupon = AppliedCoupon.new(
         customer: customer,
         coupon: coupon,
         amount_cents: amount_cents,
         amount_currency: amount_currency,
       )
+
+      ActiveRecord::Base.transaction do
+        currency_result = Customers::UpdateService.new(nil).update_currency(
+          customer: customer,
+          currency: amount_currency,
+        )
+        return currency_result unless currency_result.success?
+
+        applied_coupon.save!
+      end
 
       result.applied_coupon = applied_coupon
       track_applied_coupon_created(result.applied_coupon)
@@ -66,16 +74,8 @@ module AppliedCoupons
       result.record_validation_failure!(record: e.record)
     end
 
-    def active_subscription?
-      customer.active_subscription.present?
-    end
-
     def coupon_already_applied?
       customer.applied_coupons.active.exists?
-    end
-
-    def applicable_currency?(currency)
-      customer.active_subscription.plan.amount_currency == currency
     end
 
     def track_applied_coupon_created(applied_coupon)

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -17,8 +17,10 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
   let(:amount_cents) { nil }
   let(:amount_currency) { nil }
 
+  let(:create_subscription) { customer.present? }
+
   before do
-    create(:active_subscription, customer_id: customer_id) if customer
+    create(:active_subscription, customer_id: customer_id) if create_subscription
   end
 
   describe 'create' do
@@ -57,8 +59,8 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
           customer_id: applied_coupon.customer.id,
           coupon_code: applied_coupon.coupon.code,
           coupon_name: applied_coupon.coupon.name,
-          organization_id: applied_coupon.coupon.organization_id
-        }
+          organization_id: applied_coupon.coupon.organization_id,
+        },
       )
     end
 
@@ -72,8 +74,14 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       context 'when currency does not match' do
         let(:amount_currency) { 'NOK' }
 
-        it { expect(create_result).not_to be_success }
-        it { expect(create_result.error).to eq('currencies_does_not_match') }
+        it 'fails' do
+          aggregate_failures do
+            expect(create_result).not_to be_success
+            expect(create_result.error).to be_a(BaseService::ValidationFailure)
+            expect(create_result.error.messages.keys).to include(:currency)
+            expect(create_result.error.messages[:currency]).to include('currencies_does_not_match')
+          end
+        end
       end
     end
 
@@ -114,13 +122,6 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       end
     end
 
-    context 'when customer does not have a subscription' do
-      before { customer.active_subscription.terminated! }
-
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error).to eq('no_active_subscription') }
-    end
-
     context 'when coupon is already applied to the customer' do
       before { create(:applied_coupon, customer: customer, coupon: coupon) }
 
@@ -140,8 +141,14 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
     context 'when currency of coupon does not match customer currency' do
       let(:coupon) { create(:coupon, status: 'active', organization: organization, amount_currency: 'NOK') }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error).to eq('currencies_does_not_match') }
+      it 'fails' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::ValidationFailure)
+          expect(create_result.error.messages.keys).to include(:currency)
+          expect(create_result.error.messages[:currency]).to include('currencies_does_not_match')
+        end
+      end
     end
   end
 
@@ -203,8 +210,14 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       context 'when currency does not match' do
         let(:amount_currency) { 'NOK' }
 
-        it { expect(create_result).not_to be_success }
-        it { expect(create_result.error).to eq('currencies_does_not_match') }
+        it 'fails' do
+          aggregate_failures do
+            expect(create_result).not_to be_success
+            expect(create_result.error).to be_a(BaseService::ValidationFailure)
+            expect(create_result.error.messages.keys).to include(:currency)
+            expect(create_result.error.messages[:currency]).to include('currencies_does_not_match')
+          end
+        end
       end
     end
 
@@ -245,13 +258,6 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       end
     end
 
-    context 'when customer does not have a subscription' do
-      before { customer.active_subscription.terminated! }
-
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error).to eq('no_active_subscription') }
-    end
-
     context 'when coupon is already applied to the customer' do
       before { create(:applied_coupon, customer: customer, coupon: coupon) }
 
@@ -262,8 +268,25 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
     context 'when currency of coupon does not match customer currency' do
       let(:coupon) { create(:coupon, status: 'active', organization: organization, amount_currency: 'NOK') }
 
-      it { expect(create_result).not_to be_success }
-      it { expect(create_result.error).to eq('currencies_does_not_match') }
+      it 'fails' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::ValidationFailure)
+          expect(create_result.error.messages.keys).to include(:currency)
+          expect(create_result.error.messages[:currency]).to include('currencies_does_not_match')
+        end
+      end
+    end
+
+    context 'when customer does not have a currency' do
+      let(:create_subscription) { false }
+      let(:amount_currency) { 'NOK' }
+
+      it 'assigns the coupon currency to the customer' do
+        create_result
+
+        expect(customer.reload.currency).to eq(amount_currency)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Currently, we cannot apply a coupon, an add-on or even prepaid-credits if a customer has no active subscription. This problem happen because customer object does not hold the currency directly, but via the currency of the plan of it’s first active subscription.

It’s a problem when a plan is invoiced in-advance because it can then take up to 1 year to apply the mentioned objects on the first generated invoice.

## Description

The role of this PR is to assign the customer currency when applying a coupon to a customer with no currency

It also removes the need for a subscription before applying coupons
