### PR TITLE
feat(timezones): Use datetimes in aggregation services

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,8 +11,8 @@ class Event < ApplicationRecord
   validates :transaction_id, presence: true, uniqueness: { scope: :subscription_id }
   validates :code, presence: true
 
-  scope :from_date, ->(from_date) { where('events.timestamp >= ?', from_date.beginning_of_day) }
-  scope :to_date, ->(to_date) { where('events.timestamp <= ?', to_date.end_of_day) }
+  scope :from_datetime, ->(from_datetime) { where('events.timestamp::timestamp(0) >= ?', from_datetime) }
+  scope :to_datetime, ->(to_datetime) { where('events.timestamp::timestamp(0) <= ?', to_datetime) }
 
   def api_client
     metadata['user_agent']

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -130,8 +130,8 @@ class Invoice < ApplicationRecord
       subscription: fee.subscription,
       group: fee.group,
     ).breakdown(
-      from_date: DateTime.parse(fee.properties['charges_from_datetime']).to_date,
-      to_date: DateTime.parse(fee.properties['charges_to_datetime']).to_date,
+      from_datetime: DateTime.parse(fee.properties['charges_from_datetime']),
+      to_datetime: DateTime.parse(fee.properties['charges_to_datetime']),
     )
     result.breakdown
   end

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -11,7 +11,7 @@ module BillableMetrics
       end
 
       def aggregate(from_date:, to_date:, options: {})
-        raise NotImplementedError
+        raise(NotImplementedError)
       end
 
       protected
@@ -20,10 +20,10 @@ module BillableMetrics
 
       delegate :customer, to: :subscription
 
-      def events_scope(from_date:, to_date:)
+      def events_scope(from_datetime:, to_datetime:)
         events = subscription.events
-          .from_date(from_date)
-          .to_date(to_date)
+          .from_datetime(from_datetime)
+          .to_datetime(to_datetime)
           .where(code: billable_metric.code)
         return events unless group
 

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -3,8 +3,8 @@
 module BillableMetrics
   module Aggregations
     class CountService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:, options: {})
-        result.aggregation = events_scope(from_date: from_date, to_date: to_date).count
+      def aggregate(from_datetime:, to_datetime:, options: {})
+        result.aggregation = events_scope(from_datetime: from_datetime, to_datetime: to_datetime).count
         result.count = result.aggregation
         result.options = {}
         result

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -6,7 +6,7 @@ module BillableMetrics
       def aggregate(from_datetime:, to_datetime:, options: {})
         result.aggregation = events_scope(from_datetime: from_datetime, to_datetime: to_datetime).count
         result.count = result.aggregation
-        result.options = {}
+        result.options = options
         result
       end
     end

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -9,7 +9,7 @@ module BillableMetrics
 
         result.aggregation = events.maximum("(#{sanitized_field_name})::numeric") || 0
         result.count = events.count
-        result.options = {}
+        result.options = options
         result
       rescue ActiveRecord::StatementInvalid => e
         result.service_failure!(code: 'aggregation_failure', message: e.message)

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -3,8 +3,8 @@
 module BillableMetrics
   module Aggregations
     class MaxService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:, options: {})
-        events = events_scope(from_date: from_date, to_date: to_date)
+      def aggregate(from_datetime:, to_datetime:, options: {})
+        events = events_scope(from_datetime: from_datetime, to_datetime: to_datetime)
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.maximum("(#{sanitized_field_name})::numeric") || 0

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -9,7 +9,7 @@ module BillableMetrics
 
         result.aggregation = compute_aggregation.ceil(5)
         result.count = result.aggregation
-        result.options = {}
+        result.options = options
         result
       end
 

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -3,9 +3,9 @@
 module BillableMetrics
   module Aggregations
     class RecurringCountService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:, options: {})
-        @from_date = from_date
-        @to_date = to_date
+      def aggregate(from_datetime:, to_datetime:, options: {})
+        @from_datetime = from_datetime
+        @to_datetime = to_datetime
 
         result.aggregation = compute_aggregation.ceil(5)
         result.count = result.aggregation
@@ -13,22 +13,31 @@ module BillableMetrics
         result
       end
 
-      def breakdown(from_date:, to_date:)
-        @from_date = from_date.to_date
-        @to_date = to_date.to_date
+      def breakdown(from_datetime:, to_datetime:)
+        @from_datetime = from_datetime
+        @to_datetime = to_datetime
 
         breakdown = persisted_breakdown
         breakdown += added_breakdown
         breakdown += removed_breadown
         breakdown += added_and_removed_breakdown
 
+        # NOTE: in the breakdown, dates are in customer timezone
         result.breakdown = breakdown.sort_by(&:date)
         result
       end
 
       private
 
