### PR TITLE
hotfix(events): Remove persisted events

### DIFF
--- a/app/services/persisted_events/create_or_update_service.rb
+++ b/app/services/persisted_events/create_or_update_service.rb
@@ -50,7 +50,10 @@ module PersistedEvents
         billable_metric_id: matching_billable_metric.id,
         external_subscription_id: subscription.external_id,
         external_id: event.properties[matching_billable_metric.field_name],
+        removed_at: nil,
       )
+
+      return if metric.blank?
 
       metric.update!(removed_at: event.timestamp)
       metric

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -240,10 +240,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_24_090308) do
     t.decimal "units", default: "0.0", null: false
     t.uuid "applied_add_on_id"
     t.jsonb "properties", default: {}, null: false
+    t.integer "events_count"
     t.integer "fee_type"
     t.string "invoiceable_type"
     t.uuid "invoiceable_id"
-    t.integer "events_count"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"

--- a/spec/services/persisted_events/create_or_update_service_spec.rb
+++ b/spec/services/persisted_events/create_or_update_service_spec.rb
@@ -79,6 +79,32 @@ RSpec.describe PersistedEvents::CreateOrUpdateService, type: :service do
           expect(service_result.persisted_event.removed_at.to_s).to eq(event.timestamp.to_s)
         end
       end
+
+      context 'with already removed and an active events' do
+        before do
+          create(
+            :persisted_event,
+            customer: event.customer,
+            billable_metric: billable_metric,
+            external_subscription_id: event.subscription.external_id,
+            external_id: 'ext_12345',
+            removed_at: (Time.current - 1.hour).to_i,
+          )
+
+          persisted_event
+        end
+
+        it 'updates the active persisted metric' do
+          aggregate_failures do
+            service_result
+
+            expect(service_result).to be_success
+
+            expect(service_result.persisted_event).to eq(persisted_event)
+            expect(service_result.persisted_event.removed_at.to_s).to eq(event.timestamp.to_s)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Context

- If a `persisted_event` has already been removed, and if we add the exact same one, the `find_by` will take the already removed one (based on creation date order)

## Description

- add the `removed_at` nil into the `find_by`

NOTE : this is a hotfix, we should rework on this to find the best solution
