### PR TITLE
fix(subscription): Fix Upgrade Old Subscription Boundaries

### DIFF
--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -141,7 +141,7 @@ module Fees
 
       # NOTE: to_date for previous plan might be different from to_date
       #       if plan interval is not the same
-      old_to_date = compute_old_to_date(previous_subscription)
+      old_to_date = compute_old_to_date(previous_subscription, to_date)
 
       if plan.has_trial?
         from_date = to_date + 1.day if subscription.trial_end_date >= to_date
@@ -218,26 +218,24 @@ module Fees
       )
     end
 
-    def compute_to_date(target_subscription, base_date)
+    def compute_old_to_date(old_subscription, base_date)
       return base_date if plan.pay_in_arrear?
+
+      old_base_date = if old_subscription.anniversary?
+        date_service(old_subscription).to_date
+      else
+        base_date
+      end
 
       # NOTE: when plan is pay in advance, the_to date should be the
       #       end of the actual period
-      date_service(target_subscription).next_end_of_period(base_date)
+      date_service(old_subscription).next_end_of_period(old_base_date)
     end
 
     def compute_from_date(target_subscription)
       date_service(target_subscription).previous_beginning_of_period(
         current_period: target_subscription.plan.pay_in_advance? && subscription.plan.pay_in_advance?,
       )
-    end
-
-    def compute_old_to_date(old_subscription)
-      old_date_service = date_service(old_subscription)
-
-      return old_date_service.to_date if plan.pay_in_arrear?
-
-      date_service(old_subscription).next_end_of_period(old_date_service.to_date)
     end
   end
 end

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -141,7 +141,7 @@ module Fees
 
       # NOTE: to_date for previous plan might be different from to_date
       #       if plan interval is not the same
-      old_to_date = compute_to_date(previous_subscription, boundaries.to_date)
+      old_to_date = compute_old_to_date(previous_subscription)
 
       if plan.has_trial?
         from_date = to_date + 1.day if subscription.trial_end_date >= to_date
@@ -230,6 +230,14 @@ module Fees
       date_service(target_subscription).previous_beginning_of_period(
         current_period: target_subscription.plan.pay_in_advance? && subscription.plan.pay_in_advance?,
       )
+    end
+
+    def compute_old_to_date(old_subscription)
+      old_date_service = date_service(old_subscription)
+
+      return old_date_service.to_date if plan.pay_in_arrear?
+
+      date_service(old_subscription).next_end_of_period(old_date_service.to_date)
     end
   end
 end

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -141,7 +141,7 @@ module Fees
 
       # NOTE: to_date for previous plan might be different from to_date
       #       if plan interval is not the same
-      old_to_date = compute_old_to_date(previous_subscription, to_date)
+      old_to_date = compute_old_to_date(previous_subscription, boundaries.timestamp)
 
       if plan.has_trial?
         from_date = to_date + 1.day if subscription.trial_end_date >= to_date
@@ -221,11 +221,9 @@ module Fees
     def compute_old_to_date(old_subscription, base_date)
       return base_date if plan.pay_in_arrear?
 
-      old_base_date = date_service(old_subscription).to_date
-
       # NOTE: when plan is pay in advance, the_to date should be the
       #       end of the actual period
-      date_service(old_subscription).next_end_of_period(old_base_date)
+      date_service(old_subscription).next_end_of_period(base_date)
     end
 
     def compute_from_date(target_subscription)

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -141,7 +141,7 @@ module Fees
 
       # NOTE: to_date for previous plan might be different from to_date
       #       if plan interval is not the same
-      old_to_date = compute_old_to_date(previous_subscription, boundaries.timestamp)
+      old_to_date = compute_old_to_date(previous_subscription, Time.zone.at(boundaries.timestamp).to_date)
 
       if plan.has_trial?
         from_date = to_date + 1.day if subscription.trial_end_date >= to_date

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -221,11 +221,7 @@ module Fees
     def compute_old_to_date(old_subscription, base_date)
       return base_date if plan.pay_in_arrear?
 
