### PR TITLE
feat (gocardless): generate checkout url with billing request flow

### DIFF
--- a/app/jobs/payment_provider_customers/gocardless_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/gocardless_checkout_url_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class GocardlessCheckoutUrlJob < ApplicationJob
+    queue_as :providers
+
+    retry_on GoCardlessPro::GoCardlessError, wait: :exponentially_longer, attempts: 6
+    retry_on GoCardlessPro::ApiError, wait: :exponentially_longer, attempts: 6
+    retry_on GoCardlessPro::RateLimitError, wait: :exponentially_longer, attempts: 6
+
+    def perform(gocardless_customer)
+      result = PaymentProviderCustomers::GocardlessService.new(gocardless_customer).generate_checkout_url
+      result.throw_error
+    end
+  end
+end

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -29,6 +29,8 @@ class SendWebhookJob < ApplicationJob
       Webhooks::PaymentProviders::CustomerCreatedService.new(object).call
     when :payment_provider_customer_error
       Webhooks::PaymentProviders::CustomerErrorService.new(object, options).call
+    when :payment_provider_customer_checkout_url
+      Webhooks::PaymentProviders::CustomerCheckoutService.new(object, options).call
 
     # NOTE: This add the new way of managing webhooks
     # A refact has to be done to improve webhooks management internally

--- a/app/models/payment_providers/gocardless_provider.rb
+++ b/app/models/payment_providers/gocardless_provider.rb
@@ -2,7 +2,17 @@
 
 module PaymentProviders
   class GocardlessProvider < BaseProvider
+    BILLING_REQUEST_REDIRECT_URL = 'https://gocardless.com/'
+
     validates :access_token, presence: true
+
+    def environment
+      if Rails.env.production?
+        :live
+      else
+        :sandbox
+      end
+    end
 
     def access_token=(access_token)
       push_to_secrets(key: 'access_token', value: access_token)

--- a/app/serializers/v1/payment_providers/customer_checkout_serializer.rb
+++ b/app/serializers/v1/payment_providers/customer_checkout_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module PaymentProviders
+    class CustomerCheckoutSerializer < ModelSerializer
+      def serialize
+        {
+          lago_customer_id: model.id,
+          external_customer_id: model.external_id,
+          payment_provider: model.payment_provider,
+          checkout_url: options[:checkout_url],
+        }
+      end
+    end
+  end
+end

--- a/app/services/payment_provider_customers/gocardless_service.rb
+++ b/app/services/payment_provider_customers/gocardless_service.rb
@@ -19,9 +19,21 @@ module PaymentProviderCustomers
       )
 
       deliver_success_webhook
+      PaymentProviderCustomers::GocardlessCheckoutUrlJob.perform_later(gocardless_customer)
 
       result.gocardless_customer = gocardless_customer
       result
+    end
+
+    def generate_checkout_url
+      billing_request = create_billing_request(gocardless_customer.provider_customer_id)
+      billing_request_flow = create_billing_request_flow(billing_request.id)
+
+      SendWebhookJob.perform_later(
+        :payment_provider_customer_checkout_url,
+        customer,
+        checkout_url: billing_request_flow.authorisation_url
+      )
     end
 
     private
@@ -38,22 +50,21 @@ module PaymentProviderCustomers
       organization.gocardless_payment_provider.access_token
     end
 
+    def client
+      @client || GoCardlessPro::Client.new(access_token: access_token, environment: :sandbox)
+    end
+
     def create_gocardless_customer
-      GoCardlessPro::Client
-        .new(access_token: access_token, environment: :sandbox)
-        .customers
-        .create(params: gocardless_create_payload)
+      client.customers.create(
+        params: {
+          email: customer.email,
+          company_name: customer.name,
+        }
+      )
     rescue GoCardlessPro::Error => e
       deliver_error_webhook(e)
 
       raise
-    end
-
-    def gocardless_create_payload
-      {
-        email: customer.email,
-        company_name: customer.name,
-      }
     end
 
     def deliver_success_webhook
@@ -76,6 +87,39 @@ module PaymentProviderCustomers
           error_code: gocardless_error.code,
         },
       )
