### PR TITLE
feat(timezone): Change invoice boundaries from date to datetime

### DIFF
--- a/app/graphql/types/invoice_subscription/object.rb
+++ b/app/graphql/types/invoice_subscription/object.rb
@@ -13,8 +13,20 @@ module Types
       field :total_amount_cents, Integer, null: false
 
       field :fees, [Types::Fees::Object], null: true
-      field :from_date, GraphQL::Types::ISO8601Date, null: false
-      field :to_date, GraphQL::Types::ISO8601Date, null: false
+      field :from_datetime, GraphQL::Types::ISO8601DateTime, null: true
+      field :to_datetime, GraphQL::Types::ISO8601DateTime, null: true
+
+      # NOTE: LEGACY FIELDS
+      field :from_date, GraphQL::Types::ISO8601Date, null: true
+      field :to_date, GraphQL::Types::ISO8601Date, null: true
+
+      def from_date
+        object.from_datetime&.to_date
+      end
+
+      def to_date
+        object.to_datetime&.to_date
+      end
     end
   end
 end

--- a/app/graphql/types/invoices/usage.rb
+++ b/app/graphql/types/invoices/usage.rb
@@ -5,8 +5,9 @@ module Types
     class Usage < Types::BaseObject
       graphql_name 'CustomerUsage'
 
-      field :from_date, GraphQL::Types::ISO8601Date, null: false
-      field :to_date, GraphQL::Types::ISO8601Date, null: false
+      field :from_datetime, GraphQL::Types::ISO8601DateTime, null: false
+      field :to_datetime, GraphQL::Types::ISO8601DateTime, null: false
+
       field :issuing_date, GraphQL::Types::ISO8601Date, null: false
 
       field :amount_cents, GraphQL::Types::BigInt, null: false
@@ -20,6 +21,18 @@ module Types
 
       def charges_usage
         object.fees
+      end
+
+      # NOTE: LEGACY FIELDS
+      field :from_date, GraphQL::Types::ISO8601Date, null: false
+      field :to_date, GraphQL::Types::ISO8601Date, null: false
+
+      def from_date
+        object.from_datetime.to_date
+      end
+
+      def to_date
+        object.to_datetime.to_date
       end
     end
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -130,8 +130,8 @@ class Invoice < ApplicationRecord
       subscription: fee.subscription,
       group: fee.group,
     ).breakdown(
-      from_date: Date.parse(fee.properties['charges_from_date']),
-      to_date: Date.parse(fee.properties['charges_to_date']),
+      from_date: DateTime.parse(fee.properties['charges_from_datetime']).to_date,
+      to_date: DateTime.parse(fee.properties['charges_to_datetime']).to_date,
     )
     result.breakdown
   end

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
 class InvoiceSubscription < ApplicationRecord
+  include CustomerTimezone
+
   belongs_to :invoice
   belongs_to :subscription
+
+  has_one :customer, through: :subscription
 
   # NOTE: Readonly fields
   monetize :charge_amount_cents, disable_validation: true, allow_nil: true
@@ -16,28 +20,20 @@ class InvoiceSubscription < ApplicationRecord
     )
   end
 
-  def from_date
-    return if fees.empty?
-
-    fees.first.properties['from_date']&.to_date
+  def from_datetime
+    fees_datetime('from_datetime')&.to_datetime
   end
 
-  def to_date
-    return if fees.empty?
-
-    fees.first.properties['to_date']&.to_date
+  def to_datetime
+    fees_datetime('to_datetime')&.to_datetime
   end
 
-  def charges_from_date
-    return if fees.empty?
-
-    fees.first.properties['charges_from_date']&.to_date
+  def charges_from_datetime
+    fees_datetime('charges_from_datetime')&.to_datetime
   end
 
-  def charges_to_date
-    return if fees.empty?
-
-    fees.first.properties['charges_to_date']&.to_date
+  def charges_to_datetime
+    fees_datetime('charges_to_datetime')&.to_datetime
   end
 
   def charge_amount_cents
@@ -58,4 +54,10 @@ class InvoiceSubscription < ApplicationRecord
 
   alias charge_amount_currency total_amount_currency
   alias subscription_amount_currency total_amount_currency
+
+  def fees_datetime(field)
+    return if fees.empty?
+
+    fees.first.properties[field]
+  end
 end

--- a/app/serializers/v1/customer_usage_serializer.rb
+++ b/app/serializers/v1/customer_usage_serializer.rb
@@ -4,8 +4,8 @@ module V1
   class CustomerUsageSerializer < ModelSerializer
     def serialize
       payload = {
-        from_date: model.from_date,
-        to_date: model.to_date,
+        from_datetime: model.from_datetime,
+        to_datetime: model.to_datetime,
         issuing_date: model.issuing_date,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,
@@ -13,7 +13,7 @@ module V1
         total_amount_currency: model.total_amount_currency,
         vat_amount_cents: model.vat_amount_cents,
         vat_amount_currency: model.vat_amount_currency,
-      }
+      }.merge(legacy_values)
 
       payload.merge!(charges_usage) if include?(:charges_usage)
       payload
@@ -27,6 +27,10 @@ module V1
         ::V1::ChargeUsageSerializer,
         collection_name: 'charges_usage',
       ).serialize
+    end
+
+    def legacy_values
+      ::V1::Legacy::CustomerUsageSerializer.new(model).serialize
     end
   end
 end

--- a/app/serializers/v1/legacy/customer_usage_serializer.rb
+++ b/app/serializers/v1/legacy/customer_usage_serializer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module V1
+  module Legacy
+    class CustomerUsageSerializer < ModelSerializer
+      def serialize
+        {
+          from_date: model.from_datetime.to_date,
+          to_date: model.to_datetime.to_date,
+        }
+      end
+    end
+  end
+end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -78,8 +78,8 @@ module Fees
 
     def compute_amount(properties:, group: nil)
       aggregation_result = aggregator(group: group).aggregate(
-        from_date: boundaries.charges_from_date,
-        to_date: boundaries.charges_to_date,
+        from_date: boundaries.charges_from_datetime.to_date,
+        to_date: boundaries.charges_to_datetime.to_date,
         options: options(properties),
       )
       return aggregation_result unless aggregation_result.success?

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -97,8 +97,8 @@ module Fees
     end
 
     def first_subscription_amount
-      from_date = boundaries.from_date
-      to_date = boundaries.to_date
+      from_date = boundaries.from_datetime.to_date
+      to_date = boundaries.to_datetime.to_date
 
       if plan.has_trial?
         # NOTE: amount is 0 if trial cover the full period
@@ -124,8 +124,8 @@ module Fees
     #       **day_cost** = (plan amount_cents / full period duration)
     #       amount_to_bill = (nb_day * day_cost)
     def terminated_amount
-      from_date = boundaries.from_date
-      to_date = boundaries.to_date
+      from_date = boundaries.from_datetime.to_date
+      to_date = boundaries.to_datetime.to_date
 
       if plan.has_trial?
         # NOTE: amount is 0 if trial cover the full period
@@ -144,12 +144,12 @@ module Fees
     end
 
     def upgraded_amount
-      from_date = boundaries.from_date
-      to_date = boundaries.to_date
+      from_date = boundaries.from_datetime.to_date
+      to_date = boundaries.to_datetime.to_date
 
       # NOTE: to_date for previous plan might be different from to_date
       #       if plan interval is not the same
