### PR TITLE
feat (coupons): allow applying multiple coupons to the customer

### DIFF
--- a/app/graphql/types/applied_coupons/object.rb
+++ b/app/graphql/types/applied_coupons/object.rb
@@ -14,9 +14,18 @@ module Types
       field :percentage_rate, Float, null: true
       field :frequency, Types::Coupons::FrequencyEnum, null: false
       field :frequency_duration, Integer, null: true
+      field :frequency_duration_remaining, Integer, null: true
+      field :amount_cents_remaining, Integer, null: true
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :terminated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      def amount_cents_remaining
+        return nil if object.recurring?
+        return nil if object.coupon.percentage?
+
+        object.amount_cents - object.credits.sum(:amount_cents)
+      end
     end
   end
 end

--- a/app/services/applied_coupons/create_service.rb
+++ b/app/services/applied_coupons/create_service.rb
@@ -49,12 +49,6 @@ module AppliedCoupons
     def check_preconditions
       return result.not_found_failure!(resource: 'customer') unless customer
       return result.not_found_failure!(resource: 'coupon') unless coupon
-      return unless coupon_already_applied?
-
-      result.single_validation_failure!(
-        field: 'coupon',
-        error_code: 'coupon_already_applied',
-      )
     end
 
     def process_creation(applied_coupon_attributes)
@@ -69,6 +63,7 @@ module AppliedCoupons
         percentage_rate: applied_coupon_attributes[:percentage_rate],
         frequency: applied_coupon_attributes[:frequency],
         frequency_duration: applied_coupon_attributes[:frequency_duration],
+        frequency_duration_remaining: applied_coupon_attributes[:frequency_duration],
       )
 
       if coupon.fixed_amount?
@@ -90,10 +85,6 @@ module AppliedCoupons
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
-    end
-
-    def coupon_already_applied?
-      customer.applied_coupons.active.exists?
     end
 
     def track_applied_coupon_created(applied_coupon)

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -21,7 +21,7 @@ module Credits
         amount_currency: invoice.amount_currency,
       )
 
-      applied_coupon.frequency_duration -= 1 if applied_coupon.recurring?
+      applied_coupon.frequency_duration_remaining -= 1 if applied_coupon.recurring?
       if should_terminate_applied_coupon?(credit_amount)
         applied_coupon.mark_as_terminated!
       elsif applied_coupon.recurring?
@@ -73,7 +73,7 @@ module Credits
       if applied_coupon.once?
         applied_coupon.coupon.percentage? || credit_amount >= remaining_amount
       else
-        applied_coupon.frequency_duration <= 0
+        applied_coupon.frequency_duration_remaining <= 0
       end
     end
   end

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -178,7 +178,7 @@ module Invoices
 
     def create_coupon_credit(invoice)
       applied_coupons.each do |applied_coupon|
-        return unless invoice.amount_cents&.positive?
+        break unless invoice.amount_cents&.positive?
 
         next if applied_coupon.coupon.fixed_amount? && applied_coupon.amount_currency != currency
 

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -36,7 +36,7 @@ module Invoices
         compute_amounts(invoice)
 
         create_credit_note_credit(invoice) if should_create_credit_note_credit?
-        create_coupon_credit(invoice) if should_create_coupon_credit?
+        create_coupon_credit(invoice) if should_create_coupon_credit?(invoice)
         create_applied_prepaid_credit(invoice) if should_create_applied_prepaid_credit?(invoice)
 
         invoice.total_amount_cents = invoice.amount_cents + invoice.vat_amount_cents
@@ -132,10 +132,10 @@ module Invoices
       customer.organization.webhook_url?
     end
 
-    def applied_coupon
-      return @applied_coupon if @applied_coupon
+    def applied_coupons
+      return @applied_coupons if @applied_coupons
 
-      @applied_coupon = customer.applied_coupons.active.first
+      @applied_coupons = customer.applied_coupons.active.order(created_at: :asc)
     end
 
     def credit_notes
@@ -152,10 +152,9 @@ module Invoices
       credit_notes.any?
     end
 
-    def should_create_coupon_credit?
-      return false if applied_coupon.nil?
-
-      return applied_coupon.amount_currency == currency if applied_coupon.coupon.fixed_amount?
+    def should_create_coupon_credit?(invoice)
+      return false if applied_coupons.blank?
+      return false unless invoice.amount_cents&.positive?
 
       true
     end
@@ -178,13 +177,19 @@ module Invoices
     end
 
     def create_coupon_credit(invoice)
-      credit_result = Credits::AppliedCouponService.new(
-        invoice: invoice,
-        applied_coupon: applied_coupon,
-      ).create
-      credit_result.throw_error unless credit_result.success?
+      applied_coupons.each do |applied_coupon|
+        return unless invoice.amount_cents&.positive?
 
