### PR TITLE
feat(credit_notes): Add refund fields to credit notes

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -21,10 +21,12 @@ class CreditNote < ApplicationRecord
   monetize :refund_amount_cents
   monetize :vat_amount_cents
 
-  CREDIT_STATUS = %i[available consumed].freeze
+  CREDIT_STATUS = %i[available consumed no_credit].freeze
+  REFUND_STATUS = %i[no_refund pending refunded].freeze
   REASON = %i[duplicated_charge product_unsatisfactory order_change order_cancellation fraudulent_charge other].freeze
 
   enum credit_status: CREDIT_STATUS
+  enum refund_status: REFUND_STATUS
   enum reason: REASON
 
   sequenced scope: ->(credit_note) { CreditNote.where(invoice_id: credit_note.invoice_id) }
@@ -45,10 +47,6 @@ class CreditNote < ApplicationRecord
 
   def refunded?
     refund_amount_cents.positive?
-  end
-
-  def refund_amount_cents
-    0 # TODO: will change in credit note phase 2
   end
 
   def vat_amount_cents

--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -5,6 +5,7 @@ class CreditNoteItem < ApplicationRecord
   belongs_to :fee
 
   monetize :credit_amount_cents
+  monetize :refund_amount_cents
   monetize :total_amount_cents
 
   validates :credit_amount_cents, numericality: { greater_than_or_equal_to: 0 }

--- a/db/migrate/20221024090308_add_refund_fields_to_credit_notes.rb
+++ b/db/migrate/20221024090308_add_refund_fields_to_credit_notes.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddRefundFieldsToCreditNotes < ActiveRecord::Migration[7.0]
+  def change
+    change_table :credit_notes, bulk: true do |t|
+      t.bigint :refund_amount_cents, null: false, default: 0
+      t.string :refund_amount_currency
+      t.integer :refund_status, null: false, default: 0
+    end
+
+    change_table :credit_note_items, bulk: true do |t|
+      t.bigint :refund_amount_cents, null: false, default: 0
+      t.string :refund_amount_currency
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_18_144521) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_24_090308) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -138,6 +138,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_18_144521) do
     t.string "credit_amount_currency", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "refund_amount_cents", default: 0, null: false
+    t.string "refund_amount_currency"
     t.index ["credit_note_id"], name: "index_credit_note_items_on_credit_note_id"
     t.index ["fee_id"], name: "index_credit_note_items_on_fee_id"
   end
@@ -158,6 +160,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_18_144521) do
     t.datetime "updated_at", null: false
     t.bigint "total_amount_cents", default: 0, null: false
     t.string "total_amount_currency", null: false
+    t.bigint "refund_amount_cents", default: 0, null: false
+    t.string "refund_amount_currency"
+    t.integer "refund_status", default: 0, null: false
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end
@@ -310,6 +315,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_18_144521) do
     t.uuid "customer_id"
     t.boolean "legacy", default: false, null: false
     t.float "vat_rate"
+    t.bigint "credit_amount_cents", default: 0, null: false
+    t.string "credit_amount_currency"
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
   end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1775,6 +1775,7 @@ enum CreditNoteReasonEnum {
 enum CreditNoteTypeEnum {
   available
   consumed
+  no_credit
 }
 
 enum CurrencyEnum {

--- a/schema.json
+++ b/schema.json
@@ -5979,6 +5979,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "no_credit",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to allow credit notes to be created manually and to allow refund in parallel of existing credit.

The main reason behind this need is to handle the following case:
If a problem appeared when creating an invoice (over-bill for instance), we cannot apply a discount to a specific invoice. 

## Description

This PR adds the mandatory database fields to allow a credit note to be handled as a refund