### PR TITLE
feat (gocardless): implement gocardless payment flow

### DIFF
--- a/app/jobs/invoices/payments/gocardless_create_job.rb
+++ b/app/jobs/invoices/payments/gocardless_create_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    class GocardlessCreateJob < ApplicationJob
+      queue_as 'providers'
+
+      def perform(invoice)
+        result = Invoices::Payments::GocardlessService.new(invoice).create
+        result.throw_error unless result.success?
+      end
+    end
+  end
+end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -112,7 +112,7 @@ class BaseService
 
   def initialize(current_user = nil)
     @result = Result.new
-    @source = CurrentContext.source
+    @source = CurrentContext&.source
     result.user = current_user
   end
 

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -205,6 +205,8 @@ module Invoices
       case customer.payment_provider&.to_sym
       when :stripe
         Invoices::Payments::StripeCreateJob.perform_later(invoice)
+      when :gocardless
+        Invoices::Payments::GocardlessCreateJob.perform_later(invoice)
       end
     end
 

--- a/app/services/invoices/payments/gocardless_service.rb
+++ b/app/services/invoices/payments/gocardless_service.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    class GocardlessService < BaseService
+      PENDING_STATUSES = %w[pending_customer_approval pending_submission submitted confirmed].freeze
+      SUCCESS_STATUSES = %w[paid_out].freeze
+      FAILED_STATUSES = %w[cancelled customer_approval_denied failed charged_back].freeze
+
+      def initialize(invoice = nil)
+        @invoice = invoice
+
+        super(nil)
+      end
+
+      def create
+        result.invoice = invoice
+        return result unless should_process_payment?
+
+        unless invoice.total_amount_cents.positive?
+          update_invoice_status(:succeeded)
+          return result
+        end
+
+        gocardless_result = create_gocardless_payment
+
+        payment = Payment.new(
+          invoice: invoice,
+          payment_provider_id: organization.gocardless_payment_provider.id,
+          payment_provider_customer_id: customer.gocardless_customer.id,
+          amount_cents: gocardless_result.amount,
+          amount_currency: gocardless_result.currency&.upcase,
+          provider_payment_id: gocardless_result.id,
+          status: gocardless_result.status,
+        )
+        payment.save!
+
+        invoice_status = invoice_status(payment.status)
+        update_invoice_status(invoice_status)
+        handle_prepaid_credits(invoice_status)
+        track_payment_status_changed(payment.invoice)
+
+        result.payment = payment
+        result
+      end
+
+      def update_status(provider_payment_id:, status:)
+        payment = Payment.find_by(provider_payment_id: provider_payment_id)
+        return result.not_found_failure!(resource: 'gocardless_payment') unless payment
+
+        result.payment = payment
+        result.invoice = payment.invoice
+        return result if payment.invoice.succeeded?
+
+        payment.update!(status: status)
+
+        invoice_status = invoice_status(status)
+        payment.invoice.update!(status: invoice_status)
+        handle_prepaid_credits(invoice_status)
+        track_payment_status_changed(payment.invoice)
+
+        result
+      rescue ArgumentError
+        result.single_validation_failure!(field: :status, error_code: 'value_is_invalid')
+      end
+
+      private
+
+      attr_accessor :invoice
+
+      delegate :organization, :customer, to: :invoice
+
+      def should_process_payment?
+        return false if invoice.succeeded?
+        return false if organization.gocardless_payment_provider.blank?
+        return false if customer&.gocardless_customer&.provider_customer_id.blank?
+        return false if customer&.gocardless_customer&.provider_mandate_id.blank?
+
+        true
+      end
+
+      def client
+        @client ||= GoCardlessPro::Client.new(access_token: access_token, environment: :sandbox)
+      end
+
+      def access_token
+        organization.gocardless_payment_provider.access_token
+      end
+
+      def create_gocardless_payment
+        client.payments.create(
+          params: {
+            amount: invoice.total_amount_cents,
+            currency: invoice.total_amount_currency.upcase,
+            reference: invoice.id,
+            metadata: {
+              lago_customer_id: customer.id,
+              lago_invoice_id: invoice.id,
+              invoice_issuing_date: invoice.issuing_date.iso8601,
+            },
+            links: {
+              mandate: customer.gocardless_customer.provider_mandate_id,
+            },
+          },
+          headers: {
+            'Idempotency-Key' => invoice.id,
+          },
+        )
+      rescue GoCardlessPro::Error => e
+        deliver_error_webhook(e)
+        update_invoice_status(:failed)
+
+        raise
+      end
+
+      def invoice_status(status)
+        return 'pending' if PENDING_STATUSES.include?(status)
+        return 'succeeded' if SUCCESS_STATUSES.include?(status)
+        return 'failed' if FAILED_STATUSES.include?(status)
+
+        status
+      end
+
+      def update_invoice_status(status)
+        return unless Invoice::STATUS.include?(status&.to_sym)
+
+        invoice.update!(status: status)
+      end
+
+      def handle_prepaid_credits(invoice_status)
+        return unless invoice.invoice_type == 'credit'
+        return unless invoice_status == 'succeeded'
+
+        Invoices::PrepaidCreditJob.perform_later(invoice)
+      end
+
+      def deliver_error_webhook(gocardless_error)
+        return unless invoice.organization.webhook_url?
+
+        SendWebhookJob.perform_later(
+          :payment_provider_invoice_payment_error,
+          invoice,
+          provider_customer_id: customer.gocardless_customer.provider_customer_id,
+          provider_error: {
+            message: gocardless_error.message,
+            error_code: gocardless_error.code,
+          },
+        )
+      end
+
+      def track_payment_status_changed(invoice)
+        SegmentTrackJob.perform_later(
+          membership_id: CurrentContext.membership,
+          event: 'payment_status_changed',
+          properties: {
+            organization_id: invoice.organization.id,
+            invoice_id: invoice.id,
+            payment_status: invoice.status,
+          },
+        )
+      end
+    end
+  end
+end

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -18,8 +18,6 @@ module Invoices
           return result
         end
 
