### PR TITLE
feat(credit_notes): Expose credit notes into GraphQL

### DIFF
--- a/app/graphql/types/credit_note_items/object.rb
+++ b/app/graphql/types/credit_note_items/object.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Types
+  module CreditNoteItems
+    class Object < Types::BaseObject
+      graphql_name 'CreditNoteItem'
+
+      field :id, ID, null: false
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :amount_currency, Types::CurrencyEnum, null: false
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      field :fee, Types::Fees::Object, null: false
+    end
+  end
+end

--- a/app/graphql/types/credit_notes/object.rb
+++ b/app/graphql/types/credit_notes/object.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Types
+  module CreditNotes
+    class Object < Types::BaseObject
+      graphql_name 'CreditNote'
+
+      field :id, ID, null: false
+      field :sequential_id, ID, null: false
+      field :number, String, null: false
+
+      field :status, Types::CreditNotes::StatusTypeEnum, null: false
+      field :reason, Types::CreditNotes::ReasonTypeEnum, null: false
+
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :amount_currency, Types::CurrencyEnum, null: false
+
+      field :remaining_amount_cents, GraphQL::Types::BigInt, null: false
+      field :remaining_amount_currency, Types::CurrencyEnum, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      # TODO: Expose credit note document
+      # field :file_url, String, null: true
+
+      field :invoice, Types::Invoices::Object
+      field :items, [Types::CreditNoteItems::Object], null: false
+    end
+  end
+end

--- a/app/graphql/types/credit_notes/reason_type_enum.rb
+++ b/app/graphql/types/credit_notes/reason_type_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module CreditNotes
+    class ReasonTypeEnum < Types::BaseEnum
+      graphql_name 'CreditNoteReasonEnum'
+
+      CreditNote::REASON.each do |reason|
+        value reason
+      end
+    end
+  end
+end

--- a/app/graphql/types/credit_notes/status_type_enum.rb
+++ b/app/graphql/types/credit_notes/status_type_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module CreditNotes
+    class StatusTypeEnum < Types::BaseEnum
+      graphql_name 'CreditNoteTypeEnum'
+
+      CreditNote::STATUS.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/customers/single_object.rb
+++ b/app/graphql/types/customers/single_object.rb
@@ -9,6 +9,7 @@ module Types
       field :subscriptions, [Types::Subscriptions::Object], resolver: Resolvers::Customers::SubscriptionsResolver
       field :applied_coupons, [Types::AppliedCoupons::Object], null: true
       field :applied_add_ons, [Types::AppliedAddOns::Object], null: true
+      field :credit_notes, [Types::CreditNotes::Object], null: true
       field :currency, Types::CurrencyEnum, null: true
 
       def invoices

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  module Fees
+    class Object < Types::BaseObject
+      graphql_name 'Fee'
+      implements Types::Invoices::InvoiceItem
+
+      field :vat_amount_cents, GraphQL::Types::BigInt, null: false
+      field :vat_amount_currency, Types::CurrencyEnum, null: false
+
+      field :vat_rate, GraphQL::Types::Float, null: true
+      field :units, GraphQL::Types::Float, null: false
+      field :events_count, GraphQL::Types::BigInt, null: true
+
+      def item_type
+        object.fee_type
+      end
+    end
+  end
+end

--- a/app/graphql/types/invoices/invoice_item.rb
+++ b/app/graphql/types/invoices/invoice_item.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Types
+  module Invoices
+    module InvoiceItem
+      include Types::BaseInterface
+      description 'Invoice Item'
+
+      field :id, ID, null: false
+
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :amount_currency, Types::CurrencyEnum, null: false
+
+      field :item_type, String, null: false
+      field :item_code, String, null: false
+      field :item_name, String, null: false
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1732,6 +1732,39 @@ input CreateSubscriptionInput {
   subscriptionId: ID
 }
 
