### PR TITLE
feat(timezones): Apply customer timezone to date service

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -42,8 +42,8 @@ module Types
       end
 
       def period_end_date
-        ::Subscriptions::DatesService.new_instance(object, Time.zone.today)
-          .next_end_of_period(Time.zone.today)
+        ::Subscriptions::DatesService.new_instance(object, Time.current)
+          .next_end_of_period(Time.current)
       end
     end
   end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -105,7 +105,7 @@ class Subscription < ApplicationRecord
     return unless next_subscription.pending?
 
     ::Subscriptions::DatesService.new_instance(self, Time.zone.today)
-      .next_end_of_period(Time.zone.today) + 1.day
+      .next_end_of_period(Time.zone.today).to_date + 1.day
   end
 
   def display_name

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -104,8 +104,8 @@ class Subscription < ApplicationRecord
     return unless next_subscription
     return unless next_subscription.pending?
 
-    ::Subscriptions::DatesService.new_instance(self, Time.zone.today)
-      .next_end_of_period(Time.zone.today).to_date + 1.day
+    ::Subscriptions::DatesService.new_instance(self, Time.current)
+      .next_end_of_period(Time.current).to_date + 1.day
   end
 
   def display_name

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -80,6 +80,7 @@ module BillableMetrics
       # NOTE: Full period duration to take upgrade, terminate
       #       or start on non-anniversary day into account
       def period_duration
+        # TODO: pass a datetime argument
         @period_duration ||= Subscriptions::DatesService.new_instance(subscription, to_date + 1.day)
           .charges_duration_in_days
       end

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -216,7 +216,7 @@ module Fees
     end
 
     def date_service(subscription)
-      Subscriptions::DatesService.new_instance(subscription, Time.zone.at(boundaries.timestamp).to_date)
+      Subscriptions::DatesService.new_instance(subscription, Time.zone.at(boundaries.timestamp))
     end
 
     # NOTE: cost of a single day in a period

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -231,7 +231,7 @@ module Fees
 
       # NOTE: when plan is pay in advance, the_to date should be the
       #       end of the actual period
-      date_service(old_subscription).next_end_of_period(old_subscription.terminated_at.to_date)
+      date_service(old_subscription).next_end_of_period(old_subscription.terminated_at.to_date).to_date
     end
 
     def compute_from_date(target_subscription)

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -64,7 +64,7 @@ module Invoices
     def date_service(subscription)
       Subscriptions::DatesService.new_instance(
         subscription,
-        Time.zone.at(timestamp).to_date,
+        Time.zone.at(timestamp),
         current_usage: subscription.terminated? && subscription.upgraded?,
       )
     end

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -226,10 +226,10 @@ module Invoices
       date_service = date_service(subscription)
 
       {
-        from_date: date_service.from_date,
-        to_date: date_service.to_date,
-        charges_from_date: date_service.charges_from_date,
-        charges_to_date: date_service.charges_to_date,
+        from_date: date_service.from_datetime.to_date,
+        to_date: date_service.to_datetime.to_date,
+        charges_from_date: date_service.charges_from_datetime.to_date,
+        charges_to_date: date_service.charges_to_datetime.to_date,
         timestamp: timestamp,
       }
     end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -85,7 +85,7 @@ module Invoices
 
       date_service = Subscriptions::DatesService.new_instance(
         subscription,
-        Time.zone.now.to_date,
+        Time.current,
         current_usage: true,
       )
 

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -90,10 +90,10 @@ module Invoices
       )
 
       {
-        from_date: date_service.from_date,
-        to_date: date_service.to_date,
-        charges_from_date: date_service.charges_from_date,
-        charges_to_date: date_service.charges_to_date,
+        from_date: date_service.from_datetime.to_date,
+        to_date: date_service.to_datetime.to_date,
+        charges_from_date: date_service.charges_from_datetime.to_date,
+        charges_to_date: date_service.charges_to_datetime.to_date,
         issuing_date: date_service.next_end_of_period(Time.zone.now),
       }
     end

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -44,7 +44,7 @@ module Subscriptions
           return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_year
         end
 
-        return from_date if plan.pay_in_arrear?
+        return from_datetime if plan.pay_in_arrear?
         return base_date.beginning_of_year if calendar?
 
         previous_anniversary_day(base_date)

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -26,44 +26,45 @@ module Subscriptions
       @current_usage = current_usage
     end
 
-    def from_date
-      return @from_date if @from_date
+    def from_datetime
+      return @from_datetime if @from_datetime
 
-      @from_date = compute_from_date
+      @from_datetime = customer_timezone_shift(compute_from_date)
 
       # NOTE: On first billing period, subscription might start after the computed start of period
       #       ie: if we bill on beginning of period, and user registered on the 15th, the invoice should
       #       start on the 15th (subscription date) and not on the 1st
-      @from_date = subscription.started_at.to_date if @from_date < subscription.started_at
+      @from_datetime = subscription.started_at if @from_datetime < subscription.started_at
 
-      @from_date
+      @from_datetime
     end
 
-    def to_date
-      return @to_date if @to_date
+    def to_datetime
+      return @to_datetime if @to_datetime
 
-      @to_date = compute_to_date
-      @to_date = subscription.terminated_at.to_date if subscription.terminated? && @to_date > subscription.terminated_at
+      @to_datetime = customer_timezone_shift(compute_to_date, end_of_day: true)
+      @to_datetime = subscription.terminated_at if subscription.terminated? && @to_datetime > subscription.terminated_at
 
-      @to_date
+      @to_datetime
     end
 
-    def charges_from_date
-      date = compute_charges_from_date
-      date = subscription.started_at.to_date if date < subscription.started_at
+    def charges_from_datetime
+      datetime = customer_timezone_shift(compute_charges_from_date)
+      datetime = subscription.started_at if datetime < subscription.started_at
 
-      date
+      datetime
     end
 
-    def charges_to_date
-      date = compute_charges_to_date
-      date = subscription.terminated_at.to_date if subscription.terminated? && date > subscription.terminated_at
+    def charges_to_datetime
+      datetime = customer_timezone_shift(compute_charges_to_date, end_of_day: true)
+      datetime = subscription.terminated_at if subscription.terminated? && datetime > subscription.terminated_at
 
-      date
+      datetime
     end
 
     def next_end_of_period(date)
-      compute_next_end_of_period(date)
+      end_utc = compute_next_end_of_period(date)
+      customer_timezone_shift(end_utc, end_of_day: true)
     end
 
     # NOTE: Retrieve the beginning of the previous period based on the billing date
@@ -71,7 +72,8 @@ module Subscriptions
       date = base_date
       date = billing_date if current_period
 
-      compute_previous_beginning_of_period(date)
+      beginning_utc = compute_previous_beginning_of_period(date)
+      customer_timezone_shift(beginning_utc)
     end
 
     def single_day_price(optional_from_date: nil)
@@ -87,10 +89,16 @@ module Subscriptions
 
     attr_accessor :subscription, :billing_date, :current_usage
 
-    delegate :plan, :subscription_date, :calendar?, to: :subscription
+    delegate :plan, :subscription_date, :calendar?, :customer, to: :subscription
 
     def base_date
       @base_date ||= current_usage ? billing_date : compute_base_date
+    end
+
+    def customer_timezone_shift(date, end_of_day: false)
+      result = date.in_time_zone(customer.applicable_timezone)
+      result = result.end_of_day if end_of_day
+      result.utc
     end
 
     def terminated_pay_in_arrear?

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -9,35 +9,54 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
     create(
       :subscription,
       plan: plan,
+      customer: customer,
       subscription_date: subscription_date,
       billing_time: billing_time,
       started_at: started_at,
     )
   end
 
+  let(:customer) { create(:customer, timezone: timezone) }
   let(:plan) { create(:plan, interval: :monthly, pay_in_advance: pay_in_advance) }
   let(:pay_in_advance) { false }
 
   let(:subscription_date) { DateTime.parse('02 Feb 2021') }
   let(:billing_date) { DateTime.parse('07 Mar 2022') }
   let(:started_at) { subscription_date }
+  let(:timezone) { 'UTC' }
 
