### PR TITLE
feat (gocardless): fetch mandate before payment

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -97,7 +97,6 @@ module Api
             :payment_provider,
             :provider_customer_id,
             :sync,
-            :provider_mandate_id,
             :sync_with_provider,
           ],
         )

--- a/app/graphql/types/payment_provider_customers/provider.rb
+++ b/app/graphql/types/payment_provider_customers/provider.rb
@@ -7,7 +7,6 @@ module Types
 
       field :id, ID, null: false
       field :provider_customer_id, ID, null: true
-      field :provider_mandate_id, String, null: true
       field :sync_with_provider, Boolean, null: true
     end
   end

--- a/app/graphql/types/payment_provider_customers/provider_input.rb
+++ b/app/graphql/types/payment_provider_customers/provider_input.rb
@@ -7,7 +7,6 @@ module Types
 
       argument :provider_customer_id, ID, required: false
       argument :sync_with_provider, Boolean, required: false
-      argument :provider_mandate_id, String, required: false
     end
   end
 end

--- a/app/graphql/types/payment_providers/gocardless.rb
+++ b/app/graphql/types/payment_providers/gocardless.rb
@@ -7,6 +7,7 @@ module Types
 
       field :id, ID, null: false
       field :has_access_token, Boolean, null: false
+      field :webhook_secret, String, null: true
 
       # NOTE: Access token is a sensitive information. It should not be sent back to the
       #       front end application

--- a/app/jobs/payment_providers/gocardless/handle_event_job.rb
+++ b/app/jobs/payment_providers/gocardless/handle_event_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Gocardless
+    class HandleEventJob < ApplicationJob
+      queue_as 'providers'
+
+      def perform(events_json:)
+        result = PaymentProviders::GocardlessService.new.handle_event(events_json: events_json)
+        result.throw_error
+      end
+    end
+  end
+end

--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -35,5 +35,13 @@ module PaymentProviders
     def get_from_settings(key)
       (settings || {})[key]
     end
+
+    def webhook_secret=(value)
+      push_to_settings(key: 'webhook_secret', value: value)
+    end
+
+    def webhook_secret
+      get_from_settings('webhook_secret')
+    end
   end
 end

--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -29,13 +29,5 @@ module PaymentProviders
     def webhook_id
       get_from_settings('webhook_id')
     end
-
-    def webhook_secret=(value)
-      push_to_settings(key: 'webhook_secret', value: value)
-    end
-
-    def webhook_secret
-      get_from_settings('webhook_secret')
-    end
   end
 end

--- a/app/serializers/v1/organization_serializer.rb
+++ b/app/serializers/v1/organization_serializer.rb
@@ -4,6 +4,7 @@ module V1
   class OrganizationSerializer < ModelSerializer
     def serialize
       {
+        lago_id: model.id,
         name: model.name,
         created_at: model.created_at.iso8601,
         webhook_url: model.webhook_url,

--- a/app/services/payment_provider_customers/create_service.rb
+++ b/app/services/payment_provider_customers/create_service.rb
@@ -18,10 +18,6 @@ module PaymentProviderCustomers
         provider_customer.provider_customer_id = params[:provider_customer_id].presence
       end
 
-      if (params || {}).key?(:provider_mandate_id)
-        provider_customer.provider_mandate_id = params[:provider_mandate_id].presence
-      end
-
       if (params || {}).key?(:sync_with_provider)
         provider_customer.sync_with_provider = params[:sync_with_provider].presence
       end

--- a/app/services/payment_providers/gocardless_service.rb
+++ b/app/services/payment_providers/gocardless_service.rb
@@ -14,6 +14,7 @@ module PaymentProviders
       )
 
       gocardless_provider.access_token = access_token if access_token
+      gocardless_provider.webhook_secret = SecureRandom.alphanumeric(50)
       gocardless_provider.save!
 
       result.gocardless_provider = gocardless_provider

--- a/app/services/payment_providers/gocardless_service.rb
+++ b/app/services/payment_providers/gocardless_service.rb
@@ -5,6 +5,7 @@ module PaymentProviders
     # NOTE: These links will be changed later
     AUTH_SITE = 'https://connect-sandbox.gocardless.com'
     REDIRECT_URI = 'https://proxy.lago.dev/gocardless/callback'
+    PAYMENT_ACTIONS = %w[paid_out failed cancelled customer_approval_denied charged_back].freeze
 
     def create_or_update(**args)
       access_token = oauth.auth_code.get_token(args[:access_code], redirect_uri: REDIRECT_URI)&.token
