### PR TITLE
feat(groups): Accept group in GraphQL for billable metric

### DIFF
--- a/app/graphql/mutations/billable_metrics/create.rb
+++ b/app/graphql/mutations/billable_metrics/create.rb
@@ -14,6 +14,7 @@ module Mutations
       argument :description, String
       argument :aggregation_type, Types::BillableMetrics::AggregationTypeEnum, required: true
       argument :field_name, String, required: false
+      argument :group, GraphQL::Types::JSON, required: false
 
       type Types::BillableMetrics::Object
 

--- a/app/graphql/mutations/billable_metrics/update.rb
+++ b/app/graphql/mutations/billable_metrics/update.rb
@@ -14,6 +14,7 @@ module Mutations
       argument :description, String
       argument :aggregation_type, Types::BillableMetrics::AggregationTypeEnum, required: true
       argument :field_name, String, required: false
+      argument :group, GraphQL::Types::JSON, required: false
 
       type Types::BillableMetrics::Object
 

--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -13,6 +13,7 @@ module Types
       field :description, String
       field :aggregation_type, Types::BillableMetrics::AggregationTypeEnum, null: false
       field :field_name, String, null: true
+      field :group, GraphQL::Types::JSON, null: true
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
@@ -23,6 +24,10 @@ module Types
 
       def can_be_deleted
         object.deletable?
+      end
+
+      def group
+        object.groups_as_tree
       end
     end
   end

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -4,6 +4,7 @@ class BillableMetric < ApplicationRecord
   belongs_to :organization
 
   has_many :charges, dependent: :destroy
+  has_many :groups, dependent: :destroy
   has_many :plans, through: :charges
   has_many :persisted_events
 

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -35,6 +35,29 @@ class BillableMetric < ApplicationRecord
     AGGREGATION_TYPES.include?(value&.to_sym) ? super : nil
   end
 
+  def groups_as_tree
+    groups = self.groups.active
+    return {} if groups.blank?
+
+    unless groups.children.exists?
+      return {
+        key: groups.pluck(:key).uniq.first,
+        values: groups.pluck(:value),
+      }
+    end
+
+    {
+      key: groups.parents.pluck(:key).uniq.first,
+      values: groups.parents.map do |p|
+        {
+          name: p.value,
+          key: p.children.first.key,
+          values: p.children.pluck(:value),
+        }
+      end,
+    }
+  end
+
   private
 
   def should_have_field_name?

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Group < ApplicationRecord
+  belongs_to :billable_metric
+  belongs_to :parent, class_name: 'Group', foreign_key: 'parent_group_id', optional: true
+  has_many :children, class_name: 'Group', foreign_key: 'parent_group_id'
+
+  STATUS = %i[active inactive].freeze
+  enum status: STATUS
+
+  scope :parents, -> { where(parent_group_id: nil) }
+  scope :children, -> { where.not(parent_group_id: nil) }
+end

--- a/app/serializers/v1/billable_metric_serializer.rb
+++ b/app/serializers/v1/billable_metric_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 module V1
   class BillableMetricSerializer < ModelSerializer
     def serialize
@@ -10,7 +10,8 @@ module V1
         description: model.description,
         aggregation_type: model.aggregation_type,
         created_at: model.created_at.iso8601,
-        field_name: model.field_name
+        field_name: model.field_name,
+        group: model.groups_as_tree,
       }
     end
   end

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -15,6 +15,13 @@ module BillableMetrics
         metric.code = args[:code]
         metric.aggregation_type = args[:aggregation_type]&.to_sym
         metric.field_name = args[:field_name]
+
+        if args[:group].present?
+          ActiveRecord::Base.transaction do
+            metric.groups.each(&:inactive!)
+            Groups::CreateBatchService.call(billable_metric: metric, group_params: args[:group])
+          end
+        end
       end
 
       metric.save!

