### PR TITLE
feat(credit_notes): Download and generate credit note PDF from API

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -16,6 +16,24 @@ module Api
         )
       end
 
+      def download
+        credit_note = current_organization.credit_notes.find_by(id: params[:id])
+        return not_found_error(resource: 'credit_note') unless credit_note
+
+        if credit_note.file.present?
+          return render(
+            json: ::V1::CreditNoteSerializer.new(
+              credit_note,
+              root_name: 'credit_note',
+            ),
+          )
+        end
+
+        CreditNotes::GeneratePdfJob.perform_later(credit_note)
+
+        head(:ok)
+      end
+
       def index
         credit_notes = current_organization.credit_notes
 

--- a/app/jobs/credit_notes/generate_pdf_job.rb
+++ b/app/jobs/credit_notes/generate_pdf_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class GeneratePdfJob < ApplicationJob
+    queue_as 'invoices'
+
+    def perform(credit_note)
+      CreditNotes::GenerateService.new.call_from_api(credit_note: credit_note)
+    end
+  end
+end

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -32,10 +32,12 @@ class SendWebhookJob < ApplicationJob
 
     # NOTE: This add the new way of managing webhooks
     # A refact has to be done to improve webhooks management internally
+    when 'credit_note.generated'
+      Webhooks::CreditNotes::GeneratedService.new(object).call
     when 'invoice.generated'
       Webhooks::Invoices::GeneratedService.new(object).call
     else
-      raise NotImplementedError
+      raise(NotImplementedError)
     end
   end
 end

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -8,6 +8,8 @@ class CreditNote < ApplicationRecord
   belongs_to :customer
   belongs_to :invoice
 
+  has_one :organization, through: :customer
+
   has_many :items, class_name: 'CreditNoteItem'
   has_many :fees, through: :items
 
@@ -23,6 +25,12 @@ class CreditNote < ApplicationRecord
   enum reason: REASON
 
   sequenced scope: ->(credit_note) { CreditNote.where(invoice_id: credit_note.invoice_id) }
+
+  def file_url
+    return if file.blank?
+
+    Rails.application.routes.url_helpers.rails_blob_url(file, host: ENV['LAGO_API_URL'])
+  end
 
   private
 

--- a/app/serializers/v1/credit_note_serializer.rb
+++ b/app/serializers/v1/credit_note_serializer.rb
@@ -17,15 +17,22 @@ module V1
         remaining_amount_currency: model.remaining_amount_currency,
         created_at: model.created_at.iso8601,
         updated_at: model.updated_at.iso8601,
-        file_url: nil, # TODO: Expose credit note document in API
+        file_url: model.file_url,
       }
 
+      payload = payload.merge(customer) if include?(:customer)
       payload = payload.merge(items) if include?(:items)
 
       payload
     end
 
     private
