### PR TITLE
feat(grace_period): Create invoice as draft if applicable grace period

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -68,6 +68,12 @@ class Customer < ApplicationRecord
     organization.timezone || 'UTC'
   end
 
+  def applicable_invoice_grace_period
+    return invoice_grace_period if invoice_grace_period.positive?
+
+    organization.invoice_grace_period
+  end
+
   def editable?
     !attached_to_subscriptions? &&
       applied_add_ons.none? &&

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -49,7 +49,9 @@ module Invoices
         result.invoice = invoice
       end
 
-      unless grace_period?
+      if grace_period?
+        SendWebhookJob.perform_later('invoice.drafted', result.invoice) if should_deliver_webhook?
+      else
         SendWebhookJob.perform_later(:invoice, result.invoice) if should_deliver_webhook?
         create_payment(result.invoice)
         track_invoice_created(result.invoice)

--- a/app/services/webhooks/invoices/drafted_service.rb
+++ b/app/services/webhooks/invoices/drafted_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Invoices
+    class DraftedService < Webhooks::BaseService
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::InvoiceSerializer.new(
+          object,
+          root_name: 'invoice',
+          includes: %i[customer subscriptions fees credits],
+        )
+      end
+
+      def webhook_type
+        'invoice.drafted'
+      end
+
+      def object_type
+        'invoice'
+      end
+    end
+  end
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -105,6 +105,37 @@ RSpec.describe Customer, type: :model do
     end
   end
 
+  describe '#applicable_invoice_grace_period' do
+    subject(:customer) do
+      described_class.new(organization: organization, invoice_grace_period: 3)
+    end
+
+    it 'returns the customer invoice_grace_period' do
+      expect(customer.applicable_invoice_grace_period).to eq(3)
+    end
+
+    context 'when customer does not have an invoice grace period' do
+      let(:organization_invoice_grace_period) { 5 }
+
+      before do
+        customer.invoice_grace_period = 0
+        organization.invoice_grace_period = organization_invoice_grace_period
+      end
+
+      it 'returns the organization invoice_grace_period' do
+        expect(customer.applicable_invoice_grace_period).to eq(5)
+      end
+
+      context 'when organization invoice_grace_period is nil' do
+        let(:organization_invoice_grace_period) { 0 }
+
+        it 'returns the default invoice_grace_period' do
+          expect(customer.applicable_invoice_grace_period).to eq(0)
+        end
+      end
+    end
+  end
+
   describe 'timezones' do
     subject(:customer) do
       build(

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Invoices::CreateService, type: :service do
       it 'enqueues a SendWebhookJob' do
         expect do
           invoice_service.create
-        end.to have_enqueued_job(SendWebhookJob)
+        end.to have_enqueued_job(SendWebhookJob).with(:invoice, Invoice)
       end
 
       context 'when organization does not have a webhook url' do
@@ -276,7 +276,7 @@ RSpec.describe Invoices::CreateService, type: :service do
       it 'enqueues a SendWebhookJob' do
         expect do
           invoice_service.create
-        end.to have_enqueued_job(SendWebhookJob)
+        end.to have_enqueued_job(SendWebhookJob).with(:invoice, Invoice)
       end
     end
 
@@ -1032,6 +1032,12 @@ RSpec.describe Invoices::CreateService, type: :service do
         result = invoice_service.create
         expect(result).to be_success
         expect(result.invoice).to be_draft
+      end
+
+      it 'enqueues a SendWebhookJob' do
+        expect do
+          invoice_service.create
+        end.to have_enqueued_job(SendWebhookJob).with('invoice.drafted', Invoice)
       end
     end
   end

--- a/spec/services/webhooks/invoices/drafted_service_spec.rb
+++ b/spec/services/webhooks/invoices/drafted_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Webhooks::InvoicesService do
+RSpec.describe Webhooks::Invoices::DraftedService do
   subject(:webhook_invoice_service) { described_class.new(invoice) }
 
   let(:organization) { create(:organization, webhook_url: webhook_url) }
@@ -12,8 +12,8 @@ RSpec.describe Webhooks::InvoicesService do
   let(:webhook_url) { 'http://foo.bar' }
 
   before do
-    create_list(:fee, 4, invoice: invoice)
-    create_list(:credit, 4, invoice: invoice)
+    create_list(:fee, 2, invoice: invoice)
+    create_list(:credit, 2, invoice: invoice)
   end
 
   describe '.call' do
@@ -34,13 +34,13 @@ RSpec.describe Webhooks::InvoicesService do
       expect(lago_client).to have_received(:post)
     end
 
-    it 'builds payload with invoice.created webhook type' do
+    it 'builds payload with invoice.drafted webhook type' do
       webhook_invoice_service.call
 
       expect(LagoHttpClient::Client).to have_received(:new)
         .with(organization.webhook_url)
       expect(lago_client).to have_received(:post) do |payload|
-        expect(payload[:webhook_type]).to eq('invoice.created')
+        expect(payload[:webhook_type]).to eq('invoice.drafted')
         expect(payload[:object_type]).to eq('invoice')
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe Webhooks::InvoicesService do
         invoice,
         root_name: 'invoice',
         includes: %i[customer subscription fees],
-      ).serialize.merge(webook_type: 'invoice.created')
+      ).serialize.merge(webook_type: 'invoice.drafted')
     end
 
     it 'generates the query headers' do


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to create invoice as draft if applicable grace period.