-      attr_reader :from_date, :to_date
+      attr_reader :from_datetime, :to_datetime
+
+      def from_date_in_customer_timezone
+        from_datetime.in_time_zone(customer.applicable_timezone).to_date
+      end
+
+      def to_date_in_customer_timezone
+        to_datetime.in_time_zone(customer.applicable_timezone).to_date
+      end
 
       def compute_aggregation
         ActiveRecord::Base.connection.execute(aggregation_query).first['aggregation_result']
@@ -40,24 +49,18 @@ module BillableMetrics
           persisted.select("SUM(#{persisted_pro_rata}::numeric)").to_sql,
 
           # NOTE: Added during the period
-          added
-            .select(
-              "SUM(('#{to_date}'::date - DATE(persisted_events.added_at) + 1)::numeric / #{period_duration})::numeric",
-            )
-            .to_sql,
+          added.select(duration_ratio_sql('persisted_events.added_at', to_datetime)).to_sql,
 
           # NOTE: removed during the period
-          removed
-            .select(
-              "SUM((DATE(persisted_events.removed_at) - '#{from_date}'::date + 1)::numeric / #{period_duration})::numeric",
-            )
-            .to_sql,
+          removed.select(duration_ratio_sql(from_datetime, 'persisted_events.removed_at')).to_sql,
 
           # NOTE: Added and then removed during the period
-          added_and_removed
-            .select(
-              "SUM((DATE(persisted_events.removed_at) - DATE(persisted_events.added_at) + 1)::numeric / #{period_duration})::numeric",
-            ).to_sql,
+          added_and_removed.select(
+            duration_ratio_sql(
+              'persisted_events.added_at',
+              'persisted_events.removed_at',
+            ),
+          ).to_sql,
         ]
 
         "SELECT (#{queries.map { |q| "COALESCE((#{q}), 0)" }.join(' + ')}) AS aggregation_result"
@@ -65,6 +68,7 @@ module BillableMetrics
 
       def base_scope
         persisted_events = PersistedEvent
+          .joins(customer: :organization)
           .where(billable_metric_id: billable_metric.id)
           .where(customer_id: subscription.customer_id)
           .where(external_subscription_id: subscription.external_id)
@@ -80,8 +84,7 @@ module BillableMetrics
       # NOTE: Full period duration to take upgrade, terminate
       #       or start on non-anniversary day into account
       def period_duration
-        # TODO: pass a datetime argument
-        @period_duration ||= Subscriptions::DatesService.new_instance(subscription, to_date + 1.day)
+        @period_duration ||= Subscriptions::DatesService.new_instance(subscription, to_datetime + 1.day)
           .charges_duration_in_days
       end
 
@@ -89,13 +92,13 @@ module BillableMetrics
       #       we want to bill the persisted metrics at prorata of the full period duration.
       #       ie: the number of day of the terminated period divided by number of days without termination
       def persisted_pro_rata
-        (to_date - from_date + 1).to_i.fdiv(period_duration)
+        ((to_datetime.to_time - from_datetime.to_time) / 1.day).ceil.fdiv(period_duration)
       end
 
       def persisted
         base_scope
-          .where('DATE(persisted_events.added_at) < ?', from_date)
-          .where('persisted_events.removed_at IS NULL OR DATE(persisted_events.removed_at) > ?', to_date)
+          .where('persisted_events.added_at::timestamp(0) < ?', from_datetime)
+          .where('persisted_events.removed_at IS NULL OR persisted_events.removed_at::timestamp(0) > ?', to_datetime)
       end
 
       def persisted_breakdown
@@ -104,10 +107,10 @@ module BillableMetrics
 
         [
           OpenStruct.new(
-            date: from_date,
+            date: from_date_in_customer_timezone,
             action: 'add',
             count: persisted_count,
-            duration: (to_date - from_date + 1).to_i,
+            duration: (to_date_in_customer_timezone + 1.day - from_date_in_customer_timezone).to_i,
             total_duration: period_duration,
           ),
         ]
@@ -115,25 +118,29 @@ module BillableMetrics
 
       def added
         base_scope
-          .where('DATE(persisted_events.added_at) >= ?', from_date)
-          .where('DATE(persisted_events.added_at) <= ?', to_date)
-          .where('persisted_events.removed_at IS NULL OR DATE(persisted_events.removed_at) > ?', to_date)
+          .where('persisted_events.added_at::timestamp(0) >= ?', from_datetime)
+          .where('persisted_events.added_at::timestamp(0) <= ?', to_datetime)
+          .where('persisted_events.removed_at::timestamp(0) IS NULL OR persisted_events.removed_at > ?', to_datetime)
       end
 
       def added_breakdown
-        added_list = added.group('DATE(persisted_events.added_at)')
-          .order('DATE(persisted_events.added_at) ASC')
-          .pluck([
-            'DATE(persisted_events.added_at) as date',
-            'COUNT(persisted_events.id) as metric_count',
-          ].join(', '))
+        date_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'persisted_events.added_at')
+
+        added_list = added.group(Arel.sql("DATE(#{date_field})"))
+          .order(Arel.sql("DATE(#{date_field}) ASC"))
+          .pluck(Arel.sql(
+            [
+              "DATE(#{date_field}) as date",
+              'COUNT(persisted_events.id) as metric_count',
+            ].join(', '),
+          ))
 
         added_list.map do |aggregation|
           OpenStruct.new(
             date: aggregation.first.to_date,
             action: 'add',
             count: aggregation.last,
-            duration: (to_date + 1.day - aggregation.first).to_i,
+            duration: (to_date_in_customer_timezone + 1.day - aggregation.first).to_i,
             total_duration: period_duration,
           )
         end
@@ -141,25 +148,29 @@ module BillableMetrics
 
       def removed
         base_scope
-          .where('DATE(persisted_events.added_at) < ?', from_date)
-          .where('DATE(persisted_events.removed_at) >= ?', from_date)
-          .where('DATE(persisted_events.removed_at) <= ?', to_date)
+          .where('persisted_events.added_at::timestamp(0) < ?', from_datetime)
+          .where('persisted_events.removed_at::timestamp(0) >= ?', from_datetime)
+          .where('persisted_events.removed_at::timestamp(0) <= ?', to_datetime)
       end
 
       def removed_breadown
-        removed_list = removed.group('DATE(persisted_events.removed_at)')
-          .order('DATE(persisted_events.removed_at) ASC')
-          .pluck([
-            'DATE(persisted_events.removed_at) as date',
-            'COUNT(persisted_events.id) as metric_count',
-          ].join(', '))
+        date_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'persisted_events.removed_at')
+
+        removed_list = removed.group(Arel.sql("DATE(#{date_field})"))
+          .order(Arel.sql("DATE(#{date_field}) ASC"))
+          .pluck(Arel.sql(
+            [
+              "DATE(#{date_field}) as date",
+              'COUNT(persisted_events.id) as metric_count',
+            ].join(', '),
+          ))
 
         removed_list.map do |aggregation|
           OpenStruct.new(
             date: aggregation.first.to_date,
             action: 'remove',
             count: aggregation.last,
-            duration: (aggregation.first + 1.day - from_date).to_i,
+            duration: (aggregation.first + 1.day - from_date_in_customer_timezone).to_i,
             total_duration: period_duration,
           )
         end
