### PR TITLE
feat(groups): Change error message to value_is_invalid for groups

### DIFF
--- a/app/services/groups/create_batch_service.rb
+++ b/app/services/groups/create_batch_service.rb
@@ -14,7 +14,7 @@ module Groups
     end
 
     def call
-      return result.validation_failure!(errors: { group: %w[invalid_format] }) unless valid_format?
+      return result.validation_failure!(errors: { group: %w[value_is_invalid] }) unless valid_format?
 
       ActiveRecord::Base.transaction do
         if one_dimension?

--- a/spec/requests/api/v1/billable_metrics_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
 
         aggregate_failures do
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(json[:error_details]).to eq({ group: %w[invalid_format] })
+          expect(json[:error_details]).to eq({ group: %w[value_is_invalid] })
         end
       end
     end
@@ -114,7 +114,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
 
         aggregate_failures do
           expect(response).to have_http_status(:unprocessable_entity)
-          expect(json[:error_details]).to eq({ group: %w[invalid_format] })
+          expect(json[:error_details]).to eq({ group: %w[value_is_invalid] })
         end
       end
     end

--- a/spec/services/groups/create_batch_service_spec.rb
+++ b/spec/services/groups/create_batch_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Groups::CreateBatchService, type: :service do
       aggregate_failures do
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages[:group]).to eq(['invalid_format'])
+        expect(result.error.messages[:group]).to eq(['value_is_invalid'])
       end
     end
   end
@@ -52,7 +52,7 @@ RSpec.describe Groups::CreateBatchService, type: :service do
       aggregate_failures do
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages[:group]).to eq(['invalid_format'])
+        expect(result.error.messages[:group]).to eq(['value_is_invalid'])
       end
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to rename error message on groups from `invalid_format` to `value_is_invalid` to be consistent with other errors.