-        ensure_provider_customer
-
         stripe_result = create_stripe_payment
 
         payment = Payment.new(
@@ -67,24 +65,9 @@ module Invoices
 
       def should_process_payment?
         return false if invoice.succeeded?
+        return false if organization.stripe_payment_provider.blank?
 
-        organization.stripe_payment_provider.present?
-      end
-
-      def ensure_provider_customer
-        return if customer.stripe_customer&.provider_customer_id
-
-        customer_result = PaymentProviderCustomers::CreateService.new(customer)
-          .create_or_update(
-            customer_class: PaymentProviderCustomers::StripeCustomer,
-            payment_provider_id: organization.stripe_payment_provider.id,
-            params: {},
-            async: false,
-          )
-        customer_result.throw_error
-
-        # NOTE: stripe customer is created on an other instance of the customer
-        customer.reload
+        customer&.stripe_customer&.provider_customer_id
       end
 
       def stripe_api_key

--- a/spec/jobs/invoices/payments/gocardless_create_job_spec.rb
+++ b/spec/jobs/invoices/payments/gocardless_create_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::Payments::GocardlessCreateJob, type: :job do
+  let(:invoice) { create(:invoice) }
+
+  let(:gocardless_service) { instance_double(Invoices::Payments::GocardlessService) }
+
+  it 'calls the stripe create service' do
+    allow(Invoices::Payments::GocardlessService).to receive(:new)
+      .with(invoice)
+      .and_return(gocardless_service)
+    allow(gocardless_service).to receive(:create)
+      .and_return(BaseService::Result.new)
+
+    described_class.perform_now(invoice)
+
+    expect(Invoices::Payments::GocardlessService).to have_received(:new)
+    expect(gocardless_service).to have_received(:create)
+  end
+end

--- a/spec/services/invoices/payments/gocardless_service_spec.rb
+++ b/spec/services/invoices/payments/gocardless_service_spec.rb
@@ -2,13 +2,15 @@
 
 require 'rails_helper'
 
-RSpec.describe Invoices::Payments::StripeService, type: :service do
-  subject(:stripe_service) { described_class.new(invoice) }
+RSpec.describe Invoices::Payments::GocardlessService, type: :service do
+  subject(:gocardless_service) { described_class.new(invoice) }
 
   let(:customer) { create(:customer) }
   let(:organization) { customer.organization }
-  let(:stripe_payment_provider) { create(:stripe_provider, organization: organization) }
-  let(:stripe_customer) { create(:stripe_customer, customer: customer, payment_method_id: 'pm_123456') }
+  let(:gocardless_payment_provider) { create(:gocardless_provider, organization: organization) }
+  let(:gocardless_customer) { create(:gocardless_customer, customer: customer, provider_mandate_id: '123') }
+  let(:gocardless_client) { instance_double(GoCardlessPro::Client) }
+  let(:gocardless_payments_service) { instance_double(GoCardlessPro::Services::PaymentsService) }
 
   let(:invoice) do
     create(
@@ -20,37 +22,27 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
   end
 
   describe '.create' do
-    let(:provider_customer_service) { instance_double(PaymentProviderCustomers::StripeService) }
-    let(:provider_customer_service_result) do
-      BaseService::Result.new.tap do |result|
-        result.payment_method = Stripe::PaymentMethod.new(id: 'pm_123456')
-      end
-    end
-
     before do
-      stripe_payment_provider
-      stripe_customer
+      gocardless_payment_provider
+      gocardless_customer
 
-      allow(Stripe::PaymentIntent).to receive(:create)
-        .and_return(
-          Stripe::PaymentIntent.construct_from(
-            id: 'ch_123456',
-            status: 'succeeded',
-            amount: invoice.total_amount_cents,
-            currency: invoice.total_amount_currency,
-          ),
-        )
+      allow(GoCardlessPro::Client).to receive(:new)
+        .and_return(gocardless_client)
+      allow(gocardless_client).to receive(:payments)
+        .and_return(gocardless_payments_service)
+      allow(gocardless_payments_service).to receive(:create)
+        .and_return(GoCardlessPro::Resources::Payment.new(
+          'id' => '_ID_',
+          'amount' => invoice.total_amount_cents,
+          'currency' => invoice.total_amount_currency,
+          'status' => 'paid_out',
+        ))
       allow(SegmentTrackJob).to receive(:perform_later)
       allow(Invoices::PrepaidCreditJob).to receive(:perform_later)
-
-      allow(PaymentProviderCustomers::StripeService).to receive(:new)
-        .and_return(provider_customer_service)
-      allow(provider_customer_service).to receive(:check_payment_method)
-        .and_return(provider_customer_service_result)
     end
 
-    it 'creates a stripe payment and a payment' do
-      result = stripe_service.create
+    it 'creates a gocardless payment and a payment' do
+      result = gocardless_service.create
 
       expect(result).to be_success
 
@@ -59,14 +51,14 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
 
         expect(result.payment.id).to be_present
         expect(result.payment.invoice).to eq(invoice)
-        expect(result.payment.payment_provider).to eq(stripe_payment_provider)
-        expect(result.payment.payment_provider_customer).to eq(stripe_customer)
+        expect(result.payment.payment_provider).to eq(gocardless_payment_provider)
+        expect(result.payment.payment_provider_customer).to eq(gocardless_customer)
         expect(result.payment.amount_cents).to eq(invoice.total_amount_cents)
         expect(result.payment.amount_currency).to eq(invoice.total_amount_currency)
-        expect(result.payment.status).to eq('succeeded')
+        expect(result.payment.status).to eq('paid_out')
       end
 
-      expect(Stripe::PaymentIntent).to have_received(:create)
+      expect(gocardless_payments_service).to have_received(:create)
     end
 
     context 'when invoice type is credit and new status is succeeded' do
@@ -93,14 +85,14 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       end
 
       it 'calls Invoices::PrepaidCreditJob' do
-        stripe_service.create
+        gocardless_service.create
 
         expect(Invoices::PrepaidCreditJob).to have_received(:perform_later).with(invoice)
       end
     end
 
     it 'calls SegmentTrackJob' do
-      invoice = stripe_service.create.payment.invoice
+      invoice = gocardless_service.create.payment.invoice
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
@@ -114,10 +106,10 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
     end
 
     context 'with no payment provider' do
-      let(:stripe_payment_provider) { nil }
+      let(:gocardless_payment_provider) { nil }
 
-      it 'does not creates a stripe payment' do
-        result = stripe_service.create
+      it 'does not creates a gocardless payment' do
+        result = gocardless_service.create
 
         expect(result).to be_success
 
@@ -125,7 +117,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
           expect(result.invoice).to eq(invoice)
           expect(result.payment).to be_nil
 
-          expect(Stripe::PaymentIntent).not_to have_received(:create)
+          expect(gocardless_payments_service).not_to have_received(:create)
         end
       end
     end
@@ -140,8 +132,8 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         )
       end
 
-      it 'does not creates a stripe payment' do
-        result = stripe_service.create
+      it 'does not creates a gocardless payment' do
+        result = gocardless_service.create
 
         expect(result).to be_success
 
@@ -151,16 +143,16 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
 
           expect(result.invoice).to be_succeeded
 
-          expect(Stripe::PaymentIntent).not_to have_received(:create)
+          expect(gocardless_payments_service).not_to have_received(:create)
         end
       end
     end
 
     context 'when customer does not have a provider customer id' do
-      before { stripe_customer.update!(provider_customer_id: nil) }
+      before { gocardless_customer.update!(provider_customer_id: nil) }
 
-      it 'does not creates a stripe payment' do
-        result = stripe_service.create
+      it 'does not creates a gocardless payment' do
+        result = gocardless_service.create
 
         expect(result).to be_success
 
@@ -168,46 +160,29 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
           expect(result.invoice).to eq(invoice)
           expect(result.payment).to be_nil
 
-          expect(Stripe::PaymentIntent).not_to have_received(:create)
+          expect(gocardless_payments_service).not_to have_received(:create)
         end
       end
     end
 
-    context 'when customer does not have a payment method' do
-      let(:stripe_customer) { create(:stripe_customer, customer: customer) }
+    context 'when customer does not have a provider mandate id' do
+      before { gocardless_customer.update!(provider_mandate_id: nil) }
 
-      before do
-        allow(Stripe::PaymentMethod).to receive(:list)
-          .and_return(Stripe::ListObject.construct_from(
-            data: [
-              {
-                id: 'pm_123456',
-                object: 'payment_method',
-                card: { 'brand': 'visa' },
-                created: 1_656_422_973,
-                customer: 'cus_123456',
-                livemode: false,
-                metadata: {},
-                type: 'card',
-              },
-            ],
-          ))
-      end
-
-      it 'retrieves the payment method' do
-        result = stripe_service.create
+      it 'does not creates a gocardless payment' do
+        result = gocardless_service.create
 
         expect(result).to be_success
-        expect(customer.stripe_customer.reload).to be_present
-        expect(customer.stripe_customer.provider_customer_id).to eq(stripe_customer.provider_customer_id)
-        expect(customer.stripe_customer.payment_method_id).to eq('pm_123456')
 
-        expect(Stripe::PaymentMethod).to have_received(:list)
-        expect(Stripe::PaymentIntent).to have_received(:create)
+        aggregate_failures do
+          expect(result.invoice).to eq(invoice)
+          expect(result.payment).to be_nil
+
+          expect(gocardless_payments_service).not_to have_received(:create)
+        end
       end
     end
 
-    context 'with card error on stripe' do
+    context 'with error on gocardless' do
       let(:customer) { create(:customer, organization: organization) }
 
       let(:subscription) do
@@ -221,22 +196,22 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       before do
         subscription
 
-        allow(Stripe::PaymentIntent).to receive(:create)
-          .and_raise(Stripe::CardError.new('error', {}))
+        allow(gocardless_payments_service).to receive(:create)
+          .and_raise(GoCardlessPro::Error.new('code' => 'code', 'message' => 'error'))
       end
 
       it 'delivers an error webhook' do
-        expect { stripe_service.create }
-          .to raise_error(Stripe::CardError)
+        expect { gocardless_service.create }
+          .to raise_error(GoCardlessPro::Error)
 
         expect(SendWebhookJob).to have_been_enqueued
           .with(
             :payment_provider_invoice_payment_error,
             invoice,
-            provider_customer_id: stripe_customer.provider_customer_id,
+            provider_customer_id: gocardless_customer.provider_customer_id,
             provider_error: {
               message: 'error',
-              error_code: nil,
+              error_code: 'code',
             },
           )
       end
@@ -249,6 +224,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         :payment,
         invoice: invoice,
         provider_payment_id: 'ch_123456',
+        status: 'pending_submission',
       )
     end
 