-      old_to_date = compute_old_to_date(previous_subscription, boundaries.to_date)
+      old_to_date = compute_old_to_date(previous_subscription, to_date)
 
       if plan.has_trial?
         from_date = to_date + 1.day if subscription.trial_end_date >= to_date
@@ -195,8 +195,8 @@ module Fees
     end
 
     def full_period_amount
-      from_date = boundaries.from_date
-      to_date = boundaries.to_date
+      from_date = boundaries.from_datetime.to_date
+      to_date = boundaries.to_datetime.to_date
 
       if plan.has_trial?
         # NOTE: amount is 0 if trial cover the full period

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -202,10 +202,10 @@ module Invoices
       date_service = date_service(subscription)
 
       {
-        from_date: date_service.from_datetime.to_date,
-        to_date: date_service.to_datetime.to_date,
-        charges_from_date: date_service.charges_from_datetime.to_date,
-        charges_to_date: date_service.charges_to_datetime.to_date,
+        from_datetime: date_service.from_datetime,
+        to_datetime: date_service.to_datetime,
+        charges_from_datetime: date_service.charges_from_datetime,
+        charges_to_datetime: date_service.charges_to_datetime,
         timestamp: timestamp,
       }
     end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -90,10 +90,10 @@ module Invoices
       )
 
       {
-        from_date: date_service.from_datetime.to_date,
-        to_date: date_service.to_datetime.to_date,
-        charges_from_date: date_service.charges_from_datetime.to_date,
-        charges_to_date: date_service.charges_to_datetime.to_date,
+        from_datetime: date_service.from_datetime,
+        to_datetime: date_service.to_datetime,
+        charges_from_datetime: date_service.charges_from_datetime,
+        charges_to_datetime: date_service.charges_to_datetime,
         issuing_date: date_service.next_end_of_period(Time.zone.now),
       }
     end
@@ -119,7 +119,7 @@ module Invoices
       #       billing period starts
       [
         'current_usage',
-        "#{subscription.id}-#{boundaries[:charges_to_date].iso8601}-#{date.iso8601}",
+        "#{subscription.id}-#{boundaries[:charges_to_datetime].to_date.iso8601}-#{date.iso8601}",
         plan.updated_at.iso8601,
       ].join('/')
     end
@@ -129,7 +129,7 @@ module Invoices
     end
 
     def cache_expiration
-      expiration = (boundaries[:charges_to_date] - Time.zone.today).to_i + 1
+      expiration = (boundaries[:charges_to_datetime].to_date - Time.zone.today).to_i + 1
       return 1.day if expiration < 1
       return 4.days if expiration > 4
 
@@ -138,8 +138,8 @@ module Invoices
 
     def format_usage
       {
-        from_date: boundaries[:charges_from_date].iso8601,
-        to_date: boundaries[:charges_to_date].iso8601,
+        from_datetime: boundaries[:charges_from_datetime].iso8601,
+        to_datetime: boundaries[:charges_to_datetime].iso8601,
         issuing_date: invoice.issuing_date.iso8601,
         amount_cents: invoice.amount_cents,
         amount_currency: invoice.amount_currency,

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -514,7 +514,7 @@ html
             h2.invoice-details-title.title-2.mb-24 #{subscription.plan.name} details
           .body-1 Subscription
           .mb-24.body-3
-            | From #{invoice_subscription(subscription.id).from_date&.strftime('%b %d, %Y')} to #{invoice_subscription(subscription.id).to_date&.strftime('%b %d, %Y')}
+            | From #{invoice_subscription(subscription.id).from_datetime_in_customer_timezome&.strftime('%b %d, %Y')} to #{invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.strftime('%b %d, %Y')}
 
           .invoice-resume.mb-24.overflow-auto
             table.invoice-resume-table width="100%"
@@ -532,7 +532,7 @@ html
           - if subscription? && subscription_fees(subscription.id).charge_kind.any?
             .body-1 Charges
             .mb-24.body-3
-              | List of charges used from #{invoice_subscription(subscription.id).charges_from_date&.strftime('%b %d, %Y')} to #{invoice_subscription(subscription.id).charges_to_date&.strftime('%b %d, %Y')}
+              | List of charges used from #{invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.strftime('%b %d, %Y')} to #{invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.strftime('%b %d, %Y')}
             .charge-details.mb-24
               table.charge-details-table width="100%"
                 - subscription_fees(subscription.id).charge_kind.group_by(&:charge_id).each do |_charge_id, fees|

--- a/db/migrate/20221128132620_change_fees_boundaries.rb
+++ b/db/migrate/20221128132620_change_fees_boundaries.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChangeFeesBoundaries < ActiveRecord::Migration[7.0]
+  def change
+    # NOTE: Wait to ensure workers are loaded with the added tasks
+    MigrationTaskJob.set(wait: 40.seconds).perform_later('fees:migrate_boundaries')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_25_111605) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_28_132620) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/lib/tasks/fees.rake
+++ b/lib/tasks/fees.rake
@@ -10,4 +10,20 @@ namespace :fees do
       fee.subscription!
     end
   end
