### PR TITLE
misc: Update graduated ranges from array to hash

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -88,19 +88,8 @@ module Api
           :trial_period,
           :pay_in_advance,
           :bill_charges_monthly,
-          charges: [:id, :billable_metric_id, :charge_model],
-        ).tap do |permitted_params|
-          # NOTE: Charges properties can have 2 differents formats
-          # - An array if the charge model need many ranges (ie: graduated)
-          # - A hash if other cases (ie: standard)
-          (permitted_params[:charges] || []).each_with_index do |permitted_charge, idx|
-            permitted_charge[:properties] = if params[:plan][:charges][idx][:properties].is_a?(Array)
-              params[:plan][:charges][idx][:properties].map(&:permit!)
-            else
-              params[:plan][:charges][idx][:properties].permit!
-            end
-          end
-        end
+          charges: [:id, :billable_metric_id, :charge_model, { properties: {} }],
+        )
       end
 
       def render_plan(plan)

--- a/app/graphql/concerns/charge_model_attributes_handler.rb
+++ b/app/graphql/concerns/charge_model_attributes_handler.rb
@@ -4,10 +4,10 @@ module ChargeModelAttributesHandler
   # NOTE: Map custom arguments of charge models into the properties hash
   #       of each charges.
   #       - Standard model only has one property `amount_cents`
-  #       - Graduated model relies on the the list of `GraduatedRange`
+  #       - Graduated model has property `graduated_ranges` which relies on the the list of `GraduatedRange`
   #       - Package model has properties `amount_cents`, `package_size` and `free_units`
   #       - Percentage model has properties `rate`, `fixed_amount`, `free_units_per_events`, `free_units_per_total_aggregation`
-  #       - Volume model has property `ranges` which relies on the list of VolumeRange
+  #       - Volume model has property `volume_ranges` which relies on the list of `VolumeRange``
   def prepare_arguments(arguments)
     return arguments if arguments[:charges].blank?
 
@@ -18,7 +18,9 @@ module ChargeModelAttributesHandler
       when :standard
         output[:properties] = { amount: output[:amount] }
       when :graduated
-        output[:properties] = output[:graduated_ranges]
+        output[:properties] = {
+          graduated_ranges: output[:graduated_ranges],
+        }
       when :package
         output[:properties] = {
           amount: output[:amount],
@@ -34,7 +36,7 @@ module ChargeModelAttributesHandler
         }
       when :volume
         output[:properties] = {
-          ranges: output[:volume_ranges],
+          volume_ranges: output[:volume_ranges],
         }
       end
 

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -40,7 +40,7 @@ module Types
       def graduated_ranges
         return unless object.graduated?
 
-        object.properties
+        object.properties['graduated_ranges']
       end
 
       def free_units
@@ -82,7 +82,7 @@ module Types
       def volume_ranges
         return unless object.volume?
 
-        object.properties['ranges']
+        object.properties['volume_ranges']
       end
     end
   end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -20,7 +20,7 @@ class Charge < ApplicationRecord
   enum charge_model: CHARGE_MODELS
 
   validate :validate_amount, if: :standard?
-  validate :validate_graduated_range, if: :graduated?
+  validate :validate_graduated, if: :graduated?
   validate :validate_package, if: :package?
   validate :validate_percentage, if: :percentage?
   validate :validate_volume, if: :volume?
@@ -35,7 +35,7 @@ class Charge < ApplicationRecord
     validate_charge_model(Charges::Validators::StandardService)
   end
 
-  def validate_graduated_range
+  def validate_graduated
     validate_charge_model(Charges::Validators::GraduatedService)
   end
 

--- a/app/services/charges/charge_models/graduated_service.rb
+++ b/app/services/charges/charge_models/graduated_service.rb
@@ -6,7 +6,7 @@ module Charges
       protected
 
       def ranges
-        charge.properties.map(&:with_indifferent_access)
+        charge.properties['graduated_ranges']&.map(&:with_indifferent_access)
       end
 
       def compute_amount

