### PR TITLE
misc: Move fields related to Billing or Invoice into billing_configuration

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -91,14 +91,14 @@ module Api
           :logo_url,
           :legal_name,
           :legal_number,
-          :vat_rate,
           :currency,
-          :invoice_grace_period,
           billing_configuration: [
+            :invoice_grace_period,
             :payment_provider,
             :provider_customer_id,
             :sync,
             :sync_with_provider,
+            :vat_rate,
           ],
         )
       end

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -24,7 +24,6 @@ module Api
       def input_params
         params.require(:organization).permit(
           :webhook_url,
-          :vat_rate,
           :country,
           :address_line1,
           :address_line2,
@@ -34,8 +33,11 @@ module Api
           :city,
           :legal_name,
           :legal_number,
-          :invoice_footer,
-          :invoice_grace_period,
+          billing_configuration: [
+            :invoice_footer,
+            :invoice_grace_period,
+            :vat_rate,
+          ],
         )
       end
     end

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -9,7 +9,6 @@ module V1
         name: model.name,
         sequential_id: model.sequential_id,
         slug: model.slug,
-        vat_rate: model.vat_rate,
         created_at: model.created_at.iso8601,
         country: model.country,
         address_line1: model.address_line1,
@@ -25,7 +24,6 @@ module V1
         legal_number: model.legal_number,
         currency: model.currency,
         billing_configuration: billing_configuration,
-        invoice_grace_period: model.invoice_grace_period,
       }
     end
 
@@ -33,7 +31,9 @@ module V1
 
     def billing_configuration
       configuration = {
+        invoice_grace_period: model.invoice_grace_period,
         payment_provider: model.payment_provider,
+        vat_rate: model.vat_rate,
       }
 
       if model.payment_provider&.to_sym == :stripe

--- a/app/serializers/v1/organization_serializer.rb
+++ b/app/serializers/v1/organization_serializer.rb
@@ -8,7 +8,6 @@ module V1
         name: model.name,
         created_at: model.created_at.iso8601,
         webhook_url: model.webhook_url,
-        vat_rate: model.vat_rate,
         country: model.country,
         address_line1: model.address_line1,
         address_line2: model.address_line2,
@@ -18,8 +17,11 @@ module V1
         city: model.city,
         legal_name: model.legal_name,
         legal_number: model.legal_number,
-        invoice_footer: model.invoice_footer,
-        invoice_grace_period: model.invoice_grace_period,
+        billing_configuration: {
+          invoice_footer: model.invoice_footer,
+          invoice_grace_period: model.invoice_grace_period,
+          vat_rate: model.vat_rate,
+        },
       }
     end
   end

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -30,6 +30,13 @@ module Customers
         customer.payment_provider = args[:payment_provider] if args.key?(:payment_provider)
         customer.invoice_grace_period = args[:invoice_grace_period] if args.key?(:invoice_grace_period)
 
+        if args.key?(:billing_configuration)
+          billing = args[:billing_configuration]
+          customer.invoice_footer = billing[:invoice_footer] if billing.key?(:invoice_footer)
+          customer.invoice_grace_period = billing[:invoice_grace_period] if billing.key?(:invoice_grace_period)
+          customer.vat_rate = billing[:vat_rate] if billing.key?(:vat_rate)
+        end
+
         # NOTE: external_id is not editable if customer is attached to subscriptions
         customer.external_id = args[:external_id] if customer.editable? && args.key?(:external_id)
 

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -35,7 +35,6 @@ module Organizations
 
     def update_from_api(params:)
       organization.webhook_url = params[:webhook_url] if params.key?(:webhook_url)
-      organization.vat_rate = params[:vat_rate] if params.key?(:vat_rate)
       organization.country = params[:country] if params.key?(:country)
       organization.address_line1 = params[:address_line1] if params.key?(:address_line1)
       organization.address_line2 = params[:address_line2] if params.key?(:address_line2)
@@ -45,8 +44,14 @@ module Organizations
       organization.city = params[:city] if params.key?(:city)
       organization.legal_name = params[:legal_name] if params.key?(:legal_name)
       organization.legal_number = params[:legal_number] if params.key?(:legal_number)
-      organization.invoice_footer = params[:invoice_footer] if params.key?(:invoice_footer)
-      organization.invoice_grace_period = params[:invoice_grace_period] if params.key?(:invoice_grace_period)
+
+      if params.key?(:billing_configuration)
+        billing = params[:billing_configuration]
+        organization.invoice_footer = billing[:invoice_footer] if billing.key?(:invoice_footer)
+        organization.invoice_grace_period = billing[:invoice_grace_period] if billing.key?(:invoice_grace_period)
+        organization.vat_rate = billing[:vat_rate] if billing.key?(:vat_rate)
+      end
+
       organization.save!
 
       result.organization = organization

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         external_id: SecureRandom.uuid,
         name: 'Foo Bar',
         currency: 'EUR',