+
+    def customer
+      {
+        customer: ::V1::CustomerSerializer.new(model.customer).serialize,
+      }
+    end
 
     def items
       ::CollectionSerializer.new(

--- a/app/services/credit_notes/generate_service.rb
+++ b/app/services/credit_notes/generate_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class GenerateService < BaseService
+    def call_from_api(credit_note:)
+      generate_pdf(credit_note)
+    end
+
+    def call(credit_note_id:)
+      credit_note = CreditNote.find_by(id: credit_note_id)
+      return result.not_found_failure!(resource: 'credit_note') if credit_note.blank?
+
+      generate_pdf(credit_note) if credit_note.file.blank?
+
+      result.credit_note = credit_note
+      result
+    end
+
+    private
+
+    def generate_pdf(credit_note)
+      pdf_service = Utils::PdfGenerator.new(template: 'credit_note', context: credit_note)
+      pdf_result = pdf_service.call
+
+      credit_note.file.attach(
+        io: pdf_result.io,
+        filename: "#{credit_note.number}.pdf",
+        content_type: 'application/pdf',
+      )
+
+      credit_note.save!
+    end
+  end
+end

--- a/app/services/credit_notes/generate_service.rb
+++ b/app/services/credit_notes/generate_service.rb
@@ -4,6 +4,8 @@ module CreditNotes
   class GenerateService < BaseService
     def call_from_api(credit_note:)
       generate_pdf(credit_note)
+
+      SendWebhookJob.perform_later('credit_note.generated', credit_note)
     end
 
     def call(credit_note_id:)

--- a/app/services/invoices/generate_service.rb
+++ b/app/services/invoices/generate_service.rb
@@ -24,24 +24,11 @@ module Invoices
     private
 
     def generate_pdf(invoice)
-      template = File.read(Rails.root.join('app/views/templates/invoice.slim'), encoding: 'UTF-8')
-      invoice_html = Slim::Template.new { template }.render(invoice)
-
-      pdf_url = URI.join(ENV['LAGO_PDF_URL'], '/forms/chromium/convert/html').to_s
-      http_client = LagoHttpClient::Client.new(pdf_url)
-      response = http_client.post_multipart_file(
-        invoice_html,
-        'text/html',
-        'index.html',
-        scale: '1.28',
-        marginTop: '0.42',
-        marginBottom: '0.42',
-        marginLeft: '0.42',
-        marginRight: '0.42',
-      )
+      pdf_service = Utils::PdfGenerator.new(template: 'invoice', context: invoice)
+      pdf_result = pdf_service.call
 
       invoice.file.attach(
-        io: StringIO.new(response.body.force_encoding('UTF-8')),
+        io: pdf_result.io,
         filename: "#{invoice.number}.pdf",
         content_type: 'application/pdf',
       )

--- a/app/services/invoices/generate_service.rb
+++ b/app/services/invoices/generate_service.rb
@@ -2,8 +2,6 @@
 
 module Invoices
   class GenerateService < BaseService
-    include ActiveSupport::NumberHelper
-
     def generate_from_api(invoice)
       generate_pdf(invoice)
 

--- a/app/services/utils/pdf_generator.rb
+++ b/app/services/utils/pdf_generator.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Utils
+  class PdfGenerator < BaseService
+    def initialize(template:, context:)
+      @template = template
+      @context = context
+
+      super(nil)
+    end
+
+    def call
+      result.io = StringIO.new(render_pdf)
+      result
+    end
+
+    private
+
+    attr_reader :template, :context
+
+    def template_file
+      File.read(Rails.root.join("app/views/templates/#{template}.slim"), encoding: 'UTF-8')
+    end
+
+    def render_html
+      Slim::Template.new { template_file }.render(context)
+    end
+
+    def pdf_url
+      URI.join(ENV['LAGO_PDF_URL'], '/forms/chromium/convert/html').to_s
+    end
+
+    def render_pdf
+      http_client = LagoHttpClient::Client.new(pdf_url)
+
+      response = http_client.post_multipart_file(
+        render_html,
+        'text/html',
+        'index.html',
+        scale: '1.28',
+        marginTop: '0.42',
+        marginBottom: '0.42',
+        marginLeft: '0.42',
+        marginRight: '0.42',
+      )
+
+      response.body.force_encoding('UTF-8')
+    end
+  end
+end

--- a/app/services/utils/pdf_generator.rb
+++ b/app/services/utils/pdf_generator.rb
@@ -2,6 +2,8 @@
 
 module Utils
   class PdfGenerator < BaseService
+    include ActiveSupport::NumberHelper
+
     def initialize(template:, context:)
       @template = template
       @context = context

--- a/app/services/webhooks/credit_notes/generated_service.rb
+++ b/app/services/webhooks/credit_notes/generated_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module CreditNotes
+    class GeneratedService < Webhooks::BaseService
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::CreditNoteSerializer.new(
+          object,
+          root_name: 'credit_note',
+          includes: %i[customer],
+        )
+      end
+
+      def webhook_type
+        'credit_note.generated'
+      end
+
+      def object_type
+        'credit_note'
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,9 @@ Rails.application.routes.draw do
       resources :add_ons, param: :code
       resources :billable_metrics, param: :code
       resources :coupons, param: :code
-      resources :credit_notes, only: %i[show index]
+      resources :credit_notes, only: %i[show index] do
+        post :download, on: :member
+      end
       resources :events, only: %i[create show]
       resources :applied_coupons, only: %i[create]
       resources :applied_add_ons, only: %i[create]

--- a/spec/factories/credit_notes.rb
+++ b/spec/factories/credit_notes.rb
@@ -12,5 +12,15 @@ FactoryBot.define do
 
     remaining_amount_cents { 100 }
     remaining_amount_currency { 'EUR' }
+
+    trait :with_file do
+      after(:build) do |credit_note|
+        credit_note.file.attach(
+          io: File.open(Rails.root.join('spec/fixtures/blank.pdf')),
+          filename: 'blank.pdf',
+          content_type: 'application/pdf',
+        )
+      end
+    end
   end
 end

--- a/spec/jobs/credit_notes/generate_pdf_job_spec.rb
+++ b/spec/jobs/credit_notes/generate_pdf_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::GeneratePdfJob, type: :job do
+  let(:credit_note) { create(:credit_note) }
+
+  let(:generate_service) do
+    instance_double(CreditNotes::GenerateService)
+  end
+
+  it 'delegates to the Generate service' do
+    allow(CreditNotes::GenerateService).to receive(:new)
+      .and_return(generate_service)
+    allow(generate_service).to receive(:call_from_api)
+      .with(credit_note: credit_note)
+
+    described_class.perform_now(credit_note)
+
+    expect(CreditNotes::GenerateService).to have_received(:new)
+    expect(generate_service).to have_received(:call_from_api)
+  end
+end

--- a/spec/services/credit_notes/generate_service_spec.rb
+++ b/spec/services/credit_notes/generate_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::GenerateService, type: :service do
+  subject(:credit_note_generate_service) { described_class.new }
+
+  let(:organization) { create(:organization, name: 'LAGO') }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:invoice) { create(:invoice, customer: customer) }
+  let(:credit_note) { create(:credit_note, invoice: invoice, customer: customer) }
+  let(:fee) { create(:fee, invoice: invoice) }
+  let(:credit_note_item) { create(:credit_note_item, credit_note: credit_note, fee: fee) }
+
+  let(:pdf_content) do
+    File.read(Rails.root.join('spec/fixtures/blank.pdf'))
+  end
+
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_response) do
+    BaseService::Result.new.tap { |r| r.io = StringIO.new(pdf_content) }
+  end
+
+  before do
+    credit_note_item
+
+    allow(Utils::PdfGenerator).to receive(:new)
+      .and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call)
+      .and_return(pdf_response)
+  end
+
+  describe '.call' do
+    it 'generates the credit note synchronously' do
+      result = credit_note_generate_service.call(credit_note_id: credit_note.id)
+
+      expect(result.credit_note.file).to be_present
+    end
+
+    context 'with not found credit_note' do
+      it 'returns a result with error' do
+        result = credit_note_generate_service.call(credit_note_id: '123456')
+
+        expect(result.success).to be_falsey
+        expect(result.error.error_code).to eq('credit_note_not_found')
+      end
+    end
+
+    context 'with already generated file' do
+      before do
+        credit_note.file.attach(
+          io: StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))),
+          filename: 'credit_note.pdf',
+          content_type: 'application/pdf',
+        )
+      end
+
+      it 'does not generate the pdf' do
+        allow(LagoHttpClient::Client).to receive(:new)
+
+        credit_note_generate_service.call(credit_note_id: credit_note.id)
+
+        expect(LagoHttpClient::Client).not_to have_received(:new)
+      end
+    end
+  end
+
+  describe '.call_from_api' do
+    it 'generates the credit_note' do
+      credit_note_generate_service.call_from_api(credit_note: credit_note)
+
+      expect(credit_note.file).to be_present
+    end
+  end
+end

