### PR TITLE
feat(credit_notes): Apply credits after VAT

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -13,10 +13,12 @@ module Types
       field :charge_amount_cents, Integer, null: false
       field :amount_cents, Integer, null: false
       field :amount_currency, Types::CurrencyEnum, null: false
-      field :total_amount_cents, Integer, null: false
-      field :total_amount_currency, Types::CurrencyEnum, null: false
       field :vat_amount_cents, Integer, null: false
       field :vat_amount_currency, Types::CurrencyEnum, null: false
+      field :credit_amount_cents, Integer, null: false
+      field :credit_amount_currency, Types::CurrencyEnum, null: false
+      field :total_amount_cents, Integer, null: false
+      field :total_amount_currency, Types::CurrencyEnum, null: false
       field :invoice_type, Types::Invoices::InvoiceTypeEnum, null: false
       field :status, Types::Invoices::StatusTypeEnum, null: false
       field :file_url, String, null: true
@@ -26,6 +28,8 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      field :legacy, Boolean, null: false
+
       field :subscriptions, [Types::Subscriptions::Object]
       field :invoice_subscriptions, [Types::InvoiceSubscription::Object]
       field :fees, [Types::Fees::Object], null: true
@@ -33,8 +37,6 @@ module Types
 
       field :wallet_transaction_amount_cents, Integer, null: false
       field :subtotal_before_prepaid_credits, String, null: false
-      field :credit_amount_cents, Integer, null: false
-      field :credit_amount_currency, Types::CurrencyEnum, null: false
     end
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -20,6 +20,7 @@ class Invoice < ApplicationRecord
 
   monetize :amount_cents
   monetize :vat_amount_cents
+  monetize :credit_amount_cents
   monetize :total_amount_cents
 
   # NOTE: Readonly fields
@@ -29,7 +30,6 @@ class Invoice < ApplicationRecord
   monetize :credit_note_total_amount_cents, disable_validation: true, allow_nil: true
   monetize :charge_amount_cents, disable_validation: true, allow_nil: true
   monetize :subscription_amount_cents, disable_validation: true, allow_nil: true
-  monetize :credit_amount_cents, disable_validation: true, allow_nil: true
   monetize :wallet_transaction_amount_cents, disable_validation: true, allow_nil: true
 
   INVOICE_TYPES = %i[subscription add_on credit].freeze
@@ -85,11 +85,6 @@ class Invoice < ApplicationRecord
     fees.subscription_kind.sum(:amount_cents)
   end
   alias subscription_amount_currency currency
-
-  def credit_amount_cents
-    credits.sum(:amount_cents)
-  end
-  alias credit_amount_currency currency
 
   def wallet_transaction_amount_cents
     transaction_amount = wallet_transactions.sum(:amount)

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -14,9 +14,12 @@ module V1
         amount_currency: model.amount_currency,
         vat_amount_cents: model.vat_amount_cents,
         vat_amount_currency: model.vat_amount_currency,
+        credit_amount_cents: model.credit_amount_cents,
+        credit_amount_currency: model.credit_amount_currency,
         total_amount_cents: model.total_amount_cents,
         total_amount_currency: model.total_amount_currency,
         file_url: model.file_url,
+        legacy: model.legacy,
       }
 
       payload = payload.merge(customer) if include?(:customer)

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -18,7 +18,7 @@ module Credits
         invoice: invoice,
         applied_coupon: applied_coupon,
         amount_cents: credit_amount,
-        amount_currency: invoice.amount_currency,
+        amount_currency: invoice.currency,
       )
 
       applied_coupon.frequency_duration -= 1 if applied_coupon.recurring?
@@ -46,17 +46,17 @@ module Credits
 
     def compute_amount
       if applied_coupon.coupon.percentage?
-        discounted_value = invoice.amount_cents * applied_coupon.percentage_rate.fdiv(100)
+        discounted_value = invoice.total_amount_cents * applied_coupon.percentage_rate.fdiv(100)
 
-        return (discounted_value >= invoice.amount_cents) ? invoice.amount_cents : discounted_value.round
+        return (discounted_value >= invoice.total_amount_cents) ? invoice.total_amount_cents : discounted_value.round
       end
 
       if applied_coupon.recurring?
-        return invoice.amount_cents if applied_coupon.amount_cents > invoice.amount_cents
+        return invoice.total_amount_cents if applied_coupon.amount_cents > invoice.total_amount_cents
 
         applied_coupon.amount_cents
       else
-        return invoice.amount_cents if remaining_amount > invoice.amount_cents
+        return invoice.total_amount_cents if remaining_amount > invoice.total_amount_cents
 
         remaining_amount
       end

--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -48,9 +48,9 @@ module Credits
     end
 
     def compute_amount
