### PR TITLE
feat(credit_notes): Credit Note PDF template

### DIFF
--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -5,6 +5,11 @@ class CreditNoteItem < ApplicationRecord
   belongs_to :fee
 
   monetize :credit_amount_cents
+  monetize :total_amount_cents
 
   validates :credit_amount_cents, numericality: { greater_than_or_equal_to: 0 }
+
+  def total_amount_cents
+    credit_amount_cents # TODO: will take refund amount into account
+  end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -107,4 +107,8 @@ class Subscription < ApplicationRecord
     ::Subscriptions::DatesService.new_instance(self, Time.zone.today)
       .next_end_of_period(Time.zone.today) + 1.day
   end
+
+  def display_name
+    name.presence || plan.name
+  end
 end

--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -1,0 +1,476 @@
+doctype html
+html
+  head
+    meta charset='UTF-8'
+    meta http-equiv='X-UA-Compatible' content='IE=edge'
+    meta name='viewport' content='width=device-width, initial-scale=1.0'
+    title Credit note
+  body
+    css:
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 100;
+        font-display: swap;
+        src: local("Inter-Thin");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 100;
+        font-display: swap;
+        src: local("Inter-ThinItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 200;
+        font-display: swap;
+        src: local("Inter-ExtraLight");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 200;
+        font-display: swap;
+        src: local("Inter-ExtraLightItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 300;
+        font-display: swap;
+        src: local("Inter-Light");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 300;
+        font-display: swap;
+        src: local("Inter-LightItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 400;
+        font-display: swap;
+        src: local("Inter-Regular");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 400;
+        font-display: swap;
+        src: local("Inter-Italic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 500;
+        font-display: swap;
+        src: local("Inter-Medium");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 500;
+        font-display: swap;
+        src: local("Inter-MediumItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 600;
+        font-display: swap;
+        src: local("Inter-SemiBold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 600;
+        font-display: swap;
+        src: local("Inter-SemiBoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 700;
+        font-display: swap;
+        src: local("Inter-Bold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 700;
+        font-display: swap;
+        src: local("Inter-BoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 800;
+        font-display: swap;
+        src: local("Inter-ExtraBold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 800;
+        font-display: swap;
+        src: local("Inter-ExtraBoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 900;
+        font-display: swap;
+        src: local("Inter-Black");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 900;
+        font-display: swap;
+        src: local("Inter-BlackItalic");
+      }
+
+
+      /* ----------------------- variable ----------------------- */
+
+      @font-face {
+        font-family: 'Inter var';
+        font-style: normal;
+        font-weight: 100 900;
+        font-display: swap;
+        src: local('Inter-roman') format('woff2');
+        font-named-instance: 'Regular';
+      }
+
+      @font-face {
+        font-family: 'Inter var';
+        font-style: italic;
+        font-weight: 100 900;
+        font-display: swap;
+        src: local('Inter-italic') format('woff2');
+        font-named-instance: 'Italic';
+      }
+      h1, h2, p { margin: 0; padding: 0; }
+      html { font-family: Inter, sans-serif; }
+      h1 { color: #19212e; font-weight: 700; font-size: 24px; line-height: 32px; }
+      h2 {
+        color: #19212e;
+        font-weight: 700;
+        font-size: 18px;
+        line-height: 24px;
+      }
+      .body-1 {
+        color: #19212e;
+        font-weight: 600;
+        font-size: 10px;
+        line-height: 16px;
+      }
+      .body-2 {
+        color: #19212e;
+        font-weight: 400;
+        font-size: 10px;
+        line-height: 16px;
+      }
+      .body-3 {
+        color: #66758f;
+        font-weight: 400;
+        font-size: 9px;
+        line-height: 16px;
+      }
+      .prepaid-amount {
+        font-size: 10px;
+        font-family: Inter;
+        color: #008559;
+        font-weight: 600;
+        line-height: 16px;
+      }
+
+      .mb-8 {
+        margin-bottom: 8px;
+      }
+      .mb-24 {
+        margin-bottom: 24px;
+      }
+
+      .overflow-auto {
+        overflow: auto;
+      }
+      tr {
+        break-inside: avoid;
+      }
+
+      .credit-note-title {
+        display: inline;
+      }
+      .header-logo {
+        float: right;
+        max-height: 32px;
+      }
+
+      .credit-note-information-column {
+        float: left;
+        width: 50%;
+      }
+      .credit-note-information-table tr td:first-child {
+        padding: 0 16px 0 0;
+      }
+      .credit-note-information-table {
+        border-collapse: collapse;
+      }
+
+      .billing-information-column {
+        float: left;
+        width: 50%;
+      }
+
+      .credit-note-resume-table tr td {
+        padding-bottom: 12px;
+      }
+      .credit-note-resume-table tr td:last-child {
+        text-align: right;
+      }
+      .credit-note-resume-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .credit-note-resume table {
+        border-collapse: collapse;
+      }
+      .credit-note-resume .total-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .credit-note-resume .total-table tr:first-child td {
+        padding-top: 24px;
+      }
+      .credit-note-resume .total-table tr td {
+        padding-bottom: 12px;
+        text-align: right;
+      }
+
+      .invoice-details-title {
+        page-break-before: always;
+      }
+
+      .subscription-details-table tr td:last-child {
+        text-align: right;
+      }
+      .subscription-details-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .subscription-details table {
+        border-collapse: collapse;
+      }
+      .subscription-details .total-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .subscription-details .total-table tr:first-child td {
+        padding-top: 24px;
+      }
+      .subscription-details .total-table tr td {
+        text-align: right;
+      }
+
+      .charge-details-table tr td {
+        padding-bottom: 12px;
+      }
+      .charge-details-table tr td:last-child {
+        text-align: right;
+      }
+      .charge-details-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .charge-details table {
+        border-collapse: collapse;
+      }
+      .charge-details .total-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .charge-details .total-table tr:first-child td {
+        padding-top: 24px;
+      }
+      .charge-details .total-table tr td {
+        text-align: right;
+      }
+
+      .breakdown-details table {
+        border-collapse: collapse;
+      }
+      .breakdown-details-table tr td {
+        padding-bottom: 12px;
+      }
+      .breakdown-details-table tr td:last-child {
+        text-align: right;
+      }
+      .breakdown-details-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+
+      .powered-by {
+        width: 100%;
+        text-align: right;
+      }
+      .powered-by span {
+        color: #8c95a6;
+      }
+      .powered-by svg {
+        width: 37px;
+        height: 11px;
+        vertical-align: middle;
+        margin-top: 2px;
+      }
+      .alert {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        padding: 16px;
+        gap: 16px;
+        background: #F3F4F6;
+        border-radius: 12px;
+      }
+
+    .wrapper
+      .mb-24
+        h1.credit-note-title Credit note
+        - if organization.logo.present?
+          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+
+      .mb-24.overflow-auto
+        .credit-note-information-column
+          table.credit-note-information-table
+            tr
+              td.body-1 Credit note number
+              td.body-2 = number
+            tr
+              td.body-1 Invoice number
+              td.body-2 = invoice.number
+            tr
+              td.body-1 Issue date
+              td.body-2 = created_at.strftime('%b %d, %Y')
+
+      .mb-24.overflow-auto
+        .billing-information-column
+          .body-1 From
+          .body-2
+            - if organization.legal_name.present?
+              = organization.legal_name
+            - else
+              = organization.name
+          .body-2 = organization.address_line1
+          .body-2 = organization.address_line2
+          .body-2
+            span
+              = organization.zipcode
+            - if organization.zipcode.present? && organization.city.present?
+              span
+                | , &nbsp;
+            span
+              = organization.city
+          - if organization.state.present?
+            .body-2 = organization.state
+          .body-2 = ISO3166::Country.new(customer.country)&.common_name
+          .body-2 = organization.email
+        .billing-information-column
+          .body-1 Credit to
+          .body-2 = customer.name
+          .body-2 = customer.address_line1
+          .body-2 = customer.address_line2
+          .body-2
+            span
+              = customer.zipcode
+            - if customer.zipcode.present? && customer.city.present?
+              span
+                | , &nbsp;
+            span
+              = customer.city
+          .body-2 = customer.state
+          .body-2 = ISO3166::Country.new(customer.country)&.common_name
+          .body-2 = customer.email
+
+      .mb-24
+        h2.title-2.mb-8 = total_amount.format
+        .body-1
+          - if credited? && refunded?
+            | Credited on customer balance and refunded on #{created_at.strftime('%b %d, %Y')}
+          - elsif credited?
+            | Credited on customer balance on #{created_at.strftime('%b %d, %Y')}
+          - else
+            | Refunded on #{created_at.strftime('%b %d, %Y')}
+
+      .credit-note-resume.mb-24.overflow-auto
+        table.credit-note-resume-table width="100%"
+          - subscription_ids.each do |subscription_id|
+            - if subscription_id.present?
+              tr
+                td.body-1 width="70%"
+                  | Subscription - #{Subscription.find_by(id: subscription_id)&.display_name}
+                td.body-1 width="30%" style="text-align: right;"
+                  = subscription_item(subscription_id).credit_amount.format
+              - subscription_charge_items(subscription_id).each do |item|
+                tr
+                  td.body-1 = item.fee.item_name
+                  td.body-1 width="30%" style="text-align: right;"
+                    = item.total_amount.format
+            - else
+              - subscription_charge_items(nil).each do |item|
+                tr
+                  td.body-1 = item.fee.item_name
+                  td.body-1 width="30%" style="text-align: right;"
+                    = item.total_amount.format
+
+        table.total-table width="100%"
+          tr
+            td.body-2 width="70%" Sub total
+            td.body-1 width="30%" = total_amount.format
+          tr
+            td.body-2 Tax
+            td.body-1 = vat_amount.format
+          - if credited?
+            tr
+              td.body-2 Credited on customer balance
+              td.body-1 = credit_amount.format
+          - if refunded?
+            tr
+              td.body-2 Refunded
+              td.body-1 = refund_amount.format
+          tr
+            td.body-1 Total due
+            td.body-1 = total_amount.format
+
+      p.body-3.mb-24 = organization.invoice_footer
+
+      .powered-by
+        span.body-2
+          | Powered by &nbsp;
+        svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 37 11"
+          g fill="#8C95A6" clip-path="url(#a)"
+            path d="M32.306 8.324a2.546 2.546 0 0 1-1.075-1.066c-.258-.46-.379-.99-.379-1.587 0-.599.129-1.128.379-1.588.25-.46.613-.813 1.075-1.066a3.442 3.442 0 0 1 1.62-.375c.613 0 1.15.122 1.62.375.47.253.826.606 1.075 1.066.25.46.379.99.379 1.588 0 .605-.129 1.134-.379 1.595-.257.46-.613.812-1.075 1.058a3.442 3.442 0 0 1-1.62.375c-.613 0-1.158-.122-1.62-.375Zm2.68-1.419c.257-.314.394-.728.394-1.227 0-.506-.129-.912-.394-1.227-.265-.314-.613-.475-1.06-.475-.44 0-.787.16-1.052.475-.265.315-.394.721-.394 1.227 0 .506.129.92.394 1.227.265.314.613.476 1.052.476.447 0 .795-.162 1.06-.476ZM30.3 2.718v5.736c0 .775-.258 1.396-.758 1.856-.507.46-1.294.69-2.362.69-.825 0-1.491-.184-1.999-.552-.507-.368-.78-.89-.817-1.564h1.612c.076.283.227.498.447.651.22.154.515.23.878.23.455 0 .81-.115 1.06-.345.25-.23.379-.575.379-1.02v-.62c-.424.544-1.03.812-1.802.812a2.64 2.64 0 0 1-1.386-.368 2.548 2.548 0 0 1-.961-1.043c-.235-.444-.349-.974-.349-1.572 0-.59.114-1.112.349-1.564.227-.452.552-.798.969-1.043a2.667 2.667 0 0 1 1.393-.368c.765 0 1.37.3 1.817.897l.136-.813H30.3Zm-1.962 4.118c.258-.307.387-.705.387-1.196 0-.498-.13-.905-.387-1.22-.257-.314-.605-.467-1.037-.467-.431 0-.78.153-1.037.468-.265.306-.394.713-.394 1.211 0 .499.129.905.394 1.212.265.307.606.46 1.037.46.432-.008.78-.161 1.038-.468ZM23.69 2.718V8.63h-1.424l-.136-.828c-.462.59-1.068.882-1.817.882a2.64 2.64 0 0 1-1.386-.368 2.544 2.544 0 0 1-.961-1.058c-.235-.46-.349-.99-.349-1.603 0-.598.114-1.127.349-1.587.227-.46.552-.813.969-1.066a2.672 2.672 0 0 1 1.393-.376c.394 0 .742.077 1.045.23.303.154.552.368.75.63l.158-.783h1.409v.015Zm-1.961 4.195c.257-.307.386-.721.386-1.227 0-.514-.129-.928-.386-1.242-.258-.315-.606-.476-1.038-.476-.431 0-.78.161-1.037.476-.265.314-.394.728-.394 1.242 0 .506.13.912.394 1.227.265.314.606.467 1.037.467.432 0 .78-.16 1.038-.467ZM12.719 8.63V.58h1.703V7.15h3.157v1.48h-4.86Z"
+          g clip-path="url(#b)"
+            g fill="#8C95A6" clip-path="url(#c)"
+              path d="M9.192 5.36a4.556 4.556 0 0 1-1.296 2.547 4.545 4.545 0 0 1-2.544 1.298c0-.008-.008-.016-.008-.025v-.008c-.009-.016-.009-.025-.017-.05l-.025-.074c-.041-.116-.066-.248-.09-.38v-.009c0-.016-.009-.033-.009-.05v-.008c0-.016-.008-.033-.008-.04v-.017c0-.017-.008-.033-.008-.058-.009-.042-.009-.083-.009-.133v-.058c0-.05-.008-.099-.008-.157a2.984 2.984 0 0 1 2.973-2.977H8.358c.041 0 .091.008.132.016.017 0 .042 0 .066.009.017 0 .033.008.042.008h.008c.016 0 .033 0 .05.008h.008a3.341 3.341 0 0 1 .462.124c.017.009.025.009.041.017h.009c0 .008.008.016.016.016Z"
+              path d="M9.25 4.681h-.008c-.075-.025-.149-.041-.223-.066-.009 0-.017-.008-.033-.008a1.52 1.52 0 0 0-.207-.042h-.008c-.017 0-.041-.008-.058-.008h-.016c-.025 0-.05-.008-.067-.008-.024 0-.057-.008-.074-.008-.05-.009-.107-.009-.157-.017h-.272a3.637 3.637 0 0 0-3.634 3.64c0 .057 0 .115.008.181v.042c0 .016 0 .033.008.05.009.049.009.107.017.156 0 .025.008.05.008.075 0 .025.008.05.008.066.009.033.009.058.017.083.025.157.066.314.115.471v.008a4.545 4.545 0 0 1-2.816-.918V8.18c0-3.466 2.816-6.286 6.277-6.286h.198c.611.777.925 1.762.917 2.787Z" opacity=".6"
+              path d="M7.739 1.2c-.033 0-.075.008-.108.008-.058 0-.107.008-.165.016-.017 0-.041 0-.058.008-.016 0-.025 0-.041.009-.1.008-.198.024-.297.04-.075.01-.14.026-.215.034l-.132.025c-.05.008-.1.025-.157.033-.017.008-.042.008-.058.016-.033.009-.074.017-.107.025-.017 0-.025.009-.042.009-.041.008-.082.016-.115.033-.017.008-.042.008-.058.016-.033.008-.058.017-.091.025-.025.008-.05.017-.066.025-.041.008-.074.025-.107.033-.009 0-.017.008-.025.008-.05.017-.1.033-.149.058-.058.017-.107.041-.157.058a.305.305 0 0 0-.09.041c-.034.009-.058.025-.091.033-.05.025-.108.042-.157.067-.091.04-.182.082-.273.132a6.767 6.767 0 0 0-.339.182c-.033.025-.074.041-.107.066-.041.025-.082.05-.132.083-.041.025-.083.05-.116.074-.033.025-.074.05-.107.075l-.1.074a5.62 5.62 0 0 0-.23.174c-.033.025-.058.05-.091.074l-.157.132c-.041.034-.083.075-.124.108-.033.025-.058.058-.09.083-.1.099-.2.19-.298.297-.033.034-.058.058-.083.091-.041.042-.074.083-.107.124-.05.05-.091.108-.132.158-.025.033-.05.058-.075.09-.057.075-.115.158-.173.232l-.074.1c-.025.033-.05.074-.075.107-.025.041-.05.074-.074.116-.025.041-.058.082-.083.132-.024.033-.041.074-.066.108-.066.107-.124.223-.181.33-.05.091-.091.182-.133.273-.024.05-.05.1-.066.157-.008.025-.024.058-.033.091-.016.034-.024.067-.041.091-.025.05-.041.108-.058.158-.016.05-.033.099-.058.148 0 .009-.008.017-.008.025-.016.033-.025.075-.033.108-.008.025-.016.05-.025.066l-.024.09c-.009.017-.009.042-.017.059-.008.041-.025.083-.033.116 0 .008-.008.024-.008.041-.009.033-.017.074-.025.107 0 .017-.008.034-.017.058-.008.05-.024.1-.033.158-.008.04-.016.082-.024.132-.017.074-.025.14-.033.215-.017.1-.025.198-.042.298 0 .016 0 .024-.008.041 0 .017 0 .033-.008.058-.008.058-.008.107-.017.165 0 .033-.008.075-.008.108A4.471 4.471 0 0 1 0 4.689a4.606 4.606 0 0 1 1.272-3.25c.025-.033.058-.058.082-.083l.083-.082A4.63 4.63 0 0 1 4.625 0h.058a4.632 4.632 0 0 1 3.056 1.2Z" opacity=".3"
+          defs
+            clipPath id="a"
+              path fill="#fff" d="M0 0h24.281v10.421H0z" transform="translate(12.719 .579)"
+            clipPath id="b"
+              path fill="#fff" d="M0 0h9.25v9.263H0z"
+            clipPath id="c"
+              path fill="#fff" d="M0 0h9.25v9.263H0z"

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
 
   factory :charge_fee, parent: :fee do
     invoice
-    charge
+    charge factory: :standard_charge
     fee_type { 'charge' }
 
     invoiceable_type { 'Charge' }
@@ -32,5 +32,18 @@ FactoryBot.define do
         'charges_to_date' => Date.parse('2022-08-30'),
       }
     end
+  end
+
+  factory :add_on_fee, class: 'Fee' do
+    invoice
+    fee_type { 'add_on' }
+
+    amount_cents { 200 }
+    amount_currency { 'EUR' }
+
+    invoiceable factory: :add_on
+
+    vat_amount_cents { 2 }
+    vat_amount_currency { 'EUR' }
   end
 end

--- a/spec/models/credit_note_item_spec.rb
+++ b/spec/models/credit_note_item_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNoteItem, type: :model do
+  describe '#total_amount_cents' do
+    let(:item) { create(:credit_note_item) }
+
+    it { expect(item.total_amount_cents).to eq(item.credit_amount_cents) }
+  end
+end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -314,4 +314,20 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe '#display_name' do
+    let(:subscription) { build(:subscription, name: subscription_name, plan: plan) }
+    let(:subscription_name) { 'some_name' }
+    let(:plan) { create(:plan, name: 'some_plan_name') }
+
+    it { expect(subscription.display_name).to eq('some_name') }
+
+    context 'when name is empty' do
+      let(:subscription_name) { nil }
+
+      it 'returns the plan name' do
+        expect(subscription.display_name).to eq('some_plan_name')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR adds the PDF template