@@ -167,21 +178,27 @@ module BillableMetrics
 
       def added_and_removed
         base_scope
-          .where('DATE(persisted_events.added_at) >= ?', from_date)
-          .where('DATE(persisted_events.added_at) <= ?', to_date)
-          .where('DATE(persisted_events.removed_at) >= ?', from_date)
-          .where('DATE(persisted_events.removed_at) <= ?', to_date)
+          .where('persisted_events.added_at::timestamp(0) >= ?', from_datetime)
+          .where('persisted_events.added_at::timestamp(0) <= ?', to_datetime)
+          .where('persisted_events.removed_at::timestamp(0) >= ?', from_datetime)
+          .where('persisted_events.removed_at::timestamp(0) <= ?', to_datetime)
       end
 
       def added_and_removed_breakdown
+        added_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'persisted_events.added_at')
+        removed_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'persisted_events.removed_at')
+
         added_and_removed_list = added_and_removed.group(
-          'DATE(persisted_events.added_at), DATE(persisted_events.removed_at)',
-        ).order('DATE(persisted_events.added_at) ASC, DATE(persisted_events.removed_at) ASC')
-          .pluck([
-            'DATE(persisted_events.added_at) as added_at',
-            'DATE(persisted_events.removed_at) as removed_at',
+          Arel.sql("DATE(#{added_field}), DATE(#{removed_field})"),
+        ).order(
+          Arel.sql("DATE(#{added_field}) ASC, DATE(#{removed_field}) ASC"),
+        ).pluck(Arel.sql(
+          [
+            "DATE(#{added_field}) as added_at",
+            "DATE(#{removed_field}) as removed_at",
             'COUNT(persisted_events.id) as metric_count',
-          ].join(', '))
+          ].join(', '),
+        ))
 
         added_and_removed_list.map do |aggregation|
           OpenStruct.new(
@@ -192,6 +209,21 @@ module BillableMetrics
             total_duration: period_duration,
           )
         end