-      refresh_amounts(invoice: invoice, credit_amount_cents: credit_result.credit.amount_cents)
+        next if applied_coupon.coupon.fixed_amount? && applied_coupon.amount_currency != currency
+
+        credit_result = Credits::AppliedCouponService.new(
+          invoice: invoice,
+          applied_coupon: applied_coupon,
+        ).create
+        credit_result.throw_error unless credit_result.success?
+
+        refresh_amounts(invoice: invoice, credit_amount_cents: credit_result.credit.amount_cents)
+      end
     end
 
     def create_applied_prepaid_credit(invoice)

--- a/db/migrate/20221115135840_add_frequency_duration_remaining_to_applied_coupons.rb
+++ b/db/migrate/20221115135840_add_frequency_duration_remaining_to_applied_coupons.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddFrequencyDurationRemainingToAppliedCoupons < ActiveRecord::Migration[7.0]
+  def change
+    add_column :applied_coupons, :frequency_duration_remaining, :integer
+    remove_index :applied_coupons, column: %i[coupon_id customer_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_15_110223) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_15_135840) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -80,7 +80,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_15_110223) do
     t.decimal "percentage_rate", precision: 10, scale: 5
     t.integer "frequency", default: 0, null: false
     t.integer "frequency_duration"
-    t.index ["coupon_id", "customer_id"], name: "index_applied_coupons_on_coupon_id_and_customer_id", unique: true, where: "(status = 0)"
+    t.integer "frequency_duration_remaining"
     t.index ["coupon_id"], name: "index_applied_coupons_on_coupon_id"
     t.index ["customer_id"], name: "index_applied_coupons_on_customer_id"
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -106,11 +106,13 @@ type AppliedAddOn {
 
 type AppliedCoupon {
   amountCents: Int
+  amountCentsRemaining: Int
   amountCurrency: CurrencyEnum
   coupon: Coupon!
   createdAt: ISO8601DateTime!
   frequency: CouponFrequency!
   frequencyDuration: Int
+  frequencyDurationRemaining: Int
   id: ID!
   percentageRate: Float
   terminatedAt: ISO8601DateTime!

--- a/schema.json
+++ b/schema.json
@@ -793,6 +793,20 @@
               ]
             },
             {
+              "name": "amountCentsRemaining",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "amountCurrency",
               "description": null,
               "type": {
@@ -862,6 +876,20 @@
             },
             {
               "name": "frequencyDuration",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "frequencyDurationRemaining",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -99,6 +99,21 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       end
     end
 
+    context 'when an other coupon is already applied to the customer' do
+      let(:other_coupon) { create(:coupon, status: 'active', organization: organization) }
+
+      before { create(:applied_coupon, customer: customer, coupon: other_coupon) }
+
+      it 'applied the coupon to the customer' do
+        expect { create_result }.to change(AppliedCoupon, :count).by(1)
+
+        expect(create_result.applied_coupon.customer).to eq(customer)
+        expect(create_result.applied_coupon.coupon).to eq(coupon)
+        expect(create_result.applied_coupon.amount_cents).to eq(coupon.amount_cents)
+        expect(create_result.applied_coupon.amount_currency).to eq(coupon.amount_currency)
+      end
+    end
+
     context 'with overridden amount' do
       let(:amount_cents) { 123 }
       let(:amount_currency) { 'EUR' }
@@ -155,34 +170,6 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
           expect(create_result).not_to be_success
           expect(create_result.error).to be_a(BaseService::NotFoundFailure)
           expect(create_result.error.message).to eq('coupon_not_found')
-        end
-      end
-    end
-
-    context 'when coupon is already applied to the customer' do
-      before { create(:applied_coupon, customer: customer, coupon: coupon) }
-
-      it 'fails' do
-        aggregate_failures do
-          expect(create_result).not_to be_success
-          expect(create_result.error).to be_a(BaseService::ValidationFailure)
-          expect(create_result.error.messages.keys).to include(:coupon)
-          expect(create_result.error.messages[:coupon]).to include('coupon_already_applied')
-        end
-      end
-    end
-
-    context 'when an other coupon is already applied to the customer' do
-      let(:other_coupon) { create(:coupon, status: 'active', organization: organization) }
-
-      before { create(:applied_coupon, customer: customer, coupon: other_coupon) }
-
-      it 'fails' do
-        aggregate_failures do
-          expect(create_result).not_to be_success
-          expect(create_result.error).to be_a(BaseService::ValidationFailure)
-          expect(create_result.error.messages.keys).to include(:coupon)
-          expect(create_result.error.messages[:coupon]).to include('coupon_already_applied')
         end
       end
     end
@@ -251,6 +238,19 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       )
     end
 
+    context 'when coupon is already applied to the customer' do
+      before { create(:applied_coupon, customer: customer, coupon: coupon) }
+
+      it 'applies the coupon to the customer' do
+        expect { create_result }.to change(AppliedCoupon, :count).by(1)
+
+        expect(create_result.applied_coupon.customer).to eq(customer)
+        expect(create_result.applied_coupon.coupon).to eq(coupon)
+        expect(create_result.applied_coupon.amount_cents).to eq(coupon.amount_cents)
+        expect(create_result.applied_coupon.amount_currency).to eq(coupon.amount_currency)
+      end
+    end
+
     context 'with overridden amount' do
       let(:amount_cents) { 123 }
       let(:amount_currency) { 'EUR' }
@@ -307,19 +307,6 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
           expect(create_result).not_to be_success
           expect(create_result.error).to be_a(BaseService::NotFoundFailure)
           expect(create_result.error.message).to eq('coupon_not_found')
-        end
-      end
-    end
-
-    context 'when coupon is already applied to the customer' do
-      before { create(:applied_coupon, customer: customer, coupon: coupon) }
-
-      it 'fails' do
-        aggregate_failures do
-          expect(create_result).not_to be_success
-          expect(create_result.error).to be_a(BaseService::ValidationFailure)
-          expect(create_result.error.messages.keys).to include(:coupon)
-          expect(create_result.error.messages[:coupon]).to include('coupon_already_applied')
         end
       end
     end

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Credits::AppliedCouponService do
           frequency: 'recurring',
           frequency_duration: 3,
           frequency_duration_remaining: 3,
-          amount_cents: 12
+          amount_cents: 12,
         )
       end
 

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -131,7 +131,14 @@ RSpec.describe Credits::AppliedCouponService do
       let(:coupon) { create(:coupon, frequency: 'recurring', frequency_duration: 3) }
 
       let(:applied_coupon) do
