### PR TITLE
fix: prevent charging subscription fees twice in the same day

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -74,6 +74,10 @@ class Subscription < ApplicationRecord
     next_subscriptions.not_canceled.order(created_at: :desc).first
   end
 
+  def already_billed_today?
+    fees.subscription_kind.where(created_at: Time.current.beginning_of_day..Time.current.end_of_day).any?
+  end
+
   def already_billed?
     fees.subscription_kind.any?
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -74,10 +74,8 @@ class Subscription < ApplicationRecord
     next_subscriptions.not_canceled.order(created_at: :desc).first
   end
 
-  def fee_exists?(timestamp)
-    time = Time.zone.at(timestamp)
-
-    fees.subscription_kind.where(created_at: time.beginning_of_day..time.end_of_day).any?
+  def fee_exists?(date)
+    fees.subscription_kind.where(created_at: date.beginning_of_day..date.end_of_day).any?
   end
 
   def already_billed?

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -74,8 +74,10 @@ class Subscription < ApplicationRecord
     next_subscriptions.not_canceled.order(created_at: :desc).first
   end
 
-  def already_billed_today?
-    fees.subscription_kind.where(created_at: Time.current.beginning_of_day..Time.current.end_of_day).any?
+  def fee_exists?(timestamp)
+    time = Time.zone.at(timestamp)
+
+    fees.subscription_kind.where(created_at: time.beginning_of_day..time.end_of_day).any?
   end
 
   def already_billed?

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -84,7 +84,7 @@ module Invoices
     def should_create_subscription_fee?(subscription)
       # NOTE: When plan is pay in advance we generate an invoice upon subscription creation
       # We want to prevent creating subscription fee if subscription creation already happened on billing day
-      return false if subscription.plan.pay_in_advance? && subscription.already_billed_today?
+      return false if subscription.plan.pay_in_advance? && subscription.fee_exists?(timestamp)
 
       return false unless should_create_yearly_subscription_fee?(subscription)
 

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -82,6 +82,10 @@ module Invoices
     end
 
     def should_create_subscription_fee?(subscription)
+      # NOTE: When plan is pay in advance we generate an invoice upon subscription creation
+      # We want to prevent creating subscription fee if subscription creation already happened on billing day
+      return false if subscription.plan.pay_in_advance? && subscription.already_billed_today?
+
       return false unless should_create_yearly_subscription_fee?(subscription)
 
       # NOTE: When a subscription is terminated we still need to charge the subscription

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -84,7 +84,7 @@ module Invoices
     def should_create_subscription_fee?(subscription)
       # NOTE: When plan is pay in advance we generate an invoice upon subscription creation
       # We want to prevent creating subscription fee if subscription creation already happened on billing day
-      return false if subscription.plan.pay_in_advance? && subscription.fee_exists?(timestamp)
+      return false if subscription.plan.pay_in_advance? && subscription.fee_exists?(Time.zone.at(timestamp).to_date)
 
       return false unless should_create_yearly_subscription_fee?(subscription)
 

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -267,14 +267,14 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
-  describe '#already_billed_today?' do
+  describe '#fee_exists??' do
     let(:subscription) { create(:subscription) }
 
     context 'without subscriptions fees that are created today' do
       before { create(:fee, subscription: subscription, created_at: Time.current - 2.days) }
 
       it 'returns false' do
-        expect(subscription.already_billed_today?).to be false
+        expect(subscription.fee_exists?(Time.current.to_i)).to be false
       end
     end
 
@@ -282,7 +282,7 @@ RSpec.describe Subscription, type: :model do
       before { create(:fee, subscription: subscription) }
 
       it 'returns true' do
-        expect(subscription.already_billed_today?).to be true
+        expect(subscription.fee_exists?(Time.current.to_i)).to be true
       end
     end
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -269,12 +269,13 @@ RSpec.describe Subscription, type: :model do
 
   describe '#fee_exists??' do
     let(:subscription) { create(:subscription) }
+    let(:current_date) { Time.current.to_date }
 
     context 'without subscriptions fees that are created today' do
       before { create(:fee, subscription: subscription, created_at: Time.current - 2.days) }
 
       it 'returns false' do
-        expect(subscription.fee_exists?(Time.current.to_i)).to be false
+        expect(subscription.fee_exists?(current_date)).to be false
       end
     end
 
@@ -282,7 +283,7 @@ RSpec.describe Subscription, type: :model do
       before { create(:fee, subscription: subscription) }
 
       it 'returns true' do
-        expect(subscription.fee_exists?(Time.current.to_i)).to be true
+        expect(subscription.fee_exists?(current_date)).to be true
       end
     end
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -266,4 +266,24 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe '#already_billed_today?' do
+    let(:subscription) { create(:subscription) }
+
+    context 'without subscriptions fees that are created today' do
+      before { create(:fee, subscription: subscription, created_at: Time.current - 2.days) }
+
+      it 'returns false' do
+        expect(subscription.already_billed_today?).to be false
+      end
+    end
+
+    context 'with subscription fees that are created today' do
+      before { create(:fee, subscription: subscription) }
+
+      it 'returns true' do
+        expect(subscription.already_billed_today?).to be true
+      end
+    end
+  end
 end

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe Invoices::CreateService, type: :service do
 
       context 'when plan is pay in advance and subscription fees are created earlier today' do
         let(:pay_in_advance) { true }
+        let(:timestamp) { Time.current.to_i }
 
         before { create(:fee, subscription: subscription) }
 

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -94,6 +94,21 @@ RSpec.describe Invoices::CreateService, type: :service do
         end
       end
 
+      context 'when plan is pay in advance and subscription fees are created earlier today' do
+        let(:pay_in_advance) { true }
+
+        before { create(:fee, subscription: subscription) }
+
+        it 'creates an invoice for without subscription fees' do
+          result = invoice_service.create
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.invoice.fees.subscription_kind.count).to eq(0)
+          end
+        end
+      end
+
       context 'when subscription is billed on anniversary date' do
         let(:timestamp) { DateTime.parse('07 Mar 2022') }
         let(:started_at) { DateTime.parse('06 Jun 2021').to_date }


### PR DESCRIPTION
This bug fix prevents charging subscription fees twice in the same day when paying is in advance and when subscription is created on the billing day (just before BillingJob running time)