### PR TITLE
fix (gocardless): fix calling invoice without its instance var

### DIFF
--- a/app/models/payment_providers/gocardless_provider.rb
+++ b/app/models/payment_providers/gocardless_provider.rb
@@ -6,6 +6,14 @@ module PaymentProviders
 
     validates :access_token, presence: true
 
+    def self.auth_site
+      if Rails.env.production?
+        'https://connect.gocardless.com'
+      else
+        'https://connect-sandbox.gocardless.com'
+      end
+    end
+
     def environment
       if Rails.env.production?
         :live

--- a/app/services/invoices/payments/gocardless_service.rb
+++ b/app/services/invoices/payments/gocardless_service.rb
@@ -38,7 +38,7 @@ module Invoices
 
         invoice_status = invoice_status(payment.status)
         update_invoice_status(invoice_status)
-        handle_prepaid_credits(invoice_status)
+        handle_prepaid_credits(payment.invoice, invoice_status)
         track_payment_status_changed(payment.invoice)
 
         result.payment = payment
@@ -57,7 +57,7 @@ module Invoices
 
         invoice_status = invoice_status(status)
         payment.invoice.update!(status: invoice_status)
-        handle_prepaid_credits(invoice_status)
+        handle_prepaid_credits(payment.invoice, invoice_status)
         track_payment_status_changed(payment.invoice)
 
         result
@@ -145,7 +145,7 @@ module Invoices
         invoice.update!(status: status)
       end
 
-      def handle_prepaid_credits(invoice_status)
+      def handle_prepaid_credits(invoice, invoice_status)
         return unless invoice.invoice_type == 'credit'
         return unless invoice_status == 'succeeded'
 

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -32,7 +32,7 @@ module Invoices
         payment.save!
 
         update_invoice_status(payment.status)
-        handle_prepaid_credits(payment.status)
+        handle_prepaid_credits(payment.invoice, payment.status)
         track_payment_status_changed(payment.invoice)
 
         result.payment = payment
@@ -49,7 +49,7 @@ module Invoices
 
         payment.update!(status: status)
         payment.invoice.update!(status: status)
-        handle_prepaid_credits(status)
+        handle_prepaid_credits(payment.invoice, status)
         track_payment_status_changed(payment.invoice)
 
         result
@@ -140,7 +140,7 @@ module Invoices
         invoice.update!(status: status)
       end
 
-      def handle_prepaid_credits(status)
+      def handle_prepaid_credits(invoice, status)
         return unless invoice.invoice_type == 'credit'
         return unless status == 'succeeded'
 

--- a/db/migrate/20221114102649_fill_sync_with_provider_field.rb
+++ b/db/migrate/20221114102649_fill_sync_with_provider_field.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class FillSyncWithProviderField < ActiveRecord::Migration[7.0]
+  def change
+    LagoApi::Application.load_tasks
+    Rake::Task['customers:populate_sync_with_provider'].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_07_151038) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_14_102649) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/lib/tasks/customers.rake
+++ b/lib/tasks/customers.rake
@@ -15,4 +15,20 @@ namespace :customers do
       customer.update!(currency: currencies.first)
     end
   end
+
+  desc 'Set sync_with_provider field for existing customers'
+  task populate_sync_with_provider: :environment do
+    Organization.all.each do |org|
+      next if org&.stripe_payment_provider&.create_customers&.blank?
+
+      org.customers.each do |customer|
+        stripe_customer = customer&.stripe_customer
+
+        next unless stripe_customer
+
+        stripe_customer.sync_with_provider = true
+        stripe_customer.save!
+      end
+    end
+  end
 end

--- a/lib/tasks/customers.rake
+++ b/lib/tasks/customers.rake
@@ -19,7 +19,7 @@ namespace :customers do
   desc 'Set sync_with_provider field for existing customers'
   task populate_sync_with_provider: :environment do
     Organization.all.each do |org|
-      next if org&.stripe_payment_provider&.create_customers&.blank?
+      next if org&.stripe_payment_provider&.create_customers.blank?
 
       org.customers.each do |customer|
         stripe_customer = customer&.stripe_customer


### PR DESCRIPTION
Private method called `handle_prepaid_credits` is called from method where `invoice` instance variable is present but also from another method where `invoice` instance variable is not present

Also, in this PR few other improvements are added:
1.) gocardless auth site url is handled in model instead using hardcoded string that applies only to sandbox
2.) migration is added that sets sync_with_provider field to true for existing customers (if customer's payment provider is set to stripe)