### PR TITLE
fix(dates): Fix yearly to_date computation when subscription anniversary is on first day of a month

### DIFF
--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -105,6 +105,16 @@ module Subscriptions
 
     # NOTE: Handle leap years and anniversary date > 28
     def build_date(year, month, day)
+      if day.zero?
+        day = 31
+        month -= 1
+
+        if month.zero?
+          month = 12
+          year -= 1
+        end
+      end
+
       days_count_in_month = Time.days_in_month(month, year)
       day = days_count_in_month if days_count_in_month < day
 

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -174,6 +174,15 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
       end
 
+      context 'when anniversary date is first day of a month' do
+        let(:subscription_date) { DateTime.parse('01 Dec 2022') }
+        let(:billing_date) { DateTime.parse('02 Jan 2024') }
+
+        it 'returns the last day of the previous month on next year' do
+          expect(result).to eq('2023-11-30')
+        end
+      end
+
       context 'when plan is pay in advance' do
         before { plan.update!(pay_in_advance: true) }
 


### PR DESCRIPTION
## Context

Today, if a yearly subscription is billed on an anniversary basis with a subscription date on the first day of month (appart for January 1st), any billing job will failed with a `Date::Error invalid date` error.

The issue is related to a wrong handling of day computation in the Yearly and Monthly date service. The service tries to build a date object with 0 as day number, leading to the exception.

## Description

The fix is to  handle this 0 case and move to the last day of the previous month.