### PR TITLE
feat(groups): Create table groups

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -4,6 +4,7 @@ class BillableMetric < ApplicationRecord
   belongs_to :organization
 
   has_many :charges, dependent: :destroy
+  has_many :groups, dependent: :destroy
   has_many :plans, through: :charges
   has_many :persisted_events
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Group < ApplicationRecord
+  belongs_to :billable_metric
+  belongs_to :parent, class_name: 'Group', foreign_key: 'parent_group_id', optional: true
+  has_many :children, class_name: 'Group', foreign_key: 'parent_group_id'
+
+  STATUS = %i[active inactive].freeze
+  enum status: STATUS
+
+  scope :parents, -> { where(parent_group_id: nil) }
+  scope :children, -> { where.not(parent_group_id: nil) }
+end

--- a/db/migrate/20221004092737_create_groups.rb
+++ b/db/migrate/20221004092737_create_groups.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :groups, id: :uuid do |t|
+      t.references :billable_metric, type: :uuid, index: true, foreign_key: { on_delete: :cascade }, null: false
+      t.references :parent_group, type: :uuid, index: true, foreign_key: { to_table: 'groups' }
+      t.string :key, null: false
+      t.string :value, null: false
+      t.integer :status, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -244,6 +244,18 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_07_075812) do
     t.index ["subscription_id"], name: "index_fees_on_subscription_id"
   end
 
+  create_table "groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "billable_metric_id", null: false
+    t.uuid "parent_group_id"
+    t.string "key", null: false
+    t.string "value", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["billable_metric_id"], name: "index_groups_on_billable_metric_id"
+    t.index ["parent_group_id"], name: "index_groups_on_parent_group_id"
+  end
+
   create_table "invites", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "organization_id", null: false
     t.uuid "membership_id"
@@ -474,6 +486,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_07_075812) do
   add_foreign_key "fees", "charges"
   add_foreign_key "fees", "invoices"
   add_foreign_key "fees", "subscriptions"
+  add_foreign_key "groups", "billable_metrics", on_delete: :cascade
+  add_foreign_key "groups", "groups", column: "parent_group_id"
   add_foreign_key "invites", "memberships"
   add_foreign_key "invites", "organizations"
   add_foreign_key "invoice_subscriptions", "invoices"

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :group do
+    billable_metric
+    key { 'region' }
+    value { 'europe' }
+    status { 'active' }
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to create the `groups` table.

