### PR TITLE
feat(timezone): Expose customer and organization timezone to API and …

### DIFF
--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -27,6 +27,8 @@ module Types
       field :vat_rate, Float, null: true
       field :currency, Types::CurrencyEnum, null: true
       field :payment_provider, Types::PaymentProviders::ProviderTypeEnum, null: true
+      field :timezone, Types::TimezoneEnum, null: true
+      field :applicable_timezone, Types::TimezoneEnum, null: false
 
       field :provider_customer, Types::PaymentProviderCustomers::Provider, null: true
       field :subscriptions, [Types::Subscriptions::Object]

--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -20,6 +20,7 @@ module Types
     field :country, Types::CountryCodeEnum, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :timezone, Types::TimezoneEnum, null: true
 
     field :stripe_payment_provider, Types::PaymentProviders::Stripe, null: true
     field :gocardless_payment_provider, Types::PaymentProviders::Gocardless, null: true

--- a/app/graphql/types/timezone_enum.rb
+++ b/app/graphql/types/timezone_enum.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  class TimezoneEnum < Types::BaseEnum
+    ActiveSupport::TimeZone.all
+      .uniq { |tz| tz.tzinfo.identifier }
+      .each_with_object([]) { |tz, result| result << [tz.tzinfo.identifier.gsub('Etc/', ''), tz] }
+      .sort_by { |list| list.first.split('/') }
+      .map do |list|
+        symbol = list.first.gsub(/[^_a-zA-Z0-9]/, '_').squeeze('_').upcase
+        value("TZ_#{symbol}", "#{list.first} (#{list.last.formatted_offset})", value: list.first)
+      end
+  end
+end

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -23,6 +23,7 @@ module V1
         legal_name: model.legal_name,
         legal_number: model.legal_number,
         currency: model.currency,
+        timezone: model.timezone,
         billing_configuration: billing_configuration,
       }
     end

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -24,6 +24,7 @@ module V1
         legal_number: model.legal_number,
         currency: model.currency,
         timezone: model.timezone,
+        applicable_timezone: model.applicable_timezone,
         billing_configuration: billing_configuration,
       }
     end

--- a/app/serializers/v1/organization_serializer.rb
+++ b/app/serializers/v1/organization_serializer.rb
@@ -17,6 +17,7 @@ module V1
         city: model.city,
         legal_name: model.legal_name,
         legal_number: model.legal_number,
