### PR TITLE
feat(credit_notes): Add description field to credit note

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -8,6 +8,7 @@ module Api
           invoice: current_organization.invoices.find_by(id: input_params[:invoice_id]),
           reason: input_params[:reason],
           items_attr: input_params[:items],
+          description: input_params[:description],
         )
         result = service.call
 
@@ -83,6 +84,7 @@ module Api
           .permit(
             :invoice_id,
             :reason,
+            :description,
             items: [
               :fee_id,
               :credit_amount_cents,

--- a/app/graphql/mutations/credit_notes/create.rb
+++ b/app/graphql/mutations/credit_notes/create.rb
@@ -11,6 +11,7 @@ module Mutations
 
       argument :reason, Types::CreditNotes::ReasonTypeEnum, required: true
       argument :invoice_id, ID, required: true
+      argument :description, String, required: false
 
       argument :items, [Types::CreditNoteItems::Input], required: true
 
@@ -25,6 +26,7 @@ module Mutations
             invoice: current_organization.invoices.find_by(id: args[:invoice_id]),
             items_attr: args[:items],
             reason: args[:reason],
+            description: args[:description],
           )
           .call
 

--- a/app/graphql/types/credit_notes/object.rb
+++ b/app/graphql/types/credit_notes/object.rb
@@ -12,6 +12,7 @@ module Types
       field :credit_status, Types::CreditNotes::CreditStatusTypeEnum, null: true
       field :refund_status, Types::CreditNotes::RefundStatusTypeEnum, null: true
       field :reason, Types::CreditNotes::ReasonTypeEnum, null: false
+      field :description, String, null: true
 
       field :total_amount_cents, GraphQL::Types::BigInt, null: false
       field :total_amount_currency, Types::CurrencyEnum, null: false

--- a/app/serializers/v1/credit_note_serializer.rb
+++ b/app/serializers/v1/credit_note_serializer.rb
@@ -12,6 +12,7 @@ module V1
         credit_status: model.credit_status,
         refund_status: model.refund_status,
         reason: model.reason,
+        description: model.description,
         total_amount_cents: model.total_amount_cents,
         total_amount_currency: model.total_amount_currency,
         balance_amount_cents: model.balance_amount_cents,

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -2,10 +2,11 @@
 
 module CreditNotes
   class CreateService < BaseService
-    def initialize(invoice:, items_attr:, reason: :other)
+    def initialize(invoice:, items_attr:, description:, reason: :other)
       @invoice = invoice
       @items_attr = items_attr
       @reason = reason
+      @description = description
 
       super
     end
@@ -22,6 +23,7 @@ module CreditNotes
           refund_amount_currency: invoice.amount_currency,
           balance_amount_currency: invoice.amount_currency,
           reason: reason,
+          description: description,
           credit_status: 'available',
         )
 
@@ -43,7 +45,7 @@ module CreditNotes
 
     private
 
-    attr_accessor :invoice, :items_attr, :reason
+    attr_accessor :invoice, :items_attr, :reason, :description
 
     delegate :credit_note, to: :result
 

--- a/db/migrate/20221031144907_add_description_to_credit_notes.rb
+++ b/db/migrate/20221031144907_add_description_to_credit_notes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDescriptionToCreditNotes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :credit_notes, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_24_090308) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_31_144907) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -163,6 +163,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_24_090308) do
     t.bigint "refund_amount_cents", default: 0, null: false
     t.string "refund_amount_currency"
     t.integer "refund_status"
+    t.datetime "voided_at"
+    t.text "description"
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end
@@ -240,10 +242,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_24_090308) do
     t.decimal "units", default: "0.0", null: false
     t.uuid "applied_add_on_id"
     t.jsonb "properties", default: {}, null: false
-    t.integer "events_count"
     t.integer "fee_type"
     t.string "invoiceable_type"
     t.uuid "invoiceable_id"
+    t.integer "events_count"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1635,6 +1635,7 @@ input CreateCreditNoteInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  description: String
   invoiceId: ID!
   items: [CreditNoteItemInput!]!
   reason: CreditNoteReasonEnum!
@@ -1756,6 +1757,7 @@ type CreditNote {
   creditAmountCents: BigInt!
   creditAmountCurrency: CurrencyEnum!
   creditStatus: CreditNoteCreditStatusEnum
+  description: String
   fileUrl: String
   id: ID!
   invoice: Invoice

--- a/schema.json
+++ b/schema.json
@@ -4779,6 +4779,18 @@
               "deprecationReason": null
             },
             {
+              "name": "description",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "items",
               "description": null,
               "type": {
@@ -5692,6 +5704,20 @@
               "type": {
                 "kind": "ENUM",
                 "name": "CreditNoteCreditStatusEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "description",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/controllers/api/v1/credit_notes_controller_spec.rb
+++ b/spec/controllers/api/v1/credit_notes_controller_spec.rb
@@ -182,6 +182,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       {
         invoice_id: invoice_id,
         reason: 'duplicated_charge',
+        description: 'Duplicated charge',
         items: [
           {
             fee_id: fee1.id,
@@ -207,6 +208,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         expect(json[:credit_note][:credit_status]).to eq('available')
         expect(json[:credit_note][:refund_status]).to eq('pending')
         expect(json[:credit_note][:reason]).to eq('duplicated_charge')
+        expect(json[:credit_note][:description]).to eq('Duplicated charge')
         expect(json[:credit_note][:total_amount_cents]).to eq(30)
         expect(json[:credit_note][:total_amount_currency]).to eq('EUR')
         expect(json[:credit_note][:credit_amount_cents]).to eq(15)

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
           creditStatus
           refundStatus
           reason
+          description
           totalAmountCents
           totalAmountCurrency
           creditAmountCents
@@ -60,6 +61,7 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
         input: {
           reason: 'duplicated_charge',
           invoiceId: invoice.id,
+          description: 'Duplicated charge',
           items: [
             {
               feeId: fee1.id,
@@ -83,6 +85,7 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
       expect(result_data['creditStatus']).to eq('available')
       expect(result_data['refundStatus']).to eq('pending')
       expect(result_data['reason']).to eq('duplicated_charge')
+      expect(result_data['description']).to eq('Duplicated charge')
       expect(result_data['totalAmountCents']).to eq('30')
       expect(result_data['totalAmountCurrency']).to eq('EUR')
       expect(result_data['creditAmountCents']).to eq('15')

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CreditNotes::CreateService, type: :service do
-  subject(:create_service) { described_class.new(invoice: invoice, items_attr: items) }
+  subject(:create_service) { described_class.new(invoice: invoice, items_attr: items, description: nil) }
 
   let(:invoice) do
     create(:invoice, amount_currency: 'EUR', amount_cents: 20, total_amount_cents: 20, status: :succeeded)


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to allow credit notes to be created manually and to allow refund in parallel of existing credit.

The main reason behind this need is to handle the following case:
If a problem appeared when creating an invoice (over-bill for instance), we cannot apply a discount to a specific invoice. 

## Description

This PR adds a `description` field to the credit note object and updates the `createCreditNote` mutation and to the `POST /api/v1/credit_notes` API routes