### PR TITLE
fix(wallets): Fix GraphQL wallet type as name is not mandatory

### DIFF
--- a/app/graphql/types/wallets/object.rb
+++ b/app/graphql/types/wallets/object.rb
@@ -8,7 +8,7 @@ module Types
       field :id, ID, null: false
       field :customer, Types::Customers::Object
 
-      field :name, String, null: false
+      field :name, String, null: true
       field :status, Types::Wallets::StatusEnum, null: false
       field :rate_amount, String, null: false
       field :currency, Types::CurrencyEnum, null: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -4075,7 +4075,7 @@ type Wallet {
   id: ID!
   lastBalanceSyncAt: ISO8601DateTime
   lastConsumedCreditAt: ISO8601DateTime
-  name: String!
+  name: String
   rateAmount: String!
   status: WalletStatusEnum!
   terminatedAt: ISO8601DateTime
@@ -4099,7 +4099,7 @@ type WalletDetails {
   id: ID!
   lastBalanceSyncAt: ISO8601DateTime
   lastConsumedCreditAt: ISO8601DateTime
-  name: String!
+  name: String
   rateAmount: String!
   status: WalletStatusEnum!
   terminatedAt: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -17321,13 +17321,9 @@
               "name": "name",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -17659,13 +17655,9 @@
               "name": "name",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -46,6 +46,34 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
     end
   end
 
+  context 'when name is not present' do
+    it 'creates a wallet' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        query: mutation,
+        variables: {
+          input: {
+            customerId: customer.id,
+            name: nil,
+            rateAmount: '1',
+            paidCredits: '0.00',
+            grantedCredits: '0.00',
+            expirationDate: (Time.zone.now + 1.year).to_date,
+            currency: 'EUR',
+          },
+        },
+      )
+
+      result_data = result['data']['createCustomerWallet']
+
+      aggregate_failures do
+        expect(result_data['id']).to be_present
+        expect(result_data['name']).to be_nil
+      end
+    end
+  end
+
   context 'without current user' do
     it 'returns an error' do
       result = execute_graphql(


### PR DESCRIPTION
## Context

When creating through the API a wallet with no wallet_name, when going on customer.details.wallet on the UI, we have an error

## Description

Wallet name is not mandatory on both API and GraphQL, but GraphQL type was expecting this name to be present.

This PR fixes the issue by updating GraphQL schema to make name field as optional on `Wallet` type