+        timezone: model.timezone,
         billing_configuration: {
           invoice_footer: model.invoice_footer,
           invoice_grace_period: model.invoice_grace_period,

--- a/schema.graphql
+++ b/schema.graphql
@@ -2514,6 +2514,7 @@ type Customer {
   activeSubscriptionCount: Int!
   addressLine1: String
   addressLine2: String
+  applicableTimezone: TimezoneEnum!
 
   """
   Check if customer is deletable
@@ -2547,6 +2548,7 @@ type Customer {
   slug: String!
   state: String
   subscriptions: [Subscription!]
+  timezone: TimezoneEnum
   updatedAt: ISO8601DateTime!
   url: String
   vatRate: Float
@@ -2565,6 +2567,7 @@ type CustomerDetails {
   activeSubscriptionCount: Int!
   addressLine1: String
   addressLine2: String
+  applicableTimezone: TimezoneEnum!
   appliedAddOns: [AppliedAddOn!]
   appliedCoupons: [AppliedCoupon!]
 
@@ -2611,6 +2614,7 @@ type CustomerDetails {
     """
     status: [StatusTypeEnum!]
   ): [Subscription!]!
+  timezone: TimezoneEnum
   updatedAt: ISO8601DateTime!
   url: String
   vatRate: Float
@@ -3452,6 +3456,7 @@ type Organization {
   name: String!
   state: String
   stripePaymentProvider: StripeProvider
+  timezone: TimezoneEnum
   updatedAt: ISO8601DateTime!
   vatRate: Float!
   webhookUrl: String
@@ -3923,6 +3928,683 @@ input TerminateSubscriptionInput {
   """
   clientMutationId: String
   id: ID!
+}
+
+enum TimezoneEnum {
+  """
+  Africa/Algiers (+01:00)
+  """
+  TZ_AFRICA_ALGIERS
+
+  """
+  Africa/Cairo (+02:00)
+  """
+  TZ_AFRICA_CAIRO
+
+  """
+  Africa/Casablanca (+01:00)
+  """
+  TZ_AFRICA_CASABLANCA
+
+  """
+  Africa/Harare (+02:00)
+  """
+  TZ_AFRICA_HARARE
+
+  """
+  Africa/Johannesburg (+02:00)
+  """
+  TZ_AFRICA_JOHANNESBURG
+
+  """
+  Africa/Monrovia (+00:00)
+  """
+  TZ_AFRICA_MONROVIA
+
+  """
+  Africa/Nairobi (+03:00)
+  """
+  TZ_AFRICA_NAIROBI
+
+  """
+  America/Argentina/Buenos_Aires (-03:00)
+  """
+  TZ_AMERICA_ARGENTINA_BUENOS_AIRES
+
+  """
+  America/Bogota (-05:00)
+  """
+  TZ_AMERICA_BOGOTA
+
+  """
+  America/Caracas (-04:00)
+  """
+  TZ_AMERICA_CARACAS
+
+  """
+  America/Chicago (-06:00)
+  """
+  TZ_AMERICA_CHICAGO
+
+  """
+  America/Chihuahua (-07:00)
+  """
+  TZ_AMERICA_CHIHUAHUA
+
+  """
+  America/Denver (-07:00)
+  """
+  TZ_AMERICA_DENVER
+
+  """
+  America/Godthab (-03:00)
+  """
+  TZ_AMERICA_GODTHAB
+
+  """
+  America/Guatemala (-06:00)
+  """
+  TZ_AMERICA_GUATEMALA
+
+  """
+  America/Guyana (-04:00)
+  """
+  TZ_AMERICA_GUYANA
+
+  """
+  America/Halifax (-04:00)
+  """
+  TZ_AMERICA_HALIFAX
+
+  """
+  America/Indiana/Indianapolis (-05:00)
+  """
+  TZ_AMERICA_INDIANA_INDIANAPOLIS
+
+  """
+  America/Juneau (-09:00)
+  """
+  TZ_AMERICA_JUNEAU
+
+  """
+  America/La_Paz (-04:00)
+  """
+  TZ_AMERICA_LA_PAZ
+
+  """
+  America/Lima (-05:00)
+  """
+  TZ_AMERICA_LIMA
+
+  """
+  America/Los_Angeles (-08:00)
+  """
+  TZ_AMERICA_LOS_ANGELES
+
+  """
+  America/Mazatlan (-07:00)
+  """
+  TZ_AMERICA_MAZATLAN
+
+  """
+  America/Mexico_City (-06:00)
+  """
+  TZ_AMERICA_MEXICO_CITY
+
+  """
+  America/Monterrey (-06:00)
+  """
+  TZ_AMERICA_MONTERREY
+
+  """
+  America/Montevideo (-03:00)
+  """
+  TZ_AMERICA_MONTEVIDEO
+
+  """
+  America/New_York (-05:00)
+  """
+  TZ_AMERICA_NEW_YORK
+
+  """
+  America/Phoenix (-07:00)
+  """
+  TZ_AMERICA_PHOENIX
+
+  """
+  America/Puerto_Rico (-04:00)
+  """
+  TZ_AMERICA_PUERTO_RICO
+
+  """
+  America/Regina (-06:00)
+  """
+  TZ_AMERICA_REGINA
+
+  """
+  America/Santiago (-04:00)
+  """
+  TZ_AMERICA_SANTIAGO
+
+  """
+  America/Sao_Paulo (-03:00)
+  """
+  TZ_AMERICA_SAO_PAULO
+
+  """
+  America/St_Johns (-03:30)
+  """
+  TZ_AMERICA_ST_JOHNS
+
+  """
+  America/Tijuana (-08:00)
+  """
+  TZ_AMERICA_TIJUANA
+
+  """
+  Asia/Almaty (+06:00)
+  """
+  TZ_ASIA_ALMATY
+
+  """
+  Asia/Baghdad (+03:00)
+  """
+  TZ_ASIA_BAGHDAD
+
+  """
+  Asia/Baku (+04:00)
+  """
+  TZ_ASIA_BAKU
+
+  """
+  Asia/Bangkok (+07:00)
+  """
+  TZ_ASIA_BANGKOK
+
+  """
+  Asia/Chongqing (+08:00)
+  """
+  TZ_ASIA_CHONGQING
+
+  """
+  Asia/Colombo (+05:30)
+  """
+  TZ_ASIA_COLOMBO
+
+  """
+  Asia/Dhaka (+06:00)
+  """
+  TZ_ASIA_DHAKA
+
+  """
+  Asia/Hong_Kong (+08:00)
+  """
+  TZ_ASIA_HONG_KONG
+
+  """
+  Asia/Irkutsk (+08:00)
+  """
+  TZ_ASIA_IRKUTSK
+
+  """
+  Asia/Jakarta (+07:00)
+  """
+  TZ_ASIA_JAKARTA
+
+  """
+  Asia/Jerusalem (+02:00)
+  """
+  TZ_ASIA_JERUSALEM
+
+  """
+  Asia/Kabul (+04:30)
+  """
+  TZ_ASIA_KABUL
+
+  """
+  Asia/Kamchatka (+12:00)
+  """
+  TZ_ASIA_KAMCHATKA
+
+  """
+  Asia/Karachi (+05:00)
+  """
+  TZ_ASIA_KARACHI
+
+  """
+  Asia/Kathmandu (+05:45)
+  """
+  TZ_ASIA_KATHMANDU
+
+  """
+  Asia/Kolkata (+05:30)
+  """
+  TZ_ASIA_KOLKATA
+
+  """
+  Asia/Krasnoyarsk (+07:00)
+  """
+  TZ_ASIA_KRASNOYARSK
+
+  """
+  Asia/Kuala_Lumpur (+08:00)
+  """
+  TZ_ASIA_KUALA_LUMPUR
+
+  """
+  Asia/Kuwait (+03:00)
+  """
+  TZ_ASIA_KUWAIT
+
+  """
+  Asia/Magadan (+11:00)
+  """
+  TZ_ASIA_MAGADAN
+
+  """
+  Asia/Muscat (+04:00)
+  """
+  TZ_ASIA_MUSCAT
+
+  """
+  Asia/Novosibirsk (+07:00)
+  """
+  TZ_ASIA_NOVOSIBIRSK
+
+  """
+  Asia/Rangoon (+06:30)
+  """
+  TZ_ASIA_RANGOON
+
+  """
+  Asia/Riyadh (+03:00)
+  """
+  TZ_ASIA_RIYADH
+
+  """
+  Asia/Seoul (+09:00)
+  """
+  TZ_ASIA_SEOUL
+
+  """
+  Asia/Shanghai (+08:00)
+  """
+  TZ_ASIA_SHANGHAI
+
+  """
+  Asia/Singapore (+08:00)
+  """
+  TZ_ASIA_SINGAPORE
+
+  """
+  Asia/Srednekolymsk (+11:00)
+  """
+  TZ_ASIA_SREDNEKOLYMSK
+
+  """
+  Asia/Taipei (+08:00)
+  """
+  TZ_ASIA_TAIPEI
+
+  """
+  Asia/Tashkent (+05:00)
+  """
+  TZ_ASIA_TASHKENT
+
+  """
+  Asia/Tbilisi (+04:00)
+  """
+  TZ_ASIA_TBILISI
+
+  """
+  Asia/Tehran (+03:30)
+  """
+  TZ_ASIA_TEHRAN
+
+  """
+  Asia/Tokyo (+09:00)
+  """
+  TZ_ASIA_TOKYO
+
+  """
+  Asia/Ulaanbaatar (+08:00)
+  """
+  TZ_ASIA_ULAANBAATAR
+
+  """
+  Asia/Urumqi (+06:00)
+  """
+  TZ_ASIA_URUMQI
+
+  """
+  Asia/Vladivostok (+10:00)
+  """
+  TZ_ASIA_VLADIVOSTOK
+
+  """
+  Asia/Yakutsk (+09:00)
+  """
+  TZ_ASIA_YAKUTSK
+
+  """
+  Asia/Yekaterinburg (+05:00)
+  """
+  TZ_ASIA_YEKATERINBURG
+
+  """
+  Asia/Yerevan (+04:00)
+  """
+  TZ_ASIA_YEREVAN
+
+  """
+  Atlantic/Azores (-01:00)
+  """
+  TZ_ATLANTIC_AZORES
+
+  """
+  Atlantic/Cape_Verde (-01:00)
+  """
+  TZ_ATLANTIC_CAPE_VERDE
+
+  """
+  Atlantic/South_Georgia (-02:00)
+  """
+  TZ_ATLANTIC_SOUTH_GEORGIA
+
+  """
+  Australia/Adelaide (+09:30)
+  """
+  TZ_AUSTRALIA_ADELAIDE
+
+  """
+  Australia/Brisbane (+10:00)
+  """
+  TZ_AUSTRALIA_BRISBANE
+
+  """
+  Australia/Darwin (+09:30)
+  """
+  TZ_AUSTRALIA_DARWIN
+
+  """
+  Australia/Hobart (+10:00)
+  """
+  TZ_AUSTRALIA_HOBART
+
+  """
+  Australia/Melbourne (+10:00)
+  """
+  TZ_AUSTRALIA_MELBOURNE
+
+  """
+  Australia/Perth (+08:00)
+  """
+  TZ_AUSTRALIA_PERTH
+
+  """
+  Australia/Sydney (+10:00)
+  """
+  TZ_AUSTRALIA_SYDNEY
+
+  """
+  Europe/Amsterdam (+01:00)
+  """
+  TZ_EUROPE_AMSTERDAM
+
+  """
+  Europe/Athens (+02:00)
+  """
+  TZ_EUROPE_ATHENS
+
+  """
+  Europe/Belgrade (+01:00)
+  """
+  TZ_EUROPE_BELGRADE
+
+  """
+  Europe/Berlin (+01:00)
+  """
+  TZ_EUROPE_BERLIN
+
+  """
+  Europe/Bratislava (+01:00)
+  """
+  TZ_EUROPE_BRATISLAVA
+
+  """
+  Europe/Brussels (+01:00)
+  """
+  TZ_EUROPE_BRUSSELS
+
+  """
+  Europe/Bucharest (+02:00)
+  """
+  TZ_EUROPE_BUCHAREST
+
+  """
+  Europe/Budapest (+01:00)
+  """
+  TZ_EUROPE_BUDAPEST
+
+  """
+  Europe/Copenhagen (+01:00)
+  """
+  TZ_EUROPE_COPENHAGEN
+
+  """
+  Europe/Dublin (+01:00)
+  """
+  TZ_EUROPE_DUBLIN
+
+  """
+  Europe/Helsinki (+02:00)
+  """
+  TZ_EUROPE_HELSINKI
+
+  """
+  Europe/Istanbul (+03:00)
+  """
+  TZ_EUROPE_ISTANBUL
+
+  """
+  Europe/Kaliningrad (+02:00)
+  """
+  TZ_EUROPE_KALININGRAD
+
+  """
+  Europe/Kiev (+02:00)
+  """
+  TZ_EUROPE_KIEV
+
+  """
+  Europe/Lisbon (+00:00)
+  """
+  TZ_EUROPE_LISBON
+
+  """
+  Europe/Ljubljana (+01:00)
+  """
+  TZ_EUROPE_LJUBLJANA
+
+  """
+  Europe/London (+00:00)
+  """
+  TZ_EUROPE_LONDON
+
+  """
+  Europe/Madrid (+01:00)
+  """
+  TZ_EUROPE_MADRID
+
+  """
+  Europe/Minsk (+03:00)
+  """
+  TZ_EUROPE_MINSK
+
+  """
+  Europe/Moscow (+03:00)
+  """
+  TZ_EUROPE_MOSCOW
+
+  """
+  Europe/Paris (+01:00)
+  """
+  TZ_EUROPE_PARIS
+
+  """
+  Europe/Prague (+01:00)
+  """
+  TZ_EUROPE_PRAGUE
+
+  """
+  Europe/Riga (+02:00)
+  """
+  TZ_EUROPE_RIGA
+
+  """
+  Europe/Rome (+01:00)
+  """
+  TZ_EUROPE_ROME
+
+  """
+  Europe/Samara (+04:00)
+  """
+  TZ_EUROPE_SAMARA
+
+  """
+  Europe/Sarajevo (+01:00)
+  """
+  TZ_EUROPE_SARAJEVO
+
+  """
+  Europe/Skopje (+01:00)
+  """
+  TZ_EUROPE_SKOPJE
+
+  """
+  Europe/Sofia (+02:00)
+  """
+  TZ_EUROPE_SOFIA
+
+  """
+  Europe/Stockholm (+01:00)
+  """
+  TZ_EUROPE_STOCKHOLM
+
+  """
+  Europe/Tallinn (+02:00)
+  """
+  TZ_EUROPE_TALLINN
+
+  """
+  Europe/Vienna (+01:00)
+  """
+  TZ_EUROPE_VIENNA
+
+  """
+  Europe/Vilnius (+02:00)
+  """
+  TZ_EUROPE_VILNIUS
+
+  """
+  Europe/Volgograd (+03:00)
+  """
+  TZ_EUROPE_VOLGOGRAD
+
+  """
+  Europe/Warsaw (+01:00)
+  """
+  TZ_EUROPE_WARSAW
+
+  """
+  Europe/Zagreb (+01:00)
+  """
+  TZ_EUROPE_ZAGREB
+
+  """
+  Europe/Zurich (+01:00)
+  """
+  TZ_EUROPE_ZURICH
+
+  """
+  GMT+12 (-12:00)
+  """
+  TZ_GMT_12
+
+  """
+  Pacific/Apia (+13:00)
+  """
+  TZ_PACIFIC_APIA
+
+  """
+  Pacific/Auckland (+12:00)
+  """
+  TZ_PACIFIC_AUCKLAND
+
+  """
+  Pacific/Chatham (+12:45)
+  """
+  TZ_PACIFIC_CHATHAM
+
+  """
+  Pacific/Fakaofo (+13:00)
+  """
+  TZ_PACIFIC_FAKAOFO
+
+  """
+  Pacific/Fiji (+12:00)
+  """
+  TZ_PACIFIC_FIJI
+
+  """
+  Pacific/Guadalcanal (+11:00)
+  """
+  TZ_PACIFIC_GUADALCANAL
+
+  """
+  Pacific/Guam (+10:00)
+  """
+  TZ_PACIFIC_GUAM
+
+  """
+  Pacific/Honolulu (-10:00)
+  """
+  TZ_PACIFIC_HONOLULU
+
+  """
+  Pacific/Majuro (+12:00)
+  """
+  TZ_PACIFIC_MAJURO
+
+  """
+  Pacific/Midway (-11:00)
+  """
+  TZ_PACIFIC_MIDWAY
+
+  """
+  Pacific/Noumea (+11:00)
+  """
+  TZ_PACIFIC_NOUMEA
+
+  """
+  Pacific/Pago_Pago (-11:00)
+  """
+  TZ_PACIFIC_PAGO_PAGO
+
+  """
+  Pacific/Port_Moresby (+10:00)
+  """
+  TZ_PACIFIC_PORT_MORESBY
+
+  """
+  Pacific/Tongatapu (+13:00)
+  """
+  TZ_PACIFIC_TONGATAPU
+
+  """
+  UTC (+00:00)
+  """
+  TZ_UTC
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -7307,6 +7307,24 @@
               ]
             },
             {
+              "name": "applicableTimezone",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "TimezoneEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "canBeDeleted",
               "description": "Check if customer is deletable",
               "type": {
@@ -7641,6 +7659,20 @@
               ]
             },
             {
+              "name": "timezone",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "TimezoneEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "updatedAt",
               "description": null,
               "type": {
@@ -7809,6 +7841,24 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "applicableTimezone",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "TimezoneEnum",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -8259,6 +8309,20 @@
                   "isDeprecated": false,
                   "deprecationReason": null
                 }
+              ]
+            },
+            {
+              "name": "timezone",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "TimezoneEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
               ]
             },
             {
@@ -13087,6 +13151,20 @@
               ]
             },
             {
+              "name": "timezone",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "TimezoneEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "updatedAt",
               "description": null,
               "type": {
@@ -16097,6 +16175,827 @@
             }
           ],
           "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "TimezoneEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "TZ_AFRICA_ALGIERS",
+              "description": "Africa/Algiers (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AFRICA_CAIRO",
+              "description": "Africa/Cairo (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AFRICA_CASABLANCA",
+              "description": "Africa/Casablanca (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AFRICA_HARARE",
+              "description": "Africa/Harare (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AFRICA_JOHANNESBURG",
+              "description": "Africa/Johannesburg (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AFRICA_MONROVIA",
+              "description": "Africa/Monrovia (+00:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AFRICA_NAIROBI",
+              "description": "Africa/Nairobi (+03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_ARGENTINA_BUENOS_AIRES",
+              "description": "America/Argentina/Buenos_Aires (-03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_BOGOTA",
+              "description": "America/Bogota (-05:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_CARACAS",
+              "description": "America/Caracas (-04:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_CHICAGO",
+              "description": "America/Chicago (-06:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_CHIHUAHUA",
+              "description": "America/Chihuahua (-07:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_DENVER",
+              "description": "America/Denver (-07:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_GODTHAB",
+              "description": "America/Godthab (-03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_GUATEMALA",
+              "description": "America/Guatemala (-06:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_GUYANA",
+              "description": "America/Guyana (-04:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_HALIFAX",
+              "description": "America/Halifax (-04:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_INDIANA_INDIANAPOLIS",
+              "description": "America/Indiana/Indianapolis (-05:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_JUNEAU",
+              "description": "America/Juneau (-09:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_LA_PAZ",
+              "description": "America/La_Paz (-04:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_LIMA",
+              "description": "America/Lima (-05:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_LOS_ANGELES",
+              "description": "America/Los_Angeles (-08:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_MAZATLAN",
+              "description": "America/Mazatlan (-07:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_MEXICO_CITY",
+              "description": "America/Mexico_City (-06:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_MONTERREY",
+              "description": "America/Monterrey (-06:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_MONTEVIDEO",
+              "description": "America/Montevideo (-03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_NEW_YORK",
+              "description": "America/New_York (-05:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_PHOENIX",
+              "description": "America/Phoenix (-07:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_PUERTO_RICO",
+              "description": "America/Puerto_Rico (-04:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_REGINA",
+              "description": "America/Regina (-06:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_SANTIAGO",
+              "description": "America/Santiago (-04:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_SAO_PAULO",
+              "description": "America/Sao_Paulo (-03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_ST_JOHNS",
+              "description": "America/St_Johns (-03:30)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AMERICA_TIJUANA",
+              "description": "America/Tijuana (-08:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_ALMATY",
+              "description": "Asia/Almaty (+06:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_BAGHDAD",
+              "description": "Asia/Baghdad (+03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_BAKU",
+              "description": "Asia/Baku (+04:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_BANGKOK",
+              "description": "Asia/Bangkok (+07:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_CHONGQING",
+              "description": "Asia/Chongqing (+08:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_COLOMBO",
+              "description": "Asia/Colombo (+05:30)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_DHAKA",
+              "description": "Asia/Dhaka (+06:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_HONG_KONG",
+              "description": "Asia/Hong_Kong (+08:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_IRKUTSK",
+              "description": "Asia/Irkutsk (+08:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_JAKARTA",
+              "description": "Asia/Jakarta (+07:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_JERUSALEM",
+              "description": "Asia/Jerusalem (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_KABUL",
+              "description": "Asia/Kabul (+04:30)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_KAMCHATKA",
+              "description": "Asia/Kamchatka (+12:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_KARACHI",
+              "description": "Asia/Karachi (+05:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_KATHMANDU",
+              "description": "Asia/Kathmandu (+05:45)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_KOLKATA",
+              "description": "Asia/Kolkata (+05:30)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_KRASNOYARSK",
+              "description": "Asia/Krasnoyarsk (+07:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_KUALA_LUMPUR",
+              "description": "Asia/Kuala_Lumpur (+08:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_KUWAIT",
+              "description": "Asia/Kuwait (+03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_MAGADAN",
+              "description": "Asia/Magadan (+11:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_MUSCAT",
+              "description": "Asia/Muscat (+04:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_NOVOSIBIRSK",
+              "description": "Asia/Novosibirsk (+07:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_RANGOON",
+              "description": "Asia/Rangoon (+06:30)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_RIYADH",
+              "description": "Asia/Riyadh (+03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_SEOUL",
+              "description": "Asia/Seoul (+09:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_SHANGHAI",
+              "description": "Asia/Shanghai (+08:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_SINGAPORE",
+              "description": "Asia/Singapore (+08:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_SREDNEKOLYMSK",
+              "description": "Asia/Srednekolymsk (+11:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_TAIPEI",
+              "description": "Asia/Taipei (+08:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_TASHKENT",
+              "description": "Asia/Tashkent (+05:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_TBILISI",
+              "description": "Asia/Tbilisi (+04:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_TEHRAN",
+              "description": "Asia/Tehran (+03:30)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_TOKYO",
+              "description": "Asia/Tokyo (+09:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_ULAANBAATAR",
+              "description": "Asia/Ulaanbaatar (+08:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_URUMQI",
+              "description": "Asia/Urumqi (+06:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_VLADIVOSTOK",
+              "description": "Asia/Vladivostok (+10:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_YAKUTSK",
+              "description": "Asia/Yakutsk (+09:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_YEKATERINBURG",
+              "description": "Asia/Yekaterinburg (+05:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ASIA_YEREVAN",
+              "description": "Asia/Yerevan (+04:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ATLANTIC_AZORES",
+              "description": "Atlantic/Azores (-01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ATLANTIC_CAPE_VERDE",
+              "description": "Atlantic/Cape_Verde (-01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_ATLANTIC_SOUTH_GEORGIA",
+              "description": "Atlantic/South_Georgia (-02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AUSTRALIA_ADELAIDE",
+              "description": "Australia/Adelaide (+09:30)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AUSTRALIA_BRISBANE",
+              "description": "Australia/Brisbane (+10:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AUSTRALIA_DARWIN",
+              "description": "Australia/Darwin (+09:30)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AUSTRALIA_HOBART",
+              "description": "Australia/Hobart (+10:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AUSTRALIA_MELBOURNE",
+              "description": "Australia/Melbourne (+10:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AUSTRALIA_PERTH",
+              "description": "Australia/Perth (+08:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_AUSTRALIA_SYDNEY",
+              "description": "Australia/Sydney (+10:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_AMSTERDAM",
+              "description": "Europe/Amsterdam (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_ATHENS",
+              "description": "Europe/Athens (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_BELGRADE",
+              "description": "Europe/Belgrade (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_BERLIN",
+              "description": "Europe/Berlin (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_BRATISLAVA",
+              "description": "Europe/Bratislava (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_BRUSSELS",
+              "description": "Europe/Brussels (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_BUCHAREST",
+              "description": "Europe/Bucharest (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_BUDAPEST",
+              "description": "Europe/Budapest (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_COPENHAGEN",
+              "description": "Europe/Copenhagen (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_DUBLIN",
+              "description": "Europe/Dublin (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_HELSINKI",
+              "description": "Europe/Helsinki (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_ISTANBUL",
+              "description": "Europe/Istanbul (+03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_KALININGRAD",
+              "description": "Europe/Kaliningrad (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_KIEV",
+              "description": "Europe/Kiev (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_LISBON",
+              "description": "Europe/Lisbon (+00:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_LJUBLJANA",
+              "description": "Europe/Ljubljana (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_LONDON",
+              "description": "Europe/London (+00:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_MADRID",
+              "description": "Europe/Madrid (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_MINSK",
+              "description": "Europe/Minsk (+03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_MOSCOW",
+              "description": "Europe/Moscow (+03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_PARIS",
+              "description": "Europe/Paris (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_PRAGUE",
+              "description": "Europe/Prague (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_RIGA",
+              "description": "Europe/Riga (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_ROME",
+              "description": "Europe/Rome (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_SAMARA",
+              "description": "Europe/Samara (+04:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_SARAJEVO",
+              "description": "Europe/Sarajevo (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_SKOPJE",
+              "description": "Europe/Skopje (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_SOFIA",
+              "description": "Europe/Sofia (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_STOCKHOLM",
+              "description": "Europe/Stockholm (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_TALLINN",
+              "description": "Europe/Tallinn (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_VIENNA",
+              "description": "Europe/Vienna (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_VILNIUS",
+              "description": "Europe/Vilnius (+02:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_VOLGOGRAD",
+              "description": "Europe/Volgograd (+03:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_WARSAW",
+              "description": "Europe/Warsaw (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_ZAGREB",
+              "description": "Europe/Zagreb (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_EUROPE_ZURICH",
+              "description": "Europe/Zurich (+01:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_GMT_12",
+              "description": "GMT+12 (-12:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_APIA",
+              "description": "Pacific/Apia (+13:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_AUCKLAND",
+              "description": "Pacific/Auckland (+12:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_CHATHAM",
+              "description": "Pacific/Chatham (+12:45)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_FAKAOFO",
+              "description": "Pacific/Fakaofo (+13:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_FIJI",
+              "description": "Pacific/Fiji (+12:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_GUADALCANAL",
+              "description": "Pacific/Guadalcanal (+11:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_GUAM",
+              "description": "Pacific/Guam (+10:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_HONOLULU",
+              "description": "Pacific/Honolulu (-10:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_MAJURO",
+              "description": "Pacific/Majuro (+12:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_MIDWAY",
+              "description": "Pacific/Midway (-11:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_NOUMEA",
+              "description": "Pacific/Noumea (+11:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_PAGO_PAGO",
+              "description": "Pacific/Pago_Pago (-11:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_PORT_MORESBY",
+              "description": "Pacific/Port_Moresby (+10:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_PACIFIC_TONGATAPU",
+              "description": "Pacific/Tongatapu (+13:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_UTC",
+              "description": "UTC (+00:00)",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
         },
         {
           "kind": "INPUT_OBJECT",

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -8,18 +8,19 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
     <<~GQL
       mutation($input: UpdateOrganizationInput!) {
         updateOrganization(input: $input) {
-          webhookUrl,
-          vatRate,
-          legalNumber,
-          legalName,
-          email,
-          addressLine1,
-          addressLine2,
-          state,
-          zipcode,
-          city,
-          country,
+          webhookUrl
+          vatRate
+          legalNumber
+          legalName
+          email
+          addressLine1
+          addressLine2
+          state
+          zipcode
+          city
+          country
           invoiceFooter
+          timezone
         }
       }
     GQL
@@ -62,6 +63,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
     expect(result_data['city']).to eq('Foobar')
     expect(result_data['country']).to eq('FR')
     expect(result_data['invoiceFooter']).to eq('invoice footer')
+    expect(result_data['timezone']).to eq('TZ_UTC')
   end
 
   context 'with invalid webhook url' do

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
       query($customerId: ID!) {
         customer(id: $customerId) {
           id externalId name currency
+          timezone
+          applicableTimezone
           invoices { id invoiceType status }
           subscriptions(status: [active]) { id, status }
           appliedCoupons { id amountCents amountCurrency coupon { id name } }
@@ -49,6 +51,7 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
   let(:credit_note_item) { create(:credit_note_item, credit_note: credit_note) }
 
   before do
+    organization.update!(timezone: 'America/New_York')
     create_list(:invoice, 2, customer: customer)
     applied_add_on
     subscription
@@ -73,6 +76,8 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
       expect(customer_response['invoices'].count).to eq(2)
       expect(customer_response['appliedAddOns'].count).to eq(1)
       expect(customer_response['currency']).to be_present
+      expect(customer_response['timezone']).to be_nil
+      expect(customer_response['applicableTimezone']).to eq('TZ_AMERICA_NEW_YORK')
     end
   end
 

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe ::V1::CustomerSerializer do
       expect(result['customer']['currency']).to eq(customer.currency)
       expect(result['customer']['invoice_grace_period']).to eq(customer.invoice_grace_period)
       expect(result['customer']['timezone']).to eq(customer.timezone)
+      expect(result['customer']['applicable_timezone']).to eq(customer.applicable_timezone)
 
       expect(result['customer']['billing_configuration']['payment_provider']).to eq(customer.payment_provider)
     end

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe ::V1::CustomerSerializer do
       expect(result['customer']['name']).to eq(customer.name)
       expect(result['customer']['sequential_id']).to eq(customer.sequential_id)
       expect(result['customer']['slug']).to eq(customer.slug)
-      expect(result['customer']['vat_rate']).to eq(customer.vat_rate)
       expect(result['customer']['created_at']).to eq(customer.created_at.iso8601)
       expect(result['customer']['country']).to eq(customer.country)
       expect(result['customer']['address_line1']).to eq(customer.address_line1)
@@ -31,11 +30,11 @@ RSpec.describe ::V1::CustomerSerializer do
       expect(result['customer']['legal_name']).to eq(customer.legal_name)
       expect(result['customer']['legal_number']).to eq(customer.legal_number)
       expect(result['customer']['currency']).to eq(customer.currency)
-      expect(result['customer']['invoice_grace_period']).to eq(customer.invoice_grace_period)
       expect(result['customer']['timezone']).to eq(customer.timezone)
       expect(result['customer']['applicable_timezone']).to eq(customer.applicable_timezone)
-
       expect(result['customer']['billing_configuration']['payment_provider']).to eq(customer.payment_provider)
+      expect(result['customer']['billing_configuration']['invoice_grace_period']).to eq(customer.invoice_grace_period)
+      expect(result['customer']['billing_configuration']['vat_rate']).to eq(customer.vat_rate)
     end
   end
 end

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::CustomerSerializer do
+  subject(:serializer) { described_class.new(customer, root_name: 'customer') }
+
+  let(:customer) { create(:customer) }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['customer']['lago_id']).to eq(customer.id)
+      expect(result['customer']['external_id']).to eq(customer.external_id)
+      expect(result['customer']['name']).to eq(customer.name)
+      expect(result['customer']['sequential_id']).to eq(customer.sequential_id)
+      expect(result['customer']['slug']).to eq(customer.slug)
+      expect(result['customer']['vat_rate']).to eq(customer.vat_rate)
+      expect(result['customer']['created_at']).to eq(customer.created_at.iso8601)
+      expect(result['customer']['country']).to eq(customer.country)
+      expect(result['customer']['address_line1']).to eq(customer.address_line1)
+      expect(result['customer']['address_line2']).to eq(customer.address_line2)
+      expect(result['customer']['state']).to eq(customer.state)
+      expect(result['customer']['zipcode']).to eq(customer.zipcode)
+      expect(result['customer']['email']).to eq(customer.email)
+      expect(result['customer']['city']).to eq(customer.city)
+      expect(result['customer']['url']).to eq(customer.url)
+      expect(result['customer']['phone']).to eq(customer.phone)
+      expect(result['customer']['logo_url']).to eq(customer.logo_url)
+      expect(result['customer']['legal_name']).to eq(customer.legal_name)
+      expect(result['customer']['legal_number']).to eq(customer.legal_number)
+      expect(result['customer']['currency']).to eq(customer.currency)
+      expect(result['customer']['invoice_grace_period']).to eq(customer.invoice_grace_period)
+      expect(result['customer']['timezone']).to eq(customer.timezone)
+
+      expect(result['customer']['billing_configuration']['payment_provider']).to eq(customer.payment_provider)
+    end
+  end
+end

--- a/spec/serializers/v1/organization_serializer_spec.rb
+++ b/spec/serializers/v1/organization_serializer_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe ::V1::OrganizationSerializer do
       expect(result['organization']['billing_configuration']['invoice_footer']).to eq(org.invoice_footer)
       expect(result['organization']['billing_configuration']['invoice_grace_period']).to eq(org.invoice_grace_period)
       expect(result['organization']['billing_configuration']['vat_rate']).to eq(org.vat_rate)
+      expect(result['organization']['timezone']).to eq(org.timezone)
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR exposes the `timezone` and the customer `applicable_timezone` into the public API and GraphQL
