### PR TITLE
feat(errors): More handling of single validation errors

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -56,7 +56,7 @@ module Invoices
 
         result
       rescue ArgumentError
-        result.fail!(code: 'invalid_invoice_status')
+        result.single_validation_failure!(field: :status, error_code: 'value_is_invalid')
       end
 
       private

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -5,7 +5,13 @@ class Invoices::UpdateService < BaseService
     invoice = Invoice.find_by(id: invoice_id)
 
     return result.not_found_failure!(resource: 'invoice') if invoice.blank?
-    return result.single_validation_failure!(field: :status, error_code: 'value_is_invalid') unless valid_status?(params[:status])
+
+    unless valid_status?(params[:status])
+      return result.single_validation_failure!(
+        field: :status,
+        error_code: 'value_is_invalid',
+      )
+    end
 
     invoice.status = params[:status] if params.key?(:status)
     invoice.save!

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -1,52 +1,54 @@
 # frozen_string_literal: true
 
-class Invoices::UpdateService < BaseService
-  def update_from_api(invoice_id:, params:)
-    invoice = Invoice.find_by(id: invoice_id)
+module Invoices
+  class UpdateService < BaseService
+    def update_from_api(invoice_id:, params:)
+      invoice = Invoice.find_by(id: invoice_id)
 
-    return result.not_found_failure!(resource: 'invoice') if invoice.blank?
+      return result.not_found_failure!(resource: 'invoice') if invoice.blank?
 
-    unless valid_status?(params[:status])
-      return result.single_validation_failure!(
-        field: :status,
-        error_code: 'value_is_invalid',
+      unless valid_status?(params[:status])
+        return result.single_validation_failure!(
+          field: :status,
+          error_code: 'value_is_invalid',
+        )
+      end
+
+      invoice.status = params[:status] if params.key?(:status)
+      invoice.save!
+
+      handle_prepaid_credits(invoice, params[:status])
+
+      result.invoice = invoice
+      track_payment_status_changed(invoice)
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    def valid_status?(status)
+      Invoice::STATUS.include?(status&.to_sym)
+    end
+
+    def track_payment_status_changed(invoice)
+      SegmentTrackJob.perform_later(
+        membership_id: CurrentContext.membership,
+        event: 'payment_status_changed',
+        properties: {
+          organization_id: invoice.organization.id,
+          invoice_id: invoice.id,
+          payment_status: invoice.status,
+        },
       )
     end
 
-    invoice.status = params[:status] if params.key?(:status)
-    invoice.save!
+    def handle_prepaid_credits(invoice, status)
+      return unless invoice.invoice_type == 'credit'
+      return unless status == 'succeeded'
 
-    handle_prepaid_credits(invoice, params[:status])
-
-    result.invoice = invoice
-    track_payment_status_changed(invoice)
-    result
-  rescue ActiveRecord::RecordInvalid => e
-    result.record_validation_failure!(record: e.record)
-  end
-
-  private
-
-  def valid_status?(status)
-    Invoice::STATUS.include?(status&.to_sym)
-  end
-
-  def track_payment_status_changed(invoice)
-    SegmentTrackJob.perform_later(
-      membership_id: CurrentContext.membership,
-      event: 'payment_status_changed',
-      properties: {
-        organization_id: invoice.organization.id,
-        invoice_id: invoice.id,
-        payment_status: invoice.status,
-      },
-    )
-  end
-
-  def handle_prepaid_credits(invoice, status)
-    return unless invoice.invoice_type == 'credit'
-    return unless status == 'succeeded'
-
-    Invoices::PrepaidCreditJob.perform_later(invoice)
+      Invoices::PrepaidCreditJob.perform_later(invoice)
+    end
   end
 end

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -5,7 +5,7 @@ class Invoices::UpdateService < BaseService
     invoice = Invoice.find_by(id: invoice_id)
 
     return result.not_found_failure!(resource: 'invoice') if invoice.blank?
-    return result.fail!(code: 'invalid_status') unless valid_status?(params[:status])
+    return result.single_validation_failure!(field: :status, error_code: 'value_is_invalid') unless valid_status?(params[:status])
 
     invoice.status = params[:status] if params.key?(:status)
     invoice.save!

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -68,7 +68,7 @@ module PaymentProviderCustomers
       # NOTE: The payment method is no longer valid
       stripe_customer.update!(payment_method_id: nil)
 
-      result.fail!(code: 'invalid_payment_method')
+      result.single_validation_failure!(field: :payment_method_id, error_code: 'value_is_invalid')
     end
 
     private

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
   end
 
   describe '.create' do
-    let(:provider_customer_service){ instance_double(PaymentProviderCustomers::StripeService) }
+    let(:provider_customer_service) { instance_double(PaymentProviderCustomers::StripeService) }
     let(:provider_customer_service_result) do
       BaseService::Result.new.tap do |result|
         result.payment_method = Stripe::PaymentMethod.new(id: 'pm_123456')
@@ -76,11 +76,12 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         create(:wallet_transaction, wallet: wallet, amount: 15.0, credit_amount: 15.0, status: 'pending')
       end
       let(:fee) do
-        create(:fee,
+        create(
+          :fee,
           fee_type: 'credit',
           invoiceable_type: 'WalletTransaction',
           invoiceable_id: wallet_transaction.id,
-          invoice: invoice
+          invoice: invoice,
         )
       end
 
@@ -107,8 +108,8 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         properties: {
           organization_id: invoice.organization.id,
           invoice_id: invoice.id,
-          payment_status: invoice.status
-        }
+          payment_status: invoice.status,
+        },
       )
     end
 
@@ -293,8 +294,8 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         properties: {
           organization_id: invoice.organization.id,
           invoice_id: invoice.id,
-          payment_status: invoice.status
-        }
+          payment_status: invoice.status,
+        },
       )
     end
 
@@ -319,8 +320,12 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
           status: 'foo-bar',
         )
 
-        expect(result).not_to be_success
-        expect(result.error_code).to eq('invalid_invoice_status')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to include(:status)
+          expect(result.error.messages[:status]).to include('value_is_invalid')
+        end
       end
     end
   end

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -110,8 +110,12 @@ RSpec.describe Invoices::UpdateService do
           params: update_args,
         )
 
-        expect(result).not_to be_success
-        expect(result.error).to eq('invalid_status')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to include(:status)
+          expect(result.error.messages[:status]).to include('value_is_invalid')
+        end
       end
     end
 
@@ -124,8 +128,12 @@ RSpec.describe Invoices::UpdateService do
           params: update_args,
         )
 
-        expect(result).not_to be_success
-        expect(result.error).to eq('invalid_status')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to include(:status)
+          expect(result.error.messages[:status]).to include('value_is_invalid')
+        end
       end
     end
 


### PR DESCRIPTION
## Context

Error handling in services and the way it's rendered in API and GraphQL needs a complete refactoring.

## Description

The objective of this PR is to attach validation failures to a field when instead of rendering a single validation code.

It has been validated that this change does not require updating the frontend, as it only triggers a generic error.
