### PR TITLE
feat(credit_notes): Add refund model to handle stripe refunds

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -36,6 +36,8 @@ class SendWebhookJob < ApplicationJob
       Webhooks::CreditNotes::CreatedService.new(object).call
     when 'credit_note.generated'
       Webhooks::CreditNotes::GeneratedService.new(object).call
+    when 'credit_note.provider_refund_failure'
+      Webhooks::CreditNotes::PaymentProviderRefundFailureService.new(object, options).call
     when 'invoice.generated'
       Webhooks::Invoices::GeneratedService.new(object).call
     else

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -12,6 +12,7 @@ class CreditNote < ApplicationRecord
 
   has_many :items, class_name: 'CreditNoteItem'
   has_many :fees, through: :items
+  has_many :refunds
 
   has_one_attached :file
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -4,4 +4,6 @@ class Payment < ApplicationRecord
   belongs_to :invoice
   belongs_to :payment_provider, optional: true, class_name: 'PaymentProviders::BaseProvider'
   belongs_to :payment_provider_customer, class_name: 'PaymentProviderCustomers::BaseCustomer'
+
+  has_many :refunds
 end

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -8,6 +8,7 @@ module PaymentProviderCustomers
     belongs_to :payment_provider, optional: true, class_name: 'PaymentProviders::BaseProvider'
 
     has_many :payments
+    has_many :refunds, foreign_key: :payment_provider_customer_id
 
     def push_to_settings(key:, value:)
       self.settings ||= {}

--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -12,6 +12,7 @@ module PaymentProviders
              foreign_key: :payment_provider_id
 
     has_many :payments, dependent: :nullify, foreign_key: :payment_provider_id
+    has_many :refunds, dependent: :nullify, foreign_key: :payment_provider_id
 
     encrypts :secrets
 

--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Refund < ApplicationRecord
+  belongs_to :payment
+  belongs_to :credit_note
+  belongs_to :payment_provider, class_name: 'PaymentProviders::BaseProvider'
+  belongs_to :payment_provider_customer, class_name: 'PaymentProviderCustomers::BaseCustomer'
+end

--- a/app/serializers/v1/credit_notes/payment_provider_refund_error_serializer.rb
+++ b/app/serializers/v1/credit_notes/payment_provider_refund_error_serializer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module V1
+  module CreditNotes
+    class PaymentProviderRefundErrorSerializer < ModelSerializer
+      alias credit_note model
+
+      def serialize
+        {
+          lago_credit_note_id: credit_note.id,
+          lago_customer_id: credit_note.customer.id,
+          external_customer_id: credit_note.customer.external_id,
+          provider_customer_id: options[:provider_customer_id],
+          payment_provider: credit_note.customer.payment_provider,
+          provider_error: options[:provider_error],
+        }
+      end
+    end
+  end
+end

--- a/app/services/webhooks/credit_notes/payment_provider_refund_failure_service.rb
+++ b/app/services/webhooks/credit_notes/payment_provider_refund_failure_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module CreditNotes
+    class PaymentProviderRefundFailureService < Webhooks::BaseService
+      private
+
+      alias credit_note object
+
+      def current_organization
+        @current_organization ||= credit_note.organization
+      end
+
+      def object_serializer
+        ::V1::CreditNotes::PaymentProviderRefundErrorSerializer.new(
+          credit_note,
+          root_name: object_type,
+          provider_error: options[:provider_error],
+          provider_customer_id: options[:provider_customer_id],
+        )
+      end
+
+      def webhook_type
+        'credit_note.refund_failure'
+      end
+
+      def object_type
+        'credit_note_payment_provider_refund_error'
+      end
+    end
+  end
+end

--- a/db/migrate/20221028124549_create_refunds.rb
+++ b/db/migrate/20221028124549_create_refunds.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateRefunds < ActiveRecord::Migration[7.0]
+  def change
+    create_table :refunds, id: :uuid do |t|
+      t.references :payment, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :credit_note, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :payment_provider, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :payment_provider_customer, type: :uuid, null: false, foreign_key: true, index: true
+      t.bigint :amount_cents, null: false, default: 0
+      t.string :amount_currency, null: false
+      t.string :status, null: false
+      t.string :provider_refund_id, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -426,6 +426,23 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_31_144907) do
     t.index ["parent_id"], name: "index_plans_on_parent_id"
   end
 
