### PR TITLE
fix(errors): Add invite_not_found in error_enum

### DIFF
--- a/app/graphql/types/error_enum.rb
+++ b/app/graphql/types/error_enum.rb
@@ -21,5 +21,8 @@ module Types
     value 'no_active_subscription', 'Customer does not have an active subscription.'
     value 'currencies_does_not_match', 'Currency from customer subscription differs from the provided one.'
     value 'coupon_already_applied', 'Coupon is already applied to the customer'
+
+    # Invite related erorrs
+    value 'invite_not_found', 'Invite does not exists'
   end
 end


### PR DESCRIPTION
## Context

We recently added invite resource to the API. Hence having an error code `invite_not_found` when the invite is not found in `invite_resolver`
The API usually export all its error code to the GraphQL client so they can have them in an enum

## Description

We add the `invite_not_found` code in the error code enum as it has been forgot during implementation