### PR TITLE
feat: expose credit notes on invoices

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -35,6 +35,7 @@ module Types
       field :invoice_subscriptions, [Types::InvoiceSubscription::Object]
       field :fees, [Types::Fees::Object], null: true
       field :plan, Types::Plans::Object
+      field :credit_notes, [Types::CreditNotes::Object], null: true
 
       field :wallet_transaction_amount_cents, Integer, null: false
       field :subtotal_before_prepaid_credits, String, null: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -2952,6 +2952,7 @@ type Invoice {
   creditAmountCents: Int!
   creditAmountCurrency: CurrencyEnum!
   creditNoteTotalAmountCents: Int!
+  creditNotes: [CreditNote!]
   creditableAmountCents: Int!
   customer: Customer!
   fees: [Fee!]

--- a/schema.json
+++ b/schema.json
@@ -10773,6 +10773,28 @@
               ]
             },
             {
+              "name": "creditNotes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CreditNote",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "creditableAmountCents",
               "description": null,
               "type": {


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

This PR is part of the credit notes feature

## Description

Expose the `credit_notes` relationship in invoice model through Invoice type so Frontend can use them