### PR TITLE
feat(groups): Add service for creating groups on a billable metric

### DIFF
--- a/app/services/groups/create_batch_service.rb
+++ b/app/services/groups/create_batch_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Groups
+  class CreateBatchService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(billable_metric:, group_params:)
+      @billable_metric = billable_metric
+      @group_params = group_params.with_indifferent_access
+    end
+
+    def call
+      # TODO: return errors
+      ActiveRecord::Base.transaction do
+        if one_dimension?
+          create_groups(group_params[:key], group_params[:values])
+        else
+          group_params[:values].each do |value|
+            parent_group = billable_metric.groups.create!(key: group_params[:key], value: value[:name])
+            create_groups(value[:key], value[:values], parent_group.id)
+          end
+        end
+      end
+    end
+
+    private
+
+    attr_reader :billable_metric, :group_params
+
+    def create_groups(key, values, parent_group_id = nil)
+      values.each do |value|
+        billable_metric.groups.create!(
+          key: key,
+          value: value,
+          parent_group_id: parent_group_id,
+        )
+      end
+    end
+
+    def one_dimension?
+      # ie: { key: "region", values: ["USA", "EUROPE"] }
+      group_params[:values].all?(String)
+    end
+  end
+end

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -20,12 +20,21 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
         description: 'New metric description',
         organization_id: organization.id,
         aggregation_type: 'count_agg',
+        group: {
+          key: 'region',
+          values: %w[usa europe],
+        },
       }
     end
 
     it 'creates a billable metric' do
       expect { create_service.create(**create_args) }
-        .to change { BillableMetric.count }.by(1)
+        .to change(BillableMetric, :count).by(1)
+    end
+
+    it 'creates expected groups' do
+      expect { create_service.create(**create_args) }
+        .to change(Group, :count).by(2)
     end
 
     it 'calls SegmentTrackJob' do

--- a/spec/services/groups/create_batch_service_spec.rb
+++ b/spec/services/groups/create_batch_service_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Groups::CreateBatchService, type: :service do
+  subject(:create_batch_service) do
+    described_class.call(
+      billable_metric: billable_metric,
+      group_params: group_params,
+    )
+  end
+
+  let(:billable_metric) { create(:billable_metric) }
+
+  context 'with one dimension' do
+    let(:group_params) do
+      { "key": 'region', "values": %w[usa europe] }
+    end
+
+    it 'creates expected groups' do
+      expect { create_batch_service }.to change(Group, :count).by(2)
+
+      expect(billable_metric.reload.groups.pluck(:key, :value))
+        .to match_array([%w[region usa], %w[region europe]])
+    end
+  end
+
+  context 'with two dimensions' do
+    let(:group_params) do
+      {
+        "key": 'cloud',
+        "values": [
+          {
+            "name": 'AWS',
+            "key": 'region',
+            "values": %w[usa europe],
+          },
+          {
+            "name": 'Google',
+            "key": 'region',
+            "values": %w[usa],
+          },
+        ],
+      }
+    end
+
+    it 'creates expected groups' do
+      expect { create_batch_service }.to change(Group, :count).by(5)
+
+      groups = billable_metric.reload.groups
+      aws = groups.find_by(key: 'cloud', value: 'AWS')
+      expect(aws.children.pluck(:key, :value)).to match_array([%w[region usa], %w[region europe]])
+
+      google = groups.find_by(key: 'cloud', value: 'Google')
+      expect(google.children.pluck(:key, :value)).to eq([%w[region usa]])
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to add the service for creating groups on a specific billable metric.