### PR TITLE
feat(groups): compute aggregation based on existing groups

### DIFF
--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -4,8 +4,17 @@ module BillableMetrics
   module Aggregations
     class CountService < BillableMetrics::Aggregations::BaseService
       def aggregate(from_date:, to_date:, options: {})
-        result.aggregation = events_scope(from_date: from_date, to_date: to_date).count
+        events = events_scope(from_date: from_date, to_date: to_date)
+
+        result.aggregation = events.count
+        result.aggregation_per_group = aggregation_per_group(events, aggregation_select)
         result
+      end
+
+      private
+
+      def aggregation_select
+        'count(id)'
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -8,6 +8,7 @@ module BillableMetrics
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.maximum("(#{sanitized_field_name})::numeric") || 0
+        result.aggregation_per_group = aggregation_per_group(events, aggregation_select)
         result.count = events.count
         result
       rescue ActiveRecord::StatementInvalid => e
@@ -16,13 +17,8 @@ module BillableMetrics
 
       private
 
-      def sanitized_field_name
-        ActiveRecord::Base.sanitize_sql_for_conditions(
-          [
-            'events.properties->>?',
-            billable_metric.field_name,
-          ],
-        )
+      def aggregation_select
+        "max((#{sanitized_field_name})::numeric)"
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -8,6 +8,7 @@ module BillableMetrics
         @to_date = to_date
 
         result.aggregation = compute_aggregation.ceil(5)
+        result.aggregation_per_group = aggregation_per_group
         result
       end
 
@@ -29,9 +30,21 @@ module BillableMetrics
       attr_reader :from_date, :to_date
 
       def compute_aggregation
-        ActiveRecord::Base.connection
-          .execute(aggregation_query)
-          .first['aggregation_result']
+        ActiveRecord::Base.connection.execute(aggregation_query).first['aggregation_result']
+      end
+
+      def aggregation_per_group
+        return [] if groups.empty?
+
+        ActiveRecord::Base.connection.execute(group_aggregation_query).map do |e|
+          { e['group_name'] => e['total_sum'].ceil(5) } if e['group_name']
+        end.compact
+      end
+
+      def sanitized_name(property)
+        ActiveRecord::Base.sanitize_sql_for_conditions(
+          ['persisted_events.properties->>?', property],
+        )
       end
 
       def aggregation_query
@@ -53,7 +66,7 @@ module BillableMetrics
             )
             .to_sql,
 
