### PR TITLE
fix(webhooks): Keep query params when sending webhooks

### DIFF
--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -13,7 +13,7 @@ module LagoHttpClient
     end
 
     def post(body, headers)
-      req = Net::HTTP::Post.new(uri.path.presence || '/', 'Content-Type' => 'application/json')
+      req = Net::HTTP::Post.new(uri.request_uri, 'Content-Type' => 'application/json')
 
       headers.each do |header|
         key = header.keys.first

--- a/spec/lib/lago_http_client/client_spec.rb
+++ b/spec/lib/lago_http_client/client_spec.rb
@@ -90,5 +90,28 @@ RSpec.describe LagoHttpClient::Client do
         expect(response['message']).to eq 'Success'
       end
     end
+
+    context 'with query params' do
+      let(:url) { 'http://example.com/api?foo=bar' }
+
+      let(:response) do
+        {
+          'status' => 200,
+          'message' => 'Success',
+        }.to_json
+      end
+
+      before do
+        stub_request(:post, 'http://example.com/api?foo=bar')
+          .to_return(body: response, status: 200)
+      end
+
+      it 'returns response body' do
+        response = client.post('', {})
+
+        expect(response['status']).to eq 200
+        expect(response['message']).to eq 'Success'
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/getlago/lago/issues/123

## Context

If a webhook URL contains query parameters, these parameters are stripped out from the URL and are note delivered to the target URL.

## Description

This PR fixes the behavior by making sure that query params are sent correctly to the webhook URL