-  describe 'from_date' do
-    let(:result) { date_service.from_date.to_s }
+  describe 'from_datetime' do
+    let(:result) { date_service.from_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
       let(:billing_date) { DateTime.parse('01 Mar 2022') }
 
       it 'returns the beginning of the previous month' do
-        expect(result).to eq('2022-02-01')
+        expect(result).to eq('2022-02-01 00:00:00 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-02-01 05:00:00 UTC')
+        end
       end
 
       context 'when date is before the start date' do
-        let(:started_at) { DateTime.parse('07 Feb 2022') }
+        let(:started_at) { DateTime.parse('07 Feb 2022 05:00:00') }
 
         it 'returns the start date' do
-          expect(result).to eq(started_at.to_date.to_s)
+          expect(result).to eq(started_at.utc.to_s)
+        end
+
+        context 'with customer timezone' do
+          let(:timezone) { 'America/New_York' }
+
+          it 'returns the start date' do
+            expect(result).to eq(started_at.utc.to_s)
+          end
         end
       end
 
@@ -47,14 +66,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         before { subscription.terminated! }
 
         it 'returns the beginning of the month' do
-          expect(result).to eq('2022-03-01')
+          expect(result).to eq('2022-03-01 00:00:00 UTC')
         end
 
         context 'when plan is pay in advance' do
           let(:pay_in_advance) { true }
 
           it 'returns the beginning of the month' do
-            expect(result).to eq('2022-03-01')
+            expect(result).to eq('2022-03-01 00:00:00 UTC')
           end
         end
       end
@@ -65,14 +84,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       let(:billing_date) { DateTime.parse('02 Mar 2022') }
 
       it 'returns the day in the previous month day' do
-        expect(result).to eq('2022-02-02')
+        expect(result).to eq('2022-02-02 00:00:00 UTC')
       end
 
       context 'when date is before the start date' do
         let(:started_at) { DateTime.parse('08 Feb 2022') }
 
         it 'returns the start date' do
-          expect(result).to eq(started_at.to_date.to_s)
+          expect(result).to eq(started_at.utc.to_s)
         end
       end
 
@@ -82,14 +101,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         before { subscription.terminated! }
 
         it 'returns the previous month day' do
-          expect(result).to eq('2022-03-02')
+          expect(result).to eq('2022-03-02 00:00:00 UTC')
         end
 
         context 'when plan is pay in advance' do
           let(:pay_in_advance) { true }
 
           it 'returns the day in the current month' do
-            expect(result).to eq('2022-03-02')
+            expect(result).to eq('2022-03-02 00:00:00 UTC')
           end
         end
 
@@ -98,7 +117,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
           let(:subscription_date) { DateTime.parse('31 Mar 2021') }
 
           it 'returns the previous month last day' do
-            expect(result).to eq('2022-02-28')
+            expect(result).to eq('2022-02-28 00:00:00 UTC')
           end
         end
 
@@ -107,29 +126,37 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
           let(:subscription_date) { DateTime.parse('29 Mar 2021') }
 
           it 'returns the previous month last day' do
-            expect(result).to eq('2021-12-29')
+            expect(result).to eq('2021-12-29 00:00:00 UTC')
           end
         end
       end
     end
   end
 
-  describe 'to_date' do
-    let(:result) { date_service.to_date.to_s }
+  describe 'to_datetime' do
+    let(:result) { date_service.to_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
       let(:billing_date) { DateTime.parse('01 Mar 2022') }
 
       it 'returns the end of the previous month' do
-        expect(result).to eq('2022-02-28')
+        expect(result).to eq('2022-02-28 23:59:59 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-03-01 04:59:59 UTC')
+        end
       end
 
       context 'when plan is pay in advance' do
         let(:pay_in_advance) { true }
 
         it 'returns the end of the month' do
-          expect(result).to eq('2022-03-31')
+          expect(result).to eq('2022-03-31 23:59:59 UTC')
         end
       end
 
@@ -144,7 +171,15 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
+        end
+
+        context 'with customer timezone' do
+          let(:timezone) { 'America/New_York' }
+
+          it 'returns the termination date' do
+            expect(result).to eq(subscription.terminated_at.utc.to_s)
+          end
         end
       end
     end
@@ -154,14 +189,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       let(:billing_date) { DateTime.parse('02 Mar 2022') }
 
       it 'returns the day in the previous month' do
-        expect(result).to eq('2022-03-01')
+        expect(result).to eq('2022-03-01 23:59:59 UTC')
       end
 
       context 'when billing last month of year' do
         let(:billing_date) { DateTime.parse('04 Jan 2022') }
 
         it 'returns the day in the previous month' do
-          expect(result).to eq('2022-01-01')
+          expect(result).to eq('2022-01-01 23:59:59 UTC')
         end
       end
 
@@ -170,7 +205,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         let(:billing_date) { DateTime.parse('01 Mar 2022') }
 
         it 'returns the last day of the month' do
-          expect(result).to eq('2022-02-28')
+          expect(result).to eq('2022-02-28 23:59:59 UTC')
         end
       end
 
@@ -179,7 +214,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         let(:billing_date) { DateTime.parse('02 Mar 2022') }
 
         it 'returns the last day of the month' do
-          expect(result).to eq('2022-02-28')
+          expect(result).to eq('2022-02-28 23:59:59 UTC')
         end
       end
 
@@ -187,7 +222,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         before { plan.update!(pay_in_advance: true) }
 
         it 'returns the end of the current period' do
-          expect(result).to eq('2022-04-01')
+          expect(result).to eq('2022-04-01 23:59:59 UTC')
         end
       end
 
@@ -202,28 +237,36 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
         end
       end
     end
   end
 
-  describe 'charges_from_date' do
-    let(:result) { date_service.charges_from_date.to_s }
+  describe 'charges_from_datetime' do
+    let(:result) { date_service.charges_from_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
       let(:billing_date) { DateTime.parse('01 Mar 2022') }
 
-      it 'returns from_date' do
-        expect(result).to eq(date_service.from_date.to_s)
+      it 'returns from_datetime' do
+        expect(result).to eq(date_service.from_datetime.to_s)
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq(date_service.from_datetime.to_s)
+        end
       end
 
       context 'when subscription started in the middle of a period' do
         let(:started_at) { DateTime.parse('03 Mar 2022') }
 
         it 'returns the start date' do
-          expect(result).to eq(subscription.started_at.to_date.to_s)
+          expect(result).to eq(subscription.started_at.utc.to_s)
         end
       end
 
@@ -232,7 +275,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         let(:subscription_date) { DateTime.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
-          expect(result).to eq('2022-02-01')
+          expect(result).to eq('2022-02-01 00:00:00 UTC')
         end
       end
     end
@@ -241,15 +284,15 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       let(:billing_time) { :anniversary }
       let(:billing_date) { DateTime.parse('02 Mar 2022') }
 
-      it 'returns from_date' do
-        expect(result).to eq(date_service.from_date.to_s)
+      it 'returns from_datetime' do
+        expect(result).to eq(date_service.from_datetime.to_s)
       end
 
       context 'when subscription started in the middle of a period' do
         let(:started_at) { DateTime.parse('03 Mar 2022') }
 
         it 'returns the start date' do
-          expect(result).to eq(subscription.started_at.to_date.to_s)
+          expect(result).to eq(subscription.started_at.utc.to_s)
         end
       end
 
@@ -258,20 +301,28 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         let(:subscription_date) { DateTime.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
-          expect(result).to eq('2022-02-02')
+          expect(result).to eq('2022-02-02 00:00:00 UTC')
         end
       end
     end
   end
 
-  describe 'charges_to_date' do
-    let(:result) { date_service.charges_to_date.to_s }
+  describe 'charges_to_datetime' do
+    let(:result) { date_service.charges_to_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
 
       it 'returns to_date' do
-        expect(result).to eq(date_service.to_date.to_s)
+        expect(result).to eq(date_service.to_datetime.to_s)
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq(date_service.to_datetime.to_s)
+        end
       end
 
       context 'when subscription is terminated in the middle of a period' do
@@ -282,7 +333,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         end
 
         it 'returns the terminated date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
         end
       end
 
@@ -290,7 +341,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         let(:pay_in_advance) { true }
 
         it 'returns the end of the previous period' do
-          expect(result).to eq((date_service.from_date - 1.day).to_s)
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
         end
       end
     end
@@ -300,7 +351,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       let(:billing_date) { DateTime.parse('02 Mar 2022') }
 
       it 'returns to_date' do
-        expect(result).to eq(date_service.to_date.to_s)
+        expect(result).to eq(date_service.to_datetime.to_s)
       end
 
       context 'when subscription is terminated in the middle of a period' do
@@ -311,7 +362,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         end
 
         it 'returns the terminated date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
         end
       end
 
@@ -319,7 +370,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         let(:pay_in_advance) { true }
 
         it 'returns the end of the previous period' do
-          expect(result).to eq((date_service.from_date - 1.day).to_s)
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
         end
       end
     end
@@ -332,7 +383,15 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       let(:billing_time) { :calendar }
 
       it 'returns the last day of the month' do
-        expect(result).to eq('2022-03-31')
+        expect(result).to eq('2022-03-31 23:59:59 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-04-01 03:59:59 UTC')
+        end
       end
     end
 
@@ -340,20 +399,28 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       let(:billing_time) { :anniversary }
 
       it 'returns the end of the billing month' do
-        expect(result).to eq('2022-04-01')
+        expect(result).to eq('2022-04-01 23:59:59 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-04-02 03:59:59 UTC')
+        end
       end
 
       context 'when end of billing month is in next year' do
         let(:billing_date) { DateTime.parse('07 Dec 2021') }
 
-        it { expect(result).to eq('2022-01-01') }
+        it { expect(result).to eq('2022-01-01 23:59:59 UTC') }
       end
 
       context 'when date is the end of the period' do
         let(:billing_date) { DateTime.parse('01 Mar 2022') }
 
         it 'returns the date' do
-          expect(result).to eq(billing_date.to_date.to_s)
+          expect(result).to eq(billing_date.utc.end_of_day.to_s)
         end
       end
     end
@@ -368,14 +435,22 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       let(:billing_time) { :calendar }
 
       it 'returns the first day of the previous month' do
-        expect(result).to eq('2022-02-01')
+        expect(result).to eq('2022-02-01 00:00:00 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-02-01 05:00:00 UTC')
+        end
       end
 
       context 'with current period argument' do
         let(:current_period) { true }
 
         it 'returns the first day of the month' do
-          expect(result).to eq('2022-03-01')
+          expect(result).to eq('2022-03-01 00:00:00 UTC')
         end
       end
     end
@@ -384,14 +459,22 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       let(:billing_time) { :anniversary }
 
       it 'returns the beginning of the previous period' do
-        expect(result).to eq('2022-02-02')
+        expect(result).to eq('2022-02-02 00:00:00 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-02-02 05:00:00 UTC')
+        end
       end
 
       context 'with current period argument' do
         let(:current_period) { true }
 
         it 'returns the beginning of the current period' do
-          expect(result).to eq('2022-03-02')
+          expect(result).to eq('2022-03-02 00:00:00 UTC')
         end
       end
     end

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
-  subject(:date_service) { described_class.new(subscription, billing_date, false) }
+  subject(:date_service) { described_class.new(subscription, billing_at, false) }
 
   let(:subscription) do
     create(
@@ -21,7 +21,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
   let(:pay_in_advance) { false }
 
   let(:subscription_date) { DateTime.parse('02 Feb 2021') }
-  let(:billing_date) { DateTime.parse('07 Mar 2022') }
+  let(:billing_at) { DateTime.parse('07 Mar 2022') }
   let(:started_at) { subscription_date }
   let(:timezone) { 'UTC' }
 
@@ -30,7 +30,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_date) { DateTime.parse('01 Mar 2022') }
+      let(:billing_at) { DateTime.parse('01 Mar 2022') }
 
       it 'returns the beginning of the previous month' do
         expect(result).to eq('2022-02-01 00:00:00 UTC')
@@ -40,7 +40,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2022-02-01 05:00:00 UTC')
+          expect(result).to eq('2022-01-01 05:00:00 UTC')
         end
       end
 
@@ -61,7 +61,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_date) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { DateTime.parse('10 Mar 2022') }
 
         before { subscription.terminated! }
 
@@ -81,7 +81,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('02 Mar 2022') }
+      let(:billing_at) { DateTime.parse('02 Mar 2022') }
 
       it 'returns the day in the previous month day' do
         expect(result).to eq('2022-02-02 00:00:00 UTC')
@@ -96,7 +96,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_date) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { DateTime.parse('10 Mar 2022') }
 
         before { subscription.terminated! }
 
@@ -113,7 +113,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         end
 
         context 'when billing day after last day of billing month' do
-          let(:billing_date) { DateTime.parse('29 Mar 2022') }
+          let(:billing_at) { DateTime.parse('29 Mar 2022') }
           let(:subscription_date) { DateTime.parse('31 Mar 2021') }
 
           it 'returns the previous month last day' do
@@ -122,7 +122,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         end
 
         context 'when billing day on first month of the year' do
-          let(:billing_date) { DateTime.parse('28 Jan 2022') }
+          let(:billing_at) { DateTime.parse('28 Jan 2022') }
           let(:subscription_date) { DateTime.parse('29 Mar 2021') }
 
           it 'returns the previous month last day' do
@@ -138,7 +138,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_date) { DateTime.parse('01 Mar 2022') }
+      let(:billing_at) { DateTime.parse('01 Mar 2022') }
 
       it 'returns the end of the previous month' do
         expect(result).to eq('2022-02-28 23:59:59 UTC')
@@ -148,7 +148,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2022-03-01 04:59:59 UTC')
+          expect(result).to eq('2022-02-01 04:59:59 UTC')
         end
       end
 
@@ -161,7 +161,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_date) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { DateTime.parse('10 Mar 2022') }
 
         before do
           subscription.update!(
@@ -186,14 +186,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('02 Mar 2022') }
+      let(:billing_at) { DateTime.parse('02 Mar 2022') }
 
       it 'returns the day in the previous month' do
         expect(result).to eq('2022-03-01 23:59:59 UTC')
       end
 
       context 'when billing last month of year' do
-        let(:billing_date) { DateTime.parse('04 Jan 2022') }
+        let(:billing_at) { DateTime.parse('04 Jan 2022') }
 
         it 'returns the day in the previous month' do
           expect(result).to eq('2022-01-01 23:59:59 UTC')
@@ -202,7 +202,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       context 'when billing subscription day does not exist in the month' do
         let(:subscription_date) { DateTime.parse('31 Jan 2022') }
-        let(:billing_date) { DateTime.parse('01 Mar 2022') }
+        let(:billing_at) { DateTime.parse('01 Mar 2022') }
 
         it 'returns the last day of the month' do
           expect(result).to eq('2022-02-28 23:59:59 UTC')
@@ -211,7 +211,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       context 'when anniversary date is first day of the month' do
         let(:subscription_date) { DateTime.parse('01 Jan 2022') }
-        let(:billing_date) { DateTime.parse('02 Mar 2022') }
+        let(:billing_at) { DateTime.parse('02 Mar 2022') }
 
         it 'returns the last day of the month' do
           expect(result).to eq('2022-02-28 23:59:59 UTC')
@@ -227,7 +227,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_date) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { DateTime.parse('10 Mar 2022') }
 
         before do
           subscription.update!(
@@ -248,7 +248,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_date) { DateTime.parse('01 Mar 2022') }
+      let(:billing_at) { DateTime.parse('01 Mar 2022') }
 
       it 'returns from_datetime' do
         expect(result).to eq(date_service.from_datetime.to_s)
