### PR TITLE
feat(credit_notes): Prepare changes on invoice to apply credit after VAT

### DIFF
--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -11,6 +11,9 @@ class Credit < ApplicationRecord
 
   validates :amount_currency, inclusion: { in: currency_list }
 
+  scope :coupon_kind, -> { where.not(applied_coupon_id: nil) }
+  scope :credit_note_kind, -> { where.not(credit_note_id: nil) }
+
   def item_id
     return coupon&.id if applied_coupon_id
 

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -16,6 +16,10 @@ module Invoices
           issuing_date: date,
           invoice_type: :add_on,
           status: :pending,
+
+          # NOTE: Apply credits before VAT, will be changed with credit note feature
+          legacy: true,
+          vat_rate: customer.applicable_vat_rate,
         )
 
         create_add_on_fee(invoice)

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -17,6 +17,10 @@ module Invoices
           customer: customer,
           issuing_date: Time.zone.at(timestamp).to_date,
           invoice_type: :subscription,
+
+          # NOTE: Apply credits before VAT, will be changed with credit note feature
+          legacy: true,
+          vat_rate: customer.applicable_vat_rate,
         )
 
         subscriptions.each do |subscription|

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -17,6 +17,10 @@ module Invoices
           issuing_date: Time.zone.at(timestamp).to_date,
           invoice_type: :credit,
           status: :pending,
+
+          # NOTE: Apply credits before VAT, will be changed with credit note feature
+          legacy: true,
+          vat_rate: customer.applicable_vat_rate,
         )
 
         create_credit_fee(invoice)

--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -189,13 +189,6 @@ html
         font-size: 9px;
         line-height: 16px;
       }
-      .prepaid-amount {
-        font-size: 10px;
-        font-family: Inter;
-        color: #008559;
-        font-weight: 600;
-        line-height: 16px;
-      }
 
       .mb-8 {
         margin-bottom: 8px;
@@ -260,69 +253,6 @@ html
         text-align: right;
       }
 
-      .invoice-details-title {
-        page-break-before: always;
-      }
-
-      .subscription-details-table tr td:last-child {
-        text-align: right;
-      }
-      .subscription-details-table tr:last-child td {
-        border-bottom: 1px solid #d9dee7;
-        padding-bottom: 24px;
-      }
-      .subscription-details table {
-        border-collapse: collapse;
-      }
-      .subscription-details .total-table tr:last-child td {
-        border-bottom: 1px solid #d9dee7;
-        padding-bottom: 24px;
-      }
-      .subscription-details .total-table tr:first-child td {
-        padding-top: 24px;
-      }
-      .subscription-details .total-table tr td {
-        text-align: right;
-      }
-
-      .charge-details-table tr td {
-        padding-bottom: 12px;
-      }
-      .charge-details-table tr td:last-child {
-        text-align: right;
-      }
-      .charge-details-table tr:last-child td {
-        border-bottom: 1px solid #d9dee7;
-        padding-bottom: 24px;
-      }
-      .charge-details table {
-        border-collapse: collapse;
-      }
-      .charge-details .total-table tr:last-child td {
-        border-bottom: 1px solid #d9dee7;
-        padding-bottom: 24px;
-      }
-      .charge-details .total-table tr:first-child td {
-        padding-top: 24px;
-      }
-      .charge-details .total-table tr td {
-        text-align: right;
-      }
-
-      .breakdown-details table {
-        border-collapse: collapse;
-      }
-      .breakdown-details-table tr td {
-        padding-bottom: 12px;
-      }
-      .breakdown-details-table tr td:last-child {
-        text-align: right;
-      }
-      .breakdown-details-table tr:last-child td {
-        border-bottom: 1px solid #d9dee7;
-        padding-bottom: 24px;
-      }
-
       .powered-by {
         width: 100%;
         text-align: right;
@@ -335,15 +265,6 @@ html
         height: 11px;
         vertical-align: middle;
         margin-top: 2px;
-      }
-      .alert {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        padding: 16px;
-        gap: 16px;
-        background: #F3F4F6;
-        border-radius: 12px;
       }
 
     .wrapper

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -431,7 +431,7 @@ html
                 .body-1 All usage based fees
               td.body-1 style="text-align: right;" width="30%"
                 = charge_amount.format
-          - if credits.any?
+          - if legacy? && credits.any?
             tr
               td width="70%"
                 .body-1 Coupons
@@ -439,19 +439,48 @@ html
                 = credit_amount.format
 
         table.total-table width="100%"
