### PR TITLE
feat(groups): Ability to fetch billable metric's groups

### DIFF
--- a/app/controllers/api/v1/groups_controller.rb
+++ b/app/controllers/api/v1/groups_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class GroupsController < Api::BaseController
+      def index
+        metric = current_organization.billable_metrics.find_by(id: params[:billable_metric_id])
+        return not_found_error(resource: 'billable_metric') unless metric
+
+        groups = metric.groups.active.children.page(params[:page]).per(params[:per_page] || PER_PAGE)
+
+        render(
+          json: ::CollectionSerializer.new(
+            groups,
+            ::V1::GroupSerializer,
+            collection_name: 'groups',
+            meta: pagination_metadata(groups),
+          ),
+        )
+      end
+    end
+  end
+end

--- a/app/serializers/v1/group_serializer.rb
+++ b/app/serializers/v1/group_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module V1
+  class GroupSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        key: model.key,
+        value: model.value,
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
 
       resources :add_ons, param: :code
       resources :billable_metrics, param: :code
+      resources :groups, only: :index
       resources :coupons, param: :code
       resources :credit_notes, only: %i[show index] do
         post :download, on: :member

--- a/spec/requests/api/v1/groups_spec.rb
+++ b/spec/requests/api/v1/groups_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::GroupsController, type: :request do
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization: organization) }
+
+  describe 'GET /groups' do
+    before { billable_metric }
+
+    context 'when billable_metric_id does not exist' do
+      it 'returns a not found error' do
+        get_with_token(organization, '/api/v1/groups?billable_metric_id=unknown')
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when billable_metric_id does not belong to the current organization' do
+      it 'returns a not found error' do
+        metric = create(:billable_metric)
+        get_with_token(organization, "/api/v1/groups?billable_metric_id=#{metric.id}")
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    it 'returns expected billable metric\'s groups' do
+      parent = create(:group, billable_metric: billable_metric)
+      children1 = create(:group, billable_metric: billable_metric, parent_group_id: parent.id)
+      children2 = create(:group, billable_metric: billable_metric, parent_group_id: parent.id)
+      create(:group, billable_metric: billable_metric, parent_group_id: parent.id, status: :inactive)
+
+      get_with_token(organization, "/api/v1/groups?billable_metric_id=#{billable_metric.id}")
+
+      expect(response).to have_http_status(:success)
+      expect(json[:groups]).to match_array(
+        [
+          { lago_id: children1.id, key: children1.key, value: children1.value },
+          { lago_id: children2.id, key: children2.key, value: children2.value },
+        ],
+      )
+    end
+
+    context 'with pagination' do
+      it 'returns invoices with correct meta data' do
+        parent = create(:group, billable_metric: billable_metric)
+        create_list(:group, 2, billable_metric: billable_metric, parent_group_id: parent.id)
+
+        get_with_token(organization, "/api/v1/groups?billable_metric_id=#{billable_metric.id}&page=1&per_page=1")
+
+        expect(response).to have_http_status(:success)
+
+        expect(json[:groups].count).to eq(1)
+        expect(json[:meta][:current_page]).to eq(1)
+        expect(json[:meta][:next_page]).to eq(2)
+        expect(json[:meta][:prev_page]).to eq(nil)
+        expect(json[:meta][:total_pages]).to eq(2)
+        expect(json[:meta][:total_count]).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

This PR adds the ability to fetch all groups for a specific billable metric.

In a future PR, we'll add the ability to create a charge by defining properties on groups, something like this:
```
group_properties: [
  :group_id,
  { values: {} },
]
```

We should be able to retrieve the id of a group in order to assign values to it for a specific charge.
