### PR TITLE
eat(grace_period): Support grace period on customer/organization via GraphQL

### DIFF
--- a/app/graphql/mutations/customers/create.rb
+++ b/app/graphql/mutations/customers/create.rb
@@ -24,6 +24,7 @@ module Mutations
       argument :legal_name, String, required: false
       argument :legal_number, String, required: false
       argument :vat_rate, Float, required: false
+      argument :invoice_grace_period, Integer, required: false
       argument :currency, Types::CurrencyEnum, required: false
 
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false

--- a/app/graphql/mutations/customers/update.rb
+++ b/app/graphql/mutations/customers/update.rb
@@ -24,6 +24,7 @@ module Mutations
       argument :legal_name, String, required: false
       argument :legal_number, String, required: false
       argument :vat_rate, Float, required: false
+      argument :invoice_grace_period, Integer, required: false
       argument :currency, Types::CurrencyEnum, required: false
 
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false

--- a/app/graphql/mutations/organizations/update.rb
+++ b/app/graphql/mutations/organizations/update.rb
@@ -22,6 +22,7 @@ module Mutations
       argument :city, String, required: false
       argument :country, Types::CountryCodeEnum, required: false
       argument :invoice_footer, String, required: false
+      argument :invoice_grace_period, Integer, required: false
 
       type Types::OrganizationType
 

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -25,6 +25,7 @@ module Types
       field :legal_name, String, null: true
       field :legal_number, String, null: true
       field :vat_rate, Float, null: true
+      field :invoice_grace_period, Integer, null: false
       field :currency, Types::CurrencyEnum, null: true
       field :payment_provider, Types::PaymentProviders::ProviderTypeEnum, null: true
       field :timezone, Types::TimezoneEnum, null: true

--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -17,6 +17,7 @@ module Types
     field :zipcode, String
     field :city, String
     field :invoice_footer, String
+    field :invoice_grace_period, Integer, null: false
     field :country, Types::CountryCodeEnum, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -61,6 +61,7 @@ module Customers
         legal_name: args[:legal_name],
         legal_number: args[:legal_number],
         vat_rate: args[:vat_rate],
+        invoice_grace_period: args[:invoice_grace_period] || 0,
         payment_provider: args[:payment_provider],
         currency: args[:currency],
       )

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -26,8 +26,11 @@ module Customers
         customer.logo_url = args[:logo_url] if args.key?(:logo_url)
         customer.legal_name = args[:legal_name] if args.key?(:legal_name)
         customer.legal_number = args[:legal_number] if args.key?(:legal_number)
+
+        # TODO: delete this when GraphQL will use billing_configuration.
         customer.vat_rate = args[:vat_rate] if args.key?(:vat_rate)
         customer.payment_provider = args[:payment_provider] if args.key?(:payment_provider)
+        customer.invoice_footer = args[:invoice_footer] if args.key?(:invoice_footer)
         customer.invoice_grace_period = args[:invoice_grace_period] if args.key?(:invoice_grace_period)
 
         if args.key?(:billing_configuration)

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -21,6 +21,7 @@ module Organizations
       organization.city = args[:city] if args.key?(:city)
       organization.country = args[:country] if args.key?(:country)
       organization.invoice_footer = args[:invoice_footer] if args.key?(:invoice_footer)
+      organization.invoice_grace_period = args[:invoice_grace_period] if args.key?(:invoice_grace_period)
 
       handle_base64_logo(args[:logo]) if args.key?(:logo)
 

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -11,15 +11,16 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
     <<~GQL
       mutation($input: CreateCustomerInput!) {
         createCustomer(input: $input) {
-          id,
-          name,
-          externalId,
+          id
+          name
+          externalId
           city
           country
           paymentProvider
           providerCustomer { id, providerCustomerId }
           currency
           canEditAttributes
+          invoiceGracePeriod
         }
       }
     GQL
@@ -40,6 +41,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           country: 'GB',
           paymentProvider: 'stripe',
           currency: 'EUR',
+          invoiceGracePeriod: 2,
           providerCustomer: {
             providerCustomerId: 'cu_12345',
           },
@@ -56,6 +58,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
       expect(result_data['city']).to eq('London')
       expect(result_data['country']).to eq('GB')
       expect(result_data['currency']).to eq('EUR')
+      expect(result_data['invoiceGracePeriod']).to eq(2)
       expect(result_data['paymentProvider']).to eq('stripe')
       expect(result_data['providerCustomer']['id']).to be_present
       expect(result_data['providerCustomer']['providerCustomerId']).to eq('cu_12345')

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           paymentProvider
           currency
           canEditAttributes
+          invoiceGracePeriod
           providerCustomer { id, providerCustomerId }
         }
       }
@@ -38,6 +39,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           externalId: external_id,
           paymentProvider: 'stripe',
           currency: 'EUR',
+          invoiceGracePeriod: 2,
           providerCustomer: {
             providerCustomerId: 'cu_12345',
           },
@@ -53,6 +55,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       expect(result_data['externalId']).to eq(external_id)
       expect(result_data['paymentProvider']).to eq('stripe')
       expect(result_data['currency']).to eq('EUR')
+      expect(result_data['invoiceGracePeriod']).to eq(2)
       expect(result_data['providerCustomer']['id']).to be_present
       expect(result_data['providerCustomer']['providerCustomerId']).to eq('cu_12345')
     end

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           city
           country
           invoiceFooter