+type CreditNote {
+  amountCents: BigInt!
+  amountCurrency: CurrencyEnum!
+  createdAt: ISO8601DateTime!
+  id: ID!
+  invoice: Invoice
+  items: [CreditNoteItem!]!
+  number: String!
+  reason: CreditNoteReasonEnum!
+  remainingAmountCents: BigInt!
+  remainingAmountCurrency: CurrencyEnum!
+  sequentialId: ID!
+  status: CreditNoteTypeEnum!
+  updatedAt: ISO8601DateTime!
+}
+
+type CreditNoteItem {
+  amountCents: BigInt!
+  amountCurrency: CurrencyEnum!
+  createdAt: ISO8601DateTime!
+  fee: Fee!
+  id: ID!
+}
+
+enum CreditNoteReasonEnum {
+  overpaid
+}
+
+enum CreditNoteTypeEnum {
+  available
+  consumed
+}
+
 enum CurrencyEnum {
   """
   United Arab Emirates dirham
@@ -2492,6 +2525,7 @@ type CustomerDetails {
   city: String
   country: CountryCode
   createdAt: ISO8601DateTime!
+  creditNotes: [CreditNote!]
   currency: CurrencyEnum
   email: String
   externalId: String!
@@ -2705,6 +2739,20 @@ type EventCollection {
   metadata: CollectionMetadata!
 }
 
+type Fee implements InvoiceItem {
+  amountCents: BigInt!
+  amountCurrency: CurrencyEnum!
+  eventsCount: BigInt
+  id: ID!
+  itemCode: String!
+  itemName: String!
+  itemType: String!
+  units: Float!
+  vatAmountCents: BigInt!
+  vatAmountCurrency: CurrencyEnum!
+  vatRate: Float
+}
+
 type GraduatedRange {
   flatAmount: String!
   fromValue: Int!
@@ -2769,6 +2817,18 @@ type Invoice {
   updatedAt: ISO8601DateTime!
   vatAmountCents: Int!
   vatAmountCurrency: CurrencyEnum!
+}
+
+"""
+Invoice Item
+"""
+interface InvoiceItem {
+  amountCents: BigInt!
+  amountCurrency: CurrencyEnum!
+  id: ID!
+  itemCode: String!
+  itemName: String!
+  itemType: String!
 }
 
 enum InvoiceStatusTypeEnum {

--- a/schema.json
+++ b/schema.json
@@ -5576,6 +5576,400 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "CreditNote",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoice",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Invoice",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "items",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CreditNoteItem",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "number",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "reason",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CreditNoteReasonEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "remainingAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "remainingAmountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "sequentialId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "status",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CreditNoteTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CreditNoteItem",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fee",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Fee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "CreditNoteReasonEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "overpaid",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "CreditNoteTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "available",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "consumed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
           "kind": "ENUM",
           "name": "CurrencyEnum",
           "description": null,
@@ -7143,6 +7537,28 @@
               ]
             },
             {
+              "name": "creditNotes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CreditNote",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "currency",
               "description": null,
               "type": {
@@ -8508,6 +8924,213 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Fee",
+          "description": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "InvoiceItem",
+              "ofType": null
+            }
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "eventsCount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "itemCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "itemName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "itemType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "units",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "vatAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "vatAmountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "vatRate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
           "kind": "SCALAR",
           "name": "Float",
           "description": "Represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).",
@@ -9246,6 +9869,133 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "InvoiceItem",
+          "description": "Invoice Item",
+          "interfaces": [
+
+          ],
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "Fee",
+              "ofType": null
+            }
+          ],
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "itemCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "itemName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "itemType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 }
               },

--- a/spec/factories/coupon_factory.rb
+++ b/spec/factories/coupon_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :coupon do
     organization
     name { Faker::Name.name }
-    code { Faker::Name.first_name }
+    code { Faker::Alphanumeric.alphanumeric(number: 10) }
     coupon_type { 'fixed_amount' }
     status { 'active' }
     expiration { 'no_expiration' }

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -12,6 +12,21 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
           subscriptions(status: [active]) { id, status }
           appliedCoupons { id amountCents amountCurrency coupon { id name } }
           appliedAddOns { id amountCents amountCurrency addOn { id name } }
+          creditNotes {
+            id
+            status
+            reason
+            amountCents
+            amountCurrency
+            remainingAmountCents
+            remainingAmountCurrency
+            items {
+              id
+              amountCents
+              amountCurrency
+              fee { id amountCents amountCurrency itemType itemCode itemName vatRate units eventsCount }
+            }
+          }
         }
       }
     GQL
@@ -24,11 +39,14 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
   end
   let(:subscription) { create(:subscription, customer: customer) }
   let(:applied_add_on) { create(:applied_add_on, customer: customer) }
+  let(:credit_note) { create(:credit_note, customer: customer) }
+  let(:credit_note_item) { create(:credit_note_item, credit_note: credit_note) }
 
   before do
     create_list(:invoice, 2, customer: customer)
     applied_add_on
     subscription
+    credit_note_item
   end
 
   it 'returns a single customer' do


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR exposes the customer `creditNotes` into the GraphQL schema. It is attached to the `customerDetails` type