### PR TITLE
feat (coupons): add API endpoint for fetching all applied coupons

### DIFF
--- a/app/controllers/api/v1/applied_coupons_controller.rb
+++ b/app/controllers/api/v1/applied_coupons_controller.rb
@@ -60,7 +60,7 @@ module Api
       def valid_status?(status)
         return false unless status
 
-        AppliedCoupon.statuses.keys.include?(status)
+        AppliedCoupon.statuses.key?(status)
       end
     end
   end

--- a/app/controllers/api/v1/applied_coupons_controller.rb
+++ b/app/controllers/api/v1/applied_coupons_controller.rb
@@ -22,6 +22,27 @@ module Api
         end
       end
 
+      def index
+        applied_coupons = current_organization.applied_coupons
+        if params[:external_customer_id]
+          applied_coupons =
+            applied_coupons.joins(:customer).where(customers: { external_id: params[:external_customer_id] })
+        end
+        applied_coupons = applied_coupons.where(status: params[:status]) if valid_status?(params[:status])
+        applied_coupons = applied_coupons.order(created_at: :desc)
+          .page(params[:page])
+          .per(params[:per_page] || PER_PAGE)
+
+        render(
+          json: ::CollectionSerializer.new(
+            applied_coupons,
+            ::V1::AppliedCouponSerializer,
+            collection_name: 'applied_coupons',
+            meta: pagination_metadata(applied_coupons),
+          ),
+        )
+      end
+
       private
 
       def create_params
@@ -34,6 +55,12 @@ module Api
           :amount_currency,
           :percentage_rate,
         )
+      end
+
+      def valid_status?(status)
+        return false unless status
+
+        AppliedCoupon.statuses.keys.include?(status)
       end
     end
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -11,6 +11,7 @@ class Organization < ApplicationRecord
   has_many :credit_notes, through: :customers
   has_many :events
   has_many :coupons
+  has_many :applied_coupons, through: :coupons
   has_many :add_ons
   has_many :invites
   has_many :payment_providers

--- a/app/serializers/v1/applied_coupon_serializer.rb
+++ b/app/serializers/v1/applied_coupon_serializer.rb
@@ -9,15 +9,27 @@ module V1
         coupon_code: model.coupon.code,
         lago_customer_id: model.customer.id,
         external_customer_id: model.customer.external_id,
+        status: model.status,
         amount_cents: model.amount_cents,
+        amount_cents_remaining: amount_cents_remaining,
         amount_currency: model.amount_currency,
         percentage_rate: model.percentage_rate,
         frequency: model.frequency,
         frequency_duration: model.frequency_duration,
+        frequency_duration_remaining: model.frequency_duration_remaining,
         expiration_date: model.coupon.expiration_date&.iso8601,
         created_at: model.created_at.iso8601,
         terminated_at: model.terminated_at&.iso8601,
       }
+    end
+
+    private
+
+    def amount_cents_remaining
+      return nil if model.recurring?
+      return nil if model.coupon.percentage?
+
+      model.amount_cents - model.credits.sum(:amount_cents)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
         put :void, on: :member
       end
       resources :events, only: %i[create show]
-      resources :applied_coupons, only: %i[create]
+      resources :applied_coupons, only: %i[create index]
       resources :applied_add_ons, only: %i[create]
       resources :invoices, only: %i[update show index] do
         post :download, on: :member


### PR DESCRIPTION
## Context

API endpoint for listing all applied coupons

## Description

 `GET /api/v1/applied_coupons`

It's also allowed to filter applied coupons by `customer` and `status`