### PR TITLE
feat(customers): Apply currency to customers

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -81,6 +81,7 @@ module Api
         params.require(:wallet).permit(
           :rate_amount,
           :name,
+          :currency,
           :paid_credits,
           :granted_credits,
           :expiration_date,

--- a/app/graphql/mutations/wallets/create.rb
+++ b/app/graphql/mutations/wallets/create.rb
@@ -15,6 +15,7 @@ module Mutations
       argument :paid_credits, String, required: true
       argument :granted_credits, String, required: true
       argument :expiration_date, GraphQL::Types::ISO8601Date, required: false
+      argument :currency, Types::CurrencyEnum, required: true
 
       type Types::Wallets::Object
 
@@ -27,7 +28,7 @@ module Mutations
             **args
               .merge(organization_id: current_organization.id)
               .merge(customer: current_customer(args[:customer_id]))
-              .except(:customer_id)
+              .except(:customer_id),
           )
 
         result.success? ? result.wallet : result_error(result)

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -41,8 +41,8 @@ module Types
         description 'Check if customer is deletable'
       end
 
-      field :can_edit_currency, Boolean, null: false do
-        description 'Check if customer is deletable'
+      field :can_edit_attributes, Boolean, null: false do
+        description 'Check if customer attributes are editable'
       end
 
       def can_be_deleted
@@ -57,8 +57,8 @@ module Types
         object.active_subscriptions.count
       end
 
-      def can_edit_currency
-        object.editable_currency?
+      def can_edit_attributes
+        object.editable?
       end
     end
   end

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -41,6 +41,10 @@ module Types
         description 'Check if customer is deletable'
       end
 
+      field :can_edit_currency, Boolean, null: false do
+        description 'Check if customer is deletable'
+      end
+
       def can_be_deleted
         object.deletable?
       end
@@ -51,6 +55,10 @@ module Types
 
       def active_subscription_count
         object.active_subscriptions.count
+      end
+
+      def can_edit_currency
+        object.editable_currency?
       end
     end
   end

--- a/app/graphql/types/customers/single_object.rb
+++ b/app/graphql/types/customers/single_object.rb
@@ -22,10 +22,6 @@ module Types
       def applied_add_ons
         object.applied_add_ons.order(created_at: :desc)
       end
-
-      def currency
-        object.default_currency
-      end
     end
   end
 end

--- a/app/jobs/bill_add_on_job.rb
+++ b/app/jobs/bill_add_on_job.rb
@@ -5,13 +5,12 @@ class BillAddOnJob < ApplicationJob
 
   retry_on Sequenced::SequenceError
 
-  def perform(subscription, applied_add_on, date)
+  def perform(applied_add_on, date)
     result = Invoices::AddOnService.new(
-      subscription: subscription,
       applied_add_on: applied_add_on,
       date: date,
     ).create
 
-    raise result.throw_error unless result.success?
+    raise(result.throw_error) unless result.success?
   end
 end

--- a/app/jobs/migration_task_job.rb
+++ b/app/jobs/migration_task_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class TaskNotFoundError < StandardError
+end
+
+class MigrationTaskJob < ApplicationJob
+  queue_as 'default'
+
+  retry_on TaskNotFoundError, attempts: 5
+
+  def perform(task_name)
+    LagoApi::Application.load_tasks
+    raise(TaskNotFoundError) unless Rake::Task.task_defined?(task_name)
+
+    Rake::Task[task_name].invoke
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -39,7 +39,7 @@ class Customer < ApplicationRecord
   end
 
   def deletable?
-    !attached_to_subscriptions?
+    !attached_to_subscriptions? && applied_add_ons.none? && applied_coupons.none? && wallets.none?
   end
 
   def active_subscription
@@ -56,11 +56,8 @@ class Customer < ApplicationRecord
     organization.vat_rate || 0
   end
 
-  def editable_currency?
-    active_subscriptions.none? &&
-      applied_add_ons.none? &&
-      applied_coupons.none? &&
-      wallets.none?
+  def editable?
+    deletable?
   end
 
   private

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -56,10 +56,6 @@ class Customer < ApplicationRecord
     organization.vat_rate || 0
   end
 
-  def default_currency
-    currency || active_subscription&.plan&.amount_currency
-  end
-
   private
 
   def ensure_slug

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -56,6 +56,13 @@ class Customer < ApplicationRecord
     organization.vat_rate || 0
   end
 
