### PR TITLE
feat(timezones): Add issuing date in customer timezone on Credit notes

### DIFF
--- a/app/graphql/types/credit_notes/object.rb
+++ b/app/graphql/types/credit_notes/object.rb
@@ -8,6 +8,7 @@ module Types
       field :id, ID, null: false
       field :sequential_id, ID, null: false
       field :number, String, null: false
+      field :issuing_date, GraphQL::Types::ISO8601Date, null: false
 
       field :credit_status, Types::CreditNotes::CreditStatusTypeEnum, null: true
       field :refund_status, Types::CreditNotes::RefundStatusTypeEnum, null: true

--- a/app/serializers/v1/credit_note_serializer.rb
+++ b/app/serializers/v1/credit_note_serializer.rb
@@ -9,6 +9,7 @@ module V1
         number: model.number,
         lago_invoice_id: model.invoice_id,
         invoice_number: model.invoice.number,
+        issuing_date: model.issuing_date.iso8601,
         credit_status: model.credit_status,
         refund_status: model.refund_status,
         reason: model.reason,

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -18,6 +18,7 @@ module CreditNotes
         result.credit_note = CreditNote.create!(
           customer: invoice.customer,
           invoice: invoice,
+          issuing_date: issuing_date,
           total_amount_currency: invoice.amount_currency,
           vat_amount_currency: invoice.amount_currency,
           credit_amount_currency: invoice.amount_currency,
@@ -57,6 +58,12 @@ module CreditNotes
     attr_accessor :invoice, :items_attr, :reason, :description
 
     delegate :credit_note, to: :result
+    delegate :customer, to: :invoice
+
+    # NOTE: issuing_date must be in customer time zone (accounting date)
+    def issuing_date
+      Time.current.in_time_zone(customer.applicable_timezone).to_date
+    end
 
     def create_items
       items_attr.each do |item_attr|

--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -284,7 +284,7 @@ html
               td.body-2 = invoice.number
             tr
               td.body-1 Issue date
-              td.body-2 = created_at.strftime('%b %d, %Y')
+              td.body-2 = issuing_date.strftime('%b %d, %Y')
 
       .mb-24.overflow-auto
         .billing-information-column
@@ -329,11 +329,11 @@ html
         h2.title-2.mb-8 = total_amount.format
         .body-1
           - if credited? && refunded?
-            | Credited on customer balance and refunded on #{created_at.strftime('%b %d, %Y')}
+            | Credited on customer balance and refunded on #{issuing_date.strftime('%b %d, %Y')}
           - elsif credited?
-            | Credited on customer balance on #{created_at.strftime('%b %d, %Y')}
+            | Credited on customer balance on #{issuing_date.strftime('%b %d, %Y')}
           - else
-            | Refunded on #{created_at.strftime('%b %d, %Y')}
+            | Refunded on #{issuing_date.strftime('%b %d, %Y')}
 
       .credit-note-resume.mb-24.overflow-auto
         table.credit-note-resume-table width="100%"

--- a/db/migrate/20221125111605_add_issuing_date_to_credit_notes.rb
+++ b/db/migrate/20221125111605_add_issuing_date_to_credit_notes.rb
@@ -1,0 +1,17 @@
+# frozen_time_literal: true
+
+class AddIssuingDateToCreditNotes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :credit_notes, :issuing_date, :date
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE credit_notes SET issuing_date = DATE(created_at);
+        SQL
+      end
+    end
+
+    change_column_null :credit_notes, :issuing_date, false
+  end
+end

--- a/db/migrate/20221125111605_add_issuing_date_to_credit_notes.rb
+++ b/db/migrate/20221125111605_add_issuing_date_to_credit_notes.rb
@@ -1,4 +1,4 @@
-# frozen_time_literal: true
+# frozen_string_literal: true
 
 class AddIssuingDateToCreditNotes < ActiveRecord::Migration[7.0]
   def change

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_18_093903) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_25_111605) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -171,6 +171,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_18_093903) do
     t.string "refund_vat_amount_currency"
     t.bigint "vat_amount_cents", default: 0, null: false
     t.string "vat_amount_currency"
+    t.date "issuing_date", null: false
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1770,6 +1770,7 @@ type CreditNote {
   fileUrl: String
   id: ID!
   invoice: Invoice
+  issuingDate: ISO8601Date!
   items: [CreditNoteItem!]!
   number: String!
   reason: CreditNoteReasonEnum!

--- a/schema.json
+++ b/schema.json
@@ -5853,6 +5853,24 @@
               ]
             },
             {
+              "name": "issuingDate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "items",
               "description": null,
               "type": {

--- a/spec/factories/credit_notes.rb
+++ b/spec/factories/credit_notes.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     customer
     invoice
 
+    issuing_date { Time.zone.today }
+
     reason { 'duplicated_charge' }
     total_amount_cents { 120 }
     total_amount_currency { 'EUR' }


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR updates the logic around credit notes to add an `issuing_date`. This date will be in the customer timezone.
