### PR TITLE
feat(groups): Update charge service to support groups

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -3,10 +3,11 @@
 module BillableMetrics
   module Aggregations
     class BaseService < ::BaseService
-      def initialize(billable_metric:, subscription:)
+      def initialize(billable_metric:, subscription:, group: nil)
         super(nil)
         @billable_metric = billable_metric
         @subscription = subscription
+        @group = group
       end
 
       def aggregate(from_date:, to_date:, options: {})
@@ -15,19 +16,19 @@ module BillableMetrics
 
       protected
 
-      attr_accessor :billable_metric, :subscription
+      attr_accessor :billable_metric, :subscription, :group
 
       delegate :customer, to: :subscription
 
       def events_scope(from_date:, to_date:)
-        subscription.events
+        events = subscription.events
           .from_date(from_date)
           .to_date(to_date)
           .where(code: billable_metric.code)
-      end
 
-      def groups
-        billable_metric.selectable_groups.pluck(:key).uniq
+        return events unless group
+
+        events.where('properties @> ?', { group.key.to_s => group.value }.to_json)
       end
 
       def sanitized_name(property)
@@ -38,18 +39,6 @@ module BillableMetrics
 
       def sanitized_field_name
         sanitized_name(billable_metric.field_name)
-      end
-
-      def aggregation_per_group(events, aggregation_select)
-        groups.map do |group|
-          events.select(
-            "(#{aggregation_select}) as group_agg, #{sanitized_name(group)} as group_name",
-          ).group(
-            sanitized_name(group),
-          ).map do |e|
-            { e.group_name => e.group_agg } if e.group_name
-          end.compact
-        end
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -4,17 +4,10 @@ module BillableMetrics
   module Aggregations
     class CountService < BillableMetrics::Aggregations::BaseService
       def aggregate(from_date:, to_date:, options: {})
-        events = events_scope(from_date: from_date, to_date: to_date)
-
-        result.aggregation = events.count
-        result.aggregation_per_group = aggregation_per_group(events, aggregation_select)
+        result.aggregation = events_scope(from_date: from_date, to_date: to_date).count
+        result.count = result.aggregation
+        result.options = {}
         result
-      end
-
-      private
-
-      def aggregation_select
-        'count(id)'
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -8,17 +8,11 @@ module BillableMetrics
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.maximum("(#{sanitized_field_name})::numeric") || 0
-        result.aggregation_per_group = aggregation_per_group(events, aggregation_select)
         result.count = events.count
+        result.options = {}
         result
       rescue ActiveRecord::StatementInvalid => e
         result.service_failure!(code: 'aggregation_failure', message: e.message)
-      end
-
-      private
-
-      def aggregation_select
-        "max((#{sanitized_field_name})::numeric)"
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -8,7 +8,6 @@ module BillableMetrics
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.sum("(#{sanitized_field_name})::numeric")
-        result.aggregation_per_group = aggregation_per_group(events, aggregation_select)
         result.count = events.count
         result.options = { running_total: running_total(events, options) }
         result
@@ -16,14 +15,7 @@ module BillableMetrics
         result.service_failure!(code: 'aggregation_failure', message: e.message)
       end
 
-      private
-
-      def aggregation_select
-        "sum((#{sanitized_field_name})::numeric)"
-      end
-
       # NOTE: Return cumulative sum of field_name based on the number of free units (per_events or per_total_aggregation).
-      # TODO: Running total per groups :(
       def running_total(events, options)
         free_units_per_events = options[:free_units_per_events].to_i
         free_units_per_total_aggregation = BigDecimal(options[:free_units_per_total_aggregation] || 0)

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -8,15 +8,9 @@ module BillableMetrics
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.count("DISTINCT (#{sanitized_field_name})")
-        result.aggregation_per_group = aggregation_per_group(events, aggregation_select)
         result.count = events.count
+        result.options = {}
         result
-      end
-
-      private
-
-      def aggregation_select
-        "count(distinct(#{sanitized_field_name}))"
       end
     end
   end

--- a/app/services/charges/charge_models/base_service.rb
+++ b/app/services/charges/charge_models/base_service.rb
@@ -7,15 +7,15 @@ module Charges
         new(...).apply
       end
 
-      def initialize(charge:, aggregation_result:)
+      def initialize(charge:, aggregation_result:, properties:)
         super(nil)
         @charge = charge
         @aggregation_result = aggregation_result
+        @properties = properties
       end
 
       def apply
         result.units = aggregation_result.aggregation
-        result.group_units = aggregation_result.group_aggregation
         result.count = aggregation_result.count
         result.amount = compute_amount
         result
@@ -23,11 +23,11 @@ module Charges
 
       protected
 
-      attr_accessor :charge, :aggregation_result
+      attr_accessor :charge, :aggregation_result, :properties
 
       delegate :units, to: :result
 
-      def compute_amount(value)
+      def compute_amount
         raise NotImplementedError
       end
     end

--- a/app/services/charges/charge_models/graduated_service.rb
+++ b/app/services/charges/charge_models/graduated_service.rb
@@ -6,7 +6,7 @@ module Charges
       protected
 
       def ranges
-        charge.properties['graduated_ranges']&.map(&:with_indifferent_access)
+        properties['graduated_ranges']&.map(&:with_indifferent_access)
       end
 
       def compute_amount

--- a/app/services/charges/charge_models/package_service.rb
+++ b/app/services/charges/charge_models/package_service.rb
@@ -14,15 +14,15 @@ module Charges
         #       It's rounded up, because a group counts from its first unit
         package_count = billed_units.fdiv(package_size).ceil
 
-        package_count * BigDecimal(charge.properties['amount'])
+        package_count * BigDecimal(properties['amount'])
       end
 
       def free_units
-        charge.properties['free_units'] || 0
+        properties['free_units'] || 0
       end
 
       def package_size
-        charge.properties['package_size']
+        properties['package_size']
       end
     end
   end

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -37,29 +37,29 @@ module Charges
         if !last_running_total.zero? && last_running_total <= free_units_per_total_aggregation
           free_units_per_events
         else
