### PR TITLE
feat (subscriptions): add logic to create subscription with given subscription_date

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -90,7 +90,7 @@ module Api
       end
 
       def update_params
-        params.require(:subscription).permit(:name)
+        params.require(:subscription).permit(:name, :subscription_date)
       end
     end
   end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -86,7 +86,7 @@ module Api
 
       def create_params
         params.require(:subscription)
-          .permit(:external_customer_id, :plan_code, :name, :external_id, :billing_time)
+          .permit(:external_customer_id, :plan_code, :name, :external_id, :billing_time, :subscription_date)
       end
 
       def update_params

--- a/app/graphql/mutations/subscriptions/create.rb
+++ b/app/graphql/mutations/subscriptions/create.rb
@@ -14,6 +14,7 @@ module Mutations
       argument :name, String, required: false
       argument :subscription_id, ID, required: false
       argument :billing_time, Types::Subscriptions::BillingTimeEnum, required: true
+      argument :subscription_date, GraphQL::Types::ISO8601Date, required: false
 
       type Types::Subscriptions::Object
 

--- a/app/graphql/mutations/subscriptions/update.rb
+++ b/app/graphql/mutations/subscriptions/update.rb
@@ -9,7 +9,8 @@ module Mutations
       description 'Update a Subscription'
 
       argument :id, ID, required: true
-      argument :name, String, required: true
+      argument :name, String, required: false
+      argument :subscription_date, GraphQL::Types::ISO8601Date, required: false
 
       type Types::Subscriptions::Object
 

--- a/app/graphql/resolvers/customers/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/customers/subscriptions_resolver.rb
@@ -11,10 +11,27 @@ module Resolvers
 
       type Types::Subscriptions::Object, null: false
 
+      # FE needs possibility to fetch subscriptions by status. However if status is pending, only
+      # starting_in_the_future subscriptions should be returned since FE handles downgraded (pending)
+      # subscriptions a bit different (it checks if next_plan exists and it uses some of next plan's properties
+      # that are needed in the UI)
       def resolve(status: nil)
+        statuses = status
         subscriptions = object.subscriptions
-        subscriptions = subscriptions.where(status: status) if status.present?
-        subscriptions.order(created_at: :desc)
+
+        return subscriptions.order(created_at: :desc) if statuses.blank?
+
+        # if requested statuses do not include pending ones we should just perform filtering by given statuses
+        return subscriptions.where(status: statuses).order(created_at: :desc) unless statuses&.include?('pending')
+
+        statuses -= ['pending']
+
+        # if requested status is only pending, we should return only subscriptions that are starting later
+        return subscriptions.starting_in_the_future.order(created_at: :desc) if statuses.blank?
+
+        # if requested statuses are array of pending and some other statuses, we should return pending subscriptions
+        # that are starting later or other subscriptions filtered by statuses without pending one
+        subscriptions.where(status: statuses).or(subscriptions.starting_in_the_future).order(created_at: :desc)
       end
     end
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -30,6 +30,8 @@ class Subscription < ApplicationRecord
   enum status: STATUSES
   enum billing_time: BILLING_TIME
 
+  scope :starting_in_the_future, -> { pending.where(previous_subscription: nil) }
+
   def mark_as_active!(timestamp = Time.zone.now)
     self.started_at ||= timestamp
     active!
@@ -84,6 +86,10 @@ class Subscription < ApplicationRecord
 
   def already_billed?
     fees.subscription_kind.any?
+  end
+
+  def starting_in_the_future?
+    pending? && previous_subscription.nil?
   end
 
   def validate_external_id

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -63,6 +63,10 @@ class Subscription < ApplicationRecord
     initial_started_at.to_date + plan.trial_period.days
   end
 
+  def started_in_past?
+    subscription_date < created_at.to_date
+  end
+
   def initial_started_at
     customer.subscriptions
       .where(external_id: external_id)

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -84,8 +84,16 @@ module Fees
     #        or when it is payed in advance on an anniversary base
     def should_use_full_amount?
       return true if plan.pay_in_advance? && subscription.anniversary?