+  def editable_currency?
+    active_subscriptions.none? &&
+      applied_add_ons.none? &&
+      applied_coupons.none? &&
+      wallets.none?
+  end
+
   private
 
   def ensure_slug

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Wallet < ApplicationRecord
-  before_create :set_customer_currency
-
   belongs_to :customer
 
   has_one :organization, through: :customer
@@ -21,11 +19,5 @@ class Wallet < ApplicationRecord
     terminated!
   end
 
-  scope :expired, -> { where('wallets.expiration_date < ?', Time.current.beginning_of_day,) }
-
-  private
-
-  def set_customer_currency
-    self.currency ||= customer.default_currency
-  end
+  scope :expired, -> { where('wallets.expiration_date < ?', Time.current.beginning_of_day) }
 end

--- a/app/services/applied_add_ons/create_service.rb
+++ b/app/services/applied_add_ons/create_service.rb
@@ -40,26 +40,33 @@ module AppliedAddOns
 
     attr_reader :customer, :add_on
 
-    def check_preconditions(amount_currency:)
+    def check_preconditions
       return result.not_found_failure!(resource: 'customer') unless customer
       return result.not_found_failure!(resource: 'add_on') unless add_on
-      return result.fail!(code: 'no_active_subscription') unless active_subscription?
-      return result.fail!(code: 'currencies_does_not_match') unless applicable_currency?(amount_currency)
     end
 
     def process_creation(amount_cents:, amount_currency:)
-      check_preconditions(amount_currency: amount_currency)
+      check_preconditions
       return result if result.error
 
