### PR TITLE
feat(timezones): Create customer with timezone

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -92,6 +92,7 @@ module Api
           :legal_name,
           :legal_number,
           :currency,
+          :timezone,
           billing_configuration: [
             :invoice_grace_period,
             :payment_provider,

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -33,6 +33,7 @@ module Api
           :city,
           :legal_name,
           :legal_number,
+          :timezone,
           billing_configuration: [
             :invoice_footer,
             :invoice_grace_period,

--- a/app/graphql/mutations/customers/create.rb
+++ b/app/graphql/mutations/customers/create.rb
@@ -26,6 +26,7 @@ module Mutations
       argument :vat_rate, Float, required: false
       argument :invoice_grace_period, Integer, required: false
       argument :currency, Types::CurrencyEnum, required: false
+      argument :timezone, Types::TimezoneEnum, required: false
 
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false

--- a/app/graphql/mutations/customers/update.rb
+++ b/app/graphql/mutations/customers/update.rb
@@ -26,6 +26,7 @@ module Mutations
       argument :vat_rate, Float, required: false
       argument :invoice_grace_period, Integer, required: false
       argument :currency, Types::CurrencyEnum, required: false
+      argument :timezone, Types::TimezoneEnum, required: false
 
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false

--- a/app/graphql/mutations/organizations/update.rb
+++ b/app/graphql/mutations/organizations/update.rb
@@ -23,6 +23,7 @@ module Mutations
       argument :country, Types::CountryCodeEnum, required: false
       argument :invoice_footer, String, required: false
       argument :invoice_grace_period, Integer, required: false
+      argument :timezone, Types::TimezoneEnum, required: false
 
       type Types::OrganizationType
 

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -20,6 +20,7 @@ module Customers
         customer.logo_url = params[:logo_url] if params.key?(:logo_url)
         customer.legal_name = params[:legal_name] if params.key?(:legal_name)
         customer.legal_number = params[:legal_number] if params.key?(:legal_number)
+        customer.timezone = params[:timezone] if params.key?(:timezone)
 
         if params.key?(:currency)
           currency_result = Customers::UpdateService.new(nil).update_currency(
@@ -64,6 +65,7 @@ module Customers
         invoice_grace_period: args[:invoice_grace_period] || 0,
         payment_provider: args[:payment_provider],
         currency: args[:currency],
+        timezone: args[:timezone],
       )
 
       # NOTE: handle configuration for configured payment providers

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -26,6 +26,7 @@ module Customers
         customer.logo_url = args[:logo_url] if args.key?(:logo_url)
         customer.legal_name = args[:legal_name] if args.key?(:legal_name)
         customer.legal_number = args[:legal_number] if args.key?(:legal_number)
+        customer.timezone = args[:timezone] if args.key?(:timezone)
 
         # TODO: delete this when GraphQL will use billing_configuration.
         customer.vat_rate = args[:vat_rate] if args.key?(:vat_rate)

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -22,6 +22,7 @@ module Organizations
       organization.country = args[:country] if args.key?(:country)
       organization.invoice_footer = args[:invoice_footer] if args.key?(:invoice_footer)
       organization.invoice_grace_period = args[:invoice_grace_period] if args.key?(:invoice_grace_period)
+      organization.timezone = args[:timezone] if args.key?(:timezone)
 
       handle_base64_logo(args[:logo]) if args.key?(:logo)
 
@@ -45,6 +46,7 @@ module Organizations
       organization.city = params[:city] if params.key?(:city)
       organization.legal_name = params[:legal_name] if params.key?(:legal_name)
       organization.legal_number = params[:legal_number] if params.key?(:legal_number)
+      organization.timezone = params[:timezone] if params.key?(:timezone)
 
       if params.key?(:billing_configuration)
         billing = params[:billing_configuration]

--- a/schema.graphql
+++ b/schema.graphql
@@ -4712,6 +4712,7 @@ input UpdateCustomerInput {
   phone: String
   providerCustomer: ProviderCustomerInput
   state: String
+  timezone: TimezoneEnum
   url: String
   vatRate: Float
   zipcode: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -1669,6 +1669,7 @@ input CreateCustomerInput {
   phone: String
   providerCustomer: ProviderCustomerInput
   state: String
+  timezone: TimezoneEnum
   url: String
   vatRate: Float
   zipcode: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -4763,6 +4763,7 @@ input UpdateOrganizationInput {
   legalNumber: String
   logo: String
   state: String
+  timezone: TimezoneEnum
   vatRate: Float
   webhookUrl: String
   zipcode: String

--- a/schema.json
+++ b/schema.json
@@ -18213,6 +18213,18 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "timezone",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "TimezoneEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "enumValues": null

--- a/schema.json
+++ b/schema.json
@@ -17874,6 +17874,18 @@
               "deprecationReason": null
             },
             {
+              "name": "timezone",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "TimezoneEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "paymentProvider",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -5100,6 +5100,18 @@
               "deprecationReason": null
             },
             {
+              "name": "timezone",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "TimezoneEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "paymentProvider",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           paymentProvider
           providerCustomer { id, providerCustomerId }
           currency
+          timezone
           canEditAttributes
           invoiceGracePeriod
         }
@@ -41,6 +42,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           country: 'GB',
           paymentProvider: 'stripe',
           currency: 'EUR',
+          timezone: 'TZ_EUROPE_PARIS',
           invoiceGracePeriod: 2,
           providerCustomer: {
             providerCustomerId: 'cu_12345',
@@ -58,6 +60,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
       expect(result_data['city']).to eq('London')
       expect(result_data['country']).to eq('GB')
       expect(result_data['currency']).to eq('EUR')
+      expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
       expect(result_data['invoiceGracePeriod']).to eq(2)
       expect(result_data['paymentProvider']).to eq('stripe')
       expect(result_data['providerCustomer']['id']).to be_present

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           externalId
           paymentProvider
           currency
+          timezone
           canEditAttributes
           invoiceGracePeriod
           providerCustomer { id, providerCustomerId }
@@ -39,6 +40,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           externalId: external_id,
           paymentProvider: 'stripe',
           currency: 'EUR',
+          timezone: 'TZ_EUROPE_PARIS',
           invoiceGracePeriod: 2,
           providerCustomer: {
             providerCustomerId: 'cu_12345',
@@ -55,6 +57,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       expect(result_data['externalId']).to eq(external_id)
       expect(result_data['paymentProvider']).to eq('stripe')
       expect(result_data['currency']).to eq('EUR')
+      expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
       expect(result_data['invoiceGracePeriod']).to eq(2)
       expect(result_data['providerCustomer']['id']).to be_present
       expect(result_data['providerCustomer']['providerCustomerId']).to eq('cu_12345')

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           zipcode: 'FOO1234',
           city: 'Foobar',
           country: 'FR',
+          timezone: 'TZ_EUROPE_PARIS',
           invoiceFooter: 'invoice footer',
           invoiceGracePeriod: 3,
         },
@@ -67,7 +68,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
       expect(result_data['country']).to eq('FR')
       expect(result_data['invoiceFooter']).to eq('invoice footer')
       expect(result_data['invoiceGracePeriod']).to eq(3)
-      expect(result_data['timezone']).to eq('TZ_UTC')
+      expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
     end
   end
 

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         external_id: SecureRandom.uuid,
         name: 'Foo Bar',
         currency: 'EUR',
+        timezone: 'America/New_York',
       }
     end
 
@@ -24,6 +25,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         expect(json[:customer][:name]).to eq(create_params[:name])
         expect(json[:customer][:created_at]).to be_present
         expect(json[:customer][:currency]).to eq(create_params[:currency])
+        expect(json[:customer][:timezone]).to eq(create_params[:timezone])
       end
     end
 
@@ -225,8 +227,12 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       let(:aws) { create(:group, billable_metric: metric, key: 'cloud', value: 'aws') }
       let(:google) { create(:group, billable_metric: metric, key: 'cloud', value: 'google') }
       let(:aws_usa) { create(:group, billable_metric: metric, key: 'region', value: 'usa', parent_group_id: aws.id) }
-      let(:aws_france) { create(:group, billable_metric: metric, key: 'region', value: 'france', parent_group_id: aws.id) }
-      let(:google_usa) { create(:group, billable_metric: metric, key: 'region', value: 'usa', parent_group_id: google.id) }
+      let(:aws_france) do
+        create(:group, billable_metric: metric, key: 'region', value: 'france', parent_group_id: aws.id)
+      end
+      let(:google_usa) do
+        create(:group, billable_metric: metric, key: 'region', value: 'usa', parent_group_id: google.id)
+      end
 
       let(:charge) do
         create(

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
         city: 'test_city',
         legal_name: 'test1',
         legal_number: '123',
+        timezone: 'Europe/Paris',
         billing_configuration: {
           invoice_footer: 'footer',
           invoice_grace_period: 3,
@@ -39,6 +40,7 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
         expect(json[:organization][:name]).to eq(organization.name)
         expect(json[:organization][:webhook_url]).to eq(update_params[:webhook_url])
         expect(json[:organization][:vat_rate]).to eq(update_params[:vat_rate])
+        expect(json[:organization][:timezone]).to eq(update_params[:timezone])
 
         billing = json[:organization][:billing_configuration]
         expect(billing[:invoice_footer]).to eq('footer')

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Customers::CreateService, type: :service do
         external_id: SecureRandom.uuid,
         name: 'Foo Bar',
         currency: 'EUR',
+        timezone: 'Europe/Paris',
         billing_configuration: {
           invoice_grace_period: 3,
           vat_rate: 20,
@@ -42,6 +43,7 @@ RSpec.describe Customers::CreateService, type: :service do
         expect(customer.external_id).to eq(create_args[:external_id])
         expect(customer.name).to eq(create_args[:name])
         expect(customer.currency).to eq(create_args[:currency])
+        expect(customer.timezone).to eq(create_args[:timezone])
 
         billing = create_args[:billing_configuration]
         expect(customer.invoice_grace_period).to eq(billing[:invoice_grace_period])
@@ -304,6 +306,7 @@ RSpec.describe Customers::CreateService, type: :service do
         name: 'Foo Bar',
         organization_id: organization.id,
         currency: 'EUR',
+        timezone: 'Europe/Paris',
         invoice_grace_period: 2,
       }
     end
@@ -325,6 +328,7 @@ RSpec.describe Customers::CreateService, type: :service do
         expect(customer.external_id).to eq(create_args[:external_id])
         expect(customer.name).to eq(create_args[:name])
         expect(customer.currency).to eq('EUR')
+        expect(customer.timezone).to eq('Europe/Paris')
         expect(customer.invoice_grace_period).to eq(2)
       end
     end

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Customers::UpdateService, type: :service do
         id: customer.id,
         name: 'Updated customer name',
         external_id: external_id,
+        timezone: 'Europe/Paris',
         billing_configuration: {
           invoice_grace_period: 3,
           vat_rate: 20,
@@ -33,6 +34,7 @@ RSpec.describe Customers::UpdateService, type: :service do
       updated_customer = result.customer
       aggregate_failures do
         expect(updated_customer.name).to eq('Updated customer name')
+        expect(updated_customer.timezone).to eq('Europe/Paris')
 
         billing = update_args[:billing_configuration]
         expect(updated_customer.invoice_grace_period).to eq(billing[:invoice_grace_period])

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Organizations::UpdateService do
         zipcode: 'FOO1234',
         city: 'Foobar',
         country: 'FR',
+        timezone: 'Europe/Paris',
         invoice_footer: 'invoice footer',
         invoice_grace_period: 3,
       )
@@ -37,6 +38,7 @@ RSpec.describe Organizations::UpdateService do
         expect(result.organization.zipcode).to eq('FOO1234')
         expect(result.organization.city).to eq('Foobar')
         expect(result.organization.country).to eq('FR')
+        expect(result.organization.timezone).to eq('Europe/Paris')
         expect(result.organization.invoice_footer).to eq('invoice footer')
         expect(result.organization.invoice_grace_period).to eq(3)
       end
@@ -74,6 +76,7 @@ RSpec.describe Organizations::UpdateService do
         city: 'test_city',
         legal_name: 'test1',
         legal_number: '123',
+        timezone: 'Europe/Paris',
         billing_configuration: {
           invoice_footer: 'footer',
           invoice_grace_period: 3,
@@ -83,7 +86,7 @@ RSpec.describe Organizations::UpdateService do
     end
 
     it 'updates an organization' do
-      result = subject.update_from_api(params: update_args)
+      result = organization_update_service.update_from_api(params: update_args)
 
       aggregate_failures do
         expect(result).to be_success
@@ -91,6 +94,7 @@ RSpec.describe Organizations::UpdateService do
         organization_response = result.organization
         expect(organization_response.name).to eq(organization.name)
         expect(organization_response.webhook_url).to eq(update_args[:webhook_url])
+        expect(organization_response.timezone).to eq(update_args[:timezone])
 
         billing = update_args[:billing_configuration]
         expect(organization_response.invoice_footer).to eq(billing[:invoice_footer])
@@ -103,7 +107,7 @@ RSpec.describe Organizations::UpdateService do
       let(:country) { '---' }
 
       it 'returns an error' do
-        result = subject.update_from_api(params: update_args)
+        result = organization_update_service.update_from_api(params: update_args)
 
         aggregate_failures do
           expect(result).not_to be_success


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR adds the logic to assign and update timezone to customer and organization
