### PR TITLE
feat(invoices): A GraphQL resolver and types to fetch a single invoice with details

### DIFF
--- a/app/graphql/resolvers/invoice_resolver.rb
+++ b/app/graphql/resolvers/invoice_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class InvoiceResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description 'Query a single Invoice of an organization'
+
+    argument :id, ID, required: true, description: 'Uniq ID of the invoice'
+
+    type Types::Invoices::Object, null: true
+
+    def resolve(id:)
+      validate_organization!
+
+      current_organization.invoices.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: 'invoice')
+    end
+  end
+end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -6,12 +6,17 @@ module Types
       graphql_name 'Fee'
       implements Types::Invoices::InvoiceItem
 
+      field :charge, Types::Charges::Object, null: true
+      field :subscription, Types::Subscriptions::Object, null: true
+
       field :vat_amount_cents, GraphQL::Types::BigInt, null: false
       field :vat_amount_currency, Types::CurrencyEnum, null: false
 
       field :vat_rate, GraphQL::Types::Float, null: true
       field :units, GraphQL::Types::Float, null: false
       field :events_count, GraphQL::Types::BigInt, null: true
+
+      field :fee_type, Types::Fees::TypesEnum, null: false
 
       def item_type
         object.fee_type

--- a/app/graphql/types/fees/types_enum.rb
+++ b/app/graphql/types/fees/types_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Fees
+    class TypesEnum < Types::BaseEnum
+      graphql_name 'FeeTypesEnum'
+
+      Fee::FEE_TYPES.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/invoice_subscription/object.rb
+++ b/app/graphql/types/invoice_subscription/object.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Types
+  module InvoiceSubscription
+    class Object < Types::BaseObject
+      graphql_name 'InvoiceSubscription'
+
+      field :invoice, Types::Invoices::Object, null: false
+      field :subscription, Types::Subscriptions::Object, null: false
+
+      field :charge_amount_cents, Integer, null: false
+      field :subscription_amount_cents, Integer, null: false
+      field :total_amount_cents, Integer, null: false
+
+      field :fees, [Types::Fees::Object], null: true
+      field :from_date, GraphQL::Types::ISO8601Date, null: false
+      field :to_date, GraphQL::Types::ISO8601Date, null: false
+    end
+  end
+end

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -24,7 +24,14 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       field :subscriptions, [Types::Subscriptions::Object]
+      field :invoice_subscriptions, [Types::InvoiceSubscription::Object]
+      field :fees, [Types::Fees::Object], null: true
       field :plan, Types::Plans::Object
+
+      field :wallet_transaction_amount_cents, Integer, null: false
+      field :subtotal_before_prepaid_credits, String, null: false
+      field :credit_amount_cents, Integer, null: false
+      field :credit_amount_currency, Types::CurrencyEnum, null: false
     end
   end
 end

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -5,9 +5,12 @@ module Types
     class Object < Types::BaseObject
       graphql_name 'Invoice'
 
+      field :customer, Types::Customers::Object, null: false
+
       field :id, ID, null: false
       field :sequential_id, ID, null: false
       field :number, String, null: false
+      field :charge_amount_cents, Integer, null: false
       field :amount_cents, Integer, null: false
       field :amount_currency, Types::CurrencyEnum, null: false
       field :total_amount_cents, Integer, null: false

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -28,6 +28,7 @@ module Types
     field :wallet_transactions, resolver: Resolvers::WalletTransactionsResolver
     field :wallet_transaction, resolver: Resolvers::WalletTransactionResolver
     field :memberships, resolver: Resolvers::MembershipsResolver
+    field :invoice, resolver: Resolvers::InvoiceResolver
     field :invite, resolver: Resolvers::InviteResolver
     field :invites, resolver: Resolvers::InvitesResolver
   end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -27,6 +27,8 @@ module Types
 
       field :next_plan, Types::Plans::Object
 
