### PR TITLE
feat(timezone): Use timezone in billing service

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -32,6 +32,14 @@ class Subscription < ApplicationRecord
 
   scope :starting_in_the_future, -> { pending.where(previous_subscription: nil) }
 
+  # NOTE: SQL query to get subscription_date into customer timezone
+  def self.subscription_date_in_timezone_sql
+    <<-SQL
+      subscriptions.subscription_date::timestamptz AT TIME ZONE
+      COALESCE(customers.timezone, organizations.timezone, 'UTC')
+    SQL
+  end
+
   def mark_as_active!(timestamp = Time.zone.now)
     self.started_at ||= timestamp
     active!

--- a/app/services/billing_service.rb
+++ b/app/services/billing_service.rb
@@ -133,8 +133,8 @@ class BillingService
       .joins(:plan, customer: :organization)
       .anniversary
       .merge(Plan.yearly)
-      .where("DATE_PART(\'month\', (#{Subscription.subscription_date_in_timezone_sql})) = ?", today.month)
-      .where("DATE_PART(\'day\', (#{Subscription.subscription_date_in_timezone_sql})) IN (?)", days)
+      .where("DATE_PART('month', (#{Subscription.subscription_date_in_timezone_sql})) = ?", today.month)
+      .where("DATE_PART('day', (#{Subscription.subscription_date_in_timezone_sql})) IN (?)", days)
       .select(:id).to_sql
   end
 

--- a/app/services/billing_service.rb
+++ b/app/services/billing_service.rb
@@ -3,7 +3,7 @@
 class BillingService
   def call
     # Keep track of billing time for retry and tracking purpose
-    billing_timestamp = Time.zone.now.to_i
+    billing_timestamp = Time.current.to_i
 
     billable_subscriptions.group_by(&:customer_id).each do |_customer_id, customer_subscriptions|
       billing_subscriptions = []
@@ -33,66 +33,80 @@ class BillingService
 
   # NOTE: Retrieve list of subscriptions that should be billed today
   def billable_subscriptions
-    sql = []
+    sql = [
+      # NOTE: Calendar subscriptions
+      weekly_calendar,
+      monthly_calendar,
+      yearly_with_monthly_charges_calendar,
+      yearly_calendar,
 
-    # NOTE: Calendar subscriptions
-
-    # NOTE: For weekly interval we send invoices on Monday
-    sql << weekly_calendar if today.monday?
-
-    if today.day == 1
-      # NOTE: Billed monthly
-      sql << monthly_calendar
-
-      # NOTE: Bill charges monthly for yearly plans
-      sql << yearly_with_monthly_charges_calendar
-
-      # NOTE: Billed yearly and we are on the first day of the year
-      sql << yearly_calendar if today.month == 1
-    end
-
-    # NOTE: Anniversary subscriptions
-    sql << weekly_anniversary
-    sql << monthly_anniversary
-    sql << yearly_with_monthly_charges_anniversary
-    sql << yearly_anniversary
+      # NOTE: Anniversary subscriptions
+      weekly_anniversary,
+      monthly_anniversary,
+      yearly_with_monthly_charges_anniversary,
+      yearly_anniversary,
+    ]
 
     Subscription.where("id in (#{sql.join(' UNION ')})")
   end
 
+  # NOTE: For weekly interval we send invoices on Monday (ISODOW = 1)
   def weekly_calendar
-    Subscription.active.joins(:plan)
+    Subscription
+      .active
+      .joins(:plan)
+      .joins(customer: :organization)
       .calendar
       .merge(Plan.weekly)
+      .where("EXTRACT(ISODOW FROM (#{today_shift_sql})) = 1", today)
       .select(:id).to_sql
   end
 
+  # NOTE: Billed monthly on 1st day of the month
   def monthly_calendar
-    Subscription.active.joins(:plan)
+    Subscription
+      .active
+      .joins(:plan)
+      .joins(customer: :organization)
       .calendar
       .merge(Plan.monthly)
+      .where("DATE_PART('day', (#{today_shift_sql})) = 1", today)
       .select(:id).to_sql
   end
 
+  # NOTE: Bill charges monthly for yearly plans on 1st day of the month
   def yearly_with_monthly_charges_calendar
-    Subscription.active.joins(:plan)
+    Subscription
+      .active
+      .joins(:plan)
+      .joins(customer: :organization)
       .calendar
       .merge(Plan.yearly.where(bill_charges_monthly: true))
+      .where("DATE_PART('day', (#{today_shift_sql})) = 1", today)
       .select(:id).to_sql
   end
 
+  # NOTE: Billed yearly on first day of the year
   def yearly_calendar
-    Subscription.active.joins(:plan)
+    Subscription
+      .active
+      .joins(:plan)
+      .joins(customer: :organization)
       .calendar
       .merge(Plan.yearly)
+      .where("DATE_PART('month', (#{today_shift_sql})) = 1", today)
+      .where("DATE_PART('day', (#{today_shift_sql})) = 1", today)
       .select(:id).to_sql
   end
 
   def weekly_anniversary
-    Subscription.active.joins(:plan)
+    Subscription
+      .active
+      .joins(:plan)
+      .joins(customer: :organization)
       .anniversary
       .merge(Plan.weekly)
