### PR TITLE
feat(credit_notes): Add list of credit note reasons

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -19,7 +19,7 @@ class CreditNote < ApplicationRecord
   monetize :remaining_amount_cents
 
   STATUS = %i[available consumed].freeze
-  REASON = %i[overpaid].freeze
+  REASON = %i[duplicated_charge product_unsatisfactory order_change order_cancellation fraudulent_charge other].freeze
 
   enum status: STATUS
   enum reason: REASON

--- a/schema.graphql
+++ b/schema.graphql
@@ -1761,7 +1761,12 @@ type CreditNoteItem {
 }
 
 enum CreditNoteReasonEnum {
-  overpaid
+  duplicated_charge
+  fraudulent_charge
+  order_cancellation
+  order_change
+  other
+  product_unsatisfactory
 }
 
 enum CreditNoteTypeEnum {

--- a/schema.json
+++ b/schema.json
@@ -5991,7 +5991,37 @@
           "inputFields": null,
           "enumValues": [
             {
-              "name": "overpaid",
+              "name": "duplicated_charge",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "product_unsatisfactory",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_change",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order_cancellation",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fraudulent_charge",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "other",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/factories/credit_notes.rb
+++ b/spec/factories/credit_notes.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     invoice
 
     status { 'available' }
-    reason { 'overpaid' }
+    reason { 'duplicated_charge' }
     amount_cents { 100 }
     amount_currency { 'EUR' }
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR updates the credit note model to add the list of accepted credit note reasons