-          aggregation_result.options[:running_total].count { |e| e < free_units_per_total_aggregation }
+          aggregation_result.options[:running_total]&.count { |e| e < free_units_per_total_aggregation } || 0
         end
       end
 
       def last_running_total
-        @last_running_total ||= aggregation_result.options[:running_total].last || 0
+        @last_running_total ||= aggregation_result.options[:running_total]&.last || 0
       end
 
       def free_units_per_total_aggregation
-        @free_units_per_total_aggregation ||= BigDecimal(charge.properties['free_units_per_total_aggregation'] || 0)
+        @free_units_per_total_aggregation ||= BigDecimal(properties['free_units_per_total_aggregation'] || 0)
       end
 
       def free_units_per_events
-        @free_units_per_events ||= charge.properties['free_units_per_events'].to_i
+        @free_units_per_events ||= properties['free_units_per_events'].to_i
       end
 
       # NOTE: FE divides percentage rate with 100 and sends to BE.
       def rate
-        BigDecimal(charge.properties['rate'])
+        BigDecimal(properties['rate'])
       end
 
       def fixed_amount
-        @fixed_amount ||= BigDecimal(charge.properties['fixed_amount'] || 0)
+        @fixed_amount ||= BigDecimal(properties['fixed_amount'] || 0)
       end
     end
   end

--- a/app/services/charges/charge_models/standard_service.rb
+++ b/app/services/charges/charge_models/standard_service.rb
@@ -6,7 +6,7 @@ module Charges
       protected
 
       def compute_amount
-        (units * BigDecimal(charge.properties['amount']))
+        (units * BigDecimal(properties['amount']))
       end
     end
   end

--- a/app/services/charges/charge_models/volume_service.rb
+++ b/app/services/charges/charge_models/volume_service.rb
@@ -6,7 +6,7 @@ module Charges
       protected
 
       def ranges
-        charge.properties['volume_ranges']&.map(&:with_indifferent_access)
+        properties['volume_ranges']&.map(&:with_indifferent_access)
       end
 
       def compute_amount

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -39,7 +39,7 @@ module Invoices
           issuing_date: boundaries[:issuing_date],
         )
 
-        add_charge_fee
+        add_charge_fees
         compute_amounts
 
         format_usage
@@ -59,21 +59,21 @@ module Invoices
       )
     end
 
-    def add_charge_fee
+    def add_charge_fees
       query = subscription.plan.charges.joins(:billable_metric)
         .order(Arel.sql('lower(unaccent(billable_metrics.name)) ASC'))
 
       query.each do |charge|
-        fee_result = Fees::ChargeService.new(
+        fees_result = Fees::ChargeService.new(
           invoice: invoice,
           charge: charge,
           subscription: subscription,
           boundaries: boundaries,
         ).current_usage
 
-        fee_result.throw_error unless fee_result.success?
+        fees_result.throw_error unless fees_result.success?
 
-        invoice.fees << fee_result.fee
+        invoice.fees << fees_result.fees
       end
     end
 

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -4,12 +4,17 @@ require 'rails_helper'
 
 RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
   subject(:count_service) do
-    described_class.new(billable_metric: billable_metric, subscription: subscription)
+    described_class.new(
+      billable_metric: billable_metric,
+      subscription: subscription,
+      group: group,
+    )
   end
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
+  let(:group) { nil }
 
   let(:billable_metric) do
     create(
@@ -23,58 +28,20 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
   let(:to_date) { Time.zone.today }
 
   before do
-    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
-    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')
-    create(:group, billable_metric_id: billable_metric.id, key: 'country', value: 'france')
-
     create_list(
       :event,
-      3,
+      4,
       code: billable_metric.code,
-      customer: customer,
       subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: { region: 'europe' },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
       customer: customer,
-      subscription: subscription,
       timestamp: Time.zone.now,
-      properties: { region: 'usa' },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
-      customer: customer,
-      subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: { region: 'africa' },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
-      customer: customer,
-      subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: { country: 'france' },
     )
   end
 
   it 'aggregates the events' do
     result = count_service.aggregate(from_date: from_date, to_date: to_date)
 
-    expect(result.aggregation).to eq(6)
-    expect(result.aggregation_per_group).to eq(
-      [
-        [{ 'africa' => 1 }, { 'europe' => 3 }, { 'usa' => 1 }],
-        [{ 'france' => 1 }],
-      ],
-    )
+    expect(result.aggregation).to eq(4)
   end
 
   context 'when events are out of bounds' do
@@ -84,7 +51,56 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       result = count_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
-      expect(result.aggregation_per_group).to eq([[], []])
+    end
+  end
+
+  context 'when group_id is given' do
+    let(:group) do
+      create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+    end
+
+    before do
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          total_count: 12,
+          region: 'europe',
+        },
+      )
+
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          total_count: 8,
+          region: 'europe',
+        },
+      )
+
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          total_count: 12,
+          region: 'africa',
+        },
+      )
+    end
+
+    it 'aggregates the events' do
+      result = count_service.aggregate(from_date: from_date, to_date: to_date)
+
+      expect(result.aggregation).to eq(2)
     end
   end
 end

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -4,12 +4,17 @@ require 'rails_helper'
 
 RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
   subject(:max_service) do
