### PR TITLE
fix(user_type): only user's organizations with an active membership s…

### DIFF
--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -8,5 +8,9 @@ module Types
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
     field :organizations, [Types::OrganizationType]
+
+    def organizations
+      object.memberships.active.map(&:organization)
+    end
   end
 end


### PR DESCRIPTION
## Context

When querying for the currentUser, we can retrieve it's list of organizations.

This list is used by the Frontend app in order to log the user in the correct organization.

Today the first orga in the array is choose by default.

Recently with the 'invite member' feature, your membership can have a revoked status on an organisation.

## Description

If you were revoked by an organization, the organization was still returned in the `currentUser` query.

This PR fixes that by overriding the `organizations` relationship in the `Types::UserType`

## To go further

This Pr does not fix all issues a user can face.

For instance, if you're invite to 2 different organization, on log-in you will only access the first one you joined.

This can be fixed later with a "switch organization" feature, that appear to be Frontend only.