@@ -282,7 +282,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('02 Mar 2022') }
+      let(:billing_at) { DateTime.parse('02 Mar 2022') }
 
       it 'returns from_datetime' do
         expect(result).to eq(date_service.from_datetime.to_s)
@@ -348,7 +348,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('02 Mar 2022') }
+      let(:billing_at) { DateTime.parse('02 Mar 2022') }
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
@@ -377,7 +377,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
   end
 
   describe 'next_end_of_period' do
-    let(:result) { date_service.next_end_of_period(billing_date.to_date).to_s }
+    let(:result) { date_service.next_end_of_period(billing_at.to_date).to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
@@ -411,16 +411,16 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when end of billing month is in next year' do
-        let(:billing_date) { DateTime.parse('07 Dec 2021') }
+        let(:billing_at) { DateTime.parse('07 Dec 2021') }
 
         it { expect(result).to eq('2022-01-01 23:59:59 UTC') }
       end
 
       context 'when date is the end of the period' do
-        let(:billing_date) { DateTime.parse('01 Mar 2022') }
+        let(:billing_at) { DateTime.parse('01 Mar 2022') }
 
         it 'returns the date' do
-          expect(result).to eq(billing_date.utc.end_of_day.to_s)
+          expect(result).to eq(billing_at.utc.end_of_day.to_s)
         end
       end
     end
@@ -492,7 +492,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       context 'when on a leap year' do
         let(:subscription_date) { DateTime.parse('28 Feb 2019') }
-        let(:billing_date) { DateTime.parse('01 Mar 2020') }
+        let(:billing_at) { DateTime.parse('01 Mar 2020') }
 
         it 'returns the price of single day' do
           expect(result).to eq(plan.amount_cents.fdiv(29))
@@ -509,7 +509,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       context 'when on a leap year' do
         let(:subscription_date) { DateTime.parse('02 Feb 2019') }
-        let(:billing_date) { DateTime.parse('08 Mar 2020') }
+        let(:billing_at) { DateTime.parse('08 Mar 2020') }
 
         it 'returns the price of single day' do
           expect(result).to eq(plan.amount_cents.fdiv(29))
@@ -530,7 +530,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       context 'when on a leap year' do
         let(:subscription_date) { DateTime.parse('28 Feb 2019') }
-        let(:billing_date) { DateTime.parse('01 Mar 2020') }
+        let(:billing_at) { DateTime.parse('01 Mar 2020') }
 
         it 'returns the month duration' do
           expect(result).to eq(29)
@@ -547,7 +547,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       context 'when on a leap year' do
         let(:subscription_date) { DateTime.parse('02 Feb 2019') }
-        let(:billing_date) { DateTime.parse('08 Mar 2020') }
+        let(:billing_at) { DateTime.parse('08 Mar 2020') }
 
         it 'returns the month duration' do
           expect(result).to eq(29)

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -9,35 +9,54 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
     create(
       :subscription,
       plan: plan,
+      customer: customer,
       subscription_date: subscription_date,
       billing_time: billing_time,
       started_at: started_at,
     )
   end
 
+  let(:customer) { create(:customer, timezone: timezone) }
   let(:plan) { create(:plan, interval: :weekly, pay_in_advance: pay_in_advance) }
   let(:pay_in_advance) { false }
 
   let(:subscription_date) { DateTime.parse('02 Feb 2021') }
   let(:billing_date) { DateTime.parse('07 Mar 2022') }
   let(:started_at) { subscription_date }
+  let(:timezone) { 'UTC' }
 
-  describe 'from_date' do
-    let(:result) { date_service.from_date.to_s }
+  describe 'from_datetime' do
+    let(:result) { date_service.from_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
 
       it 'returns the beginning of the previous week' do
-        expect(result).to eq('2022-02-28')
+        expect(result).to eq('2022-02-28 00:00:00 UTC')
         expect(Time.zone.parse(result).wday).to eq(1)
       end
 
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-02-28 05:00:00 UTC')
+        end
+      end
+
       context 'when date is before the start date' do
-        let(:started_at) { DateTime.parse('01 Mar 2022') }
+        let(:started_at) { DateTime.parse('01 Mar 2022 05:00:00') }
 
         it 'returns the start date' do
-          expect(result).to eq(started_at.to_date.to_s)
+          expect(result).to eq(started_at.utc.to_s)
+        end
+
+        context 'with customer timezone' do
+          let(:timezone) { 'America/New_York' }
+
+          it 'returns the start date' do
+            expect(result).to eq(started_at.utc.to_s)
+          end
         end
       end
 
@@ -47,7 +66,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         before { subscription.terminated! }
 
         it 'returns the beginning of the week' do
-          expect(result).to eq('2022-03-07')
+          expect(result).to eq('2022-03-07 00:00:00 UTC')
           expect(Time.zone.parse(result).wday).to eq(1)
         end
 
@@ -55,7 +74,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
           let(:pay_in_advance) { true }
 
           it 'returns the beginning of the current week' do
-            expect(result).to eq('2022-03-07')
+            expect(result).to eq('2022-03-07 00:00:00 UTC')
             expect(Time.zone.parse(result).wday).to eq(1)
           end
         end
@@ -67,7 +86,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       let(:billing_date) { DateTime.parse('09 Mar 2022') }
 
       it 'returns the previous week week day' do
-        expect(result).to eq('2022-03-01')
+        expect(result).to eq('2022-03-01 00:00:00 UTC')
         expect(Time.zone.parse(result).wday).to eq(subscription_date.wday)
       end
 
@@ -75,7 +94,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         let(:started_at) { DateTime.parse('08 Mar 2022') }
 
         it 'returns the start date' do
-          expect(result).to eq(started_at.to_date.to_s)
+          expect(result).to eq(started_at.utc.to_s)
           expect(Time.zone.parse(result).wday).to eq(subscription_date.wday)
         end
       end
@@ -84,7 +103,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         before { subscription.terminated! }
 
         it 'returns the previous week day' do
-          expect(result).to eq('2022-03-08')
+          expect(result).to eq('2022-03-08 00:00:00 UTC')
           expect(Time.zone.parse(result).wday).to eq(subscription_date.wday)
         end
 
@@ -92,7 +111,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
           let(:pay_in_advance) { true }
 
           it 'returns the current week week day' do
-            expect(result).to eq('2022-03-08')
+            expect(result).to eq('2022-03-08 00:00:00 UTC')
             expect(Time.zone.parse(result).wday).to eq(subscription_date.wday)
           end
         end
@@ -100,22 +119,30 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
     end
   end
 
-  describe 'to_date' do
-    let(:result) { date_service.to_date.to_s }
+  describe 'to_datetime' do
+    let(:result) { date_service.to_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
       let(:billing_date) { DateTime.parse('07 Mar 2022') }
 
       it 'returns the end of the previous week' do
-        expect(result).to eq('2022-03-06')
+        expect(result).to eq('2022-03-06 23:59:59 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-03-07 04:59:59 UTC')
+        end
       end
 
       context 'when plan is pay in advance' do
         before { plan.update!(pay_in_advance: true) }
 
         it 'returns the end of the week' do
-          expect(result).to eq('2022-03-13')
+          expect(result).to eq('2022-03-13 23:59:59 UTC')
           expect(Time.zone.parse(result).wday).to eq(0)
         end
       end
@@ -132,7 +159,15 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
+        end
+
+        context 'with customer timezone' do
+          let(:timezone) { 'America/New_York' }
+
+          it 'returns the termination date' do
+            expect(result).to eq(subscription.terminated_at.utc.to_s)
+          end
         end
       end
     end
@@ -142,14 +177,14 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       let(:billing_date) { DateTime.parse('09 Mar 2022') }
 
       it 'returns the previous week week day' do
-        expect(result).to eq('2022-03-07')
+        expect(result).to eq('2022-03-07 23:59:59 UTC')
       end
 
       context 'when plan is pay in advance' do
         before { plan.update!(pay_in_advance: true) }
 
         it 'returns the end of the current period' do
-          expect(result).to eq('2022-03-14')
+          expect(result).to eq('2022-03-14 23:59:59 UTC')
         end
       end
 
@@ -162,27 +197,35 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
         end
       end
     end
   end
 
-  describe 'charges_from_date' do
-    let(:result) { date_service.charges_from_date.to_s }
+  describe 'charges_from_datetime' do
+    let(:result) { date_service.charges_from_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
 
       it 'returns from_date' do
-        expect(result).to eq(date_service.from_date.to_s)
+        expect(result).to eq(date_service.from_datetime.to_s)
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq(date_service.from_datetime.to_s)
+        end
       end
 
       context 'when subscription started in the middle of a period' do
         let(:started_at) { DateTime.parse('03 Mar 2022') }
 
         it 'returns the start date' do
-          expect(result).to eq(subscription.started_at.to_date.to_s)
+          expect(result).to eq(subscription.started_at.utc.to_s)
         end
       end
 
@@ -190,7 +233,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         let(:pay_in_advance) { true }
 
         it 'returns the start of the previous period' do
-          expect(result).to eq((date_service.from_date - 1.week).to_s)
+          expect(result).to eq((date_service.from_datetime - 1.week).to_s)
         end
       end
     end
@@ -200,14 +243,14 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       let(:billing_date) { DateTime.parse('09 Mar 2022') }
 
       it 'returns from_date' do
-        expect(result).to eq(date_service.from_date.to_s)
+        expect(result).to eq(date_service.from_datetime.to_s)
       end
 
       context 'when subscription started in the middle of a period' do
         let(:started_at) { DateTime.parse('03 Mar 2022') }
 
         it 'returns the start date' do
-          expect(result).to eq(subscription.started_at.to_date.to_s)
+          expect(result).to eq(subscription.started_at.utc.to_s)
         end
       end
 
@@ -215,20 +258,28 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         let(:pay_in_advance) { true }
 
         it 'returns the start of the previous period' do
-          expect(result).to eq((date_service.from_date - 1.week).to_s)
+          expect(result).to eq((date_service.from_datetime - 1.week).to_s)
         end
       end
     end
   end
 
-  describe 'charges_to_date' do
-    let(:result) { date_service.charges_to_date.to_s }
+  describe 'charges_to_datetime' do
+    let(:result) { date_service.charges_to_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
 
       it 'returns to_date' do
-        expect(result).to eq(date_service.to_date.to_s)
+        expect(result).to eq(date_service.to_datetime.to_s)
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq(date_service.to_datetime.to_s)
+        end
       end
 
       context 'when subscription is terminated in the middle of a period' do
@@ -239,7 +290,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         end
 
         it 'returns the terminated date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
         end
       end
 
@@ -247,7 +298,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         let(:pay_in_advance) { true }
 
         it 'returns the end of the previous period' do
-          expect(result).to eq((date_service.from_date - 1.day).to_s)
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
         end
       end
     end
@@ -257,7 +308,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       let(:billing_date) { DateTime.parse('09 Mar 2022') }
 
       it 'returns to_date' do
-        expect(result).to eq(date_service.to_date.to_s)
+        expect(result).to eq(date_service.to_datetime.to_s)
       end
 
       context 'when subscription is terminated in the middle of a period' do
@@ -268,7 +319,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         end
 
         it 'returns the terminated date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
         end
       end
 
@@ -276,7 +327,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         let(:pay_in_advance) { true }
 
         it 'returns the end of the previous period' do
-          expect(result).to eq((date_service.from_date - 1.day).to_s)
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
         end
       end
     end
@@ -289,7 +340,15 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       let(:billing_time) { :calendar }
 
       it 'returns the last day of the week' do
-        expect(result).to eq('2022-03-13')
+        expect(result).to eq('2022-03-13 23:59:59 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-03-14 03:59:59 UTC')
+        end
       end
     end
 
@@ -298,14 +357,22 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       let(:billing_date) { DateTime.parse('08 Mar 2022') }
 
       it 'returns the end of the billing week' do
-        expect(result).to eq('2022-03-14')
+        expect(result).to eq('2022-03-14 23:59:59 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-03-15 03:59:59 UTC')
+        end
       end
 
       context 'when date is the end of the period' do
         let(:billing_date) { DateTime.parse('07 Mar 2022') }
 
         it 'returns the date' do
-          expect(result).to eq(billing_date.to_date.to_s)
+          expect(result).to eq(billing_date.utc.end_of_day.to_s)
         end
       end
     end
@@ -320,14 +387,22 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       let(:billing_time) { :calendar }
 
       it 'returns the first day of the previous week' do
-        expect(result).to eq('2022-02-28')
+        expect(result).to eq('2022-02-28 00:00:00 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-02-28 05:00:00 UTC')
+        end
       end
 
       context 'with current period argument' do
         let(:current_period) { true }
 
         it 'returns the first day of the week' do
-          expect(result).to eq('2022-03-07')
+          expect(result).to eq('2022-03-07 00:00:00 UTC')
         end
       end
     end
@@ -336,14 +411,22 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       let(:billing_time) { :anniversary }
 
       it 'returns the beginning of the previous period' do
-        expect(result).to eq('2022-02-22')
+        expect(result).to eq('2022-02-22 00:00:00 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-02-22 05:00:00 UTC')
+        end
       end
 
       context 'with current period argument' do
         let(:current_period) { true }
 
         it 'returns the beginning of the current period' do
-          expect(result).to eq('2022-03-01')
+          expect(result).to eq('2022-03-01 00:00:00 UTC')
         end
       end
     end

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
-  subject(:date_service) { described_class.new(subscription, billing_date, false) }
+  subject(:date_service) { described_class.new(subscription, billing_at, false) }
 
   let(:subscription) do
     create(
@@ -21,7 +21,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
   let(:pay_in_advance) { false }
 
   let(:subscription_date) { DateTime.parse('02 Feb 2021') }
-  let(:billing_date) { DateTime.parse('07 Mar 2022') }
+  let(:billing_at) { DateTime.parse('07 Mar 2022') }
   let(:started_at) { subscription_date }
   let(:timezone) { 'UTC' }
 
@@ -40,7 +40,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2022-02-28 05:00:00 UTC')
+          expect(result).to eq('2022-02-21 05:00:00 UTC')
         end
       end
 
@@ -61,7 +61,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_date) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { DateTime.parse('10 Mar 2022') }
 
         before { subscription.terminated! }
 
@@ -83,7 +83,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('09 Mar 2022') }
+      let(:billing_at) { DateTime.parse('09 Mar 2022') }
 
       it 'returns the previous week week day' do
         expect(result).to eq('2022-03-01 00:00:00 UTC')
@@ -124,7 +124,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_date) { DateTime.parse('07 Mar 2022') }
+      let(:billing_at) { DateTime.parse('07 Mar 2022') }
 
       it 'returns the end of the previous week' do
         expect(result).to eq('2022-03-06 23:59:59 UTC')
@@ -134,7 +134,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2022-03-07 04:59:59 UTC')
+          expect(result).to eq('2022-02-28 04:59:59 UTC')
         end
       end
 
@@ -148,7 +148,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_date) { DateTime.parse('07 Mar 2022') }
+        let(:billing_at) { DateTime.parse('07 Mar 2022') }
         let(:terminated_at) { DateTime.parse('02 Mar 2022') }
 
         before do
@@ -174,7 +174,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('09 Mar 2022') }
+      let(:billing_at) { DateTime.parse('09 Mar 2022') }
 
       it 'returns the previous week week day' do
         expect(result).to eq('2022-03-07 23:59:59 UTC')
@@ -240,7 +240,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('09 Mar 2022') }
+      let(:billing_at) { DateTime.parse('09 Mar 2022') }
 
       it 'returns from_date' do
         expect(result).to eq(date_service.from_datetime.to_s)