-          tr
-            td.body-2 width="70%" Sub total
-            td.body-1 width="30%" = subtotal_before_prepaid_credits.format
-          - if subscription? && wallet_transactions.exists?
+          - if legacy?
             tr
-              td.body-2 width="70%" Prepaid credits
-              td.prepaid-amount width="30%" = wallet_transaction_amount.format
-          tr
-            td.body-2 Tax
-            td.body-1 = vat_amount.format
-          tr
-            td.body-2 Total due
-            td.body-1 = total_amount.format
+              td.body-2 width="70%" Sub total
+              td.body-1 width="30%" = subtotal_before_prepaid_credits.format
+            - if subscription? && wallet_transactions.exists?
+              tr
+                td.body-2 width="70%" Prepaid credits
+                td.prepaid-amount width="30%" = wallet_transaction_amount.format
+            tr
+              td.body-2 Tax
+              td.body-1 = vat_amount.format
+            tr
+              td.body-2 Total due
+              td.body-1 = total_amount.format
+          - else
+            tr
+              td.body-1 width="70%" Sub total (excl. tax)
+              td.body-1 width="30%" = sub_total_vat_excluded_amount.format
+            tr
+              td.body-2 Tax (#{vat_rate || 0})%
+              td.body-1 = vat_amount.format
+            tr
+              td.body-1 Sub total (incl. tax)
+              td.body-1 = sub_total_vat_included_amount.format
+            - if credits.credit_note_kind.any?
+              tr
+                td.body-2 Credit Notes
+                td.body-1 style="text-align: right; color: #008559;"
+                  = credit_notes_total_amount.format
+            - if credits.coupon_kind.any?
+              tr
+                td.body-2 Coupons
+                td.body-1 style="text-align: right; color: #008559;"
+                  = coupon_total_amount.format
+            - if subscription? && wallet_transactions.exists?
+              tr
+                td.body-2 width="70%" Prepaid credits
+                td.prepaid-amount width="30%" = wallet_transaction_amount.format
+            tr
+              td.body-1 Total due
+              td.body-1 = total_amount.format
+
 
       p.body-3.mb-24 = organization.invoice_footer
 

--- a/db/migrate/20221018144521_add_legacy_flag_to_invoices.rb
+++ b/db/migrate/20221018144521_add_legacy_flag_to_invoices.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddLegacyFlagToInvoices < ActiveRecord::Migration[7.0]
+  def up
+    change_table :invoices, bulk: true do |t|
+      t.boolean :legacy, null: false, default: false
+      t.float :vat_rate
+    end
+
+    execute "UPDATE invoices SET legacy = 'true';"
+    MigrationTaskJob.set(wait: 40.seconds).perform_later('invoices:fill_vat_rate')
+  end
+
+  def down
+    change_table :invoices, bulk: true do |t|
+      t.remove :legacy
+      t.remove :vat_rate
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_11_133055) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_18_144521) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -308,6 +308,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_11_133055) do
     t.integer "sequential_id"
     t.string "file"
     t.uuid "customer_id"
+    t.boolean "legacy", default: false, null: false
+    t.float "vat_rate"
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
   end
 

--- a/lib/tasks/invoices.rake
+++ b/lib/tasks/invoices.rake
@@ -14,7 +14,7 @@ namespace :invoices do
 
       invoice_subscription = InvoiceSubscription.find_by(
         invoice_id: invoice.id,
-        subscription_id: subscription_id
+        subscription_id: subscription_id,
       )
 
       next if invoice_subscription
@@ -27,6 +27,15 @@ namespace :invoices do
   task fill_customer: :environment do
     Invoice.where(customer_id: nil).find_each do |invoice|
       invoice.update!(customer_id: invoice.subscriptions&.first&.customer_id)
+    end
+  end
+
+  desc 'Fill invoice VAT rate'
+  task fill_vat_rate: :environment do
+    Invoice.where(vat_rate: nil).find_each do |invoice|
+      invoice.update!(
+        vat_rate: (invoice.vat_amount_cents.fdiv(invoice.amount_cents) * 100).round(2),
+      )
     end
   end
 end

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -30,8 +30,11 @@ RSpec.describe Invoices::AddOnService, type: :service do
         expect(result.invoice.amount_currency).to eq('EUR')
         expect(result.invoice.vat_amount_cents).to eq(40)
         expect(result.invoice.vat_amount_currency).to eq('EUR')
+        expect(result.invoice.vat_rate).to eq(20)
         expect(result.invoice.total_amount_cents).to eq(240)
         expect(result.invoice.total_amount_currency).to eq('EUR')