-      applied_add_on = AppliedAddOn.create!(
+      applied_add_on = AppliedAddOn.new(
         customer: customer,
         add_on: add_on,
         amount_cents: amount_cents,
         amount_currency: amount_currency,
       )
 
+      ActiveRecord::Base.transaction do
+        currency_result = Customers::UpdateService.new(nil).update_currency(
+          customer: customer,
+          currency: amount_currency,
+        )
+        return currency_result unless currency_result.success?
+
+        applied_add_on.save!
+      end
+
       BillAddOnJob.perform_later(
-        active_subscription,
         applied_add_on,
         Time.zone.now.to_date,
       )
@@ -69,18 +76,6 @@ module AppliedAddOns
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    end
-
-    def active_subscription?
-      active_subscription.present?
-    end
-
-    def applicable_currency?(currency)
-      active_subscription.plan.amount_currency == currency
-    end
-
-    def active_subscription
-      @active_subscription ||= customer.active_subscription
     end
 
     def track_applied_add_on_created(applied_add_on)

--- a/app/services/applied_coupons/create_service.rb
+++ b/app/services/applied_coupons/create_service.rb
@@ -43,7 +43,12 @@ module AppliedCoupons
     def check_preconditions
       return result.not_found_failure!(resource: 'customer') unless customer
       return result.not_found_failure!(resource: 'coupon') unless coupon
-      return result.fail!(code: 'coupon_already_applied') if coupon_already_applied?
+      return unless coupon_already_applied?
+
+      result.single_validation_failure!(
+        field: 'coupon',
+        error_code: 'coupon_already_applied',
+      )
     end
 
     def process_creation(amount_cents:, amount_currency:)

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -26,6 +26,7 @@ module Customers
           currency_result = Customers::UpdateService.new(nil).update_currency(
             customer: customer,
             currency: params[:currency],
+            customer_update: true,
           )
           return currency_result unless currency_result.success?
         end

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -46,7 +46,7 @@ module Customers
     def update_currency(customer:, currency:)
       result.customer = customer
 
-      if !editable_currency? && customer.currency != currency
+      if !editable_currency? && customer.currency.present? && customer.currency != currency
         return result.single_validation_failure!(
           field: :currency,
           error_code: 'currencies_does_not_match',

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -46,7 +46,7 @@ module Customers
     def update_currency(customer:, currency:)
       result.customer = customer
 
-      if !editable_currency? && customer.currency.present? && customer.currency != currency
+      if !customer.editable_currency? && customer.currency.present? && customer.currency != currency
         return result.single_validation_failure!(
           field: :currency,
           error_code: 'currencies_does_not_match',
@@ -76,13 +76,6 @@ module Customers
 
       # NOTE: Create service is modifying an other instance of the provider customer
       customer.stripe_customer&.reload
-    end
-
-    def editable_currency?
-      !result.customer.active_subscription &&
-        result.customer.applied_add_ons.none? &&
-        result.customer.applied_coupons.none? &&
-        result.customer.wallets.none?
     end
   end
 end

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -29,7 +29,7 @@ module Customers
         customer.payment_provider = args[:payment_provider] if args.key?(:payment_provider)
 
         # NOTE: external_id is not editable if customer is attached to subscriptions
-        customer.external_id = args[:external_id] if !customer.attached_to_subscriptions? && args.key?(:external_id)
+        customer.external_id = args[:external_id] if customer.editable? && args.key?(:external_id)
 
         customer.save!
       end
@@ -48,13 +48,13 @@ module Customers
 
       if customer_update
         # NOTE: direct update of the customer currency
-        unless customer.editable_currency?
+        unless customer.editable?
           return result.single_validation_failure!(
             field: :currency,
             error_code: 'currencies_does_not_match',
           )
         end
-      elsif customer.currency.present? || !customer.editable_currency?
+      elsif customer.currency.present? || !customer.editable?
         # NOTE: Assign currency from another resource
         return result.single_validation_failure!(
           field: :currency,

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -46,8 +46,7 @@ module Customers
     def update_currency(customer:, currency:)
       result.customer = customer
 
-      # TODO: remove default currency check after migration to customer currency
-      if !editable_currency? && customer.default_currency != currency
+      if !editable_currency? && customer.currency != currency
         return result.single_validation_failure!(
           field: :currency,
           error_code: 'currencies_does_not_match',

--- a/app/services/fees/add_on_service.rb
+++ b/app/services/fees/add_on_service.rb
@@ -2,9 +2,8 @@
 
 module Fees
   class AddOnService < BaseService
-    def initialize(invoice:, applied_add_on:, subscription:)
+    def initialize(invoice:, applied_add_on:)
       @invoice = invoice
-      @subscription = subscription
       @applied_add_on = applied_add_on
       super(nil)
     end
@@ -14,10 +13,9 @@ module Fees
 
       new_fee = Fee.new(
         invoice: invoice,
-        subscription: subscription,
         applied_add_on: applied_add_on,
         amount_cents: applied_add_on.amount_cents,
-        amount_currency: plan.amount_currency,
+        amount_currency: applied_add_on.amount_currency,
         fee_type: :add_on,
         invoiceable_type: 'AppliedAddOn',
         invoiceable: applied_add_on,
@@ -36,10 +34,9 @@ module Fees
 
     private
 
-    attr_reader :invoice, :applied_add_on, :subscription
+    attr_reader :invoice, :applied_add_on
 
     delegate :customer, to: :invoice
-    delegate :plan, to: :subscription
 
     def already_billed?
       existing_fee = invoice.fees.find_by(applied_add_on_id: applied_add_on.id)

--- a/app/services/fees/paid_credit_service.rb
+++ b/app/services/fees/paid_credit_service.rb
@@ -22,7 +22,7 @@ module Fees
         invoiceable_type: 'WalletTransaction',
         invoiceable: wallet_transaction,
         amount_cents: amount_cents,
-        amount_currency: customer.default_currency,
+        amount_currency: wallet_transaction.wallet.currency,
         vat_rate: customer.applicable_vat_rate,
         units: 1,
       )

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -44,7 +44,7 @@ module Invoices
     attr_accessor :customer, :timestamp, :wallet_transaction
 
     def currency
-      @currency ||= customer.default_currency
+      @currency ||= wallet_transaction.wallet.currency
     end
 
     def compute_amounts(invoice)

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -53,9 +53,12 @@ module Subscriptions
       return result.not_found_failure!(resource: 'customer') unless current_customer
       return result.not_found_failure!(resource: 'plan') unless current_plan
 
-      if currency_missmatch?(current_customer&.active_subscription&.plan, current_plan)
-        return result.fail!(code: 'currencies_does_not_match', message: 'currencies does not match')
-      end
+      # TODO: db transaction ??
+      currency_result = Customers::UpdateService.new(nil).update_currency(
+        customer: current_customer,
+        currency: current_plan.amount_currency,
+      )
+      return currency_result unless currency_result.success?
 
       result.subscription = handle_subscription
       track_subscription_created(result.subscription)

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -53,14 +53,16 @@ module Subscriptions
       return result.not_found_failure!(resource: 'customer') unless current_customer
       return result.not_found_failure!(resource: 'plan') unless current_plan
 
-      # TODO: db transaction ??
-      currency_result = Customers::UpdateService.new(nil).update_currency(
-        customer: current_customer,
-        currency: current_plan.amount_currency,
-      )
-      return currency_result unless currency_result.success?
+      ActiveRecord::Base.transaction do
+        currency_result = Customers::UpdateService.new(nil).update_currency(
+          customer: current_customer,
+          currency: current_plan.amount_currency,
+        )
+        return currency_result unless currency_result.success?
 
-      result.subscription = handle_subscription
+        result.subscription = handle_subscription
+      end
+
       track_subscription_created(result.subscription)
       result
     rescue ActiveRecord::RecordInvalid => e
@@ -102,10 +104,14 @@ module Subscriptions
       new_subscription.mark_as_active!
 
       if current_plan.pay_in_advance?
-        BillSubscriptionJob.perform_later(
-          [new_subscription],
-          Time.zone.now.to_i,
-        )
+        # NOTE: Since job is laucnhed from inside a db transaction
+        #       we must wait for it to be commited before processing the job
+        BillSubscriptionJob
+          .set(wait: 2.seconds)
+          .perform_later(
+            [new_subscription],
+            Time.zone.now.to_i,
+          )
       end
 
       new_subscription
@@ -122,49 +128,53 @@ module Subscriptions
         billing_time: current_subscription.billing_time,
       )
 
-      ActiveRecord::Base.transaction do
-        cancel_pending_subscription if pending_subscription?
+      cancel_pending_subscription if pending_subscription?
 
-        # NOTE: When upgrading, the new subscription becomes active immediatly
-        #       The previous one must be terminated
-        current_subscription.mark_as_terminated!
-        new_subscription.mark_as_active!
-      end
+      # NOTE: When upgrading, the new subscription becomes active immediatly
+      #       The previous one must be terminated
+      current_subscription.mark_as_terminated!
+      new_subscription.mark_as_active!
 
       if current_subscription.plan.pay_in_arrear?
-        BillSubscriptionJob.perform_later(
-          [current_subscription],
-          Time.zone.now.to_i,
-        )
+        # NOTE: Since job is laucnhed from inside a db transaction
+        #       we must wait for it to be commited before processing the job
+        BillSubscriptionJob
+          .set(wait: 2.seconds)
+          .perform_later(
+            [current_subscription],
+            Time.zone.now.to_i,
+          )
       end
 
       if current_plan.pay_in_advance?
-        BillSubscriptionJob.perform_later(
-          [new_subscription],
-          Time.zone.now.to_i,
-        )
+        # NOTE: Since job is laucnhed from inside a db transaction
+        #       we must wait for it to be commited before processing the job
+        BillSubscriptionJob
+          .set(wait: 2.seconds)
+          .perform_later(
+            [new_subscription],
+            Time.zone.now.to_i,
+          )
       end
 
       new_subscription
     end
 
     def downgrade_subscription
-      ActiveRecord::Base.transaction do
-        cancel_pending_subscription if pending_subscription?
+      cancel_pending_subscription if pending_subscription?
 
-        # NOTE: When downgrading a subscription, we keep the current one active
-        #       until the next billing day. The new subscription will become active at this date
-        Subscription.create!(
-          customer: current_customer,
-          plan: current_plan,
-          name: name,
-          external_id: current_subscription.external_id,
-          previous_subscription_id: current_subscription.id,
-          subscription_date: current_subscription.subscription_date,
-          status: :pending,
-          billing_time: current_subscription.billing_time,
-        )
-      end
+      # NOTE: When downgrading a subscription, we keep the current one active
+      #       until the next billing day. The new subscription will become active at this date
+      Subscription.create!(
+        customer: current_customer,
+        plan: current_plan,
+        name: name,
+        external_id: current_subscription.external_id,
+        previous_subscription_id: current_subscription.id,
+        subscription_date: current_subscription.subscription_date,
+        status: :pending,
+        billing_time: current_subscription.billing_time,
+      )
 
       current_subscription
     end

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -29,10 +29,6 @@ module Wallets
         )
       end
 
-      unless result.current_customer.subscriptions.active.exists?
-        return add_error(field: :customer, error_code: 'no_active_subscription')
-      end
-
       true
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,3 +28,4 @@ en:
         invalid_content_type: invalid_content_type
         invalid_size: invalid_size
         value_already_exists: value_already_exists
+        too_long: value_is_too_long

--- a/db/migrate/20220919133338_run_customer_currency_task.rb
+++ b/db/migrate/20220919133338_run_customer_currency_task.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RunCustomerCurrencyTask < ActiveRecord::Migration[7.0]
+  def change
+    # NOTE: Wait to ensure workers are loaded with the added tasks
+    MigrationTaskJob.set(wait: 20.seconds).perform_later('customers:populate_currency')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_16_131538) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_19_133338) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,7 +34,7 @@ Charge.create_with(
   amount_currency: 'EUR',
   properties: {
     amount: Faker::Number.between(from: 100, to: 500).to_s,
-  }
+  },
 ).find_or_create_by!(
   plan: plan,
   billable_metric: billable_metric,
@@ -56,6 +56,7 @@ Charge.create_with(
     logo_url: Faker::Internet.url,
     legal_name: Faker::Company.name,
     legal_number: Faker::Company.duns_number,
+    currency: 'EUR',
   ).find_or_create_by!(
     organization: organization,
     external_id: "cust_#{i + 1}",

--- a/lib/tasks/customers.rake
+++ b/lib/tasks/customers.rake
@@ -5,4 +5,14 @@ namespace :customers do
   task generate_slug: :environment do
     Customer.order(:created_at).find_each(&:save)
   end
+
+  desc 'Set customer currency from active subscription'
+  task populate_currency: :environment do
+    Customer.where(currency: nil).find_each do |customer|
+      subscription = customer.active_subscription
+      next unless subscription
+
+      customer.update!(currency: subscription.plan.amount_currency)
+    end
+  end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2405,6 +2405,11 @@ type Customer {
   Check if customer is deletable
   """
   canBeDeleted: Boolean!
+
+  """
+  Check if customer is deletable
+  """
+  canEditCurrency: Boolean!
   city: String
   country: CountryCode
   createdAt: ISO8601DateTime!
@@ -2453,6 +2458,11 @@ type CustomerDetails {
   Check if customer is deletable
   """
   canBeDeleted: Boolean!
+
+  """
+  Check if customer is deletable
+  """
+  canEditCurrency: Boolean!
   city: String
   country: CountryCode
   createdAt: ISO8601DateTime!

--- a/schema.graphql
+++ b/schema.graphql
@@ -2407,9 +2407,9 @@ type Customer {
   canBeDeleted: Boolean!
 
   """
-  Check if customer is deletable
+  Check if customer attributes are editable
   """
-  canEditCurrency: Boolean!
+  canEditAttributes: Boolean!
   city: String
   country: CountryCode
   createdAt: ISO8601DateTime!
@@ -2460,9 +2460,9 @@ type CustomerDetails {
   canBeDeleted: Boolean!
 
   """
-  Check if customer is deletable
+  Check if customer attributes are editable
   """
-  canEditCurrency: Boolean!
+  canEditAttributes: Boolean!
   city: String
   country: CountryCode
   createdAt: ISO8601DateTime!

--- a/schema.graphql
+++ b/schema.graphql
@@ -1635,6 +1635,7 @@ input CreateCustomerWalletInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  currency: CurrencyEnum!
   customerId: ID!
   expirationDate: ISO8601Date
   grantedCredits: String!

--- a/schema.json
+++ b/schema.json
@@ -6273,8 +6273,8 @@
               ]
             },
             {
-              "name": "canEditCurrency",
-              "description": "Check if customer is deletable",
+              "name": "canEditAttributes",
+              "description": "Check if customer attributes are editable",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6827,8 +6827,8 @@
               ]
             },
             {
-              "name": "canEditCurrency",
-              "description": "Check if customer is deletable",
+              "name": "canEditAttributes",
+              "description": "Check if customer attributes are editable",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,

--- a/schema.json
+++ b/schema.json
@@ -6273,6 +6273,24 @@
               ]
             },
             {
+              "name": "canEditCurrency",
+              "description": "Check if customer is deletable",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "city",
               "description": null,
               "type": {
@@ -6792,6 +6810,24 @@
             },
             {
               "name": "canBeDeleted",
+              "description": "Check if customer is deletable",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "canEditCurrency",
               "description": "Check if customer is deletable",
               "type": {
                 "kind": "NON_NULL",

--- a/schema.json
+++ b/schema.json
@@ -4907,6 +4907,22 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "currency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "enumValues": null

--- a/spec/factories/customer_factory.rb
+++ b/spec/factories/customer_factory.rb
@@ -17,5 +17,6 @@ FactoryBot.define do
     logo_url { Faker::Internet.url }
     legal_name { Faker::Company.name }
     legal_number { Faker::Company.duns_number }
+    currency { 'EUR' }
   end
 end

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           paymentProvider
           stripeCustomer { id, providerCustomerId }
           currency
+          canEditCurrency
         }
       }
     GQL

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           paymentProvider
           stripeCustomer { id, providerCustomerId }
           currency
-          canEditCurrency
+          canEditAttributes
         }
       }
     GQL

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           externalId
           paymentProvider
           currency
