### PR TITLE
feat(grace_period): Ability to fetch invoices by status

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -30,6 +30,7 @@ module Api
         if params[:external_customer_id]
           invoices = invoices.joins(:customer).where(customers: { external_id: params[:external_customer_id] })
         end
+        invoices = invoices.where(status: params[:status]) if valid_status?(params[:status])
         invoices = invoices.where(date_from_criteria) if valid_date?(params[:issuing_date_from])
         invoices = invoices.where(date_to_criteria) if valid_date?(params[:issuing_date_to])
         invoices = invoices.order(created_at: :desc)
@@ -87,6 +88,10 @@ module Api
 
       def date_to_criteria
         { issuing_date: ..Date.strptime(params[:issuing_date_to]) }
+      end
+
+      def valid_status?(status)
+        Invoice.statuses.key?(status)
       end
     end
   end

--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module Customers
+    class InvoicesResolver < Resolvers::BaseResolver
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      description 'Query invoices of a customer'
+
+      argument :customer_id, type: ID, required: true
+      argument :status, Types::Invoices::StatusTypeEnum, required: false
+      argument :page, Integer, required: false
+      argument :limit, Integer, required: false
+
+      type Types::Invoices::Object.collection_type, null: false
+
+      def resolve(customer_id:, status: nil, page: nil, limit: nil)
+        validate_organization!
+        current_customer = Customer.find(customer_id)
+
+        invoices = current_customer.invoices
+        invoices = invoices.where(status: status) if status.present?
+        invoices.order(created_at: :desc).page(page).per(limit)
+      rescue ActiveRecord::RecordNotFound
+        not_found_error(resource: 'customer')
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -20,6 +20,7 @@ module Types
     field :customer, resolver: Resolvers::CustomerResolver
     field :events, resolver: Resolvers::EventsResolver
     field :customer_usage, resolver: Resolvers::Customers::UsageResolver
+    field :customer_invoices, resolver: Resolvers::Customers::InvoicesResolver
     field :plans, resolver: Resolvers::PlansResolver
     field :plan, resolver: Resolvers::PlanResolver
     field :current_version, resolver: Resolvers::VersionResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -2945,6 +2945,11 @@ type Invoice {
   walletTransactionAmountCents: Int!
 }
 
+type InvoiceCollection {
+  collection: [Invoice!]!
+  metadata: CollectionMetadata!
+}
+
 """
 Invoice Item
 """
@@ -3690,6 +3695,11 @@ type Query {
     """
     id: ID!
   ): CustomerDetails
+
+  """
+  Query invoices of a customer
+  """
+  customerInvoices(customerId: ID!, limit: Int, page: Int, status: InvoiceStatusTypeEnum): InvoiceCollection!
 
   """
   Query the usage of the customer on the current billing period

--- a/schema.json
+++ b/schema.json
@@ -11076,6 +11076,63 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "InvoiceCollection",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Invoice",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
           "kind": "INTERFACE",
           "name": "InvoiceItem",
           "description": "Invoice Item",
@@ -14898,6 +14955,75 @@
                       "name": "ID",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "customerInvoices",
+              "description": "Query invoices of a customer",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "InvoiceCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "customerId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "status",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "InvoiceStatusTypeEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::Customers::InvoicesResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($customerId: ID!) {
+        customerInvoices(customerId: $customerId) {
+          collection { id }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:subscription) { create(:subscription, customer: customer, organization: organization) }
+  let(:draft_invoice) { create(:invoice, customer: customer) }
+  let(:finalized_invoice) { create(:invoice, status: :finalized, customer: customer) }
+
+  before do
+    subscription
+    draft_invoice
+    finalized_invoice
+  end
+
+  it 'returns a list of invoices' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query: query,
+      variables: { customerId: customer.id },
+    )
+
+    invoices_response = result['data']['customerInvoices']
+
+    aggregate_failures do
+      expect(invoices_response['collection'].count).to eq(customer.invoices.count)
+      expect(invoices_response['collection'].pluck('id')).to match_array(
+        [draft_invoice.id, finalized_invoice.id],
+      )
+      expect(invoices_response['metadata']['currentPage']).to eq(1)
+      expect(invoices_response['metadata']['totalCount']).to eq(2)
+    end
+  end
+
+  context 'with filter on status' do
+    let(:query) do
+      <<~GQL
+        query($customerId: ID!, $status: InvoiceStatusTypeEnum!) {
+          customerInvoices(customerId: $customerId, status: $status) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    it 'only returns draft invoice' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query: query,
+        variables: { customerId: customer.id, status: 'draft' },
+      )
+
+      invoices_response = result['data']['customerInvoices']
+
+      aggregate_failures do
+        expect(invoices_response['collection'].count).to eq(1)
+        expect(invoices_response['collection'].first['id']).to eq(draft_invoice.id)
+        expect(invoices_response['metadata']['totalCount']).to eq(1)
+      end
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query: query,
+        variables: { customerId: customer.id },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Missing organization id',
+      )
+    end
+  end
+
+  context 'when not member of the organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: create(:organization),
+        query: query,
+        variables: { customerId: customer.id },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Not in organization',
+      )
+    end
+  end
+
+  context 'when customer does not exists' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query: query,
+        variables: { customerId: '123456' },
+      )
+
+      expect_graphql_error(
+        result: result,
+        message: 'Resource not found',
+      )
+    end
+  end
+end

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -136,5 +136,17 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         expect(json[:invoices].first[:lago_id]).to eq(invoice.id)
       end
     end
+
+    context 'with status params' do
+      it 'returns invoices for the given status' do
+        invoice = create(:invoice, customer: customer, status: :finalized)
+
+        get_with_token(organization, '/api/v1/invoices?status=finalized')
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].count).to eq(1)
+        expect(json[:invoices].first[:lago_id]).to eq(invoice.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to be able to fetch customer invoices and filter them by `status`.
