### PR TITLE
feat(credit_notes): Create a credit note from subscription upgrade

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -43,7 +43,7 @@ module Types
 
       def period_end_date
         ::Subscriptions::DatesService.new_instance(object, Time.zone.today)
-          .next_end_of_period(Time.zone.today)
+          .next_end_of_period
       end
     end
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -105,7 +105,7 @@ class Subscription < ApplicationRecord
     return unless next_subscription.pending?
 
     ::Subscriptions::DatesService.new_instance(self, Time.zone.today)
-      .next_end_of_period(Time.zone.today) + 1.day
+      .next_end_of_period + 1.day
   end
 
   def display_name

--- a/app/services/credit_notes/create_from_upgrade.rb
+++ b/app/services/credit_notes/create_from_upgrade.rb
@@ -8,7 +8,6 @@ module CreditNotes
       super
     end
 
-    # TODO: take VAT into account
     def call
       return result if (last_subscription_fee&.amount_cents || 0).zero?
 

--- a/app/services/credit_notes/create_from_upgrade.rb
+++ b/app/services/credit_notes/create_from_upgrade.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class CreateFromUpgrade < BaseService
+    def initialize(subscription:)
+      @subscription = subscription
+
+      super
+    end
+
+    # TODO: take VAT into account
+    def call
+      return result if (last_subscription_fee&.amount_cents || 0).zero?
+
+      amount = compute_amount
+      return result unless amount.positive?
+
+      vat_amount = (amount * last_subscription_fee.vat_rate).fdiv(100).ceil
+
+      CreditNotes::CreateService.new(
+        invoice: last_subscription_fee.invoice,
+        items_attr: [
+          {
+            fee_id: last_subscription_fee.id,
+            credit_amount_cents: amount + vat_amount,
+          },
+        ],
+      ).call
+    end
+
+    private
+
+    attr_accessor :subscription
+
+    delegate :plan, to: :subscription
+
+    def last_subscription_fee
+      @last_subscription_fee ||= subscription.fees.order(created_at: :desc).last
+    end
+
+    def compute_amount
+      day_price * remaining_duration
+    end
+
+    def termination_date
+      @termination_date ||= subscription.terminated_at.to_date
+    end
+
+    def date_service
+      @date_service ||= Subscriptions::DatesService.new_instance(
+        subscription,
+        termination_date,
+      )
+    end
+
+    def from_date
+      date_service.previous_beginning_of_period(current_period: true)
+    end
+
+    def to_date
+      date_service.next_end_of_period
+    end
+
+    def day_price
+      date_service.single_day_price(optional_from_date: from_date)
+    end
+
+    def remaining_duration
+      billed_from = termination_date
+
+      if plan.has_trial? && subscription.trial_end_date >= termination_date
+        billed_from = if subscription.trial_end_date > to_date
+          to_date
+        else
+          subscription.trial_end_date
+        end
+      end
+
+      (to_date - billed_from).to_i
+    end
+  end
+end

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -201,19 +201,5 @@ module Fees
         optional_from_date: optional_from_date,
       )
     end
-
-    def compute_old_to_date(old_subscription, base_date)
-      return base_date if plan.pay_in_arrear?
-
-      # NOTE: when plan is pay in advance, the_to date should be the
-      #       end of the actual period
-      date_service(old_subscription).next_end_of_period(old_subscription.terminated_at.to_date)
-    end
-
-    def compute_from_date(target_subscription)
-      date_service(target_subscription).previous_beginning_of_period(
-        current_period: target_subscription.plan.pay_in_advance? && subscription.plan.pay_in_advance?,
-      )
-    end
   end
 end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -91,7 +91,7 @@ module Invoices
         to_date: date_service.to_date,
         charges_from_date: date_service.charges_from_date,
         charges_to_date: date_service.charges_to_date,
-        issuing_date: date_service.next_end_of_period(Time.zone.now),
+        issuing_date: date_service.next_end_of_period,
       }
     end
 

--- a/app/services/subscriptions/dates/monthly_service.rb
+++ b/app/services/subscriptions/dates/monthly_service.rb
@@ -58,16 +58,16 @@ module Subscriptions
         build_date(year, month, day)
       end
 
-      def compute_next_end_of_period(date)
-        return date.end_of_month if calendar?
+      def compute_next_end_of_period
+        return billing_date.end_of_month if calendar?
 
-        year = date.year
-        month = date.month
+        year = billing_date.year
+        month = billing_date.month
         day = subscription_date.day
 
         # NOTE: we need the last day of the period, and not the first of the next one
         result_date = build_date(year, month, day) - 1.day
