### PR TITLE
feat: add subscription end date in subscription resolver

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -14,6 +14,7 @@ module Types
       field :name, String, null: true
       field :next_name, String, null: true
       field :next_pending_start_date, GraphQL::Types::ISO8601Date
+      field :period_end_date, GraphQL::Types::ISO8601Date
 
       field :billing_time, Types::Subscriptions::BillingTimeEnum
       field :subscription_date, GraphQL::Types::ISO8601Date
@@ -36,6 +37,11 @@ module Types
 
       def next_pending_start_date
         object.downgrade_plan_date
+      end
+
+      def period_end_date
+        ::Subscriptions::DatesService.new_instance(object, Time.zone.today)
+          .next_end_of_period(Time.zone.today)
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3549,6 +3549,7 @@ type Subscription {
   nextName: String
   nextPendingStartDate: ISO8601Date
   nextPlan: Plan
+  periodEndDate: ISO8601Date
   plan: Plan!
   startedAt: ISO8601DateTime
   status: StatusTypeEnum

--- a/schema.json
+++ b/schema.json
@@ -13026,6 +13026,20 @@
               ]
             },
             {
+              "name": "periodEndDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "plan",
               "description": null,
               "type": {


### PR DESCRIPTION
## Context

Add `subscription_end_date` in subscription resolver. This change is needed for _duplicate plans_ feature. We need this information on FE side in order to present valid end date in notification pop-up while downgrading subscription.