### PR TITLE
feat(groups): Expose flat groups to graphql

### DIFF
--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -14,6 +14,7 @@ module Types
       field :aggregation_type, Types::BillableMetrics::AggregationTypeEnum, null: false
       field :field_name, String, null: true
       field :group, GraphQL::Types::JSON, null: true
+      field :flat_groups, [GraphQL::Types::JSON], null: true
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
@@ -28,6 +29,12 @@ module Types
 
       def group
         object.groups_as_tree
+      end
+
+      def flat_groups
+        object.groups.active.children.map do |group|
+          { id: group.id, key: group.parent.value, value: group.value }
+        end
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -121,6 +121,7 @@ type BillableMetric {
   createdAt: ISO8601DateTime!
   description: String
   fieldName: String
+  flatGroups: [JSON!]
   group: JSON
   id: ID!
   name: String!
@@ -144,6 +145,7 @@ type BillableMetricDetail {
   createdAt: ISO8601DateTime!
   description: String
   fieldName: String
+  flatGroups: [JSON!]
   group: JSON
   id: ID!
   name: String!

--- a/schema.json
+++ b/schema.json
@@ -1013,6 +1013,28 @@
               ]
             },
             {
+              "name": "flatGroups",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "JSON",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "group",
               "description": null,
               "type": {
@@ -1257,6 +1279,28 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "flatGroups",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "JSON",
+                    "ofType": null
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to expose flat groups related to a billable metric.
It's used to display and select groups when creating or updating a plan.