-        create(:applied_coupon, coupon: coupon, frequency: 'recurring', frequency_duration: 3, amount_cents: 12)
+        create(
+          :applied_coupon,
+          coupon: coupon,
+          frequency: 'recurring',
+          frequency_duration: 3,
+          frequency_duration_remaining: 3,
+          amount_cents: 12
+        )
       end
 
       it 'creates a credit' do
@@ -143,7 +150,8 @@ RSpec.describe Credits::AppliedCouponService do
           expect(result.credit.amount_currency).to eq('EUR')
           expect(result.credit.invoice).to eq(invoice)
           expect(result.credit.applied_coupon).to eq(applied_coupon)
-          expect(result.credit.applied_coupon.frequency_duration).to eq(2)
+          expect(result.credit.applied_coupon.frequency_duration).to eq(3)
+          expect(result.credit.applied_coupon.frequency_duration_remaining).to eq(2)
         end
       end
 
@@ -175,6 +183,7 @@ RSpec.describe Credits::AppliedCouponService do
           coupon: coupon,
           frequency: 'recurring',
           frequency_duration: 3,
+          frequency_duration_remaining: 3,
           percentage_rate: 20.00,
         )
       end
@@ -188,7 +197,8 @@ RSpec.describe Credits::AppliedCouponService do
           expect(result.credit.amount_currency).to eq('EUR')
           expect(result.credit.invoice).to eq(invoice)
           expect(result.credit.applied_coupon).to eq(applied_coupon)
-          expect(result.credit.applied_coupon.frequency_duration).to eq(2)
+          expect(result.credit.applied_coupon.frequency_duration).to eq(3)
+          expect(result.credit.applied_coupon.frequency_duration_remaining).to eq(2)
         end
       end
 
@@ -205,7 +215,8 @@ RSpec.describe Credits::AppliedCouponService do
             :applied_coupon,
             coupon: coupon,
             frequency: 'recurring',
-            frequency_duration: 1,
+            frequency_duration: 3,
+            frequency_duration_remaining: 1,
             percentage_rate: 20.00,
           )
         end
@@ -219,7 +230,8 @@ RSpec.describe Credits::AppliedCouponService do
             expect(result.credit.amount_currency).to eq('EUR')
             expect(result.credit.invoice).to eq(invoice)
             expect(result.credit.applied_coupon).to eq(applied_coupon)
-            expect(result.credit.applied_coupon.frequency_duration).to eq(0)
+            expect(result.credit.applied_coupon.frequency_duration).to eq(3)
+            expect(result.credit.applied_coupon.frequency_duration_remaining).to eq(0)
           end
         end
 


### PR DESCRIPTION
## Context

This change handles applying multiple coupons to the customer.

## Description

Applying multiple coupons to the customer requires removing validation on the BE side upon apply_coupon creation and updating logic when generating an invoice.

From now on, we will also track `recurring` case with the `frequency_duration_remaining` field so that we don't change originally value that is set on applied coupon object. This field will also be needed in the API endpoint for applied_coupons collection.
