### PR TITLE
feat: add invoice_credit_notes_resolver

### DIFF
--- a/app/graphql/resolvers/invoice_credit_notes_resolver.rb
+++ b/app/graphql/resolvers/invoice_credit_notes_resolver.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class InvoiceCreditNotesResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description "Query invoice's credit note"
+
+    argument :invoice_id, ID, required: true, description: 'Uniq ID of the invoice'
+    argument :page, Integer, required: false
+    argument :limit, Integer, required: false
+
+    type Types::CreditNotes::Object.collection_type, null: true
+
+    def resolve(invoice_id: nil, page: nil, limit: nil)
+      validate_organization!
+
+      Invoice.find(invoice_id)
+        .credit_notes
+        .order(created_at: :desc)
+        .page(page)
+        .per(limit)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: 'invoice')
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -17,6 +17,7 @@ module Types
     field :coupon, resolver: Resolvers::CouponResolver
     field :credit_note, resolver: Resolvers::CreditNoteResolver
     field :customer_credit_notes, resolver: Resolvers::CustomerCreditNotesResolver
+    field :invoice_credit_notes, resolver: Resolvers::InvoiceCreditNotesResolver
     field :customers, resolver: Resolvers::CustomersResolver
     field :customer, resolver: Resolvers::CustomerResolver
     field :events, resolver: Resolvers::EventsResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -3739,6 +3739,18 @@ type Query {
   ): Invoice
 
   """
+  Query invoice's credit note
+  """
+  invoiceCreditNotes(
+    """
+    Uniq ID of the invoice
+    """
+    invoiceId: ID!
+    limit: Int
+    page: Int
+  ): CreditNoteCollection
+
+  """
   Query memberships of an organization
   """
   memberships(limit: Int, page: Int): MembershipCollection!

--- a/schema.json
+++ b/schema.json
@@ -15099,6 +15099,59 @@
               ]
             },
             {
+              "name": "invoiceCreditNotes",
+              "description": "Query invoice's credit note",
+              "type": {
+                "kind": "OBJECT",
+                "name": "CreditNoteCollection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "invoiceId",
+                  "description": "Uniq ID of the invoice",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "memberships",
               "description": "Query memberships of an organization",
               "type": {

--- a/spec/graphql/resolvers/invoice_credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_credit_notes_resolver_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::InvoiceCreditNotesResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($invoiceId: ID!) {
+        invoiceCreditNotes(invoiceId: $invoiceId, limit: 5) {
+          collection { id }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:invoice) { create(:invoice, customer: customer) }
+  let(:subscription) { create(:subscription, customer: customer, organization: organization) }
+  let(:credit_note) { create(:credit_note, organization: organization, customer: customer, invoice: invoice) }
+
+  before do
+    subscription
+    credit_note
+  end
+
+  it 'returns a list of credit_notes for an invoice' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query: query,
+      variables: {
+        invoiceId: invoice.id,
+      },
+    )
+
+    credit_notes_response = result['data']['invoiceCreditNotes']
+
+    aggregate_failures do
+      expect(credit_notes_response['collection'].count).to eq(invoice.credit_notes.count)
+      expect(credit_notes_response['collection'].first['id']).to eq(credit_note.id)
+
+      expect(credit_notes_response['metadata']['currentPage']).to eq(1)
+      expect(credit_notes_response['metadata']['totalCount']).to eq(1)
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query: query,
+        variables: {
+          invoiceId: invoice.id,
+        },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Missing organization id',
+      )
+    end
+  end
+
+  context 'when not member of the organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: create(:organization),
+        query: query,
+        variables: {
+          invoiceId: invoice.id,
+        },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Not in organization',
+      )
+    end
+  end
+
+  context 'when invoice does not exists' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query: query,
+        variables: {
+          invoiceId: '123456',
+        },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Resource not found',
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉 https://github.com/getlago/lago/issues/59

## Context

We need 2 ways to fetch credit note list: via an invoice or a customer id

## Description

This PR adds the invoice credit notes resolver, as the customer already exists on the feature branch