### PR TITLE
feat(customers): HOTFIX for customer currency migration

### DIFF
--- a/db/migrate/20221007075812_run_customer_currency_task_again.rb
+++ b/db/migrate/20221007075812_run_customer_currency_task_again.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RunCustomerCurrencyTaskAgain < ActiveRecord::Migration[7.0]
+  def change
+    # NOTE: Wait to ensure workers are loaded with the added tasks
+    MigrationTaskJob.set(wait: 20.seconds).perform_later('customers:populate_currency')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_30_143002) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_07_075812) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/lib/tasks/customers.rake
+++ b/lib/tasks/customers.rake
@@ -9,7 +9,7 @@ namespace :customers do
   desc 'Set customer currency from active subscription'
   task populate_currency: :environment do
     Customer.where(currency: nil).find_each do |customer|
-      currencies = customer.subscriptions.map { |s| s.plan.currency }.uniq
+      currencies = customer.subscriptions.map { |s| s.plan.amount_currency }.uniq
       next if currencies.size > 1 || currencies.size.zero?
 
       customer.update!(currency: currencies.first)


### PR DESCRIPTION
## Context

There is an issue with the migration task to populate customer currency

## Description

The objective of this PR is to fix the migration task and force it to run again on app upgrade to prevent some user to be blocked with the subscription update of some of their customers