### PR TITLE
feat: support new field called parent_id on plan creation

### DIFF
--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -19,6 +19,7 @@ module Mutations
       argument :trial_period, Float, required: false
       argument :description, String, required: false
       argument :bill_charges_monthly, Boolean, required: false
+      argument :parent_id, ID, required: false
 
       argument :charges, [Types::Charges::Input]
 

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -17,6 +17,7 @@ module Types
       field :trial_period, Float
       field :description, String
       field :bill_charges_monthly, Boolean
+      field :parent_id, ID, null: true
 
       field :charges, [Types::Charges::Object]
 

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -4,11 +4,13 @@ class Plan < ApplicationRecord
   include Currencies
 
   belongs_to :organization
+  belongs_to :parent, class_name: 'Plan', optional: true
 
   has_many :charges, dependent: :destroy
   has_many :billable_metrics, through: :charges
   has_many :subscriptions
   has_many :customers, through: :subscriptions
+  has_many :children, class_name: 'Plan', foreign_key: :parent_id
 
   INTERVALS = %i[
     weekly

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -8,6 +8,7 @@ module Plans
         name: args[:name],
         code: args[:code],
         description: args[:description],
+        parent_id: args[:parent_id],
         interval: args[:interval].to_sym,
         pay_in_advance: args[:pay_in_advance],
         amount_cents: args[:amount_cents],

--- a/db/migrate/20220916131538_add_parent_id_on_plans.rb
+++ b/db/migrate/20220916131538_add_parent_id_on_plans.rb
@@ -1,0 +1,5 @@
+class AddParentIdOnPlans < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :plans, :parent, type: :uuid, null: true, index: true, foreign_key: { to_table: :plans }
+  end
+end

--- a/db/migrate/20220916131538_add_parent_id_on_plans.rb
+++ b/db/migrate/20220916131538_add_parent_id_on_plans.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddParentIdOnPlans < ActiveRecord::Migration[7.0]
   def change
     add_reference :plans, :parent, type: :uuid, null: true, index: true, foreign_key: { to_table: :plans }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_15_092730) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_16_131538) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -348,8 +348,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_092730) do
     t.float "trial_period"
     t.boolean "pay_in_advance", default: false, null: false
     t.boolean "bill_charges_monthly"
+    t.uuid "parent_id"
     t.index ["code", "organization_id"], name: "index_plans_on_code_and_organization_id", unique: true
     t.index ["organization_id"], name: "index_plans_on_organization_id"
+    t.index ["parent_id"], name: "index_plans_on_parent_id"
   end
 
   create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -443,6 +445,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_15_092730) do
   add_foreign_key "payments", "payment_providers"
   add_foreign_key "persisted_events", "customers"
   add_foreign_key "plans", "organizations"
+  add_foreign_key "plans", "plans", column: "parent_id"
   add_foreign_key "subscriptions", "customers"
   add_foreign_key "subscriptions", "plans"
   add_foreign_key "wallet_transactions", "invoices"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1684,6 +1684,7 @@ input CreatePlanInput {
   description: String
   interval: PlanInterval!
   name: String!
+  parentId: ID
   payInAdvance: Boolean!
   trialPeriod: Float
 }
@@ -3209,6 +3210,7 @@ type Plan {
   interval: PlanInterval!
   name: String!
   organization: Organization
+  parentId: ID
   payInAdvance: Boolean!
   trialPeriod: Float
   updatedAt: ISO8601DateTime!
@@ -3246,6 +3248,7 @@ type PlanDetails {
   interval: PlanInterval!
   name: String!
   organization: Organization
+  parentId: ID
   payInAdvance: Boolean!
   trialPeriod: Float
   updatedAt: ISO8601DateTime!

--- a/schema.json
+++ b/schema.json
@@ -5174,6 +5174,18 @@
               "deprecationReason": null
             },
             {
+              "name": "parentId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "charges",
               "description": null,
               "type": {
@@ -10991,6 +11003,20 @@
               ]
             },
             {
+              "name": "parentId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "payInAdvance",
               "description": null,
               "type": {
@@ -11346,6 +11372,20 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Organization",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "parentId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
                 "ofType": null
               },
               "isDeprecated": false,


### PR DESCRIPTION
## Context

There is a new feature that eases the process of plan creation with pre-filling information from selected plan.

## Description

While creating a new plan based on selected 'parent' plan we still want to keep this relationship in order to keep possibility to group such a plans in the UI