@@ -23,6 +24,42 @@ module PaymentProviders
       result.record_validation_failure!(record: e.record)
     rescue OAuth2::Error => e
       result.service_failure!(code: 'unauthorized', message: e.description)
+    end
+
+    def handle_incoming_webhook(organization_id:, body:, signature:)
+      organization = Organization.find_by(id: organization_id)
+
+      events = GoCardlessPro::Webhook.parse(
+        request_body: body,
+        signature_header: signature,
+        webhook_endpoint_secret: organization&.gocardless_payment_provider&.webhook_secret,
+      )
+
+      PaymentProviders::Gocardless::HandleEventJob.perform_later(events_json: body)
+
+      result.events = events
+      result
+    rescue JSON::ParserError
+      result.service_failure!(code: 'webhook_error', message: 'Invalid payload')
+    rescue GoCardlessPro::Webhook::InvalidSignatureError
+      result.service_failure!(code: 'webhook_error', message: 'Invalid signature')
+    end
+
+    def handle_event(events_json:)
+      events = JSON.parse(events_json)['events']
+      parsed_events = events.map { |event| GoCardlessPro::Resources::Event.new(event) }
+      parsed_events.each do |event|
+        case event.resource_type
+        when 'payments'
+          if PAYMENT_ACTIONS.include?(event.action)
+            Invoices::Payments::GocardlessService
+              .new.update_status(
+                provider_payment_id: event.links.payment,
+                status: event.action,
+              )
+          end
+        end
+      end
     end
 
     private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
 
   resources :webhooks, only: [] do
     post 'stripe/:organization_id', to: 'webhooks#stripe', on: :collection, as: :stripe
+    post 'gocardless/:organization_id', to: 'webhooks#gocardless', on: :collection, as: :gocardless
   end
 
   match '*unmatched' => 'application#not_found',

