### PR TITLE
feat(credit_notes): Update refund status via API

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -38,6 +38,27 @@ module Api
         )
       end
 
+      def update
+        credit_note = current_organization.credit_notes.find_by(id: params[:id])
+        return not_found_error(resource: 'credit_note') unless credit_note
+
+        result = CreditNotes::UpdateService.new(
+          credit_note: credit_note, **update_params,
+        ).call
+
+        if result.success?
+          render(
+            json: ::V1::CreditNoteSerializer.new(
+              credit_note,
+              root_name: 'credit_note',
+              includes: %i[items],
+            ),
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
       def download
         credit_note = current_organization.credit_notes.find_by(id: params[:id])
         return not_found_error(resource: 'credit_note') unless credit_note
@@ -91,6 +112,10 @@ module Api
               :refund_amount_cents,
             ],
           )
+      end
+
+      def update_params
+        params.require(:credit_note).permit(:refund_status)
       end
     end
   end

--- a/app/services/credit_notes/update_service.rb
+++ b/app/services/credit_notes/update_service.rb
@@ -4,7 +4,7 @@ module CreditNotes
   class UpdateService < BaseService
     def initialize(credit_note:, **params)
       @credit_note = credit_note
-      @params = params
+      @params = params&.with_indifferent_access
 
       super
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
       get '/billable_metrics/:code/groups', to: 'billable_metrics/groups#index', as: 'billable_metric_groups'
 
       resources :coupons, param: :code
-      resources :credit_notes, only: %i[create show index] do
+      resources :credit_notes, only: %i[create update show index] do
         post :download, on: :member
       end
       resources :events, only: %i[create show]

--- a/spec/controllers/api/v1/credit_notes_controller_spec.rb
+++ b/spec/controllers/api/v1/credit_notes_controller_spec.rb
@@ -78,6 +78,39 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
     end
   end
 
+  describe 'PUT /credit_notes/:id' do
+    let(:update_params) { { refund_status: 'refunded' } }
+
+    it 'updates the credit note' do
+      put_with_token(organization, "/api/v1/credit_notes/#{credit_note.id}", credit_note: update_params)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+
+        expect(json[:credit_note][:lago_id]).to eq(credit_note.id)
+        expect(json[:credit_note][:refund_status]).to eq('refunded')
+      end
+    end
+
+    context 'when credit note does not exist' do
+      it 'returns a not found error' do
+        put_with_token(organization, '/api/v1/credit_notes/555', credit_note: update_params)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when provided refund status is invalid' do
+      let(:update_params) { { refund_status: 'foo_bar' } }
+
+      it 'returns an unprocessable entity error' do
+        put_with_token(organization, "/api/v1/credit_notes/#{credit_note.id}", credit_note: update_params)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
   describe 'GET /credit_notes/:id/download' do
     it 'enqueues a job to generate the PDF' do
       post_with_token(organization, "/api/v1/credit_notes/#{credit_note.id}/download")

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'when invoice does not exist' do
-      it 'returns an unprocessable entity error' do
+      it 'returns a not found error' do
         put_with_token(organization, '/api/v1/invoices/555', { invoice: update_params })
 
         expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to allow credit notes to be created manually and to allow refund in parallel of existing credit.

The main reason behind this need is to handle the following case:
If a problem appeared when creating an invoice (over-bill for instance), we cannot apply a discount to a specific invoice. 

## Description

This PR adds the a new a new API route to update the refund status of a credit note