--- a/app/services/charges/charge_models/volume_service.rb
+++ b/app/services/charges/charge_models/volume_service.rb
@@ -6,7 +6,7 @@ module Charges
       protected
 
       def ranges
-        charge.properties['ranges']&.map(&:with_indifferent_access)
+        charge.properties['volume_ranges']&.map(&:with_indifferent_access)
       end
 
       def compute_amount

--- a/app/services/charges/validators/graduated_service.rb
+++ b/app/services/charges/validators/graduated_service.rb
@@ -5,14 +5,14 @@ module Charges
     class GraduatedService < Charges::Validators::BaseService
       def valid?
         if ranges.blank?
-          add_error(field: :ranges, error_code: 'missing_graduated_range')
+          add_error(field: :graduated_ranges, error_code: 'missing_graduated_ranges')
         else
           next_from_value = 0
           ranges.each_with_index do |range, index|
             validate_amounts(range)
 
             unless valid_bounds?(range, index, next_from_value)
-              add_error(field: :ranges, error_code: 'invalid_graduated_ranges')
+              add_error(field: :graduated_ranges, error_code: 'invalid_graduated_ranges')
             end
 
             next_from_value = (range[:to_value] || 0) + 1
@@ -25,7 +25,7 @@ module Charges
       private
 
       def ranges
-        charge.properties.map(&:with_indifferent_access)
+        charge.properties['graduated_ranges'].map(&:with_indifferent_access)
       end
 
       def validate_amounts(range)

--- a/app/services/charges/validators/volume_service.rb
+++ b/app/services/charges/validators/volume_service.rb
@@ -5,12 +5,14 @@ module Charges
     class VolumeService < Charges::Validators::BaseService
       def valid?
         if ranges.blank?
-          add_error(field: :ranges, error_code: 'missing_ranges')
+          add_error(field: :volume_ranges, error_code: 'missing_volume_ranges')
         else
           next_from_value = 0
           ranges.each_with_index do |range, index|
             validate_amounts(range)
-            add_error(field: :ranges, error_code: 'invalid_ranges') unless valid_bounds?(range, index, next_from_value)
+            unless valid_bounds?(range, index, next_from_value)
+              add_error(field: :volume_ranges, error_code: 'invalid_volume_ranges')
+            end
 
             next_from_value = (range[:to_value] || 0) + 1
           end
@@ -22,7 +24,7 @@ module Charges
       private
 
       def ranges
-        charge.properties['ranges']&.map(&:with_indifferent_access)
+        charge.properties['volume_ranges']&.map(&:with_indifferent_access)
       end
 
       def validate_amounts(range)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,12 +13,13 @@ en:
         greater_than_or_equal_to: value_is_out_of_range
         less_than_or_equal_to: value_is_out_of_range
         greater_than: value_is_out_of_range
-        missing_graduated_range: missing_graduated_range
+        missing_graduated_ranges: missing_graduated_ranges
+        missing_volume_ranges: missing_volume_ranges
         invalid_amount: invalid_amount
         invalid_flat_amount: invalid_flat_amount
         invalid_per_unit_amount: invalid_per_unit_amount
         invalid_graduated_ranges: invalid_graduated_ranges
-        invalid_ranges: invalid_ranges
+        invalid_volume_ranges: invalid_volume_ranges
         invalid_free_units: invalid_free_units
         invalid_package_size: invalid_package_size
         invalid_rate: invalid_rate

--- a/db/migrate/20221013140147_update_graduated_properties_to_hash.rb
+++ b/db/migrate/20221013140147_update_graduated_properties_to_hash.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UpdateGraduatedPropertiesToHash < ActiveRecord::Migration[7.0]
+  def change
+    # NOTE: Wait to ensure workers are loaded with the added tasks
+    MigrationTaskJob.set(wait: 20.seconds).perform_later('charges:update_graduated_properties_to_hash')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -235,10 +235,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_18_144521) do
     t.decimal "units", default: "0.0", null: false
     t.uuid "applied_add_on_id"
     t.jsonb "properties", default: {}, null: false