+      end
+
+      # NOTE: Compute pro-rata of the duration in days between the datetimes over the duration of the billing period
+      #       Dates are in customer timezone to make sure the duration is good
+      def duration_ratio_sql(from, to)
+        from_in_timezone = Utils::TimezoneService.date_in_customer_timezone_sql(customer, from)
+        to_in_timezone = Utils::TimezoneService.date_in_customer_timezone_sql(customer, to)
+
+        "SUM((DATE(#{to_in_timezone}) - DATE(#{from_in_timezone}) + 1)::numeric / #{period_duration})::numeric"
+      end
+
+      def sanitize_date(value)
+        return ActiveRecord::Base.sanitize_sql_for_conditions(value) if value.is_a?(String)
+
+        "'#{value}'"
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -3,8 +3,8 @@
 module BillableMetrics
   module Aggregations
     class SumService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:, options: {})
-        events = events_scope(from_date: from_date, to_date: to_date)
+      def aggregate(from_datetime:, to_datetime:, options: {})
+        events = events_scope(from_datetime: from_datetime, to_datetime: to_datetime)
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.sum("(#{sanitized_field_name})::numeric")

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -3,8 +3,8 @@
 module BillableMetrics
   module Aggregations
     class UniqueCountService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_date:, to_date:, options: {})
-        events = events_scope(from_date: from_date, to_date: to_date)
+      def aggregate(from_datetime:, to_datetime:, options: {})
+        events = events_scope(from_datetime: from_datetime, to_datetime: to_datetime)
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.count("DISTINCT (#{sanitized_field_name})")

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -9,7 +9,7 @@ module BillableMetrics
 
         result.aggregation = events.count("DISTINCT (#{sanitized_field_name})")
         result.count = events.count
-        result.options = {}
+        result.options = options
         result
       end
     end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -78,8 +78,8 @@ module Fees
 
     def compute_amount(properties:, group: nil)
       aggregation_result = aggregator(group: group).aggregate(
-        from_date: boundaries.charges_from_datetime.to_date,
-        to_date: boundaries.charges_to_datetime.to_date,
+        from_datetime: boundaries.charges_from_datetime,
+        to_datetime: boundaries.charges_to_datetime,
         options: options(properties),
       )
       return aggregation_result unless aggregation_result.success?

--- a/app/services/utils/timezone_service.rb
+++ b/app/services/utils/timezone_service.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Utils
+  class TimezoneService < BaseService
+    def self.date_in_customer_timezone_sql(customer, value)
+      sanitized_field_name = if value.is_a?(String)
+        ActiveRecord::Base.sanitize_sql_for_conditions(value)
+      else
+        "'#{value}'"
+      end
+      sanitized_timezone = ActiveRecord::Base.sanitize_sql_for_conditions(customer.applicable_timezone)
+
+      "#{sanitized_field_name}::timestamptz AT TIME ZONE '#{sanitized_timezone}'"
+    end
+  end
+end

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
     )
   end
 
-  let(:from_date) { Time.zone.today - 1.month }
-  let(:to_date) { Time.zone.today }
+  let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
+  let(:to_datetime) { Time.current.end_of_day }
 
   before do
     create_list(
@@ -34,21 +34,21 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       code: billable_metric.code,
       subscription: subscription,
       customer: customer,
-      timestamp: Time.zone.now,
+      timestamp: Time.zone.now - 1.day,
     )
   end
 
   it 'aggregates the events' do
-    result = count_service.aggregate(from_date: from_date, to_date: to_date)
+    result = count_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
     expect(result.aggregation).to eq(4)
   end
 
   context 'when events are out of bounds' do
-    let(:to_date) { Time.zone.now - 2.days }
+    let(:to_datetime) { Time.zone.now - 2.days }
 
     it 'does not take events into account' do
-      result = count_service.aggregate(from_date: from_date, to_date: to_date)
+      result = count_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(0)
     end
@@ -75,7 +75,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 12,
           cloud: 'AWS',
@@ -88,7 +88,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 8,
           cloud: 'AWS',
@@ -101,7 +101,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 12,
           cloud: 'AWS',
@@ -111,7 +111,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
     end
 
     it 'aggregates the events' do
-      result = count_service.aggregate(from_date: from_date, to_date: to_date)
+      result = count_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(2)
     end

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     )
   end
 