+
+  desc 'Migrate boundaries'
+  task migrate_boundaries: :environment do
+    Fee.find_each do |fee|
+      next if fee.properties['from_datetime'].present?
+      next if fee.properties['from_date'].blank?
+
+      fee.properties = {
+        'from_datetime' => fee.properties['from_date'].to_date.beginning_of_day,
+        'to_datetime' => fee.properties['to_date'].to_date.end_of_day,
+        'charges_from_datetime' => fee.properties['charges_from_date'].to_date.beginning_of_day,
+        'charges_to_datetime' => fee.properties['charges_to_date'].to_date.end_of_day,
+      }
+      fee.save!
+    end
+  end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2633,8 +2633,10 @@ type CustomerUsage {
   amountCurrency: CurrencyEnum!
   chargesUsage: [ChargeUsage!]!
   fromDate: ISO8601Date!
+  fromDatetime: ISO8601DateTime!
   issuingDate: ISO8601Date!
   toDate: ISO8601Date!
+  toDatetime: ISO8601DateTime!
   totalAmountCents: BigInt!
   totalAmountCurrency: CurrencyEnum!
   vatAmountCents: BigInt!
@@ -2970,11 +2972,13 @@ enum InvoiceStatusTypeEnum {
 type InvoiceSubscription {
   chargeAmountCents: Int!
   fees: [Fee!]
-  fromDate: ISO8601Date!
+  fromDate: ISO8601Date
+  fromDatetime: ISO8601DateTime
   invoice: Invoice!
   subscription: Subscription!
   subscriptionAmountCents: Int!
-  toDate: ISO8601Date!
+  toDate: ISO8601Date
+  toDatetime: ISO8601DateTime
   totalAmountCents: Int!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -8573,6 +8573,24 @@
               ]
             },
             {
+              "name": "fromDatetime",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "issuingDate",
               "description": null,
               "type": {
@@ -8599,6 +8617,24 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "toDatetime",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
                   "ofType": null
                 }
               },
@@ -11330,13 +11366,23 @@
               "name": "fromDate",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601Date",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fromDatetime",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -11402,13 +11448,23 @@
               "name": "toDate",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601Date",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "toDatetime",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -28,8 +28,10 @@ FactoryBot.define do
 
     properties do
       {
-        'charges_from_date' => Date.parse('2022-08-01'),
-        'charges_to_date' => Date.parse('2022-08-30'),
+        'from_datetime' => Date.parse('2022-08-01 00:00:00'),
+        'to_datetime' => Date.parse('2022-08-30 23:59:59'),
+        'charges_from_datetime' => Date.parse('2022-08-01 00:00:00'),
+        'charges_to_datetime' => Date.parse('2022-08-30 23:59:59'),
       }
     end
   end

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
     <<~GQL
       query($customerId: ID!, $subscriptionId: ID!) {
         customerUsage(customerId: $customerId, subscriptionId: $subscriptionId) {
+          fromDatetime
           fromDate
+          toDatetime
           toDate
           issuingDate
           amountCents
@@ -93,6 +95,8 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
     aggregate_failures do
       expect(usage_response['fromDate']).to eq(Time.zone.today.beginning_of_month.iso8601)
       expect(usage_response['toDate']).to eq(Time.zone.today.end_of_month.iso8601)
+      expect(usage_response['fromDatetime']).to eq(Time.current.beginning_of_month.iso8601)
+      expect(usage_response['toDatetime']).to eq(Time.current.end_of_month.iso8601)
       expect(usage_response['issuingDate']).to eq(Time.zone.today.end_of_month.iso8601)
       expect(usage_response['amountCents']).to eq('5')
       expect(usage_response['amountCurrency']).to eq('EUR')
@@ -189,8 +193,12 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
     let(:aws) { create(:group, billable_metric: metric, key: 'cloud', value: 'aws') }
     let(:google) { create(:group, billable_metric: metric, key: 'cloud', value: 'google') }
     let(:aws_usa) { create(:group, billable_metric: metric, key: 'region', value: 'usa', parent_group_id: aws.id) }
-    let(:aws_france) { create(:group, billable_metric: metric, key: 'region', value: 'france', parent_group_id: aws.id) }
-    let(:google_usa) { create(:group, billable_metric: metric, key: 'region', value: 'usa', parent_group_id: google.id) }
+    let(:aws_france) do
+      create(:group, billable_metric: metric, key: 'region', value: 'france', parent_group_id: aws.id)
+    end
+    let(:google_usa) do
+      create(:group, billable_metric: metric, key: 'region', value: 'usa', parent_group_id: google.id)
+    end
 
     let(:charge) do
       create(

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
             name
           }
           invoiceSubscriptions {
+            fromDatetime
+            toDatetime
+            fromDate
+            toDate
             subscription {
               id
             }

--- a/spec/models/invoice_subscription_spec.rb
+++ b/spec/models/invoice_subscription_spec.rb
@@ -17,78 +17,78 @@ RSpec.describe InvoiceSubscription, type: :model do
     end
   end
 
-  describe '#from_date' do
+  describe '#from_datetime' do
     it 'returns first fee from_date' do
       create(
         :fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
-        properties: { from_date: "2022-01-01" }
+        properties: { from_datetime: '2022-01-01 00:00:00' },
       )
 
-      expect(invoice_subscription.from_date).to eq(Date.parse("2022-01-01"))
+      expect(invoice_subscription.from_datetime).to match_datetime('2022-01-01 00:00:00')
     end
 
     context 'when fees are empty' do
       it 'returns nil' do
-        expect(invoice_subscription.from_date).to be_nil
+        expect(invoice_subscription.from_datetime).to be_nil
       end
     end
   end
 
-  describe '#to_date' do
+  describe '#to_datetime' do
     it 'returns first fee to_date' do
       create(
         :fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
-        properties: { to_date: "2022-01-31" }
+        properties: { to_datetime: '2022-01-31 23:59:59' },
       )
 
-      expect(invoice_subscription.to_date).to eq(Date.parse("2022-01-31"))
+      expect(invoice_subscription.to_datetime).to match_datetime('2022-01-31 12 23:59:59')
     end
 
     context 'when fees are empty' do
       it 'returns nil' do
-        expect(invoice_subscription.to_date).to be_nil
+        expect(invoice_subscription.to_datetime).to be_nil
       end
     end
   end
 
-  describe '#charges_from_date' do
+  describe '#charges_from_datetime' do
     it 'returns first fee charges_from_date' do
       create(
         :fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
-        properties: { charges_from_date: '2022-01-01' },
+        properties: { charges_from_datetime: '2022-01-01 00:00:00' },
       )
 
-      expect(invoice_subscription.charges_from_date).to eq(Date.parse('2022-01-01'))
+      expect(invoice_subscription.charges_from_datetime).to match_datetime('2022-01-01 00:00:00')
     end
 
     context 'when fees are empty' do
       it 'returns nil' do
-        expect(invoice_subscription.charges_from_date).to be_nil
+        expect(invoice_subscription.charges_from_datetime).to be_nil
       end
     end
   end
 
-  describe '#charges_to_date' do
+  describe '#charges_to_datetime' do
     it 'returns first fee charges_to_date' do
       create(
         :fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
-        properties: { charges_to_date: '2022-01-31' },
+        properties: { charges_to_datetime: '2022-01-31 23:59:59' },
       )
 
-      expect(invoice_subscription.charges_to_date).to eq(Date.parse('2022-01-31'))
+      expect(invoice_subscription.charges_to_datetime).to match_datetime('2022-01-31 23:59:59')
     end
 
     context 'when fees are empty' do
       it 'returns nil' do
-        expect(invoice_subscription.charges_to_date).to be_nil
+        expect(invoice_subscription.charges_to_datetime).to be_nil
       end
     end
   end
@@ -102,7 +102,7 @@ RSpec.describe InvoiceSubscription, type: :model do
         invoice_id: invoice.id,
         charge: charge,
         fee_type: 'charge',
-        amount_cents: 100
+        amount_cents: 100,
       )
 
       create(
@@ -111,14 +111,14 @@ RSpec.describe InvoiceSubscription, type: :model do
         invoice_id: invoice.id,
         charge: charge,
         fee_type: 'charge',
-        amount_cents: 200
+        amount_cents: 200,
       )
 
       create(
         :fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
-        amount_cents: 400
+        amount_cents: 400,
       )
 
       expect(invoice_subscription.charge_amount_cents).to eq(300)
@@ -131,7 +131,7 @@ RSpec.describe InvoiceSubscription, type: :model do
         :fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
-        amount_cents: 50
+        amount_cents: 50,
       )
 
       create(
@@ -140,7 +140,7 @@ RSpec.describe InvoiceSubscription, type: :model do
         invoice_id: invoice.id,
         charge: create(:standard_charge),
         fee_type: 'charge',
-        amount_cents: 200
+        amount_cents: 200,
       )
 
       expect(invoice_subscription.subscription_amount_cents).to eq(50)
@@ -154,7 +154,7 @@ RSpec.describe InvoiceSubscription, type: :model do
         :fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
-        amount_cents: 50
+        amount_cents: 50,
       )
 
       create(
@@ -163,7 +163,7 @@ RSpec.describe InvoiceSubscription, type: :model do
         invoice_id: invoice.id,
         charge: charge,
         fee_type: 'charge',
-        amount_cents: 200
+        amount_cents: 200,
       )
 
       create(
@@ -172,7 +172,7 @@ RSpec.describe InvoiceSubscription, type: :model do
         invoice_id: invoice.id,
         charge: charge,
         fee_type: 'charge',
-        amount_cents: 100
+        amount_cents: 100,
       )
 
       expect(invoice_subscription.total_amount_cents).to eq(350)

--- a/spec/serializers/v1/customer_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customer_usage_serializer_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::CustomerUsageSerializer do
+  subject(:serializer) { described_class.new(usage, root_name: 'customer_usage', includes: [:charges_usage]) }
+
+  let(:usage) do
+    OpenStruct.new(
+      from_datetime: Time.current.beginning_of_month.iso8601,
+      to_datetime: Time.current.end_of_month.iso8601,
+      issuing_date: Time.current.end_of_month.iso8601,
+      amount_cents: 5,
+      amount_currency: 'EUR',
+      total_amount_cents: 6,
+      total_amount_currency: 'EUR',
+      vat_amount_cents: 1,
+      vat_amount_currency: 'EUR',
+      fees: [
+        OpenStruct.new(
+          billable_metric: OpenStruct.new(
+            id: SecureRandom.uuid,
+            name: 'Charge',
+            code: 'charge',
+            aggregation_type: 'count_agg',
+          ),
+          charge: OpenStruct.new(
+            id: SecureRandom.uuid,
+            charge_model: 'graduated',
+          ),
+          units: '4.0',
+          amount_cents: 5,
+          amount_currency: 'EUR',
+          groups: [],
+        ),
+      ],
+    )
+  end
+
+  let(:result) { JSON.parse(serializer.to_json) }
+
+  it 'serializes the customer usage' do
+    aggregate_failures do
+      expect(result['customer_usage']['from_datetime']).to eq(Time.current.beginning_of_month.iso8601)
+      expect(result['customer_usage']['to_datetime']).to eq(Time.current.end_of_month.iso8601)
+      expect(result['customer_usage']['issuing_date']).to eq(Time.current.end_of_month.iso8601)
+      expect(result['customer_usage']['amount_cents']).to eq(5)
+      expect(result['customer_usage']['amount_currency']).to eq('EUR')
+      expect(result['customer_usage']['total_amount_cents']).to eq(6)
+      expect(result['customer_usage']['total_amount_currency']).to eq('EUR')
+      expect(result['customer_usage']['vat_amount_cents']).to eq(1)
+      expect(result['customer_usage']['vat_amount_currency']).to eq('EUR')
+
+      charge_usage = result['customer_usage']['charges_usage'].first
+      expect(charge_usage['billable_metric']['name']).to eq('Charge')
+      expect(charge_usage['billable_metric']['code']).to eq('charge')
+      expect(charge_usage['billable_metric']['aggregation_type']).to eq('count_agg')
+      expect(charge_usage['charge']['charge_model']).to eq('graduated')
+      expect(charge_usage['units']).to eq('4.0')
+      expect(charge_usage['amount_cents']).to eq(5)
+      expect(charge_usage['amount_currency']).to eq('EUR')
+      expect(charge_usage['groups']).to eq([])
+    end
+  end
+
+  it 'serializes the legacy value' do
+    aggregate_failures do
+      expect(result['customer_usage']['from_date']).to eq(Time.current.beginning_of_month.to_date.iso8601)
+      expect(result['customer_usage']['to_date']).to eq(Time.current.end_of_month.to_date.iso8601)
+    end
+  end
+end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe Fees::ChargeService do
 
   let(:boundaries) do
     {
-      from_date: subscription.started_at.to_date,
-      to_date: subscription.started_at.end_of_month.to_date,
-      charges_from_date: subscription.started_at.to_date,
-      charges_to_date: subscription.started_at.end_of_month.to_date,
+      from_datetime: subscription.started_at.to_date.beginning_of_day,
+      to_datetime: subscription.started_at.end_of_month.end_of_day,
+      charges_from_datetime: subscription.started_at.beginning_of_day,
+      charges_to_datetime: subscription.started_at.end_of_month.end_of_day,
     }
   end
 
@@ -145,10 +145,10 @@ RSpec.describe Fees::ChargeService do
 
         let(:boundaries) do
           {
-            from_date: Time.zone.parse('15 Apr 2022 00:01:00').to_date,
-            to_date: Time.zone.parse('30 Apr 2022 00:01:00').to_date,
-            charges_from_date: subscription.started_at.to_date,
-            charges_to_date: Time.zone.parse('30 Apr 2022 00:01:00').to_date,
+            from_datetime: Time.zone.parse('15 Apr 2022 00:01:00'),
+            to_datetime: Time.zone.parse('30 Apr 2022 00:01:00'),
+            charges_from_datetime: subscription.started_at,
+            charges_to_datetime: Time.zone.parse('30 Apr 2022 00:01:00'),
           }
         end
 
@@ -440,10 +440,10 @@ RSpec.describe Fees::ChargeService do
 
       it 'creates expected fees for recurring_count_agg aggregation type' do
         boundaries = {
-          from_date: subscription.started_at.at_beginning_of_month.next_month.to_date,
-          to_date: subscription.started_at.next_month.end_of_month.to_date,
-          charges_from_date: subscription.started_at.at_beginning_of_month.next_month.to_date,
-          charges_to_date: subscription.started_at.next_month.end_of_month.to_date,
+          from_datetime: subscription.started_at.at_beginning_of_month.next_month.beginning_of_day,
+          to_datetime: subscription.started_at.next_month.end_of_month.end_of_day,
+          charges_from_datetime: subscription.started_at.at_beginning_of_month.next_month.beginning_of_day,
+          charges_to_datetime: subscription.started_at.next_month.end_of_month.end_of_day,
         }
 
         create(
@@ -490,7 +490,12 @@ RSpec.describe Fees::ChargeService do
         )
 
         billable_metric.update!(aggregation_type: :recurring_count_agg, field_name: 'foo_bar')
-        result = described_class.new(invoice: invoice, charge: charge, subscription: subscription, boundaries: boundaries).create
+        result = described_class.new(
+          invoice: invoice,
+          charge: charge,
+          subscription: subscription,
+          boundaries: boundaries,
+        ).create
         expect(result).to be_success
         created_fees = result.fees
 

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Fees::SubscriptionService do
   let(:invoice) { create(:invoice) }
   let(:boundaries) do
     {
-      from_date: Time.zone.parse('2022-03-01 00:00').to_date,
-      to_date: Time.zone.parse('2022-03-01 00:00').end_of_month.to_date,
+      from_datetime: Time.zone.parse('2022-03-01 00:00:00'),
+      to_datetime: Time.zone.parse('2022-03-31 23:59:59'),
       timestamp: Time.zone.parse('2022-04-02 00:00').end_of_month.to_i,
     }
   end
@@ -65,7 +65,7 @@ RSpec.describe Fees::SubscriptionService do
     context 'when plan has a trial period' do
       before do
         plan.update(trial_period: trial_duration)
-        subscription.update(started_at: boundaries[:from_date])
+        subscription.update(started_at: boundaries[:from_datetime])
       end
 
       context 'when trial end in period' do
@@ -97,8 +97,8 @@ RSpec.describe Fees::SubscriptionService do
   context 'when subscription has never been billed' do
     let(:boundaries) do
       {
-        from_date: subscription.started_at.to_date,
-        to_date: subscription.started_at.end_of_month.to_date,
+        from_datetime: subscription.started_at.beginning_of_day,
+        to_datetime: subscription.started_at.end_of_month.end_of_day,
         timestamp: (subscription.started_at.end_of_month + 1.day).to_i,
       }
     end
@@ -106,8 +106,8 @@ RSpec.describe Fees::SubscriptionService do
     context 'when plan is weekly' do
       let(:boundaries) do
         {
-          from_date: subscription.started_at.to_date,
-          to_date: subscription.started_at.end_of_week.to_date,
+          from_datetime: subscription.started_at.to_date.beginning_of_day,
+          to_datetime: subscription.started_at.end_of_week.end_of_day,
           timestamp: (subscription.started_at.end_of_week + 1.day).to_i,
         }
       end
@@ -295,8 +295,8 @@ RSpec.describe Fees::SubscriptionService do
 
             let(:boundaries) do
               {
-                from_date: subscription.created_at.beginning_of_week.to_date,
-                to_date: subscription.created_at.end_of_week.to_date,
+                from_datetime: subscription.created_at.beginning_of_week.beginning_of_day,
+                to_datetime: subscription.created_at.end_of_week.end_of_day,
                 timestamp: (subscription.created_at.end_of_week + 1.day).to_i,
               }
             end
@@ -360,8 +360,8 @@ RSpec.describe Fees::SubscriptionService do
         context 'when plan is pay in advance' do
           let(:boundaries) do
             {
-              from_date: subscription.started_at.to_date,
-              to_date: subscription.started_at.end_of_month.to_date,
+              from_datetime: subscription.started_at.to_date.beginning_of_day,
+              to_datetime: subscription.started_at.end_of_month.end_of_day,
               timestamp: (subscription.started_at + 1.day).to_i,
             }
           end
@@ -448,8 +448,8 @@ RSpec.describe Fees::SubscriptionService do
         context 'when plan is pay in advance' do
           let(:boundaries) do
             {
-              from_date: subscription.started_at.to_date,
-              to_date: subscription.started_at.end_of_month.to_date,
+              from_datetime: subscription.started_at.to_date.beginning_of_day,
+              to_datetime: subscription.started_at.end_of_month.end_of_day,
               timestamp: (subscription.started_at + 1.day).to_i,
             }
           end
@@ -516,8 +516,8 @@ RSpec.describe Fees::SubscriptionService do
 
         let(:boundaries) do
           {
-            from_date: Time.zone.parse('2022-08-31 00:00').to_date,
-            to_date: Time.zone.parse('2022-09-30 00:00').to_date,
+            from_datetime: Time.zone.parse('2022-08-31 00:00:00'),
+            to_datetime: Time.zone.parse('2022-09-30 23:59:59'),
             timestamp: Time.zone.parse('2022-04-02 00:00').end_of_month.to_i,
           }
         end
@@ -546,8 +546,8 @@ RSpec.describe Fees::SubscriptionService do
 
         let(:boundaries) do
           {
-            from_date: subscription.started_at.beginning_of_year.to_date,
-            to_date: subscription.started_at.end_of_year.to_date,
+            from_datetime: subscription.started_at.beginning_of_year.beginning_of_day,
+            to_datetime: subscription.started_at.end_of_year.end_of_day,
             timestamp: (subscription.started_at.end_of_year + 1.day).to_i,
           }
         end
@@ -585,8 +585,8 @@ RSpec.describe Fees::SubscriptionService do
 
         let(:boundaries) do
           {
-            from_date: subscription.started_at.to_date,
-            to_date: subscription.started_at.end_of_year.to_date,
+            from_datetime: subscription.started_at.beginning_of_day,
+            to_datetime: subscription.started_at.end_of_year.end_of_day,
             timestamp: (subscription.started_at.end_of_year + 1.day).to_i,
           }
         end
@@ -626,8 +626,8 @@ RSpec.describe Fees::SubscriptionService do
 
     let(:boundaries) do
       {
-        from_date: subscription.started_at.to_date,
-        to_date: subscription.started_at.end_of_month.to_date,
+        from_datetime: subscription.started_at.beginning_of_day,
+        to_datetime: subscription.started_at.end_of_month.end_of_day,
         timestamp: (subscription.started_at.end_of_month + 1.day).to_i,
       }
     end
@@ -675,8 +675,8 @@ RSpec.describe Fees::SubscriptionService do
           context 'when plan is weekly' do
             let(:boundaries) do
               {
-                from_date: subscription.started_at.to_date.end_of_week,
-                to_date: (subscription.started_at.end_of_week + 1.week).to_date,
+                from_datetime: subscription.started_at.to_date.end_of_week.beginning_of_day,
+                to_datetime: (subscription.started_at.end_of_week + 1.week).end_of_day,
                 timestamp: (subscription.started_at.end_of_week + 1.day).to_i,
               }
             end
@@ -697,8 +697,8 @@ RSpec.describe Fees::SubscriptionService do
 
             let(:boundaries) do
               {
-                from_date: subscription.started_at.to_date,
-                to_date: subscription.started_at.end_of_month.to_date,
+                from_datetime: subscription.started_at.beginning_of_day,
+                to_datetime: subscription.started_at.end_of_month.end_of_day,
                 timestamp: (subscription.started_at + 1.day).to_i,
               }
             end
@@ -713,8 +713,8 @@ RSpec.describe Fees::SubscriptionService do
           context 'when plan is yearly' do
             let(:boundaries) do
               {
-                from_date: subscription.started_at.to_date.beginning_of_year,
-                to_date: subscription.started_at.end_of_year.to_date,
+                from_datetime: subscription.started_at.beginning_of_year.beginning_of_day,
+                to_datetime: subscription.started_at.end_of_year.end_of_day,
                 timestamp: (subscription.started_at.beginning_of_year + 1.day).to_i,
               }
             end
@@ -756,8 +756,8 @@ RSpec.describe Fees::SubscriptionService do
 
     let(:boundaries) do
       {
-        from_date: subscription.started_at + 1.month,
-        to_date: subscription.started_at + 2.months,
+        from_datetime: (subscription.started_at + 1.month).beginning_of_day,
+        to_datetime: (subscription.started_at + 2.months).end_of_day,
         timestamp: (subscription.started_at + 2.months + 1.day).to_i,
       }
     end
@@ -788,8 +788,8 @@ RSpec.describe Fees::SubscriptionService do
 
     let(:boundaries) do
       {
-        from_date: subscription.started_at.beginning_of_month.to_date,
-        to_date: subscription.started_at.to_date + 5.days,
+        from_datetime: subscription.started_at.beginning_of_month.beginning_of_day,
+        to_datetime: (subscription.started_at + 5.days).end_of_day,
         timestamp: (subscription.started_at + 6.days).to_i,
       }
     end
@@ -815,8 +815,8 @@ RSpec.describe Fees::SubscriptionService do
     context 'when plan is weekly' do
       let(:boundaries) do
         {
-          from_date: subscription.started_at.beginning_of_week.to_date,
-          to_date: subscription.started_at.to_date + 1.day,
+          from_datetime: subscription.started_at.beginning_of_week.beginning_of_day,
+          to_datetime: (subscription.started_at + 1.day).end_of_day,
           timestamp: (subscription.started_at + 2.days).to_i,
         }
       end
@@ -916,8 +916,8 @@ RSpec.describe Fees::SubscriptionService do
 
     let(:boundaries) do
       {
-        from_date: subscription.started_at.to_date,
-        to_date: subscription.started_at.to_date.end_of_month,
+        from_datetime: subscription.started_at.beginning_of_day,
+        to_datetime: subscription.started_at.end_of_month.end_of_day,
         timestamp: (subscription.started_at.end_of_month + 1.day).to_i,
       }
     end
@@ -967,8 +967,8 @@ RSpec.describe Fees::SubscriptionService do
 
         let(:boundaries) do
           {
-            from_date: DateTime.parse('2022-05-09').to_date,
-            to_date: DateTime.parse('2022-05-24').to_date,
+            from_datetime: DateTime.parse('2022-05-09 00:00:00'),
+            to_datetime: DateTime.parse('2022-05-24 23:59:59'),
             timestamp: DateTime.parse('2022-05-26').to_i,
           }
         end
@@ -1024,8 +1024,8 @@ RSpec.describe Fees::SubscriptionService do
 
         let(:boundaries) do
           {
-            from_date: subscription.started_at.to_date,
-            to_date: subscription.started_at.end_of_month.to_date,
+            from_datetime: subscription.started_at.beginning_of_day,
+            to_datetime: subscription.started_at.end_of_month.end_of_day,
             timestamp: (subscription.started_at + 1.day).to_i,
           }
         end
@@ -1046,8 +1046,8 @@ RSpec.describe Fees::SubscriptionService do
 
         let(:boundaries) do
           {
-            from_date: subscription.started_at.to_date,
-            to_date: subscription.started_at.end_of_year.to_date,
+            from_datetime: subscription.started_at.beginning_of_day,
+            to_datetime: subscription.started_at.end_of_year.end_of_day,
             timestamp: subscription.started_at.to_i,
           }
         end
@@ -1069,8 +1069,8 @@ RSpec.describe Fees::SubscriptionService do
 
         let(:boundaries) do
           {
-            from_date: subscription.started_at.to_date,
-            to_date: subscription.started_at.end_of_week.to_date,
+            from_datetime: subscription.started_at.beginning_of_day,
+            to_datetime: subscription.started_at.end_of_week.end_of_day,
             timestamp: subscription.started_at.to_i,
           }
         end
@@ -1150,8 +1150,8 @@ RSpec.describe Fees::SubscriptionService do
 
         let(:boundaries) do
           {
-            from_date: subscription.started_at.to_date,
-            to_date: subscription.started_at.end_of_month.to_date,
+            from_datetime: subscription.started_at.beginning_of_day,
+            to_datetime: subscription.started_at.end_of_month.end_of_day,
             timestamp: subscription.started_at.to_i,
           }
         end
@@ -1195,8 +1195,8 @@ RSpec.describe Fees::SubscriptionService do
 
       let(:boundaries) do
         {
-          from_date: DateTime.parse('2022-05-08').to_date,
-          to_date: DateTime.parse('2022-05-24').to_date,
+          from_datetime: DateTime.parse('2022-05-08 00:00:00'),
+          to_datetime: DateTime.parse('2022-05-24 23:59:59'),
           timestamp: DateTime.parse('2022-05-26').to_i,
         }
       end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -119,8 +119,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
           aggregate_failures do
             expect(result).to be_success
-            expect(result.invoice.fees.first.properties['to_date']).to eq('2022-03-05')
-            expect(result.invoice.fees.first.properties['from_date']).to eq('2022-02-06')
+            expect(result.invoice.fees.first.properties['to_datetime']).to match_datetime('2022-03-05 23:59:59')
+            expect(result.invoice.fees.first.properties['from_datetime']).to match_datetime('2022-02-06 00:00:00')
             expect(result.invoice.subscriptions.first).to eq(subscription)
             expect(result.invoice.status).to eq('pending')
             expect(result.invoice.fees.subscription_kind.count).to eq(1)
@@ -139,8 +139,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
             aggregate_failures do
               expect(result).to be_success
-              expect(result.invoice.fees.first.properties['to_date']).to eq('2022-04-05')
-              expect(result.invoice.fees.first.properties['from_date']).to eq('2022-03-06')
+              expect(result.invoice.fees.first.properties['to_datetime']).to match_datetime('2022-04-05 23:59:59')
+              expect(result.invoice.fees.first.properties['from_datetime']).to match_datetime('2022-03-06 00:00:00')
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.status).to eq('pending')
               expect(result.invoice.fees.subscription_kind.count).to eq(1)