-        return result_date if result_date >= date
+        return result_date if result_date >= billing_date
 
         month += 1
         if month > 12

--- a/app/services/subscriptions/dates/weekly_service.rb
+++ b/app/services/subscriptions/dates/weekly_service.rb
@@ -43,12 +43,12 @@ module Subscriptions
         compute_charges_from_date + 6.days
       end
 
-      def compute_next_end_of_period(date)
-        return date.end_of_week if calendar?
-        return date if date.wday == (subscription_date - 1.day).wday
+      def compute_next_end_of_period
+        return billing_date.end_of_week if calendar?
+        return billing_date if billing_date.wday == (subscription_date - 1.day).wday
 
         # NOTE: we need the last day of the period, and not the first of the next one
-        date.next_occurring(subscription_day_name) - 1.day
+        billing_date.next_occurring(subscription_day_name) - 1.day
       end
 
       def compute_previous_beginning_of_period(date)

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -57,16 +57,16 @@ module Subscriptions
         compute_to_date(compute_charges_from_date)
       end
 
-      def compute_next_end_of_period(date)
-        return date.end_of_year if calendar?
+      def compute_next_end_of_period
+        return billing_date.end_of_year if calendar?
 
-        year = date.year
+        year = billing_date.year
         month = subscription_date.month
         day = subscription_date.day
 
         # NOTE: we need the last day of the period, and not the first of the next one
         result_date = build_date(year, month, day) - 1.day
-        return result_date if result_date >= date
+        return result_date if result_date >= billing_date
 
         build_date(year + 1, month, day) - 1.day
       end

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -62,8 +62,8 @@ module Subscriptions
       date
     end
 
-    def next_end_of_period(date = billing_date)
-      compute_next_end_of_period(date)
+    def next_end_of_period
+      compute_next_end_of_period
     end
 
     # NOTE: Retrieve the beginning of the previous period based on the billing date
@@ -131,7 +131,7 @@ module Subscriptions
       raise(NotImplementedError)
     end
 
-    def compute_next_end_of_period(date)
+    def compute_next_end_of_period
       raise(NotImplementedError)
     end
 

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -62,7 +62,7 @@ module Subscriptions
       date
     end
 
-    def next_end_of_period(date)
+    def next_end_of_period(date = billing_date)
       compute_next_end_of_period(date)
     end
 

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -6,5 +6,7 @@ FactoryBot.define do
 
     issuing_date { Time.zone.now - 1.day }
     status { 'pending' }
+    amount_currency { 'EUR' }
+    total_amount_currency { 'EUR' }
   end
 end

--- a/spec/services/credit_notes/create_from_upgrade_spec.rb
+++ b/spec/services/credit_notes/create_from_upgrade_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::CreateFromUpgrade, type: :service do
+  subject(:create_service) { described_class.new(subscription: subscription) }
+
+  let(:started_at) { Time.zone.parse('2022-09-01 10:00') }
+  let(:subscription_date) { Time.zone.parse('2022-09-01 10:00') }
+  let(:terminated_at) { Time.zone.parse('2022-10-15 10:00') }
+
+  let(:subscription) do
+    create(
+      :subscription,
+      plan: plan,
+      status: :terminated,
+      subscription_date: subscription_date,
+      started_at: started_at,
+      terminated_at: terminated_at,
+      billing_time: :calendar,
+    )
+  end
+
+  let(:plan) do
+    create(
+      :plan,
+      pay_in_advance: true,
+      amount_cents: 31,
+    )
+  end
+
+  let(:subscription_fee) do
+    create(
+      :fee,
+      subscription: subscription,
+      invoice: invoice,
+      amount_cents: 100,
+      vat_amount_cents: 20,
+      invoiceable_type: 'Subscription',
+      invoiceable_id: subscription.id,
+      vat_rate: 20,
+    )
+  end
+
+  let(:invoice) do
+    create(
+      :invoice,
+      customer: subscription.customer,
+      amount_currency: 'EUR',
+      total_amount_currency: 'EUR',
+    )
+  end
+
+  describe '.call' do
+    before { subscription_fee }
+
+    it 'creates a credit note' do
+      result = create_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+
+        credit_note = result.credit_note
+        expect(credit_note).to be_available
+        expect(credit_note).to be_other
+        expect(credit_note.total_amount_cents).to eq(20)
+        expect(credit_note.total_amount_currency).to eq('EUR')
+        expect(credit_note.credit_amount_cents).to eq(20)
+        expect(credit_note.credit_amount_currency).to eq('EUR')
+        expect(credit_note.balance_amount_cents).to eq(20)
+        expect(credit_note.balance_amount_currency).to eq('EUR')
+
+        expect(credit_note.items.count).to eq(1)
+      end
+    end
+
+    context 'when fee amount is zero' do
+      let(:subscription_fee) do
+        create(
+          :fee,
+          subscription: subscription,
+          invoice: invoice,
+          amount_cents: 0,
+          vat_amount_cents: 0,
+          invoiceable_type: 'Subscription',
+          invoiceable_id: subscription.id,
+          vat_rate: 20,
+        )
+      end
+
+      it 'does not create a credit note' do
+        expect { create_service.call }.not_to change(CreditNote, :count)
+      end
+    end
+
+    context 'when plan has trial period ending after terminated_at' do
+      let(:plan) do
+        create(
+          :plan,
+          pay_in_advance: true,
+          amount_cents: 31,
+          trial_period: 46,
+        )
+      end
+
+      it 'excludes the trial from the credit amount' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          credit_note = result.credit_note
+          expect(credit_note).to be_available
+          expect(credit_note).to be_other
+          expect(credit_note.total_amount_cents).to eq(17)
+          expect(credit_note.total_amount_currency).to eq('EUR')
+          expect(credit_note.credit_amount_cents).to eq(17)
+          expect(credit_note.credit_amount_currency).to eq('EUR')
+          expect(credit_note.balance_amount_cents).to eq(17)
+          expect(credit_note.balance_amount_currency).to eq('EUR')
+
+          expect(credit_note.items.count).to eq(1)
+        end
+      end
+
+      context 'when trial ends after the end of the billing period' do
+        let(:plan) do
+          create(
+            :plan,
+            pay_in_advance: true,
+            amount_cents: 31,
+            trial_period: 120,
+          )
+        end
+
+        it 'does not creates a credit note' do
+          expect { create_service.call }.not_to change(CreditNote, :count)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -668,7 +668,7 @@ RSpec.describe Invoices::CreateService, type: :service do
 
       before { subscription }
 