-          canEditCurrency
+          canEditAttributes
           stripeCustomer { id, providerCustomerId }
         }
       }

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           externalId
           paymentProvider
           currency
+          canEditCurrency
           stripeCustomer { id, providerCustomerId }
         }
       }

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Mutations::Wallets::Create, type: :graphql do
   let(:membership) { create(:membership) }
-  let(:customer) { create(:customer, organization: membership.organization) }
+  let(:customer) { create(:customer, organization: membership.organization, currency: 'EUR') }
 
   let(:mutation) do
     <<-GQL

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -5,7 +5,6 @@ require 'rails_helper'
 RSpec.describe Mutations::Wallets::Create, type: :graphql do
   let(:membership) { create(:membership) }
   let(:customer) { create(:customer, organization: membership.organization) }
-  let(:subscription) { create(:subscription, customer: customer) }
 
   let(:mutation) do
     <<-GQL
@@ -14,14 +13,11 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
           id,
           name,
           rateAmount,
-          status
+          status,
+          currency
         }
       }
     GQL
-  end
-
-  before do
-    subscription
   end
 
   it 'create a wallet' do
@@ -37,6 +33,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
           paidCredits: '0.00',
           grantedCredits: '0.00',
           expirationDate: (Time.zone.now + 1.year).to_date,