-    t.integer "events_count"
     t.integer "fee_type"
     t.string "invoiceable_type"
     t.uuid "invoiceable_id"
+    t.integer "events_count"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"

--- a/lib/tasks/charges.rake
+++ b/lib/tasks/charges.rake
@@ -14,4 +14,19 @@ namespace :charges do
       charge.save!
     end
   end
+
+  desc 'Set graduated properties to hash and rename volume ranges'
+  task update_graduated_properties_to_hash: :environment do
+    # Rename existing volume ranges from `ranges: []` to `volume_ranges: []`
+    Charge.volume.find_each do |charge|
+      charge.properties['volume_ranges'] = charge.properties.delete('ranges')
+      charge.save!
+    end
+
+    # Update graduated charges from array `[]` to hash `graduated_ranges: []`
+    Charge.graduated.find_each do |charge|
+      charge.properties = { graduated_ranges: charge.properties }
+      charge.save!
+    end
+  end
 end

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -24,7 +24,9 @@ FactoryBot.define do
 
     factory :graduated_charge do
       charge_model { 'graduated' }
-      properties { [] }
+      properties do
+        { graduated_ranges: [] }
+      end
     end
 
     factory :package_charge do
@@ -52,7 +54,7 @@ FactoryBot.define do
       charge_model { 'volume' }
       properties do
         {
-          ranges: [
+          volume_ranges: [
             { from_value: 0, to_value: 100, per_unit_amount: '2', flat_amount: '1' },
             { from_value: 101, to_value: nil, per_unit_amount: '1', flat_amount: '0' },
           ],

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -48,14 +48,16 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
       plan: subscription.plan,
       charge_model: 'graduated',
       billable_metric: billable_metric,
-      properties: [
-        {
-          from_value: 0,
-          to_value: nil,
-          per_unit_amount: '0.01',
-          flat_amount: '0.01',
-        },
-      ],
+      properties: {
+        graduated_ranges: [
+          {
+            from_value: 0,
+            to_value: nil,
+            per_unit_amount: '0.01',
+            flat_amount: '0.01',
+          },
+        ],
+      },
     )
   end
 

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -22,12 +22,14 @@ RSpec.describe Charge, type: :model do
     end
   end
 
-  describe '.validate_graduated_range' do
+  describe '.validate_graduated' do
     subject(:charge) do
       build(:graduated_charge, properties: charge_properties)
     end
 
-    let(:charge_properties) { [{ 'foo' => 'bar' }] }
+    let(:charge_properties) do
+      { graduated_ranges: [{ 'foo' => 'bar' }] }
+    end
     let(:validation_service) { instance_double(Charges::Validators::GraduatedService) }
 
     let(:service_response) do
@@ -260,14 +262,14 @@ RSpec.describe Charge, type: :model do
       build(:volume_charge, properties: charge_properties)
     end
 
-    let(:charge_properties) { { ranges: [{ 'foo' => 'bar' }] } }
+    let(:charge_properties) { { volume_ranges: [{ 'foo' => 'bar' }] } }
     let(:validation_service) { instance_double(Charges::Validators::VolumeService) }
 
     let(:service_response) do
       BaseService::Result.new.validation_failure!(
         errors: {
           amount: ['invalid_amount'],
-          ranges: ['invalid_ranges'],
+          volume_ranges: ['invalid_volume_ranges'],
         },
       )
     end
@@ -284,7 +286,7 @@ RSpec.describe Charge, type: :model do
         expect(charge).not_to be_valid
         expect(charge.errors.messages.keys).to include(:properties)
         expect(charge.errors.messages[:properties]).to include('invalid_amount')
-        expect(charge.errors.messages[:properties]).to include('invalid_ranges')
+        expect(charge.errors.messages[:properties]).to include('invalid_volume_ranges')
 
         expect(Charges::Validators::VolumeService).to have_received(:new)
           .with(charge: charge)

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -83,14 +83,16 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         plan: subscription.plan,
         charge_model: 'graduated',
         billable_metric: billable_metric,
-        properties: [
-          {
-            from_value: 0,
-            to_value: nil,
-            per_unit_amount: '0.01',
-            flat_amount: '0.01',
-          },
-        ],
+        properties: {
+          graduated_ranges: [
+            {
+              from_value: 0,
+              to_value: nil,
+              per_unit_amount: '0.01',
+              flat_amount: '0.01',
+            },
+          ],
+        },
       )
     end
 

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -56,20 +56,22 @@ RSpec.describe Api::V1::PlansController, type: :request do
             {
               billable_metric_id: billable_metric.id,
               charge_model: 'graduated',
-              properties: [
-                {
-                  to_value: 1,
-                  from_value: 0,
-                  flat_amount: '0',
-                  per_unit_amount: '0',
-                },
-                {
-                  to_value: nil,
-                  from_value: 2,
-                  flat_amount: '0',
-                  per_unit_amount: '3200',
-                },
-              ],
+              properties: {
+                graduated_ranges: [
+                  {
+                    to_value: 1,
+                    from_value: 0,
+                    flat_amount: '0',
+                    per_unit_amount: '0',
+                  },
+                  {
+                    to_value: nil,
+                    from_value: 2,
+                    flat_amount: '0',
+                    per_unit_amount: '3200',
+                  },
+                ],
+              },
             },
           ],
         }

