### PR TITLE
feat(credit_note): Track creation on Segment

### DIFF
--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -68,6 +68,22 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       end
     end
 
+    it 'calls SegmentTrackJob' do
+      allow(SegmentTrackJob).to receive(:perform_later)
+
+      credit_note = create_service.call.credit_note
+
+      expect(SegmentTrackJob).to have_received(:perform_later).with(
+        membership_id: CurrentContext.membership,
+        event: 'credit_note_created',
+        properties: {
+          organization_id: credit_note.organization.id,
+          credit_note_id: credit_note.id,
+          credit_note_type: 'credit_and_refund',
+        },
+      )
+    end
+
     context 'with invalid items' do
       let(:items) do
         [


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to allow credit notes to be created manually and to allow refund in parallel of existing credit.

The main reason behind this need is to handle the following case:
If a problem appeared when creating an invoice (over-bill for instance), we cannot apply a discount to a specific invoice. 

## Description

This PR adds tracking of the credit note creation on Segment