### PR TITLE
feat(credit_notes): Improve credit note schema

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -6,9 +6,7 @@ module Api
       def create
         service = CreditNotes::CreateService.new(
           invoice: current_organization.invoices.find_by(id: input_params[:invoice_id]),
-          reason: input_params[:reason],
-          items_attr: input_params[:items],
-          description: input_params[:description],
+          **input_params,
         )
         result = service.call
 
@@ -125,10 +123,11 @@ module Api
             :invoice_id,
             :reason,
             :description,
+            :credit_amount_cents,
+            :refund_amount_cents,
             items: [
               :fee_id,
-              :credit_amount_cents,
-              :refund_amount_cents,
+              :amount_cents,
             ],
           )
       end

--- a/app/graphql/mutations/credit_notes/create.rb
+++ b/app/graphql/mutations/credit_notes/create.rb
@@ -13,6 +13,9 @@ module Mutations
       argument :invoice_id, ID, required: true
       argument :description, String, required: false
 
+      argument :credit_amount_cents, GraphQL::Types::BigInt, required: false
+      argument :refund_amount_cents, GraphQL::Types::BigInt, required: false
+
       argument :items, [Types::CreditNoteItems::Input], required: true
 
       type Types::CreditNotes::Object
@@ -24,9 +27,7 @@ module Mutations
         result = ::CreditNotes::CreateService
           .new(
             invoice: current_organization.invoices.find_by(id: args[:invoice_id]),
-            items_attr: args[:items],
-            reason: args[:reason],
-            description: args[:description],
+            **args,
           )
           .call
 

--- a/app/graphql/types/credit_note_items/input.rb
+++ b/app/graphql/types/credit_note_items/input.rb
@@ -6,8 +6,7 @@ module Types
       graphql_name 'CreditNoteItemInput'
 
       argument :fee_id, ID, required: true
-      argument :credit_amount_cents, GraphQL::Types::BigInt, required: true
-      argument :refund_amount_cents, GraphQL::Types::BigInt, required: true
+      argument :amount_cents, GraphQL::Types::BigInt, required: true
     end
   end
 end

--- a/app/graphql/types/credit_note_items/object.rb
+++ b/app/graphql/types/credit_note_items/object.rb
@@ -7,11 +7,8 @@ module Types
 
       field :id, ID, null: false
 
-      field :credit_amount_cents, GraphQL::Types::BigInt, null: false
-      field :credit_amount_currency, Types::CurrencyEnum, null: false
-
-      field :refund_amount_cents, GraphQL::Types::BigInt, null: false
-      field :refund_amount_currency, Types::CurrencyEnum, null: false
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :amount_currency, Types::CurrencyEnum, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
 

--- a/app/graphql/types/credit_notes/object.rb
+++ b/app/graphql/types/credit_notes/object.rb
@@ -36,6 +36,9 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      field :voided_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :refunded_at, GraphQL::Types::ISO8601DateTime, null: true
+
       field :file_url, String, null: true
 
       field :invoice, Types::Invoices::Object

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -18,8 +18,14 @@ module Types
 
       field :fee_type, Types::Fees::TypesEnum, null: false
 
+      field :creditable_amount_cents, Integer, null: false
+
       def item_type
         object.fee_type
+      end
+
+      def creditable_amount_cents
+        object.total_amount_cents - object.credit_note_items.sum(:amount_cents)
       end
     end
   end

--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -4,18 +4,7 @@ class CreditNoteItem < ApplicationRecord
   belongs_to :credit_note
   belongs_to :fee
 
-  monetize :credit_amount_cents
-  monetize :refund_amount_cents
-  monetize :total_amount_cents
+  monetize :amount_cents
 
-  validates :credit_amount_cents, numericality: { greater_than_or_equal_to: 0 }
-
-  def currency
-    credit_amount_currency
-  end
-
-  def total_amount_cents
-    credit_amount_cents + refund_amount_cents
-  end
-  alias total_amount_currency currency
+  validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
 end

