### PR TITLE
feat(coupons): add expiration_date coupon changes

### DIFF
--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -87,7 +87,7 @@ module Api
           :frequency,
           :frequency_duration,
           :expiration,
-          :expiration_duration,
+          :expiration_date,
         )
       end
 

--- a/app/graphql/mutations/coupons/create.rb
+++ b/app/graphql/mutations/coupons/create.rb
@@ -19,7 +19,7 @@ module Mutations
       argument :frequency_duration, Integer, required: false
 
       argument :expiration, Types::Coupons::ExpirationEnum, required: true
-      argument :expiration_duration, Integer, required: false
+      argument :expiration_date, GraphQL::Types::ISO8601Date, required: false
 
       type Types::Coupons::Object
 

--- a/app/graphql/mutations/coupons/update.rb
+++ b/app/graphql/mutations/coupons/update.rb
@@ -19,7 +19,7 @@ module Mutations
       argument :frequency_duration, Integer, required: false
 
       argument :expiration, Types::Coupons::ExpirationEnum, required: true
-      argument :expiration_duration, Integer, required: false
+      argument :expiration_date, GraphQL::Types::ISO8601Date, required: false
 
       type Types::Coupons::Object
 

--- a/app/graphql/types/coupons/object.rb
+++ b/app/graphql/types/coupons/object.rb
@@ -19,7 +19,6 @@ module Types
       field :frequency_duration, Integer, null: true
 
       field :expiration, Types::Coupons::ExpirationEnum, null: false
-      field :expiration_duration, Integer, null: true
       field :expiration_date, GraphQL::Types::ISO8601Date, null: true
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -53,7 +53,7 @@ class Coupon < ApplicationRecord
     )
   }
 
-  scope :expired, -> { where('coupons.expiration_date < ?', Time.current.beginning_of_day,) }
+  scope :expired, -> { where('coupons.expiration_date < ?', Time.current.beginning_of_day) }
 
   def attached_to_customers?
     applied_coupons.exists?

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -41,26 +41,19 @@ class Coupon < ApplicationRecord
   validates :amount_cents, numericality: { greater_than: 0 }
   validates :amount_currency, inclusion: { in: currency_list }
 
-  validates :expiration_duration, numericality: { greater_than: 0 }, if: :time_limit?
-
   scope :order_by_status_and_expiration, lambda {
     order(
       Arel.sql(
         [
           'coupons.status ASC',
           'coupons.expiration ASC',
-          'coupons.created_at + make_interval(days => COALESCE(coupons.expiration_duration, 0)) ASC',
+          'coupons.expiration_date ASC',
         ].join(', '),
       ),
     )
   }
 
-  scope :expired, lambda {
-    where(
-      '(coupons.created_at + make_interval(days => coupons.expiration_duration)) < ?',
-      Time.zone.now.beginning_of_day,
-    )
-  }
+  scope :expired, -> { where('coupons.expiration_date < ?', Time.current.beginning_of_day,) }
 
   def attached_to_customers?
     applied_coupons.exists?
@@ -73,11 +66,5 @@ class Coupon < ApplicationRecord
   def mark_as_terminated!(timestamp = Time.zone.now)
     self.terminated_at ||= timestamp
     terminated!
-  end
-
-  def expiration_date
-    return unless expiration_duration
-
-    created_at.to_date + expiration_duration.days
   end
 end

--- a/app/serializers/v1/coupon_serializer.rb
+++ b/app/serializers/v1/coupon_serializer.rb
@@ -15,7 +15,7 @@ module V1
         frequency_duration: model.frequency_duration,
         created_at: model.created_at.iso8601,
         expiration: model.expiration,
-        expiration_date: model.expiration_date&.iso8601
+        expiration_date: model.expiration_date&.iso8601,
       }
     end
   end

--- a/app/serializers/v1/coupon_serializer.rb
+++ b/app/serializers/v1/coupon_serializer.rb
@@ -15,7 +15,7 @@ module V1
         frequency_duration: model.frequency_duration,
         created_at: model.created_at.iso8601,
         expiration: model.expiration,
-        expiration_duration: model.expiration_duration
+        expiration_date: model.expiration_date&.iso8601
       }
     end
   end