+          currency: 'EUR',
         },
       },
     )
@@ -62,6 +59,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
             paidCredits: '0.00',
             grantedCredits: '0.00',
             expirationDate: (Time.zone.now + 1.year).to_date,
+            currency: 'EUR',
           },
         },
       )
@@ -83,6 +81,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
             paidCredits: '0.00',
             grantedCredits: '0.00',
             expirationDate: (Time.zone.now + 1.year).to_date,
+            currency: 'EUR',
           },
         },
       )

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) do
-    create(:customer, organization: organization)
+    create(:customer, organization: organization, currency: 'EUR')
   end
   let(:subscription) { create(:subscription, customer: customer) }
   let(:applied_add_on) { create(:applied_add_on, customer: customer) }

--- a/spec/jobs/bill_add_on_job_spec.rb
+++ b/spec/jobs/bill_add_on_job_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe BillAddOnJob, type: :job do
-  let(:subscription) { create(:subscription) }
   let(:applied_add_on) { create(:applied_add_on) }
   let(:date) { Time.zone.now.to_date }
 
@@ -12,14 +11,14 @@ RSpec.describe BillAddOnJob, type: :job do
 
   before do
     allow(Invoices::AddOnService).to receive(:new)
-      .with(subscription: subscription, applied_add_on: applied_add_on, date: date)
+      .with(applied_add_on: applied_add_on, date: date)
       .and_return(invoice_service)
     allow(invoice_service).to receive(:create)
       .and_return(result)
   end
 
   it 'calls the add on create service' do
