### PR TITLE
misc: Fix unique index on customers external_id

### DIFF
--- a/db/migrate/20221115110223_add_unique_index_on_customers_external_id.rb
+++ b/db/migrate/20221115110223_add_unique_index_on_customers_external_id.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnCustomersExternalId < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :customers, :external_id
+    add_index :customers, [:external_id, :organization_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_15_100834) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_15_110223) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -212,7 +212,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_15_100834) do
     t.bigint "sequential_id"
     t.string "currency"
     t.integer "invoice_grace_period", default: 0, null: false
-    t.index ["external_id"], name: "index_customers_on_external_id"
+    t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true
     t.index ["organization_id"], name: "index_customers_on_organization_id"
     t.check_constraint "invoice_grace_period >= 0", name: "check_customers_on_invoice_grace_period"
   end


### PR DESCRIPTION
The `external_id` of the `customers` must be unique, within the scope of the `organization`.

In the model, we have the same validation:
`validates :external_id, presence: true, uniqueness: { scope: :organization_id }`

The goal of this PR is to be consistent at the database level.