--- a/app/services/coupons/create_service.rb
+++ b/app/services/coupons/create_service.rb
@@ -14,7 +14,7 @@ module Coupons
         frequency: args[:frequency],
         frequency_duration: args[:frequency_duration],
         expiration: args[:expiration]&.to_sym,
-        expiration_duration: args[:expiration_duration],
+        expiration_date: args[:expiration_date],
       )
 
       result.coupon = coupon

--- a/app/services/coupons/update_service.rb
+++ b/app/services/coupons/update_service.rb
@@ -7,6 +7,8 @@ module Coupons
       return result.not_found_failure!(resource: 'coupon') unless coupon
 
       coupon.name = args[:name]
+      coupon.expiration = args[:expiration]&.to_sym
+      coupon.expiration_date = args[:expiration_date]
 
       unless coupon.attached_to_customers?
         coupon.code = args[:code]
@@ -16,8 +18,6 @@ module Coupons
         coupon.percentage_rate = args[:percentage_rate]
         coupon.frequency = args[:frequency]
         coupon.frequency_duration = args[:frequency_duration]
-        coupon.expiration = args[:expiration]&.to_sym
-        coupon.expiration_duration = args[:expiration_duration]
       end
 
       coupon.save!
@@ -33,6 +33,8 @@ module Coupons
       return result.not_found_failure!(resource: 'coupon') unless coupon
 
       coupon.name = params[:name] if params.key?(:name)
+      coupon.expiration = params[:expiration] if params.key?(:expiration)
+      coupon.expiration_date = params[:expiration_date] if params.key?(:expiration_date)
 
       unless coupon.attached_to_customers?
         coupon.code = params[:code] if params.key?(:code)
@@ -42,8 +44,6 @@ module Coupons
         coupon.percentage_rate = params[:percentage_rate] if params.key?(:percentage_rate)
         coupon.frequency = params[:frequency] if params.key?(:frequency)
         coupon.frequency_duration = params[:frequency_duration] if params.key?(:frequency_duration)
-        coupon.expiration = params[:expiration] if params.key?(:expiration)
-        coupon.expiration_duration = params[:expiration_duration] if params.key?(:expiration_duration)
       end
 
       coupon.save!

--- a/db/migrate/20220923092906_add_expiration_date_to_coupons.rb
+++ b/db/migrate/20220923092906_add_expiration_date_to_coupons.rb
@@ -7,6 +7,6 @@ class AddExpirationDateToCoupons < ActiveRecord::Migration[7.0]
     LagoApi::Application.load_tasks
     Rake::Task['coupons:fill_expiration_date'].invoke
 
-    remove_column :coupons, :expiration_duration
+    remove_column :coupons, :expiration_duration, :integer
   end
 end

--- a/db/migrate/20220923092906_add_expiration_date_to_coupons.rb
+++ b/db/migrate/20220923092906_add_expiration_date_to_coupons.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddExpirationDateToCoupons < ActiveRecord::Migration[7.0]
+  def change
+    add_column :coupons, :expiration_date, :date
+
+    LagoApi::Application.load_tasks
+    Rake::Task['coupons:fill_expiration_date'].invoke
+
+    remove_column :coupons, :expiration_duration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_22_105251) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_23_092906) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -120,13 +120,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_22_105251) do
     t.bigint "amount_cents"
     t.string "amount_currency"
     t.integer "expiration", null: false
-    t.integer "expiration_duration"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "coupon_type", default: 0, null: false
     t.decimal "percentage_rate", precision: 10, scale: 5
     t.integer "frequency", default: 0, null: false
     t.integer "frequency_duration"
+    t.date "expiration_date"
     t.index ["organization_id", "code"], name: "index_coupons_on_organization_id_and_code", unique: true, where: "(code IS NOT NULL)"
     t.index ["organization_id"], name: "index_coupons_on_organization_id"
   end

