### PR TITLE
fix(invite): remove check on user.id when accepting an invite

### DIFF
--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -39,8 +39,6 @@ class UsersService < BaseService
   def register_from_invite(email, password, organization_id)
     result.user = User.find_or_initialize_by(email: email)
 
-    return result.fail!(code: 'user_already_exists') if result.user.id
-
     ActiveRecord::Base.transaction do
       result.organization = Organization.find(organization_id)
 


### PR DESCRIPTION
## Context

When building the invite flow, we duplicated the `register` method.

This method does include a check on the user id, that stops the process if a user with the same email were already existing. 

## Description

We decided to remove this check in the accept invite flow, in order to allow users to be invited multiple time.

Indeed, as the user is never deleted, this check will make the call fail if a revoked user is invited once again.

We agreed that the situation when the user creates an organization (using the existing `register` method), then is invited to an organization will not work, as in the frontend we'll need to make a organization switcher in order to make them choose between multiple orga. By default we display the first organization fetched