-      .where('EXTRACT(ISODOW FROM subscriptions.subscription_date) = ?', today.wday)
+      .where("EXTRACT(ISODOW FROM (#{timezone_shift_sql})) = ?", today.wday)
       .select(:id).to_sql
   end
 
@@ -103,10 +117,13 @@ class BillingService
     # we need to take all days up to 31 into account
     ((today.day + 1)..31).each { |day| days << day } if today.day == today.end_of_month.day
 
-    Subscription.active.joins(:plan)
+    Subscription
+      .active
+      .joins(:plan)
+      .joins(customer: :organization)
       .anniversary
       .merge(Plan.monthly)
-      .where('DATE_PART(\'day\', subscriptions.subscription_date) IN (?)', days)
+      .where("DATE_PART('day', (#{timezone_shift_sql})) IN (?)", days)
       .select(:id).to_sql
   end
 
@@ -117,11 +134,14 @@ class BillingService
     # If we are not in leap year and we are on 28/02 take 29/02 into account
     days << 29 if !Date.leap?(today.year) && today.day == 28 && today.month == 2
 
-    Subscription.active.joins(:plan)
+    Subscription
+      .active
+      .joins(:plan)
+      .joins(customer: :organization)
       .anniversary
       .merge(Plan.yearly)
-      .where('DATE_PART(\'month\', subscriptions.subscription_date) = ?', today.month)
-      .where('DATE_PART(\'day\', subscriptions.subscription_date) IN (?)', days)
+      .where("DATE_PART(\'month\', (#{timezone_shift_sql})) = ?", today.month)
+      .where("DATE_PART(\'day\', (#{timezone_shift_sql})) IN (?)", days)
       .select(:id).to_sql
   end
 
@@ -137,5 +157,19 @@ class BillingService
       .merge(Plan.yearly.where(bill_charges_monthly: true))
       .where('DATE_PART(\'day\', subscriptions.subscription_date) IN (?)', days)
       .select(:id).to_sql
+  end
+
+  def timezone_shift_sql
+    <<-SQL
+      subscriptions.subscription_date::timestamptz AT TIME ZONE
+      COALESCE(customers.timezone, organizations.timezone, 'UTC')
+    SQL
+  end
+
+  def today_shift_sql
+    <<-SQL
+      ?::timestamptz AT TIME ZONE
+      COALESCE(customers.timezone, organizations.timezone, 'UTC')
+    SQL
   end
 end

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -10,9 +10,10 @@ module Subscriptions
 
     def activate_all_pending
       Subscription
+        .joins(customer: :organization)
         .pending
         .where(previous_subscription: nil)
-        .where(subscription_date: Time.zone.at(timestamp).to_date)
+        .where("DATE(#{Subscription.subscription_date_in_timezone_sql}) = ?", Time.zone.at(timestamp).to_date)
         .find_each do |subscription|
           subscription.mark_as_active!(Time.zone.at(timestamp))
 

--- a/clock.rb
+++ b/clock.rb
@@ -16,12 +16,12 @@ module Clockwork
     Sentry.capture_exception(error)
   end
 
-  every(1.day, 'schedule:activate_subscriptions', at: '00:30') do
+  every(1.hour, 'schedule:activate_subscriptions', at: '**:30') do
     Clock::ActivateSubscriptionsJob.perform_later
   end
 
-  # NOTE: Keep at on a "plain hour" to prevent double billing on "time change" day
-  #       for countries located on an UTC-1
+  # NOTE: Keep "at" >= 1 to prevent double billing on "time change" day
+  #       for countries located on an UTC-1 timezone
   every(1.day, 'schedule:bill_customers', at: '01:00') do
     Clock::SubscriptionsBillerJob.perform_later
   end

--- a/clock.rb
+++ b/clock.rb
@@ -20,6 +20,8 @@ module Clockwork
     Clock::ActivateSubscriptionsJob.perform_later
   end
 
+  # NOTE: Keep at on a "plain hour" to prevent double billing on "time change" day
+  #       for countries located on an UTC-1
   every(1.day, 'schedule:bill_customers', at: '01:00') do
     Clock::SubscriptionsBillerJob.perform_later
   end

--- a/clock.rb
+++ b/clock.rb
@@ -16,6 +16,7 @@ module Clockwork
     Sentry.capture_exception(error)
   end
 
+  # NOTE: Run every hour to take customer timezone into account
   every(1.hour, 'schedule:activate_subscriptions', at: '**:30') do
     Clock::ActivateSubscriptionsJob.perform_later
   end

--- a/spec/services/billing_service_spec.rb
+++ b/spec/services/billing_service_spec.rb
@@ -289,13 +289,14 @@ RSpec.describe BillingService, type: :service do
           :subscription,
           subscription_date: subscription_date,
           started_at: Time.zone.now,
+          billing_time: :anniversary,
         )
       end
 
       before { subscription }
 
       it 'enqueues a job on billing day' do
-        current_date = DateTime.parse('01 Feb 2022')
+        current_date = DateTime.parse('20 Feb 2022')
 
         travel_to(current_date) do
           billing_service.call


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR updates `Clock::ActivateSubscriptionsJob` and `Clock::SubscriptionsBillerJob` to takes customer (assigned or inherited from organization) timezone into account
