### PR TITLE
feat(groups): Create or update groups via API

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -29,7 +29,7 @@ module Api
         result = service.update_from_api(
           organization: current_organization,
           code: params[:code],
-          params: input_params,
+          params: input_params.to_h,
         )
 
         if result.success?
@@ -103,6 +103,7 @@ module Api
           :description,
           :aggregation_type,
           :field_name,
+          group: {},
         )
       end
     end

--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -16,7 +16,7 @@ module BillableMetrics
         if args[:group].present?
           Groups::CreateBatchService.call(
             billable_metric: metric,
-            group_params: args[:group],
+            group_params: args[:group].with_indifferent_access,
           )
         end
 

--- a/app/services/groups/create_batch_service.rb
+++ b/app/services/groups/create_batch_service.rb
@@ -8,7 +8,7 @@ module Groups
 
     def initialize(billable_metric:, group_params:)
       @billable_metric = billable_metric
-      @group_params = group_params.with_indifferent_access
+      @group_params = group_params
     end
 
     def call

--- a/spec/graphql/mutations/billable_metrics/update_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/update_spec.rb
@@ -47,15 +47,18 @@ RSpec.describe Mutations::BillableMetrics::Update, type: :graphql do
   end
 
   context 'with group parameter' do
-    it 'updates billable metric\'s group' do
-      create(:group, billable_metric: billable_metric)
-      group = {
+    let(:group) do
+      {
         key: 'cloud',
         values: [
           { name: 'AWS', key: 'region', values: %w[usa europe] },
           { name: 'Google', key: 'region', values: ['usa'] },
         ],
       }
+    end
+
+    it 'updates billable metric\'s group' do
+      create(:group, billable_metric: billable_metric)
 
       result = execute_graphql(
         current_user: membership.user,
@@ -71,8 +74,8 @@ RSpec.describe Mutations::BillableMetrics::Update, type: :graphql do
           },
         },
       )
-
       result_data = result['data']['updateBillableMetric']
+
       expect(result_data['group']).to eq(group)
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to accept groups in API for a billable metric, on creation and update.