### PR TITLE
fix(subscription): Charge fees on terminated subscription after upgrade

### DIFF
--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -56,7 +56,11 @@ module Invoices
     attr_accessor :subscriptions, :timestamp, :customer, :currency
 
     def date_service(subscription)
-      Subscriptions::DatesService.new_instance(subscription, Time.zone.at(timestamp).to_date)
+      Subscriptions::DatesService.new_instance(
+        subscription,
+        Time.zone.at(timestamp).to_date,
+        current_usage: subscription.terminated? && subscription.upgraded?,
+      )
     end
 
     def compute_amounts(invoice)

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -424,10 +424,12 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           end
 
           it 'terminates the existing subscription' do
-            create_service.create_from_api(
-              organization: organization,
-              params: params,
-            )
+            expect do
+              create_service.create_from_api(
+                organization: organization,
+                params: params,
+              )
+            end.to have_enqueued_job(BillSubscriptionJob)
 
             old_subscription = Subscription.find(subscription.id)
 


### PR DESCRIPTION
## Context

When upgraded a subscription pay in advance, we do not create an invoice with fees for the charges on the period between beginning of period and termination date.

It is a regression introduce by the refactoring done with the anniversary date feature as charges for the period were billed on the new subscription and not on the terminated one.

## Description

This PR fixes the behavior by enqueuing a `BillSubscriptionJob`. The service is already able to create fees at pro-rata for the charges