-      old_base_date = if old_subscription.anniversary?
-        date_service(old_subscription).to_date
-      else
-        base_date
-      end
+      old_base_date = date_service(old_subscription).to_date
 
       # NOTE: when plan is pay in advance, the_to date should be the
       #       end of the actual period

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -141,7 +141,7 @@ module Fees
 
       # NOTE: to_date for previous plan might be different from to_date
       #       if plan interval is not the same
-      old_to_date = compute_old_to_date(previous_subscription, Time.zone.at(boundaries.timestamp).to_date)
+      old_to_date = compute_old_to_date(previous_subscription, boundaries.to_date)
 
       if plan.has_trial?
         from_date = to_date + 1.day if subscription.trial_end_date >= to_date
@@ -223,7 +223,7 @@ module Fees
 
       # NOTE: when plan is pay in advance, the_to date should be the
       #       end of the actual period
-      date_service(old_subscription).next_end_of_period(base_date)
+      date_service(old_subscription).next_end_of_period(old_subscription.terminated_at.to_date)
     end
 
     def compute_from_date(target_subscription)

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -900,6 +900,7 @@ RSpec.describe Fees::SubscriptionService do
           create(
             :subscription,
             status: :terminated,
+            terminated_at: DateTime.parse('2022-05-09'),
             plan: previous_plan,
             subscription_date: DateTime.parse('2021-03-25'),
             billing_time: :anniversary,
@@ -954,7 +955,10 @@ RSpec.describe Fees::SubscriptionService do
       end
 
       context 'when new plan is pay in advance' do
-        before { plan.update(pay_in_advance: true) }
+        before do
+          plan.update(pay_in_advance: true)
+          subscription.previous_subscription.update(terminated_at: subscription.started_at)
+        end
 
         let(:boundaries) do
           {
@@ -973,7 +977,10 @@ RSpec.describe Fees::SubscriptionService do
       end
 
       context 'when new plan is yearly and pay in advance' do
-        before { plan.update(interval: :yearly, pay_in_advance: true, amount_cents: 100_000) }
+        before do
+          plan.update(interval: :yearly, pay_in_advance: true, amount_cents: 100_000)
+          subscription.previous_subscription.update(terminated_at: subscription.started_at)
+        end
 
         let(:boundaries) do
           {
@@ -987,7 +994,7 @@ RSpec.describe Fees::SubscriptionService do
           result = fees_subscription_service.create
           created_fee = result.fee
 
-          expect(created_fee.amount_cents).to eq(79_246)
+          expect(created_fee.amount_cents).to eq(79_956)
         end
       end
 
@@ -995,6 +1002,7 @@ RSpec.describe Fees::SubscriptionService do
         before do
           plan.update(interval: :weekly, pay_in_advance: true, amount_cents: 100_000)
           previous_plan.update(interval: :weekly)
+          subscription.previous_subscription.update(terminated_at: subscription.started_at)
         end
 
         let(:boundaries) do
@@ -1017,6 +1025,7 @@ RSpec.describe Fees::SubscriptionService do
         before do
           plan.update(interval: :monthly, pay_in_advance: true, amount_cents: 1_000)
           previous_plan.update(interval: :yearly, amount_cents: 10_000)
+          subscription.previous_subscription.update(terminated_at: subscription.started_at)
         end
 
         it 'creates a subscription fee with amount zero' do
@@ -1070,7 +1079,10 @@ RSpec.describe Fees::SubscriptionService do
       end
 
       context 'when new plan is pay in advance' do
-        before { plan.update(pay_in_advance: true) }
+        before do
+          plan.update(pay_in_advance: true)
+          subscription.previous_subscription.update(terminated_at: subscription.started_at)
+        end
 
         let(:boundaries) do
           {

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -1104,6 +1104,7 @@ RSpec.describe Fees::SubscriptionService do
         create(
           :subscription,
           status: :terminated,
+          terminated_at: DateTime.parse('2022-05-08'),
           plan: previous_plan,
           subscription_date: DateTime.parse('2021-03-25'),
           billing_time: :anniversary,


### PR DESCRIPTION
## Context

During a subscription upgrade, the amount calculated for an in advance and a different interval is wrong.
The boudaries passed to calculate the previous subscription are wrong.

## Description

- Use the previous subscription boundaries instead of the new one
- Fix some specs