### PR TITLE
feat(credit_notes): Add credit note details in invoice webhook and API payload

### DIFF
--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -11,15 +11,28 @@ class Credit < ApplicationRecord
 
   validates :amount_currency, inclusion: { in: currency_list }
 
+  def item_id
+    return coupon&.id if applied_coupon_id
+
+    credit_note.id
+  end
+
   def item_type
-    'coupon'
+    return 'coupon' if applied_coupon_id?
+
+    'credit_note'
   end
 
   def item_code
-    coupon&.code
+    return coupon&.code if applied_coupon_id?
+
+    credit_note.number
   end
 
   def item_name
-    coupon&.name
+    return coupon&.name if applied_coupon_id?
+
+    # TODO: change it depending on invoice template
+    credit_note.invoice.number
   end
 end

--- a/app/serializers/v1/credit_serializer.rb
+++ b/app/serializers/v1/credit_serializer.rb
@@ -4,9 +4,11 @@ module V1
   class CreditSerializer < ModelSerializer
     def serialize
       {
+        lago_id: model.id,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,
         item: {
+          lago_id: model.item_id,
           type: model.item_type,
           code: model.item_code,
           name: model.item_name,

--- a/db/migrate/20221010083509_rename_credit_credit_note.rb
+++ b/db/migrate/20221010083509_rename_credit_credit_note.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameCreditCreditNote < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :credits, :credit_notes_id, :credit_note_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_07_075812) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_10_083509) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -167,9 +167,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_07_075812) do
     t.string "amount_currency", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "credit_notes_id"
+    t.uuid "credit_note_id"
     t.index ["applied_coupon_id"], name: "index_credits_on_applied_coupon_id"
-    t.index ["credit_notes_id"], name: "index_credits_on_credit_notes_id"
+    t.index ["credit_note_id"], name: "index_credits_on_credit_note_id"
     t.index ["invoice_id"], name: "index_credits_on_invoice_id"
   end
 
@@ -464,7 +464,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_07_075812) do
   add_foreign_key "credit_notes", "customers"
   add_foreign_key "credit_notes", "invoices"
   add_foreign_key "credits", "applied_coupons"
-  add_foreign_key "credits", "credit_notes", column: "credit_notes_id"
+  add_foreign_key "credits", "credit_notes"
   add_foreign_key "credits", "invoices"
   add_foreign_key "customers", "organizations"
   add_foreign_key "events", "customers"

--- a/spec/factories/credit_factory.rb
+++ b/spec/factories/credit_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     amount_currency { 'EUR' }
   end
 
-  factory :credit_note_credit do
+  factory :credit_note_credit, class: 'Credit' do
     invoice
     credit_note
 

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -3,4 +3,42 @@
 require 'rails_helper'
 
 RSpec.describe Credit, type: :model do
+  describe 'invoice item' do
+    context 'when credit is a coupon' do
+      subject(:credit) { create(:credit, applied_coupon: applied_coupon) }
+
+      let(:applied_coupon) { create(:applied_coupon, coupon: coupon) }
+      let(:coupon) do
+        create(
+          :coupon,
+          code: 'coupon_code',
+          name: 'Coupon name',
+        )
+      end
+
+      it 'returns coupon details' do
+        aggregate_failures do
+          expect(credit.item_id).to eq(coupon.id)
+          expect(credit.item_type).to eq('coupon')
+          expect(credit.item_code).to eq('coupon_code')
+          expect(credit.item_name).to eq('Coupon name')
+        end
+      end
+    end
+
+    context 'when credit is a credit note' do
+      subject(:credit) { create(:credit_note_credit) }
+
+      let(:credit_note) { credit.credit_note }
+
+      it 'returns credit note details' do
+        aggregate_failures do
+          expect(credit.item_id).to eq(credit_note.id)
+          expect(credit.item_type).to eq('credit_note')
+          expect(credit.item_code).to eq(credit_note.number)
+          expect(credit.item_name).to eq(credit_note.invoice.number)
+        end
+      end
+    end
+  end
 end

--- a/spec/serializers/v1/credit_serializer_spec.rb
+++ b/spec/serializers/v1/credit_serializer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::CreditSerializer do
+  subject(:serializer) { described_class.new(credit, root_name: 'credit') }
+
+  let(:credit) { create(:credit) }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['credit']['lago_id']).to eq(credit.id)
+      expect(result['credit']['amount_cents']).to eq(credit.amount_cents)
+      expect(result['credit']['amount_currency']).to eq(credit.amount_currency)
+      expect(result['credit']['item']['lago_id']).to eq(credit.item_id)
+      expect(result['credit']['item']['type']).to eq(credit.item_type)
+      expect(result['credit']['item']['code']).to eq(credit.item_code)
+      expect(result['credit']['item']['name']).to eq(credit.item_name)
+    end
+  end
+end


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR adds the credit note details in the `credit` serializer used in both invoice webhooks and API response payloads