--- a/app/services/groups/create_batch_service.rb
+++ b/app/services/groups/create_batch_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Groups
+  class CreateBatchService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(billable_metric:, group_params:)
+      @billable_metric = billable_metric
+      @group_params = group_params.with_indifferent_access
+    end
+
+    def call
+      # TODO: return errors
+      ActiveRecord::Base.transaction do
+        if one_dimension?
+          create_groups(group_params[:key], group_params[:values])
+        else
+          group_params[:values].each do |value|
+            parent_group = billable_metric.groups.create!(key: group_params[:key], value: value[:name])
+            create_groups(value[:key], value[:values], parent_group.id)
+          end
+        end
+      end
+    end
+
+    private
+
+    attr_reader :billable_metric, :group_params
+
+    def create_groups(key, values, parent_group_id = nil)
+      values.each do |value|
+        billable_metric.groups.create!(
+          key: key,
+          value: value,
+          parent_group_id: parent_group_id,
+        )
+      end
+    end
+
+    def one_dimension?
+      # ie: { key: "region", values: ["USA", "EUROPE"] }
+      group_params[:values].all?(String)
+    end
+  end
+end

--- a/db/migrate/20221004092737_create_groups.rb
+++ b/db/migrate/20221004092737_create_groups.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :groups, id: :uuid do |t|
+      t.references :billable_metric, type: :uuid, index: true, foreign_key: { on_delete: :cascade }, null: false
+      t.references :parent_group, type: :uuid, index: true, foreign_key: { to_table: 'groups' }
+      t.string :key, null: false
+      t.string :value, null: false
+      t.integer :status, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -244,6 +244,18 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_07_075812) do
     t.index ["subscription_id"], name: "index_fees_on_subscription_id"
   end
 
+  create_table "groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "billable_metric_id", null: false
+    t.uuid "parent_group_id"
+    t.string "key", null: false
+    t.string "value", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["billable_metric_id"], name: "index_groups_on_billable_metric_id"
+    t.index ["parent_group_id"], name: "index_groups_on_parent_group_id"
+  end
+
   create_table "invites", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "organization_id", null: false
     t.uuid "membership_id"
@@ -474,6 +486,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_07_075812) do
   add_foreign_key "fees", "charges"
   add_foreign_key "fees", "invoices"
   add_foreign_key "fees", "subscriptions"
+  add_foreign_key "groups", "billable_metrics", on_delete: :cascade
+  add_foreign_key "groups", "groups", column: "parent_group_id"
   add_foreign_key "invites", "memberships"
   add_foreign_key "invites", "organizations"
   add_foreign_key "invoice_subscriptions", "invoices"

--- a/schema.graphql
+++ b/schema.graphql
@@ -121,6 +121,7 @@ type BillableMetric {
   createdAt: ISO8601DateTime!
   description: String
   fieldName: String
+  group: JSON
   id: ID!
   name: String!
   organization: Organization
@@ -143,6 +144,7 @@ type BillableMetricDetail {
   createdAt: ISO8601DateTime!
   description: String
   fieldName: String
+  group: JSON
   id: ID!
   name: String!
   organization: Organization
@@ -1600,6 +1602,7 @@ input CreateBillableMetricInput {
   code: String!
   description: String!
   fieldName: String
+  group: JSON
   name: String!
 }
 
@@ -3729,6 +3732,7 @@ input UpdateBillableMetricInput {
   code: String!
   description: String!
   fieldName: String
+  group: JSON
   id: String!
   name: String!
 }

--- a/schema.json
+++ b/schema.json
@@ -1013,6 +1013,20 @@
               ]
             },
             {
+              "name": "group",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -1242,6 +1256,20 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "group",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -4637,6 +4665,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "group",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
                 "ofType": null
               },
               "defaultValue": null,
@@ -14566,6 +14606,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "group",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :group do
+    billable_metric
+    key { 'region' }
+    value { 'europe' }
+    status { 'active' }
+  end
+end

--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe BillableMetric, type: :model do
-  subject(:billable_metric) { described_class.new }
+  let(:billable_metric) { described_class.new }
 
   describe '#aggregation_type=' do
     it 'assigns the aggregation type' do
@@ -25,6 +25,62 @@ RSpec.describe BillableMetric, type: :model do
           expect(billable_metric.aggregation_type).to be_nil
           expect(billable_metric.errors[:aggregation_type]).to include('value_is_invalid')
         end
