### PR TITLE
feat(customers): Assign customer currency from wallet creation

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -81,6 +81,7 @@ module Api
         params.require(:wallet).permit(
           :rate_amount,
           :name,
+          :currency,
           :paid_credits,
           :granted_credits,
           :expiration_date,

--- a/app/graphql/mutations/wallets/create.rb
+++ b/app/graphql/mutations/wallets/create.rb
@@ -15,6 +15,7 @@ module Mutations
       argument :paid_credits, String, required: true
       argument :granted_credits, String, required: true
       argument :expiration_date, GraphQL::Types::ISO8601Date, required: false
+      argument :currency, Types::CurrencyEnum, required: true
 
       type Types::Wallets::Object
 
@@ -27,7 +28,7 @@ module Mutations
             **args
               .merge(organization_id: current_organization.id)
               .merge(customer: current_customer(args[:customer_id]))
-              .except(:customer_id)
+              .except(:customer_id),
           )
 
         result.success? ? result.wallet : result_error(result)

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Wallet < ApplicationRecord
-  before_create :set_customer_currency
-
   belongs_to :customer
 
   has_one :organization, through: :customer
@@ -21,11 +19,5 @@ class Wallet < ApplicationRecord
     terminated!
   end
 
-  scope :expired, -> { where('wallets.expiration_date < ?', Time.current.beginning_of_day,) }
-
-  private
-
-  def set_customer_currency
-    self.currency ||= customer.default_currency
-  end
+  scope :expired, -> { where('wallets.expiration_date < ?', Time.current.beginning_of_day) }
 end

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -29,10 +29,6 @@ module Wallets
         )
       end
 
-      unless result.current_customer.subscriptions.active.exists?
-        return add_error(field: :customer, error_code: 'no_active_subscription')
-      end
-
       true
     end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1635,6 +1635,7 @@ input CreateCustomerWalletInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  currency: CurrencyEnum!
   customerId: ID!
   expirationDate: ISO8601Date
   grantedCredits: String!

--- a/schema.json
+++ b/schema.json
@@ -4907,6 +4907,22 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "currency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "enumValues": null

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe Mutations::Wallets::Create, type: :graphql do
   let(:membership) { create(:membership) }
   let(:customer) { create(:customer, organization: membership.organization) }
-  let(:subscription) { create(:subscription, customer: customer) }
 
   let(:mutation) do
     <<-GQL
@@ -14,14 +13,11 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
           id,
           name,
           rateAmount,
-          status
+          status,
+          currency
         }
       }
     GQL
-  end
-
-  before do
-    subscription
   end
 
   it 'create a wallet' do
@@ -37,6 +33,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
           paidCredits: '0.00',
           grantedCredits: '0.00',
           expirationDate: (Time.zone.now + 1.year).to_date,
+          currency: 'EUR',
         },
       },
     )
@@ -62,6 +59,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
             paidCredits: '0.00',
             grantedCredits: '0.00',
             expirationDate: (Time.zone.now + 1.year).to_date,
+            currency: 'EUR',
           },
         },
       )
@@ -83,6 +81,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
             paidCredits: '0.00',
             grantedCredits: '0.00',
             expirationDate: (Time.zone.now + 1.year).to_date,
+            currency: 'EUR',
           },
         },
       )

--- a/spec/requests/api/v1/wallets_spec.rb
+++ b/spec/requests/api/v1/wallets_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
         external_customer_id: customer.external_id,
         rate_amount: '1',
         name: 'Wallet1',
+        currency: 'EUR',
         paid_credits: '10',
         granted_credits: '10',
         expiration_date: '2022-06-06',

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -45,15 +45,6 @@ RSpec.describe Wallets::ValidateService, type: :service do
       end
     end
 
-    context 'when customer has no active subscription' do
-      before { subscription.mark_as_terminated! }
-
-      it 'returns false and result has errors' do
-        expect(validate_service).not_to be_valid
-        expect(result.error.messages[:customer]).to eq(['no_active_subscription'])
-      end
-    end
-
     context 'when customer already has a wallet' do
       before { create(:wallet, customer: customer) }
 


### PR DESCRIPTION
## Context

Currently, we cannot apply a coupon, an add-on or even prepaid-credits if a customer has no active subscription. This problem happen because customer object does not hold the currency directly, but via the currency of the plan of it’s first active subscription.

It’s a problem when a plan is invoiced in-advance because it can then take up to 1 year to apply the mentioned objects on the first generated invoice.

## Description

The role of this PR is to assign the customer currency when creation a wallet for a customer with no currency

As a side effect it forces us to update the `createWallet` mutation and the `POST /api/v1/wallets` API route to accept a mandatory currency parameter.

It also removes the need for a subscription before creating a wallet
