### PR TITLE
feat(credit_notes): Add credit_note.created webhook

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -32,6 +32,8 @@ class SendWebhookJob < ApplicationJob
 
     # NOTE: This add the new way of managing webhooks
     # A refact has to be done to improve webhooks management internally
+    when 'credit_note.created'
+      Webhooks::CreditNotes::CreatedService.new(object).call
     when 'credit_note.generated'
       Webhooks::CreditNotes::GeneratedService.new(object).call
     when 'invoice.generated'

--- a/app/services/webhooks/credit_notes/created_service.rb
+++ b/app/services/webhooks/credit_notes/created_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module CreditNotes
+    class CreatedService < Webhooks::BaseService
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::CreditNoteSerializer.new(
+          object,
+          root_name: 'credit_note',
+          includes: %i[customer items],
+        )
+      end
+
+      def webhook_type
+        'credit_note.created'
+      end
+
+      def object_type
+        'credit_note'
+      end
+    end
+  end
+end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -154,6 +154,28 @@ RSpec.describe SendWebhookJob, type: :job do
     end
   end
 
+  context 'when webhook_type is credit_note.created' do
+    let(:webhook_service) { instance_double(Webhooks::CreditNotes::CreatedService) }
+    let(:credit_note) { create(:credit_note) }
+
+    before do
+      allow(Webhooks::CreditNotes::CreatedService).to receive(:new)
+        .with(credit_note)
+        .and_return(webhook_service)
+      allow(webhook_service).to receive(:call)
+    end
+
+    it 'calls the webhook service' do
+      described_class.perform_now(
+        'credit_note.created',
+        credit_note,
+      )
+
+      expect(Webhooks::CreditNotes::CreatedService).to have_received(:new)
+      expect(webhook_service).to have_received(:call)
+    end
+  end
+
   context 'when webhook_type is credit_note.generated' do
     let(:webhook_service) { instance_double(Webhooks::CreditNotes::GeneratedService) }
     let(:credit_note) { create(:credit_note) }

--- a/spec/services/webhooks/credit_notes/created_service_spec.rb
+++ b/spec/services/webhooks/credit_notes/created_service_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::CreditNotes::CreatedService do
+  subject(:webhook_service) { described_class.new(credit_note) }
+
+  let(:credit_note) { create(:credit_note, customer: customer) }
+
+  let(:organization) { create(:organization, webhook_url: webhook_url) }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:webhook_url) { 'http://foo.bar' }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post)
+    end
+
+    it 'builds payload with credit_note.created webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post) do |payload|
+        expect(payload[:webhook_type]).to eq('credit_note.created')
+        expect(payload[:object_type]).to eq('credit_note')
+        expect(payload['credit_note'][:customer]).to be_present
+        expect(payload['credit_note']['items']).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR adds the new `credit_note.created` webhook type