### PR TITLE
feat: add has_credit_notes boolean on customer type

### DIFF
--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -35,6 +35,7 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       field :has_active_wallet, Boolean, null: false, description: 'Define if a customer has an active wallet'
+      field :has_credit_notes, Boolean, null: false, description: 'Define if a customer has any credit note'
       field :active_subscription_count, Integer, null: false, description: 'Number of active subscriptions per customer'
 
       field :can_be_deleted, Boolean, null: false do
@@ -51,6 +52,10 @@ module Types
 
       def has_active_wallet
         object.wallets.active.any?
+      end
+
+      def has_credit_notes
+        object.credit_notes.any?
       end
 
       def active_subscription_count

--- a/schema.graphql
+++ b/schema.graphql
@@ -2539,6 +2539,11 @@ type Customer {
   Define if a customer has an active wallet
   """
   hasActiveWallet: Boolean!
+
+  """
+  Define if a customer has any credit note
+  """
+  hasCreditNotes: Boolean!
   id: ID!
   legalName: String
   legalNumber: String
@@ -2593,6 +2598,11 @@ type CustomerDetails {
   Define if a customer has an active wallet
   """
   hasActiveWallet: Boolean!
+
+  """
+  Define if a customer has any credit note
+  """
+  hasCreditNotes: Boolean!
   id: ID!
   invoices: [Invoice!]
   legalName: String

--- a/schema.json
+++ b/schema.json
@@ -7482,6 +7482,24 @@
               ]
             },
             {
+              "name": "hasCreditNotes",
+              "description": "Define if a customer has any credit note",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -8042,6 +8060,24 @@
             {
               "name": "hasActiveWallet",
               "description": "Define if a customer has an active wallet",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "hasCreditNotes",
+              "description": "Define if a customer has any credit note",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
     <<~GQL
       query($customerId: ID!) {
         customer(id: $customerId) {
-          id externalId name currency
+          id externalId name currency hasCreditNotes
           invoices {
             id
             invoiceType
@@ -83,6 +83,7 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
       expect(customer_response['invoices'].count).to eq(2)
       expect(customer_response['appliedAddOns'].count).to eq(1)
       expect(customer_response['currency']).to be_present
+      expect(customer_response['hasCreditNotes']).to be true
     end
   end
 


### PR DESCRIPTION
## Roadmap Task

👉 https://github.com/getlago/lago/issues/59

## Context

This PR is part of the credit note feature.

We need the information if a customer has or not any credit notes already existing, for display purpose (handle a tab display)

## Description

We add a boolean to be returned to frontend app in order to handle UI logic