-    described_class.perform_now(subscription, applied_add_on, date)
+    described_class.perform_now(applied_add_on, date)
 
     expect(Invoices::AddOnService).to have_received(:new)
     expect(invoice_service).to have_received(:create)
@@ -32,7 +31,7 @@ RSpec.describe BillAddOnJob, type: :job do
 
     it 'raises an error' do
       expect do
-        described_class.perform_now(subscription, applied_add_on, date)
+        described_class.perform_now(applied_add_on, date)
       end.to raise_error(BaseService::FailedResult)
 
       expect(Invoices::AddOnService).to have_received(:new)

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -82,4 +82,34 @@ RSpec.describe Customer, type: :model do
       end
     end
   end
+
+  describe 'deletable?' do
+    let(:customer) { create(:customer) }
+
+    it { expect(customer).to be_deletable }
+
+    context 'when attached to a subscription' do
+      before { create(:subscription, customer: customer) }
+
+      it { expect(customer).not_to be_deletable }
+    end
+
+    context 'when attached to an add-on' do
+      before { create(:applied_add_on, customer: customer) }
+
+      it { expect(customer).not_to be_deletable }
+    end
+
+    context 'when attached to a coupon' do
+      before { create(:applied_coupon, customer: customer) }
+
+      it { expect(customer).not_to be_deletable }
+    end
+
+    context 'when attached to a wallet' do
+      before { create(:wallet, customer: customer) }
+
+      it { expect(customer).not_to be_deletable }
+    end
+  end
 end

