### PR TITLE
feat(:credit_notes): Add error webhook for refund on payment providers

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -36,6 +36,8 @@ class SendWebhookJob < ApplicationJob
       Webhooks::CreditNotes::CreatedService.new(object).call
     when 'credit_note.generated'
       Webhooks::CreditNotes::GeneratedService.new(object).call
+    when 'credit_note.provider_refund_failure'
+      Webhooks::CreditNotes::PaymentProviderRefundFailureService.new(object, options).call
     when 'invoice.generated'
       Webhooks::Invoices::GeneratedService.new(object).call
     else

--- a/app/serializers/v1/credit_notes/payment_provider_refund_error_serializer.rb
+++ b/app/serializers/v1/credit_notes/payment_provider_refund_error_serializer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module CreditNotes
+    class PaymentProviderRefundErrorSerializer < ModelSerializer
+      alias credit_note model
+
+      def serialize
+        {
+          lago_credit_note_id: credit_note.id,
+          lago_customer_id: credit_note.customer.id,
+          external_customer_id: credit_note.customer.external_id,
+          provider_customer_id: options[:provider_customer_id],
+          payment_provider: credit_note.customer.payment_provider,
+          provider_error: options[:provider_error],
+        }
+      end
+    end
+  end
+end

--- a/app/services/webhooks/credit_notes/payment_provider_refund_failure_service.rb
+++ b/app/services/webhooks/credit_notes/payment_provider_refund_failure_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module CreditNotes
+    class PaymentProviderRefundFailureService < Webhooks::BaseService
+      private
+
+      alias credit_note object
+
+      def current_organization
+        @current_organization ||= credit_note.organization
+      end
+
+      def object_serializer
+        ::V1::CreditNotes::PaymentProviderRefundErrorSerializer.new(
+          credit_note,
+          root_name: object_type,
+          provider_error: options[:provider_error],
+          provider_customer_id: options[:provider_customer_id],
+        )
+      end
+
+      def webhook_type
+        'credit_note.refund_failure'
+      end
+
+      def object_type
+        'credit_note_payment_provider_refund_error'
+      end
+    end
+  end
+end

--- a/spec/serializers/v1/credit_notes/payment_provider_refund_error_serializer_spec.rb
+++ b/spec/serializers/v1/credit_notes/payment_provider_refund_error_serializer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::CreditNotes::PaymentProviderRefundErrorSerializer do
+  subject(:serializer) { described_class.new(credit_note, options) }
+
+  let(:credit_note) { create(:credit_note) }
+  let(:options) do
+    {
+      'provider_customer_id' => 'customer',
+      'provider_error' => {
+        'error_message' => 'message',
+        'error_code' => 'code',
+      },
+    }.with_indifferent_access
+  end
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['data']['lago_credit_note_id']).to eq(credit_note.id)
+      expect(result['data']['lago_customer_id']).to eq(credit_note.customer.id)
+      expect(result['data']['external_customer_id']).to eq(credit_note.customer.external_id)
+      expect(result['data']['provider_customer_id']).to eq(options[:provider_customer_id])
+      expect(result['data']['payment_provider']).to eq(credit_note.customer.payment_provider)
+      expect(result['data']['provider_error']).to eq(options[:provider_error])
+    end
+  end
+end

--- a/spec/services/webhooks/credit_notes/payment_provider_refund_failure_service_spec.rb
+++ b/spec/services/webhooks/credit_notes/payment_provider_refund_failure_service_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::CreditNotes::PaymentProviderRefundFailureService do
+  subject(:webhook_service) { described_class.new(credit_note, webhook_options) }
+
+  let(:credit_note) { create(:credit_note, customer: customer) }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:organization) { create(:organization, webhook_url: webhook_url) }
+  let(:webhook_url) { 'http://foo.bar' }
+
+  let(:webhook_options) { { provider_error: { message: 'message', error_code: 'code' } } }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post)
+    end
+
+    it 'calls the organization webhook url' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post)
+    end
+
+    it 'builds payload with credit_note.refund_failure webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post) do |payload|
+        expect(payload[:webhook_type]).to eq('credit_note.refund_failure')
+        expect(payload[:object_type]).to eq('credit_note_payment_provider_refund_error')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to allow credit notes to be created manually and to allow refund in parallel of existing credit.

The main reason behind this need is to handle the following case:
If a problem appeared when creating an invoice (over-bill for instance), we cannot apply a discount to a specific invoice. 

## Description

This PR adds a new `credit_note.provider_refund_failure` webhook  to notify about failure in refund processing