--- a/spec/services/credit_notes/generate_service_spec.rb
+++ b/spec/services/credit_notes/generate_service_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe CreditNotes::GenerateService, type: :service do
   let(:credit_note) { create(:credit_note, invoice: invoice, customer: customer) }
   let(:fee) { create(:fee, invoice: invoice) }
   let(:credit_note_item) { create(:credit_note_item, credit_note: credit_note, fee: fee) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
 
   let(:pdf_content) do
     File.read(Rails.root.join('spec/fixtures/blank.pdf'))
   end
 
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
   let(:pdf_response) do
     BaseService::Result.new.tap { |r| r.io = StringIO.new(pdf_content) }
   end

--- a/spec/services/credit_notes/generate_service_spec.rb
+++ b/spec/services/credit_notes/generate_service_spec.rb
@@ -71,5 +71,11 @@ RSpec.describe CreditNotes::GenerateService, type: :service do
 
       expect(credit_note.file).to be_present
     end
+
+    it 'calls the SendWebhook job' do
+      expect do
+        credit_note_generate_service.call_from_api(credit_note: credit_note)
+      end.to have_enqueued_job(SendWebhookJob)
+    end
   end
 end

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -307,17 +307,18 @@ RSpec.describe Events::CreateService, type: :service do
         end
 
         it 'returns an error and send an error webhook' do
-          result = create_service.call(
-            organization: organization,
-            params: create_args,
-            timestamp: timestamp,
-            metadata: {},
-          )
+          result = nil
 
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(SendWebhookJob).to have_been_enqueued
-          end
+          expect do
+            result = create_service.call(
+              organization: organization,
+              params: create_args,
+              timestamp: timestamp,
+              metadata: {},
+            )
+          end.to have_enqueued_job(SendWebhookJob)
+
+          expect(result).not_to be_success
         end
       end
     end

--- a/spec/services/utils/pdf_generator_spec.rb
+++ b/spec/services/utils/pdf_generator_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Utils::PdfGenerator, type: :service do
+  subject(:pdf_generator_service) { described_class.new(template: 'invoice', context: invoice) }
+
+  let(:invoice) { create(:invoice) }
+  let(:pdf_response) do
+    File.read(Rails.root.join('spec/fixtures/blank.pdf'))
+  end
+
+  before do
+    stub_request(:post, "#{ENV['LAGO_PDF_URL']}/forms/chromium/convert/html")
+      .to_return(body: pdf_response, status: 200)
+  end
+
+  describe '.call' do
+    it 'generated the document synchronously' do
+      result = pdf_generator_service.call
+
+      expect(result.io).to be_present
+    end
+  end
+end

--- a/spec/services/webhooks/credit_notes/generated_service_spec.rb
+++ b/spec/services/webhooks/credit_notes/generated_service_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::CreditNotes::GeneratedService do
+  subject(:webhook_service) { described_class.new(credit_note) }
+
+  let(:credit_note) { create(:credit_note, customer: customer) }
+
+  let(:organization) { create(:organization, webhook_url: webhook_url) }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:webhook_url) { 'http://foo.bar' }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post)
+    end
+
+    it 'builds payload with credit_note.generated webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post) do |payload|
+        expect(payload[:webhook_type]).to eq('credit_note.generated')
+        expect(payload[:object_type]).to eq('credit_note')
+        expect(payload['credit_note'][:customer]).to be_present
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR adds:
- A new route to download a credit note PDF
- A new webhook `credit_note.generated` sent when the credit note PDF is generated
- The credit note PDF generation logic