+      return true if subscription.fees.subscription_kind.exists?
 
-      subscription.fees.subscription_kind.exists?
+      return true if subscription.started_in_past? && plan.pay_in_advance?
+
+      if subscription.started_in_past? &&
+        subscription.started_at < date_service(subscription).previous_beginning_of_period
+        return true
+      end
+
+      false
     end
 
     def first_subscription_amount

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -89,7 +89,7 @@ module Fees
       return true if subscription.started_in_past? && plan.pay_in_advance?
 
       if subscription.started_in_past? &&
-        subscription.started_at < date_service(subscription).previous_beginning_of_period
+         subscription.started_at < date_service(subscription).previous_beginning_of_period
         return true
       end
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -117,6 +117,8 @@ module Subscriptions
 
       if new_subscription.subscription_date > Time.current.to_date
         new_subscription.pending!
+      elsif new_subscription.subscription_date < Time.current.to_date
+        new_subscription.mark_as_active!(new_subscription.subscription_date.beginning_of_day)
       else
         new_subscription.mark_as_active!
       end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -2,8 +2,15 @@
 
 module Subscriptions
   class CreateService < BaseService
-    attr_reader :current_customer, :current_plan, :current_subscription, :name, :external_id, :billing_time,
-                :subscription_date
+    attr_reader(
+      :current_customer,
+      :current_plan,
+      :current_subscription,
+      :name,
+      :external_id,
+      :billing_time,
+      :subscription_date,
+    )
 
     def create_from_api(organization:, params:)
       if params[:external_customer_id]
@@ -53,9 +60,7 @@ module Subscriptions
     private
 
     def process_create