+  create_table "refunds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "payment_id", null: false
+    t.uuid "credit_note_id", null: false
+    t.uuid "payment_provider_id", null: false
+    t.uuid "payment_provider_customer_id", null: false
+    t.bigint "amount_cents", default: 0, null: false
+    t.string "amount_currency", null: false
+    t.string "status", null: false
+    t.string "provider_refund_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["credit_note_id"], name: "index_refunds_on_credit_note_id"
+    t.index ["payment_id"], name: "index_refunds_on_payment_id"
+    t.index ["payment_provider_customer_id"], name: "index_refunds_on_payment_provider_customer_id"
+    t.index ["payment_provider_id"], name: "index_refunds_on_payment_provider_id"
+  end
+
   create_table "subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "customer_id", null: false
     t.uuid "plan_id", null: false
@@ -527,6 +544,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_31_144907) do
   add_foreign_key "persisted_events", "customers"
   add_foreign_key "plans", "organizations"
   add_foreign_key "plans", "plans", column: "parent_id"
+  add_foreign_key "refunds", "credit_notes"
+  add_foreign_key "refunds", "payment_provider_customers"
+  add_foreign_key "refunds", "payment_providers"
+  add_foreign_key "refunds", "payments"
   add_foreign_key "subscriptions", "customers"
   add_foreign_key "subscriptions", "plans"
   add_foreign_key "wallet_transactions", "invoices"

--- a/spec/serializers/v1/credit_notes/payment_provider_refund_error_serializer_spec.rb
+++ b/spec/serializers/v1/credit_notes/payment_provider_refund_error_serializer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::CreditNotes::PaymentProviderRefundErrorSerializer do
+  subject(:serializer) { described_class.new(credit_note, options) }
+
+  let(:credit_note) { create(:credit_note) }
+  let(:options) do
+    {
+      'provider_customer_id' => 'customer',
+      'provider_error' => {
+        'error_message' => 'message',
+        'error_code' => 'code',
+      },
+    }.with_indifferent_access
+  end
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['data']['lago_credit_note_id']).to eq(credit_note.id)
+      expect(result['data']['lago_customer_id']).to eq(credit_note.customer.id)
+      expect(result['data']['external_customer_id']).to eq(credit_note.customer.external_id)
+      expect(result['data']['provider_customer_id']).to eq(options[:provider_customer_id])
+      expect(result['data']['payment_provider']).to eq(credit_note.customer.payment_provider)
+      expect(result['data']['provider_error']).to eq(options[:provider_error])
+    end
+  end
+end

--- a/spec/services/webhooks/credit_notes/payment_provider_refund_failure_service_spec.rb
+++ b/spec/services/webhooks/credit_notes/payment_provider_refund_failure_service_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::CreditNotes::PaymentProviderRefundFailureService do
+  subject(:webhook_service) { described_class.new(credit_note, webhook_options) }
+
+  let(:credit_note) { create(:credit_note, customer: customer) }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:organization) { create(:organization, webhook_url: webhook_url) }
+  let(:webhook_url) { 'http://foo.bar' }
+
+  let(:webhook_options) { { provider_error: { message: 'message', error_code: 'code' } } }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post)
+    end
+
+    it 'calls the organization webhook url' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post)
+    end
+
+    it 'builds payload with credit_note.refund_failure webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post) do |payload|
+        expect(payload[:webhook_type]).to eq('credit_note.refund_failure')
+        expect(payload[:object_type]).to eq('credit_note_payment_provider_refund_error')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to allow credit notes to be created manually and to allow refund in parallel of existing credit.

The main reason behind this need is to handle the following case:
If a problem appeared when creating an invoice (over-bill for instance), we cannot apply a discount to a specific invoice. 

## Description

This PR adds a new `refund` model to handle refunds on stripe