### PR TITLE
fix(s3): Add compatible S3 Bucket config

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -18,3 +18,4 @@ amazon_compatible_endpoint:
   access_key_id: <%= ENV['LAGO_AWS_S3_ACCESS_KEY_ID'] %>
   secret_access_key: <%= ENV['LAGO_AWS_S3_SECRET_ACCESS_KEY'] %>
   endpoint: <%= ENV['LAGO_AWS_S3_ENDPOINT'] %>
+  bucket: <%= ENV['LAGO_AWS_S3_BUCKET'] %>


### PR DESCRIPTION
## Context

- We do not support bucket name for AWS S3 Compatible systems

## Description

- Add the `bucket` configuration option for AWS S3 Compatible systems