+          invoiceGracePeriod
           timezone
         }
       }
@@ -45,25 +46,29 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           city: 'Foobar',
           country: 'FR',
           invoiceFooter: 'invoice footer',
+          invoiceGracePeriod: 3,
         },
       },
     )
 
     result_data = result['data']['updateOrganization']
 
-    expect(result_data['webhookUrl']).to eq('http://foo.bar')
-    expect(result_data['vatRate']).to eq(12.5)
-    expect(result_data['legalNumber']).to eq('1234')
-    expect(result_data['legalName']).to eq('Foobar')
-    expect(result_data['email']).to eq('foo@bar.com')
-    expect(result_data['addressLine1']).to eq('Line 1')
-    expect(result_data['addressLine2']).to eq('Line 2')
-    expect(result_data['state']).to eq('Foobar')
-    expect(result_data['zipcode']).to eq('FOO1234')
-    expect(result_data['city']).to eq('Foobar')
-    expect(result_data['country']).to eq('FR')
-    expect(result_data['invoiceFooter']).to eq('invoice footer')
-    expect(result_data['timezone']).to eq('TZ_UTC')
+    aggregate_failures do
+      expect(result_data['webhookUrl']).to eq('http://foo.bar')
+      expect(result_data['vatRate']).to eq(12.5)
+      expect(result_data['legalNumber']).to eq('1234')
+      expect(result_data['legalName']).to eq('Foobar')
+      expect(result_data['email']).to eq('foo@bar.com')
+      expect(result_data['addressLine1']).to eq('Line 1')
+      expect(result_data['addressLine2']).to eq('Line 2')
+      expect(result_data['state']).to eq('Foobar')
+      expect(result_data['zipcode']).to eq('FOO1234')
+      expect(result_data['city']).to eq('Foobar')
+      expect(result_data['country']).to eq('FR')
+      expect(result_data['invoiceFooter']).to eq('invoice footer')
+      expect(result_data['invoiceGracePeriod']).to eq(3)
+      expect(result_data['timezone']).to eq('TZ_UTC')
+    end
   end
 
   context 'with invalid webhook url' do

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -304,6 +304,7 @@ RSpec.describe Customers::CreateService, type: :service do
         name: 'Foo Bar',
         organization_id: organization.id,
         currency: 'EUR',
+        invoice_grace_period: 2,
       }
     end
 
@@ -324,6 +325,7 @@ RSpec.describe Customers::CreateService, type: :service do
         expect(customer.external_id).to eq(create_args[:external_id])
         expect(customer.name).to eq(create_args[:name])
         expect(customer.currency).to eq('EUR')
+        expect(customer.invoice_grace_period).to eq(2)
       end
     end
 

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -40,6 +40,25 @@ RSpec.describe Customers::UpdateService, type: :service do
       end
     end
 
+    context 'without billing configuration namespace' do
+      let(:update_args) do
+        {
+          id: customer.id,
+          name: 'Updated customer name',
+          external_id: external_id,
+          invoice_grace_period: 3,
+          vat_rate: 20,
+        }
+      end
+
+      it 'updates billing information' do
+        result = customers_service.update(**update_args)
+
+        expect(result.customer.invoice_grace_period).to eq(update_args[:invoice_grace_period])
+        expect(result.customer.vat_rate).to eq(update_args[:vat_rate])
+      end
+    end
+
     context 'with validation error' do
       let(:external_id) { nil }
 

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -22,20 +22,24 @@ RSpec.describe Organizations::UpdateService do
         city: 'Foobar',
         country: 'FR',
         invoice_footer: 'invoice footer',
+        invoice_grace_period: 3,
       )
 
-      expect(result.organization.webhook_url).to eq('http://foo.bar')
-      expect(result.organization.vat_rate).to eq(12.5)
-      expect(result.organization.legal_name).to eq('Foobar')
-      expect(result.organization.legal_number).to eq('1234')
-      expect(result.organization.email).to eq('foo@bar.com')
-      expect(result.organization.address_line1).to eq('Line 1')
-      expect(result.organization.address_line2).to eq('Line 2')
-      expect(result.organization.state).to eq('Foobar')
-      expect(result.organization.zipcode).to eq('FOO1234')
-      expect(result.organization.city).to eq('Foobar')
-      expect(result.organization.country).to eq('FR')
-      expect(result.organization.invoice_footer).to eq('invoice footer')
+      aggregate_failures do
+        expect(result.organization.webhook_url).to eq('http://foo.bar')
+        expect(result.organization.vat_rate).to eq(12.5)
+        expect(result.organization.legal_name).to eq('Foobar')
+        expect(result.organization.legal_number).to eq('1234')
+        expect(result.organization.email).to eq('foo@bar.com')
+        expect(result.organization.address_line1).to eq('Line 1')
+        expect(result.organization.address_line2).to eq('Line 2')
+        expect(result.organization.state).to eq('Foobar')
+        expect(result.organization.zipcode).to eq('FOO1234')
+        expect(result.organization.city).to eq('Foobar')
+        expect(result.organization.country).to eq('FR')
+        expect(result.organization.invoice_footer).to eq('invoice footer')
+        expect(result.organization.invoice_grace_period).to eq(3)
+      end
     end
 
     context 'with base64 logo' do


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to be able to set `invoice_grace_period` on `organizations` and `customers` via GraphQL.