--- a/app/serializers/v1/credit_note_item_serializer.rb
+++ b/app/serializers/v1/credit_note_item_serializer.rb
@@ -5,10 +5,8 @@ module V1
     def serialize
       {
         lago_id: model.id,
-        credit_amount_cents: model.credit_amount_cents,
-        credit_amount_currency: model.credit_amount_currency,
-        refund_amount_cents: model.refund_amount_cents,
-        refund_amount_currency: model.refund_amount_currency,
+        amount_cents: model.amount_cents,
+        amount_currency: model.amount_currency,
         fee: fee,
       }
     end

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -132,7 +132,9 @@ module CreditNotes
       end
 
       def update_credit_note_status(status)
-        credit_note.update!(refund_status: status)
+        credit_note.refund_status = status
+        credit_note.refunded_at = Time.current if credit_note.succeeded?
+        credit_note.save!
       end
 
       def track_refund_status_changed(status)

--- a/app/services/credit_notes/update_service.rb
+++ b/app/services/credit_notes/update_service.rb
@@ -12,7 +12,10 @@ module CreditNotes
     def call
       return result.not_found_failure!(resource: 'credit_note') if credit_note.nil?
 
-      credit_note.refund_status = params[:refund_status] if params.key?(:refund_status)
+      if params.key?(:refund_status)
+        credit_note.refund_status = params[:refund_status]
+        credit_note.refunded_at = Time.current if credit_note.succeeded?
+      end
       credit_note.save!
 
       result.credit_note = credit_note

--- a/app/services/credit_notes/validate_item_service.rb
+++ b/app/services/credit_notes/validate_item_service.rb
@@ -5,13 +5,8 @@ module CreditNotes
     def valid?
       return false unless valid_fee?
 
-      valid_invoice_status?
-
-      valid_individual_credit_amount?
-      valid_individual_refund_amount?
+      valid_item_amount?
       valid_individual_amount?
-      valid_global_credit_amount?
-      valid_global_refund_amount?
       valid_global_amount?
 
       if errors?
@@ -32,23 +27,15 @@ module CreditNotes
     delegate :invoice, to: :credit_note
 
     def credited_fee_amount_cents
-      fee.credit_note_items.sum(:credit_amount_cents)
-    end
-
-    def refunded_fee_amount_cents
-      fee.credit_note_items.sum(:refund_amount_cents)
-    end
-
-    def total_fee_amount_cents
-      credited_fee_amount_cents + refunded_fee_amount_cents
-    end
-
-    def credited_invoice_amount_cents
-      invoice.credit_notes.sum(:credit_amount_cents)
+      fee.credit_note_items.sum(:amount_cents)
     end
 
     def refunded_invoice_amount_cents
-      invoice.credit_notes.sum(:refund_amount_cents)
+      invoice.credit_notes.where.not(id: credit_note.id).sum(:refund_amount_cents)
+    end
+
+    def credited_invoice_amount_cents
+      invoice.credit_notes.where.not(id: credit_note.id).sum(:credit_amount_cents)
     end
 
     def invoice_credit_note_total_amount_cents
@@ -63,69 +50,25 @@ module CreditNotes
       false
     end
 
-    def valid_invoice_status?
-      if item.refund_amount_cents.positive?
-        return true if invoice.succeeded?
+    # NOTE: Check if item amount is positive
+    def valid_item_amount?
+      return true if item.amount_cents.positive?
 
-        add_error(field: :refund_amount_cents, error_code: 'cannot_refund_unpaid_invoice')
-        return false
-      end
-
-      true
+      add_error(field: :amount_cents, error_code: 'invalid_value')
     end
 
-    # NOTE: Check if item credit amount is less than or equal to fee remaining creditable amount
-    def valid_individual_credit_amount?
-      return true if item.credit_amount_cents.zero?
-      return true if credit_match_fee_amount?
-
-      add_error(field: :credit_amount_cents, error_code: 'higher_than_remaining_fee_amount')
-    end
-
-    def credit_match_fee_amount?
-      item.credit_amount_cents.positive? &&
-        item.credit_amount_cents <= fee.total_amount_cents - credited_fee_amount_cents
-    end
-
-    # NOTE: Check if refund amount is less than or equal to fee remaining refundable amount
-    def valid_individual_refund_amount?
-      return true if item.refund_amount_cents.zero?
-      return true if refund_match_fee_amount?
-
-      add_error(field: :refund_amount_cents, error_code: 'higher_than_remaining_fee_amount')
-    end
-
-    def refund_match_fee_amount?
-      item.refund_amount_cents.positive? &&
-        item.refund_amount_cents <= fee.total_amount_cents - refunded_fee_amount_cents
-    end
-
-    # NOTE: Check if total credit note amount is less than or equal to fee remaining amount
+    # NOTE: Check if item amount is less than or equal to fee remaining creditable amount
     def valid_individual_amount?
