### PR TITLE
feat(credit_notes): Add service to create a credit note

### DIFF
--- a/app/graphql/types/credit_note_items/object.rb
+++ b/app/graphql/types/credit_note_items/object.rb
@@ -6,8 +6,8 @@ module Types
       graphql_name 'CreditNoteItem'
 
       field :id, ID, null: false
-      field :amount_cents, GraphQL::Types::BigInt, null: false
-      field :amount_currency, Types::CurrencyEnum, null: false
+      field :credit_amount_cents, GraphQL::Types::BigInt, null: false
+      field :credit_amount_currency, Types::CurrencyEnum, null: false
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
 
       field :fee, Types::Fees::Object, null: false

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -26,6 +26,9 @@ class CreditNote < ApplicationRecord
 
   sequenced scope: ->(credit_note) { CreditNote.where(invoice_id: credit_note.invoice_id) }
 
+  validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
+  validates :remaining_amount_cents, numericality: { greater_than_or_equal_to: 0 }
+
   def file_url
     return if file.blank?
 

--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -5,4 +5,6 @@ class CreditNoteItem < ApplicationRecord
   belongs_to :fee
 
   monetize :credit_amount_cents
+
+  validates :credit_amount_cents, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -4,5 +4,5 @@ class CreditNoteItem < ApplicationRecord
   belongs_to :credit_note
   belongs_to :fee
 
-  monetize :amount_cents
+  monetize :credit_amount_cents
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -44,6 +44,10 @@ class Invoice < ApplicationRecord
     Rails.application.routes.url_helpers.rails_blob_url(file, host: ENV['LAGO_API_URL'])
   end
 
+  def fee_total_amount_cents
+    fees.sum(:amount_cents) + fees.sum(:vat_amount_cents)
+  end
+
   def charge_amount_cents
     fees.charge_kind.sum(:amount_cents)
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -14,6 +14,7 @@ class Invoice < ApplicationRecord
   has_many :invoice_subscriptions
   has_many :subscriptions, through: :invoice_subscriptions
   has_many :plans, through: :subscriptions
+  has_many :credit_notes
 
   has_one_attached :file
 

--- a/app/serializers/v1/credit_note_item_serializer.rb
+++ b/app/serializers/v1/credit_note_item_serializer.rb
@@ -5,8 +5,8 @@ module V1
     def serialize
       {
         lago_id: model.id,
-        amount_cents: model.amount_cents,
-        amount_currency: model.amount_currency,
+        credit_amount_cents: model.credit_amount_cents,
+        credit_amount_currency: model.credit_amount_currency,
         fee: fee,
       }
     end

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -2,7 +2,7 @@
 
 module CreditNotes
   class CreateService < BaseService
-    def initialize(invoice:, items_attr:, reason: :overpaid)
+    def initialize(invoice:, items_attr:, reason: :other)
       @invoice = invoice
       @items_attr = items_attr
       @reason = reason

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -7,7 +7,7 @@ module CreditNotes
       @items_attr = items_attr
       @reason = reason
 
-      super(nil)
+      super
     end
 
     def call

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class CreateService < BaseService
+    def initialize(invoice:, items_attr:, reason: :overpaid)
+      @invoice = invoice
+      @items_attr = items_attr
+      @reason = reason
+
+      super(nil)
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        result.credit_note = CreditNote.create!(
+          customer: invoice.customer,
+          invoice: invoice,
+          amount_currency: invoice.amount_currency,
+          remaining_amount_currency: invoice.amount_currency,
+          reason: reason,
+        )
+
+        create_items
+        return result unless result.success?
+
+        credit_note.update!(
+          remaining_amount_cents: credit_note.credit_amount_cents,
+        )
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_accessor :invoice, :items_attr, :reason
+
+    delegate :credit_note, to: :result
+
+    def create_items
+      items_attr.each do |item_attr|
+        item = credit_note.items.new(
+          fee: invoice.fees.find_by(id: item_attr[:fee_id]),
+          credit_amount_cents: item_attr[:credit_amount_cents],
+          credit_amount_currency: fee.amount_currency,
+        )
+        break unless valid_item?(item)
+
+        item.save!
+
+        # NOTE: update credit note credit amount to allow validation on next item
+        credit_note.update!(
+          credit_amount_cents: credit_note.credit_amount_cents + item.credit_amount_cents,
+        )
+      end
+    end
+
+    def valid_item?(item)
+      CreditNotes::ValidateItemService.new(result, item: item).valid?
+    end
+  end
+end

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -24,7 +24,7 @@ module CreditNotes
         return result unless result.success?
 
         credit_note.update!(
-          remaining_amount_cents: credit_note.credit_amount_cents,
+          remaining_amount_cents: credit_note.amount_cents,
         )
       end
 
