### PR TITLE
fix(subscription): Terminate from API only with active sub

### DIFF
--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -10,7 +10,7 @@ module Subscriptions
     end
 
     def terminate_from_api(organization:, external_id:)
-      subscription = organization.subscriptions.find_by(external_id: external_id)
+      subscription = organization.subscriptions.active.find_by(external_id: external_id)
       return result.not_found_failure!(resource: 'subscription') if subscription.blank?
 
       process_terminate(subscription)

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -15,5 +15,10 @@ FactoryBot.define do
     factory :pending_subscription do
       status { :pending }
     end
+
+    factory :terminated_subscription do
+      status { :terminated }
+      terminated_at { Time.zone.now }
+    end
   end
 end

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -105,6 +105,19 @@ RSpec.describe Subscriptions::TerminateService do
         expect(result.error.error_code).to eq('subscription_not_found')
       end
     end
+
+    context 'when subscription is not active' do
+      let(:subscription) { create(:terminated_subscription) }
+
+      it 'returns an error' do
+        result = terminate_service.terminate_from_api(
+          organization: organization,
+          external_id: subscription.external_id,
+        )
+
+        expect(result.error.error_code).to eq('subscription_not_found')
+      end
+    end
   end
 
   describe '.terminate_and_start_next' do


### PR DESCRIPTION
## Context

When we reactivate a subscription with the same `external_id`, if we want to terminate it, it does not found the right subscription.

## Description

- We should search for subscriptions only into the `active` one
