### PR TITLE
chore(issue-template): ask for lago version in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,3 +25,6 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+**Version**
+- Lago: vX.X.X


### PR DESCRIPTION
## Context

We have hard time to understand whereas a bug is reported using the last version of the app or not.

## Description

This PR adds a new section in github issue template, asking for the Lago version used
