### PR TITLE
fix: prevent revoked users to log in

### DIFF
--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -3,9 +3,11 @@
 class UsersService < BaseService
   def login(email, password)
     result.user = User.find_by(email: email)&.authenticate(password)
-    result.token = generate_token if result.user
 
     return result.fail!(code: 'incorrect_login_or_password') unless result.user
+    return result.fail!(code: 'incorrect_login_or_password') unless result.user.memberships.first.active?
+
+    result.token = generate_token if result.user
 
     # Note: We're tracking the first membership linked to the user.
     SegmentIdentifyJob.perform_later(membership_id: "membership/#{result.user.memberships.first.id}")

--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -5,7 +5,7 @@ class UsersService < BaseService
     result.user = User.find_by(email: email)&.authenticate(password)
 
     return result.fail!(code: 'incorrect_login_or_password') unless result.user
-    return result.fail!(code: 'incorrect_login_or_password') unless result.user.memberships.first.active?
+    return result.fail!(code: 'incorrect_login_or_password') unless result.user.memberships.active.any?
 
     result.token = generate_token if result.user
 


### PR DESCRIPTION
User without an active status were still able to log in the app.

This PR brings a check to prevent them to do so.

I has been agree with product that the returned error should be the same as if the user does not exists