-      return true if item.total_amount_cents <= fee.total_amount_cents - total_fee_amount_cents
+      return true if item.amount_cents <= fee.total_amount_cents - credited_fee_amount_cents
 
-      add_error(field: :base, error_code: 'higher_than_remaining_fee_amount')
+      add_error(field: :amount_cents, error_code: 'higher_than_remaining_fee_amount')
     end
 
-    # NOTE: Check if item credit amount is less than or equal to invoice remaining creditable amount
-    def valid_global_credit_amount?
-      return true if item.credit_amount_cents <= invoice.fee_total_amount_cents - credited_invoice_amount_cents
-
-      add_error(field: :credit_amount_cents, error_code: 'higher_than_remaining_invoice_amount')
-    end
-
-    # NOTE: Check if item refund amount is less than or equal to invoice remaining refundable amount
-    def valid_global_refund_amount?
-      return true if item.refund_amount_cents <= invoice.total_amount_cents - refunded_invoice_amount_cents
-
-      add_error(field: :refund_amount_cents, error_code: 'higher_than_remaining_invoice_amount')
-    end
-
-    # NOTE: Check if item credit note amount is less than or equal to invoice fee amount
+    # NOTE: Check if item amount is less than or equal to invoice remaining creditable amount
     def valid_global_amount?
-      return true if item.total_amount_cents <= invoice.total_amount_cents - invoice_credit_note_total_amount_cents
+      return true if item.amount_cents <= invoice.fee_total_amount_cents - credited_invoice_amount_cents
 
-      add_error(field: :base, error_code: 'higher_than_remaining_invoice_amount')
+      add_error(field: :amount_cents, error_code: 'higher_than_remaining_invoice_amount')
     end
   end
 end

--- a/app/services/credit_notes/validate_service.rb
+++ b/app/services/credit_notes/validate_service.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class ValidateService < BaseValidator
+    def valid?
+      valid_invoice_status?
+      valid_items_amount?
+      valid_refund_amount?
+      valid_credit_amount?
+      valid_global_amount?
+
+      if errors?
+        result.validation_failure!(errors: errors)
+        return false
+      end
+
+      true
+    end
+
+    private
+
+    def credit_note
+      args[:item]
+    end
+
+    delegate :invoice, to: :credit_note
+
+    def total_amount_cents
+      credit_note.credit_amount_cents + credit_note.refund_amount_cents
+    end
+
+    def refunded_invoice_amount_cents
+      invoice.credit_notes.where.not(id: credit_note.id).sum(:refund_amount_cents)
+    end
+
+    def credited_invoice_amount_cents
+      invoice.credit_notes.where.not(id: credit_note.id).sum(:credit_amount_cents)
+    end
+
+    def invoice_credit_note_total_amount_cents
+      credited_invoice_amount_cents + refunded_invoice_amount_cents
+    end
+
+    def valid_invoice_status?
+      if credit_note.refund_amount_cents.positive?
+        return true if invoice.succeeded?
+
+        add_error(field: :refund_amount_cents, error_code: 'cannot_refund_unpaid_invoice')
+        return false
+      end
+
+      true
+    end
+
+    # NOTE: Check if total amount matched the items amount
+    def valid_items_amount?
+      return true if total_amount_cents == credit_note.items.sum(&:amount_cents)
+
+      add_error(field: :base, error_code: 'does_not_match_item_amounts')
+    end
+
+    # NOTE: Check if refunded amount is less than or equal to invoice total amount
+    def valid_refund_amount?
+      return true if credit_note.refund_amount_cents <= invoice.total_amount_cents - refunded_invoice_amount_cents
+
+      add_error(field: :refund_amount_cents, error_code: 'higher_than_remaining_invoice_amount')
+    end
+
+    # NOTE: Check if credited amount is less than or equal to invoice fee amount
+    def valid_credit_amount?
+      return true if credit_note.credit_amount_cents <= invoice.fee_total_amount_cents - credited_invoice_amount_cents
+
+      add_error(field: :credit_amount_cents, error_code: 'higher_than_remaining_invoice_amount')
+    end
+
+    # NOTE: Check if total amount is less than or equal to invoice fee amount
+    def valid_global_amount?
+      return true if total_amount_cents <= invoice.fee_total_amount_cents - invoice_credit_note_total_amount_cents
+
+      add_error(field: :base, error_code: 'higher_than_remaining_invoice_amount')
+    end
+  end
+end

