### PR TITLE
feat(groups): Add group properties table

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -7,6 +7,7 @@ class Charge < ApplicationRecord
   belongs_to :billable_metric
 
   has_many :fees
+  has_many :group_properties, dependent: :destroy
 
   CHARGE_MODELS = %i[
     standard
@@ -23,6 +24,10 @@ class Charge < ApplicationRecord
   validate :validate_package, if: :package?
   validate :validate_percentage, if: :percentage?
   validate :validate_volume, if: :volume?
+
+  def properties(group_id: nil)
+    group_properties.find_by(group_id: group_id)&.values || read_attribute(:properties)
+  end
 
   private
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,9 +4,12 @@ class Group < ApplicationRecord
   belongs_to :billable_metric
   belongs_to :parent, class_name: 'Group', foreign_key: 'parent_group_id', optional: true
   has_many :children, class_name: 'Group', foreign_key: 'parent_group_id'
+  has_many :properties, class_name: 'GroupProperty'
 
   STATUS = %i[active inactive].freeze
   enum status: STATUS
+
+  validates :key, :value, presence: true
 
   scope :parents, -> { where(parent_group_id: nil) }
   scope :children, -> { where.not(parent_group_id: nil) }

--- a/app/models/group_property.rb
+++ b/app/models/group_property.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class GroupProperty < ApplicationRecord
+  belongs_to :charge
+  belongs_to :group
+
+  validates :values, presence: true
+end

--- a/db/migrate/20221011133055_create_group_properties.rb
+++ b/db/migrate/20221011133055_create_group_properties.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateGroupProperties < ActiveRecord::Migration[7.0]
+  def change
+    create_table :group_properties, id: :uuid do |t|
+      t.references :charge, type: :uuid, index: true, foreign_key: { on_delete: :cascade }, null: false
+      t.references :group, type: :uuid, index: true, foreign_key: { on_delete: :cascade }, null: false
+      t.jsonb :values, null: false, default: {}
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_11_083520) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_11_133055) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -242,6 +242,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_11_083520) do
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"
     t.index ["invoiceable_type", "invoiceable_id"], name: "index_fees_on_invoiceable"
     t.index ["subscription_id"], name: "index_fees_on_subscription_id"
+  end
+
+  create_table "group_properties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "charge_id", null: false
+    t.uuid "group_id", null: false
+    t.jsonb "values", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["charge_id"], name: "index_group_properties_on_charge_id"
+    t.index ["group_id"], name: "index_group_properties_on_group_id"
   end
 
   create_table "groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -486,6 +496,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_11_083520) do
   add_foreign_key "fees", "charges"
   add_foreign_key "fees", "invoices"
   add_foreign_key "fees", "subscriptions"
+  add_foreign_key "group_properties", "charges", on_delete: :cascade
+  add_foreign_key "group_properties", "groups", on_delete: :cascade
   add_foreign_key "groups", "billable_metrics", on_delete: :cascade
   add_foreign_key "groups", "groups", column: "parent_group_id"
   add_foreign_key "invites", "memberships"

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -5,6 +5,16 @@ FactoryBot.define do
     billable_metric
     plan
 
+    trait :with_group do
+      after(:build) do |charge|
+        create(
+          :group_property,
+          charge: charge,
+          values: charge.properties,
+        )
+      end
+    end
+
     factory :standard_charge do
       charge_model { 'standard' }
       properties do
@@ -33,7 +43,7 @@ FactoryBot.define do
       properties do
         {
           rate: '0.0555',
-          fixed_amount: '2'
+          fixed_amount: '2',
         }
       end
     end

--- a/spec/factories/group_properties.rb
+++ b/spec/factories/group_properties.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :group_property do
+    charge
+    group
+    values do
+      { amount: Faker::Number.between(from: 100, to: 500).to_s }
+    end
+  end
+end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -3,6 +3,25 @@
 require 'rails_helper'
 
 RSpec.describe Charge, type: :model do
+  describe '#properties' do
+    context 'with group properties' do
+      it 'returns the group properties' do
+        charge = create(:standard_charge)
+        property = create(:group_property, charge: charge, values: { foo: 'bar' })
+
+        expect(charge.properties(group_id: property.group_id)).to eq(property.values)
+      end
+    end
+
+    context 'without group properties' do
+      it 'returns the charge properties' do
+        charge = create(:standard_charge)
+
+        expect(charge.properties).to eq(charge.properties)
+      end
+    end
+  end
+
   describe '.validate_graduated_range' do
     subject(:charge) do
       build(:graduated_charge, properties: charge_properties)


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to create the table `group_properties`.