### PR TITLE
feat(errors): Handle inner service failures

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -9,7 +9,9 @@ class WebhooksController < ApplicationController
     )
 
     unless result.success?
-      return head(:bad_request) if result.error_code == 'webhook_error'
+      if result.error.is_a?(BaseService::ServiceFailure) && result.error.code == 'webhook_error'
+        return head(:bad_request)
+      end
 
       result.throw_error
     end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -56,6 +56,17 @@ class BaseService
     end
   end
 
+  class ServiceFailure < FailedResult
+    attr_reader :code, :error_message
+
+    def initialize(code:, error_message:)
+      @code = code
+      @error_message = error_message
+
+      super("#{code}: #{error_message}")
+    end
+  end
+
   class Result < OpenStruct
     attr_reader :error, :error_code, :error_details
 
@@ -108,6 +119,10 @@ class BaseService
 
     def single_validation_failure!(error_code:, field: :base)
       validation_failure!(errors: { field.to_sym => [error_code] })
+    end
+
+    def service_failure!(code:, message:)
+      fail_with_error!(ServiceFailure.new(code: code, error_message: message))
     end
 
     def throw_error

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -11,7 +11,7 @@ module BillableMetrics
         result.count = events.count
         result
       rescue ActiveRecord::StatementInvalid => e
-        result.fail!(code: 'aggregation_failure', message: e.message)
+        result.service_failure!(code: 'aggregation_failure', message: e.message)
       end
 
       private

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -12,7 +12,7 @@ module BillableMetrics
         result.options = { running_total: running_total(events, options) }
         result
       rescue ActiveRecord::StatementInvalid => e
-        result.fail!(code: 'aggregation_failure', message: e.message)
+        result.service_failure!(code: 'aggregation_failure', message: e.message)
       end
 
       private

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -36,7 +36,7 @@ module Fees
 
     def init_fee
       amount_result = compute_amount
-      return result.fail!(code: amount_result.error_code, message: amount_result.error) unless amount_result.success?
+      return result.fail_with_error!(amount_result.error) unless amount_result.success?
 
       # NOTE: amount_result should be a BigDecimal, we need to round it
       # to the currency decimals and transform it into currency cents

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe WebhooksController, type: :request do
       expect(response).to have_http_status(:success)
 
       expect(PaymentProviders::StripeService).to have_received(:new)
-      expect(stripe_service). to have_received(:handle_incoming_webhook)
+      expect(stripe_service).to have_received(:handle_incoming_webhook)
     end
 
     context 'when failing to handle stripe event' do
       let(:result) do
-        BaseService::Result.new.fail!(code: 'webhook_error', message: 'Invalid payload')
+        BaseService::Result.new.service_failure!(code: 'webhook_error', message: 'Invalid payload')
       end
 
       it 'returns a bad request' do

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -117,8 +117,12 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     it 'returns a failed result' do
       result = max_service.aggregate(from_date: from_date, to_date: to_date)
 
-      expect(result).not_to be_success
-      expect(result.error_code).to eq('aggregation_failure')
+      aggregate_failures do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq('aggregation_failure')
+        expect(result.error.error_message).to be_present
+      end
     end
   end
 

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
 
     expect(result.aggregation).to eq(48)
     expect(result.count).to eq(4)
-    expect(result.options).to eq({ running_total: [12, 24]})
+    expect(result.options).to eq({ running_total: [12, 24] })
   end
 
   context 'when options are not present' do
@@ -53,7 +53,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
 
     it 'returns an empty running total array' do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
-      expect(result.options).to eq({ running_total: []})
+      expect(result.options).to eq({ running_total: [] })
     end
   end
 
@@ -64,7 +64,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
 
     it 'returns an empty running total array' do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
-      expect(result.options).to eq({ running_total: []})
+      expect(result.options).to eq({ running_total: [] })
     end
   end
 
@@ -75,7 +75,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
 
     it 'returns running total based on per total aggregation' do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