--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -348,13 +348,13 @@ html
                 tr
                   td.body-1 = item.fee.item_name
                   td.body-1 width="30%" style="text-align: right;"
-                    = item.total_amount.format
+                    = item.amount.format
             - else
               - subscription_charge_items(nil).each do |item|
                 tr
                   td.body-1 = item.fee.item_name
                   td.body-1 width="30%" style="text-align: right;"
-                    = item.total_amount.format
+                    = item.amount.format
 
         table.total-table width="100%"
           tr

--- a/db/migrate/20221110151027_changes_credit_note_items_columns.rb
+++ b/db/migrate/20221110151027_changes_credit_note_items_columns.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ChangesCreditNoteItemsColumns < ActiveRecord::Migration[7.0]
+  def up
+    change_table :credit_note_items, bulk: true do |t|
+      t.remove :refund_amount_cents
+      t.remove :refund_amount_currency
+
+      t.rename :credit_amount_cents, :amount_cents
+      t.rename :credit_amount_currency, :amount_currency
+    end
+  end
+
+  def down
+    change_table :credit_note_items, bulk: true do |t|
+      t.bigint :refund_amount_cents, null: false, default: 0
+      t.string :refund_amount_currency, null: true
+
+      t.rename :amount_cents, :credit_amount_cents
+      t.rename :amount_currency, :credit_amount_currency
+    end
+  end
+end

--- a/db/migrate/20221118084547_add_refunded_at_to_credit_notes.rb
+++ b/db/migrate/20221118084547_add_refunded_at_to_credit_notes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRefundedAtToCreditNotes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :credit_notes, :refunded_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -134,12 +134,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_25_111605) do
   create_table "credit_note_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "credit_note_id", null: false
     t.uuid "fee_id", null: false
-    t.bigint "credit_amount_cents", default: 0, null: false
-    t.string "credit_amount_currency", null: false
+    t.bigint "amount_cents", default: 0, null: false
+    t.string "amount_currency", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "refund_amount_cents", default: 0, null: false
-    t.string "refund_amount_currency"
     t.index ["credit_note_id"], name: "index_credit_note_items_on_credit_note_id"
     t.index ["fee_id"], name: "index_credit_note_items_on_fee_id"
   end
@@ -172,6 +170,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_25_111605) do
     t.bigint "vat_amount_cents", default: 0, null: false
     t.string "vat_amount_currency"
     t.date "issuing_date", null: false
+    t.datetime "refunded_at"
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end

--- a/db/seeds/invoices.rb
+++ b/db/seeds/invoices.rb
@@ -29,7 +29,7 @@ Invoice.all.find_each do |invoice|
 
   credit_note.items.create!(
     fee: fee,
-    credit_amount_cents: amount,
-    credit_amount_currency: fee.amount_currency,
+    amount_cents: amount,
+    amount_currency: fee.amount_currency,
   )
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1638,10 +1638,12 @@ input CreateCreditNoteInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  creditAmountCents: BigInt
   description: String
   invoiceId: ID!
   items: [CreditNoteItemInput!]!
   reason: CreditNoteReasonEnum!