@@ -171,8 +171,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
         aggregate_failures do
           expect(result).to be_success
-          expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
-          expect(result.invoice.fees.first.properties['from_date']).to eq (timestamp - 1.month).to_date.to_s
+          expect(result.invoice.fees.first.properties['to_datetime'])
+            .to match_datetime((timestamp - 1.day).end_of_day)
+          expect(result.invoice.fees.first.properties['from_datetime'])
+            .to match_datetime((timestamp - 1.month).beginning_of_day)
           expect(result.invoice.subscriptions).to eq(subscriptions)
           expect(result.invoice.status).to eq('pending')
           expect(result.invoice.fees.subscription_kind.count).to eq(2)
@@ -208,8 +210,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         aggregate_failures do
           expect(result).to be_success
 
-          expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
-          expect(result.invoice.fees.first.properties['from_date']).to eq subscription.subscription_date.to_date.to_s
+          expect(result.invoice.fees.first.properties['to_datetime'])
+            .to match_datetime((timestamp - 1.day).end_of_day)
+          expect(result.invoice.fees.first.properties['from_datetime'])
+            .to match_datetime(subscription.subscription_date.beginning_of_day)
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
@@ -230,9 +234,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         aggregate_failures do
           expect(result).to be_success
 
-          expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
-          expect(result.invoice.fees.first.properties['from_date']).to eq (timestamp - 1.week).to_date.to_s
-          subscription.subscription_date
+          expect(result.invoice.fees.first.properties['to_datetime'])
+            .to match_datetime((timestamp - 1.day).end_of_day)
+          expect(result.invoice.fees.first.properties['from_datetime'])
+            .to match_datetime((timestamp - 1.week).beginning_of_day)
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
@@ -261,9 +266,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           aggregate_failures do
             expect(result).to be_success
 