@@ -305,7 +305,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('09 Mar 2022') }
+      let(:billing_at) { DateTime.parse('09 Mar 2022') }
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
@@ -334,7 +334,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
   end
 
   describe 'next_end_of_period' do
-    let(:result) { date_service.next_end_of_period(billing_date.to_date).to_s }
+    let(:result) { date_service.next_end_of_period(billing_at.to_date).to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
@@ -354,7 +354,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('08 Mar 2022') }
+      let(:billing_at) { DateTime.parse('08 Mar 2022') }
 
       it 'returns the end of the billing week' do
         expect(result).to eq('2022-03-14 23:59:59 UTC')
@@ -369,10 +369,10 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       end
 
       context 'when date is the end of the period' do
-        let(:billing_date) { DateTime.parse('07 Mar 2022') }
+        let(:billing_at) { DateTime.parse('07 Mar 2022') }
 
         it 'returns the date' do
-          expect(result).to eq(billing_date.utc.end_of_day.to_s)
+          expect(result).to eq(billing_at.utc.end_of_day.to_s)
         end
       end
     end
@@ -394,7 +394,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2022-02-28 05:00:00 UTC')
+          expect(result).to eq('2022-02-21 05:00:00 UTC')
         end
       end
 
@@ -434,7 +434,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
   describe 'single_day_price' do
     let(:billing_time) { :anniversary }