-    described_class.new(billable_metric: billable_metric, subscription: subscription)
+    described_class.new(
+      billable_metric: billable_metric,
+      subscription: subscription,
+      group: group,
+    )
   end
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
+  let(:group) { nil }
 
   let(:billable_metric) do
     create(
@@ -24,55 +29,15 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
   let(:to_date) { Time.zone.today }
 
   before do
-    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
-    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')
-    create(:group, billable_metric_id: billable_metric.id, key: 'country', value: 'france')
-
-    create(
+    create_list(
       :event,
+      4,
       code: billable_metric.code,
       customer: customer,
       subscription: subscription,
       timestamp: Time.zone.now,
       properties: {
-        total_count: 6,
-        region: 'europe',
-      },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
-      customer: customer,
-      subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: {
-        total_count: 8,
-        region: 'europe',
-      },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
-      customer: customer,
-      subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: {
-        total_count: 6,
-        region: 'usa',
-      },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
-      customer: customer,
-      subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: {
-        total_count: 8,
-        region: 'africa',
+        total_count: rand(10),
       },
     )
 
@@ -84,7 +49,6 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       timestamp: Time.zone.now,
       properties: {
         total_count: 12,
-        country: 'france',
       },
     )
   end
@@ -93,12 +57,6 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     result = max_service.aggregate(from_date: from_date, to_date: to_date)
 
     expect(result.aggregation).to eq(12)
-    expect(result.aggregation_per_group).to eq(
-      [
-        [{ 'africa' => 8 }, { 'europe' => 8 }, { 'usa' => 6 }],
-        [{ 'france' => 12 }],
-      ],
-    )
     expect(result.count).to eq(5)
   end
 
@@ -109,7 +67,6 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       result = max_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
-      expect(result.aggregation_per_group).to eq([[], []])
       expect(result.count).to eq(0)
     end
   end
@@ -123,7 +80,6 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       result = max_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
-      expect(result.aggregation_per_group).to eq([[], []])
       expect(result.count).to eq(0)
     end
   end
@@ -191,6 +147,57 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
 
       expect(result).to be_success
       expect(result.aggregation).to eq(12)
+    end
+  end
+
+  context 'when group_id is given' do
+    let(:group) do
+      create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+    end
+
+    before do
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          total_count: 12,
+          region: 'europe',
+        },
+      )
+
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          total_count: 8,
+          region: 'europe',
+        },
+      )
+
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          total_count: 12,
+          region: 'africa',
+        },
+      )
+    end
+
+    it 'aggregates the events' do
+      result = max_service.aggregate(from_date: from_date, to_date: to_date)
+
+      expect(result.aggregation).to eq(12)
+      expect(result.count).to eq(2)
     end
   end
 end

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -4,12 +4,17 @@ require 'rails_helper'
 
 RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
   subject(:sum_service) do
-    described_class.new(billable_metric: billable_metric, subscription: subscription)
+    described_class.new(
+      billable_metric: billable_metric,
+      subscription: subscription,
+      group: group,
+    )
   end
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
+  let(:group) { nil }
 
   let(:billable_metric) do
     create(
@@ -27,56 +32,15 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
   end
 
   before do
-    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
-    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')
-    create(:group, billable_metric_id: billable_metric.id, key: 'country', value: 'france')
-
     create_list(
       :event,
-      3,
+      4,
       code: billable_metric.code,
       customer: customer,
       subscription: subscription,
       timestamp: Time.zone.now,
       properties: {
         total_count: 12,
-        region: 'europe',
-      },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
-      customer: customer,
-      subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: {
-        total_count: 6,
-        region: 'usa',
-      },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
-      customer: customer,
-      subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: {
-        total_count: 8,
-        region: 'africa',
-      },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
-      customer: customer,
-      subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: {
-        total_count: 4,
-        country: 'france',
       },
     )
   end
@@ -84,14 +48,8 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
   it 'aggregates the events' do
     result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
 
-    expect(result.aggregation).to eq(54)
-    expect(result.aggregation_per_group).to eq(
-      [
-        [{ 'africa' => 8 }, { 'europe' => 36 }, { 'usa' => 6 }],
-        [{ 'france' => 4 }],
-      ],
-    )
-    expect(result.count).to eq(6)
+    expect(result.aggregation).to eq(48)
+    expect(result.count).to eq(4)
     expect(result.options).to eq({ running_total: [12, 24] })
   end
 
@@ -144,7 +102,6 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
-      expect(result.aggregation_per_group).to eq([[], []])
       expect(result.count).to eq(0)
       expect(result.options).to eq({ running_total: [] })
     end
@@ -159,7 +116,6 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
-      expect(result.aggregation_per_group).to eq([[], []])
       expect(result.count).to eq(0)
       expect(result.options).to eq({ running_total: [] })
     end
@@ -175,7 +131,6 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
         timestamp: Time.zone.now,
         properties: {
           total_count: 4.5,
-          country: 'france',
         },
       )
     end
@@ -183,13 +138,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     it 'aggregates the events' do
       result = sum_service.aggregate(from_date: from_date, to_date: to_date)
 
-      expect(result.aggregation).to eq(58.5)
-      expect(result.aggregation_per_group).to eq(
-        [
-          [{ 'africa' => 8 }, { 'europe' => 36 }, { 'usa' => 6 }],
-          [{ 'france' => 8.5 }],
-        ],
-      )
+      expect(result.aggregation).to eq(52.5)
     end
   end
 
@@ -216,6 +165,58 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
         expect(result.error.code).to eq('aggregation_failure')
         expect(result.error.error_message).to be_present
       end
+    end
+  end
+
+  context 'when group_id is given' do
+    let(:group) do
+      create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+    end
+
+    before do
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          total_count: 12,
+          region: 'europe',
+        },
+      )
+
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          total_count: 8,
+          region: 'europe',
+        },
+      )
+
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          total_count: 12,
+          region: 'africa',
+        },
+      )
+    end
+
+    it 'aggregates the events' do
+      result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
+
+      expect(result.aggregation).to eq(20)
+      expect(result.count).to eq(2)
+      expect(result.options).to eq({ running_total: [12, 20] })
     end
   end
 end

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -4,12 +4,17 @@ require 'rails_helper'
 
 RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service do
   subject(:count_service) do
