### PR TITLE
feat(credit_notes): Handle refund amount for credit note creation

### DIFF
--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -10,7 +10,12 @@ class CreditNoteItem < ApplicationRecord
 
   validates :credit_amount_cents, numericality: { greater_than_or_equal_to: 0 }
 
-  def total_amount_cents
-    credit_amount_cents # TODO: will take refund amount into account
+  def currency
+    credit_amount_currency
   end
+
+  def total_amount_cents
+    credit_amount_cents + refund_amount_cents
+  end
+  alias total_amount_currency currency
 end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -19,6 +19,7 @@ class Fee < ApplicationRecord
 
   monetize :amount_cents
   monetize :vat_amount_cents
+  monetize :total_amount_cents
 
   FEE_TYPES = %i[charge add_on subscription credit].freeze
 
@@ -52,4 +53,13 @@ class Fee < ApplicationRecord
 
     subscription.plan.name
   end
+
+  def currency
+    amount_currency
+  end
+
+  def total_amount_cents
+    amount_cents + vat_amount_cents
+  end
+  alias total_amount_currency currency
 end

--- a/app/services/credit_notes/validate_item_service.rb
+++ b/app/services/credit_notes/validate_item_service.rb
@@ -5,7 +5,13 @@ module CreditNotes
     def valid?
       return false unless valid_fee?
 
+      valid_invoice_status?
+
+      valid_individual_credit_amount?
+      valid_individual_refund_amount?
       valid_individual_amount?
+      valid_global_credit_amount?
+      valid_global_refund_amount?
       valid_global_amount?
 
       if errors?
@@ -29,8 +35,24 @@ module CreditNotes
       fee.credit_note_items.sum(:credit_amount_cents)
     end
 
+    def refunded_fee_amount_cents
+      fee.credit_note_items.sum(:refund_amount_cents)
+    end
+
+    def total_fee_amount_cents
+      credited_fee_amount_cents + refunded_fee_amount_cents
+    end
+
     def credited_invoice_amount_cents
       invoice.credit_notes.sum(:credit_amount_cents)
+    end
+
+    def refunded_invoice_amount_cents
+      invoice.credit_notes.sum(:refund_amount_cents)
+    end
+
+    def invoice_credit_note_total_amount_cents
+      credited_invoice_amount_cents + refunded_invoice_amount_cents
     end
 
     def valid_fee?
@@ -41,23 +63,69 @@ module CreditNotes
       false
     end
 
+    def valid_invoice_status?
+      if item.refund_amount_cents.positive?
+        return true if invoice.succeeded?
+
+        add_error(field: :refund_amount_cents, error_code: 'cannot_refund_unpaid_invoice')
+        return false
+      end
+
+      true
+    end
+
     # NOTE: Check if item credit amount is less than or equal to fee remaining creditable amount
-    def valid_individual_amount?
-      return true if match_fee_amount?
+    def valid_individual_credit_amount?
+      return true if item.credit_amount_cents.zero?
+      return true if credit_match_fee_amount?
 
       add_error(field: :credit_amount_cents, error_code: 'higher_than_remaining_fee_amount')
     end
 
-    def match_fee_amount?
+    def credit_match_fee_amount?
       item.credit_amount_cents.positive? &&
-        item.credit_amount_cents <= fee.amount_cents - credited_fee_amount_cents
+        item.credit_amount_cents <= fee.total_amount_cents - credited_fee_amount_cents
+    end
+
+    # NOTE: Check if refund amount is less than or equal to fee remaining refundable amount
+    def valid_individual_refund_amount?
+      return true if item.refund_amount_cents.zero?
+      return true if refund_match_fee_amount?
+
+      add_error(field: :refund_amount_cents, error_code: 'higher_than_remaining_fee_amount')
+    end
+
+    def refund_match_fee_amount?
+      item.refund_amount_cents.positive? &&
+        item.refund_amount_cents <= fee.total_amount_cents - refunded_fee_amount_cents
+    end
+
+    # NOTE: Check if total credit note amount is less than or equal to fee remaining amount
+    def valid_individual_amount?
+      return true if item.total_amount_cents <= fee.total_amount_cents - total_fee_amount_cents
+
+      add_error(field: :base, error_code: 'higher_than_remaining_fee_amount')
     end
 
     # NOTE: Check if item credit amount is less than or equal to invoice remaining creditable amount
-    def valid_global_amount?
+    def valid_global_credit_amount?
       return true if item.credit_amount_cents <= invoice.fee_total_amount_cents - credited_invoice_amount_cents
 
       add_error(field: :credit_amount_cents, error_code: 'higher_than_remaining_invoice_amount')
+    end
+
+    # NOTE: Check if item refund amount is less than or equal to invoice remaining refundable amount
+    def valid_global_refund_amount?
+      return true if item.refund_amount_cents <= invoice.total_amount_cents - refunded_invoice_amount_cents
+
+      add_error(field: :refund_amount_cents, error_code: 'higher_than_remaining_invoice_amount')
+    end
+
+    # NOTE: Check if item credit note amount is less than or equal to invoice fee amount
+    def valid_global_amount?
+      return true if item.total_amount_cents <= invoice.amount_cents - invoice_credit_note_total_amount_cents
+
+      add_error(field: :base, error_code: 'higher_than_remaining_invoice_amount')
     end
   end
 end

