### PR TITLE
feat(customer): add credit notes related data for UI purpose

### DIFF
--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -37,6 +37,14 @@ module Types
       field :has_active_wallet, Boolean, null: false, description: 'Define if a customer has an active wallet'
       field :has_credit_notes, Boolean, null: false, description: 'Define if a customer has any credit note'
       field :active_subscription_count, Integer, null: false, description: 'Number of active subscriptions per customer'
+      field :credit_notes_credits_available_count,
+            Integer,
+            null: false,
+            description: 'Number of available credits from credit notes per customer'
+      field :credit_notes_balance_amount_cents,
+            GraphQL::Types::BigInt,
+            null: false,
+            description: 'Credit notes credits balance available per customer'
 
       field :can_be_deleted, Boolean, null: false do
         description 'Check if customer is deletable'
@@ -64,6 +72,14 @@ module Types
 
       def can_edit_attributes
         object.editable?
+      end
+
+      def credit_notes_credits_available_count
+        object.credit_notes.where('credit_notes.credit_amount_cents > 0').count
+      end
+
+      def credit_notes_balance_amount_cents
+        object.credit_notes.sum('credit_notes.balance_amount_cents')
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2531,6 +2531,16 @@ type Customer {
   city: String
   country: CountryCode
   createdAt: ISO8601DateTime!
+
+  """
+  Credit notes credits balance available per customer
+  """
+  creditNotesBalanceAmountCents: BigInt!
+
+  """
+  Number of available credits from credit notes per customer
+  """
+  creditNotesCreditsAvailableCount: Int!
   currency: CurrencyEnum
   email: String
   externalId: String!
@@ -2590,6 +2600,16 @@ type CustomerDetails {
   country: CountryCode
   createdAt: ISO8601DateTime!
   creditNotes: [CreditNote!]
+
+  """
+  Credit notes credits balance available per customer
+  """
+  creditNotesBalanceAmountCents: BigInt!
+
+  """
+  Number of available credits from credit notes per customer
+  """
+  creditNotesCreditsAvailableCount: Int!
   currency: CurrencyEnum
   email: String
   externalId: String!

--- a/schema.json
+++ b/schema.json
@@ -7418,6 +7418,42 @@
               ]
             },
             {
+              "name": "creditNotesBalanceAmountCents",
+              "description": "Credit notes credits balance available per customer",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditNotesCreditsAvailableCount",
+              "description": "Number of available credits from credit notes per customer",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "currency",
               "description": null,
               "type": {
@@ -8003,6 +8039,42 @@
                     "name": "CreditNote",
                     "ofType": null
                   }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditNotesBalanceAmountCents",
+              "description": "Credit notes credits balance available per customer",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditNotesCreditsAvailableCount",
+              "description": "Number of available credits from credit notes per customer",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -7,7 +7,13 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
     <<~GQL
       query($customerId: ID!) {
         customer(id: $customerId) {
-          id externalId name currency hasCreditNotes
+          id
+          externalId
+          name
+          currency
+          hasCreditNotes
+          creditNotesCreditsAvailableCount
+          creditNotesBalanceAmountCents
           invoices {
             id
             invoiceType
@@ -84,6 +90,8 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
       expect(customer_response['appliedAddOns'].count).to eq(1)
       expect(customer_response['currency']).to be_present
       expect(customer_response['hasCreditNotes']).to be true
+      expect(customer_response['creditNotesCreditsAvailableCount']).to eq(1)
+      expect(customer_response['creditNotesBalanceAmountCents']).to eq('120')
     end
   end
 


### PR DESCRIPTION
## Roadmap Task

👉 https://github.com/getlago/lago/issues/59

## Context

This PR is part of the credit note feature.

We need the information about customer credit notes (count and remaining credits)

## Description

We add those datas to the customer type, to be returned to frontend app in order to handle UI logic