-    described_class.new(billable_metric: billable_metric, subscription: subscription)
+    described_class.new(
+      billable_metric: billable_metric,
+      subscription: subscription,
+      group: group,
+    )
   end
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
+  let(:group) { nil }
 
   let(:billable_metric) do
     create(
@@ -24,56 +29,15 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
   let(:to_date) { Time.zone.today }
 
   before do
-    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
-    create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')
-    create(:group, billable_metric_id: billable_metric.id, key: 'country', value: 'france')
-
     create_list(
       :event,
-      3,
+      4,
       code: billable_metric.code,
       customer: customer,
       subscription: subscription,
       timestamp: Time.zone.now,
       properties: {
         anonymous_id: 'foo_bar',
-        region: 'europe',
-      },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
-      customer: customer,
-      subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: {
-        anonymous_id: 'foo_bar',
-        region: 'usa',
-      },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
-      customer: customer,
-      subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: {
-        anonymous_id: 'foo_bar',
-        region: 'africa',
-      },
-    )
-
-    create(
-      :event,
-      code: billable_metric.code,
-      customer: customer,
-      subscription: subscription,
-      timestamp: Time.zone.now,
-      properties: {
-        anonymous_id: 'foo_bar',
-        country: 'france',
       },
     )
   end
@@ -82,13 +46,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
     result = count_service.aggregate(from_date: from_date, to_date: to_date)
 
     expect(result.aggregation).to eq(1)
-    expect(result.aggregation_per_group).to eq(
-      [
-        [{ 'africa' => 1 }, { 'europe' => 1 }, { 'usa' => 1 }],
-        [{ 'france' => 1 }],
-      ],
-    )
-    expect(result.count).to eq(6)
+    expect(result.count).to eq(4)
   end
 
   context 'when events are out of bounds' do
@@ -98,7 +56,6 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       result = count_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
-      expect(result.aggregation_per_group).to eq([[], []])
       expect(result.count).to eq(0)
     end
   end
@@ -112,8 +69,58 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       result = count_service.aggregate(from_date: from_date, to_date: to_date)
 
       expect(result.aggregation).to eq(0)
-      expect(result.aggregation_per_group).to eq([[], []])
       expect(result.count).to eq(0)
+    end
+  end
+
+  context 'when group_id is given' do
+    let(:group) do
+      create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+    end
+
+    before do
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          anonymous_id: 'foo_bar',
+          region: 'europe',
+        },
+      )
+
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          anonymous_id: 'foo_bar',
+          region: 'europe',
+        },
+      )
+
+      create(
+        :event,
+        code: billable_metric.code,
+        customer: customer,
+        subscription: subscription,
+        timestamp: Time.zone.now,
+        properties: {
+          anonymous_id: 'foo_bar',
+          region: 'africa',
+        },
+      )
+    end
+
+    it 'aggregates the events' do
+      result = count_service.aggregate(from_date: from_date, to_date: to_date)
+
+      expect(result.aggregation).to eq(1)
+      expect(result.count).to eq(2)
     end
   end
 end

--- a/spec/services/charges/charge_models/graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/graduated_service_spec.rb
@@ -4,7 +4,11 @@ require 'rails_helper'
 
 RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
   subject(:apply_graduated_service) do
-    described_class.apply(charge: charge, aggregation_result: aggregation_result)
+    described_class.apply(
+      charge: charge,
+      aggregation_result: aggregation_result,
+      properties: charge.properties,
+    )
   end
 
   before do

--- a/spec/services/charges/charge_models/package_service_spec.rb
+++ b/spec/services/charges/charge_models/package_service_spec.rb
@@ -4,7 +4,11 @@ require 'rails_helper'
 
 RSpec.describe Charges::ChargeModels::PackageService, type: :service do
   subject(:apply_package_service) do
-    described_class.apply(charge: charge, aggregation_result: aggregation_result)
+    described_class.apply(
+      charge: charge,
+      aggregation_result: aggregation_result,
+      properties: charge.properties,
+    )
   end
 
   before do

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -4,7 +4,11 @@ require 'rails_helper'
 
 RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
   subject(:apply_percentage_service) do
-    described_class.apply(charge: charge, aggregation_result: aggregation_result)
+    described_class.apply(
+      charge: charge,
+      aggregation_result: aggregation_result,
+      properties: charge.properties,
+    )
   end
 
   before do

--- a/spec/services/charges/charge_models/standard_service_spec.rb
+++ b/spec/services/charges/charge_models/standard_service_spec.rb
@@ -4,7 +4,11 @@ require 'rails_helper'
 
 RSpec.describe Charges::ChargeModels::StandardService, type: :service do
   subject(:apply_standard_service) do
-    described_class.apply(charge: charge, aggregation_result: aggregation_result)
+    described_class.apply(
+      charge: charge,
+      aggregation_result: aggregation_result,
+      properties: charge.properties,
+    )
   end
 
   before do

--- a/spec/services/charges/charge_models/volume_service_spec.rb
+++ b/spec/services/charges/charge_models/volume_service_spec.rb
@@ -4,7 +4,11 @@ require 'rails_helper'
 
 RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
   subject(:apply_volume_service) do
-    described_class.apply(charge: charge, aggregation_result: aggregation_result)
+    described_class.apply(
+      charge: charge,
+      aggregation_result: aggregation_result,
+      properties: charge.properties,
+    )
   end
 
   before do

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -42,170 +42,911 @@ RSpec.describe Fees::ChargeService do
   end
 
   describe '.create' do
-    it 'creates a fee' do
-      result = charge_subscription_service.create
-
-      expect(result).to be_success
-
-      created_fee = result.fee
-
-      aggregate_failures do
-        expect(created_fee.id).not_to be_nil
-        expect(created_fee.invoice_id).to eq(invoice.id)
-        expect(created_fee.charge_id).to eq(charge.id)
-        expect(created_fee.amount_cents).to eq(0)
-        expect(created_fee.amount_currency).to eq('EUR')
-        expect(created_fee.vat_amount_cents).to eq(0)
-        expect(created_fee.vat_rate).to eq(20.0)
-        expect(created_fee.units).to eq(0)
-        expect(created_fee.events_count).to be_nil
-      end
-    end
-
-    context 'with graduated charge model' do
-      let(:charge) do
-        create(
-          :graduated_charge,
-          plan: subscription.plan,
-          charge_model: 'graduated',
-          billable_metric: billable_metric,
-          properties: {
-            graduated_ranges: [
-              {
-                from_value: 0,
-                to_value: nil,
-                per_unit_amount: '0.01',
-                flat_amount: '0.01',
-              },
-            ],
-          },
-        )
-      end
-
-      before do
-        create_list(
-          :event,
-          4,
-          organization: subscription.organization,
-          customer: subscription.customer,
-          subscription: subscription,
-          code: charge.billable_metric.code,
-          timestamp: DateTime.parse('2022-03-16'),
-        )
-      end
-
+    context 'without group properties' do
       it 'creates a fee' do
         result = charge_subscription_service.create