--- a/spec/factories/credit_note_items.rb
+++ b/spec/factories/credit_note_items.rb
@@ -6,5 +6,7 @@ FactoryBot.define do
     fee
     credit_amount_cents { 100 }
     credit_amount_currency { 'EUR' }
+    refund_amount_cents { 100 }
+    refund_amount_currency { 'EUR' }
   end
 end

--- a/spec/models/credit_note_item_spec.rb
+++ b/spec/models/credit_note_item_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe CreditNoteItem, type: :model do
   describe '#total_amount_cents' do
     let(:item) { create(:credit_note_item) }
 
-    it { expect(item.total_amount_cents).to eq(item.credit_amount_cents) }
+    it 'returns the credit and refund amounts' do
+      expect(item.total_amount_cents).to eq(
+        item.credit_amount_cents + item.refund_amount_cents,
+      )
+    end
+  end
+
+  describe '#total_amount_currency' do
+    let(:item) { create(:credit_note_item, credit_amount_currency: 'JPY') }
+
+    it { expect(item.total_amount_currency).to eq('JPY') }
   end
 end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -87,4 +87,18 @@ RSpec.describe Fee, type: :model do
       end
     end
   end
+
+  describe '#total_amount_cents' do
+    let(:fee) { create(:fee, amount_cents: 100, vat_amount_cents: 20) }
+
+    it 'returns the sum of amount and vat' do
+      expect(fee.total_amount_cents).to eq(120)
+    end
+  end
+
+  describe '#total_amount_currency' do
+    let(:fee) { create(:fee, amount_currency: 'EUR') }
+
+    it { expect(fee.total_amount_currency).to eq('EUR') }
+  end
 end

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe CreditNotes::CreateService, type: :service do
   subject(:create_service) { described_class.new(invoice: invoice, items_attr: items) }
 
-  let(:invoice) { create(:invoice, amount_currency: 'EUR', amount_cents: 20, total_amount_cents: 20) }
+  let(:invoice) do
+    create(:invoice, amount_currency: 'EUR', amount_cents: 20, total_amount_cents: 20, status: :succeeded)
+  end
   let(:fee1) { create(:fee, invoice: invoice, amount_cents: 10) }
   let(:fee2) { create(:fee, invoice: invoice, amount_cents: 10) }
   let(:items) do
@@ -13,10 +15,12 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       {
         fee_id: fee1.id,
         credit_amount_cents: 10,
+        refund_amount_cents: 2,
       },
       {
         fee_id: fee2.id,
         credit_amount_cents: 5,
+        refund_amount_cents: 2,
       },
     ]
   end
@@ -31,24 +35,36 @@ RSpec.describe CreditNotes::CreateService, type: :service do
         credit_note = result.credit_note
         expect(credit_note.invoice).to eq(invoice)
         expect(credit_note.customer).to eq(invoice.customer)
+
         expect(credit_note.total_amount_currency).to eq(invoice.amount_currency)
-        expect(credit_note.total_amount_cents).to eq(15)
+        expect(credit_note.total_amount_cents).to eq(19)
+
         expect(credit_note.credit_amount_currency).to eq(invoice.amount_currency)
         expect(credit_note.credit_amount_cents).to eq(15)
         expect(credit_note.balance_amount_currency).to eq(invoice.amount_currency)
         expect(credit_note.balance_amount_cents).to eq(15)
+        expect(credit_note.credit_status).to eq('available')
+
+        expect(credit_note.refund_amount_currency).to eq(invoice.amount_currency)
+        expect(credit_note.refund_amount_cents).to eq(4)
+        expect(credit_note.refund_status).to eq('pending')
+
         expect(credit_note).to be_other
 
         expect(credit_note.items.count).to eq(2)
-        items1 = credit_note.items.order(created_at: :asc).first
-        expect(items1.fee).to eq(fee1)
-        expect(items1.credit_amount_cents).to eq(10)
-        expect(items1.credit_amount_currency).to eq(invoice.amount_currency)
+        item1 = credit_note.items.order(created_at: :asc).first
+        expect(item1.fee).to eq(fee1)
+        expect(item1.credit_amount_cents).to eq(10)
+        expect(item1.credit_amount_currency).to eq(invoice.amount_currency)
+        expect(item1.refund_amount_cents).to eq(2)
+        expect(item1.refund_amount_currency).to eq(invoice.amount_currency)
 
