### PR TITLE
fix(docker): arm64 image is missing dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ COPY . /app
 RUN apk add --no-cache \
   bash \
   postgresql-dev \
-  tzdata
+  tzdata \
+  libc6-compat
 
 ARG SEGMENT_WRITE_KEY
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ COPY . /app
 RUN apk add --no-cache \
   bash \
   postgresql-dev \
-  tzdata \
-  libc6-compat
+  tzdata
 
 ARG SEGMENT_WRITE_KEY
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -29,7 +29,8 @@ COPY . /app
 RUN apk add --no-cache \
   bash \
   postgresql-dev \
-  tzdata
+  tzdata \
+  libc6-compat
 
 ARG SEGMENT_WRITE_KEY
 


### PR DESCRIPTION
## Context

ARM64 image is missing dependency on the last version `v0.11.0-alpha`

## Description

- Add the missing dependency in the `Dockerfile.arm64` file