-          # # NOTE: Added and then removed during the period
+          # NOTE: Added and then removed during the period
           added_and_removed
             .select(
               "SUM((DATE(persisted_events.removed_at) - DATE(persisted_events.added_at) + 1)::numeric / #{period_duration})::numeric",
@@ -61,6 +74,38 @@ module BillableMetrics
         ]
 
         "SELECT (#{queries.map { |q| "COALESCE((#{q}), 0)" }.join(' + ')}) AS aggregation_result"
+      end
+
+      def group_aggregation_query
+        group_queries = groups.each_with_object([]) do |group, result|
+          result << [
+            # NOTE: Billed on the full period
+            persisted.select(
+              "(SUM(#{persisted_pro_rata}::numeric)) as group_sum, #{sanitized_name(group)} as group_name",
+            ).group(sanitized_name(group)).to_sql,
+
+            # NOTE: Added during the period
+            added.select(
+              "(SUM(('#{to_date}'::date - DATE(persisted_events.added_at) + 1)::numeric  / #{period_duration})::numeric) as group_sum, \
+              #{sanitized_name(group)} as group_name",
+            ).group(sanitized_name(group)).to_sql,
+
+            # NOTE: removed during the period
+            removed.select(
+              "(SUM((DATE(persisted_events.removed_at) - '#{from_date}'::date + 1)::numeric / #{period_duration})::numeric) as group_sum, \
+              #{sanitized_name(group)} as group_name",
+            ).group(sanitized_name(group)).to_sql,
+
+            # NOTE: Added and then removed during the period
+            added_and_removed.select(
+              "(SUM((DATE(persisted_events.removed_at) - DATE(persisted_events.added_at) + 1)::numeric / #{period_duration})::numeric) as group_sum, \
+              #{sanitized_name(group)} as group_name",
+            ).group(sanitized_name(group)).to_sql,
+          ]
+        end
+
+        "SELECT SUM(COALESCE(group_sum, 0)) as total_sum, group_name \
+        FROM (#{group_queries.join(' UNION ')}) AS global_query GROUP BY group_name"
       end
 
       def base_scope

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -8,19 +8,15 @@ module BillableMetrics
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.count("DISTINCT (#{sanitized_field_name})")
+        result.aggregation_per_group = aggregation_per_group(events, aggregation_select)
         result.count = events.count
         result
       end
 
       private
 
-      def sanitized_field_name
-        ActiveRecord::Base.sanitize_sql_for_conditions(
-          [
-            'events.properties->>?',
-            billable_metric.field_name,
-          ],
-        )
+      def aggregation_select
+        "count(distinct(#{sanitized_field_name}))"
       end
     end
   end

--- a/app/services/charges/charge_models/base_service.rb
+++ b/app/services/charges/charge_models/base_service.rb
@@ -15,6 +15,7 @@ module Charges
 
       def apply
         result.units = aggregation_result.aggregation
+        result.group_units = aggregation_result.group_aggregation
         result.count = aggregation_result.count
         result.amount = compute_amount
         result

--- a/app/services/persisted_events/create_or_update_service.rb
+++ b/app/services/persisted_events/create_or_update_service.rb
@@ -39,6 +39,7 @@ module PersistedEvents
         billable_metric: matching_billable_metric,
         external_subscription_id: subscription.external_id,
         external_id: event.properties[matching_billable_metric.field_name],
+        properties: event.properties,
         added_at: event.timestamp,
       )
     end

--- a/db/migrate/20221021135428_add_properties_to_persisted_events.rb
+++ b/db/migrate/20221021135428_add_properties_to_persisted_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPropertiesToPersistedEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :persisted_events, :properties, :jsonb, null: false, default: {}
+  end
+end

--- a/db/migrate/20221021135946_fill_properties_on_persisted_events.rb
+++ b/db/migrate/20221021135946_fill_properties_on_persisted_events.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class FillPropertiesOnPersistedEvents < ActiveRecord::Migration[7.0]
+  def change
+    # NOTE: Wait to ensure workers are loaded with the added tasks
+    MigrationTaskJob.set(wait: 20.seconds).perform_later('events:fill_persisted_properties')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -400,6 +400,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_24_090308) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "billable_metric_id"
+    t.jsonb "properties", default: {}, null: false
     t.index ["billable_metric_id"], name: "index_persisted_events_on_billable_metric_id"
     t.index ["customer_id", "external_subscription_id", "billable_metric_id"], name: "index_search_persisted_events"
     t.index ["customer_id"], name: "index_persisted_events_on_customer_id"

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -22,4 +22,19 @@ namespace :events do
       event.update!(subscription_id: subscription.id)
     end
   end
+
+  desc 'Fill missing properties on persisted_events'
+  task fill_persisted_properties: :environment do
+    PersistedEvent.find_each do |persisted_event|
+      event = Event.where(
+        organization_id: persisted_event.billable_metric.organization_id,
+        customer_id: persisted_event.customer_id,
+      ).where(
+        "properties -> '#{persisted_event.billable_metric.field_name}' = ?",
+        persisted_event.external_id,
+      ).first
+
+      persisted_event.update!(properties: event.properties)
+    end
+  end
 end

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
   let(:from_date) { Time.zone.today - 1.month }
   let(:to_date) { Time.zone.today }
 
-  # TODO : only count existing groups (not africa)
   before do
     create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
     create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -23,16 +23,57 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
   let(:from_date) { Time.zone.today - 1.month }
   let(:to_date) { Time.zone.today }
 
+  # TODO : only count existing groups (not africa)
   before do
-    create_list(
+    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')
+    create(:group, billable_metric_id: billable_metric.id, key: 'country', value: 'france')
+
+    create(
       :event,
-      4,
       code: billable_metric.code,
       customer: customer,
       subscription: subscription,
       timestamp: Time.zone.now,
       properties: {
-        total_count: rand(10),
+        total_count: 6,
+        region: 'europe',
+      },
+    )
+
+    create(
+      :event,
+      code: billable_metric.code,
+      customer: customer,
+      subscription: subscription,
+      timestamp: Time.zone.now,
+      properties: {
+        total_count: 8,
+        region: 'europe',
+      },
+    )
+
+    create(
+      :event,
+      code: billable_metric.code,
+      customer: customer,
+      subscription: subscription,
+      timestamp: Time.zone.now,
+      properties: {
+        total_count: 6,
+        region: 'usa',
+      },
+    )
+
+    create(
+      :event,
+      code: billable_metric.code,
+      customer: customer,
+      subscription: subscription,
+      timestamp: Time.zone.now,
+      properties: {
+        total_count: 8,
+        region: 'africa',
       },
     )
 
@@ -44,6 +85,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       timestamp: Time.zone.now,
       properties: {
         total_count: 12,
+        country: 'france',
       },
     )
   end