-  let(:from_date) { Time.zone.today - 1.month }
-  let(:to_date) { Time.zone.today }
+  let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
+  let(:to_datetime) { Time.current.end_of_day }
 
   before do
     create_list(
@@ -35,7 +35,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       code: billable_metric.code,
       customer: customer,
       subscription: subscription,
-      timestamp: Time.zone.now,
+      timestamp: Time.zone.now - 1.day,
       properties: {
         total_count: rand(10),
       },
@@ -46,7 +46,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       code: billable_metric.code,
       customer: customer,
       subscription: subscription,
-      timestamp: Time.zone.now,
+      timestamp: Time.zone.now - 1.day,
       properties: {
         total_count: 12,
       },
@@ -54,17 +54,17 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
   end
 
   it 'aggregates the events' do
-    result = max_service.aggregate(from_date: from_date, to_date: to_date)
+    result = max_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
     expect(result.aggregation).to eq(12)
     expect(result.count).to eq(5)
   end
 
   context 'when events are out of bounds' do
-    let(:to_date) { Time.zone.now - 2.days }
+    let(:to_datetime) { Time.zone.now - 2.days }
 
     it 'does not take events into account' do
-      result = max_service.aggregate(from_date: from_date, to_date: to_date)
+      result = max_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(0)
       expect(result.count).to eq(0)
@@ -77,7 +77,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     end
 
     it 'counts as zero' do
-      result = max_service.aggregate(from_date: from_date, to_date: to_date)
+      result = max_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(0)
       expect(result.count).to eq(0)
@@ -91,7 +91,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 14.2,
         },
@@ -99,7 +99,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     end
 
     it 'aggregates the events' do
-      result = max_service.aggregate(from_date: from_date, to_date: to_date)
+      result = max_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(14.2)
     end
@@ -112,7 +112,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 'foo_bar',
         },
@@ -120,7 +120,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     end
 
     it 'returns a failed result' do
-      result = max_service.aggregate(from_date: from_date, to_date: to_date)
+      result = max_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       aggregate_failures do
         expect(result).not_to be_success
@@ -138,12 +138,12 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
       )
     end
 
     it 'ignore the event' do
-      result = max_service.aggregate(from_date: from_date, to_date: to_date)
+      result = max_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result).to be_success
       expect(result.aggregation).to eq(12)
@@ -161,7 +161,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 12,
           region: 'europe',
@@ -173,7 +173,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 8,
           region: 'europe',
@@ -185,7 +185,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 12,
           region: 'africa',
@@ -194,7 +194,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     end
 
     it 'aggregates the events' do
-      result = max_service.aggregate(from_date: from_date, to_date: to_date)
+      result = max_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(12)
       expect(result.count).to eq(2)

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
     )
   end
 
-  let(:from_date) { Date.parse('2022-07-09') }
-  let(:to_date) { Date.parse('2022-08-08') }
+  let(:from_datetime) { DateTime.parse('2022-07-09 00:00:00 UTC') }
+  let(:to_datetime) { DateTime.parse('2022-08-08 23:59:59 UTC') }
 
-  let(:added_at) { from_date - 1.month }
+  let(:added_at) { from_datetime - 1.month }
   let(:removed_at) { nil }
   let(:persisted_event) do
     create(
@@ -54,7 +54,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
   before { persisted_event }
 
   describe '#aggregate' do
-    let(:result) { recurring_service.aggregate(from_date: from_date, to_date: to_date) }
+    let(:result) { recurring_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime) }
 
     context 'with persisted metric on full period' do
       it 'returns the number of persisted metric' do
@@ -68,11 +68,11 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
             started_at: started_at,
             subscription_date: subscription_date,
             billing_time: :anniversary,
-            terminated_at: to_date,
+            terminated_at: to_datetime,
             status: :terminated,
           )
         end
-        let(:to_date) { Date.parse('2022-07-24') }
+        let(:to_datetime) { DateTime.parse('2022-07-24 23:59:59') }
 
         it 'returns the prorata of the full duration' do
           expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
@@ -86,11 +86,11 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
             started_at: started_at,
             subscription_date: subscription_date,
             billing_time: :anniversary,
-            terminated_at: to_date,
+            terminated_at: to_datetime,
             status: :terminated,
           )
         end
-        let(:to_date) { Date.parse('2022-07-24') }
+        let(:to_datetime) { DateTime.parse('2022-07-24 23:59:59') }
 
         before do
           create(
@@ -98,7 +98,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
             previous_subscription: subscription,
             organization: organization,
             customer: customer,
-            started_at: to_date,
+            started_at: to_datetime,
           )
         end
 
@@ -108,8 +108,8 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       end
 
       context 'when subscription was started in the period' do
-        let(:started_at) { Date.parse('2022-08-01') }
-        let(:from_date) { started_at }
+        let(:started_at) { DateTime.parse('2022-08-01') }
+        let(:from_datetime) { started_at }
 
         it 'returns the prorata of the full duration' do
           expect(result.aggregation).to eq(8.fdiv(31).ceil(5))