-      unless valid?(customer: current_customer, plan: current_plan, subscription_date: subscription_date)
-        return result
-      end
+      return result unless valid?(customer: current_customer, plan: current_plan, subscription_date: subscription_date)
 
       ActiveRecord::Base.transaction do
         currency_result = Customers::UpdateService.new(nil).update_currency(

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -28,7 +28,7 @@ module Subscriptions
       @name = params[:name]&.strip
       @external_id = params[:external_id]&.strip
       @billing_time = params[:billing_time]
-      @subscription_date = params[:subscription_date]
+      @subscription_date = params[:subscription_date] || Time.current.to_date
       @current_subscription = active_subscriptions&.find_by(external_id: external_id)
 
       process_create
@@ -51,7 +51,7 @@ module Subscriptions
       @name = args[:name]&.strip
       @external_id = SecureRandom.uuid
       @billing_time = args[:billing_time]
-      @subscription_date = args[:subscription_date]
+      @subscription_date = args[:subscription_date] || Time.current.to_date
       @current_subscription = active_subscriptions&.find_by(id: args[:subscription_id])
 
       process_create
@@ -109,7 +109,7 @@ module Subscriptions
       new_subscription = Subscription.new(
         customer: current_customer,
         plan_id: current_plan.id,
-        subscription_date: subscription_date || Time.current.to_date,
+        subscription_date: subscription_date,
         name: name,
         external_id: external_id,
         billing_time: billing_time || :calendar,

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -30,7 +30,6 @@ module Subscriptions
     end
 
     def valid_subscription_date?
-      return true if args[:subscription_date].nil?
       return true if args[:subscription_date].is_a?(Date)
       return true if args[:subscription_date].is_a?(String) && Date._strptime(args[:subscription_date]).present?
 

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -3,8 +3,9 @@
 module Subscriptions
   class ValidateService < BaseValidator
     def valid?
-      valid_customer?
-      valid_plan?
+      return false unless valid_customer?
+      return false unless valid_plan?
+
       valid_subscription_date?
 
       if errors?
@@ -20,20 +21,26 @@ module Subscriptions
     def valid_customer?
       return true if args[:customer]
 
-      add_error(field: :customer, error_code: 'customer_not_found')
+      result.not_found_failure!(resource: 'customer')
+
+      false
     end
 
     def valid_plan?
       return true if args[:plan]
 
-      add_error(field: :plan, error_code: 'plan_not_found')
+      result.not_found_failure!(resource: 'plan')
+
+      false
     end
 
     def valid_subscription_date?
       return true if args[:subscription_date].is_a?(Date)
       return true if args[:subscription_date].is_a?(String) && Date._strptime(args[:subscription_date]).present?
 
-      add_error(field: :subscription_date, error_code: 'invalid_subscription_date')
+      add_error(field: :subscription_date, error_code: 'invalid_date')
+
+      false
     end
   end
 end

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class ValidateService < BaseValidator
+    def valid?
+      valid_customer?
+      valid_plan?
+      valid_subscription_date?
+
+      if errors?
+        result.validation_failure!(errors: errors)
+        return false
+      end
+
+      true
+    end
+
+    private
+
+    def valid_customer?
+      return true if args[:customer]
+
+      add_error(field: :customer, error_code: 'customer_not_found')
+    end
+
+    def valid_plan?
+      return true if args[:plan]
+
+      add_error(field: :plan, error_code: 'plan_not_found')
+    end
+
+    def valid_subscription_date?
+      return true if args[:subscription_date].nil?
+      return true if args[:subscription_date].is_a?(Date)
+      return true if args[:subscription_date].is_a?(String) && Date._strptime(args[:subscription_date]).present?
+
+      add_error(field: :subscription_date, error_code: 'invalid_subscription_date')
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
         invalid_free_units: invalid_free_units
         invalid_package_size: invalid_package_size
         invalid_rate: invalid_rate
+        invalid_subscription_date: invalid_subscription_date
         invalid_fixed_amount: invalid_fixed_amount
         invalid_free_units_per_events: invalid_free_units_per_events
         invalid_free_units_per_total_aggregation: invalid_free_units_per_total_aggregation

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,7 +22,7 @@ en:
         invalid_free_units: invalid_free_units
         invalid_package_size: invalid_package_size
         invalid_rate: invalid_rate
-        invalid_subscription_date: invalid_subscription_date
+        invalid_date: invalid_date
         invalid_fixed_amount: invalid_fixed_amount
         invalid_free_units_per_events: invalid_free_units_per_events
         invalid_free_units_per_total_aggregation: invalid_free_units_per_total_aggregation

--- a/schema.graphql
+++ b/schema.graphql
@@ -1729,6 +1729,7 @@ input CreateSubscriptionInput {
   customerId: ID!
   name: String
   planId: ID!
+  subscriptionDate: ISO8601Date
   subscriptionId: ID
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -3806,7 +3806,8 @@ input UpdateSubscriptionInput {
   """
   clientMutationId: String
   id: ID!
-  name: String!
+  name: String
+  subscriptionDate: ISO8601Date
 }
 
 type User {

--- a/schema.json
+++ b/schema.json
@@ -5571,6 +5571,18 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "subscriptionDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "enumValues": null

--- a/schema.json
+++ b/schema.json
@@ -14803,13 +14803,21 @@
               "name": "name",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -287,4 +287,31 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe '#starting_in_the_future?' do
+    context 'when subscription is active' do
+      let(:subscription) { create(:active_subscription) }
+
+      it 'returns false' do
+        expect(subscription.starting_in_the_future?).to be false
+      end
+    end
+
+    context 'when subscription is pending and starting in the future' do
+      let(:subscription) { create(:pending_subscription) }
+
+      it 'returns true' do
+        expect(subscription.starting_in_the_future?).to be true
+      end
+    end
+
+    context 'when subscription is pending and downgraded' do
+      let(:old_subscription) { create(:active_subscription) }
+      let(:subscription) { create(:pending_subscription, previous_subscription: old_subscription) }
+
+      it 'returns false' do
+        expect(subscription.starting_in_the_future?).to be false
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -8,13 +8,17 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
   let(:plan) { create(:plan, organization: organization) }
 
   describe 'create' do
+    let(:subscription_date) { '2022-06-06' }
+    let(:plan_code) { plan.code }
+
     let(:params) do
       {
         external_customer_id: customer.external_id,
-        plan_code: plan.code,
+        plan_code: plan_code,
         name: 'subscription name',
         external_id: SecureRandom.uuid,
         billing_time: 'anniversary',
+        subscription_date: subscription_date,
       }
     end
 
@@ -32,20 +36,29 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       expect(json[:subscription][:name]).to eq('subscription name')
       expect(json[:subscription][:started_at]).to be_present
       expect(json[:subscription][:billing_time]).to eq('anniversary')
+      expect(json[:subscription][:subscription_date].to_s).to eq('2022-06-06')
       expect(json[:subscription][:previous_plan_code]).to be_nil
       expect(json[:subscription][:next_plan_code]).to be_nil
       expect(json[:subscription][:downgrade_plan_date]).to be_nil
     end
 
     context 'with invalid plan code' do
-      let(:params) do
-        { plan_code: plan.code }
-      end
+      let(:plan_code) { "#{plan.code}-invalid" }
 
-      it 'returns a not_found error' do
+      it 'returns an unprocessable_entity error' do
         post_with_token(organization, '/api/v1/subscriptions', { subscription: params })
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'with invalid subscription_date' do
+      let(:subscription_date) { 'hello' }
+
+      it 'returns an unprocessable_entity error' do
+        post_with_token(organization, '/api/v1/subscriptions', { subscription: params })
+
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
   end
 
   describe 'update' do
-    let(:subscription) { create(:subscription, customer: customer, plan: plan) }
-    let(:update_params) { { name: 'subscription name new' } }
+    let(:subscription) { create(:pending_subscription, customer: customer, plan: plan) }
+    let(:update_params) { { name: 'subscription name new', subscription_date: '2022-09-05' } }
 
     before { subscription }
 
@@ -98,6 +98,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       expect(response).to have_http_status(:success)
       expect(json[:subscription][:lago_id]).to eq(subscription.id)
       expect(json[:subscription][:name]).to eq('subscription name new')
+      expect(json[:subscription][:subscription_date].to_s).to eq('2022-09-05')
     end
 
     context 'with not existing subscription' do

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -45,10 +45,10 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
     context 'with invalid plan code' do
       let(:plan_code) { "#{plan.code}-invalid" }
 
-      it 'returns an unprocessable_entity error' do
+      it 'returns a not_found error' do
         post_with_token(organization, '/api/v1/subscriptions', { subscription: params })
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -451,6 +451,24 @@ RSpec.describe Subscriptions::CreateService, type: :service do
             end
           end
 
+          context 'when current subscription is pending' do
+            before { subscription.pending! }
+
+            it 'returns existing subscription with updated attributes' do
+              result = create_service.create_from_api(
+                organization: organization,
+                params: params,
+              )
+
+              aggregate_failures do
+                expect(result).to be_success
+                expect(result.subscription.id).to eq(subscription.id)
+                expect(result.subscription.plan_id).to eq(higher_plan.id)
+                expect(result.subscription.name).to eq('invoice display name new')
+              end
+            end
+          end
+
           context 'when old subscription is payed in arrear' do
             before { plan.update!(pay_in_advance: false) }
 
@@ -546,6 +564,24 @@ RSpec.describe Subscriptions::CreateService, type: :service do
               expect(result.subscription.id).to eq(subscription.id)
               expect(result.subscription).to be_active
               expect(result.subscription.next_subscription).to be_present
+            end
+          end
+
+          context 'when current subscription is pending' do
+            before { subscription.pending! }
+
+            it 'returns existing subscription with updated attributes' do
+              result = create_service.create_from_api(
+                organization: organization,
+                params: params,
+              )
+
+              aggregate_failures do
+                expect(result).to be_success
+                expect(result.subscription.id).to eq(subscription.id)
+                expect(result.subscription.plan_id).to eq(lower_plan.id)
+                expect(result.subscription.name).to eq('invoice display name new')
+              end
             end
           end
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -190,7 +190,8 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error.messages[:customer]).to eq(['customer_not_found'])
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('customer_not_found')
         end
       end
     end
@@ -212,7 +213,8 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error.messages[:plan]).to eq(['plan_not_found'])
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('plan_not_found')
         end
       end
     end
@@ -229,7 +231,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         }
       end
 
-      it 'returns invalid_subscription_date error' do
+      it 'returns invalid_date error' do
         result = create_service.create_from_api(
           organization: organization,
           params: params,
@@ -237,7 +239,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error.messages[:subscription_date]).to eq(['invalid_subscription_date'])
+          expect(result.error.messages[:subscription_date]).to eq(['invalid_date'])
         end
       end
     end
@@ -607,7 +609,8 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error.messages[:customer]).to eq(['customer_not_found'])
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('customer_not_found')
         end
       end
     end
@@ -626,7 +629,8 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error.messages[:plan]).to eq(['plan_not_found'])
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('plan_not_found')
         end
       end
     end
@@ -642,12 +646,12 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         }
       end
 
-      it 'returns invalid_subscription_date error' do
+      it 'returns invalid_date error' do
         result = create_service.create(**params)
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error.messages[:subscription_date]).to eq(['invalid_subscription_date'])
+          expect(result.error.messages[:subscription_date]).to eq(['invalid_date'])
         end
       end
     end

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Subscriptions::ValidateService, type: :service do
+  subject(:validate_service) { described_class.new(result, **args) }
+
+  let(:result) { BaseService::Result.new }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:plan) { create(:plan, organization: organization) }
+  let(:subscription_date) { '2022-07-07' }
+
+  let(:args) do
+    {
+      customer: customer,
+      plan: plan,
+      subscription_date: subscription_date,
+    }
+  end
+
+  describe '.valid?' do
+    it 'returns true' do
+      expect(validate_service).to be_valid
+    end
+
+    context 'when customer does not exist' do
+      let(:customer) { nil }
+
+      it 'returns false and result has errors' do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:customer]).to eq(['customer_not_found'])
+      end
+    end
+
+    context 'when plan does not exist' do
+      let(:plan) { nil }
+
+      it 'returns false and result has errors' do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:plan]).to eq(['plan_not_found'])
+      end
+    end
+
+    context 'with invalid subscription_date' do
+      context 'when string cannot be parsed to date' do
+        let(:subscription_date) { 'invalid' }
+
+        it 'returns false and result has errors' do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:subscription_date]).to eq(['invalid_subscription_date'])
+        end
+      end
+
+      context 'when subscription_date is integer' do
+        let(:subscription_date) { 123 }
+
+        it 'returns false and result has errors' do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:subscription_date]).to eq(['invalid_subscription_date'])
+        end
+      end
+    end
+  end
+end

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -30,7 +30,11 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error.messages[:customer]).to eq(['customer_not_found'])
+
+        aggregate_failures do
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('customer_not_found')
+        end
       end
     end
 
@@ -39,7 +43,11 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error.messages[:plan]).to eq(['plan_not_found'])
+
+        aggregate_failures do
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('plan_not_found')
+        end
       end
     end
 
@@ -49,7 +57,7 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
 
         it 'returns false and result has errors' do
           expect(validate_service).not_to be_valid
-          expect(result.error.messages[:subscription_date]).to eq(['invalid_subscription_date'])
+          expect(result.error.messages[:subscription_date]).to eq(['invalid_date'])
         end
       end
 
@@ -58,7 +66,7 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
 
         it 'returns false and result has errors' do
           expect(validate_service).not_to be_valid
-          expect(result.error.messages[:subscription_date]).to eq(['invalid_subscription_date'])
+          expect(result.error.messages[:subscription_date]).to eq(['invalid_date'])
         end
       end
     end


### PR DESCRIPTION
## Context

This change allows creating subscription with preselected subscription_date.

## Description

This is the first PR for `subscription on specific date` feature

In this PR only necessary logic for creating subscription on specific date is added.

Upgrade/downgrade; subscription update and converting pending to active subscriptions will be handled in following PRs
