### PR TITLE
fix(billable_metrics): Wrong aggregation type should raise a validation error

### DIFF
--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetric, type: :model do
+  subject(:billable_metric) { described_class.new }
+
+  describe '#aggregation_type=' do
+    it 'assigns the aggregation type' do
+      billable_metric.aggregation_type = :count_agg
+      billable_metric.valid?
+
+      aggregate_failures do
+        expect(billable_metric).to be_count_agg
+        expect(billable_metric.errors[:aggregation_type]).to be_blank
+      end
+    end
+
+    context 'when aggregation type is invalid' do
+      it 'does not assign the aggregation type' do
+        billable_metric.aggregation_type = :invalid_agg
+        billable_metric.valid?
+
+        aggregate_failures do
+          expect(billable_metric.aggregation_type).to be_nil
+          expect(billable_metric.errors[:aggregation_type]).to include('value_is_invalid')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       :billable_metric,
       organization: organization,
       aggregation_type: 'count_agg',
-      billable_period: 'one_shot',
     )
   end
 


### PR DESCRIPTION
## Context

Trying to assign an invalid aggregation type when creating a billable metric leads to an HTTP 500 error when it should returns a 422.

## Description

This behavior is related to the Rails `enum` implementation. When assigning an invalid value to an enum, a ruby `ArgumentError` is raised immediately, making it impossible to validate the provided value with the standard model validations.

In order to fix the issue, the idea is:
- to override the default enum setter, to add filter invalid inputs
- add a validation rule to validate inclusion of the value (or nil) in the list of aggregation types