-      return balance_cents if balance_cents <= invoice.amount_cents
+      return balance_cents if balance_cents <= invoice.total_amount_cents
 
-      invoice.amount_cents
+      invoice.total_amount_cents
     end
 
     def compute_amount_from_cents(amount)

--- a/app/services/credits/credit_note_service.rb
+++ b/app/services/credits/credit_note_service.rb
@@ -13,7 +13,7 @@ module Credits
       return result if already_applied?
 
       result.credits = []
-      remaining_invoice_amount = invoice.amount_cents
+      remaining_invoice_amount = invoice.total_amount_cents
 
       ActiveRecord::Base.transaction do
         credit_notes.each do |credit_note|
@@ -25,7 +25,7 @@ module Credits
             invoice: invoice,
             credit_note: credit_note,
             amount_cents: credit_amount,
-            amount_currency: invoice.amount_currency,
+            amount_currency: invoice.currency,
           )
 
           # NOTE: Consume remaining credit on the credit note
@@ -55,7 +55,6 @@ module Credits
     end
 
     def compute_credit_amount(credit_note, remaining_invoice_amount)
-      # TODO: might change to be applied VAT included
       if credit_note.balance_amount_cents > remaining_invoice_amount
         remaining_invoice_amount
       else

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -18,6 +18,10 @@ module Invoices
           issuing_date: Time.zone.at(timestamp).to_date,
           invoice_type: :subscription,
 
+          amount_currency: currency,
+          vat_amount_currency: currency,
+          total_amount_currency: currency,
+
           # NOTE: Apply credits before VAT, will be changed with credit note feature
           legacy: true,
           vat_rate: customer.applicable_vat_rate,
@@ -36,8 +40,6 @@ module Invoices
         create_coupon_credit(invoice) if should_create_coupon_credit?
         create_applied_prepaid_credit(invoice) if should_create_applied_prepaid_credit?(invoice)
 
-        invoice.total_amount_cents = invoice.amount_cents + invoice.vat_amount_cents
-        invoice.total_amount_currency = currency
         invoice.status = invoice.total_amount_cents.positive? ? :pending : :succeeded
         invoice.save!
 
@@ -71,9 +73,9 @@ module Invoices
       fee_amounts = invoice.fees.select(:amount_cents, :vat_amount_cents)
 
       invoice.amount_cents = fee_amounts.sum(&:amount_cents)
-      invoice.amount_currency = currency
       invoice.vat_amount_cents = fee_amounts.sum(&:vat_amount_cents)
-      invoice.vat_amount_currency = currency
+
+      invoice.total_amount_cents = invoice.amount_cents + invoice.vat_amount_cents
     end
 
     def create_subscription_fee(invoice, subscription, boundaries)
@@ -162,7 +164,7 @@ module Invoices
 
     def should_create_applied_prepaid_credit?(invoice)
       return false unless wallet&.active?
-      return false unless invoice.amount_cents&.positive?
+      return false unless invoice.total_amount_cents&.positive?
 
       wallet.balance.positive?
     end
@@ -194,11 +196,9 @@ module Invoices
       refresh_amounts(invoice: invoice, credit_amount_cents: prepaid_credit_result.prepaid_credit_amount_cents)
     end
 
-    # NOTE: Since credit impact the invoice amount, we need to recompute the amount and
-    #       the VAT amount
+    # NOTE: Since credit impact the invoice total amount, we need to recompute it
     def refresh_amounts(invoice:, credit_amount_cents:)
-      invoice.amount_cents = invoice.amount_cents - credit_amount_cents
-      invoice.vat_amount_cents = (invoice.amount_cents * customer.applicable_vat_rate).fdiv(100).ceil
+      invoice.total_amount_cents -= credit_amount_cents
     end
 
     def create_payment(invoice)

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -20,6 +20,7 @@ module Invoices
 
           amount_currency: currency,
           vat_amount_currency: currency,
+          credit_amount_currency: currency,
           total_amount_currency: currency,
 
           # NOTE: Apply credits before VAT, will be changed with credit note feature
@@ -74,6 +75,8 @@ module Invoices
 
       invoice.amount_cents = fee_amounts.sum(&:amount_cents)
       invoice.vat_amount_cents = fee_amounts.sum(&:vat_amount_cents)
+
+      invoice.credit_amount_cents = 0
 
       invoice.total_amount_cents = invoice.amount_cents + invoice.vat_amount_cents
     end
@@ -198,6 +201,7 @@ module Invoices
 
     # NOTE: Since credit impact the invoice total amount, we need to recompute it
     def refresh_amounts(invoice:, credit_amount_cents:)