--- a/lib/tasks/coupons.rake
+++ b/lib/tasks/coupons.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :coupons do
+  desc 'Populate expiration_date for coupons'
+  task fill_expiration_date: :environment do
+    Coupon.find_each do |coupon|
+      next unless coupon.expiration_duration
+
+      expiration_date = coupon.created_at.to_date + coupon.expiration_duration.days
+      coupon.update!(expiration_date: expiration_date)
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1473,7 +1473,6 @@ type Coupon {
   customerCount: Int!
   expiration: CouponExpiration!
   expirationDate: ISO8601Date
-  expirationDuration: Int
   frequency: CouponFrequency!
   frequencyDuration: Int
   id: ID!
@@ -1508,7 +1507,6 @@ type CouponDetails {
   customerCount: Int!
   expiration: CouponExpiration!
   expirationDate: ISO8601Date
-  expirationDuration: Int
   frequency: CouponFrequency!
   frequencyDuration: Int
   id: ID!
@@ -1619,7 +1617,7 @@ input CreateCouponInput {
   code: String
   couponType: CouponTypeEnum!
   expiration: CouponExpiration!
-  expirationDuration: Int
+  expirationDate: ISO8601Date
   frequency: CouponFrequency!
   frequencyDuration: Int
   name: String!
@@ -3678,7 +3676,7 @@ input UpdateCouponInput {
   code: String
   couponType: CouponTypeEnum!
   expiration: CouponExpiration!
-  expirationDuration: Int
+  expirationDate: ISO8601Date
   frequency: CouponFrequency!
   frequencyDuration: Int
   id: String!

--- a/schema.json
+++ b/schema.json
@@ -3659,20 +3659,6 @@
               ]
             },
             {
-              "name": "expirationDuration",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "frequency",
               "description": null,
               "type": {
@@ -4026,20 +4012,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "ISO8601Date",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "expirationDuration",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -4827,11 +4799,11 @@
               "deprecationReason": null
             },
             {
-              "name": "expirationDuration",
+              "name": "expirationDate",
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "ISO8601Date",
                 "ofType": null
               },
               "defaultValue": null,
@@ -13970,11 +13942,11 @@
               "deprecationReason": null
             },
             {
-              "name": "expirationDuration",
+              "name": "expirationDate",
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "ISO8601Date",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/coupons/create_spec.rb
+++ b/spec/graphql/mutations/coupons/create_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
           amountCents,
           amountCurrency,
           expiration,
-          expirationDuration,
+          expirationDate,
           status
         }
       }
@@ -35,7 +35,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
           amountCents: 5000,
           amountCurrency: 'EUR',
           expiration: 'time_limit',
-          expirationDuration: 3,
+          expirationDate: (Time.current + 3.days).to_date,
         },
       },
     )
@@ -49,7 +49,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
       expect(result_data['amountCents']).to eq(5000)
       expect(result_data['amountCurrency']).to eq('EUR')
       expect(result_data['expiration']).to eq('time_limit')
-      expect(result_data['expirationDuration']).to eq(3)
+      expect(result_data['expirationDate']).to eq (Time.current + 3.days).to_date.to_s
       expect(result_data['status']).to eq('active')
     end
   end
@@ -68,7 +68,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
             amountCents: 5000,
             amountCurrency: 'EUR',
             expiration: 'time_limit',
-            expirationDuration: 3,
+            expirationDate: (Time.current + 3.days).to_date,
           },
         },
       )
@@ -91,7 +91,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
             amountCents: 5000,
             amountCurrency: 'EUR',
             expiration: 'time_limit',
-            expirationDuration: 3,
+            expirationDate: (Time.current + 3.days).to_date,
           },
         },
       )

--- a/spec/graphql/mutations/coupons/update_spec.rb
+++ b/spec/graphql/mutations/coupons/update_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Mutations::Coupons::Update, type: :graphql do
           amountCents,
           amountCurrency,
           expiration,
-          expirationDuration
+          expirationDate
         }
       }
     GQL
@@ -36,7 +36,7 @@ RSpec.describe Mutations::Coupons::Update, type: :graphql do
           amountCents: 123,
           amountCurrency: 'USD',
           expiration: 'time_limit',
-          expirationDuration: 33,
+          expirationDate: (Time.current + 33.days).to_date,
         },
       },
     )
@@ -50,7 +50,7 @@ RSpec.describe Mutations::Coupons::Update, type: :graphql do
       expect(result_data['amountCents']).to eq(123)
       expect(result_data['amountCurrency']).to eq('USD')
       expect(result_data['expiration']).to eq('time_limit')