+  refundAmountCents: BigInt
 }
 
 """
@@ -1777,6 +1779,7 @@ type CreditNote {
   refundAmountCents: BigInt!
   refundAmountCurrency: CurrencyEnum!
   refundStatus: CreditNoteRefundStatusEnum
+  refundedAt: ISO8601DateTime
   sequentialId: ID!
   subTotalVatExcludedAmountCents: BigInt!
   subTotalVatExcludedAmountCurrency: CurrencyEnum!
@@ -1785,6 +1788,7 @@ type CreditNote {
   updatedAt: ISO8601DateTime!
   vatAmountCents: BigInt!
   vatAmountCurrency: CurrencyEnum!
+  voidedAt: ISO8601DateTime
 }
 
 enum CreditNoteCreditStatusEnum {
@@ -1794,19 +1798,16 @@ enum CreditNoteCreditStatusEnum {
 }
 
 type CreditNoteItem {
+  amountCents: BigInt!
+  amountCurrency: CurrencyEnum!
   createdAt: ISO8601DateTime!
-  creditAmountCents: BigInt!
-  creditAmountCurrency: CurrencyEnum!
   fee: Fee!
   id: ID!
-  refundAmountCents: BigInt!
-  refundAmountCurrency: CurrencyEnum!
 }
 
 input CreditNoteItemInput {
-  creditAmountCents: BigInt!
+  amountCents: BigInt!
   feeId: ID!
-  refundAmountCents: BigInt!
 }
 
 enum CreditNoteReasonEnum {
@@ -2821,6 +2822,7 @@ type Fee implements InvoiceItem {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   charge: Charge
+  creditableAmountCents: Int!
   eventsCount: BigInt
   feeType: FeeTypesEnum!
   group: Group

--- a/schema.json
+++ b/schema.json
@@ -4841,6 +4841,30 @@
               "deprecationReason": null
             },
             {
+              "name": "creditAmountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "refundAmountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "items",
               "description": null,
               "type": {
@@ -5983,6 +6007,20 @@
               ]
             },
             {
+              "name": "refundedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "sequentialId",
               "description": null,
               "type": {
@@ -6125,6 +6163,20 @@
               "args": [
 
               ]
+            },
+            {
+              "name": "voidedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
             }
           ],
           "inputFields": null,
@@ -6169,25 +6221,7 @@
           "possibleTypes": null,
           "fields": [
             {
-              "name": "createdAt",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601DateTime",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "creditAmountCents",
+              "name": "amountCents",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -6205,7 +6239,7 @@
               ]
             },
             {
-              "name": "creditAmountCurrency",
+              "name": "amountCurrency",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -6213,6 +6247,24 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
                   "ofType": null
                 }
               },
@@ -6257,42 +6309,6 @@
               "args": [
 
               ]
-            },
-            {
-              "name": "refundAmountCents",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "refundAmountCurrency",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "CurrencyEnum",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
             }
           ],
           "inputFields": null,
@@ -6323,23 +6339,7 @@
               "deprecationReason": null
             },
             {
-              "name": "creditAmountCents",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "refundAmountCents",
+              "name": "amountCents",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -9614,6 +9614,24 @@
                 "kind": "OBJECT",
                 "name": "Charge",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditableAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/controllers/api/v1/credit_notes_controller_spec.rb
+++ b/spec/controllers/api/v1/credit_notes_controller_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         json_item = json[:credit_note][:items].first
         item = credit_note_items.first
         expect(json_item[:lago_id]).to eq(item.id)
-        expect(json_item[:credit_amount_cents]).to eq(item.credit_amount_cents)
-        expect(json_item[:credit_amount_currency]).to eq(item.credit_amount_currency)
+        expect(json_item[:amount_cents]).to eq(item.amount_cents)
+        expect(json_item[:amount_currency]).to eq(item.amount_currency)
         expect(json_item[:fee][:lago_id]).to eq(item.fee.id)
         expect(json_item[:fee][:amount_cents]).to eq(item.fee.amount_cents)
         expect(json_item[:fee][:amount_currency]).to eq(item.fee.amount_currency)
@@ -216,16 +216,16 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         invoice_id: invoice_id,
         reason: 'duplicated_charge',
         description: 'Duplicated charge',
+        credit_amount_cents: 10,
+        refund_amount_cents: 5,
         items: [
           {
             fee_id: fee1.id,
-            credit_amount_cents: 10,
-            refund_amount_cents: 5,
+            amount_cents: 10,
           },
           {
             fee_id: fee2.id,
-            credit_amount_cents: 5,
-            refund_amount_cents: 10,
+            amount_cents: 5,
           },
         ],
       }
@@ -242,27 +242,23 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         expect(json[:credit_note][:refund_status]).to eq('pending')
         expect(json[:credit_note][:reason]).to eq('duplicated_charge')
         expect(json[:credit_note][:description]).to eq('Duplicated charge')
-        expect(json[:credit_note][:total_amount_cents]).to eq(30)
+        expect(json[:credit_note][:total_amount_cents]).to eq(15)
         expect(json[:credit_note][:total_amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:credit_amount_cents]).to eq(15)
+        expect(json[:credit_note][:credit_amount_cents]).to eq(10)
         expect(json[:credit_note][:credit_amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:balance_amount_cents]).to eq(15)
+        expect(json[:credit_note][:balance_amount_cents]).to eq(10)
         expect(json[:credit_note][:balance_amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:refund_amount_cents]).to eq(15)
+        expect(json[:credit_note][:refund_amount_cents]).to eq(5)
         expect(json[:credit_note][:refund_amount_currency]).to eq('EUR')
 
         expect(json[:credit_note][:items][0][:lago_id]).to be_present
-        expect(json[:credit_note][:items][0][:credit_amount_cents]).to eq(10)
-        expect(json[:credit_note][:items][0][:credit_amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:items][0][:refund_amount_cents]).to eq(5)
-        expect(json[:credit_note][:items][0][:refund_amount_currency]).to eq('EUR')
+        expect(json[:credit_note][:items][0][:amount_cents]).to eq(10)
+        expect(json[:credit_note][:items][0][:amount_currency]).to eq('EUR')
         expect(json[:credit_note][:items][0][:fee][:lago_id]).to eq(fee1.id)
 
         expect(json[:credit_note][:items][1][:lago_id]).to be_present
-        expect(json[:credit_note][:items][1][:credit_amount_cents]).to eq(5)
-        expect(json[:credit_note][:items][1][:credit_amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:items][1][:refund_amount_cents]).to eq(10)
-        expect(json[:credit_note][:items][1][:refund_amount_currency]).to eq('EUR')
+        expect(json[:credit_note][:items][1][:amount_cents]).to eq(5)
+        expect(json[:credit_note][:items][1][:amount_currency]).to eq('EUR')
         expect(json[:credit_note][:items][1][:fee][:lago_id]).to eq(fee2.id)
       end
     end

--- a/spec/factories/credit_note_items.rb
+++ b/spec/factories/credit_note_items.rb
@@ -4,9 +4,7 @@ FactoryBot.define do
   factory :credit_note_item do
     credit_note
     fee
-    credit_amount_cents { 100 }
-    credit_amount_currency { 'EUR' }
-    refund_amount_cents { 100 }
-    refund_amount_currency { 'EUR' }
+    amount_cents { 100 }
+    amount_currency { 'EUR' }
   end
 end

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -41,10 +41,8 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
           refundAmountCurrency
           items {
             id
-            creditAmountCents
-            creditAmountCurrency
-            refundAmountCents
-            refundAmountCurrency
+            amountCents
+            amountCurrency
             fee { id }
           }
         }
@@ -62,16 +60,16 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
           reason: 'duplicated_charge',
           invoiceId: invoice.id,
           description: 'Duplicated charge',
+          creditAmountCents: 10,
+          refundAmountCents: 5,
           items: [
             {
               feeId: fee1.id,
-              creditAmountCents: 10,
-              refundAmountCents: 5,
+              amountCents: 10,
             },
             {
               feeId: fee2.id,
-              creditAmountCents: 5,
-              refundAmountCents: 10,
+              amountCents: 5,
             },
           ],
         },
@@ -86,27 +84,23 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
       expect(result_data['refundStatus']).to eq('pending')
       expect(result_data['reason']).to eq('duplicated_charge')
       expect(result_data['description']).to eq('Duplicated charge')
-      expect(result_data['totalAmountCents']).to eq('30')
+      expect(result_data['totalAmountCents']).to eq('15')
       expect(result_data['totalAmountCurrency']).to eq('EUR')
-      expect(result_data['creditAmountCents']).to eq('15')
+      expect(result_data['creditAmountCents']).to eq('10')
       expect(result_data['creditAmountCurrency']).to eq('EUR')
-      expect(result_data['balanceAmountCents']).to eq('15')
+      expect(result_data['balanceAmountCents']).to eq('10')
       expect(result_data['balanceAmountCurrency']).to eq('EUR')
-      expect(result_data['refundAmountCents']).to eq('15')
+      expect(result_data['refundAmountCents']).to eq('5')
       expect(result_data['refundAmountCurrency']).to eq('EUR')
 
       expect(result_data['items'][0]['id']).to be_present
-      expect(result_data['items'][0]['creditAmountCents']).to eq('10')
-      expect(result_data['items'][0]['creditAmountCurrency']).to eq('EUR')
-      expect(result_data['items'][0]['refundAmountCents']).to eq('5')
-      expect(result_data['items'][0]['refundAmountCurrency']).to eq('EUR')
+      expect(result_data['items'][0]['amountCents']).to eq('10')
+      expect(result_data['items'][0]['amountCurrency']).to eq('EUR')
       expect(result_data['items'][0]['fee']['id']).to eq(fee1.id)
 
       expect(result_data['items'][1]['id']).to be_present
-      expect(result_data['items'][1]['creditAmountCents']).to eq('5')
-      expect(result_data['items'][1]['creditAmountCurrency']).to eq('EUR')
-      expect(result_data['items'][1]['refundAmountCents']).to eq('10')
-      expect(result_data['items'][1]['refundAmountCurrency']).to eq('EUR')
+      expect(result_data['items'][1]['amountCents']).to eq('5')
+      expect(result_data['items'][1]['amountCurrency']).to eq('EUR')
       expect(result_data['items'][1]['fee']['id']).to eq(fee2.id)
     end
   end
@@ -121,11 +115,12 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
           input: {
             reason: 'duplicated_charge',
             invoiceId: 'foo_id',
+            creditAmountCents: 10,
+            refundAmountCents: 5,
             items: [
               {
                 feeId: fee1.id,
-                creditAmountCents: 10,
-                refundAmountCents: 5,
+                amountCents: 15,
               },
             ],
           },
@@ -145,11 +140,12 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
           input: {
             reason: 'duplicated_charge',
             invoiceId: invoice.id,
+            creditAmountCents: 10,
+            refundAmountCents: 5,
             items: [
               {
                 feeId: fee1.id,
-                creditAmountCents: 10,
-                refundAmountCents: 5,
+                amountCents: 15,
               },
             ],
           },
@@ -169,11 +165,12 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
           input: {
             reason: 'duplicated_charge',
             invoiceId: invoice.id,
+            creditAmountCents: 10,
+            refundAmountCents: 5,
             items: [
               {
                 feeId: fee1.id,
-                creditAmountCents: 10,
-                refundAmountCents: 5,
+                amountCents: 15,
               },
             ],
           },

--- a/spec/graphql/resolvers/credit_note_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_note_resolver_spec.rb
@@ -25,12 +25,14 @@ RSpec.describe Resolvers::CreditNoteResolver, type: :graphql do
           subTotalVatExcludedAmountCurrency
           createdAt
           updatedAt
+          voidedAt
+          refundedAt
           fileUrl
           invoice { id number }
           items {
             id
-            creditAmountCents
-            creditAmountCurrency
+            amountCents
+            amountCurrency
             createdAt
             fee { id amountCents itemType itemCode itemName }
           }

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -28,10 +28,8 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
             refundAmountCurrency
             items {
               id
-              creditAmountCents
-              creditAmountCurrency
-              refundAmountCents
-              refundAmountCurrency
+              amountCents
+              amountCurrency
               fee { id amountCents amountCurrency itemType itemCode itemName vatRate units eventsCount }
             }
           }

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
           subscriptions {
             id
           }
+          fees {
+            id
+            creditableAmountCents
+          }
         }
       }
     GQL

--- a/spec/models/credit_note_item_spec.rb
+++ b/spec/models/credit_note_item_spec.rb
@@ -3,19 +3,4 @@
 require 'rails_helper'
 
 RSpec.describe CreditNoteItem, type: :model do
-  describe '#total_amount_cents' do
-    let(:item) { create(:credit_note_item) }
-
-    it 'returns the credit and refund amounts' do
-      expect(item.total_amount_cents).to eq(
-        item.credit_amount_cents + item.refund_amount_cents,
-      )
-    end
-  end
-
-  describe '#total_amount_currency' do
-    let(:item) { create(:credit_note_item, credit_amount_currency: 'JPY') }
-
-    it { expect(item.total_amount_currency).to eq('JPY') }
-  end
 end

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
         expect(result.refund.provider_refund_id).to eq('re_123456')
 
         expect(result.credit_note).to be_succeeded
+        expect(result.credit_note.refunded_at).to be_present
       end
     end
 

--- a/spec/services/credit_notes/update_service_spec.rb
+++ b/spec/services/credit_notes/update_service_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe CreditNotes::UpdateService, type: :service do
     aggregate_failures do
       expect(result).to be_success
       expect(result.credit_note.refund_status).to eq('succeeded')
+      expect(result.credit_note.refunded_at).to be_present
     end
   end
 

--- a/spec/services/credit_notes/validate_service_spec.rb
+++ b/spec/services/credit_notes/validate_service_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::ValidateService, type: :service do
+  subject(:validator) { described_class.new(result, item: credit_note) }
+
+  let(:result) { BaseService::Result.new }
+  let(:amount_cents) { 10 }
+  let(:credit_amount_cents) { 10 }
+  let(:refund_amount_cents) { 0 }
+  let(:credit_note) do
+    create(
+      :credit_note,
+      invoice: invoice,
+      customer: customer,
+      credit_amount_cents: credit_amount_cents,
+      refund_amount_cents: refund_amount_cents,
+    )
+  end
+  let(:item) do
+    create(
+      :credit_note_item,
+      credit_note: credit_note,
+      amount_cents: amount_cents,
+      fee: fee,
+    )
+  end
+
+  let(:invoice) { create(:invoice, total_amount_cents: 100, amount_cents: 100) }
+  let(:customer) { invoice.customer }
+
+  let(:fee) do
+    create(
+      :fee,
+      invoice: invoice,
+      amount_cents: 100,
+    )
+  end
+
+  before { item }
+
+  describe '.call' do
+    it 'validates the credit_note' do
+      expect(validator).to be_valid
+    end
+
+    context 'when invoice is not paid' do
+      let(:invoice_status) { 'pending' }
+      let(:refund_amount_cents) { 2 }
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:refund_amount_cents]).to eq(['cannot_refund_unpaid_invoice'])
+        end
+      end
+    end
+
+    context 'when amount does not matches items' do
+      let(:amount_cents) { 1 }
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(['does_not_match_item_amounts'])
+        end
+      end
+    end
+
+    context 'when credit amount is higher than invoice amount' do
+      let(:credit_amount_cents) { 250 }
+
+      before do
+        create(:fee, invoice: invoice, amount_cents: 100, vat_amount_cents: 20)
+      end
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:credit_amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
+        end
+      end
+    end
+
+    context 'when refund amount is higher than invoice amount' do
+      let(:refund_amount_cents) { 200 }
+
+      before do
+        invoice.succeeded!
+        create(:fee, invoice: invoice, amount_cents: 100, vat_amount_cents: 20)
+      end
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:refund_amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
+        end
+      end
+    end
+
+    context 'when reaching invoice creditable amount' do
+      before do
+        create(:credit_note, invoice: invoice, total_amount_cents: 99)
+      end
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:credit_amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
+        end
+      end
+    end
+
+    context 'when reaching invoice refundable amount' do
+      before do
+        invoice.succeeded!
+        create(:credit_note, invoice: invoice, total_amount_cents: 99, refund_amount_cents: 99, credit_amount_cents: 0)
+      end
+
+      let(:credit_amount_cents) { 0 }
+      let(:refund_amount_cents) { 10 }
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:refund_amount_cents]).to eq(['higher_than_remaining_invoice_amount'])
+        end
+      end
+    end
+
+    context 'when total amount is higher than invoice amount' do
+      before do
+        create(
+          :credit_note,
+          invoice: invoice,
+          credit_amount_cents: 66,
+          refund_amount_cents: 33,
+          total_amount_cents: 99,
+        )
+      end
+
+      it 'fails the validation' do
+        aggregate_failures do
+          expect(validator).not_to be_valid
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(['higher_than_remaining_invoice_amount'])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR Improves the currently merged credit note features:
- Adds a `refunded_at` fields to credit note
- Removes `refund_amount_cents` and `refund_amount_currency` from credit note item
- Renames `credit_amount_cents` and `credit_amount_currency` into `amount_*`