-            expect(result.invoice.fees.first.properties['to_date']).to eq('2022-03-05')
-            expect(result.invoice.fees.first.properties['from_date']).to eq('2022-02-27')
-            subscription.subscription_date
+            expect(result.invoice.fees.first.properties['to_datetime']).to match_datetime('2022-03-05 23:59:59')
+            expect(result.invoice.fees.first.properties['from_datetime']).to match_datetime('2022-02-27 00:00:00')
             expect(result.invoice.subscriptions.first).to eq(subscription)
             expect(result.invoice.fees.subscription_kind.count).to eq(1)
             expect(result.invoice.fees.charge_kind.count).to eq(1)
@@ -279,9 +283,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             aggregate_failures do
               expect(result).to be_success
 
-              expect(result.invoice.fees.first.properties['to_date']).to eq('2022-03-12')
-              expect(result.invoice.fees.first.properties['from_date']).to eq('2022-03-06')
-              subscription.subscription_date
+              expect(result.invoice.fees.first.properties['to_datetime']).to match_datetime('2022-03-12 23:59:59')
+              expect(result.invoice.fees.first.properties['from_datetime']).to match_datetime('2022-03-06 00:00:00')
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.fees.subscription_kind.count).to eq(1)
               expect(result.invoice.fees.charge_kind.count).to eq(0)
