### PR TITLE
feat(grace_period): Add status to invoices

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -18,6 +18,7 @@ module Types
       field :vat_amount_cents, Integer, null: false
       field :vat_amount_currency, Types::CurrencyEnum, null: false
       field :invoice_type, Types::Invoices::InvoiceTypeEnum, null: false
+      field :status, Types::Invoices::StatusTypeEnum, null: false
       field :payment_status, Types::Invoices::PaymentStatusTypeEnum, null: false
       field :file_url, String, null: true
 

--- a/app/graphql/types/invoices/status_type_enum.rb
+++ b/app/graphql/types/invoices/status_type_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Invoices
+    class StatusTypeEnum < Types::BaseEnum
+      graphql_name 'InvoiceStatusTypeEnum'
+
+      Invoice::STATUS.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -34,9 +34,11 @@ class Invoice < ApplicationRecord
 
   INVOICE_TYPES = %i[subscription add_on credit].freeze
   PAYMENT_STATUS = %i[pending succeeded failed].freeze
+  STATUS = %i[draft finalized].freeze
 
   enum invoice_type: INVOICE_TYPES
   enum payment_status: PAYMENT_STATUS
+  enum status: STATUS
 
   sequenced scope: ->(invoice) { invoice.customer.invoices }
 

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -9,6 +9,7 @@ module V1
         number: model.number,
         issuing_date: model.issuing_date.iso8601,
         invoice_type: model.invoice_type,
+        status: model.status,
         payment_status: model.payment_status,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,

--- a/schema.graphql
+++ b/schema.graphql
@@ -2933,6 +2933,7 @@ type Invoice {
   paymentStatus: InvoicePaymentStatusTypeEnum!
   plan: Plan
   sequentialId: ID!
+  status: InvoiceStatusTypeEnum!
   subscriptions: [Subscription!]
   subtotalBeforePrepaidCredits: String!
   totalAmountCents: Int!
@@ -2960,6 +2961,11 @@ enum InvoicePaymentStatusTypeEnum {
   failed
   pending
   succeeded
+}
+
+enum InvoiceStatusTypeEnum {
+  draft
+  finalized
 }
 
 type InvoiceSubscription {

--- a/schema.json
+++ b/schema.json
@@ -10888,6 +10888,24 @@
               ]
             },
             {
+              "name": "status",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "InvoiceStatusTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "subscriptions",
               "description": null,
               "type": {
@@ -11203,6 +11221,29 @@
             },
             {
               "name": "failed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "InvoiceStatusTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "draft",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "finalized",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
         invoice(id: $id) {
           id
           number
+          paymentStatus
+          status
           customer {
             id
             name
@@ -52,12 +54,16 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
 
     data = result['data']['invoice']
 
-    expect(data['id']).to eq(invoice.id)
-    expect(data['number']).to eq(invoice.number)
-    expect(data['customer']['id']).to eq(customer.id)
-    expect(data['customer']['name']).to eq(customer.name)
-    expect(data['invoiceSubscriptions'][0]['subscription']['id']).to eq(subscription.id)
-    expect(data['invoiceSubscriptions'][0]['fees'][0]['id']).to eq(fee.id)
+    aggregate_failures do
+      expect(data['id']).to eq(invoice.id)
+      expect(data['number']).to eq(invoice.number)
+      expect(data['paymentStatus']).to eq(invoice.payment_status)
+      expect(data['status']).to eq(invoice.status)
+      expect(data['customer']['id']).to eq(customer.id)
+      expect(data['customer']['name']).to eq(customer.name)
+      expect(data['invoiceSubscriptions'][0]['subscription']['id']).to eq(subscription.id)
+      expect(data['invoiceSubscriptions'][0]['fees'][0]['id']).to eq(fee.id)
+    end
   end
 
   it 'includes group for each fee' do

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         expect(response).to have_http_status(:success)
         expect(json[:invoice][:lago_id]).to eq(invoice.id)
         expect(json[:invoice][:payment_status]).to eq(invoice.payment_status)
+        expect(json[:invoice][:status]).to eq(invoice.status)
         expect(json[:invoice][:customer]).not_to be_nil
         expect(json[:invoice][:subscriptions]).not_to be_nil
         expect(json[:invoice][:fees].first).to include(lago_group_id: group.id)
@@ -79,6 +80,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       expect(json[:invoices].count).to eq(1)
       expect(json[:invoices].first[:lago_id]).to eq(invoice.id)
       expect(json[:invoices].first[:payment_status]).to eq(invoice.payment_status)
+      expect(json[:invoices].first[:status]).to eq(invoice.status)
     end
 
     context 'with pagination' do


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to add `invoice#status` for defining draft or finalized invoices.