--- a/spec/services/charges/charge_models/graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/graduated_service_spec.rb
@@ -16,26 +16,28 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
   let(:charge) do
     create(
       :graduated_charge,
-      properties: [
-        {
-          from_value: 0,
-          to_value: 10,
-          per_unit_amount: '10',
-          flat_amount: '2',
-        },
-        {
-          from_value: 11,
-          to_value: 20,
-          per_unit_amount: '5',
-          flat_amount: '3',
-        },
-        {
-          from_value: 21,
-          to_value: nil,
-          per_unit_amount: '5',
-          flat_amount: '3',
-        },
-      ],
+      properties: {
+        graduated_ranges: [
+          {
+            from_value: 0,
+            to_value: 10,
+            per_unit_amount: '10',
+            flat_amount: '2',
+          },
+          {
+            from_value: 11,
+            to_value: 20,
+            per_unit_amount: '5',
+            flat_amount: '3',
+          },
+          {
+            from_value: 21,
+            to_value: nil,
+            per_unit_amount: '5',
+            flat_amount: '3',
+          },
+        ],
+      },
     )
   end
 

--- a/spec/services/charges/charge_models/volume_service_spec.rb
+++ b/spec/services/charges/charge_models/volume_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
     create(
       :volume_charge,
       properties: {
-        ranges: [
+        volume_ranges: [
           { from_value: 0, to_value: 100, per_unit_amount: '2', flat_amount: '10' },
           { from_value: 101, to_value: 200, per_unit_amount: '1', flat_amount: '0' },
           { from_value: 201, to_value: nil, per_unit_amount: '0.5', flat_amount: '50' },

--- a/spec/services/charges/validators/graduated_service_spec.rb
+++ b/spec/services/charges/validators/graduated_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Charges::Validators::GraduatedService, type: :service do
   subject(:graduated_service) { described_class.new(charge: charge) }
 
-  let(:charge) { build(:graduated_charge, properties: ranges) }
+  let(:charge) { build(:graduated_charge, properties: { graduated_ranges: ranges }) }
 
   let(:ranges) do
     []
@@ -16,8 +16,8 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
       aggregate_failures do
         expect(graduated_service).not_to be_valid
         expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-        expect(graduated_service.result.error.messages.keys).to include(:ranges)
-        expect(graduated_service.result.error.messages[:ranges]).to include('missing_graduated_range')
+        expect(graduated_service.result.error.messages.keys).to include(:graduated_ranges)
+        expect(graduated_service.result.error.messages[:graduated_ranges]).to include('missing_graduated_ranges')
       end
     end
 
@@ -30,8 +30,8 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
         aggregate_failures do
           expect(graduated_service).not_to be_valid
           expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:ranges)
-          expect(graduated_service.result.error.messages[:ranges]).to include('invalid_graduated_ranges')
+          expect(graduated_service.result.error.messages.keys).to include(:graduated_ranges)
+          expect(graduated_service.result.error.messages[:graduated_ranges]).to include('invalid_graduated_ranges')
         end
       end
     end
@@ -45,8 +45,8 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
         aggregate_failures do
           expect(graduated_service).not_to be_valid
           expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:ranges)
-          expect(graduated_service.result.error.messages[:ranges]).to include('invalid_graduated_ranges')
+          expect(graduated_service.result.error.messages.keys).to include(:graduated_ranges)
+          expect(graduated_service.result.error.messages[:graduated_ranges]).to include('invalid_graduated_ranges')
         end
       end
     end
@@ -63,8 +63,8 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
         aggregate_failures do
           expect(graduated_service).not_to be_valid
           expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:ranges)
-          expect(graduated_service.result.error.messages[:ranges]).to include('invalid_graduated_ranges')
+          expect(graduated_service.result.error.messages.keys).to include(:graduated_ranges)
+          expect(graduated_service.result.error.messages[:graduated_ranges]).to include('invalid_graduated_ranges')
         end
       end
     end
@@ -81,8 +81,8 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
         aggregate_failures do
           expect(graduated_service).not_to be_valid
           expect(graduated_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(graduated_service.result.error.messages.keys).to include(:ranges)
-          expect(graduated_service.result.error.messages[:ranges]).to include('invalid_graduated_ranges')
+          expect(graduated_service.result.error.messages.keys).to include(:graduated_ranges)
+          expect(graduated_service.result.error.messages[:graduated_ranges]).to include('invalid_graduated_ranges')
         end
       end
     end

--- a/spec/services/charges/validators/volume_service_spec.rb
+++ b/spec/services/charges/validators/volume_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Charges::Validators::VolumeService, type: :service do
   subject(:volume_service) { described_class.new(charge: charge) }
 
-  let(:charge) { build(:volume_charge, properties: { ranges: ranges }) }
+  let(:charge) { build(:volume_charge, properties: { volume_ranges: ranges }) }
 
   let(:ranges) do
     []
@@ -16,8 +16,8 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
       aggregate_failures do
         expect(volume_service).not_to be_valid
         expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-        expect(volume_service.result.error.messages.keys).to include(:ranges)
-        expect(volume_service.result.error.messages[:ranges]).to include('missing_ranges')
+        expect(volume_service.result.error.messages.keys).to include(:volume_ranges)
+        expect(volume_service.result.error.messages[:volume_ranges]).to include('missing_volume_ranges')
       end
     end
 
@@ -30,8 +30,8 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
         aggregate_failures do
           expect(volume_service).not_to be_valid
           expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:ranges)
-          expect(volume_service.result.error.messages[:ranges]).to include('invalid_ranges')
+          expect(volume_service.result.error.messages.keys).to include(:volume_ranges)
+          expect(volume_service.result.error.messages[:volume_ranges]).to include('invalid_volume_ranges')
         end
       end
     end
@@ -45,8 +45,8 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
         aggregate_failures do
           expect(volume_service).not_to be_valid
           expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:ranges)