@@ -44,7 +44,7 @@ module CreditNotes
         item = credit_note.items.new(
           fee: invoice.fees.find_by(id: item_attr[:fee_id]),
           credit_amount_cents: item_attr[:credit_amount_cents],
-          credit_amount_currency: fee.amount_currency,
+          credit_amount_currency: invoice.amount_currency,
         )
         break unless valid_item?(item)
 
@@ -52,7 +52,7 @@ module CreditNotes
 
         # NOTE: update credit note credit amount to allow validation on next item
         credit_note.update!(
-          credit_amount_cents: credit_note.credit_amount_cents + item.credit_amount_cents,
+          amount_cents: credit_note.amount_cents + item.credit_amount_cents,
         )
       end
     end

--- a/app/services/credit_notes/validate_item_service.rb
+++ b/app/services/credit_notes/validate_item_service.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class ValidateItemService < BaseValidator
+    def valid?
+      return false unless valid_fee?
+
+      valid_individual_amount?
+      valid_global_amount?
+
+      if errors?
+        result.validation_failure!(errors: errors)
+        return false
+      end
+
+      true
+    end
+
+    private
+
+    def item
+      args[:item]
+    end
+
+    delegate :credit_note, :fee, to: :item
+    delegate :invoice, to: :credit_note
+
+    def credited_fee_amount_cents
+      fee.credit_note_items.sum(:credit_amount_cents)
+    end
+
+    def credited_invoice_amount_cents
+      invoice.credit_notes.sum(:amount_cents)
+    end
+
+    def valid_fee?
+      return true if item.fee.present?
+
+      result.not_found_failure!(resource: 'fee')
+
+      false
+    end
+
+    # NOTE: Check if item credit amount is less than or equal to fee remaining creditable amount
+    def valid_individual_amount?
+      return true if match_fee_amount?
+
+      add_error(field: :credit_amount_cents, error_code: 'higher_than_remaining_fee_amount')
+    end
+
+    def match_fee_amount?
+      item.credit_amount_cents.positive? &&
+        item.credit_amount_cents <= fee.amount_cents - credited_fee_amount_cents
+    end
+
+    # NOTE: Check if item credit amount is less than or equal to invoice remaining creditable amount
+    def valid_global_amount?
+      return true if item.credit_amount_cents <= invoice.total_amount_cents - credited_invoice_amount_cents
+
+      add_error(field: :credit_amount_cents, error_code: 'higher_than_remaining_invoice_amount')
+    end
+  end
+end

--- a/app/services/credit_notes/validate_item_service.rb
+++ b/app/services/credit_notes/validate_item_service.rb
@@ -55,7 +55,7 @@ module CreditNotes
 
     # NOTE: Check if item credit amount is less than or equal to invoice remaining creditable amount
     def valid_global_amount?
-      return true if item.credit_amount_cents <= invoice.total_amount_cents - credited_invoice_amount_cents
+      return true if item.credit_amount_cents <= invoice.fee_total_amount_cents - credited_invoice_amount_cents
 
       add_error(field: :credit_amount_cents, error_code: 'higher_than_remaining_invoice_amount')
     end

--- a/db/migrate/20221011083520_rename_credit_note_items.rb
+++ b/db/migrate/20221011083520_rename_credit_note_items.rb
@@ -1,0 +1,8 @@
+# frozen_String_literal: true
+
+class RenameCreditNoteItems < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :credit_note_items, :amount_cents, :credit_amount_cents
+    rename_column :credit_note_items, :amount_currency, :credit_amount_currency
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_10_083509) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_11_083520) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -134,8 +134,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_10_083509) do
   create_table "credit_note_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "credit_note_id", null: false
     t.uuid "fee_id", null: false
-    t.bigint "amount_cents", default: 0, null: false
-    t.string "amount_currency", null: false
+    t.bigint "credit_amount_cents", default: 0, null: false
+    t.string "credit_amount_currency", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["credit_note_id"], name: "index_credit_note_items_on_credit_note_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1753,9 +1753,9 @@ type CreditNote {
 }
 
 type CreditNoteItem {
-  amountCents: BigInt!
-  amountCurrency: CurrencyEnum!
   createdAt: ISO8601DateTime!
+  creditAmountCents: BigInt!
+  creditAmountCurrency: CurrencyEnum!
   fee: Fee!
   id: ID!
 }

