### PR TITLE
feat(credit-notes): Add credit note database structure

### DIFF
--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -4,7 +4,8 @@ class Credit < ApplicationRecord
   include Currencies
 
   belongs_to :invoice
-  belongs_to :applied_coupon
+  belongs_to :applied_coupon, optional: true
+  belongs_to :credit_note, optional: true
 
   has_one :coupon, through: :applied_coupon
 

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class CreditNote < ApplicationRecord
+  include Sequenced
+
+  before_save :ensure_number
+
+  belongs_to :customer
+  belongs_to :invoice
+
+  has_many :items, class_name: 'CreditNoteItem'
+  has_many :fees, through: :items
+
+  has_one_attached :file
+
+  monetize :amount_cents
+  monetize :remaining_amount_cents
+
+  STATUS = %i[available consumed].freeze
+  REASON = %i[overpaid].freeze
+
+  enum status: STATUS
+  enum reason: REASON
+
+  sequenced scope: ->(credit_note) { CreditNote.where(invoice_id: credit_note.invoice_id) }
+
+  private
+
+  def ensure_number
+    return if number.present?
+
+    formatted_sequential_id = format('%03d', sequential_id)
+
+    self.number = "#{invoice.number}-CN#{formatted_sequential_id}"
+  end
+end

--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CreditNoteItem < ApplicationRecord
+  belongs_to :credit_note
+  belongs_to :fee
+end

--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -3,4 +3,6 @@
 class CreditNoteItem < ApplicationRecord
   belongs_to :credit_note
   belongs_to :fee
+
+  monetize :amount_cents
 end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -14,6 +14,9 @@ class Fee < ApplicationRecord
   has_one :billable_metric, through: :charge
   has_one :add_on, through: :applied_add_on
 
+  has_many :credit_note_items
+  has_many :credit_notes, through: :credit_note_items
+
   monetize :amount_cents
   monetize :vat_amount_cents
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -8,6 +8,7 @@ class Organization < ApplicationRecord
   has_many :customers
   has_many :subscriptions, through: :customers
   has_many :invoices, through: :customers
+  has_many :credit_notes, through: :customers
   has_many :events
   has_many :coupons
   has_many :add_ons
@@ -28,7 +29,9 @@ class Organization < ApplicationRecord
   validates :country, country_code: true, unless: -> { country.nil? }
   validates :invoice_footer, length: { maximum: 600 }
   validates :email, email: true, if: :email?
-  validates :logo, image: { authorized_content_type: %w[image/png image/jpg image/jpeg], max_size: 800.kilobytes }, if: :logo?
+  validates :logo,
+            image: { authorized_content_type: %w[image/png image/jpg image/jpeg], max_size: 800.kilobytes },
+            if: :logo?
 
   def logo_url
     return if logo.blank?

--- a/db/migrate/20220930123935_create_credit_notes.rb
+++ b/db/migrate/20220930123935_create_credit_notes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateCreditNotes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :credit_notes, id: :uuid do |t|
+      t.references :customer, type: :uuid, index: true, foreign_key: true, null: false
+      t.references :invoice, type: :uuid, index: true, foreign_key: true, null: false
+      t.integer :sequential_id, null: false
+      t.string :number, null: false
+      t.bigint :amount_cents, default: 0, null: false
+      t.string :amount_currency, null: false
+      t.integer :status, null: false, default: 0
+      t.bigint :remaining_amount_cents, default: 0, null: false
+      t.string :remaining_amount_currency, default: 0, null: false
+      t.integer :reason, null: false
+      t.string :file
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220930134327_create_credit_note_items.rb
+++ b/db/migrate/20220930134327_create_credit_note_items.rb
@@ -5,6 +5,8 @@ class CreateCreditNoteItems < ActiveRecord::Migration[7.0]
     create_table :credit_note_items, id: :uuid do |t|
       t.references :credit_note, type: :uuid, foreign_key: true, index: true, null: false
       t.references :fee, type: :uuid, foreign_key: true, index: true, null: false
+      t.bigint :amount_cents, default: 0, null: false
+      t.string :amount_currency, null: false
       t.timestamps
     end
   end

--- a/db/migrate/20220930134327_create_credit_note_items.rb
+++ b/db/migrate/20220930134327_create_credit_note_items.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateCreditNoteItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :credit_note_items, id: :uuid do |t|
+      t.references :credit_note, type: :uuid, foreign_key: true, index: true, null: false
+      t.references :fee, type: :uuid, foreign_key: true, index: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220930143002_add_credit_note_id_to_credits.rb
+++ b/db/migrate/20220930143002_add_credit_note_id_to_credits.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCreditNoteIdToCredits < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :credits, :credit_notes, type: :uuid, null: true, foreign_key: true, index: true
+    change_column_null :credits, :applied_coupon_id, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_23_092906) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_30_143002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -131,6 +131,33 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_23_092906) do
     t.index ["organization_id"], name: "index_coupons_on_organization_id"
   end
 