-    let(:billing_date) { DateTime.parse('08 Mar 2022') }
+    let(:billing_at) { DateTime.parse('08 Mar 2022') }
     let(:result) { date_service.single_day_price }
 
     it 'returns the price of single day' do
@@ -444,7 +444,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
   describe 'charges_duration_in_days' do
     let(:billing_time) { :anniversary }
-    let(:billing_date) { DateTime.parse('08 Mar 2022') }
+    let(:billing_at) { DateTime.parse('08 Mar 2022') }
     let(:result) { date_service.charges_duration_in_days }
 
     it 'returns the duration of the period' do

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -9,21 +9,24 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
     create(
       :subscription,
       plan: plan,
+      customer: customer,
       subscription_date: subscription_date,
       billing_time: billing_time,
       started_at: started_at,
     )
   end
 
+  let(:customer) { create(:customer, timezone: timezone) }
   let(:plan) { create(:plan, interval: :yearly, pay_in_advance: pay_in_advance) }
   let(:pay_in_advance) { false }
 
   let(:subscription_date) { DateTime.parse('02 Feb 2021') }
   let(:billing_date) { DateTime.parse('07 Mar 2022') }
   let(:started_at) { subscription_date }
+  let(:timezone) { 'UTC' }
 
-  describe 'from_date' do
-    let(:result) { date_service.from_date.to_s }
+  describe 'from_datetime' do
+    let(:result) { date_service.from_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
@@ -31,14 +34,30 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       let(:subscription_date) { DateTime.parse('02 Feb 2020') }
 
       it 'returns the beginning of the previous year' do
-        expect(result).to eq('2021-01-01')
+        expect(result).to eq('2021-01-01 00:00:00 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2021-01-01 05:00:00 UTC')
+        end
       end
 
       context 'when date is before the start date' do
         let(:started_at) { DateTime.parse('07 Feb 2021') }
 
         it 'returns the start date' do
-          expect(result).to eq(started_at.to_date.to_s)
+          expect(result).to eq(started_at.utc.to_s)
+        end
+
+        context 'with customer timezone' do
+          let(:timezone) { 'America/New_York' }
+
+          it 'returns the start date' do
+            expect(result).to eq('2021-02-07 00:00:00 UTC')
+          end
         end
       end
 
@@ -48,14 +67,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         before { subscription.terminated! }
 
         it 'returns the beginning of the year' do
-          expect(result).to eq('2022-01-01')
+          expect(result).to eq('2022-01-01 00:00:00 UTC')
         end
 
         context 'when plan is pay in advance' do
           let(:pay_in_advance) { true }
 
           it 'returns the beginning of the current year' do
-            expect(result).to eq('2022-01-01')
+            expect(result).to eq('2022-01-01 00:00:00 UTC')
           end
         end
       end
@@ -66,14 +85,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       let(:billing_date) { DateTime.parse('02 Feb 2022') }
 
       it 'returns the previous year day and month' do
-        expect(result).to eq('2021-02-02')
+        expect(result).to eq('2021-02-02 00:00:00 UTC')
       end
 
       context 'when date is before the start date' do
         let(:started_at) { DateTime.parse('02 Sep 2022') }
 
         it 'returns the start date' do
-          expect(result).to eq(started_at.to_date.to_s)
+          expect(result).to eq(started_at.utc.to_s)
         end
       end
 
@@ -81,14 +100,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         before { subscription.terminated! }
 
         it 'returns the previous year day' do
-          expect(result).to eq('2022-02-02')
+          expect(result).to eq('2022-02-02 00:00:00 UTC')
         end
 
         context 'when plan is pay in advance' do
           let(:pay_in_advance) { true }
 
           it 'returns the current year day and month' do
-            expect(result).to eq('2022-02-02')
+            expect(result).to eq('2022-02-02 00:00:00 UTC')
           end
         end
 
@@ -97,7 +116,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
           let(:billing_date) { DateTime.parse('28 Mar 2022') }
 
           it 'returns the previous month last day' do
-            expect(result).to eq('2022-02-28')
+            expect(result).to eq('2022-02-28 00:00:00 UTC')
           end
         end
 
@@ -105,15 +124,15 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
           let(:billing_date) { DateTime.parse('03 Jan 2022') }
 
           it 'returns the previous year day' do
-            expect(result).to eq('2021-02-02')
+            expect(result).to eq('2021-02-02 00:00:00 UTC')
           end
         end
       end
     end
   end
 
-  describe 'to_date' do
-    let(:result) { date_service.to_date.to_s }
+  describe 'to_datetime' do
+    let(:result) { date_service.to_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
@@ -121,14 +140,22 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       let(:subscription_date) { DateTime.parse('02 Feb 2020') }
 
       it 'returns the end of the previous year' do
-        expect(result).to eq('2021-12-31')
+        expect(result).to eq('2021-12-31 23:59:59 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2022-01-01 04:59:59 UTC')
+        end
       end
 
       context 'when plan is pay in advance' do
         before { plan.update!(pay_in_advance: true) }
 
         it 'returns the end of the currrent year' do
-          expect(result).to eq('2022-12-31')
+          expect(result).to eq('2022-12-31 23:59:59 UTC')
         end
       end
 
@@ -143,7 +170,15 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
+        end
+
+        context 'with customer timezone' do
+          let(:timezone) { 'America/New_York' }
+
+          it 'returns the termination date' do
+            expect(result).to eq(subscription.terminated_at.utc.to_s)
+          end
         end
       end
     end
@@ -153,7 +188,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       let(:billing_date) { DateTime.parse('02 Feb 2022') }
 
       it 'returns the previous year day and month' do
-        expect(result).to eq('2022-02-01')
+        expect(result).to eq('2022-02-01 23:59:59 UTC')
       end
 
       context 'when subscription date on 29/02 of a leap year' do
@@ -161,7 +196,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:billing_date) { DateTime.parse('01 Mar 2022') }
 
         it 'returns the previous month last day' do
-          expect(result).to eq('2022-02-28')
+          expect(result).to eq('2022-02-28 23:59:59 UTC')
         end
       end
 
@@ -170,7 +205,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:billing_date) { DateTime.parse('02 Mar 2022') }
 
         it 'returns the last day of the year' do