@@ -128,14 +128,14 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
     end
 
     context 'with persisted metrics added in the period' do
-      let(:added_at) { from_date + 15.days }
+      let(:added_at) { from_datetime + 15.days }
 
       it 'returns the prorata of the full duration' do
         expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
       end
 
       context 'when added on the first day of the period' do
-        let(:added_at) { from_date }
+        let(:added_at) { from_datetime }
 
         it 'returns the full duration' do
           expect(result.aggregation).to eq(1)
@@ -144,14 +144,14 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
     end
 
     context 'with persisted metrics terminated in the period' do
-      let(:removed_at) { to_date - 15.days }
+      let(:removed_at) { to_datetime - 15.days }
 
       it 'returns the prorata of the full duration' do
         expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
       end
 
       context 'when removed on the last day of the period' do
-        let(:removed_at) { to_date }
+        let(:removed_at) { to_datetime }
 
         it 'returns the full duration' do
           expect(result.aggregation).to eq(1)
@@ -160,16 +160,16 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
     end
 
     context 'with persisted metrics added and terminated in the period' do
-      let(:added_at) { from_date + 1.day }
-      let(:removed_at) { to_date - 1.day }
+      let(:added_at) { from_datetime + 1.day }
+      let(:removed_at) { to_datetime - 1.day }
 
       it 'returns the prorata of the full duration' do
         expect(result.aggregation).to eq(29.fdiv(31).ceil(5))
       end
 
       context 'when added and removed the same day' do
-        let(:added_at) { from_date + 1.day }
-        let(:removed_at) { added_at }
+        let(:added_at) { from_datetime + 1.day }
+        let(:removed_at) { added_at.end_of_day }
 
         it 'returns a 1 day duration' do
           expect(result.aggregation).to eq(1.fdiv(31).ceil(5))
@@ -179,7 +179,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
   end
 
   describe '#breakdown' do
-    let(:result) { recurring_service.breakdown(from_date: from_date, to_date: to_date).breakdown }
+    let(:result) { recurring_service.breakdown(from_datetime: from_datetime, to_datetime: to_datetime).breakdown }
 
     context 'with persisted metric on full period' do
       it 'returns the detail the persisted metrics' do
@@ -187,7 +187,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
           expect(result.count).to eq(1)
 
           item = result.first
-          expect(item.date.to_s).to eq(from_date.to_s)
+          expect(item.date.to_s).to eq(from_datetime.to_date.to_s)
           expect(item.action).to eq('add')
           expect(item.count).to eq(1)
           expect(item.duration).to eq(31)
@@ -202,18 +202,18 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
             started_at: started_at,
             subscription_date: subscription_date,
             billing_time: :anniversary,
-            terminated_at: to_date,
+            terminated_at: to_datetime,
             status: :terminated,
           )
         end
-        let(:to_date) { Date.parse('2022-07-24') }
+        let(:to_datetime) { DateTime.parse('2022-07-24 23:59:59') }
 
         it 'returns the detail the persisted metrics' do
           aggregate_failures do
             expect(result.count).to eq(1)
 
             item = result.first
-            expect(item.date.to_s).to eq(from_date.to_s)
+            expect(item.date.to_s).to eq(from_datetime.to_date.to_date.to_s)
             expect(item.action).to eq('add')
             expect(item.count).to eq(1)
             expect(item.duration).to eq(16)
@@ -229,11 +229,11 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
             started_at: started_at,
             subscription_date: subscription_date,
             billing_time: :anniversary,
-            terminated_at: to_date,
+            terminated_at: to_datetime,
             status: :terminated,
           )
         end
-        let(:to_date) { Date.parse('2022-07-24') }
+        let(:to_datetime) { DateTime.parse('2022-07-24 23:59:59') }
 
         before do
           create(
@@ -241,7 +241,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
             previous_subscription: subscription,
             organization: organization,
             customer: customer,
-            started_at: to_date,
+            started_at: to_datetime,
           )
         end
 
@@ -250,7 +250,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
             expect(result.count).to eq(1)
 
             item = result.first
-            expect(item.date.to_s).to eq(from_date.to_s)
+            expect(item.date.to_s).to eq(from_datetime.to_date.to_s)
             expect(item.action).to eq('add')
             expect(item.count).to eq(1)
             expect(item.duration).to eq(16)
@@ -260,15 +260,15 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       end
 
       context 'when subscription was started in the period' do
-        let(:started_at) { Date.parse('2022-08-01') }
-        let(:from_date) { started_at }
+        let(:started_at) { DateTime.parse('2022-08-01') }
+        let(:from_datetime) { started_at }
 
         it 'returns the detail the persisted metrics' do
           aggregate_failures do
             expect(result.count).to eq(1)
 
             item = result.first