-        invoice_grace_period: 3,
       }
     end
 
@@ -25,7 +24,6 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         expect(json[:customer][:name]).to eq(create_params[:name])
         expect(json[:customer][:created_at]).to be_present
         expect(json[:customer][:currency]).to eq(create_params[:currency])
-        expect(json[:customer][:invoice_grace_period]).to eq(create_params[:invoice_grace_period])
       end
     end
 
@@ -35,8 +33,10 @@ RSpec.describe Api::V1::CustomersController, type: :request do
           external_id: SecureRandom.uuid,
           name: 'Foo Bar',
           billing_configuration: {
+            invoice_grace_period: 3,
             payment_provider: 'stripe',
             provider_customer_id: 'stripe_id',
+            vat_rate: 20,
           },
         }
       end
@@ -49,9 +49,14 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         expect(json[:customer][:lago_id]).to be_present
         expect(json[:customer][:external_id]).to eq(create_params[:external_id])
 
-        expect(json[:customer][:billing_configuration]).to be_present
-        expect(json[:customer][:billing_configuration][:payment_provider]).to eq('stripe')
-        expect(json[:customer][:billing_configuration][:provider_customer_id]).to eq('stripe_id')
+        billing = json[:customer][:billing_configuration]
+        aggregate_failures do
+          expect(billing).to be_present
+          expect(billing[:payment_provider]).to eq('stripe')
+          expect(billing[:provider_customer_id]).to eq('stripe_id')
+          expect(billing[:invoice_grace_period]).to eq(3)
+          expect(billing[:vat_rate]).to eq(20)
+        end
       end
     end
 

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
     let(:update_params) do
       {
         webhook_url: 'http://test.example',
-        vat_rate: 20,
         country: 'pl',
         address_line1: 'address1',
         address_line2: 'address2',
@@ -19,8 +18,11 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
         city: 'test_city',
         legal_name: 'test1',
         legal_number: '123',
-        invoice_footer: 'footer',
-        invoice_grace_period: 3,
+        billing_configuration: {
+          invoice_footer: 'footer',
+          invoice_grace_period: 3,
+          vat_rate: 20,
+        },
       }
     end
 
@@ -37,8 +39,11 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
         expect(json[:organization][:name]).to eq(organization.name)
         expect(json[:organization][:webhook_url]).to eq(update_params[:webhook_url])
         expect(json[:organization][:vat_rate]).to eq(update_params[:vat_rate])
-        expect(json[:organization][:invoice_footer]).to eq(update_params[:invoice_footer])
-        expect(json[:organization][:invoice_grace_period]).to eq(update_params[:invoice_grace_period])
+
+        billing = json[:organization][:billing_configuration]
+        expect(billing[:invoice_footer]).to eq('footer')
+        expect(billing[:invoice_grace_period]).to eq(3)
+        expect(billing[:vat_rate]).to eq(20)
       end
     end
   end

--- a/spec/serializers/v1/organization_serializer_spec.rb
+++ b/spec/serializers/v1/organization_serializer_spec.rb
@@ -3,29 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe ::V1::OrganizationSerializer do
-  subject(:serializer) { described_class.new(organization, root_name: 'organization') }
+  subject(:serializer) { described_class.new(org, root_name: 'organization') }
 
-  let(:organization) { create(:organization) }
+  let(:org) { create(:organization) }
 
   it 'serializes the object' do
     result = JSON.parse(serializer.to_json)
 
     aggregate_failures do