-          expect(result).to eq('2021-12-31')
+          expect(result).to eq('2021-12-31 23:59:59 UTC')
         end
       end
 
@@ -179,7 +214,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:billing_date) { DateTime.parse('02 Jan 2024') }
 
         it 'returns the last day of the previous month on next year' do
-          expect(result).to eq('2023-11-30')
+          expect(result).to eq('2023-11-30 23:59:59 UTC')
         end
       end
 
@@ -187,7 +222,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         before { plan.update!(pay_in_advance: true) }
 
         it 'returns the end of the current period' do
-          expect(result).to eq('2023-02-01')
+          expect(result).to eq('2023-02-01 23:59:59 UTC')
         end
       end
 
@@ -200,14 +235,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         it 'returns the termination date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
         end
       end
     end
   end
 
-  describe 'charges_from_date' do
-    let(:result) { date_service.charges_from_date.to_s }
+  describe 'charges_from_datetime' do
+    let(:result) { date_service.charges_from_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
@@ -215,14 +250,22 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       let(:subscription_date) { DateTime.parse('02 Feb 2020') }
 
       it 'returns from_date' do
-        expect(result).to eq(date_service.from_date.to_s)
+        expect(result).to eq(date_service.from_datetime.to_s)
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq(date_service.from_datetime.to_s)
+        end
       end
 
       context 'when subscription started in the middle of a period' do
         let(:started_at) { DateTime.parse('03 Mar 2022') }
 
         it 'returns the start date' do
-          expect(result).to eq(subscription.started_at.to_date.to_s)
+          expect(result).to eq(subscription.started_at.utc.to_s)
         end
       end
 
@@ -231,7 +274,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:subscription_date) { DateTime.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
-          expect(result).to eq('2021-01-01')
+          expect(result).to eq('2021-01-01 00:00:00 UTC')
         end
       end
 
@@ -239,14 +282,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         before { plan.update!(bill_charges_monthly: true) }
 
         it 'returns the begining of the previous month' do
-          expect(result).to eq('2021-12-01')
+          expect(result).to eq('2021-12-01 00:00:00 UTC')
         end
 
         context 'when subscription started in the middle of a period' do
           let(:started_at) { DateTime.parse('03 Mar 2022') }
 
           it 'returns the start date' do
-            expect(result).to eq(subscription.started_at.to_date.to_s)
+            expect(result).to eq(subscription.started_at.utc.to_s)
           end
         end
       end
@@ -257,14 +300,14 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       let(:billing_date) { DateTime.parse('02 Feb 2022') }
 
       it 'returns from_date' do
-        expect(result).to eq(date_service.from_date.to_s)
+        expect(result).to eq(date_service.from_datetime.to_s)
       end
 
       context 'when subscription started in the middle of a period' do
         let(:started_at) { DateTime.parse('03 Mar 2022') }
 
         it 'returns the start date' do
-          expect(result).to eq(subscription.started_at.to_date.to_s)
+          expect(result).to eq(subscription.started_at.utc.to_s)
         end
       end
 
@@ -273,7 +316,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:subscription_date) { DateTime.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
-          expect(result).to eq('2021-02-02')
+          expect(result).to eq('2021-02-02 00:00:00 UTC')
         end
       end
 
@@ -281,28 +324,36 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         before { plan.update!(bill_charges_monthly: true) }
 
         it 'returns the begining of the previous monthly period' do
-          expect(result).to eq('2022-01-02')
+          expect(result).to eq('2022-01-02 00:00:00 UTC')
         end
 
         context 'when subscription started in the middle of a period' do
           let(:started_at) { DateTime.parse('03 Mar 2022') }
 
           it 'returns the start date' do
-            expect(result).to eq(subscription.started_at.to_date.to_s)
+            expect(result).to eq(subscription.started_at.utc.to_s)
           end
         end
       end
     end
   end
 
-  describe 'charges_to_date' do
-    let(:result) { date_service.charges_to_date.to_s }
+  describe 'charges_to_datetime' do
+    let(:result) { date_service.charges_to_datetime.to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
 
       it 'returns to_date' do
-        expect(result).to eq(date_service.to_date.to_s)
+        expect(result).to eq(date_service.to_datetime.to_s)
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq(date_service.to_datetime.to_s)
+        end
       end
 
       context 'when subscription is terminated in the middle of a period' do
@@ -313,7 +364,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         it 'returns the terminated date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
         end
       end
 
@@ -321,7 +372,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:pay_in_advance) { true }
 
         it 'returns the end of the previous period' do
-          expect(result).to eq((date_service.from_date - 1.day).to_s)
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
         end
       end
 
@@ -331,7 +382,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         before { plan.update!(bill_charges_monthly: true) }
 
         it 'returns to_date' do
-          expect(result).to eq(date_service.to_date.to_s)
+          expect(result).to eq(date_service.to_datetime.to_s)
         end
 
         context 'when subscription terminated in the middle of a period' do
@@ -343,7 +394,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
           end
 
           it 'returns the terminated_at date' do
-            expect(result).to eq(subscription.terminated_at.to_date.to_s)
+            expect(result).to eq(subscription.terminated_at.utc.to_s)
           end
         end
 
@@ -353,7 +404,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
           let(:billing_date) { DateTime.parse('07 Mar 2022') }
 
           it 'returns the end of the current period' do
-            expect(result).to eq('2022-02-28')
+            expect(result).to eq('2022-02-28 23:59:59 UTC')
           end
         end
       end
@@ -364,7 +415,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       let(:billing_date) { DateTime.parse('02 Feb 2022') }
 
       it 'returns to_date' do
-        expect(result).to eq(date_service.to_date.to_s)
+        expect(result).to eq(date_service.to_datetime.to_s)
       end
 
       context 'when subscription is terminated in the middle of a period' do
@@ -375,7 +426,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         it 'returns the terminated date' do
-          expect(result).to eq(subscription.terminated_at.to_date.to_s)
+          expect(result).to eq(subscription.terminated_at.utc.to_s)
         end
       end
 
@@ -383,7 +434,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:pay_in_advance) { true }
 
         it 'returns the end of the previous period' do
