### PR TITLE
fix: Fix credit note seeds

### DIFF
--- a/db/seeds/invoices.rb
+++ b/db/seeds/invoices.rb
@@ -24,6 +24,7 @@ Invoice.all.find_each do |invoice|
     reason: :other,
     total_amount_cents: amount,
     total_amount_currency: fee.amount_currency,
+    issuing_date: Time.current.to_date,
   )
 
   credit_note.items.create!(


### PR DESCRIPTION
## Context

Since the merge of https://github.com/getlago/lago-api/pull/628, seeds are not working anymore.

## Description

The issue is that issuing_date is now a mandatory field on the credit note but the seed are not setting the value