@@ -258,20 +234,20 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
     end
 
     it 'updates the payment and invoice status' do
-      result = stripe_service.update_status(
+      result = gocardless_service.update_status(
         provider_payment_id: 'ch_123456',
-        status: 'succeeded',
+        status: 'paid_out',
       )
 
       expect(result).to be_success
-      expect(result.payment.status).to eq('succeeded')
+      expect(result.payment.status).to eq('paid_out')
       expect(result.invoice.status).to eq('succeeded')
     end
 
     it 'calls SegmentTrackJob' do
-      invoice = stripe_service.update_status(
+      invoice = gocardless_service.update_status(
         provider_payment_id: 'ch_123456',
-        status: 'succeeded',
+        status: 'paid_out',
       ).payment.invoice
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
@@ -289,9 +265,9 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       before { invoice.succeeded! }
 
       it 'does not update the status of invoice and payment' do
-        result = stripe_service.update_status(
+        result = gocardless_service.update_status(
           provider_payment_id: 'ch_123456',
-          status: 'succeeded',
+          status: 'paid_out',
         )
 
         expect(result).to be_success
@@ -300,8 +276,8 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
     end
 
     context 'with invalid status' do
-      it 'does not update the status of invoice and payment' do
-        result = stripe_service.update_status(
+      it 'does not update the status of invoice' do
+        result = gocardless_service.update_status(
           provider_payment_id: 'ch_123456',
           status: 'foo-bar',
         )


### PR DESCRIPTION
## Context

Implement gocardless payment flow. When invoice is generate trigger gocardless payment if gocardless is selected as customer's payment provider.

Additionally, In this PR, logic for force-creating customer is stripe is removed since it's not used. Force-created customer does not have payment method anyways and such a payment usually fails...