-      it 'creates an invoice without charge fee and with amount equal to zero' do
+      it 'creates an invoice with pro-rated charge fee and without charge fees' do
         result = invoice_service.create
 
         aggregate_failures do
@@ -676,8 +676,8 @@ RSpec.describe Invoices::CreateService, type: :service do
             .to eq(subscription.started_at.to_date.end_of_month.to_s)
           expect(result.invoice.fees.first.properties['from_date'])
             .to eq(subscription.started_at.to_date.to_s)
-          expect(result.invoice.total_amount_cents).to eq(0)
-          expect(result.invoice.status).to eq('succeeded')
+          expect(result.invoice.total_amount_cents).to eq(81)
+          expect(result.invoice).to be_pending
           expect(result.invoice.fees.charge_kind.count).to eq(0)
         end
       end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -484,7 +484,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
             end
           end
 
-          context 'when old subscription was payed in advabce' do
+          context 'when old subscription was payed in advance' do
             before do
               plan.update!(pay_in_advance: true)
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -484,6 +484,31 @@ RSpec.describe Subscriptions::CreateService, type: :service do
             end
           end
 
+          context 'when old subscription was payed in advabce' do
+            before do
+              plan.update!(pay_in_advance: true)
+
+              create(
+                :fee,
+                subscription: subscription,
+                amount_cents: 100,
+                vat_amount_cents: 20,
+                invoiceable_type: 'Subscription',
+                invoiceable_id: subscription.id,
+                vat_rate: 20,
+              )
+            end
+
+            it 'creates a credit note for the remaining days' do
+              expect do
+                create_service.create_from_api(
+                  organization: organization,
+                  params: params,
+                )
+              end.to change(CreditNote, :count)
+            end
+          end
+
           context 'when new subscription is payed in advance' do
             before { higher_plan.update!(pay_in_advance: false) }
 

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
   end
 
   describe 'next_end_of_period' do
-    let(:result) { date_service.next_end_of_period(billing_date.to_date).to_s }
+    let(:result) { date_service.next_end_of_period.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
   end
 
   describe 'next_end_of_period' do
-    let(:result) { date_service.next_end_of_period(billing_date.to_date).to_s }
+    let(:result) { date_service.next_end_of_period.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
   end
 
   describe 'next_end_of_period' do
-    let(:result) { date_service.next_end_of_period(billing_date.to_date).to_s }
+    let(:result) { date_service.next_end_of_period.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Subscriptions::DatesService, type: :service do
 
   describe 'next_end_of_period' do
     it 'raises a not implemented error' do
-      expect { date_service.next_end_of_period(billing_date.to_date) }
+      expect { date_service.next_end_of_period }
         .to raise_error(NotImplementedError)
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR adds the logic to create a credit note from a subscription upgrade