### PR TITLE
fix (subscriptions): add new condition for invoicing upon subscription termination

### DIFF
--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -53,11 +53,12 @@ module Subscriptions
     private
 
     def process_terminate(subscription)
-      unless subscription.terminated?
+      if subscription.starting_in_the_future?
+        subscription.mark_as_terminated!
+      elsif !subscription.terminated?
         subscription.mark_as_terminated!
 
-        BillSubscriptionJob
-          .perform_later([subscription], subscription.terminated_at)
+        BillSubscriptionJob.perform_later([subscription], subscription.terminated_at)
       end
 
       # NOTE: Pending next subscription should be canceled as well

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe Subscriptions::TerminateService do
       end.to have_enqueued_job(BillSubscriptionJob)
     end
 
+    context 'when subscription is starting in the future' do
+      let(:subscription) { create(:pending_subscription) }
+
+      it 'does not enqueue a BillSubscriptionJob' do
+        expect do
+          terminate_service.terminate(subscription.id)
+        end.not_to have_enqueued_job(BillSubscriptionJob)
+      end
+    end
+
     context 'when subscription is not found' do
       let(:subscription) { OpenStruct.new(id: '123456') }
 


### PR DESCRIPTION
## Context

When terminating _starting in the future_ subscription, we don't want to trigger invoice generation