-          expect(result).to eq((date_service.from_date - 1.day).to_s)
+          expect(result).to eq((date_service.from_datetime - 1.day).end_of_day.to_s)
         end
       end
     end
@@ -396,7 +447,15 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       let(:billing_time) { :calendar }
 
       it 'returns the last day of the year' do
-        expect(result).to eq('2022-12-31')
+        expect(result).to eq('2022-12-31 23:59:59 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2023-01-01 04:59:59 UTC')
+        end
       end
     end
 
@@ -404,14 +463,22 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       let(:billing_time) { :anniversary }
 
       it 'returns the end of the billing year' do
-        expect(result).to eq('2023-02-01')
+        expect(result).to eq('2023-02-01 23:59:59 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2023-02-02 04:59:59 UTC')
+        end
       end
 
       context 'when date is the end of the period' do
         let(:billing_date) { DateTime.parse('01 Feb 2022') }
 
         it 'returns the date' do
-          expect(result).to eq(billing_date.to_date.to_s)
+          expect(result).to eq(billing_date.utc.end_of_day.to_s)
         end
       end
     end
@@ -426,14 +493,22 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       let(:billing_time) { :calendar }
 
       it 'returns the first day of the previous year' do
-        expect(result).to eq('2021-01-01')
+        expect(result).to eq('2021-01-01 00:00:00 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2021-01-01 05:00:00 UTC')
+        end
       end
 
       context 'with current period argument' do
         let(:current_period) { true }
 
         it 'returns the first day of the year' do
-          expect(result).to eq('2022-01-01')
+          expect(result).to eq('2022-01-01 00:00:00 UTC')
         end
       end
     end
@@ -442,14 +517,22 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       let(:billing_time) { :anniversary }
 
       it 'returns the beginning of the previous period' do
-        expect(result).to eq('2021-02-02')
+        expect(result).to eq('2021-02-02 00:00:00 UTC')
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'America/New_York' }
+
+        it 'takes customer timezone into account' do
+          expect(result).to eq('2021-02-02 05:00:00 UTC')
+        end
       end
 
       context 'with current period argument' do
         let(:current_period) { true }
 
         it 'returns the beginning of the current period' do
-          expect(result).to eq('2022-02-02')
+          expect(result).to eq('2022-02-02 00:00:00 UTC')
         end
       end
     end

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
-  subject(:date_service) { described_class.new(subscription, billing_date, false) }
+  subject(:date_service) { described_class.new(subscription, billing_at, false) }
 
   let(:subscription) do
     create(
@@ -21,7 +21,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
   let(:pay_in_advance) { false }
 
   let(:subscription_date) { DateTime.parse('02 Feb 2021') }
-  let(:billing_date) { DateTime.parse('07 Mar 2022') }
+  let(:billing_at) { DateTime.parse('07 Mar 2022') }
   let(:started_at) { subscription_date }
   let(:timezone) { 'UTC' }
 
@@ -30,8 +30,8 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_date) { DateTime.parse('01 Jan 2022') }
-      let(:subscription_date) { DateTime.parse('02 Feb 2020') }
+      let(:billing_at) { DateTime.parse('01 Jan 2022') }
+      let(:subscription_date) { DateTime.parse('02 Feb 2019') }
 
       it 'returns the beginning of the previous year' do
         expect(result).to eq('2021-01-01 00:00:00 UTC')
@@ -41,7 +41,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2021-01-01 05:00:00 UTC')
+          expect(result).to eq('2020-01-01 05:00:00 UTC')
         end
       end
 
@@ -62,7 +62,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_date) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { DateTime.parse('10 Mar 2022') }
 
         before { subscription.terminated! }
 
@@ -82,7 +82,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('02 Feb 2022') }
+      let(:billing_at) { DateTime.parse('02 Feb 2022') }
 
       it 'returns the previous year day and month' do
         expect(result).to eq('2021-02-02 00:00:00 UTC')
@@ -113,7 +113,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
         context 'when subscription date on 29/02 of a leap year' do
           let(:subscription_date) { DateTime.parse('29 Feb 2020') }
