### PR TITLE
fix(groups): Update charge with group properties

### DIFF
--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -96,9 +96,7 @@ module Plans
         if charge
           # NOTE: charges cannot be edited if plan is attached to a subscription
           unless plan.attached_to_subscriptions?
-            if payload_charge[:group_properties]
-              charge.group_properties = payload_charge[:group_properties].map { |gp| GroupProperty.new(gp) }
-            end
+            payload_charge[:group_properties]&.map! { |gp| GroupProperty.new(gp) }
             charge.update(payload_charge)
             charge
           end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -120,9 +120,12 @@ RSpec.describe Plans::UpdateService, type: :service do
               id: existing_charge.id,
               billable_metric_id: billable_metrics.first.id,
               charge_model: 'standard',
-              properties: {
-                amount: '100',
-              },
+              group_properties: [
+                {
+                  group_id: group.id,
+                  values: { amount: '100' },
+                },
+              ],
             },
             {
               billable_metric_id: billable_metrics.last.id,
@@ -138,6 +141,16 @@ RSpec.describe Plans::UpdateService, type: :service do
       it 'updates existing charge and creates an other one' do
         expect { plans_service.update(**update_args) }
           .to change(Charge, :count).by(1)
+      end
+
+      it 'updates group properties' do
+        expect { plans_service.update(**update_args) }
+          .to change(GroupProperty, :count).by(1)
+
+        expect(existing_charge.reload.group_properties.first).to have_attributes(
+          group_id: group.id,
+          values: { 'amount' => '100' },
+        )
       end
     end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to be able to update a plan by setting group properties to a charge.