-      expect(result['organization']['name']).to eq(organization.name)
-      expect(result['organization']['created_at']).to eq(organization.created_at.iso8601)
-      expect(result['organization']['webhook_url']).to eq(organization.webhook_url)
-      expect(result['organization']['vat_rate']).to eq(organization.vat_rate)
-      expect(result['organization']['country']).to eq(organization.country)
-      expect(result['organization']['address_line1']).to eq(organization.address_line1)
-      expect(result['organization']['address_line2']).to eq(organization.address_line2)
-      expect(result['organization']['state']).to eq(organization.state)
-      expect(result['organization']['zipcode']).to eq(organization.zipcode)
-      expect(result['organization']['email']).to eq(organization.email)
-      expect(result['organization']['city']).to eq(organization.city)
-      expect(result['organization']['legal_name']).to eq(organization.legal_name)
-      expect(result['organization']['legal_number']).to eq(organization.legal_number)
-      expect(result['organization']['invoice_footer']).to eq(organization.invoice_footer)
-      expect(result['organization']['invoice_grace_period']).to eq(organization.invoice_grace_period)
+      expect(result['organization']['name']).to eq(org.name)
+      expect(result['organization']['created_at']).to eq(org.created_at.iso8601)
+      expect(result['organization']['webhook_url']).to eq(org.webhook_url)
+      expect(result['organization']['country']).to eq(org.country)
+      expect(result['organization']['address_line1']).to eq(org.address_line1)
+      expect(result['organization']['address_line2']).to eq(org.address_line2)
+      expect(result['organization']['state']).to eq(org.state)
+      expect(result['organization']['zipcode']).to eq(org.zipcode)
+      expect(result['organization']['email']).to eq(org.email)
+      expect(result['organization']['city']).to eq(org.city)
+      expect(result['organization']['legal_name']).to eq(org.legal_name)
+      expect(result['organization']['legal_number']).to eq(org.legal_number)
+      expect(result['organization']['billing_configuration']['invoice_footer']).to eq(org.invoice_footer)
+      expect(result['organization']['billing_configuration']['invoice_grace_period']).to eq(org.invoice_grace_period)
+      expect(result['organization']['billing_configuration']['vat_rate']).to eq(org.vat_rate)
     end
   end
 end

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Customers::CreateService, type: :service do
         external_id: SecureRandom.uuid,
         name: 'Foo Bar',
         currency: 'EUR',
+        billing_configuration: {
+          invoice_grace_period: 3,
+          vat_rate: 20,
+        },
       }
     end
 
@@ -31,12 +35,18 @@ RSpec.describe Customers::CreateService, type: :service do
 
       expect(result).to be_success
 
-      customer = result.customer
-      expect(customer.id).to be_present
-      expect(customer.organization_id).to eq(organization.id)
-      expect(customer.external_id).to eq(create_args[:external_id])
-      expect(customer.name).to eq(create_args[:name])
-      expect(customer.currency).to eq(create_args[:currency])
+      aggregate_failures do
+        customer = result.customer
+        expect(customer.id).to be_present
+        expect(customer.organization_id).to eq(organization.id)
+        expect(customer.external_id).to eq(create_args[:external_id])
+        expect(customer.name).to eq(create_args[:name])
+        expect(customer.currency).to eq(create_args[:currency])
+
+        billing = create_args[:billing_configuration]
+        expect(customer.invoice_grace_period).to eq(billing[:invoice_grace_period])
+        expect(customer.vat_rate).to eq(billing[:vat_rate])
+      end
     end
 
     it 'calls SegmentTrackJob' do

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Customers::UpdateService, type: :service do
         id: customer.id,
         name: 'Updated customer name',
         external_id: external_id,
+        billing_configuration: {
+          invoice_grace_period: 3,
+          vat_rate: 20,
+        },
       }
     end
 
@@ -29,6 +33,10 @@ RSpec.describe Customers::UpdateService, type: :service do
       updated_customer = result.customer
       aggregate_failures do
         expect(updated_customer.name).to eq('Updated customer name')
+
+        billing = update_args[:billing_configuration]
+        expect(updated_customer.invoice_grace_period).to eq(billing[:invoice_grace_period])
+        expect(updated_customer.vat_rate).to eq(billing[:vat_rate])
       end
     end
 

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe Organizations::UpdateService do
     let(:update_args) do
       {
         webhook_url: 'http://test.example',
-        vat_rate: 20,
         country: country,
         address_line1: 'address1',
         address_line2: 'address2',
@@ -71,7 +70,11 @@ RSpec.describe Organizations::UpdateService do
         city: 'test_city',
         legal_name: 'test1',
         legal_number: '123',
-        invoice_footer: 'footer',
+        billing_configuration: {
+          invoice_footer: 'footer',
+          invoice_grace_period: 3,
+          vat_rate: 20,
+        },
       }
     end
 
@@ -84,8 +87,11 @@ RSpec.describe Organizations::UpdateService do
         organization_response = result.organization
         expect(organization_response.name).to eq(organization.name)
         expect(organization_response.webhook_url).to eq(update_args[:webhook_url])
-        expect(organization_response.vat_rate).to eq(update_args[:vat_rate])
-        expect(organization_response.invoice_footer).to eq(update_args[:invoice_footer])
+
+        billing = update_args[:billing_configuration]
+        expect(organization_response.invoice_footer).to eq(billing[:invoice_footer])
+        expect(organization_response.invoice_grace_period).to eq(billing[:invoice_grace_period])
+        expect(organization_response.vat_rate).to eq(billing[:vat_rate])
       end
     end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Description

The goal of this PR is to move fields related to Billing or Invoice into `billing_configuration`.

For customer: `invoice_grace_period`, `vat_rate`.

For organization: `invoice_footer`, `invoice_grace_period`, `vat_rate`.