--- a/spec/requests/api/v1/wallets_spec.rb
+++ b/spec/requests/api/v1/wallets_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
         external_customer_id: customer.external_id,
         rate_amount: '1',
         name: 'Wallet1',
+        currency: 'EUR',
         paid_credits: '10',
         granted_credits: '10',
         expiration_date: '2022-06-06',

--- a/spec/requests/api/v1/wallets_spec.rb
+++ b/spec/requests/api/v1/wallets_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::WalletsController, type: :request do
   let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization: organization) }
+  let(:customer) { create(:customer, organization: organization, currency: 'EUR') }
   let(:subscription) { create(:subscription, customer: customer) }
 
   before { subscription }

--- a/spec/services/applied_add_ons/create_service_spec.rb
+++ b/spec/services/applied_add_ons/create_service_spec.rb
@@ -134,6 +134,8 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
       let(:create_subscription) { false }
       let(:amount_currency) { 'NOK' }
 
+      before { customer.update!(currency: nil) }
+
       it 'assigns the add on currency to the customer' do
         create_result
 

--- a/spec/services/applied_add_ons/create_service_spec.rb
+++ b/spec/services/applied_add_ons/create_service_spec.rb
@@ -77,6 +77,8 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
       context 'when currency does not match' do
         let(:amount_currency) { 'NOK' }
 
+        before { customer.update!(currency: 'EUR') }
+
         it 'fails' do
           aggregate_failures do
             expect(create_result).not_to be_success
@@ -115,6 +117,8 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
 
     context 'when currency of an add-on does not match customer currency' do
       let(:add_on) { create(:add_on, organization: organization, amount_currency: 'NOK') }
+
+      before { customer.update!(currency: 'EUR') }
 
       it 'fails' do
         aggregate_failures do
@@ -199,6 +203,8 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
       context 'when currency does not match' do
         let(:amount_currency) { 'NOK' }
 
+        before { customer.update!(currency: 'EUR') }
+
         it 'fails' do
           aggregate_failures do
             expect(create_result).not_to be_success
@@ -237,6 +243,8 @@ RSpec.describe AppliedAddOns::CreateService, type: :service do
 
     context 'when currency of add-on does not match customer currency' do
       let(:add_on) { create(:add_on, organization: organization, amount_currency: 'NOK') }
+
+      before { customer.update!(currency: 'EUR') }
 
       it 'fails' do
         aggregate_failures do

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -308,6 +308,8 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       let(:create_subscription) { false }
       let(:amount_currency) { 'NOK' }
 
+      before { customer.update!(currency: nil) }
+
       it 'assigns the coupon currency to the customer' do
         create_result
 

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -74,6 +74,8 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       context 'when currency does not match' do
         let(:amount_currency) { 'NOK' }
 
+        before { customer.update!(currency: 'EUR') }
+
         it 'fails' do
           aggregate_failures do
             expect(create_result).not_to be_success
@@ -153,6 +155,8 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
     context 'when currency of coupon does not match customer currency' do
       let(:coupon) { create(:coupon, status: 'active', organization: organization, amount_currency: 'NOK') }
 
+      before { customer.update!(currency: 'EUR') }
+
       it 'fails' do
         aggregate_failures do
           expect(create_result).not_to be_success