-      expect(result_data['expirationDuration']).to eq(33)
+      expect(result_data['expirationDate']).to eq (Time.current + 33.days).to_date.to_s
     end
   end
 
@@ -68,7 +68,7 @@ RSpec.describe Mutations::Coupons::Update, type: :graphql do
             amountCents: 123,
             amountCurrency: 'USD',
             expiration: 'time_limit',
-            expirationDuration: 33,
+            expirationDate: (Time.current + 33.days).to_date,
           },
         },
       )

--- a/spec/requests/api/v1/coupons_spec.rb
+++ b/spec/requests/api/v1/coupons_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V1::CouponsController, type: :request do
         amount_cents: 123,
         amount_currency: 'EUR',
         expiration: 'time_limit',
-        expiration_duration: 15,
+        expiration_date: (Time.current + 15.days).to_date,
       }
     end
 
@@ -42,7 +42,7 @@ RSpec.describe Api::V1::CouponsController, type: :request do
         amount_cents: 123,
         amount_currency: 'EUR',
         expiration: 'time_limit',
-        expiration_duration: 15,
+        expiration_date: (Time.current + 15.days).to_date,
       }
     end
 

--- a/spec/serializers/v1/coupon_serializer_spec.rb
+++ b/spec/serializers/v1/coupon_serializer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ::V1::CouponSerializer do
       expect(result['coupon']['amount_cents']).to eq(coupon.amount_cents)
       expect(result['coupon']['amount_currency']).to eq(coupon.amount_currency)
       expect(result['coupon']['expiration']).to eq(coupon.expiration)
-      expect(result['coupon']['expiration_duration']).to eq(coupon.expiration_duration)
+      expect(result['coupon']['expiration_date']).to eq(coupon.expiration_date&.iso8601)
       expect(result['coupon']['created_at']).to eq(coupon.created_at.iso8601)
     end
   end

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Coupons::CreateService, type: :service do
         amount_cents: 100,
         amount_currency: 'EUR',
         expiration: 'time_limit',
-        expiration_duration: 3,
+        expiration_date: (Time.current + 3.days).to_date,
       }
     end
 

--- a/spec/services/coupons/terminate_service_spec.rb
+++ b/spec/services/coupons/terminate_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Coupons::TerminateService, type: :service do
         organization: organization,
         status: 'active',
         expiration: 'time_limit',
-        expiration_duration: rand(1..30),
+        expiration_date: (Time.current - 30.days).to_date,
         created_at: Time.zone.now - 40.days,
       )
     end
@@ -52,7 +52,7 @@ RSpec.describe Coupons::TerminateService, type: :service do
         organization: organization,
         status: 'active',
         expiration: 'time_limit',
-        expiration_duration: rand(1..30),
+        expiration_date: (Time.current + 15.days).to_date,
         created_at: Time.zone.now,
       )
     end

--- a/spec/services/coupons/update_service_spec.rb
+++ b/spec/services/coupons/update_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
         amount_cents: 100,
         amount_currency: 'EUR',
         expiration: 'time_limit',
-        expiration_duration: 30,
+        expiration_date: (Time.current + 30.days).to_date,
       }
     end
 
@@ -36,7 +36,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
         expect(result.coupon.amount_cents).to eq(100)
         expect(result.coupon.amount_currency).to eq('EUR')
         expect(result.coupon.expiration).to eq('time_limit')
-        expect(result.coupon.expiration_duration).to eq(30)
+        expect(result.coupon.expiration_date).to eq (Time.current + 30.days).to_date
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
           amount_cents: 100,
           amount_currency: 'EUR',
           expiration: 'time_limit',
-          expiration_duration: 30,
+          expiration_date: (Time.current + 30.days).to_date,
         }
       end
 
@@ -78,7 +78,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
         amount_cents: 123,
         amount_currency: 'EUR',
         expiration: 'time_limit',
-        expiration_duration: 15,
+        expiration_date: (Time.current + 15.days).to_date,
       }
     end
 


### PR DESCRIPTION
## Context

This change includes expiration logic around coupons.

## Description

We have several changes around expiration:

> We will use expiration_date instead of expiration_duration

> Expiration fields are editable from now on even if coupon is already assigned to customer