+      field :fees, [Types::Fees::Object], null: true
+
       def next_plan
         object.next_subscription&.plan
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2779,15 +2779,25 @@ type EventCollection {
 type Fee implements InvoiceItem {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
+  charge: Charge
   eventsCount: BigInt
+  feeType: FeeTypesEnum!
   id: ID!
   itemCode: String!
   itemName: String!
   itemType: String!
+  subscription: Subscription
   units: Float!
   vatAmountCents: BigInt!
   vatAmountCurrency: CurrencyEnum!
   vatRate: Float
+}
+
+enum FeeTypesEnum {
+  add_on
+  charge
+  credit
+  subscription
 }
 
 type GocardlessProvider {
@@ -2844,12 +2854,15 @@ enum InviteStatusTypeEnum {
 type Invoice {
   amountCents: Int!
   amountCurrency: CurrencyEnum!
+  chargeAmountCents: Int!
   createdAt: ISO8601DateTime!
   creditAmountCents: Int!
   creditAmountCurrency: CurrencyEnum!
+  customer: Customer!
   fees: [Fee!]
   fileUrl: String
   id: ID!
+  invoiceSubscriptions: [InvoiceSubscription!]
   invoiceType: InvoiceTypeEnum!
   issuingDate: ISO8601Date!
   number: String!
@@ -2882,6 +2895,17 @@ enum InvoiceStatusTypeEnum {
   failed
   pending
   succeeded
+}
+
+type InvoiceSubscription {
+  chargeAmountCents: Int!
+  fees: [Fee!]
+  fromDate: ISO8601Date!
+  invoice: Invoice!
+  subscription: Subscription!
+  subscriptionAmountCents: Int!
+  toDate: ISO8601Date!
+  totalAmountCents: Int!
 }
 
 enum InvoiceTypeEnum {
@@ -3728,6 +3752,7 @@ type Subscription {
   createdAt: ISO8601DateTime!
   customer: Customer!
   externalId: String!
+  fees: [Fee!]
   id: ID!
   name: String
   nextName: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -2845,6 +2845,9 @@ type Invoice {
   amountCents: Int!
   amountCurrency: CurrencyEnum!
   createdAt: ISO8601DateTime!
+  creditAmountCents: Int!
+  creditAmountCurrency: CurrencyEnum!
+  fees: [Fee!]
   fileUrl: String
   id: ID!
   invoiceType: InvoiceTypeEnum!
@@ -2854,11 +2857,13 @@ type Invoice {
   sequentialId: ID!
   status: InvoiceStatusTypeEnum!
   subscriptions: [Subscription!]
+  subtotalBeforePrepaidCredits: String!
   totalAmountCents: Int!
   totalAmountCurrency: CurrencyEnum!
   updatedAt: ISO8601DateTime!
   vatAmountCents: Int!
   vatAmountCurrency: CurrencyEnum!
+  walletTransactionAmountCents: Int!
 }
 
 """
@@ -3557,6 +3562,16 @@ type Query {
   Query pending invites of an organization
   """
   invites(limit: Int, page: Int): InviteCollection!
+
+  """
+  Query a single Invoice of an organization
+  """
+  invoice(
+    """
+    Uniq ID of the invoice
+    """
+    id: ID!
+  ): Invoice
 
   """
   Query memberships of an organization

--- a/schema.json
+++ b/schema.json
@@ -9938,6 +9938,64 @@
               ]
             },
             {
+              "name": "creditAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditAmountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fees",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Fee",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "fileUrl",
               "description": null,
               "type": {
@@ -10096,6 +10154,24 @@
               ]
             },
             {
+              "name": "subtotalBeforePrepaidCredits",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "totalAmountCents",
               "description": null,
               "type": {
@@ -10176,6 +10252,24 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "walletTransactionAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
                   "ofType": null
                 }
               },
@@ -13504,6 +13598,35 @@
                     "kind": "SCALAR",
                     "name": "Int",
                     "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "invoice",
+              "description": "Query a single Invoice of an organization",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Invoice",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the invoice",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -9223,12 +9223,44 @@
               ]
             },
             {
+              "name": "charge",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Charge",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "eventsCount",
               "description": null,
               "type": {
                 "kind": "SCALAR",
                 "name": "BigInt",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "feeType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "FeeTypesEnum",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -9309,6 +9341,20 @@
               ]
             },
             {
+              "name": "subscription",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Subscription",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "units",
               "description": null,
               "type": {
@@ -9379,6 +9425,41 @@
           ],
           "inputFields": null,
           "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "FeeTypesEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "charge",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "add_on",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscription",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "credit",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
         },
         {
           "kind": "SCALAR",
@@ -9920,6 +10001,24 @@
               ]
             },
             {
+              "name": "chargeAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "createdAt",
               "description": null,
               "type": {
@@ -9964,6 +10063,24 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customer",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Customer",
                   "ofType": null
                 }
               },
@@ -10019,6 +10136,28 @@
                   "kind": "SCALAR",
                   "name": "ID",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoiceSubscriptions",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "InvoiceSubscription",
+                    "ofType": null
+                  }
                 }
               },
               "isDeprecated": false,
@@ -10438,6 +10577,167 @@
               "deprecationReason": null
             }
           ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InvoiceSubscription",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "chargeAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fees",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Fee",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fromDate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoice",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Invoice",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "subscription",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Subscription",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "subscriptionAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "toDate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "totalAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
         },
         {
           "kind": "ENUM",
@@ -14514,6 +14814,28 @@
                   "kind": "SCALAR",
                   "name": "String",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fees",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Fee",
+                    "ofType": null
+                  }
                 }
               },
               "isDeprecated": false,

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($id: ID!) {
+        invoice(id: $id) {
+          id
+          number
+          customer {
+            id
+            name
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:invoice) { create(:invoice, customer: customer) }
+
+  it 'returns a single invoice' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query: query,
+      variables: {
+        id: invoice.id,
+      },
+    )
+
+    data = result['data']['invoice']
+
+    expect(data['id']).to eq(invoice.id)
+    expect(data['number']).to eq(invoice.number)
+    expect(data['customer']['id']).to eq(customer.id)
+    expect(data['customer']['name']).to eq(customer.name)
+  end
+
+  context 'when invoice is not found' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: invoice.organization,
+        query: query,
+        variables: {
+          id: 'foo',
+        },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Resource not found',
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

To ease the work of Credit note, we’ll have an invoice details page to see the details of it and issue a credit note. We don’t have this screen so far so the goal is to build it before credit note.

## Description

This PR does 2 things, in 2 commits:
- [Creates a new invoice resolver](https://github.com/getlago/lago-api/pull/547/commits/e3ca9dddb41eed7a6fa2520c0e7a4afbbd050e5b)
- [Expose missing fields to all frontend to build and invoice details page](https://github.com/getlago/lago-api/pull/547/commits/3911ef891f70bc6f1c855cc28573baa0f1b144e6)

## Links

- Frontend related task: https://github.com/getlago/lago-front/pull/504