--- a/schema.json
+++ b/schema.json
@@ -5888,7 +5888,25 @@
           "possibleTypes": null,
           "fields": [
             {
-              "name": "amountCents",
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditAmountCents",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -5906,7 +5924,7 @@
               ]
             },
             {
-              "name": "amountCurrency",
+              "name": "creditAmountCurrency",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -5914,24 +5932,6 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "CurrencyEnum",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "createdAt",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601DateTime",
                   "ofType": null
                 }
               },

--- a/spec/controllers/api/v1/credit_notes_controller_spec.rb
+++ b/spec/controllers/api/v1/credit_notes_controller_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         json_item = json[:credit_note][:items].first
         item = credit_note_items.first
         expect(json_item[:lago_id]).to eq(item.id)
-        expect(json_item[:amount_cents]).to eq(item.amount_cents)
-        expect(json_item[:amount_currency]).to eq(item.amount_currency)
+        expect(json_item[:credit_amount_cents]).to eq(item.credit_amount_cents)
+        expect(json_item[:credit_amount_currency]).to eq(item.credit_amount_currency)
         expect(json_item[:fee][:lago_id]).to eq(item.fee.id)
         expect(json_item[:fee][:amount_cents]).to eq(item.fee.amount_cents)
         expect(json_item[:fee][:amount_currency]).to eq(item.fee.amount_currency)

--- a/spec/factories/credit_note_items.rb
+++ b/spec/factories/credit_note_items.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :credit_note_item do
     credit_note
     fee
-    amount_cents { 100 }
-    amount_currency { 'EUR' }
+    credit_amount_cents { 100 }
+    credit_amount_currency { 'EUR' }
   end
 end

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
             remainingAmountCurrency
             items {
               id
-              amountCents
-              amountCurrency
+              creditAmountCents
+              creditAmountCurrency
               fee { id amountCents amountCurrency itemType itemCode itemName vatRate units eventsCount }
             }
           }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -149,6 +149,19 @@ RSpec.describe Invoice, type: :model do
     end
   end
 
+  describe '#fee_total_amount_cents' do
+    let(:organization) { create(:organization, name: 'LAGO') }
+    let(:customer) { create(:customer, organization: organization) }
+    let(:invoice) { create(:invoice, customer: customer) }
+    let(:fees) { create_list(:fee, 2, invoice: invoice, amount_cents: 100, vat_amount_cents: 20) }
+
+    before { fees }
+
+    it 'returns the fee amount vat included' do
+      expect(invoice.fee_total_amount_cents).to eq(240)
+    end
+  end
+
   describe '#subscription_amount' do
     let(:organization) { create(:organization, name: 'LAGO') }
     let(:customer) { create(:customer, organization: organization) }

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
         expect(credit_note.amount_cents).to eq(15)
         expect(credit_note.remaining_amount_currency).to eq(invoice.amount_currency)
         expect(credit_note.remaining_amount_cents).to eq(15)