-        items2 = credit_note.items.order(created_at: :asc).last
-        expect(items2.fee).to eq(fee2)
-        expect(items2.credit_amount_cents).to eq(5)
-        expect(items2.credit_amount_currency).to eq(invoice.amount_currency)
+        item2 = credit_note.items.order(created_at: :asc).last
+        expect(item2.fee).to eq(fee2)
+        expect(item2.credit_amount_cents).to eq(5)
+        expect(item2.credit_amount_currency).to eq(invoice.amount_currency)
+        expect(item2.refund_amount_cents).to eq(2)
+        expect(item2.refund_amount_currency).to eq(invoice.amount_currency)
       end
     end
 
@@ -72,7 +88,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages.keys).to eq([:credit_amount_cents])
+          expect(result.error.messages.keys).to include(:credit_amount_cents)
           expect(result.error.messages[:credit_amount_cents]).to eq(
             %w[
               higher_than_remaining_fee_amount

--- a/spec/services/credit_notes/validate_item_service_spec.rb
+++ b/spec/services/credit_notes/validate_item_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
 
   let(:result) { BaseService::Result.new }
   let(:credit_amount_cents) { 10 }
+  let(:refund_amount_cents) { 0 }
   let(:credit_note) do
     create(
       :credit_note,
@@ -20,11 +21,13 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
       :credit_note_item,
       credit_note: credit_note,
       credit_amount_cents: credit_amount_cents,
+      refund_amount_cents: refund_amount_cents,
       fee: fee,
     )
   end
-  let(:invoice) { create(:invoice, total_amount_cents: 100) }
+  let(:invoice) { create(:invoice, total_amount_cents: 100, amount_cents: 100, status: invoice_status) }
   let(:customer) { invoice.customer }
+  let(:invoice_status) { 'succeeded' }
 
   let(:fee) { create(:fee, invoice: invoice, amount_cents: 100) }
 
@@ -46,6 +49,20 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
       end
     end
 
+    context 'when invoice is not paid' do
+      let(:invoice_status) { 'pending' }
+      let(:refund_amount_cents) { 2 }
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:refund_amount_cents]).to eq(['cannot_refund_unpaid_invoice'])
+        end
+      end
+    end
+
     context 'when credit amount is higher than fee amount' do
       let(:credit_amount_cents) { fee.amount_cents + 10 }
 
@@ -63,7 +80,7 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
       end
     end
 
-    context 'when fee already has credit note items' do
+    context 'when reaching fee creditable amount' do
       before { create(:credit_note_item, fee: fee, credit_amount_cents: 99) }
 
       it 'fails the validation' do
@@ -76,7 +93,7 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
       end
     end
 
-    context 'when invoice already has credit note items' do
+    context 'when reaching invoice creditable amount' do
       before do
         create(:credit_note, invoice: invoice, total_amount_cents: 99)
       end
@@ -87,6 +104,99 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
 
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages[:credit_amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
+        end
+      end
+    end
+
+    context 'when refund amount is higher than fee amount' do
+      let(:credit_amount_cents) { 0 }
+      let(:refund_amount_cents) { fee.amount_cents + 10 }
+
+      before do
+        create(:fee, invoice: invoice, amount_cents: 100, vat_amount_cents: 20)
+        invoice.update!(amount_cents: 220, total_amount_cents: 220)
+      end
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:refund_amount_cents]).to eq(['higher_than_remaining_fee_amount'])
+        end
+      end
+    end
+
+    context 'when reaching fee refundable amount' do
+      before { create(:credit_note_item, fee: fee, credit_amount_cents: 99) }
+
+      let(:credit_amount_cents) { 0 }
+      let(:refund_amount_cents) { 10 }
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:refund_amount_cents]).to eq(['higher_than_remaining_fee_amount'])
+        end
+      end
+    end
+
+    context 'when reaching invoice refundable amount' do
+      before do
+        create(:credit_note, invoice: invoice, total_amount_cents: 99, refund_amount_cents: 99, credit_amount_cents: 0)
+      end
+
+      let(:credit_amount_cents) { 0 }
+      let(:refund_amount_cents) { 10 }
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:refund_amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
+        end
+      end
+    end
+
+    context 'when total amount is higher than fee amount' do
+      let(:credit_amount_cents) { fee.amount_cents - 5 }
+      let(:refund_amount_cents) { 10 }
+
+      before do
+        create(:fee, invoice: invoice, amount_cents: 100, vat_amount_cents: 20)
+        invoice.update!(amount_cents: 220, total_amount_cents: 220)
+      end
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(['higher_than_remaining_fee_amount'])
+        end
+      end
+    end
+
+    context 'when total amount is higher than invoice amount' do
+      before do
+        create(
+          :credit_note,
+          invoice: invoice,
+          credit_amount_cents: 66,
+          refund_amount_cents: 33,
+          total_amount_cents: 99,
+        )
+      end
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(['higher_than_remaining_invoice_amount'])
         end
       end
     end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to allow credit notes to be created manually and to allow refund in parallel of existing credit.

The main reason behind this need is to handle the following case:
If a problem appeared when creating an invoice (over-bill for instance), we cannot apply a discount to a specific invoice. 

## Description

This PR adds the logic to handle refund amount when creating a credit note