@@ -315,8 +318,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         aggregate_failures do
           expect(result).to be_success
 
-          expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
-          expect(result.invoice.fees.first.properties['from_date']).to eq subscription.subscription_date.to_date.to_s
+          expect(result.invoice.fees.first.properties['to_datetime'])
+            .to match_datetime((timestamp - 1.day).end_of_day)
+          expect(result.invoice.fees.first.properties['from_datetime'])
+            .to match_datetime(subscription.subscription_date.beginning_of_day)
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
@@ -337,8 +342,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         aggregate_failures do
           expect(result).to be_success
 
-          expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
-          expect(result.invoice.fees.first.properties['from_date']).to eq (timestamp - 1.year).to_date.to_s
+          expect(result.invoice.fees.first.properties['to_datetime'])
+            .to match_datetime((timestamp - 1.day).end_of_day)
+          expect(result.invoice.fees.first.properties['from_datetime'])
+            .to match_datetime((timestamp - 1.year).beginning_of_day)
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
@@ -367,9 +374,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           aggregate_failures do
             expect(result).to be_success
 
-            expect(result.invoice.fees.first.properties['to_date']).to eq('2022-06-05')
-            expect(result.invoice.fees.first.properties['from_date']).to eq('2021-06-06')
-            subscription.subscription_date
+            expect(result.invoice.fees.first.properties['to_datetime']).to match_datetime('2022-06-05 23:59:59')
+            expect(result.invoice.fees.first.properties['from_datetime']).to match_datetime('2021-06-06 00:00:00')
             expect(result.invoice.subscriptions.first).to eq(subscription)
             expect(result.invoice.fees.subscription_kind.count).to eq(1)
             expect(result.invoice.fees.charge_kind.count).to eq(1)
