### PR TITLE
fix(invoices): Fix Typo on persistent BM on Inovoice PDF

### DIFF
--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -531,7 +531,7 @@ html
               - else
                 h2.invoice-details-title.title-2.mb-24 #{subscription.plan.name} details
 
-              .body-1.mb-24 Breackdown of #{fee.item_name}
+              .body-1.mb-24 Breakdown of #{fee.item_name}
               .breakdown-details.mb-24
                 table.breakdown-details-table width="100%"
                   - recurring_breakdown(fee).each do |breakdown|


### PR DESCRIPTION
## Context

<img width="837" alt="Screenshot 2022-10-07 at 15 37 13" src="https://user-images.githubusercontent.com/471200/194569486-6106d715-51f4-4b94-8337-61657aa88585.png">

## Description

The objective of this PR is to fix a typo in the invoice PDF template