-            expect(item.date.to_s).to eq(from_date.to_s)
+            expect(item.date.to_s).to eq(from_datetime.to_date.to_s)
             expect(item.action).to eq('add')
             expect(item.count).to eq(1)
             expect(item.duration).to eq(8)
@@ -279,14 +279,14 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
     end
 
     context 'with persisted metrics added in the period' do
-      let(:added_at) { from_date + 15.days }
+      let(:added_at) { from_datetime + 15.days }
 
       it 'returns the detail the persisted metrics' do
         aggregate_failures do
           expect(result.count).to eq(1)
 
           item = result.first
-          expect(item.date.to_s).to eq(added_at.to_s)
+          expect(item.date.to_s).to eq(added_at.to_date.to_s)
           expect(item.action).to eq('add')
           expect(item.count).to eq(1)
           expect(item.duration).to eq(16)
@@ -295,14 +295,14 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       end
 
       context 'when added on the first day of the period' do
-        let(:added_at) { from_date }
+        let(:added_at) { from_datetime }
 
         it 'returns the detail the persisted metrics' do
           aggregate_failures do
             expect(result.count).to eq(1)
 
             item = result.first
-            expect(item.date.to_s).to eq(from_date.to_s)
+            expect(item.date.to_s).to eq(from_datetime.to_date.to_s)
             expect(item.action).to eq('add')
             expect(item.count).to eq(1)
             expect(item.duration).to eq(31)
@@ -313,14 +313,14 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
     end
 
     context 'with persisted metrics terminated in the period' do
-      let(:removed_at) { to_date - 15.days }
+      let(:removed_at) { to_datetime - 15.days }
 
       it 'returns the detail the persisted metrics' do
         aggregate_failures do
           expect(result.count).to eq(1)
 
           item = result.first
-          expect(item.date.to_s).to eq(removed_at.to_s)
+          expect(item.date.to_s).to eq(removed_at.to_date.to_s)
           expect(item.action).to eq('remove')
           expect(item.count).to eq(1)
           expect(item.duration).to eq(16)
@@ -329,14 +329,14 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       end
 
       context 'when removed on the last day of the period' do
-        let(:removed_at) { to_date }
+        let(:removed_at) { to_datetime }
 
         it 'returns the detail the persisted metrics' do
           aggregate_failures do
             expect(result.count).to eq(1)
 
             item = result.first
-            expect(item.date.to_s).to eq(to_date.to_s)
+            expect(item.date.to_s).to eq(to_datetime.to_date.to_s)
             expect(item.action).to eq('remove')
             expect(item.count).to eq(1)
             expect(item.duration).to eq(31)
@@ -347,15 +347,15 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
     end
 
     context 'with persisted metrics added and terminated in the period' do
-      let(:added_at) { from_date + 1.day }
-      let(:removed_at) { to_date - 1.day }
+      let(:added_at) { from_datetime + 1.day }
+      let(:removed_at) { to_datetime - 1.day }
 
       it 'returns the detail the persisted metrics' do
         aggregate_failures do
           expect(result.count).to eq(1)
 
           item = result.first
-          expect(item.date.to_s).to eq(added_at.to_s)
+          expect(item.date.to_s).to eq(added_at.to_date.to_s)
           expect(item.action).to eq('add_and_removed')
           expect(item.count).to eq(1)
           expect(item.duration).to eq(29)
@@ -364,7 +364,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       end
 
       context 'when added and removed the same day' do
-        let(:added_at) { from_date + 1.day }
+        let(:added_at) { from_datetime + 1.day }
         let(:removed_at) { added_at }
 
         it 'returns the detail the persisted metrics' do
@@ -372,7 +372,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
             expect(result.count).to eq(1)
 
             item = result.first
-            expect(item.date.to_s).to eq(added_at.to_s)
+            expect(item.date.to_s).to eq(added_at.to_date.to_s)
             expect(item.action).to eq('add_and_removed')
             expect(item.count).to eq(1)
             expect(item.duration).to eq(1)
@@ -429,7 +429,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       end
 
       it 'aggregates the events' do
-        result = recurring_service.aggregate(from_date: from_date, to_date: to_date)
+        result = recurring_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
         expect(result.aggregation).to eq(2)
       end

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     )
   end
 
-  let(:from_date) { Time.zone.today - 1.month }
-  let(:to_date) { Time.zone.today }
+  let(:from_datetime) { Time.current - 1.month }
+  let(:to_datetime) { Time.current }
   let(:options) do
     { free_units_per_events: 2, free_units_per_total_aggregation: 30 }
   end
@@ -38,7 +38,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       code: billable_metric.code,
       customer: customer,
       subscription: subscription,
