### PR TITLE
bug: fix customer count wrongly calculated

### DIFF
--- a/app/graphql/types/coupons/object.rb
+++ b/app/graphql/types/coupons/object.rb
@@ -32,7 +32,7 @@ module Types
       end
 
       def customer_count
-        object.applied_coupons.active.count
+        object.applied_coupons.active.select(:customer_id).distinct.count
       end
 
       def can_be_deleted

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -36,7 +36,7 @@ module Types
       end
 
       def customer_count
-        object.subscriptions.active.count
+        object.subscriptions.active.select(:customer_id).distinct.count
       end
 
       def can_be_deleted


### PR DESCRIPTION
## Context

We display the number of "customer count" on different places in the app.
- Plans list
- Coupons list
- Addons list

This value were wrong at 2 places, as we calculated all active subscription instead

## Description

This PR corrects the value returned by those methods