### PR TITLE
feat(credit_notes): Add credit note seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -203,3 +203,28 @@ Subscription.all.find_each do |subscription|
     timestamp: Time.zone.now - 2.months,
   ).create
 end
+
+Invoice.all.find_each do |invoice|
+  fee = invoice.fees.sample
+  amount = fee.amount_cents / 2
+  next if amount.zero?
+
+  credit_note = CreditNote.create!(
+    customer: invoice.customer,
+    invoice: invoice,
+    credit_amount_cents: amount,
+    credit_amount_currency: fee.amount_currency,
+    credit_status: :available,
+    balance_amount_cents: amount,
+    balance_amount_currency: fee.amount_currency,
+    reason: :other,
+    total_amount_cents: amount,
+    total_amount_currency: fee.amount_currency,
+  )
+
+  credit_note.items.create!(
+    fee: fee,
+    credit_amount_cents: amount,
+    credit_amount_currency: fee.amount_currency,
+  )
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR adds new seeds to create credit notes