+  create_table "credit_note_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "credit_note_id", null: false
+    t.uuid "fee_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["credit_note_id"], name: "index_credit_note_items_on_credit_note_id"
+    t.index ["fee_id"], name: "index_credit_note_items_on_fee_id"
+  end
+
+  create_table "credit_notes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "customer_id", null: false
+    t.uuid "invoice_id", null: false
+    t.integer "sequential_id", null: false
+    t.string "number", null: false
+    t.bigint "amount_cents", default: 0, null: false
+    t.string "amount_currency", null: false
+    t.integer "status", default: 0, null: false
+    t.bigint "remaining_amount_cents", default: 0, null: false
+    t.string "remaining_amount_currency", default: "0", null: false
+    t.integer "reason", null: false
+    t.string "file"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
+    t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
+  end
+
   create_table "credits", force: :cascade do |t|
     t.uuid "invoice_id"
     t.uuid "applied_coupon_id"
@@ -138,7 +165,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_23_092906) do
     t.string "amount_currency", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "credit_notes_id"
     t.index ["applied_coupon_id"], name: "index_credits_on_applied_coupon_id"
+    t.index ["credit_notes_id"], name: "index_credits_on_credit_notes_id"
     t.index ["invoice_id"], name: "index_credits_on_invoice_id"
   end
 
@@ -428,7 +457,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_23_092906) do
   add_foreign_key "billable_metrics", "organizations"
   add_foreign_key "charges", "billable_metrics"
   add_foreign_key "charges", "plans"
+  add_foreign_key "credit_note_items", "credit_notes"
+  add_foreign_key "credit_note_items", "fees"
+  add_foreign_key "credit_notes", "customers"
+  add_foreign_key "credit_notes", "invoices"
   add_foreign_key "credits", "applied_coupons"
+  add_foreign_key "credits", "credit_notes", column: "credit_notes_id"
   add_foreign_key "credits", "invoices"
   add_foreign_key "customers", "organizations"
   add_foreign_key "events", "customers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -134,6 +134,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_30_143002) do
   create_table "credit_note_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "credit_note_id", null: false
     t.uuid "fee_id", null: false
+    t.bigint "amount_cents", default: 0, null: false
+    t.string "amount_currency", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["credit_note_id"], name: "index_credit_note_items_on_credit_note_id"

--- a/spec/factories/credit_factory.rb
+++ b/spec/factories/credit_factory.rb
@@ -8,4 +8,12 @@ FactoryBot.define do
     amount_cents { 200 }
     amount_currency { 'EUR' }
   end
+
+  factory :credit_note_credit do
+    invoice
+    credit_note
+
+    amount_cents { 200 }
+    amount_currency { 'EUR' }
+  end
 end

--- a/spec/factories/credit_note_items.rb
+++ b/spec/factories/credit_note_items.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :credit_note_item do
+    credit_note
+    fee
+  end
+end

--- a/spec/factories/credit_notes.rb
+++ b/spec/factories/credit_notes.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :credit_note do
+    customer
+    invoice
+
+    status { 'available' }
+    reason { 'overpaid' }
+    amount_cents { 100 }
+    amount_currency { 'EUR' }
+
+    remaining_amount_cents { 100 }
+    remaining_amount_currency { 'EUR' }
+  end
+end

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNote, type: :model do
+  describe 'sequential_id' do
+    let(:invoice) { create(:invoice) }
+    let(:customer) { invoice.customer }
+
+    let(:credit_note) do
+      build(:credit_note, invoice: invoice, customer: customer)
+    end
+
+    it 'assigns a sequential_id is present' do
+      credit_note.save
+
+      aggregate_failures do
+        expect(credit_note).to be_valid
+        expect(credit_note.sequential_id).to eq(1)
+      end
+    end
+
+    context 'when sequential_id is present' do
+      before { credit_note.sequential_id = 3 }
+
+      it 'does not replace the sequential_id' do
+        credit_note.save
+
+        aggregate_failures do
+          expect(credit_note).to be_valid
+          expect(credit_note.sequential_id).to eq(3)
+        end
+      end
+    end
+
+    context 'when credit note already exists' do
+      before do
+        create(
+          :credit_note,
+          invoice: invoice,
+          sequential_id: 5,
+        )
+      end
+
+      it 'takes the next available id' do
+        credit_note.save!
+
+        aggregate_failures do
+          expect(credit_note).to be_valid
+          expect(credit_note.sequential_id).to eq(6)
+        end
+      end
+    end
+
+    context 'with credit note on other invoice' do
+      before do
+        create(
+          :credit_note,
+          sequential_id: 1,
+        )
+      end
+
+      it 'scopes the sequence to the invoice' do
+        credit_note.save
+
+        aggregate_failures do
+          expect(credit_note).to be_valid
+          expect(credit_note.sequential_id).to eq(1)
+        end
+      end
+    end
+  end
+
+  describe 'number' do
+    let(:invoice) { create(:invoice, number: 'CUST-001') }
+    let(:customer) { invoice.customer }
+    let(:credit_note) { build(:credit_note, invoice: invoice, customer: customer) }
+
+    it 'generates the credit_note_number' do
+      credit_note.save
+
+      expect(credit_note.number).to eq('CUST-001-CN001')
+    end
+  end
+end


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This pull request is the first one for the feature.
It updates the data structure:
- Add the new `CreditNote` model, to store allowed and remaining credit
- Add the new `CreditNoteItem` model to store the link between a credit note and a targeted fee
- Add a new relation between the `Credit` model and the new `CreditNote` to apply a credit note to an invoice