### PR TITLE
feat(grace_period): Set invoice grace period on customers and organizations via API

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -93,6 +93,7 @@ module Api
           :legal_number,
           :vat_rate,
           :currency,
+          :invoice_grace_period,
           billing_configuration: [
             :payment_provider,
             :provider_customer_id,

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -35,6 +35,7 @@ module Api
           :legal_name,
           :legal_number,
           :invoice_footer,
+          :invoice_grace_period,
         )
       end
     end

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -25,6 +25,7 @@ module V1
         legal_number: model.legal_number,
         currency: model.currency,
         billing_configuration: billing_configuration,
+        invoice_grace_period: model.invoice_grace_period,
       }
     end
 

--- a/app/serializers/v1/organization_serializer.rb
+++ b/app/serializers/v1/organization_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 module V1
   class OrganizationSerializer < ModelSerializer
     def serialize
@@ -17,7 +17,8 @@ module V1
         city: model.city,
         legal_name: model.legal_name,
         legal_number: model.legal_number,
-        invoice_footer: model.invoice_footer
+        invoice_footer: model.invoice_footer,
+        invoice_grace_period: model.invoice_grace_period,
       }
     end
   end

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -21,6 +21,7 @@ module Customers
         customer.legal_name = params[:legal_name] if params.key?(:legal_name)
         customer.legal_number = params[:legal_number] if params.key?(:legal_number)
         customer.vat_rate = params[:vat_rate] if params.key?(:vat_rate)
+        customer.invoice_grace_period = params[:invoice_grace_period] if params.key?(:invoice_grace_period)
 
         if params.key?(:currency)
           currency_result = Customers::UpdateService.new(nil).update_currency(

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -27,6 +27,7 @@ module Customers
         customer.legal_number = args[:legal_number] if args.key?(:legal_number)
         customer.vat_rate = args[:vat_rate] if args.key?(:vat_rate)
         customer.payment_provider = args[:payment_provider] if args.key?(:payment_provider)
+        customer.invoice_grace_period = args[:invoice_grace_period] if args.key?(:invoice_grace_period)
 
         # NOTE: external_id is not editable if customer is attached to subscriptions
         customer.external_id = args[:external_id] if customer.editable? && args.key?(:external_id)

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -46,6 +46,7 @@ module Organizations
       organization.legal_name = params[:legal_name] if params.key?(:legal_name)
       organization.legal_number = params[:legal_number] if params.key?(:legal_number)
       organization.invoice_footer = params[:invoice_footer] if params.key?(:invoice_footer)
+      organization.invoice_grace_period = params[:invoice_grace_period] if params.key?(:invoice_grace_period)
       organization.save!
 
       result.organization = organization

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         external_id: SecureRandom.uuid,
         name: 'Foo Bar',
         currency: 'EUR',
+        invoice_grace_period: 3,
       }
     end
 
@@ -17,11 +18,15 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       post_with_token(organization, '/api/v1/customers', { customer: create_params })
 
       expect(response).to have_http_status(:success)
-      expect(json[:customer][:lago_id]).to be_present
-      expect(json[:customer][:external_id]).to eq(create_params[:external_id])
-      expect(json[:customer][:name]).to eq(create_params[:name])
-      expect(json[:customer][:created_at]).to be_present
-      expect(json[:customer][:currency]).to eq(create_params[:currency])
+
+      aggregate_failures do
+        expect(json[:customer][:lago_id]).to be_present
+        expect(json[:customer][:external_id]).to eq(create_params[:external_id])
+        expect(json[:customer][:name]).to eq(create_params[:name])
+        expect(json[:customer][:created_at]).to be_present
+        expect(json[:customer][:currency]).to eq(create_params[:currency])
+        expect(json[:customer][:invoice_grace_period]).to eq(create_params[:invoice_grace_period])
+      end
     end
 
     context 'with billing configuration' do

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
         legal_name: 'test1',
         legal_number: '123',
         invoice_footer: 'footer',
+        invoice_grace_period: 3,
       }
     end
 
@@ -32,10 +33,13 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
 
       expect(response).to have_http_status(:success)
 
-      expect(json[:organization][:name]).to eq(organization.name)
-      expect(json[:organization][:webhook_url]).to eq(update_params[:webhook_url])
-      expect(json[:organization][:vat_rate]).to eq(update_params[:vat_rate])
-      expect(json[:organization][:invoice_footer]).to eq(update_params[:invoice_footer])
+      aggregate_failures do
+        expect(json[:organization][:name]).to eq(organization.name)
+        expect(json[:organization][:webhook_url]).to eq(update_params[:webhook_url])
+        expect(json[:organization][:vat_rate]).to eq(update_params[:vat_rate])
+        expect(json[:organization][:invoice_footer]).to eq(update_params[:invoice_footer])
+        expect(json[:organization][:invoice_grace_period]).to eq(update_params[:invoice_grace_period])
+      end
     end
   end
 end

--- a/spec/serializers/v1/organization_serializer_spec.rb
+++ b/spec/serializers/v1/organization_serializer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe ::V1::OrganizationSerializer do
       expect(result['organization']['legal_name']).to eq(organization.legal_name)
       expect(result['organization']['legal_number']).to eq(organization.legal_number)
       expect(result['organization']['invoice_footer']).to eq(organization.invoice_footer)
+      expect(result['organization']['invoice_grace_period']).to eq(organization.invoice_grace_period)
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to be able to set `invoice_grace_period` on `organizations` and `customers` via the API.