--- a/schema.graphql
+++ b/schema.graphql
@@ -2818,6 +2818,7 @@ enum FeeTypesEnum {
 type GocardlessProvider {
   hasAccessToken: Boolean!
   id: ID!
+  webhookSecret: String
 }
 
 type GraduatedRange {
@@ -3511,13 +3512,11 @@ input PropertiesInput {
 type ProviderCustomer {
   id: ID!
   providerCustomerId: ID
-  providerMandateId: String
   syncWithProvider: Boolean
 }
 
 input ProviderCustomerInput {
   providerCustomerId: ID
-  providerMandateId: String
   syncWithProvider: Boolean
 }
 

--- a/schema.json
+++ b/schema.json
@@ -9560,6 +9560,20 @@
               "args": [
 
               ]
+            },
+            {
+              "name": "webhookSecret",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
             }
           ],
           "inputFields": null,
@@ -13802,20 +13816,6 @@
               ]
             },
             {
-              "name": "providerMandateId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "syncWithProvider",
               "description": null,
               "type": {
@@ -13859,18 +13859,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "providerMandateId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/fixtures/gocardless/events.json
+++ b/spec/fixtures/gocardless/events.json
@@ -1,0 +1,22 @@
+{
+  "events": [
+    {
+      "id": "EVTESTYM78PGEM",
+      "created_at": "2022-10-29T16:26:50.380Z",
+      "resource_type": "payments",
+      "action": "paid_out",
+      "links": {
+        "payment": "PM0068WBTXDQ0Q"
+      },
+      "details": {
+        "origin": "gocardless",
+        "cause": "payment_paid_out",
+        "description": "The payment has been paid out by GoCardless."
+      },
+      "metadata": {}
+    }
+  ],
+  "meta": {
+    "webhook_id": "WB001F6SJ8MG2S"
+  }
+}

--- a/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
+++ b/spec/jobs/payment_providers/gocardless/handle_event_job_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentProviders::Gocardless::HandleEventJob, type: :job do
+  subject(:handle_event_job) { described_class }
+
+  let(:gocardless_service) { instance_double(PaymentProviders::GocardlessService) }
+  let(:result) { BaseService::Result.new }
+  let(:organization) { create(:organization) }
+
+  let(:gocardless_events) do
+    []
+  end
+
+  before do
+    allow(PaymentProviders::GocardlessService).to receive(:new)
+      .and_return(gocardless_service)
+    allow(gocardless_service).to receive(:handle_event)
+      .and_return(result)
+  end
+
+  it 'calls the handle event service' do
+    handle_event_job.perform_now(events_json: gocardless_events)
+
+    expect(PaymentProviders::GocardlessService).to have_received(:new)
+    expect(gocardless_service).to have_received(:handle_event)
+  end
+end

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -184,7 +184,6 @@ RSpec.describe Customers::CreateService, type: :service do
           billing_configuration: {
             payment_provider: 'gocardless',
             provider_customer_id: 'gocardless_id',
-            provider_mandate_id: 'mandate_id',
           },
         }
       end
@@ -207,7 +206,6 @@ RSpec.describe Customers::CreateService, type: :service do
           gocardless_customer = customer.gocardless_customer
           expect(gocardless_customer.id).to be_present
           expect(gocardless_customer.provider_customer_id).to eq('gocardless_id')
-          expect(gocardless_customer.provider_mandate_id).to eq('mandate_id')
         end
       end
     end

--- a/spec/services/invoices/payments/gocardless_service_spec.rb
+++ b/spec/services/invoices/payments/gocardless_service_spec.rb
@@ -35,9 +35,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
       allow(gocardless_mandates_service).to receive(:list)
         .and_return(gocardless_list_response)
       allow(gocardless_list_response).to receive(:records)
-        .and_return([GoCardlessPro::Resources::Mandate.new(
-          'id' => 'mandate_id',
-        )])
+        .and_return([GoCardlessPro::Resources::Mandate.new('id' => 'mandate_id')])
       allow(gocardless_client).to receive(:payments)
         .and_return(gocardless_payments_service)
       allow(gocardless_payments_service).to receive(:create)

--- a/spec/services/payment_providers/gocardless_service_spec.rb
+++ b/spec/services/payment_providers/gocardless_service_spec.rb
@@ -73,4 +73,97 @@ RSpec.describe PaymentProviders::GocardlessService, type: :service do
       end
     end
   end
+
+  describe '.handle_incoming_webhook' do
+    let(:gocardless_provider) { create(:gocardless_provider, organization: organization) }
+    let(:events_result) { events['events'].map { |event| GoCardlessPro::Resources::Event.new(event) } }
+
+    let(:events) do
+      path = Rails.root.join('spec/fixtures/gocardless/events.json')
+      JSON.parse(File.read(path))
+    end
+
+    before { gocardless_provider }
+
+    it 'checks the webhook' do
+      allow(GoCardlessPro::Webhook).to receive(:parse)
+        .and_return(events_result)
+
+      result = gocardless_service.handle_incoming_webhook(
+        organization_id: organization.id,
+        body: events.to_json,
+        signature: 'signature',
+      )
+
+      expect(result).to be_success
+
+      expect(result.events).to eq(events_result)
+      expect(PaymentProviders::Gocardless::HandleEventJob).to have_been_enqueued
+    end
+
+    context 'when failing to parse payload' do
+      it 'returns an error' do
+        allow(GoCardlessPro::Webhook).to receive(:parse).and_raise(JSON::ParserError)
+
+        result = gocardless_service.handle_incoming_webhook(
+          organization_id: organization.id,
+          body: events.to_json,
+          signature: 'signature',
+        )
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq('webhook_error')
+          expect(result.error.error_message).to eq('Invalid payload')
+        end
+      end
+    end
+
+    context 'when failing to validate the signature' do
+      it 'returns an error' do
+        allow(GoCardlessPro::Webhook).to receive(:parse)
+          .and_raise(GoCardlessPro::Webhook::InvalidSignatureError.new('error'))
+
+        result = gocardless_service.handle_incoming_webhook(
+          organization_id: organization.id,
+          body: events.to_json,
+          signature: 'signature',
+        )
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq('webhook_error')
+          expect(result.error.error_message).to eq('Invalid signature')
+        end
+      end
+    end
+  end
+
+  describe '.handle_event' do
+    let(:payment_service) { instance_double(Invoices::Payments::GocardlessService) }
+    let(:service_result) { BaseService::Result.new }
+
+    before do
+      allow(Invoices::Payments::GocardlessService).to receive(:new)
+        .and_return(payment_service)
+      allow(payment_service).to receive(:update_status)
+        .and_return(service_result)
+    end
+
+    context 'when succeeded payment event' do
+      let(:events) do
+        path = Rails.root.join('spec/fixtures/gocardless/events.json')
+        File.read(path)
+      end
+
+      it 'routes the event to an other service' do
+        gocardless_service.handle_event(events_json: events)
+
+        expect(Invoices::Payments::GocardlessService).to have_received(:new)
+        expect(payment_service).to have_received(:update_status)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Add few improvements related to gocardless feature

## Description

1. Fetch mandate before each payment
2. On UI, we won't be using mandate_id field anymore, so it should be removed
3. Generate webhook secret key (will be used on UI) while generating gocardless access token