+
+        expect(result.invoice).to be_legacy
       end
     end
 

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -65,8 +65,11 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.amount_currency).to eq('EUR')
           expect(result.invoice.vat_amount_cents).to eq(20)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
+          expect(result.invoice.vat_rate).to eq(20)
           expect(result.invoice.total_amount_cents).to eq(120)
           expect(result.invoice.total_amount_currency).to eq('EUR')
+
+          expect(result.invoice).to be_legacy
         end
       end
 
@@ -183,8 +186,11 @@ RSpec.describe Invoices::CreateService, type: :service do
             expect(result.invoice.amount_currency).to eq('EUR')
             expect(result.invoice.vat_amount_cents).to eq(20)
             expect(result.invoice.vat_amount_currency).to eq('EUR')
+            expect(result.invoice.vat_rate).to eq(20)
             expect(result.invoice.total_amount_cents).to eq(120)
             expect(result.invoice.total_amount_currency).to eq('EUR')
+
+            expect(result.invoice).to be_legacy
           end
         end
 
@@ -210,8 +216,11 @@ RSpec.describe Invoices::CreateService, type: :service do
               expect(result.invoice.amount_currency).to eq('EUR')
               expect(result.invoice.vat_amount_cents).to eq(20)
               expect(result.invoice.vat_amount_currency).to eq('EUR')
+              expect(result.invoice.vat_rate).to eq(20)
               expect(result.invoice.total_amount_cents).to eq(120)
               expect(result.invoice.total_amount_currency).to eq('EUR')
+
+              expect(result.invoice).to be_legacy
             end
           end
         end
@@ -249,8 +258,11 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.amount_currency).to eq('EUR')
           expect(result.invoice.vat_amount_cents).to eq(40)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
+          expect(result.invoice.vat_rate).to eq(20)
           expect(result.invoice.total_amount_cents).to eq(240)
           expect(result.invoice.total_amount_currency).to eq('EUR')
+
+          expect(result.invoice).to be_legacy
         end
       end
 
@@ -751,10 +763,13 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.amount_currency).to eq('EUR')
           expect(result.invoice.vat_amount_cents).to eq(18)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
+          expect(result.invoice.vat_rate).to eq(20)
           expect(result.invoice.total_amount_cents).to eq(108)
           expect(result.invoice.total_amount_currency).to eq('EUR')
 
           expect(result.invoice.credits.count).to eq(1)
+
+          expect(result.invoice).to be_legacy
 
           credit = result.invoice.credits.first
           expect(credit.credit_note).to eq(credit_note)
@@ -798,8 +813,11 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.amount_currency).to eq('EUR')
           expect(result.invoice.vat_amount_cents).to eq(18)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
+          expect(result.invoice.vat_rate).to eq(20)
           expect(result.invoice.total_amount_cents).to eq(108)
           expect(result.invoice.total_amount_currency).to eq('EUR')
+
+          expect(result.invoice).to be_legacy
 
           expect(result.invoice.credits.count).to eq(1)
         end
@@ -851,8 +869,11 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.amount_currency).to eq('EUR')
           expect(result.invoice.vat_amount_cents).to eq(14)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
+          expect(result.invoice.vat_rate).to eq(20)
           expect(result.invoice.total_amount_cents).to eq(84)
           expect(result.invoice.total_amount_currency).to eq('EUR')
+
+          expect(result.invoice).to be_legacy
 
           expect(result.invoice.wallet_transactions.count).to eq(1)
         end

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
   subject(:invoice_service) do
     described_class.new(wallet_transaction: wallet_transaction, timestamp: timestamp)
   end
+
   let(:timestamp) { Time.current.to_i }
 
   describe 'create' do
@@ -36,8 +37,11 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
         expect(result.invoice.amount_currency).to eq('EUR')
         expect(result.invoice.vat_amount_cents).to eq(300)
         expect(result.invoice.vat_amount_currency).to eq('EUR')
+        expect(result.invoice.vat_rate).to eq(20)
         expect(result.invoice.total_amount_cents).to eq(1800)
         expect(result.invoice.total_amount_currency).to eq('EUR')
+
+        expect(result.invoice).to be_legacy
       end
     end
 
@@ -56,8 +60,8 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
         properties: {
           organization_id: invoice.organization.id,
           invoice_id: invoice.id,
-          invoice_type: invoice.invoice_type
-        }
+          invoice_type: invoice.invoice_type,
+        },
       )
     end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR adds some changes on the invoice to allow application of prepaid credit, coupon and credit notes after the VAT instead of before as it is today