@@ -222,6 +226,8 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       context 'when currency does not match' do
         let(:amount_currency) { 'NOK' }
 
+        before { customer.update!(currency: 'EUR') }
+
         it 'fails' do
           aggregate_failures do
             expect(create_result).not_to be_success
@@ -285,6 +291,8 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
 
     context 'when currency of coupon does not match customer currency' do
       let(:coupon) { create(:coupon, status: 'active', organization: organization, amount_currency: 'NOK') }
+
+      before { customer.update!(currency: 'EUR') }
 
       it 'fails' do
         aggregate_failures do

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -103,7 +103,10 @@ RSpec.describe Customers::CreateService, type: :service do
           }
         end
 
-        before { create(:subscription, customer: customer) }
+        before do
+          subscription = create(:subscription, customer: customer)
+          customer.update!(currency: subscription.plan.amount_currency)
+        end
 
         it 'fails is we change the subscription' do
           result = customers_service.create_from_api(

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe Customers::UpdateService, type: :service do
 
     context 'when attached to a subscription' do
       before do
-        create(:subscription, customer: customer)
+        subscription = create(:subscription, customer: customer)
+        customer.update!(currency: subscription.plan.amount_currency)
       end
 
       it 'updates only the name' do

--- a/spec/services/fees/add_on_service_spec.rb
+++ b/spec/services/fees/add_on_service_spec.rb
@@ -4,10 +4,9 @@ require 'rails_helper'
 
 RSpec.describe Fees::AddOnService do
   subject(:add_on_service) do
-    described_class.new(invoice: invoice, applied_add_on: applied_add_on, subscription: subscription)
+    described_class.new(invoice: invoice, applied_add_on: applied_add_on)
   end
 
-  let(:subscription) { create(:subscription) }
   let(:invoice) { create(:invoice) }
   let(:applied_add_on) { create(:applied_add_on) }
 
@@ -37,7 +36,6 @@ RSpec.describe Fees::AddOnService do
         create(
           :fee,
           applied_add_on: applied_add_on,
-          subscription: subscription,
           invoice: invoice,
         )
       end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -275,6 +275,8 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           }
         end
 
+        before { customer.update!(currency: plan.amount_currency) }
+
         it 'fails' do
           result = create_service.create_from_api(
             organization: organization,

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -281,8 +281,12 @@ RSpec.describe Subscriptions::CreateService, type: :service do
             params: params,
           )
 
-          expect(result).not_to be_success
-          expect(result.error).to eq('currencies does not match')
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages.keys).to include(:currency)
+            expect(result.error.messages[:currency]).to include('currencies_does_not_match')
+          end
         end
       end
 

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -45,15 +45,6 @@ RSpec.describe Wallets::ValidateService, type: :service do
       end
     end
 
-    context 'when customer has no active subscription' do
-      before { subscription.mark_as_terminated! }
-
-      it 'returns false and result has errors' do
-        expect(validate_service).not_to be_valid
-        expect(result.error.messages[:customer]).to eq(['no_active_subscription'])
-      end
-    end
-
     context 'when customer already has a wallet' do
       before { create(:wallet, customer: customer) }
 


### PR DESCRIPTION
## Context

Currently, we cannot apply a coupon, an add-on or even prepaid-credits if a customer has no active subscription. This problem happen because customer object does not hold the currency directly, but via the currency of the plan of it’s first active subscription.

It’s a problem when a plan is invoiced in-advance because it can then take up to 1 year to apply the mentioned objects on the first generated invoice.

## Description

This PR is the final branch for this feature, it's the merge in a single branch of pre-reviewed feature branch, in order to QA and merge the feature in a single branch.

Previous closed PR:
- https://github.com/getlago/lago-api/pull/466
- https://github.com/getlago/lago-api/pull/467
- https://github.com/getlago/lago-api/pull/469
- https://github.com/getlago/lago-api/pull/472
- https://github.com/getlago/lago-api/pull/473

## Related Task

- API documentation: https://github.com/getlago/lago-docs/pull/49
- Go client: https://github.com/getlago/lago-go-client/pull/15
- NodeJS client: https://github.com/getlago/lago-nodejs-client/pull/24
- Python client: https://github.com/getlago/lago-python-client/pull/32
- Ruby client: https://github.com/getlago/lago-ruby-client/pull/40