### PR TITLE
feat(customers): Add migration task to populate customer currency

### DIFF
--- a/app/graphql/types/customers/single_object.rb
+++ b/app/graphql/types/customers/single_object.rb
@@ -22,10 +22,6 @@ module Types
       def applied_add_ons
         object.applied_add_ons.order(created_at: :desc)
       end
-
-      def currency
-        object.default_currency
-      end
     end
   end
 end

--- a/app/jobs/migration_task_job.rb
+++ b/app/jobs/migration_task_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class TaskNotFoundError < StandardError
+end
+
+class MigrationTaskJob < ApplicationJob
+  queue_as 'default'
+
+  retry_on TaskNotFoundError, attempts: 5
+
+  def perform(task_name)
+    LagoApi::Application.load_tasks
+    raise(TaskNotFoundError) unless Rake::Task.task_defined?(task_name)
+
+    Rake::Task[task_name].invoke
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -56,10 +56,6 @@ class Customer < ApplicationRecord
     organization.vat_rate || 0
   end
 
-  def default_currency
-    currency || active_subscription&.plan&.amount_currency
-  end
-
   private
 
   def ensure_slug

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -21,11 +21,11 @@ class Wallet < ApplicationRecord
     terminated!
   end
 
-  scope :expired, -> { where('wallets.expiration_date < ?', Time.current.beginning_of_day,) }
+  scope :expired, -> { where('wallets.expiration_date < ?', Time.current.beginning_of_day) }
 
   private
 
   def set_customer_currency
-    self.currency ||= customer.default_currency
+    self.currency ||= customer.currency
   end
 end

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -46,8 +46,7 @@ module Customers
     def update_currency(customer:, currency:)
       result.customer = customer
 
-      # TODO: remove default currency check after migration to customer currency
-      if !editable_currency? && customer.default_currency != currency
+      if !editable_currency? && customer.currency != currency
         return result.single_validation_failure!(
           field: :currency,
           error_code: 'currencies_does_not_match',

--- a/app/services/fees/paid_credit_service.rb
+++ b/app/services/fees/paid_credit_service.rb
@@ -22,7 +22,7 @@ module Fees
         invoiceable_type: 'WalletTransaction',
         invoiceable: wallet_transaction,
         amount_cents: amount_cents,
-        amount_currency: customer.default_currency,
+        amount_currency: wallet_transaction.wallet.currency,
         vat_rate: customer.applicable_vat_rate,
         units: 1,
       )

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -44,7 +44,7 @@ module Invoices
     attr_accessor :customer, :timestamp, :wallet_transaction
 
     def currency
-      @currency ||= customer.default_currency
+      @currency ||= wallet_transaction.wallet.currency
     end
 
     def compute_amounts(invoice)

--- a/db/migrate/20220919133338_run_customer_currency_task.rb
+++ b/db/migrate/20220919133338_run_customer_currency_task.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RunCustomerCurrencyTask < ActiveRecord::Migration[7.0]
+  def change
+    # NOTE: Wait to ensure workers are loaded with the added tasks
+    MigrationTaskJob.set(wait: 20.seconds).perform_later('customers:populate_currency')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_16_131538) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_19_133338) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/lib/tasks/customers.rake
+++ b/lib/tasks/customers.rake
@@ -5,4 +5,14 @@ namespace :customers do
   task generate_slug: :environment do
     Customer.order(:created_at).find_each(&:save)
   end
+
+  desc 'Set customer currency from active subscription'
+  task populate_currency: :environment do
+    Customer.where(currency: nil).find_each do |customer|
+      subscription = customer.active_subscription
+      next unless subscription
+
+      customer.update!(currency: subscription.plan.amount_currency)
+    end
+  end
 end

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Mutations::Wallets::Create, type: :graphql do
   let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization: membership.organization) }
+  let(:customer) { create(:customer, organization: membership.organization, currency: 'EUR') }
   let(:subscription) { create(:subscription, customer: customer) }
 
   let(:mutation) do

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) do
-    create(:customer, organization: organization)
+    create(:customer, organization: organization, currency: 'EUR')
   end
   let(:subscription) { create(:subscription, customer: customer) }
   let(:applied_add_on) { create(:applied_add_on, customer: customer) }

--- a/spec/requests/api/v1/wallets_spec.rb
+++ b/spec/requests/api/v1/wallets_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::WalletsController, type: :request do
   let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization: organization) }
+  let(:customer) { create(:customer, organization: organization, currency: 'EUR') }
   let(:subscription) { create(:subscription, customer: customer) }
 
   before { subscription }

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Wallets::CreateService, type: :service do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization: organization, external_id: 'foobar') }
+  let(:customer) { create(:customer, organization: organization, external_id: 'foobar', currency: 'EUR') }
   let(:subscription) { create(:subscription, customer: customer) }
 
   before { subscription }


### PR DESCRIPTION
## Context

Currently, we cannot apply a coupon, an add-on or even prepaid-credits if a customer has no active subscription. This problem happen because customer object does not hold the currency directly, but via the currency of the plan of it’s first active subscription.

It’s a problem when a plan is invoiced in-advance because it can then take up to 1 year to apply the mentioned objects on the first generated invoice.

## Description

The role of this PR is to run a migration task to assign customer currency from the active subscription
