### PR TITLE
feat(timezone): Add timezone to organizations and customers

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -34,6 +34,7 @@ class Customer < ApplicationRecord
   validates :external_id, presence: true, uniqueness: { scope: :organization_id }
   validates :invoice_grace_period, numericality: { greater_than_or_equal_to: 0 }
   validates :payment_provider, inclusion: { in: PAYMENT_PROVIDERS }, allow_nil: true
+  validates :timezone, timezone: true, allow_nil: true
   validates :vat_rate, numericality: { less_than_or_equal_to: 100, greater_than_or_equal_to: 0 }, allow_nil: true
 
   def attached_to_subscriptions?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -31,6 +31,7 @@ class Organization < ApplicationRecord
             image: { authorized_content_type: %w[image/png image/jpg image/jpeg], max_size: 800.kilobytes },
             if: :logo?
   validates :name, presence: true
+  validates :timezone, timezone: true
   validates :vat_rate, numericality: { less_than_or_equal_to: 100, greater_than_or_equal_to: 0 }
   validates :webhook_url, url: true, allow_nil: true
 

--- a/app/validators/timezone_validator.rb
+++ b/app/validators/timezone_validator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TimezoneValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add(attribute, :timzone_invalid) unless valid?(value)
+  end
+
+  protected
+
+  def valid?(value)
+    value && ActiveSupport::TimeZone[value].present?
+  end
+end

--- a/db/migrate/20221115155550_add_timezone_to_organizations.rb
+++ b/db/migrate/20221115155550_add_timezone_to_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTimezoneToOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :timezone, :string, null: false, default: 'UTC'
+  end
+end

--- a/db/migrate/20221115160325_add_timezone_to_customers.rb
+++ b/db/migrate/20221115160325_add_timezone_to_customers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTimezoneToCustomers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :customers, :timezone, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_15_110223) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_15_160325) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -212,6 +212,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_15_110223) do
     t.bigint "sequential_id"
     t.string "currency"
     t.integer "invoice_grace_period", default: 0, null: false
+    t.string "timezone"
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true
     t.index ["organization_id"], name: "index_customers_on_organization_id"
     t.check_constraint "invoice_grace_period >= 0", name: "check_customers_on_invoice_grace_period"
@@ -361,6 +362,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_15_110223) do
     t.string "legal_number"
     t.text "invoice_footer"
     t.integer "invoice_grace_period", default: 0, null: false
+    t.string "timezone", default: "UTC", null: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"
   end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe Customer, type: :model do
       customer.country = ''
       expect(customer).not_to be_valid
     end
+
+    it 'validates the timezone' do
+      expect(customer).to be_valid
+
+      customer.timezone = 'Europe/Paris'
+      expect(customer).to be_valid
+
+      customer.timezone = 'foo'
+      expect(customer).not_to be_valid
+
+      customer.timezone = nil
+      expect(customer).to be_valid
+    end
   end
 
   describe 'applicable_vat_rate' do

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -36,9 +36,6 @@ RSpec.describe Customer, type: :model do
 
       customer.timezone = 'foo'
       expect(customer).not_to be_valid
-
-      customer.timezone = nil
-      expect(customer).to be_valid
     end
   end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -92,6 +92,12 @@ RSpec.describe Organization, type: :model do
 
       expect(organization).not_to be_valid
     end
+
+    it 'is invalid with invalid timezone' do
+      organization.timezone = 'foo'
+
+      expect(organization).not_to be_valid
+    end
   end
 
   describe 'Callbacks' do


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR is the first of the feature. It adds two new database columnes:
- `organizations#timezone`
- `customers#timezone`
