### PR TITLE
activate pending subscriptions

### DIFF
--- a/app/jobs/clock/activate_subscriptions_job.rb
+++ b/app/jobs/clock/activate_subscriptions_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Clock
+  class ActivateSubscriptionsJob < ApplicationJob
+    queue_as 'clock'
+
+    def perform
+      Subscriptions::ActivateService.new.activate_all_pending
+    end
+  end
+end

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class ActivateService < BaseService
+    def activate_all_pending
+      Subscription
+        .pending
+        .where(previous_subscription: nil)
+        .where(subscription_date: Time.current.to_date)
+        .find_each do |subscription|
+          subscription.mark_as_active!
+
+          BillSubscriptionJob.perform_later([subscription], Time.current.to_i) if subscription.plan.pay_in_advance?
+        end
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -16,6 +16,10 @@ module Clockwork
     Sentry.capture_exception(error)
   end
 
+  every(1.day, 'schedule:activate_subscriptions', at: '00:30') do
+    Clock::ActivateSubscriptionsJob.perform_later
+  end
+
   every(1.day, 'schedule:bill_customers', at: '01:00') do
     Clock::SubscriptionsBillerJob.perform_later
   end

--- a/spec/clock_spec.rb
+++ b/spec/clock_spec.rb
@@ -27,4 +27,25 @@ describe Clockwork do
       expect(Clock::SubscriptionsBillerJob).to have_been_enqueued
     end
   end
+
+  describe 'schedule:activate_subscriptions' do
+    let(:job) { 'schedule:activate_subscriptions' }
+    let(:start_time) { Time.zone.parse('1 Apr 2022 00:01:00') }
+    let(:end_time) { Time.zone.parse('1 Apr 2022 00:31:00') }
+
+    it 'enqueue a activate subscriptions job' do
+      Clockwork::Test.run(
+        file: clock_file,
+        start_time: start_time,
+        end_time: end_time,
+        tick_speed: 1.second,
+      )
+
+      expect(Clockwork::Test).to be_ran_job(job)
+      expect(Clockwork::Test.times_run(job)).to eq(1)
+
+      Clockwork::Test.block_for(job).call
+      expect(Clock::ActivateSubscriptionsJob).to have_been_enqueued
+    end
+  end
 end

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Subscriptions::ActivateService, type: :service do
+  subject(:activate_service) { described_class.new }
+
+  describe 'activate_all_expired' do
+    let(:active_subscription) { create(:active_subscription) }
+    let(:pending_subscriptions) { create_list(:pending_subscription, 3, subscription_date: Time.current.to_date) }
+
+    let(:future_pending_subscriptions) do
+      create_list(:pending_subscription, 2, subscription_date: (Time.current + 10.days).to_date)
+    end
+
+    before do
+      active_subscription
+      pending_subscriptions
+      future_pending_subscriptions
+    end
+
+    it 'activates all pending subscriptions with subscription date set to today' do
+      expect do
+        activate_service.activate_all_pending
+      end.to change(Subscription.pending, :count).by(-3).and change(Subscription.active, :count).by(3)
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR belongs to subscription on specific date feature

## Description

This PR is follow up to the https://github.com/getlago/lago-api/pull/506. When current date is the same as subscription date on pending subscriptions; we should activate them and trigger invoice if paying is in advance
