### PR TITLE
fix(groups): Correct validation format of groups

### DIFF
--- a/app/services/groups/create_batch_service.rb
+++ b/app/services/groups/create_batch_service.rb
@@ -51,13 +51,11 @@ module Groups
     #   }]
     # }
     def valid_format?
-      return false unless group_params[:key].is_a?(String)
+      return false unless group_params[:key].is_a?(String) && group_params[:values].is_a?(Array)
       return true if one_dimension?
+      return false unless group_params[:values].all?(Hash)
 
-      values = group_params[:values]
-      return false if !values.is_a?(Array) && values.size != 2
-
-      values.map { |e| [e[:name], e[:key], e[:values]] }.flatten.all?(String)
+      group_params[:values].map { |e| [e[:name], e[:key], e[:values]] }.flatten.all?(String)
     end
 
     def create_groups(key, values, parent_group_id = nil)
@@ -72,7 +70,7 @@ module Groups
 
     def one_dimension?
       # ie: { key: "region", values: ["USA", "EUROPE"] }
-      group_params[:key].is_a?(String) && group_params[:values].all?(String)
+      group_params[:key].is_a?(String) && group_params[:values]&.all?(String)
     end
   end
 end

--- a/spec/graphql/mutations/billable_metrics/update_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/update_spec.rb
@@ -82,10 +82,10 @@ RSpec.describe Mutations::BillableMetrics::Update, type: :graphql do
 
   context 'with invalid group parameter' do
     let(:group) do
-      { foo: 'bar' }
+      { key: 'foo', foo: 'bar' }
     end
 
-    it 'creates billable metric\'s group' do
+    it 'returns an error' do
       result = execute_graphql(
         current_user: membership.user,
         query: mutation,

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -52,6 +52,16 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
           update_service.update(**update_args.merge(group: group))
         end.to change { billable_metric.groups.active.reload.count }.from(1).to(5)
       end
+
+      it 'returns an error if group is invalid' do
+        result = update_service.update(**update_args.merge(group: { key: 1 }))
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:group]).to eq(['value_is_invalid'])
+        end
+      end
     end
 
     context 'with validation errors' do
@@ -140,6 +150,20 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
             params: update_args.merge(group: group),
           )
         end.to change { billable_metric.groups.active.reload.count }.from(1).to(5)
+      end
+
+      it 'returns an error if group is invalid' do
+        result = update_service.update_from_api(
+          organization: organization,
+          code: billable_metric.code,
+          params: update_args.merge(group: { key: 1 }),
+        )
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:group]).to eq(['value_is_invalid'])
+        end
       end
     end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to fix the validation of `group` format.