### PR TITLE
fix(invoices): Show credit list on API invoice results

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -76,7 +76,7 @@ module Api
           json: ::V1::InvoiceSerializer.new(
             invoice,
             root_name: 'invoice',
-            includes: %i[customer subscriptions fees],
+            includes: %i[customer subscriptions fees credits],
           ),
         )
       end

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -45,7 +45,7 @@ module V1
     end
 
     def credits
-      ::CollectionSerializer.new(model.credits, ::V1::CreditSerializer, collection_name: 'credit').serialize
+      ::CollectionSerializer.new(model.credits, ::V1::CreditSerializer, collection_name: 'credits').serialize
     end
   end
 end

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -33,9 +33,15 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     it 'returns a invoice' do
       get_with_token(organization, "/api/v1/invoices/#{invoice.id}")
 
-      expect(response).to have_http_status(:success)
-      expect(json[:invoice][:lago_id]).to eq(invoice.id)
-      expect(json[:invoice][:status]).to eq(invoice.status)
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:invoice][:lago_id]).to eq(invoice.id)
+        expect(json[:invoice][:status]).to eq(invoice.status)
+        expect(json[:invoice][:customer]).not_to be_nil
+        expect(json[:invoice][:subscriptions]).not_to be_nil
+        expect(json[:invoice][:fees]).not_to be_nil
+        expect(json[:invoice][:credits]).not_to be_nil
+      end
     end
 
     context 'when invoice does not exist' do


### PR DESCRIPTION
## Context

Calling `GET /api/v1/invoices/:id` does not return the list of credits applied to the invoice

## Description

This PR goals is to fix the behavior documented in the API reference documentation and include invoice credits in the response payload