@@ -52,6 +94,12 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     result = max_service.aggregate(from_date: from_date, to_date: to_date)
 
     expect(result.aggregation).to eq(12)
+    expect(result.aggregation_per_group).to eq(
+      [
+        [{ 'africa' => 8 }, { 'europe' => 8 }, { 'usa' => 6 }],
+        [{ 'france' => 12 }],
+      ],
+    )
     expect(result.count).to eq(5)
   end
 
@@ -62,6 +110,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       result = max_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.aggregation_per_group).to eq([[], []])
       expect(result.count).to eq(0)
     end
   end
@@ -75,6 +124,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       result = max_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.aggregation_per_group).to eq([[], []])
       expect(result.count).to eq(0)
     end
   end

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -24,15 +24,56 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
   let(:to_date) { Time.zone.today }
 
   before do
+    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')
+    create(:group, billable_metric_id: billable_metric.id, key: 'country', value: 'france')
+
     create_list(
       :event,
-      4,
+      3,
       code: billable_metric.code,
       customer: customer,
       subscription: subscription,
       timestamp: Time.zone.now,
       properties: {
         anonymous_id: 'foo_bar',
+        region: 'europe',
+      },
+    )
+
+    create(
+      :event,
+      code: billable_metric.code,
+      customer: customer,
+      subscription: subscription,
+      timestamp: Time.zone.now,
+      properties: {
+        anonymous_id: 'foo_bar',
+        region: 'usa',
+      },
+    )
+
+    create(
+      :event,
+      code: billable_metric.code,
+      customer: customer,
+      subscription: subscription,
+      timestamp: Time.zone.now,
+      properties: {
+        anonymous_id: 'foo_bar',
+        region: 'africa',
+      },
+    )
+
+    create(
+      :event,
+      code: billable_metric.code,
+      customer: customer,
+      subscription: subscription,
+      timestamp: Time.zone.now,
+      properties: {
+        anonymous_id: 'foo_bar',
+        country: 'france',
       },
     )
   end
@@ -41,7 +82,13 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
     result = count_service.aggregate(from_date: from_date, to_date: to_date)
 
     expect(result.aggregation).to eq(1)
-    expect(result.count).to eq(4)
+    expect(result.aggregation_per_group).to eq(
+      [
+        [{ 'africa' => 1 }, { 'europe' => 1 }, { 'usa' => 1 }],
+        [{ 'france' => 1 }],
+      ],
+    )
+    expect(result.count).to eq(6)
   end
 
   context 'when events are out of bounds' do
@@ -51,6 +98,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       result = count_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.aggregation_per_group).to eq([[], []])
       expect(result.count).to eq(0)
     end
   end
@@ -64,6 +112,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       result = count_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
+      expect(result.aggregation_per_group).to eq([[], []])
       expect(result.count).to eq(0)
     end
   end

--- a/spec/services/persisted_events/create_or_update_service_spec.rb
+++ b/spec/services/persisted_events/create_or_update_service_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe PersistedEvents::CreateOrUpdateService, type: :service do
     {
       'operation_type' => operation_type,
       billable_metric.field_name => 'ext_12345',
+      'region' => 'europe',
     }
   end
 
@@ -47,6 +48,7 @@ RSpec.describe PersistedEvents::CreateOrUpdateService, type: :service do
           expect(persisted_event.customer).to eq(event.customer)
           expect(persisted_event.external_subscription_id).to eq(event.subscription.external_id)
           expect(persisted_event.external_id).to eq('ext_12345')
+          expect(persisted_event.properties).to eq(event.properties)
           expect(persisted_event.added_at.to_s).to eq(event.timestamp.to_s)
         end
       end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to be able to compute aggregation based on existing groups for a billable metric.
