### PR TITLE
fix(test): method called should be the same as describe

### DIFF
--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -64,9 +64,11 @@ RSpec.describe UsersService, type: :service do
   end
 
   describe 'login' do
+    let(:membership) { create(:membership) }
+
     it 'calls SegmentIdentifyJob' do
       allow(SegmentIdentifyJob).to receive(:perform_later)
-      result = user_service.register('email', 'password', 'organization_name')
+      result = user_service.login(membership.user.email, membership.user.password)
 
       expect(SegmentIdentifyJob).to have_received(:perform_later).with(
         membership_id: "membership/#{result.user.memberships.first.id}",


### PR DESCRIPTION
## Context

A user service spec is present in the codebase.

It does have `describe` blocks per methods in the service.

I noticed the `login` block was calling `register` method

## Description

This PR fixes this by calling the `login` method instead.

We need to create a membership first too.

Please note the `login` method accept only 2 args

A test for the `register` method is already present in the file
