### PR TITLE
feat(credit_notes): Void a credit note via API

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -77,6 +77,25 @@ module Api
         head(:ok)
       end
 
+      def void
+        credit_note = current_organization.credit_notes.find_by(id: params[:id])
+        return not_found_error(resource: 'credit_note') unless credit_note
+
+        result = CreditNotes::VoidService.new(credit_note: credit_note).call
+
+        if result.success?
+          render(
+            json: ::V1::CreditNoteSerializer.new(
+              credit_note,
+              root_name: 'credit_note',
+              includes: %i[items],
+            ),
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
       def index
         credit_notes = current_organization.credit_notes
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
       resources :coupons, param: :code
       resources :credit_notes, only: %i[create update show index] do
         post :download, on: :member
+        put :void, on: :member
       end
       resources :events, only: %i[create show]
       resources :applied_coupons, only: %i[create]


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to allow credit notes to be created manually and to allow refund in parallel of existing credit.

The main reason behind this need is to handle the following case:
If a problem appeared when creating an invoice (over-bill for instance), we cannot apply a discount to a specific invoice. 

## Description

This PR adds the `PUT /api/v1/credit_notes/:id/void` route to void a credit note via the API