### PR TITLE
fix (customer): change editable? method in customer model

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -57,7 +57,10 @@ class Customer < ApplicationRecord
   end
 
   def editable?
-    deletable?
+    !attached_to_subscriptions? &&
+      applied_add_ons.none? &&
+      applied_coupons.where.not(amount_currency: nil).none? &&
+      wallets.none?
   end
 
   private


### PR DESCRIPTION
With the old behaviour, `Customers::UpdateService` is returning error when we try to assign a subscription to customer that have applied percentage coupon. `currencies_does_not_match` error is raised if customer currency does not exist but the customer is not editable. If customer have percentage coupon applied and customer currency is nil, currency should still be editable...