-
         expect(result).to be_success
-
-        created_fee = result.fee
+        created_fee = result.fees.first
 
         aggregate_failures do
           expect(created_fee.id).not_to be_nil
           expect(created_fee.invoice_id).to eq(invoice.id)
           expect(created_fee.charge_id).to eq(charge.id)
-          expect(created_fee.amount_cents).to eq(5)
+          expect(created_fee.amount_cents).to eq(0)
           expect(created_fee.amount_currency).to eq('EUR')
-          expect(created_fee.vat_amount_cents).to eq(1)
+          expect(created_fee.vat_amount_cents).to eq(0)
           expect(created_fee.vat_rate).to eq(20.0)
-          expect(created_fee.units.to_s).to eq('4.0')
+          expect(created_fee.units).to eq(0)
+          expect(created_fee.events_count).to eq(0)
         end
       end
-    end
 
-    context 'when fee already exists on the period' do
-      before do
-        create(
-          :fee,
-          charge: charge,
-          subscription: subscription,
-          invoice: invoice,
-        )
-      end
-
-      it 'does not create a new fee' do
-        expect { charge_subscription_service.create }.not_to change(Fee, :count)
-      end
-    end
-
-    context 'when billing an new upgraded subscription' do
-      let(:previous_plan) { create(:plan, amount_cents: subscription.plan.amount_cents - 20) }
-      let(:previous_subscription) do
-        create(:subscription, plan: previous_plan, status: :terminated)
-      end
-
-      let(:event) do
-        create(
-          :event,
-          organization: invoice.organization,
-          customer: subscription.customer,
-          subscription: subscription,
-          code: billable_metric.code,
-          timestamp: Time.zone.parse('10 Apr 2022 00:01:00'),
-        )
-      end
-
-      let(:boundaries) do
-        {
-          from_date: Time.zone.parse('15 Apr 2022 00:01:00').to_date,
-          to_date: Time.zone.parse('30 Apr 2022 00:01:00').to_date,
-          charges_from_date: subscription.started_at.to_date,
-          charges_to_date: Time.zone.parse('30 Apr 2022 00:01:00').to_date,
-        }
-      end
-
-      before do
-        subscription.update!(previous_subscription: previous_subscription)
-        event
-      end
-
-      it 'creates a new fee for the complete period' do
-        result = charge_subscription_service.create
-
-        expect(result).to be_success
-
-        created_fee = result.fee
-
-        aggregate_failures do
-          expect(created_fee.id).not_to be_nil
-          expect(created_fee.invoice_id).to eq(invoice.id)
-          expect(created_fee.charge_id).to eq(charge.id)
-          expect(created_fee.amount_cents).to eq(2000)
-          expect(created_fee.amount_currency).to eq('EUR')
-          expect(created_fee.vat_amount_cents).to eq(400)
-          expect(created_fee.vat_rate).to eq(20.0)
-          expect(created_fee.units).to eq(1)
-        end
-      end
-    end
-
-    context 'with all types of aggregation' do
-      BillableMetric::AGGREGATION_TYPES.each do |aggregation_type|
-        before do
-          billable_metric.update!(
-            aggregation_type: aggregation_type,
-            field_name: 'foo_bar',
+      context 'with graduated charge model' do
+        let(:charge) do
+          create(
+            :graduated_charge,
+            plan: subscription.plan,
+            charge_model: 'graduated',
+            billable_metric: billable_metric,
+            properties: {
+              graduated_ranges: [
+                {
+                  from_value: 0,
+                  to_value: nil,
+                  per_unit_amount: '0.01',
+                  flat_amount: '0.01',
+                },
+              ],
+            },
           )
         end
 
-        it 'creates fees' do
+        before do
+          create_list(
+            :event,
+            4,
+            organization: subscription.organization,
+            customer: subscription.customer,
+            subscription: subscription,
+            code: charge.billable_metric.code,
+            timestamp: DateTime.parse('2022-03-16'),
+          )
+        end
+
+        it 'creates a fee' do
           result = charge_subscription_service.create
-
           expect(result).to be_success
-
-          created_fee = result.fee
+          created_fee = result.fees.first
 
           aggregate_failures do
             expect(created_fee.id).not_to be_nil
             expect(created_fee.invoice_id).to eq(invoice.id)
             expect(created_fee.charge_id).to eq(charge.id)
-            expect(created_fee.amount_cents).to eq(0)
+            expect(created_fee.amount_cents).to eq(5)
             expect(created_fee.amount_currency).to eq('EUR')
-            expect(created_fee.vat_amount_cents).to eq(0)
+            expect(created_fee.vat_amount_cents).to eq(1)
             expect(created_fee.vat_rate).to eq(20.0)
-            expect(created_fee.units).to eq(0)
+            expect(created_fee.units.to_s).to eq('4.0')
           end
+        end
+      end
+
+      context 'when fee already exists on the period' do
+        before do
+          create(
+            :fee,
+            charge: charge,
+            subscription: subscription,
+            invoice: invoice,
+          )
+        end
+
+        it 'does not create a new fee' do
+          expect { charge_subscription_service.create }.not_to change(Fee, :count)
+        end
+      end
+
+      context 'when billing an new upgraded subscription' do
+        let(:previous_plan) { create(:plan, amount_cents: subscription.plan.amount_cents - 20) }
+        let(:previous_subscription) do
+          create(:subscription, plan: previous_plan, status: :terminated)
+        end
+
+        let(:event) do
+          create(
+            :event,
+            organization: invoice.organization,
+            customer: subscription.customer,
+            subscription: subscription,
+            code: billable_metric.code,
+            timestamp: Time.zone.parse('10 Apr 2022 00:01:00'),
+          )
+        end
+
+        let(:boundaries) do
+          {
+            from_date: Time.zone.parse('15 Apr 2022 00:01:00').to_date,
+            to_date: Time.zone.parse('30 Apr 2022 00:01:00').to_date,
+            charges_from_date: subscription.started_at.to_date,
+            charges_to_date: Time.zone.parse('30 Apr 2022 00:01:00').to_date,
+          }
+        end
+
+        before do
+          subscription.update!(previous_subscription: previous_subscription)
+          event
+        end
+
+        it 'creates a new fee for the complete period' do
+          result = charge_subscription_service.create
+          expect(result).to be_success
+          created_fee = result.fees.first
+
+          aggregate_failures do
+            expect(created_fee.id).not_to be_nil
+            expect(created_fee.invoice_id).to eq(invoice.id)
+            expect(created_fee.charge_id).to eq(charge.id)
+            expect(created_fee.amount_cents).to eq(2000)
+            expect(created_fee.amount_currency).to eq('EUR')
+            expect(created_fee.vat_amount_cents).to eq(400)
+            expect(created_fee.vat_rate).to eq(20.0)
+            expect(created_fee.units).to eq(1)
+          end
+        end
+      end
+
+      context 'with all types of aggregation' do
+        BillableMetric::AGGREGATION_TYPES.each do |aggregation_type|
+          before do
+            billable_metric.update!(
+              aggregation_type: aggregation_type,
+              field_name: 'foo_bar',
+            )
+          end
+
+          it 'creates fees' do
+            result = charge_subscription_service.create
+            expect(result).to be_success
+            created_fee = result.fees.first
+
+            aggregate_failures do
+              expect(created_fee.id).not_to be_nil
+              expect(created_fee.invoice_id).to eq(invoice.id)
+              expect(created_fee.charge_id).to eq(charge.id)
+              expect(created_fee.amount_cents).to eq(0)
+              expect(created_fee.amount_currency).to eq('EUR')
+              expect(created_fee.vat_amount_cents).to eq(0)
+              expect(created_fee.vat_rate).to eq(20.0)
+              expect(created_fee.units).to eq(0)
+            end
+          end
+        end
+      end
+    end
+
+    context 'with standard charge, all types of aggregation and presence of groups' do
+      let(:europe) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+      end
+
+      let(:usa) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')
+      end
+
+      let(:france) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'country', value: 'france')
+      end
+
+      let(:charge) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          billable_metric: billable_metric,
+          group_properties: [
+            build(
+              :group_property,
+              group: europe,
+              values: {
+                amount: '20',
+                amount_currency: 'EUR',
+              },
+            ),
+            build(
+              :group_property,
+              group: usa,
+              values: {
+                amount: '50',
+                amount_currency: 'EUR',
+              },
+            ),
+            build(
+              :group_property,
+              group: france,
+              values: {
+                amount: '40',
+                amount_currency: 'EUR',
+              },
+            ),
+          ],
+        )
+      end
+
+      before do
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'usa', foo_bar: 12 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe', foo_bar: 10 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe', foo_bar: 5 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { country: 'france', foo_bar: 5 },
+        )
+      end
+
+      it 'creates expected fees for count_agg aggregation type' do
+        billable_metric.update!(aggregation_type: :count_agg)
+        result = charge_subscription_service.create
+        expect(result).to be_success
+        created_fees = result.fees
+
+        aggregate_failures do
+          expect(created_fees.count).to eq(3)
+          expect(created_fees).to all(
+            have_attributes(
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_currency: 'EUR',
+              vat_rate: 20.0,
+            ),
+          )
+          expect(created_fees.first).to have_attributes(
+            amount_cents: 4000,
+            vat_amount_cents: 800,
+            units: 2,
+          )
+          expect(created_fees.second).to have_attributes(
+            amount_cents: 5000,
+            vat_amount_cents: 1000,
+            units: 1,
+          )
+          expect(created_fees.third).to have_attributes(
+            amount_cents: 4000,
+            vat_amount_cents: 800,
+            units: 1,
+          )
+        end
+      end
+
+      it 'creates expected fees for sum_agg aggregation type' do
+        billable_metric.update!(aggregation_type: :sum_agg, field_name: 'foo_bar')
+        result = charge_subscription_service.create
+        expect(result).to be_success
+        created_fees = result.fees
+
+        aggregate_failures do
+          expect(created_fees.count).to eq(3)
+          expect(created_fees).to all(
+            have_attributes(
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_currency: 'EUR',
+              vat_rate: 20.0,
+            ),
+          )
+          expect(created_fees.first).to have_attributes(
+            amount_cents: 30_000,
+            vat_amount_cents: 6000,
+            units: 15,
+          )
+          expect(created_fees.second).to have_attributes(
+            amount_cents: 60_000,
+            vat_amount_cents: 12_000,
+            units: 12,
+          )
+          expect(created_fees.third).to have_attributes(
+            amount_cents: 20_000,
+            vat_amount_cents: 4000,
+            units: 5,
+          )
+        end
+      end
+
+      it 'creates expected fees for max_agg aggregation type' do
+        billable_metric.update!(aggregation_type: :max_agg, field_name: 'foo_bar')
+        result = charge_subscription_service.create
+        expect(result).to be_success
+        created_fees = result.fees
+
+        aggregate_failures do
+          expect(created_fees.count).to eq(3)
+          expect(created_fees).to all(
+            have_attributes(
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_currency: 'EUR',
+              vat_rate: 20.0,
+            ),
+          )
+          expect(created_fees.first).to have_attributes(
+            amount_cents: 20_000,
+            vat_amount_cents: 4000,
+            units: 10,
+          )
+          expect(created_fees.second).to have_attributes(
+            amount_cents: 60_000,
+            vat_amount_cents: 12_000,
+            units: 12,
+          )
+          expect(created_fees.third).to have_attributes(
+            amount_cents: 20_000,
+            vat_amount_cents: 4000,
+            units: 5,
+          )
+        end
+      end
+
+      it 'creates expected fees for unique_count_agg aggregation type' do
+        billable_metric.update!(aggregation_type: :unique_count_agg, field_name: 'foo_bar')
+        result = charge_subscription_service.create
+        expect(result).to be_success
+        created_fees = result.fees
+
+        aggregate_failures do
+          expect(created_fees.count).to eq(3)
+          expect(created_fees).to all(
+            have_attributes(
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_currency: 'EUR',
+              vat_rate: 20.0,
+            ),
+          )
+          expect(created_fees.first).to have_attributes(
+            amount_cents: 4000,
+            vat_amount_cents: 800,
+            units: 2,
+          )
+          expect(created_fees.second).to have_attributes(
+            amount_cents: 5000,
+            vat_amount_cents: 1000,
+            units: 1,
+          )
+          expect(created_fees.third).to have_attributes(
+            amount_cents: 4000,
+            vat_amount_cents: 800,
+            units: 1,
+          )
+        end
+      end
+
+      it 'creates expected fees for recurring_count_agg aggregation type' do
+        boundaries = {
+          from_date: subscription.started_at.at_beginning_of_month.next_month.to_date,
+          to_date: subscription.started_at.next_month.end_of_month.to_date,
+          charges_from_date: subscription.started_at.at_beginning_of_month.next_month.to_date,
+          charges_to_date: subscription.started_at.next_month.end_of_month.to_date,
+        }
+
+        create(
+          :persisted_event,
+          customer: subscription.customer,
+          billable_metric: billable_metric,
+          external_subscription_id: subscription.external_id,
+          external_id: 'ext_11',
+          added_at: subscription.started_at - 1.day,
+          properties: {
+            'operation_type' => 'add',
+            'unique_id' => 'ext_123',
+            'region' => 'usa',
+            'foo_bar' => 12,
+          },
+        )
+        create(
+          :persisted_event,
+          customer: subscription.customer,
+          billable_metric: billable_metric,
+          external_subscription_id: subscription.external_id,
+          external_id: 'ext_12',
+          added_at: subscription.started_at - 1.day,
+          properties: {
+            'operation_type' => 'add',
+            'unique_id' => 'ext_456',
+            'region' => 'europe',
+            'foo_bar' => 10,
+          },
+        )
+        create(
+          :persisted_event,
+          customer: subscription.customer,
+          billable_metric: billable_metric,
+          external_subscription_id: subscription.external_id,
+          external_id: 'ext_13',
+          added_at: subscription.started_at - 1.day,
+          properties: {
+            'operation_type' => 'add',
+            'unique_id' => 'ext_789',
+            'country' => 'france',
+            'foo_bar' => 5,
+          },
+        )
+
+        billable_metric.update!(aggregation_type: :recurring_count_agg, field_name: 'foo_bar')
+        result = described_class.new(invoice: invoice, charge: charge, subscription: subscription, boundaries: boundaries).create
+        expect(result).to be_success
+        created_fees = result.fees
+
+        aggregate_failures do
+          expect(created_fees.count).to eq(3)
+          expect(created_fees).to all(
+            have_attributes(
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_currency: 'EUR',
+              vat_rate: 20.0,
+            ),
+          )
+          expect(created_fees.first).to have_attributes(
+            amount_cents: 2000,
+            vat_amount_cents: 400,
+            units: 1,
+          )
+          expect(created_fees.second).to have_attributes(
+            amount_cents: 5000,
+            vat_amount_cents: 1000,
+            units: 1,
+          )
+          expect(created_fees.third).to have_attributes(
+            amount_cents: 4000,
+            vat_amount_cents: 800,
+            units: 1,
+          )
+        end
+      end
+    end
+
+    context 'with package charge and presence of groups' do
+      let(:europe) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+      end
+
+      let(:usa) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')
+      end
+
+      let(:france) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'country', value: 'france')
+      end
+
+      let(:charge) do
+        create(
+          :package_charge,
+          plan: subscription.plan,
+          billable_metric: billable_metric,
+          group_properties: [
+            build(
+              :group_property,
+              group: europe,
+              values: {
+                amount: '100',
+                free_units: 1,
+                package_size: 8,
+              },
+            ),
+            build(
+              :group_property,
+              group: usa,
+              values: {
+                amount: '50',
+                free_units: 0,
+                package_size: 10,
+              },
+            ),
+            build(
+              :group_property,
+              group: france,
+              values: {
+                amount: '40',
+                free_units: 1,
+                package_size: 5,
+              },
+            ),
+          ],
+        )
+      end
+
+      before do
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'usa', foo_bar: 12 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe', foo_bar: 10 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe', foo_bar: 5 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { country: 'france', foo_bar: 5 },
+        )
+      end
+
+      it 'creates expected fees for count_agg aggregation type' do
+        billable_metric.update!(aggregation_type: :count_agg)
+        result = charge_subscription_service.create
+        expect(result).to be_success
+        created_fees = result.fees
+
+        aggregate_failures do
+          expect(created_fees.count).to eq(3)
+          expect(created_fees).to all(
+            have_attributes(
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_currency: 'EUR',
+              vat_rate: 20.0,
+            ),
+          )
+          expect(created_fees.first).to have_attributes(
+            amount_cents: 10_000,
+            vat_amount_cents: 2000,
+            units: 2,
+          )
+          expect(created_fees.second).to have_attributes(
+            amount_cents: 5000,
+            vat_amount_cents: 1000,
+            units: 1,
+          )
+          expect(created_fees.third).to have_attributes(
+            amount_cents: 0,
+            vat_amount_cents: 0,
+            units: 1,
+          )
+        end
+      end
+    end
+
+    context 'with percentage charge and presence of groups' do
+      let(:europe) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+      end
+
+      let(:usa) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')
+      end
+
+      let(:france) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'country', value: 'france')
+      end
+
+      let(:charge) do
+        create(
+          :percentage_charge,
+          plan: subscription.plan,
+          billable_metric: billable_metric,
+          group_properties: [
+            build(
+              :group_property,
+              group: europe,
+              values: { rate: '2', fixed_amount: '1' },
+            ),
+            build(
+              :group_property,
+              group: usa,
+              values: { rate: '1', fixed_amount: '0' },
+            ),
+            build(
+              :group_property,
+              group: france,
+              values: { rate: '5', fixed_amount: '1' },
+            ),
+          ],
+        )
+      end
+
+      before do
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'usa', foo_bar: 12 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe', foo_bar: 10 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe', foo_bar: 5 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { country: 'france', foo_bar: 5 },
+        )
+      end
+
+      it 'creates expected fees for count_agg aggregation type' do
+        billable_metric.update!(aggregation_type: :count_agg)
+        result = charge_subscription_service.create
+        expect(result).to be_success
+        created_fees = result.fees
+
+        aggregate_failures do
+          expect(created_fees.count).to eq(3)
+          expect(created_fees).to all(
+            have_attributes(
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_currency: 'EUR',
+              vat_rate: 20.0,
+            ),
+          )
+          expect(created_fees.first).to have_attributes(
+            amount_cents: 200 + 2 * 2,
+            vat_amount_cents: 41,
+            units: 2,
+          )
+          expect(created_fees.second).to have_attributes(
+            amount_cents: 1 * 1,
+            vat_amount_cents: 1,
+            units: 1,
+          )
+          expect(created_fees.third).to have_attributes(
+            amount_cents: 100 + 5 * 1,
+            vat_amount_cents: 21,
+            units: 1,
+          )
+        end
+      end
+    end
+
+    context 'with graduated charge and presence of groups' do
+      let(:europe) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+      end
+
+      let(:usa) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')
+      end
+
+      let(:charge) do
+        create(
+          :graduated_charge,
+          plan: subscription.plan,
+          billable_metric: billable_metric,
+          group_properties: [
+            build(
+              :group_property,
+              group: europe,
+              values: {
+                graduated_ranges: [
+                  {
+                    from_value: 0,
+                    to_value: nil,
+                    per_unit_amount: '0.01',
+                    flat_amount: '0.01',
+                  },
+                ],
+              },
+            ),
+            build(
+              :group_property,
+              group: usa,
+              values: {
+                graduated_ranges: [
+                  {
+                    from_value: 0,
+                    to_value: nil,
+                    per_unit_amount: '0.03',
+                    flat_amount: '0.01',
+                  },
+                ],
+              },
+            ),
+          ],
+        )
+      end
+
+      before do
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'usa', foo_bar: 12 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe', foo_bar: 10 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe', foo_bar: 5 },
+        )
+      end
+
+      it 'creates expected fees for count_agg aggregation type' do
+        billable_metric.update!(aggregation_type: :count_agg)
+        result = charge_subscription_service.create
+        expect(result).to be_success
+        created_fees = result.fees
+
+        aggregate_failures do
+          expect(created_fees.count).to eq(2)
+          expect(created_fees).to all(
+            have_attributes(
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_currency: 'EUR',
+              vat_rate: 20.0,
+            ),
+          )
+          expect(created_fees.first).to have_attributes(
+            amount_cents: 3,
+            vat_amount_cents: 1,
+            units: 2,
+          )
+          expect(created_fees.second).to have_attributes(
+            amount_cents: 4,
+            vat_amount_cents: 1,
+            units: 1,
+          )
+        end
+      end
+    end
+
+    context 'with volume charge and presence of groups' do
+      let(:europe) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+      end
+
+      let(:usa) do
+        create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'usa')
+      end
+
+      let(:charge) do
+        create(
+          :volume_charge,
+          plan: subscription.plan,
+          billable_metric: billable_metric,
+          group_properties: [
+            build(
+              :group_property,
+              group: europe,
+              values: {
+                volume_ranges: [
+                  { from_value: 0, to_value: 100, per_unit_amount: '2', flat_amount: '10' },
+                ],
+              },
+            ),
+            build(
+              :group_property,
+              group: usa,
+              values: {
+                volume_ranges: [
+                  { from_value: 0, to_value: 100, per_unit_amount: '1', flat_amount: '10' },
+                ],
+              },
+            ),
+          ],
+        )
+      end
+
+      before do
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'usa', foo_bar: 12 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe', foo_bar: 10 },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription: subscription,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe', foo_bar: 5 },
+        )
+      end
+
+      it 'creates expected fees for count_agg aggregation type' do
+        billable_metric.update!(aggregation_type: :count_agg)
+        result = charge_subscription_service.create
+        expect(result).to be_success
+        created_fees = result.fees
+
+        aggregate_failures do
+          expect(created_fees.count).to eq(2)
+          expect(created_fees).to all(
+            have_attributes(
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_currency: 'EUR',
+              vat_rate: 20.0,
+            ),
+          )
+          expect(created_fees.first).to have_attributes(
+            amount_cents: 1400,
+            vat_amount_cents: 280,
+            units: 2,
+          )
+          expect(created_fees.second).to have_attributes(
+            amount_cents: 1100,
+            vat_amount_cents: 220,
+            units: 1,
+          )
         end
       end
     end
@@ -257,7 +998,7 @@ RSpec.describe Fees::ChargeService do
 
           expect(result).to be_success
 
-          usage_fee = result.fee
+          usage_fee = result.fees.first
 
           aggregate_failures do
             expect(usage_fee.id).to be_nil
@@ -310,7 +1051,7 @@ RSpec.describe Fees::ChargeService do
 
         expect(result).to be_success
 
-        usage_fee = result.fee
+        usage_fee = result.fees.first
 
         aggregate_failures do
           expect(usage_fee.id).to be_nil


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to be able to aggregate and create fees for each group properties.