-      timestamp: Time.zone.now,
+      timestamp: Time.zone.now - 1.day,
       properties: {
         total_count: 12,
       },
@@ -46,7 +46,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
   end
 
   it 'aggregates the events' do
-    result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
+    result = sum_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime, options: options)
 
     expect(result.aggregation).to eq(48)
     expect(result.count).to eq(4)
@@ -57,7 +57,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     let(:options) { {} }
 
     it 'returns an empty running total array' do
-      result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
+      result = sum_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime, options: options)
       expect(result.options).to eq({ running_total: [] })
     end
   end
@@ -68,7 +68,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'returns an empty running total array' do
-      result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
+      result = sum_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime, options: options)
       expect(result.options).to eq({ running_total: [] })
     end
   end
@@ -79,7 +79,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'returns running total based on per total aggregation' do
-      result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
+      result = sum_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime, options: options)
       expect(result.options).to eq({ running_total: [12, 24, 36] })
     end
   end
@@ -90,16 +90,16 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'returns running total based on per events' do
-      result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
+      result = sum_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime, options: options)
       expect(result.options).to eq({ running_total: [12, 24] })
     end
   end
 
   context 'when events are out of bounds' do
-    let(:to_date) { Time.zone.now - 2.days }
+    let(:to_datetime) { Time.zone.now - 2.days }
 
     it 'does not take events into account' do
-      result = sum_service.aggregate(from_date: from_date, to_date: to_date)
+      result = sum_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(0)
       expect(result.count).to eq(0)
@@ -113,7 +113,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'counts as zero' do
-      result = sum_service.aggregate(from_date: from_date, to_date: to_date)
+      result = sum_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(0)
       expect(result.count).to eq(0)
@@ -128,7 +128,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 4.5,
         },
@@ -136,7 +136,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'aggregates the events' do
-      result = sum_service.aggregate(from_date: from_date, to_date: to_date)
+      result = sum_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(52.5)
     end
@@ -149,7 +149,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 'foo_bar',
         },
@@ -157,7 +157,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'returns a failed result' do
-      result = sum_service.aggregate(from_date: from_date, to_date: to_date)
+      result = sum_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       aggregate_failures do
         expect(result).not_to be_success
@@ -179,7 +179,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 12,
           region: 'europe',
@@ -191,7 +191,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 8,
           region: 'europe',
@@ -203,7 +203,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
         code: billable_metric.code,
         customer: customer,
         subscription: subscription,
-        timestamp: Time.zone.now,
+        timestamp: Time.zone.now - 1.day,
         properties: {
           total_count: 12,
           region: 'africa',
@@ -212,7 +212,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'aggregates the events' do
-      result = sum_service.aggregate(from_date: from_date, to_date: to_date, options: options)
+      result = sum_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime, options: options)
 
       expect(result.aggregation).to eq(20)
       expect(result.count).to eq(2)

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
     )
   end
 
-  let(:from_date) { Time.zone.today - 1.month }
-  let(:to_date) { Time.zone.today }
+  let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
+  let(:to_datetime) { Time.current.end_of_day }
 
   before do
     create_list(
@@ -35,7 +35,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       code: billable_metric.code,
       customer: customer,
       subscription: subscription,
-      timestamp: Time.zone.now,
+      timestamp: Time.zone.now - 1.day,
       properties: {
         anonymous_id: 'foo_bar',
       },
@@ -43,17 +43,17 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
   end
 
   it 'aggregates the events' do
-    result = count_service.aggregate(from_date: from_date, to_date: to_date)
+    result = count_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
     expect(result.aggregation).to eq(1)
     expect(result.count).to eq(4)
   end
 
   context 'when events are out of bounds' do
-    let(:to_date) { Time.zone.now - 2.days }
+    let(:to_datetime) { Time.zone.now - 2.days }
 
     it 'does not take events into account' do
-      result = count_service.aggregate(from_date: from_date, to_date: to_date)
+      result = count_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(0)
       expect(result.count).to eq(0)
@@ -66,7 +66,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
     end
 
     it 'counts as zero' do
-      result = count_service.aggregate(from_date: from_date, to_date: to_date)
+      result = count_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(0)
       expect(result.count).to eq(0)
@@ -117,7 +117,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
     end
 
     it 'aggregates the events' do
-      result = count_service.aggregate(from_date: from_date, to_date: to_date)
+      result = count_service.aggregate(from_datetime: from_datetime, to_datetime: to_datetime)
 
       expect(result.aggregation).to eq(1)
       expect(result.count).to eq(2)


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR updates the aggregation service to use datetime instead of dates for calculation.
It will allow the usage of the datetime in customer timezone once the changes on the date service will be merged
