### PR TITLE
feat(timezones): Invoice issuing date must be in customer timezone

### DIFF
--- a/app/jobs/bill_add_on_job.rb
+++ b/app/jobs/bill_add_on_job.rb
@@ -5,10 +5,10 @@ class BillAddOnJob < ApplicationJob
 
   retry_on Sequenced::SequenceError
 
-  def perform(applied_add_on, date)
+  def perform(applied_add_on, timestamp)
     result = Invoices::AddOnService.new(
       applied_add_on: applied_add_on,
-      date: date,
+      datetime: Time.zone.at(timestamp),
     ).create
 
     raise(result.throw_error) unless result.success?

--- a/app/services/applied_add_ons/create_service.rb
+++ b/app/services/applied_add_ons/create_service.rb
@@ -68,7 +68,7 @@ module AppliedAddOns
 
       BillAddOnJob.perform_later(
         applied_add_on,
-        Time.zone.now.to_date,
+        Time.zone.now.to_i,
       )
 
       result.applied_add_on = applied_add_on

--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    class CreateService < BaseService
+      def initialize(invoice)
+        @invoice = invoice
+
+        super
+      end
+
+      def call
+        case payment_provider
+        when :stripe
+          Invoices::Payments::StripeCreateJob.perform_later(invoice)
+        when :gocardless
+          Invoices::Payments::GocardlessCreateJob.perform_later(invoice)
+        end
+      end
+
+      private
+
+      attr_reader :invoice
+
+      def payment_provider
+        invoice.customer.payment_provider&.to_sym
+      end
+    end
+  end
+end

--- a/spec/jobs/bill_add_on_job_spec.rb
+++ b/spec/jobs/bill_add_on_job_spec.rb
@@ -4,21 +4,21 @@ require 'rails_helper'
 
 RSpec.describe BillAddOnJob, type: :job do
   let(:applied_add_on) { create(:applied_add_on) }
-  let(:date) { Time.zone.now.to_date }
+  let(:datetime) { Time.current.round }
 
   let(:invoice_service) { instance_double(Invoices::AddOnService) }
   let(:result) { BaseService::Result.new }
 
   before do
     allow(Invoices::AddOnService).to receive(:new)
-      .with(applied_add_on: applied_add_on, date: date)
+      .with(applied_add_on: applied_add_on, datetime: datetime)
       .and_return(invoice_service)
     allow(invoice_service).to receive(:create)
       .and_return(result)
   end
 
   it 'calls the add on create service' do
-    described_class.perform_now(applied_add_on, date)
+    described_class.perform_now(applied_add_on, datetime.to_i)
 
     expect(Invoices::AddOnService).to have_received(:new)
     expect(invoice_service).to have_received(:create)
@@ -31,7 +31,7 @@ RSpec.describe BillAddOnJob, type: :job do
 
     it 'raises an error' do
       expect do
-        described_class.perform_now(applied_add_on, date)
+        described_class.perform_now(applied_add_on, datetime.to_i)
       end.to raise_error(BaseService::FailedResult)
 
       expect(Invoices::AddOnService).to have_received(:new)

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::Payments::CreateService, type: :service do
+  subject(:create_service) { described_class.new(invoice) }
+
+  let(:invoice) { create(:invoice, customer: customer) }
+  let(:customer) { create(:customer, payment_provider: payment_provider) }
+  let(:payment_provider) { 'stripe' }
+
+  describe '#call' do
+    it 'enqueues a job to create a stripe payment' do
+      expect do
+        create_service.call
+      end.to have_enqueued_job(Invoices::Payments::StripeCreateJob)
+    end
+
+    context 'with gocardless payment provider' do
+      let(:payment_provider) { 'gocardless' }
+
+      it 'enqueues a job to create a gocardless payment' do
+        expect do
+          create_service.call
+        end.to have_enqueued_job(Invoices::Payments::GocardlessCreateJob)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR updates the logic around invoice `issuing_date` to make sure the date is always in customer timezone.
