### PR TITLE
fix (subscriptions): update logic for including charges in the first invoice

### DIFF
--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -107,6 +107,11 @@ module Invoices
     end
 
     def should_create_charge_fees?(invoice, subscription)
+      # We should take a look at charges if subscription is created in the past and if it is not upgrade
+      if subscription.plan.pay_in_advance? && subscription.started_in_past? && subscription.previous_subscription.nil?
+        return true
+      end
+
       # NOTE: Charges should not be billed in advance when we are just upgrading to a new
       #       pay_in_advance subscription
       return false if subscription.plan.pay_in_advance? && subscription.invoices.where.not(id: invoice.id).count.zero?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -63,7 +63,8 @@ Charge.create_with(
   )
 
   sub = Subscription.create_with(
-    started_at: Time.zone.now - 3.months,
+    started_at: Time.current - 3.months,
+    subscription_date: (Time.current - 3.months).to_date,
     status: :active,
   ).find_or_create_by!(
     customer: customer,


### PR DESCRIPTION
## Context

Include charges in the first invoice for subscription created in the past

## Description

Usually we do not include charges in the first invoice when plan is pay in advance because for payment in advance first invoice is generated right after subscription creation so there are not charges at that time. However, with this change we still want to bill charges even with first invoice but only for subscription that are created with subscription date in the past.