### PR TITLE
fix: Empty webhook URI path sould not raise an error

### DIFF
--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -13,7 +13,7 @@ module LagoHttpClient
     end
 
     def post(body, headers)
-      req = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
+      req = Net::HTTP::Post.new(uri.path.presence || '/', 'Content-Type' => 'application/json')
 
       headers.each do |header|
         key = header.keys.first
@@ -83,7 +83,7 @@ module LagoHttpClient
     attr_reader :uri, :http_client
 
     def raise_error(response)
-      raise ::LagoHttpClient::HttpError.new(response.code, response.body, uri)
+      raise(::LagoHttpClient::HttpError.new(response.code, response.body, uri))
     end
   end
 end

--- a/spec/lib/lago_http_client/client_spec.rb
+++ b/spec/lib/lago_http_client/client_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe LagoHttpClient::Client do
       let(:response) do
         {
           'status' => 200,
-          'message' => 'Success'
+          'message' => 'Success',
         }.to_json
       end
 
@@ -65,6 +65,29 @@ RSpec.describe LagoHttpClient::Client do
 
       it 'raises an error' do
         expect { client.post('', {}) }.to raise_error LagoHttpClient::HttpError
+      end
+    end
+
+    context 'when path is empty' do
+      let(:url) { 'http://example.com' }
+
+      let(:response) do
+        {
+          'status' => 200,
+          'message' => 'Success',
+        }.to_json
+      end
+
+      before do
+        stub_request(:post, 'http://example.com/')
+          .to_return(body: response, status: 200)
+      end
+
+      it 'returns response body' do
+        response = client.post('', {})
+
+        expect(response['status']).to eq 200
+        expect(response['message']).to eq 'Success'
       end
     end
   end


### PR DESCRIPTION
## Context

If a webhook url is set to a domain wihtout path, it raises an error when trying to deliver it.

## Description

Instead of trying to send the webhook to a blank path, it should be sent to the root path (`/`)