### PR TITLE
feat(groups): Update invoice to support groups

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -14,4 +14,8 @@ class Group < ApplicationRecord
 
   scope :parents, -> { where(parent_group_id: nil) }
   scope :children, -> { where.not(parent_group_id: nil) }
+
+  def name
+    parent ? "#{parent.value} • #{value}" : value
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -128,6 +128,7 @@ class Invoice < ApplicationRecord
     result = BillableMetrics::Aggregations::RecurringCountService.new(
       billable_metric: fee.charge.billable_metric,
       subscription: fee.subscription,
+      group: fee.group,
     ).breakdown(
       from_date: Date.parse(fee.properties['charges_from_date']),
       to_date: Date.parse(fee.properties['charges_to_date']),

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -532,18 +532,44 @@ html
               | List of charges used from #{invoice_subscription(subscription.id).charges_from_date&.strftime('%b %d, %Y')} to #{invoice_subscription(subscription.id).charges_to_date&.strftime('%b %d, %Y')}
             .charge-details.mb-24
               table.charge-details-table width="100%"
-                - subscription_fees(subscription.id).charge_kind.each do |fee|
-                  tr
-                    td width="70%"
-                      .body-1 = fee.billable_metric.name
-                      .body-3
-                        - if fee.charge.billable_metric.recurring_count_agg?
-                          | See breakdown for total unit
-                        - elsif fee.charge.percentage?
-                          | Total unit: #{fee.events_count} events for #{fee.units}
-                        - else
-                          | Total unit: #{fee.units}
-                    td.body-1 width="30%" = fee.amount.format
+                - subscription_fees(subscription.id).charge_kind.group_by(&:charge_id).each do |_charge_id, fees|
+                  - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
+                    tr
+                      td width="70%"
+                        .body-1 = fees.first.billable_metric.name
+                        .body-3
+                          - if fees.first.charge.billable_metric.recurring_count_agg?
+                            | See breakdown for total unit
+                          - elsif fees.first.charge.percentage?
+                            | Total unit: #{fees.sum(&:events_count)} events for #{fees.sum(&:units)}
+                          - else
+                            | Total unit: #{fees.sum(&:units)}
+                      td width="30%"
+
+                    - fees.select { |f| f.amount.positive? }.each do |fee|
+                      tr
+                        td width="70%" style="padding-left: 16px;"
+                          .body-1 = fee.group.name
+                          .body-3
+                            - if fee.charge.billable_metric.recurring_count_agg?
+                              | See breakdown for total unit
+                            - elsif fee.charge.percentage?
+                              | Total unit: #{fee.events_count} events for #{fee.units}
+                            - else
+                              | Total unit: #{fee.units}
+                        td.body-1 width="30%" = fee.amount.format
+                  - else
+                    tr
+                      td width="70%"
+                        .body-1 = fees.first.billable_metric.name
+                        .body-3
+                          - if fees.first.charge.billable_metric.recurring_count_agg?
+                            | See breakdown for total unit
+                          - elsif fees.first.charge.percentage?
+                            | Total unit: #{fees.sum(&:events_count)} events for #{fees.sum(&:units)}
+                          - else
+                            | Total unit: #{fees.sum(&:units)}
+                      td.body-1 width="30%" = fees.sum(&:amount).format
 
               table.total-table width="100%"
                 tr

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -533,14 +533,15 @@ html
             .charge-details.mb-24
               table.charge-details-table width="100%"
                 - subscription_fees(subscription.id).charge_kind.group_by(&:charge_id).each do |_charge_id, fees|
+                  - fee = fees.first
                   - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
                     tr
                       td width="70%"
-                        .body-1 = fees.first.billable_metric.name
+                        .body-1 = fee.billable_metric.name
                         .body-3
-                          - if fees.first.charge.billable_metric.recurring_count_agg?
+                          - if fee.charge.billable_metric.recurring_count_agg?
                             | See breakdown for total unit
-                          - elsif fees.first.charge.percentage?
+                          - elsif fee.charge.percentage?
                             | Total unit: #{fees.sum(&:events_count)} events for #{fees.sum(&:units)}
                           - else
                             | Total unit: #{fees.sum(&:units)}
@@ -550,22 +551,21 @@ html
                       tr
                         td width="70%" style="padding-left: 16px;"
                           .body-1 = fee.group.name
-                          .body-3
-                            - if fee.charge.billable_metric.recurring_count_agg?
-                              | See breakdown for total unit
-                            - elsif fee.charge.percentage?
-                              | Total unit: #{fee.events_count} events for #{fee.units}
-                            - else
-                              | Total unit: #{fee.units}
+                          - unless fee.charge.billable_metric.recurring_count_agg?
+                            .body-3
+                              - if fee.charge.percentage?
+                                | Total unit: #{fee.events_count} events for #{fee.units}
+                              - else
+                                | Total unit: #{fee.units}
                         td.body-1 width="30%" = fee.amount.format
                   - else
                     tr
                       td width="70%"
-                        .body-1 = fees.first.billable_metric.name
+                        .body-1 = fee.billable_metric.name
                         .body-3
-                          - if fees.first.charge.billable_metric.recurring_count_agg?
+                          - if fee.charge.billable_metric.recurring_count_agg?
                             | See breakdown for total unit
-                          - elsif fees.first.charge.percentage?
+                          - elsif fee.charge.percentage?
                             | Total unit: #{fees.sum(&:events_count)} events for #{fees.sum(&:units)}
                           - else
                             | Total unit: #{fees.sum(&:units)}
@@ -580,26 +580,47 @@ html
                   td.body-2 width="70%" Total
                   td.body-1 width="30%" = invoice_subscription(subscription.id).total_amount.format
 
-            - recurring_fees(subscription.id).each do |fee|
+            - recurring_fees(subscription.id).group_by(&:charge_id).each do |_charge_id, fees|
               - if subscription.name.present?
                 h2.invoice-details-title.title-2.mb-24 #{subscription.name} details
               - else
                 h2.invoice-details-title.title-2.mb-24 #{subscription.plan.name} details
 
-              .body-1.mb-24 Breakdown of #{fee.item_name}
-              .breakdown-details.mb-24
-                table.breakdown-details-table width="100%"
-                  - recurring_breakdown(fee).each do |breakdown|
-                    tr
-                      td.body-3 width="15%" = breakdown.date.strftime('%b %d, %Y')
-                      td.body-1 width="65%"
-                        - if breakdown.action.to_sym == :add
-                          | +#{breakdown.count} #{fee.item_name}
-                        - elsif breakdown.action.to_sym == :remove
-                          | -#{breakdown.count} #{fee.item_name}
-                        - else
-                          | +/-#{breakdown.count} #{fee.item_name}
-                      td.body-3 width="20%"
-                        | #{breakdown.duration} of #{breakdown.total_duration} days
+              .body-3 = fee.billable_metric.name
+              - if fees.all? { |f| f.group_id? }
+                - fees.select { |f| f.amount.positive? }.each do |fee|
+                  .body-1.mb-24 Breakdown of #{fee.group.name}
+                  .breakdown-details.mb-24
+                    table.breakdown-details-table width="100%"
+                      - recurring_breakdown(fee).each do |breakdown|
+                        tr
+                          td.body-3 width="15%" = breakdown.date.strftime('%b %d, %Y')
+                          td.body-1 width="65%"
+                            - if breakdown.action.to_sym == :add
+                              | +#{breakdown.count} #{fee.item_name}
+                            - elsif breakdown.action.to_sym == :remove
+                              | -#{breakdown.count} #{fee.item_name}
+                            - else
+                              | +/-#{breakdown.count} #{fee.item_name}
+                          td.body-3 width="20%"
+                            | #{breakdown.duration} of #{breakdown.total_duration} days
+              - else
+                .body-1.mb-24 Breakdown
+                .breakdown-details.mb-24
+                  table.breakdown-details-table width="100%"
+                    - fees.each do |fee|
+                      - recurring_breakdown(fee).each do |breakdown|
+                        tr
+                          td.body-3 width="15%" = breakdown.date.strftime('%b %d, %Y')
+                          td.body-1 width="65%"
+                            - if breakdown.action.to_sym == :add
+                              | +#{breakdown.count} #{fee.item_name}
+                            - elsif breakdown.action.to_sym == :remove
+                              | -#{breakdown.count} #{fee.item_name}
+                            - else
+                              | +/-#{breakdown.count} #{fee.item_name}
+                          td.body-3 width="20%"
+                            | #{breakdown.duration} of #{breakdown.total_duration} days
+
               .alert.body-3
                 | For example, if a unit is added with 15 days left in your monthly plan, we multiply the price by 15/31 (days remaining divided by the total number of days in your plan) to calculate the prorated price. Same logic when removing a unit used during 10 days, we multiply the price by 10/31.


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/32

## Context

We want to be able to price differently billable metrics according to several dimensions (groups).

For example, creating a `storage` pricing based on the `region of the server` and the `cloud provider` used.

## Description

The goal of this PR is to be able to support groups on the invoice.