### PR TITLE
fix: Return 0 when free unit per events is not reached

### DIFF
--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -18,6 +18,7 @@ module Charges
       def compute_fixed_amount
         return 0 if units.zero?
         return 0 if fixed_amount.nil?
+        return 0 if free_units_count >= aggregation_result.count
 
         (aggregation_result.count - free_units_count) * fixed_amount
       end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -76,8 +76,6 @@ module Fees
     end
 
     def options
-      return {} unless charge.properties.is_a?(Hash)
-
       {
         free_units_per_events: charge.properties['free_units_per_events'].to_i,
         free_units_per_total_aggregation: BigDecimal(charge.properties['free_units_per_total_aggregation'] || 0),

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
   context 'when fixed amount value is 0' do
     it 'returns expected percentage amount' do
       expect(apply_percentage_service.amount).to eq(
-        (expected_percentage_amount + expected_fixed_amount)
+        (expected_percentage_amount + expected_fixed_amount),
       )
     end
   end
@@ -58,7 +58,7 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
 
     it 'returns expected percentage amount' do
       expect(apply_percentage_service.amount).to eq(
-        (expected_percentage_amount + expected_fixed_amount)
+        (expected_percentage_amount + expected_fixed_amount),
       )
     end
   end
@@ -70,7 +70,7 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
 
     it 'returns expected percentage amount' do
       expect(apply_percentage_service.amount).to eq(
-        (expected_percentage_amount + expected_fixed_amount)
+        (expected_percentage_amount + expected_fixed_amount),
       )
     end
   end
@@ -85,7 +85,7 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
 
     it 'returns expected percentage amount' do
       expect(apply_percentage_service.amount).to eq(
-        (expected_percentage_amount + expected_fixed_amount)
+        (expected_percentage_amount + expected_fixed_amount),
       )
     end
   end
@@ -97,8 +97,18 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
 
     it 'returns expected percentage amount based on last running total' do
       expect(apply_percentage_service.amount).to eq(
-        (expected_percentage_amount + expected_fixed_amount)
+        (expected_percentage_amount + expected_fixed_amount),
       )
+    end
+  end
+
+  context 'when free_units_count > number of events' do
+    let(:free_units_per_events) { 5 }
+    let(:free_units_per_total_aggregation) { nil }
+    let(:aggregation) { 400 }
+
+    it 'returns 0' do
+      expect(apply_percentage_service.amount).to eq(0)
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

--

## Description

When a fixed amount is set on a percentage charge model with some free unit per events, and we’re receiving some events but the limit of free units is not reached, amount can be negative instead of 0.

## Screenshot

<img width="1101" alt="Capture d’écran 2022-10-25 à 14 19 05" src="https://user-images.githubusercontent.com/226046/197797742-6eb1d60a-080d-4d70-8198-e21a71697e2c.png">
