### PR TITLE
feat (coupons): add migration to populate frequency_duration_remaining field

### DIFF
--- a/db/migrate/20221118093903_fill_frequency_duration_remaining_field.rb
+++ b/db/migrate/20221118093903_fill_frequency_duration_remaining_field.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class FillFrequencyDurationRemainingField < ActiveRecord::Migration[7.0]
+  def change
+    LagoApi::Application.load_tasks
+    Rake::Task['applied_coupons:populate_frequency_duration_remaining'].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_15_160325) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_18_093903) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/lib/tasks/applied_coupons.rake
+++ b/lib/tasks/applied_coupons.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :applied_coupons do
+  desc 'Populate frequency duration remaining field'
+  task populate_frequency_duration_remaining: :environment do
+    AppliedCoupon.find_each do |applied_coupon|
+      next unless applied_coupon.recurring?
+
+      applied_coupon.frequency_duration_remaining = applied_coupon.frequency_duration
+      applied_coupon.save!
+    end
+  end
+end


### PR DESCRIPTION
## Context

Set `frequency_duration_remaining` field

## Description

Currently we use `frequency_duration` field to count number of cycles in which certain coupon is used. Since we are switching to `frequency_duration_remaining` field, we need to set it for existing applied_coupons objects