+      invoice.credit_amount_cents += credit_amount_cents
       invoice.total_amount_cents -= credit_amount_cents
     end
 

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -436,7 +436,7 @@ html
               td width="70%"
                 .body-1 Coupons
               td.body-1 style="text-align: right; color: #008559;" width="30%"
-                = credit_amount.format
+                = coupon_total_amount.format
 
         table.total-table width="100%"
           - if legacy?

--- a/db/migrate/20221020093745_add_credit_amount_to_invoices.rb
+++ b/db/migrate/20221020093745_add_credit_amount_to_invoices.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddCreditAmountToInvoices < ActiveRecord::Migration[7.0]
+  def up
+    change_table :invoices, bulk: true do |t|
+      t.bigint :credit_amount_cents, null: false, default: 0
+      t.string :credit_amount_currency
+    end
+
+    MigrationTaskJob.set(wait: 40.seconds).perform_later('invoices:fill_credit_amount')
+  end
+
+  def down
+    change_table :invoices, bulk: true do |t|
+      t.remove :credit_amount_cents
+      t.remove :credit_amount_currency
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_18_144521) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_20_093745) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -310,6 +310,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_18_144521) do
     t.uuid "customer_id"
     t.boolean "legacy", default: false, null: false
     t.float "vat_rate"
+    t.bigint "credit_amount_cents", default: 0, null: false
+    t.string "credit_amount_currency"
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
   end
 

--- a/lib/tasks/invoices.rake
+++ b/lib/tasks/invoices.rake
@@ -38,4 +38,14 @@ namespace :invoices do
       )
     end
   end
+
+  desc 'Fill invoice credit amount'
+  task fill_credit_amount: :environment do
+    Invoice.where(credit_amount_cents: 0).find_each do |invoice|
+      invoice.update!(
+        credit_amount_cents: invoice.credit_amount_cents + invoice.wallet_transaction_amount_cents,
+        credit_amount_currency: invoice.currency,
+      )
+    end
+  end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2865,6 +2865,7 @@ type Invoice {
   invoiceSubscriptions: [InvoiceSubscription!]
   invoiceType: InvoiceTypeEnum!
   issuingDate: ISO8601Date!
+  legacy: Boolean!
   number: String!
   plan: Plan
   sequentialId: ID!

--- a/schema.json
+++ b/schema.json
@@ -10203,6 +10203,24 @@
               ]
             },
             {
+              "name": "legacy",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "number",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -8,7 +8,15 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
       query($customerId: ID!) {
         customer(id: $customerId) {
           id externalId name currency
-          invoices { id invoiceType status }
+          invoices {
+            id
+            invoiceType
+            status
+            totalAmountCents
+            creditAmountCents
+            vatAmountCents
+            amountCents
+          }
           subscriptions(status: [active]) { id, status }
           appliedCoupons { id amountCents amountCurrency coupon { id name } }
           appliedAddOns { id amountCents amountCurrency addOn { id name } }

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Credits::AppliedCouponService do
       :invoice,
       amount_cents: amount_cents,
       amount_currency: 'EUR',
+      total_amount_cents: amount_cents,
+      total_amount_currency: 'EUR',
     )
   end
   let(:amount_cents) { 123 }

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
       customer: customer,
       amount_cents: amount_cents,
       amount_currency: 'EUR',
+      total_amount_cents: amount_cents,
+      total_amount_currency: 'EUR',
     )
   end
   let(:amount_cents) { 100 }

--- a/spec/services/credits/credit_note_service_spec.rb
+++ b/spec/services/credits/credit_note_service_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Credits::CreditNoteService do
       customer: customer,
       amount_cents: amount_cents,
       amount_currency: 'EUR',
+      total_amount_cents: amount_cents,
+      total_amount_currency: 'EUR',
     )
   end
 

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.vat_amount_cents).to eq(20)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
           expect(result.invoice.vat_rate).to eq(20)
+          expect(result.invoice.credit_amount_cents).to eq(0)
+          expect(result.invoice.credit_amount_currency).to eq('EUR')
           expect(result.invoice.total_amount_cents).to eq(120)
           expect(result.invoice.total_amount_currency).to eq('EUR')
 
@@ -187,6 +189,8 @@ RSpec.describe Invoices::CreateService, type: :service do
             expect(result.invoice.vat_amount_cents).to eq(20)
             expect(result.invoice.vat_amount_currency).to eq('EUR')
             expect(result.invoice.vat_rate).to eq(20)
+            expect(result.invoice.credit_amount_cents).to eq(0)
+            expect(result.invoice.credit_amount_currency).to eq('EUR')
             expect(result.invoice.total_amount_cents).to eq(120)
             expect(result.invoice.total_amount_currency).to eq('EUR')
 