-          expect(volume_service.result.error.messages[:ranges]).to include('invalid_ranges')
+          expect(volume_service.result.error.messages.keys).to include(:volume_ranges)
+          expect(volume_service.result.error.messages[:volume_ranges]).to include('invalid_volume_ranges')
         end
       end
     end
@@ -63,8 +63,8 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
         aggregate_failures do
           expect(volume_service).not_to be_valid
           expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:ranges)
-          expect(volume_service.result.error.messages[:ranges]).to include('invalid_ranges')
+          expect(volume_service.result.error.messages.keys).to include(:volume_ranges)
+          expect(volume_service.result.error.messages[:volume_ranges]).to include('invalid_volume_ranges')
         end
       end
     end
@@ -81,8 +81,8 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
         aggregate_failures do
           expect(volume_service).not_to be_valid
           expect(volume_service.result.error).to be_a(BaseService::ValidationFailure)
-          expect(volume_service.result.error.messages.keys).to include(:ranges)
-          expect(volume_service.result.error.messages[:ranges]).to include('invalid_ranges')
+          expect(volume_service.result.error.messages.keys).to include(:volume_ranges)
+          expect(volume_service.result.error.messages[:volume_ranges]).to include('invalid_volume_ranges')
         end
       end
     end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -69,14 +69,16 @@ RSpec.describe Fees::ChargeService do
           plan: subscription.plan,
           charge_model: 'graduated',
           billable_metric: billable_metric,