+    end
+
+    def create_billing_request(gocardless_customer_id)
+      client.billing_requests.create(
+        params: {
+          mandate_request: {
+            scheme: 'bacs',
+          },
+          links: {
+            customer: gocardless_customer_id,
+          }
+        }
+      )
+    rescue GoCardlessPro::Error => e
+      deliver_error_webhook(e)
+
+      raise
+    end
+
+    def create_billing_request_flow(billing_request_id)
+      client.billing_request_flows.create(
+        params: {
+          redirect_uri: 'https://gocardless.com/',
+          exit_uri: 'https://gocardless.com/',
+          links: {
+            billing_request: billing_request_id,
+          }
+        }
+      )
+    rescue GoCardlessPro::Error => e
+      deliver_error_webhook(e)
+
+      raise
     end
   end
 end

--- a/app/services/payment_provider_customers/gocardless_service.rb
+++ b/app/services/payment_provider_customers/gocardless_service.rb
@@ -32,7 +32,7 @@ module PaymentProviderCustomers
       SendWebhookJob.perform_later(
         :payment_provider_customer_checkout_url,
         customer,
-        checkout_url: billing_request_flow.authorisation_url
+        checkout_url: billing_request_flow.authorisation_url,
       )
     end
 
@@ -59,7 +59,7 @@ module PaymentProviderCustomers
         params: {
           email: customer.email,
           company_name: customer.name,
-        }
+        },
       )
     rescue GoCardlessPro::Error => e
       deliver_error_webhook(e)
@@ -97,8 +97,8 @@ module PaymentProviderCustomers
           },
           links: {
             customer: gocardless_customer_id,
-          }
-        }
+          },
+        },
       )
     rescue GoCardlessPro::Error => e
       deliver_error_webhook(e)
@@ -113,8 +113,8 @@ module PaymentProviderCustomers
           exit_uri: 'https://gocardless.com/',
           links: {
             billing_request: billing_request_id,
-          }
-        }
+          },
+        },
       )
     rescue GoCardlessPro::Error => e
       deliver_error_webhook(e)

--- a/app/services/payment_provider_customers/gocardless_service.rb
+++ b/app/services/payment_provider_customers/gocardless_service.rb
@@ -46,12 +46,15 @@ module PaymentProviderCustomers
       @organization ||= customer.organization
     end
 
-    def access_token
-      organization.gocardless_payment_provider.access_token
+    def gocardless_payment_provider
+      @gocardless_payment_provider || organization.gocardless_payment_provider
     end
 
     def client
-      @client || GoCardlessPro::Client.new(access_token: access_token, environment: :sandbox)
+      @client || GoCardlessPro::Client.new(
+        access_token: gocardless_payment_provider.access_token,
+        environment: gocardless_payment_provider.environment,
+      )
     end
 
     def create_gocardless_customer