@@ -385,9 +391,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             aggregate_failures do
               expect(result).to be_success
 
-              expect(result.invoice.fees.first.properties['to_date']).to eq('2023-06-05')
-              expect(result.invoice.fees.first.properties['from_date']).to eq('2022-06-06')
-              subscription.subscription_date
+              expect(result.invoice.fees.first.properties['to_datetime']).to match_datetime('2023-06-05 23:59:59')
+              expect(result.invoice.fees.first.properties['from_datetime']).to match_datetime('2022-06-06 00:00:00')
               expect(result.invoice.subscriptions.first).to eq(subscription)
               expect(result.invoice.fees.subscription_kind.count).to eq(1)
               expect(result.invoice.fees.charge_kind.count).to eq(0)
@@ -420,8 +425,9 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         aggregate_failures do
           expect(result).to be_success
 
-          expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
-          expect(result.invoice.fees.first.properties['from_date']).to eq subscription.subscription_date.to_date.to_s
+          expect(result.invoice.fees.first.properties['to_datetime']).to match_datetime((timestamp - 1.day).end_of_day)
+          expect(result.invoice.fees.first.properties['from_datetime'])
+            .to match_datetime(subscription.subscription_date.beginning_of_day)
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
@@ -453,10 +459,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         result = invoice_service.call
 
         aggregate_failures do
-          expect(result.invoice.fees.first.properties['to_date'])
-            .to eq(terminated_at.to_date.to_s)
-          expect(result.invoice.fees.first.properties['from_date'])
-            .to eq(terminated_at.to_date.beginning_of_month.to_s)
+          expect(result.invoice.fees.first.properties['to_datetime'])
+            .to match_datetime(terminated_at)
+          expect(result.invoice.fees.first.properties['from_datetime'])
+            .to match_datetime(terminated_at.beginning_of_month)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
         end
       end
@@ -483,10 +489,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           result = invoice_service.call
 
           aggregate_failures do
-            expect(result.invoice.fees.first.properties['to_date'])
-              .to eq(terminated_at.to_date.to_s)
-            expect(result.invoice.fees.first.properties['from_date'])
-              .to eq('2022-03-06')
+            expect(result.invoice.fees.first.properties['to_datetime'])
+              .to match_datetime(terminated_at)
+            expect(result.invoice.fees.first.properties['from_datetime'])
+              .to match_datetime('2022-03-06 00:00:00')
             expect(result.invoice.fees.subscription_kind.count).to eq(1)
           end
         end
@@ -531,10 +537,9 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         result = invoice_service.call
 
         aggregate_failures do
-          expect(result.invoice.fees.first.properties['to_date'])
-            .to eq(subscription.started_at.to_date.end_of_month.to_s)
-          expect(result.invoice.fees.first.properties['from_date'])
-            .to eq(subscription.started_at.to_date.to_s)
+          expect(result.invoice.fees.first.properties['to_datetime'])
+            .to match_datetime(subscription.started_at.end_of_month)
+          expect(result.invoice.fees.first.properties['from_datetime']).to match_datetime(subscription.started_at)
           expect(result.invoice.total_amount_cents).to eq(0)
           expect(result.invoice.status).to eq('succeeded')
           expect(result.invoice.fees.charge_kind.count).to eq(0)
@@ -560,7 +565,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       end
 
       let(:started_at) { DateTime.parse('07 Mar 2022') }
-      let(:terminated_at) { DateTime.parse('17 Oct 2022') }
+      let(:terminated_at) { DateTime.parse('17 Oct 2022 12:35:12') }
       let(:timestamp) { DateTime.parse('17 Oct 2022') }
 
       let(:subscription) do
@@ -591,8 +596,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           expect(result.invoice.fees.charge_kind.count).to eq(1)
 
           charge_fee = result.invoice.fees.charge_kind.first
-          expect(charge_fee.properties['charges_from_date']).to eq('2022-10-01')
-          expect(charge_fee.properties['charges_to_date']).to eq('2022-10-17')
+          expect(charge_fee.properties['charges_from_datetime']).to match_datetime('2022-10-01 00:00:00')
+          expect(charge_fee.properties['charges_to_datetime']).to match_datetime(terminated_at)
         end
       end
     end
@@ -666,8 +671,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         aggregate_failures do
           expect(result).to be_success
 
-          expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
-          expect(result.invoice.fees.first.properties['from_date']).to eq (timestamp - 1.month).to_date.to_s
+          expect(result.invoice.fees.first.properties['to_datetime'])
+            .to match_datetime((timestamp - 1.day).end_of_day)
+          expect(result.invoice.fees.first.properties['from_datetime'])
+            .to match_datetime((timestamp - 1.month).beginning_of_day)
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.issuing_date.to_date).to eq(timestamp)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
@@ -699,8 +706,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           aggregate_failures do
             expect(result).to be_success
 