-          properties: [
-            {
-              from_value: 0,
-              to_value: nil,
-              per_unit_amount: '0.01',
-              flat_amount: '0.01',
-            },
-          ],
+          properties: {
+            graduated_ranges: [
+              {
+                from_value: 0,
+                to_value: nil,
+                per_unit_amount: '0.01',
+                flat_amount: '0.01',
+              },
+            ],
+          },
         )
       end
 
@@ -278,14 +280,16 @@ RSpec.describe Fees::ChargeService do
           plan: subscription.plan,
           charge_model: 'graduated',
           billable_metric: billable_metric,
-          properties: [
-            {
-              from_value: 0,
-              to_value: nil,
-              per_unit_amount: '0.01',
-              flat_amount: '0.01',
-            },
-          ],
+          properties: {
+            graduated_ranges: [
+              {
+                from_value: 0,
+                to_value: nil,
+                per_unit_amount: '0.01',
+                flat_amount: '0.01',
+              },
+            ],
+          },
         )
       end
 

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -32,20 +32,22 @@ RSpec.describe Plans::CreateService, type: :service do
           {
             billable_metric_id: billable_metrics.last.id,
             charge_model: 'graduated',
-            properties: [
-              {
-                from_value: 0,
-                to_value: 10,
-                per_unit_amount: '2',
-                flat_amount: '0',
-              },
-              {
-                from_value: 11,
-                to_value: nil,
-                per_unit_amount: '3',
-                flat_amount: '3',
-              },
-            ],
+            properties: {
+              graduated_ranges: [
+                {
+                  from_value: 0,
+                  to_value: 10,
+                  per_unit_amount: '2',
+                  flat_amount: '0',
+                },
+                {
+                  from_value: 11,
+                  to_value: nil,
+                  per_unit_amount: '3',
+                  flat_amount: '3',
+                },
+              ],
+            },
           },
         ],
       }

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -32,20 +32,22 @@ RSpec.describe Plans::UpdateService, type: :service do
         {
           billable_metric_id: billable_metrics.last.id,
           charge_model: 'graduated',
-          properties: [
-            {
-              from_value: 0,
-              to_value: 10,
-              per_unit_amount: '2',
-              flat_amount: '0',
-            },
-            {
-              from_value: 11,
-              to_value: nil,
-              per_unit_amount: '3',
-              flat_amount: '3',
-            },
-          ],
+          properties: {
+            graduated_ranges: [
+              {
+                from_value: 0,
+                to_value: 10,
+                per_unit_amount: '2',
+                flat_amount: '0',
+              },
+              {
+                from_value: 11,
+                to_value: nil,
+                per_unit_amount: '3',
+                flat_amount: '3',
+              },
+            ],
+          },
         },
       ],
     }


### PR DESCRIPTION
## Context

In order to be consistent between all charge models, we want to store `properties` by using the same type.

## Description

The goal of this MR is to:
- update `properties` from `array` to `hash` for graduated charges
- rename `ranges` to `volume_ranges` for the volume properties key