+      end
+    end
+  end
+
+  describe '#groups_as_tree' do
+    let(:billable_metric) { create(:billable_metric) }
+
+    context 'without active groups' do
+      it 'returns {}' do
+        expect(billable_metric.groups_as_tree).to eq({})
+      end
+    end
+
+    context 'when groups contain one dimension' do
+      before do
+        create(:group, billable_metric: billable_metric, key: 'country', value: 'france')
+        create(:group, billable_metric: billable_metric, key: 'country', value: 'italy')
+      end
+
+      it 'returns a tree with one dimension' do
+        expect(billable_metric.groups_as_tree).to eq(
+          {
+            key: 'country',
+            values: %w[france italy],
+          },
+        )
+      end
+    end
+
+    context 'when groups contain two dimensions' do
+      before do
+        france = create(:group, billable_metric: billable_metric, key: 'country', value: 'france')
+        italy = create(:group, billable_metric: billable_metric, key: 'country', value: 'italy')
+        create(:group, billable_metric: billable_metric, key: 'cloud', value: 'aws', parent_group_id: france.id)
+        create(:group, billable_metric: billable_metric, key: 'cloud', value: 'google', parent_group_id: france.id)
+        create(:group, billable_metric: billable_metric, key: 'cloud', value: 'google', parent_group_id: italy.id)
+      end
+
+      it 'returns a tree with two dimensions' do
+        expect(billable_metric.groups_as_tree).to eq(
+          {
+            key: 'country',
+            values: [
+              {
+                name: 'france',
+                key: 'cloud',
+                values: %w[aws google],
+              },
+              {
+                name: 'italy',
+                key: 'cloud',
+                values: %w[google],
+              },
+            ],
+          },
+        )
       end
     end
   end

--- a/spec/serializers/v1/billable_metric_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_serializer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ::V1::BillableMetricSerializer do
       expect(result['billable_metric']['aggregation_type']).to eq(billable_metric.aggregation_type)
       expect(result['billable_metric']['field_name']).to eq(billable_metric.field_name)
       expect(result['billable_metric']['created_at']).to eq(billable_metric.created_at.iso8601)
+      expect(result['billable_metric']['group']).to eq({})
     end
   end
 end

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -20,12 +20,21 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
         description: 'New metric description',
         organization_id: organization.id,
         aggregation_type: 'count_agg',
+        group: {
+          key: 'region',
+          values: %w[usa europe],
+        },
       }
     end
 
     it 'creates a billable metric' do
       expect { create_service.create(**create_args) }
-        .to change { BillableMetric.count }.by(1)
+        .to change(BillableMetric, :count).by(1)
+    end
+
+    it 'creates expected groups' do
+      expect { create_service.create(**create_args) }
+        .to change(Group, :count).by(2)
     end
 
     it 'calls SegmentTrackJob' do

--- a/spec/services/groups/create_batch_service_spec.rb
+++ b/spec/services/groups/create_batch_service_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Groups::CreateBatchService, type: :service do
+  subject(:create_batch_service) do
+    described_class.call(
+      billable_metric: billable_metric,
+      group_params: group_params,
+    )
+  end
+
+  let(:billable_metric) { create(:billable_metric) }
+
+  context 'with one dimension' do
+    let(:group_params) do
+      { "key": 'region', "values": %w[usa europe] }
+    end
+
+    it 'creates expected groups' do
+      expect { create_batch_service }.to change(Group, :count).by(2)
+
+      expect(billable_metric.reload.groups.pluck(:key, :value))
+        .to match_array([%w[region usa], %w[region europe]])
+    end
+  end
+
+  context 'with two dimensions' do
+    let(:group_params) do
+      {
+        "key": 'cloud',
+        "values": [
+          {
+            "name": 'AWS',
+            "key": 'region',
+            "values": %w[usa europe],
+          },
+          {
+            "name": 'Google',
+            "key": 'region',
+            "values": %w[usa],
+          },
+        ],
+      }
+    end
+
+    it 'creates expected groups' do
+      expect { create_batch_service }.to change(Group, :count).by(5)
+
+      groups = billable_metric.reload.groups
+      aws = groups.find_by(key: 'cloud', value: 'AWS')
+      expect(aws.children.pluck(:key, :value)).to match_array([%w[region usa], %w[region europe]])
+
+      google = groups.find_by(key: 'cloud', value: 'Google')
+      expect(google.children.pluck(:key, :value)).to eq([%w[region usa]])
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to accept groups in GraphQL for a billable metric, on creation and update.