-      expect(result.options).to eq({ running_total: [12, 24, 36]})
+      expect(result.options).to eq({ running_total: [12, 24, 36] })
     end
   end
 
@@ -86,7 +86,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
 
     it 'returns running total based on per events' do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
-      expect(result.options).to eq({ running_total: [12, 24]})
+      expect(result.options).to eq({ running_total: [12, 24] })
     end
   end
 
@@ -154,8 +154,12 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     it 'returns a failed result' do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date)
 
-      expect(result).not_to be_success
-      expect(result.error_code).to eq('aggregation_failure')
+      aggregate_failures do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq('aggregation_failure')
+        expect(result.error.error_message).to be_present
+      end
     end
   end
 end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -217,7 +217,9 @@ RSpec.describe Fees::ChargeService do
         )
       end
       let(:aggregator_service) { instance_double(BillableMetrics::Aggregations::MaxService) }
-      let(:error_result) { BaseService::Result.new.fail!(code: 'aggregation_failure') }
+      let(:error_result) do
+        BaseService::Result.new.service_failure!(code: 'aggregation_failure', message: 'Test message')
+      end
 
       it 'returns an error' do
         allow(BillableMetrics::Aggregations::MaxService).to receive(:new)
@@ -228,7 +230,9 @@ RSpec.describe Fees::ChargeService do
         result = charge_subscription_service.create
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('aggregation_failure')
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq('aggregation_failure')
+        expect(result.error.error_message).to eq('Test message')
 
         expect(BillableMetrics::Aggregations::MaxService).to have_received(:new)
         expect(aggregator_service).to have_received(:aggregate)
@@ -326,7 +330,9 @@ RSpec.describe Fees::ChargeService do
         )
       end
       let(:aggregator_service) { instance_double(BillableMetrics::Aggregations::MaxService) }
-      let(:error_result) { BaseService::Result.new.fail!(code: 'aggregation_failure') }
+      let(:error_result) do
+        BaseService::Result.new.service_failure!(code: 'aggregation_failure', message: 'Test message')
+      end
 
       it 'returns an error' do
         allow(BillableMetrics::Aggregations::MaxService).to receive(:new)
@@ -337,7 +343,9 @@ RSpec.describe Fees::ChargeService do
         result = charge_subscription_service.current_usage
 
         expect(result).not_to be_success
-        expect(result.error_code).to eq('aggregation_failure')
+        expect(result.error).to be_a(BaseService::ServiceFailure)
+        expect(result.error.code).to eq('aggregation_failure')
+        expect(result.error.error_message).to eq('Test message')
 
         expect(BillableMetrics::Aggregations::MaxService).to have_received(:new)
         expect(aggregator_service).to have_received(:aggregate)

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -181,9 +181,12 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
           signature: 'signature',
         )
 
-        expect(result).not_to be_success
-        expect(result.error_code).to eq('webhook_error')
-        expect(result.error).to eq('Invalid payload')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq('webhook_error')
+          expect(result.error.error_message).to eq('Invalid payload')
+        end
       end
     end
 
@@ -200,9 +203,12 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
           signature: 'signature',
         )
 
-        expect(result).not_to be_success
-        expect(result.error_code).to eq('webhook_error')
-        expect(result.error).to eq('Invalid signature')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq('webhook_error')
+          expect(result.error.error_message).to eq('Invalid signature')
+        end
       end
     end
   end
@@ -307,8 +313,12 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
           event_json: event.to_json,
         )
 
-        expect(result).not_to be_success
-        expect(result.error_code).to eq('invalid_stripe_event_type')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq('webhook_error')
+          expect(result.error.error_message).to eq('Invalid stripe event type: invalid')
+        end
 
         expect(Invoices::Payments::StripeService).not_to have_received(:new)
         expect(payment_service).not_to have_received(:update_status)


### PR DESCRIPTION
## Context

Error handling in services and the way it's rendered in API and GraphQL needs a complete refactoring.

## Description

The objective of this PR is to handle a new type of error `ServiceFailure`. This type apply when error are not supposed to bubble up to end users, but instead needs to be handled internally