-        expect(credit_note).to be_overpaid
+        expect(credit_note).to be_other
 
         expect(credit_note.items.count).to eq(2)
         items1 = credit_note.items.order(created_at: :asc).first

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::CreateService, type: :service do
+  subject(:create_service) { described_class.new(invoice: invoice, items_attr: items) }
+
+  let(:invoice) { create(:invoice, amount_currency: 'EUR', amount_cents: 20, total_amount_cents: 20) }
+  let(:fee1) { create(:fee, invoice: invoice, amount_cents: 10) }
+  let(:fee2) { create(:fee, invoice: invoice, amount_cents: 10) }
+  let(:items) do
+    [
+      {
+        fee_id: fee1.id,
+        credit_amount_cents: 10,
+      },
+      {
+        fee_id: fee2.id,
+        credit_amount_cents: 5,
+      },
+    ]
+  end
+
+  describe '.call' do
+    it 'creates a credit note' do
+      result = create_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+
+        credit_note = result.credit_note
+        expect(credit_note.invoice).to eq(invoice)
+        expect(credit_note.customer).to eq(invoice.customer)
+        expect(credit_note.amount_currency).to eq(invoice.amount_currency)
+        expect(credit_note.amount_cents).to eq(15)
+        expect(credit_note.remaining_amount_currency).to eq(invoice.amount_currency)
+        expect(credit_note.remaining_amount_cents).to eq(15)
+        expect(credit_note).to be_overpaid
+
+        expect(credit_note.items.count).to eq(2)
+        items1 = credit_note.items.order(created_at: :asc).first
+        expect(items1.fee).to eq(fee1)
+        expect(items1.credit_amount_cents).to eq(10)
+        expect(items1.credit_amount_currency).to eq(invoice.amount_currency)
+
+        items2 = credit_note.items.order(created_at: :asc).last
+        expect(items2.fee).to eq(fee2)
+        expect(items2.credit_amount_cents).to eq(5)
+        expect(items2.credit_amount_currency).to eq(invoice.amount_currency)
+      end
+    end
+
+    context 'with invalid items' do
+      let(:items) do
+        [
+          {
+            fee_id: fee1.id,
+            credit_amount_cents: 10,
+          },
+          {
+            fee_id: fee2.id,
+            credit_amount_cents: 15,
+          },
+        ]
+      end
+
+      it 'returns a failed result' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to eq([:credit_amount_cents])
+          expect(result.error.messages[:credit_amount_cents]).to eq(
+            %w[
+              higher_than_remaining_fee_amount
+              higher_than_remaining_invoice_amount
+            ],
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/credit_notes/validate_item_service_spec.rb
+++ b/spec/services/credit_notes/validate_item_service_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::ValidateItemService, type: :service do
+  subject(:validator) { CreditNotes::ValidateItemService.new(result, item: item) }
+
+  let(:result) { BaseService::Result.new }
+  let(:credit_amount_cents) { 10 }
+  let(:credit_note) do
+    create(
+      :credit_note,
+      invoice: invoice,
+      customer: customer,
+      amount_cents: 0,
+    )
+  end
+  let(:item) do
+    build(
+      :credit_note_item,
+      credit_note: credit_note,
+      credit_amount_cents: credit_amount_cents,
+      fee: fee,
+    )
+  end
+  let(:invoice) { create(:invoice, total_amount_cents: 100) }
+  let(:customer) { invoice.customer }
+
+  let(:fee) { create(:fee, invoice: invoice, amount_cents: 100) }
+
+  describe '.call' do
+    it 'validates the item' do
+      expect(validator).to be_valid
+    end
+
+    context 'when credit amount is higher than fee amount' do
+      let(:credit_amount_cents) { fee.amount_cents + 10 }
+
+      before do
+        invoice.update!(total_amount_cents: 200)
+      end
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:credit_amount_cents]).to eq(['higher_than_remaining_fee_amount'])
+        end
+      end
+    end
+
+    context 'when fee already has credit note items' do
+      before { create(:credit_note_item, fee: fee, credit_amount_cents: 99) }
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:credit_amount_cents]).to eq(['higher_than_remaining_fee_amount'])
+        end
+      end
+    end
+
+    context 'when credit amount is higher than invoice total amount' do
+      before do
+        create(:credit, invoice: invoice, amount_cents: 99)
+        invoice.update!(total_amount_cents: 1)
+      end
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:credit_amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
+        end
+      end
+    end
+
+    context 'when invoice already has credit note items' do
+      before do
+        create(:credit_note, invoice: invoice, amount_cents: 99)
+      end
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:credit_amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
+        end
+      end
+    end
+  end
+end

--- a/spec/services/credit_notes/validate_item_service_spec.rb
+++ b/spec/services/credit_notes/validate_item_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CreditNotes::ValidateItemService, type: :service do
-  subject(:validator) { CreditNotes::ValidateItemService.new(result, item: item) }
+  subject(:validator) { described_class.new(result, item: item) }
 
   let(:result) { BaseService::Result.new }
   let(:credit_amount_cents) { 10 }

--- a/spec/services/credit_notes/validate_item_service_spec.rb
+++ b/spec/services/credit_notes/validate_item_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
       let(:credit_amount_cents) { fee.amount_cents + 10 }
 
       before do
-        invoice.update!(total_amount_cents: 200)
+        create(:fee, invoice: invoice, amount_cents: 100, vat_amount_cents: 20)
       end
 
       it 'fails the validation' do
@@ -72,22 +72,6 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
 
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages[:credit_amount_cents]).to eq(['higher_than_remaining_fee_amount'])
-        end
-      end
-    end
-
-    context 'when credit amount is higher than invoice total amount' do
-      before do
-        create(:credit, invoice: invoice, amount_cents: 99)
-        invoice.update!(total_amount_cents: 1)
-      end
-
-      it 'fails the validation' do
-        aggregate_failures do
-          expect(validator).not_to be_valid
-
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:credit_amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
         end
       end
     end

--- a/spec/services/credit_notes/validate_item_service_spec.rb
+++ b/spec/services/credit_notes/validate_item_service_spec.rb
@@ -33,6 +33,19 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
       expect(validator).to be_valid
     end
 
+    context 'when fee is missing' do
+      let(:fee) { nil }
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq('fee')
+        end
+      end
+    end
+
     context 'when credit amount is higher than fee amount' do
       let(:credit_amount_cents) { fee.amount_cents + 10 }
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR adds the logic to create a credit note from an invoice and a list of fees