-          let(:billing_date) { DateTime.parse('28 Mar 2022') }
+          let(:billing_at) { DateTime.parse('28 Mar 2022') }
 
           it 'returns the previous month last day' do
             expect(result).to eq('2022-02-28 00:00:00 UTC')
@@ -121,7 +121,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         context 'when billing month is before subscription month' do
-          let(:billing_date) { DateTime.parse('03 Jan 2022') }
+          let(:billing_at) { DateTime.parse('03 Jan 2022') }
 
           it 'returns the previous year day' do
             expect(result).to eq('2021-02-02 00:00:00 UTC')
@@ -136,7 +136,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_date) { DateTime.parse('01 Jan 2022') }
+      let(:billing_at) { DateTime.parse('01 Jan 2022') }
       let(:subscription_date) { DateTime.parse('02 Feb 2020') }
 
       it 'returns the end of the previous year' do
@@ -147,7 +147,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2022-01-01 04:59:59 UTC')
+          expect(result).to eq('2021-01-01 04:59:59 UTC')
         end
       end
 
@@ -160,7 +160,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        let(:billing_date) { DateTime.parse('10 Mar 2022') }
+        let(:billing_at) { DateTime.parse('10 Mar 2022') }
 
         before do
           subscription.update!(
@@ -185,7 +185,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('02 Feb 2022') }
+      let(:billing_at) { DateTime.parse('02 Feb 2022') }
 
       it 'returns the previous year day and month' do
         expect(result).to eq('2022-02-01 23:59:59 UTC')
@@ -193,7 +193,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when subscription date on 29/02 of a leap year' do
         let(:subscription_date) { DateTime.parse('29 Feb 2020') }
-        let(:billing_date) { DateTime.parse('01 Mar 2022') }
+        let(:billing_at) { DateTime.parse('01 Mar 2022') }
 
         it 'returns the previous month last day' do
           expect(result).to eq('2022-02-28 23:59:59 UTC')
@@ -202,7 +202,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when anniversary date is first day of the year' do
         let(:subscription_date) { DateTime.parse('01 Jan 2021') }
-        let(:billing_date) { DateTime.parse('02 Mar 2022') }
+        let(:billing_at) { DateTime.parse('02 Mar 2022') }
 
         it 'returns the last day of the year' do
           expect(result).to eq('2021-12-31 23:59:59 UTC')
@@ -211,7 +211,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when anniversary date is first day of a month' do
         let(:subscription_date) { DateTime.parse('01 Dec 2022') }
-        let(:billing_date) { DateTime.parse('02 Jan 2024') }
+        let(:billing_at) { DateTime.parse('02 Jan 2024') }
 
         it 'returns the last day of the previous month on next year' do
           expect(result).to eq('2023-11-30 23:59:59 UTC')
@@ -246,7 +246,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_date) { DateTime.parse('01 Jan 2022') }
+      let(:billing_at) { DateTime.parse('01 Jan 2022') }
       let(:subscription_date) { DateTime.parse('02 Feb 2020') }
 
       it 'returns from_date' do
@@ -297,7 +297,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('02 Feb 2022') }
+      let(:billing_at) { DateTime.parse('02 Feb 2022') }
 
       it 'returns from_date' do
         expect(result).to eq(date_service.from_datetime.to_s)
@@ -377,7 +377,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when billing charge monthly' do
-        let(:billing_date) { DateTime.parse('01 Jan 2022') }
+        let(:billing_at) { DateTime.parse('01 Jan 2022') }
 
         before { plan.update!(bill_charges_monthly: true) }
 
@@ -387,7 +387,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
         context 'when subscription terminated in the middle of a period' do
           let(:terminated_at) { DateTime.parse('10 Mar 2022') }
-          let(:billing_date) { DateTime.parse('07 Mar 2022') }
+          let(:billing_at) { DateTime.parse('07 Mar 2022') }
 
           before do
             subscription.update!(status: :terminated, terminated_at: terminated_at)
@@ -401,7 +401,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         context 'when plan is pay in advance' do
           let(:pay_in_advance) { true }
           let(:subscription_date) { DateTime.parse('02 Feb 2020') }
-          let(:billing_date) { DateTime.parse('07 Mar 2022') }
+          let(:billing_at) { DateTime.parse('07 Mar 2022') }
 
           it 'returns the end of the current period' do
             expect(result).to eq('2022-02-28 23:59:59 UTC')
@@ -412,7 +412,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is anniversary' do
       let(:billing_time) { :anniversary }
-      let(:billing_date) { DateTime.parse('02 Feb 2022') }
+      let(:billing_at) { DateTime.parse('02 Feb 2022') }
 
       it 'returns to_date' do
         expect(result).to eq(date_service.to_datetime.to_s)
@@ -441,7 +441,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
   end
 
   describe 'next_end_of_period' do
-    let(:result) { date_service.next_end_of_period(billing_date.to_date).to_s }
+    let(:result) { date_service.next_end_of_period(billing_at.to_date).to_s }
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
@@ -475,10 +475,10 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when date is the end of the period' do
-        let(:billing_date) { DateTime.parse('01 Feb 2022') }
+        let(:billing_at) { DateTime.parse('01 Feb 2022') }
 
         it 'returns the date' do
-          expect(result).to eq(billing_date.utc.end_of_day.to_s)
+          expect(result).to eq(billing_at.utc.end_of_day.to_s)
         end
       end
     end
@@ -550,7 +550,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when on a leap year' do
         let(:subscription_date) { DateTime.parse('28 Feb 2019') }
-        let(:billing_date) { DateTime.parse('01 Jan 2021') }
+        let(:billing_at) { DateTime.parse('01 Jan 2021') }
 
         it 'returns the price of single day' do
           expect(result).to eq(plan.amount_cents.fdiv(366))
@@ -567,7 +567,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when on a leap year' do
         let(:subscription_date) { DateTime.parse('02 Feb 2019') }
-        let(:billing_date) { DateTime.parse('08 Mar 2021') }
+        let(:billing_at) { DateTime.parse('08 Mar 2021') }
 
         it 'returns the price of single day' do
           expect(result).to eq(plan.amount_cents.fdiv(366))
@@ -588,7 +588,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when on a leap year' do
         let(:subscription_date) { DateTime.parse('28 Feb 2019') }
-        let(:billing_date) { DateTime.parse('01 Jan 2021') }
+        let(:billing_at) { DateTime.parse('01 Jan 2021') }
 
         it 'returns the year duration' do
           expect(result).to eq(366)
@@ -613,7 +613,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when on a leap year' do
         let(:subscription_date) { DateTime.parse('02 Feb 2019') }
-        let(:billing_date) { DateTime.parse('08 Mar 2021') }
+        let(:billing_at) { DateTime.parse('08 Mar 2021') }
 
         it 'returns the year duration' do
           expect(result).to eq(366)

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -65,30 +65,30 @@ RSpec.describe Subscriptions::DatesService, type: :service do
     end
   end
 
-  describe 'from_date' do
+  describe 'from_datetime' do
     it 'raises a not implemented error' do
-      expect { date_service.from_date }
+      expect { date_service.from_datetime }
         .to raise_error(NotImplementedError)
     end
   end
 
-  describe 'to_date' do
+  describe 'to_datetime' do
     it 'raises a not implemented error' do
-      expect { date_service.to_date }
+      expect { date_service.to_datetime }
         .to raise_error(NotImplementedError)
     end
   end
 
-  describe 'charges_from_date' do
+  describe 'charges_from_datetime' do
     it 'raises a not implemented error' do
-      expect { date_service.charges_from_date }
+      expect { date_service.charges_from_datetime }
         .to raise_error(NotImplementedError)
     end
   end
 
-  describe 'charges_to_date' do
+  describe 'charges_to_datetime' do
     it 'raises a not implemented error' do
-      expect { date_service.charges_to_date }
+      expect { date_service.charges_to_datetime }
         .to raise_error(NotImplementedError)
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR updates the Subscriptions::Dates::*Services to take customer timezone into account.

**NOTE**: It changes the behavior of the services by returning `datetime` instead of `date` for boundaries. For now results are converted back into `date` to prevent a too large number of changes in this PR. The handling of `datetime` boundaries will be done in a next pull request.
