### PR TITLE
feat(timezone): Add timezone concerns to customer and organization

### DIFF
--- a/app/models/concerns/customer_timezone.rb
+++ b/app/models/concerns/customer_timezone.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module CustomerTimezone
+  CUSTOMER_SUFFIX = '_in_customer_timezone'
+
+  def method_missing(method_name, *arguments, &block)
+    return super unless method_name.to_s.end_with?(CUSTOMER_SUFFIX)
+
+    target = if is_a?(Customer)
+      self
+    else
+      customer
+    end
+
+    initial_method_name = method_name.to_s.gsub(CUSTOMER_SUFFIX, '')
+    __send__(initial_method_name)&.in_time_zone(target.applicable_timezone)
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    method_name.to_s.end_with?(CUSTOMER_SUFFIX) && respond_to?(
+      method_name.gsub(CUSTOMER_SUFFIX, ''),
+    ) || super
+  end
+
+  def self.included(base)
+    base.extend(self)
+  end
+end

--- a/app/models/concerns/organization_timezone.rb
+++ b/app/models/concerns/organization_timezone.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module OrganizationTimezone
+  ORGANIZATION_SUFFIX = '_in_organization_timezone'
+
+  def method_missing(method_name, *arguments, &block)
+    return super unless method_name.to_s.end_with?(ORGANIZATION_SUFFIX)
+
+    target = if is_a?(Organization)
+      self
+    else
+      organization
+    end
+
+    initial_method_name = method_name.to_s.gsub(ORGANIZATION_SUFFIX, '')
+    __send__(initial_method_name)&.in_time_zone(target.timezone)
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    method_name.to_s.end_with?(ORGANIZATION_SUFFIX) && respond_to?(
+      method_name.gsub(ORGANIZATION_SUFFIX, ''),
+    ) || super
+  end
+
+  def self.included(base)
+    base.extend(self)
+  end
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,6 +3,8 @@
 class Customer < ApplicationRecord
   include Sequenced
   include Currencies
+  include CustomerTimezone
+  include OrganizationTimezone
 
   before_save :ensure_slug
 
@@ -57,6 +59,12 @@ class Customer < ApplicationRecord
     return vat_rate if vat_rate.present?
 
     organization.vat_rate || 0
+  end
+
+  def applicable_timezone
+    return timezone if timezone.present?
+
+    organization.timezone || 'UTC'
   end
 
   def editable?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Organization < ApplicationRecord
+  include OrganizationTimezone
+
   has_many :memberships
   has_many :users, through: :memberships
   has_many :billable_metrics


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR adds:
- `Customer#applicable_timezone` to get the timezone applicable for the customer
- `CustomerTimezone` concern to allow `*_in_customer_timezone` and `*_in_organization_timzone` on models datetime fields