-            expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
-            expect(result.invoice.fees.first.properties['from_date']).to eq (timestamp - 1.month).to_date.to_s
+            expect(result.invoice.fees.first.properties['to_datetime'])
+              .to match_datetime((timestamp - 1.day).end_of_day)
+            expect(result.invoice.fees.first.properties['from_datetime'])
+              .to match_datetime((timestamp - 1.month).beginning_of_day)
             expect(result.invoice.subscriptions.first).to eq(subscription)
             expect(result.invoice.issuing_date.to_date).to eq(timestamp)
             expect(result.invoice.fees.subscription_kind.count).to eq(1)
@@ -731,8 +740,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           aggregate_failures do
             expect(result).to be_success
 
-            expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
-            expect(result.invoice.fees.first.properties['from_date']).to eq (timestamp - 1.month).to_date.to_s
+            expect(result.invoice.fees.first.properties['to_datetime'])
+              .to match_datetime((timestamp - 1.day).end_of_day)
+            expect(result.invoice.fees.first.properties['from_datetime'])
+              .to match_datetime((timestamp - 1.month).beginning_of_day)
             expect(result.invoice.subscriptions.first).to eq(subscription)
             expect(result.invoice.issuing_date.to_date).to eq(timestamp)
             expect(result.invoice.fees.subscription_kind.count).to eq(1)
@@ -783,8 +794,10 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         aggregate_failures do
           expect(result).to be_success
 
-          expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
-          expect(result.invoice.fees.first.properties['from_date']).to eq (timestamp - 1.month).to_date.to_s
+          expect(result.invoice.fees.first.properties['to_datetime'])
+            .to eq (timestamp - 1.day).end_of_day.as_json
+          expect(result.invoice.fees.first.properties['from_datetime'])
+            .to eq (timestamp - 1.month).beginning_of_day.as_json
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -67,8 +67,11 @@ RSpec.describe Invoices::CreateService, type: :service do
       aggregate_failures do
         expect(result).to be_success
 
-        expect(result.invoice.fees.first.properties['to_date']).to eq (timestamp - 1.day).to_date.to_s
-        expect(result.invoice.fees.first.properties['from_date']).to eq (timestamp - 1.month).to_date.to_s
+        expect(result.invoice.fees.first.properties['to_datetime'])
+          .to eq (timestamp - 1.day).end_of_day.as_json
+        expect(result.invoice.fees.first.properties['from_datetime'])
+          .to eq (timestamp - 1.month).beginning_of_day.as_json
+
         expect(result.invoice.subscriptions.first).to eq(subscription)
         expect(result.invoice.issuing_date.to_date).to eq(timestamp)
         expect(result.invoice.invoice_type).to eq('subscription')

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
     end
 
     it 'uses the Rails cache' do
-      to_date = invoice_service.__send__(:boundaries)[:charges_to_date]
+      to_date = invoice_service.__send__(:boundaries)[:charges_to_datetime].to_date
       key = [
         'current_usage',
         "#{subscription.id}-#{to_date.iso8601}-#{subscription.created_at.iso8601}",
@@ -60,8 +60,8 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
           expect(result).to be_success
 
           expect(result.usage.id).to be_nil
-          expect(result.usage.from_date).to eq(Time.zone.today.beginning_of_month.iso8601)
-          expect(result.usage.to_date).to eq(Time.zone.today.end_of_month.iso8601)
+          expect(result.usage.from_datetime).to eq(Time.current.beginning_of_month.iso8601)
+          expect(result.usage.to_datetime).to eq(Time.current.end_of_month.iso8601)
           expect(result.usage.issuing_date).to eq(Time.zone.today.end_of_month.iso8601)
           expect(result.usage.fees.size).to eq(1)
 
@@ -84,7 +84,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
             expect(result).to be_success
 
             expect(result.usage.id).to be_nil
-            expect(result.usage.from_date).to eq(subscription.started_at.to_date.iso8601)
+            expect(result.usage.from_datetime).to eq(subscription.started_at.iso8601)
           end
         end
       end
@@ -113,8 +113,8 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
               expect(result).to be_success
 
               expect(result.usage.id).to be_nil
-              expect(result.usage.from_date.to_date.to_s).to eq('2022-06-07')
-              expect(result.usage.to_date.to_date.to_s).to eq('2022-07-06')
+              expect(result.usage.from_datetime.to_date.to_s).to eq('2022-06-07')
+              expect(result.usage.to_datetime.to_date.to_s).to eq('2022-07-06')
               expect(result.usage.issuing_date).to eq('2022-07-06')
               expect(result.usage.fees.size).to eq(1)
 
@@ -140,8 +140,8 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
           expect(result).to be_success
 
           expect(result.usage.id).to be_nil
-          expect(result.usage.from_date).to eq(Time.zone.today.beginning_of_week.iso8601)
-          expect(result.usage.to_date).to eq(Time.zone.today.end_of_week.iso8601)
+          expect(result.usage.from_datetime).to eq(Time.current.beginning_of_week.iso8601)
+          expect(result.usage.to_datetime).to eq(Time.current.end_of_week.iso8601)
           expect(result.usage.issuing_date).to eq(Time.zone.today.end_of_week.iso8601)
           expect(result.usage.fees.size).to eq(1)
 
@@ -178,8 +178,8 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
               expect(result).to be_success
 
               expect(result.usage.id).to be_nil
-              expect(result.usage.from_date.to_date.to_s).to eq('2022-06-20')
-              expect(result.usage.to_date.to_date.to_s).to eq('2022-06-26')
+              expect(result.usage.from_datetime.to_date.to_s).to eq('2022-06-20')
+              expect(result.usage.to_datetime.to_date.to_s).to eq('2022-06-26')
               expect(result.usage.issuing_date).to eq('2022-06-26')
               expect(result.usage.fees.size).to eq(1)
 
@@ -205,8 +205,8 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
           expect(result).to be_success
 
           expect(result.usage.id).to be_nil
-          expect(result.usage.from_date).to eq(Time.zone.today.beginning_of_year.iso8601)
-          expect(result.usage.to_date).to eq(Time.zone.today.end_of_year.iso8601)
+          expect(result.usage.from_datetime).to eq(Time.current.beginning_of_year.iso8601)
+          expect(result.usage.to_datetime).to eq(Time.current.end_of_year.iso8601)
           expect(result.usage.issuing_date).to eq(Time.zone.today.end_of_year.iso8601)
           expect(result.usage.fees.size).to eq(1)
 
@@ -243,8 +243,8 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
               expect(result).to be_success
 
               expect(result.usage.id).to be_nil
-              expect(result.usage.from_date.to_date.to_s).to eq('2022-03-07')
-              expect(result.usage.to_date.to_date.to_s).to eq('2023-03-06')
+              expect(result.usage.from_datetime.to_date.to_s).to eq('2022-03-07')
+              expect(result.usage.to_datetime.to_date.to_s).to eq('2023-03-06')
               expect(result.usage.issuing_date).to eq('2023-03-06')
               expect(result.usage.fees.size).to eq(1)
 

--- a/spec/support/matchers/datetime_matcher.rb
+++ b/spec/support/matchers/datetime_matcher.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :match_datetime do |expectation|
+  match do |subject|
+    subject = subject.to_datetime.change(usec: 0) if subject.is_a?(String)
+    expectation = DateTime.parse(expectation) if expectation.is_a?(String)
+
+    subject == expectation.change(usec: 0)
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR updates the invoice, fees and subscription_invoice object to manage boundaries as datetime rather than date, it will allow these boundaries to be converted into customer timezones
