### PR TITLE
feat(creadit_notes): Set credit balance to 0 when voided

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -90,6 +90,7 @@ class CreditNote < ApplicationRecord
     update!(
       credit_status: :voided,
       voided_at: timestamp,
+      balance_amount_cents: 0,
     )
   end
 

--- a/app/services/credit_notes/void_service.rb
+++ b/app/services/credit_notes/void_service.rb
@@ -14,6 +14,7 @@ module CreditNotes
       result.credit_note = credit_note
       return result.not_allowed_failure!(code: 'no_voidable_amount') unless credit_note.voidable?
 
+      credit_note.balance_amount_cents = 0
       credit_note.mark_as_voided!
 
       result

--- a/app/services/credit_notes/void_service.rb
+++ b/app/services/credit_notes/void_service.rb
@@ -14,7 +14,6 @@ module CreditNotes
       result.credit_note = credit_note
       return result.not_allowed_failure!(code: 'no_voidable_amount') unless credit_note.voidable?
 
-      credit_note.balance_amount_cents = 0
       credit_note.mark_as_voided!
 
       result

--- a/spec/services/credit_notes/void_service_spec.rb
+++ b/spec/services/credit_notes/void_service_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe CreditNotes::VoidService, type: :service do
 
         expect(result.credit_note).to be_voided
         expect(result.credit_note.voided_at).to be_present
+        expect(result.credit_note.balance_amount_cents).to eq(0)
       end
     end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to allow credit notes to be created manually and to allow refund in parallel of existing credit.

The main reason behind this need is to handle the following case:
If a problem appeared when creating an invoice (over-bill for instance), we cannot apply a discount to a specific invoice. 

## Description

This PR set the credit_note `balance_amount_cents` to 0 when voiding the credit note