### PR TITLE
fix(errors): Event error webhook after error management refactoring

### DIFF
--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -72,7 +72,7 @@ module Events
       if organization.webhook_url?
         SendWebhookJob.perform_later(
           :event,
-          { input_params: params, error: result.error, organization_id: organization.id },
+          { input_params: params, error: result.error.message, organization_id: organization.id },
         )
       end
 


### PR DESCRIPTION
## Context

The recent changes related to the error management have introduce a regression with the error web-hook for event ingestion.

Before the change, error attached to a service result was a message or a code, and it was sent as the error message in the web-hook.
With the new error management, result error are subclass of `Base::FailedResult`. The issue is that this error cannot be serialized for sidekiq job, leading to an `ActiveJob::SerializationError` when trying to send the webhook.

## Description

This fixes changes the behavior to send the error message, and adds a test for this specific case
