### PR TITLE
feat(invoices): add customers into generated webhook

### DIFF
--- a/app/services/webhooks/invoices/generated_service.rb
+++ b/app/services/webhooks/invoices/generated_service.rb
@@ -11,6 +11,7 @@ module Webhooks
         ::V1::InvoiceSerializer.new(
           object,
           root_name: 'invoice',
+          includes: %i[customer],
         )
       end
 

--- a/spec/services/webhooks/invoices/generated_service_spec.rb
+++ b/spec/services/webhooks/invoices/generated_service_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Webhooks::Invoices::GeneratedService do
       expect(lago_client).to have_received(:post) do |payload|
         expect(payload[:webhook_type]).to eq('invoice.generated')
         expect(payload[:object_type]).to eq('invoice')
+        expect(payload['invoice'][:customer]).to be_present
       end
     end
   end


### PR DESCRIPTION
## Context

On the `invoice.generated` webhook we do not have the customer informations

## Description

- Add the `customer` information on the `invoice.generated` webhook