### PR TITLE
feat(credit_notes): Add a single credit note GraphQL resolver

### DIFF
--- a/app/graphql/resolvers/credit_note_resolver.rb
+++ b/app/graphql/resolvers/credit_note_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class CreditNoteResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description 'Query a single credit note'
+
+    argument :id, ID, required: true, description: 'Uniq ID of the credit note'
+
+    type Types::CreditNotes::Object, null: true
+
+    def resolve(id: nil)
+      validate_organization!
+
+      current_organization.credit_notes.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: 'credit_note')
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -15,6 +15,7 @@ module Types
     field :billable_metric, resolver: Resolvers::BillableMetricResolver
     field :coupons, resolver: Resolvers::CouponsResolver
     field :coupon, resolver: Resolvers::CouponResolver
+    field :credit_note, resolver: Resolvers::CreditNoteResolver
     field :customers, resolver: Resolvers::CustomersResolver
     field :customer, resolver: Resolvers::CustomerResolver
     field :events, resolver: Resolvers::EventsResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -3492,6 +3492,16 @@ type Query {
   ): CouponCollection!
 
   """
+  Query a single credit note
+  """
+  creditNote(
+    """
+    Uniq ID of the credit note
+    """
+    id: ID!
+  ): CreditNote
+
+  """
   Retrieves currently connected user
   """
   currentUser: User!

--- a/schema.json
+++ b/schema.json
@@ -13205,6 +13205,35 @@
               ]
             },
             {
+              "name": "creditNote",
+              "description": "Query a single credit note",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CreditNote",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the credit note",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "currentUser",
               "description": "Retrieves currently connected user",
               "type": {

--- a/spec/graphql/resolvers/credit_note_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_note_resolver_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::CreditNoteResolver, type: :graphql do
+  let(:query) do
+    <<-GQL
+      query($creditNoteId: ID!) {
+        creditNote(id: $creditNoteId) {
+          id
+          number
+          creditStatus
+          reason
+          totalAmountCents
+          totalAmountCurrency
+          creditAmountCents
+          creditAmountCurrency
+          balanceAmountCents
+          balanceAmountCurrency
+          totalAmountCents
+          totalAmountCurrency
+          createdAt
+          updatedAt
+          fileUrl
+          invoice { id number }
+          items {
+            id
+            creditAmountCents
+            creditAmountCurrency
+            createdAt
+            fee { id amountCents itemType itemCode itemName }
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+
+  let(:customer) { create(:customer, organization: membership.organization) }
+  let(:credit_note) { create(:credit_note, customer: customer) }
+
+  it 'returns a single credit note' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: customer.organization,
+      query: query,
+      variables: {
+        creditNoteId: credit_note.id,
+      },
+    )
+
+    credit_note_response = result['data']['creditNote']
+
+    aggregate_failures do
+      expect(credit_note_response['id']).to eq(credit_note.id)
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR adds a single Credit Note GraphQL resolver to fetch a Credit Note by it's id