@@ -217,6 +221,8 @@ RSpec.describe Invoices::CreateService, type: :service do
               expect(result.invoice.vat_amount_cents).to eq(20)
               expect(result.invoice.vat_amount_currency).to eq('EUR')
               expect(result.invoice.vat_rate).to eq(20)
+              expect(result.invoice.credit_amount_cents).to eq(0)
+              expect(result.invoice.credit_amount_currency).to eq('EUR')
               expect(result.invoice.total_amount_cents).to eq(120)
               expect(result.invoice.total_amount_currency).to eq('EUR')
 
@@ -259,6 +265,8 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.vat_amount_cents).to eq(40)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
           expect(result.invoice.vat_rate).to eq(20)
+          expect(result.invoice.credit_amount_cents).to eq(0)
+          expect(result.invoice.credit_amount_currency).to eq('EUR')
           expect(result.invoice.total_amount_cents).to eq(240)
           expect(result.invoice.total_amount_currency).to eq('EUR')
 
@@ -764,6 +772,8 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.vat_amount_cents).to eq(20)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
           expect(result.invoice.vat_rate).to eq(20)
+          expect(result.invoice.credit_amount_cents).to eq(10)
+          expect(result.invoice.credit_amount_currency).to eq('EUR')
           expect(result.invoice.total_amount_cents).to eq(110)
           expect(result.invoice.total_amount_currency).to eq('EUR')
 
@@ -814,6 +824,8 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.vat_amount_cents).to eq(20)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
           expect(result.invoice.vat_rate).to eq(20)
+          expect(result.invoice.credit_amount_cents).to eq(10)
+          expect(result.invoice.credit_amount_currency).to eq('EUR')
           expect(result.invoice.total_amount_cents).to eq(110)
           expect(result.invoice.total_amount_currency).to eq('EUR')
 
@@ -870,6 +882,8 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.vat_amount_cents).to eq(20)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
           expect(result.invoice.vat_rate).to eq(20)
+          expect(result.invoice.credit_amount_cents).to eq(30)
+          expect(result.invoice.credit_amount_currency).to eq('EUR')
           expect(result.invoice.total_amount_cents).to eq(90)
           expect(result.invoice.total_amount_currency).to eq('EUR')
 

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -759,12 +759,12 @@ RSpec.describe Invoices::CreateService, type: :service do
         aggregate_failures do
           expect(result).to be_success
 
-          expect(result.invoice.amount_cents).to eq(90)
+          expect(result.invoice.amount_cents).to eq(100)
           expect(result.invoice.amount_currency).to eq('EUR')
-          expect(result.invoice.vat_amount_cents).to eq(18)
+          expect(result.invoice.vat_amount_cents).to eq(20)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
           expect(result.invoice.vat_rate).to eq(20)
-          expect(result.invoice.total_amount_cents).to eq(108)
+          expect(result.invoice.total_amount_cents).to eq(110)
           expect(result.invoice.total_amount_currency).to eq('EUR')
 
           expect(result.invoice.credits.count).to eq(1)
@@ -809,12 +809,12 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
 
-          expect(result.invoice.amount_cents).to eq(90)
+          expect(result.invoice.amount_cents).to eq(100)
           expect(result.invoice.amount_currency).to eq('EUR')
-          expect(result.invoice.vat_amount_cents).to eq(18)
+          expect(result.invoice.vat_amount_cents).to eq(20)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
           expect(result.invoice.vat_rate).to eq(20)
-          expect(result.invoice.total_amount_cents).to eq(108)
+          expect(result.invoice.total_amount_cents).to eq(110)
           expect(result.invoice.total_amount_currency).to eq('EUR')
 
           expect(result.invoice).to be_legacy
@@ -865,12 +865,12 @@ RSpec.describe Invoices::CreateService, type: :service do
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
 
-          expect(result.invoice.amount_cents).to eq(70)
+          expect(result.invoice.amount_cents).to eq(100)
           expect(result.invoice.amount_currency).to eq('EUR')
-          expect(result.invoice.vat_amount_cents).to eq(14)
+          expect(result.invoice.vat_amount_cents).to eq(20)
           expect(result.invoice.vat_amount_currency).to eq('EUR')
           expect(result.invoice.vat_rate).to eq(20)
-          expect(result.invoice.total_amount_cents).to eq(84)
+          expect(result.invoice.total_amount_cents).to eq(90)
           expect(result.invoice.total_amount_currency).to eq('EUR')
 
           expect(result.invoice).to be_legacy
@@ -890,7 +890,7 @@ RSpec.describe Invoices::CreateService, type: :service do
           create(
             :applied_coupon,
             customer: subscription.customer,
-            amount_cents: 100,
+            amount_cents: 120,
             amount_currency: plan.amount_currency,
           )
         end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR changes the way credit and coupons are applied on an invoice from vat excluded to vat included