@@ -109,8 +112,8 @@ module PaymentProviderCustomers
     def create_billing_request_flow(billing_request_id)
       client.billing_request_flows.create(
         params: {
-          redirect_uri: 'https://gocardless.com/',
-          exit_uri: 'https://gocardless.com/',
+          redirect_uri: PaymentProviders::GocardlessProvider::BILLING_REQUEST_REDIRECT_URL,
+          exit_uri: PaymentProviders::GocardlessProvider::BILLING_REQUEST_REDIRECT_URL,
           links: {
             billing_request: billing_request_id,
           },

--- a/app/services/webhooks/payment_providers/customer_checkout_service.rb
+++ b/app/services/webhooks/payment_providers/customer_checkout_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module PaymentProviders
+    class CustomerCheckoutService < Webhooks::BaseService
+      private
+
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::PaymentProviders::CustomerCheckoutSerializer.new(
+          object,
+          root_name: object_type,
+          checkout_url: options[:checkout_url],
+        )
+      end
+
+      def webhook_type
+        'customer.checkout_url_generated'
+      end
+
+      def object_type
+        'payment_provider_customer_checkout_url'
+      end
+    end
+  end
+end

--- a/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe PaymentProviderCustomers::GocardlessCheckoutUrlJob, type: :job do
-  subject { described_class }
+  subject(:gocardless_checkout_job) { described_class }
 
   let(:gocardless_customer) { create(:gocardless_customer) }
 
@@ -16,7 +16,7 @@ RSpec.describe PaymentProviderCustomers::GocardlessCheckoutUrlJob, type: :job do
     allow(gocardless_service).to receive(:generate_checkout_url)
       .and_return(BaseService::Result.new)
 
-    subject.perform_now(gocardless_customer)
+    gocardless_checkout_job.perform_now(gocardless_customer)
 
     expect(PaymentProviderCustomers::GocardlessService).to have_received(:new)
     expect(gocardless_service).to have_received(:generate_checkout_url)

--- a/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe PaymentProviderCustomers::GocardlessCheckoutUrlJob, type: :job do
+  subject { described_class }
+
   let(:gocardless_customer) { create(:gocardless_customer) }
 
   let(:gocardless_service) { instance_double(PaymentProviderCustomers::GocardlessService) }
@@ -14,7 +16,7 @@ RSpec.describe PaymentProviderCustomers::GocardlessCheckoutUrlJob, type: :job do
     allow(gocardless_service).to receive(:generate_checkout_url)
       .and_return(BaseService::Result.new)
 
-    described_class.perform_now(gocardless_customer)
+    subject.perform_now(gocardless_customer)
 
     expect(PaymentProviderCustomers::GocardlessService).to have_received(:new)
     expect(gocardless_service).to have_received(:generate_checkout_url)

--- a/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/gocardless_checkout_url_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentProviderCustomers::GocardlessCheckoutUrlJob, type: :job do
+  let(:gocardless_customer) { create(:gocardless_customer) }
+
+  let(:gocardless_service) { instance_double(PaymentProviderCustomers::GocardlessService) }
+
+  it 'calls generate_checkout_url method' do
+    allow(PaymentProviderCustomers::GocardlessService).to receive(:new)
+      .with(gocardless_customer)
+      .and_return(gocardless_service)
+    allow(gocardless_service).to receive(:generate_checkout_url)
+      .and_return(BaseService::Result.new)
+
+    described_class.perform_now(gocardless_customer)
+
+    expect(PaymentProviderCustomers::GocardlessService).to have_received(:new)
+    expect(gocardless_service).to have_received(:generate_checkout_url)
+  end
+end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe SendWebhookJob, type: :job do
-  subject { described_class }
+  subject(:send_webhook_job) { described_class }
 
   let(:webhook_invoice_service) { instance_double(Webhooks::InvoicesService) }
   let(:webhook_add_on_service) { instance_double(Webhooks::AddOnService) }
@@ -20,7 +20,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook invoice service' do
-      subject.perform_now(:invoice, invoice)
+      send_webhook_job.perform_now(:invoice, invoice)
 
       expect(Webhooks::InvoicesService).to have_received(:new)
       expect(webhook_invoice_service).to have_received(:call)
@@ -36,7 +36,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook invoice service' do
-      subject.perform_now(:add_on, invoice)
+      send_webhook_job.perform_now(:add_on, invoice)
 
       expect(Webhooks::AddOnService).to have_received(:new)
       expect(webhook_add_on_service).to have_received(:call)
@@ -64,7 +64,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook event service' do
-      subject.perform_now(:event, object)
+      send_webhook_job.perform_now(:event, object)
 
       expect(Webhooks::EventService).to have_received(:new)
       expect(webhook_event_service).to have_received(:call)
@@ -91,7 +91,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook event service' do
-      subject.perform_now(
+      send_webhook_job.perform_now(
         :payment_provider_invoice_payment_error,
         invoice,
         webhook_options,
@@ -114,7 +114,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook event service' do
-      subject.perform_now(
+      send_webhook_job.perform_now(
         :payment_provider_customer_created,
         customer,
       )
@@ -136,7 +136,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook service' do
-      subject.perform_now(
+      send_webhook_job.perform_now(
         :payment_provider_customer_checkout_url,
         customer,
         checkout_url: 'https://example.com',
@@ -168,7 +168,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook event service' do
-      subject.perform_now(
+      send_webhook_job.perform_now(
         :payment_provider_customer_error,
         customer,
         webhook_options,
@@ -191,7 +191,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook service' do
-      subject.perform_now(
+      send_webhook_job.perform_now(
         'credit_note.created',
         credit_note,
       )
@@ -213,7 +213,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook service' do
-      subject.perform_now(
+      send_webhook_job.perform_now(
         'credit_note.generated',
         credit_note,
       )
@@ -225,7 +225,7 @@ RSpec.describe SendWebhookJob, type: :job do
 
   context 'with not implemented webhook type' do
     it 'raises a NotImplementedError' do
-      expect { subject.perform_now(:subscription, invoice) }
+      expect { send_webhook_job.perform_now(:subscription, invoice) }
         .to raise_error(NotImplementedError)
     end
   end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -122,6 +122,29 @@ RSpec.describe SendWebhookJob, type: :job do
     end
   end
 
+  context 'when webhook_type is payment_provider_customer_checkout_url' do
+    let(:webhook_service) { instance_double(Webhooks::PaymentProviders::CustomerCheckoutService) }
+    let(:customer) { create(:customer) }
+
+    before do
+      allow(Webhooks::PaymentProviders::CustomerCheckoutService).to receive(:new)
+        .with(customer, checkout_url: 'https://example.com')
+        .and_return(webhook_service)
+      allow(webhook_service).to receive(:call)
+    end
+
+    it 'calls the webhook service' do
+      described_class.perform_now(
+        :payment_provider_customer_checkout_url,
+        customer,
+        checkout_url: 'https://example.com'
+      )
+
+      expect(Webhooks::PaymentProviders::CustomerCheckoutService).to have_received(:new)
+      expect(webhook_service).to have_received(:call)
+    end
+  end
+
   context 'when webhook_type is payment_provider_customer_error' do
     let(:webhook_service) { instance_double(Webhooks::PaymentProviders::CustomerErrorService) }
     let(:customer) { create(:customer) }

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe SendWebhookJob, type: :job do
+  subject { described_class }
+
   let(:webhook_invoice_service) { instance_double(Webhooks::InvoicesService) }
   let(:webhook_add_on_service) { instance_double(Webhooks::AddOnService) }
   let(:webhook_event_service) { instance_double(Webhooks::EventService) }
@@ -18,7 +20,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook invoice service' do
-      described_class.perform_now(:invoice, invoice)
+      subject.perform_now(:invoice, invoice)
 
       expect(Webhooks::InvoicesService).to have_received(:new)
       expect(webhook_invoice_service).to have_received(:call)
@@ -34,7 +36,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook invoice service' do
-      described_class.perform_now(:add_on, invoice)
+      subject.perform_now(:add_on, invoice)
 
       expect(Webhooks::AddOnService).to have_received(:new)
       expect(webhook_add_on_service).to have_received(:call)
@@ -62,7 +64,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook event service' do
-      described_class.perform_now(:event, object)
+      subject.perform_now(:event, object)
 
       expect(Webhooks::EventService).to have_received(:new)
       expect(webhook_event_service).to have_received(:call)
@@ -89,7 +91,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook event service' do
-      described_class.perform_now(
+      subject.perform_now(
         :payment_provider_invoice_payment_error,
         invoice,
         webhook_options,
@@ -112,7 +114,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook event service' do
-      described_class.perform_now(
+      subject.perform_now(
         :payment_provider_customer_created,
         customer,
       )
@@ -134,7 +136,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook service' do
-      described_class.perform_now(
+      subject.perform_now(
         :payment_provider_customer_checkout_url,
         customer,
         checkout_url: 'https://example.com',
@@ -166,7 +168,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook event service' do
-      described_class.perform_now(
+      subject.perform_now(
         :payment_provider_customer_error,
         customer,
         webhook_options,
@@ -189,7 +191,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook service' do
-      described_class.perform_now(
+      subject.perform_now(
         'credit_note.created',
         credit_note,
       )
@@ -211,7 +213,7 @@ RSpec.describe SendWebhookJob, type: :job do
     end
 
     it 'calls the webhook service' do
-      described_class.perform_now(
+      subject.perform_now(
         'credit_note.generated',
         credit_note,
       )
@@ -223,7 +225,7 @@ RSpec.describe SendWebhookJob, type: :job do
 
   context 'with not implemented webhook type' do
     it 'raises a NotImplementedError' do
-      expect { described_class.perform_now(:subscription, invoice) }
+      expect { subject.perform_now(:subscription, invoice) }
         .to raise_error(NotImplementedError)
     end
   end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe SendWebhookJob, type: :job do
       described_class.perform_now(
         :payment_provider_customer_checkout_url,
         customer,
-        checkout_url: 'https://example.com'
+        checkout_url: 'https://example.com',
       )
 
       expect(Webhooks::PaymentProviders::CustomerCheckoutService).to have_received(:new)

--- a/spec/serializers/v1/payment_providers/customer_checkout_serializer_spec.rb
+++ b/spec/serializers/v1/payment_providers/customer_checkout_serializer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::PaymentProviders::CustomerCheckoutSerializer do
+  subject(:serializer) { described_class.new(customer, options) }
+
+  let(:customer) { create(:customer) }
+  let(:options) do
+    { 'checkout_url' => 'https://example.com' }.with_indifferent_access
+  end
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['data']['lago_customer_id']).to eq(customer.id)
+      expect(result['data']['external_customer_id']).to eq(customer.external_id)
+      expect(result['data']['payment_provider']).to eq(customer.payment_provider)
+      expect(result['data']['checkout_url']).to eq('https://example.com')
+    end
+  end
+end

--- a/spec/services/payment_provider_customers/gocardless_service_spec.rb
+++ b/spec/services/payment_provider_customers/gocardless_service_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe PaymentProviderCustomers::GocardlessService, type: :service do
   let(:organization) { gocardless_provider.organization }
   let(:gocardless_client) { instance_double(GoCardlessPro::Client) }
   let(:gocardless_customers_service) { instance_double(GoCardlessPro::Services::CustomersService) }
+  let(:gocardless_billing_request_service) { instance_double(GoCardlessPro::Services::BillingRequestsService) }
+  let(:gocardless_billing_request_flow_service) { instance_double(GoCardlessPro::Services::BillingRequestFlowsService) }
 
   let(:gocardless_customer) do
     create(:gocardless_customer, customer: customer, provider_customer_id: nil)
@@ -40,12 +42,20 @@ RSpec.describe PaymentProviderCustomers::GocardlessService, type: :service do
         .with(:payment_provider_customer_created, customer)
     end
 
+    it 'triggers checkout job' do
+      gocardless_service.create
+
+      expect(gocardless_customers_service).to have_received(:create)
+      expect(PaymentProviderCustomers::GocardlessCheckoutUrlJob).to have_been_enqueued
+        .with(gocardless_customer)
+    end
+
     context 'when customer already have a gocardless customer id' do
       let(:gocardless_customer) do
         create(:gocardless_customer, customer: customer, provider_customer_id: 'cus_123456')
       end
 
-      it 'does not call stripe API' do
+      it 'does not call gocardless API' do
         gocardless_service.create
 
         expect(gocardless_customers_service).not_to have_received(:create)
@@ -69,6 +79,42 @@ RSpec.describe PaymentProviderCustomers::GocardlessService, type: :service do
               error_code: nil,
             },
           )
+      end
+    end
+  end
+
+  describe '.generate_checkout_url' do
+    before do
+      allow(GoCardlessPro::Client).to receive(:new)
+        .and_return(gocardless_client)
+      allow(gocardless_client).to receive(:billing_requests)
+        .and_return(gocardless_billing_request_service)
+      allow(gocardless_billing_request_service).to receive(:create)
+        .and_return(GoCardlessPro::Resources::BillingRequest.new('id' => '123'))
+
+      allow(gocardless_client).to receive(:billing_request_flows)
+        .and_return(gocardless_billing_request_flow_service)
+      allow(gocardless_billing_request_flow_service).to receive(:create)
+        .and_return(GoCardlessPro::Resources::BillingRequestFlow.new('authorisation_url' => 'https://example.com'))
+    end
+
+    it 'receives billing request flow response' do
+      gocardless_service.generate_checkout_url
+
+      aggregate_failures do
+        expect(gocardless_billing_request_service).to have_received(:create)
+        expect(gocardless_billing_request_flow_service).to have_received(:create)
+      end
+    end
+
+    it 'delivers a webhook with checkout url' do
+      gocardless_service.generate_checkout_url
+
+      aggregate_failures do
+        expect(gocardless_billing_request_service).to have_received(:create)
+        expect(gocardless_billing_request_flow_service).to have_received(:create)
+        expect(SendWebhookJob).to have_been_enqueued
+          .with(:payment_provider_customer_checkout_url, customer, checkout_url: 'https://example.com')
       end
     end
   end

--- a/spec/services/webhooks/payment_providers/customer_checkout_service_spec.rb
+++ b/spec/services/webhooks/payment_providers/customer_checkout_service_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::PaymentProviders::CustomerCheckoutService do
+  subject(:webhook_service) { described_class.new(customer) }
+
+  let(:customer) { create(:customer, organization: organization) }
+  let(:organization) { create(:organization, webhook_url: webhook_url) }
+  let(:webhook_url) { 'http://foo.bar' }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post)
+    end
+
+    it 'calls the organization webhook url' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post)
+    end
+
+    it 'builds payload with customer.checkout_url_generated webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post) do |payload|
+        expect(payload[:webhook_type]).to eq('customer.checkout_url_generated')
+        expect(payload[:object_type]).to eq('payment_provider_customer_checkout_url')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Generate gocardless checkout url

## Description

Gocardless payment request cannot be made unless customer have `mandate_id`. We need to trigger generation of the checkout url (where end-user will fill billing details) and pass the url in the webhook. When end-user fills the form we can expect mandate_id in the incoming webhook...
