### PR TITLE
feat(timezones): Coupon expiration date

### DIFF
--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -6,10 +6,10 @@ module Api
       def create
         service = Coupons::CreateService.new
         result = service.create(
-          **input_params
-            .merge(organization_id: current_organization.id)
-            .to_h
-            .symbolize_keys,
+          CouponLegacyInput.new(
+            current_organization,
+            input_params.merge(organization_id: current_organization.id),
+          ).create_input,
         )
 
         if result.success?
@@ -24,7 +24,10 @@ module Api
         result = service.update_from_api(
           organization: current_organization,
           code: params[:code],
-          params: input_params,
+          params: CouponLegacyInput.new(
+            current_organization,
+            input_params,
+          ).update_input,
         )
 
         if result.success?
@@ -87,6 +90,8 @@ module Api
           :frequency,
           :frequency_duration,
           :expiration,
+          :expiration_at,
+          # NOTE: Legacy field
           :expiration_date,
           :reusable,
         )

--- a/app/graphql/mutations/coupons/create.rb
+++ b/app/graphql/mutations/coupons/create.rb
@@ -20,6 +20,9 @@ module Mutations
       argument :reusable, Boolean, required: false
 
       argument :expiration, Types::Coupons::ExpirationEnum, required: true
+      argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
+
+      # NOTE: Legacy fields, will be removed when releasing the timezone feature
       argument :expiration_date, GraphQL::Types::ISO8601Date, required: false
 
       type Types::Coupons::Object
@@ -29,7 +32,12 @@ module Mutations
 
         result = ::Coupons::CreateService
           .new(context[:current_user])
-          .create(**args.merge(organization_id: current_organization.id))
+          .create(
+            CouponLegacyInput.new(
+              current_organization,
+              args.merge(organization_id: current_organization.id),
+            ).create_input,
+          )
 
         result.success? ? result.coupon : result_error(result)
       end

--- a/app/graphql/mutations/coupons/update.rb
+++ b/app/graphql/mutations/coupons/update.rb
@@ -20,13 +20,23 @@ module Mutations
       argument :reusable, Boolean, required: false
 
       argument :expiration, Types::Coupons::ExpirationEnum, required: true
+      argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
+
+      # NOTE: Legacy fields, will be removed when releasing the timezone feature
       argument :expiration_date, GraphQL::Types::ISO8601Date, required: false
 
       type Types::Coupons::Object
 
       def resolve(**args)
+        coupon = context[:current_user].coupons.find_by(id: args[:id])
+
         result = ::Coupons::UpdateService.new(context[:current_user])
-          .update(**args)
+          .update(
+            CouponLegacyInput.new(
+              coupon&.organization,
+              args,
+            ).update_input,
+          )
 
         result.success? ? result.coupon : result_error(result)
       end

--- a/app/graphql/types/coupons/object.rb
+++ b/app/graphql/types/coupons/object.rb
@@ -20,7 +20,7 @@ module Types
       field :reusable, Boolean, null: false
 
       field :expiration, Types::Coupons::ExpirationEnum, null: false
-      field :expiration_date, GraphQL::Types::ISO8601Date, null: true
+      field :expiration_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
@@ -38,6 +38,13 @@ module Types
 
       def can_be_deleted
         object.deletable?
+      end
+
+      # NOTE: Legacy fields, will be removed when releasing the timezone feature
+      field :expiration_date, GraphQL::Types::ISO8601Date, null: true
+
+      def expiration_date
+        object.expiration_at&.to_date
       end
     end
   end

--- a/app/legacy_inputs/coupon_legacy_input.rb
+++ b/app/legacy_inputs/coupon_legacy_input.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CouponLegacyInput < BaseLegacyInput
+  def create_input
+    if args[:expiration_date].present?
+      args[:expiration_at] ||= date_in_organization_timezone(args[:expiration_date], end_of_day: true)
+    end
+
+    args
+  end
+  alias update_input create_input
+end

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -41,19 +41,20 @@ class Coupon < ApplicationRecord
   validates :amount_cents, numericality: { greater_than: 0 }, allow_nil: true
   validates :amount_currency, inclusion: { in: currency_list }, allow_nil: true
 
-  scope :order_by_status_and_expiration, lambda {
-    order(
-      Arel.sql(
-        [
-          'coupons.status ASC',
-          'coupons.expiration ASC',
-          'coupons.expiration_date ASC',
-        ].join(', '),
-      ),
-    )
-  }
+  scope :order_by_status_and_expiration,
+        lambda {
+          order(
+            Arel.sql(
+              [
+                'coupons.status ASC',
+                'coupons.expiration ASC',
+                'coupons.expiration_at ASC',
+              ].join(', '),
+            ),
+          )
+        }
 
-  scope :expired, -> { where('coupons.expiration_date < ?', Time.current.beginning_of_day) }
+  scope :expired, -> { where('coupons.expiration_at::timestamp(0) < ?', Time.current) }
 
   def attached_to_customers?
     applied_coupons.exists?

--- a/app/serializers/v1/applied_coupon_serializer.rb
+++ b/app/serializers/v1/applied_coupon_serializer.rb
@@ -17,10 +17,10 @@ module V1
         frequency: model.frequency,
         frequency_duration: model.frequency_duration,
         frequency_duration_remaining: model.frequency_duration_remaining,
-        expiration_date: model.coupon.expiration_date&.iso8601,
+        expiration_at: model.coupon.expiration_at&.iso8601,
         created_at: model.created_at.iso8601,
         terminated_at: model.terminated_at&.iso8601,
-      }
+      }.merge(legacy_values)
     end
 
     private
@@ -30,6 +30,12 @@ module V1
       return nil if model.coupon.percentage?
 
       model.amount_cents - model.credits.sum(:amount_cents)
+    end
+
+    def legacy_values
+      ::V1::Legacy::AppliedCouponSerializer.new(
+        model,
+      ).serialize
     end
   end
 end

--- a/app/serializers/v1/coupon_serializer.rb
+++ b/app/serializers/v1/coupon_serializer.rb
@@ -16,8 +16,16 @@ module V1
         reusable: model.reusable,
         created_at: model.created_at.iso8601,
         expiration: model.expiration,
-        expiration_date: model.expiration_date&.iso8601,
-      }
+        expiration_at: model.expiration_at&.iso8601,
+      }.merge(legacy_values)
+    end
+
+    private
+
+    def legacy_values
+      ::V1::Legacy::CouponSerializer.new(
+        model,
+      ).serialize
     end
   end
 end

--- a/app/serializers/v1/legacy/applied_coupon_serializer.rb
+++ b/app/serializers/v1/legacy/applied_coupon_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module V1
+  module Legacy
+    class AppliedCouponSerializer < ModelSerializer
+      def serialize
+        {
+          expiration_date: model.coupon.expiration_at&.to_date&.iso8601,
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/v1/legacy/coupon_serializer.rb
+++ b/app/serializers/v1/legacy/coupon_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module V1
+  module Legacy
+    class CouponSerializer < ModelSerializer
+      def serialize
+        {
+          expiration_date: model.expiration_at&.to_date&.iso8601,
+        }
+      end
+    end
+  end
+end

--- a/app/services/coupons/create_service.rb
+++ b/app/services/coupons/create_service.rb
@@ -2,7 +2,7 @@
 
 module Coupons
   class CreateService < BaseService
-    def create(**args)
+    def create(args)
       reusable = args.key?(:reusable) ? args[:reusable] : true
 
       coupon = Coupon.create!(
@@ -16,7 +16,7 @@ module Coupons
         frequency: args[:frequency],
         frequency_duration: args[:frequency_duration],
         expiration: args[:expiration]&.to_sym,
-        expiration_date: args[:expiration_date],
+        expiration_at: args[:expiration_at],
         reusable: reusable,
       )
 

--- a/app/services/coupons/update_service.rb
+++ b/app/services/coupons/update_service.rb
@@ -2,13 +2,13 @@
 
 module Coupons
   class UpdateService < BaseService
-    def update(**args)
+    def update(args)
       coupon = result.user.coupons.find_by(id: args[:id])
       return result.not_found_failure!(resource: 'coupon') unless coupon
 
       coupon.name = args[:name]
       coupon.expiration = args[:expiration]&.to_sym
-      coupon.expiration_date = args[:expiration_date]
+      coupon.expiration_at = args[:expiration_at]
 
       unless coupon.attached_to_customers?
         coupon.code = args[:code]
@@ -35,7 +35,7 @@ module Coupons
 
       coupon.name = params[:name] if params.key?(:name)
       coupon.expiration = params[:expiration] if params.key?(:expiration)
-      coupon.expiration_date = params[:expiration_date] if params.key?(:expiration_date)
+      coupon.expiration_at = params[:expiration_at] if params.key?(:expiration_at)
 
       unless coupon.attached_to_customers?
         coupon.code = params[:code] if params.key?(:code)

--- a/clock.rb
+++ b/clock.rb
@@ -27,7 +27,7 @@ module Clockwork
     Clock::SubscriptionsBillerJob.perform_later
   end
 
-  every(1.day, 'schedule:terminate_coupons', at: '5:00') do
+  every(1.hour, 'schedule:terminate_coupons', at: '*:30') do
     Clock::TerminateCouponsJob.perform_later
   end
 

--- a/db/migrate/20221129133433_change_expiration_dates_type.rb
+++ b/db/migrate/20221129133433_change_expiration_dates_type.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class ChangeExpirationDatesType < ActiveRecord::Migration[7.0]
+  def up
+    add_column :coupons, :expiration_at, :datetime
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE coupons SET expiration_at = (date_trunc('day', expiration_date) + interval '1 day' - interval '1 second')::timestamp
+          WHERE expiration_date IS NOT NULL;
+        SQL
+      end
+    end
+
+    remove_column :coupons, :expiration_date
+  end
+
+  def down
+    add_column :coupons, :expiration_date, :date
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE coupons SET expiration_date = DATE(expiration_at)
+          WHERE expiration_at IS NOT NULL;
+        SQL
+      end
+    end
+
+    remove_column :coupons, :expiration_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -126,7 +126,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_05_112007) do
     t.decimal "percentage_rate", precision: 10, scale: 5
     t.integer "frequency", default: 0, null: false
     t.integer "frequency_duration"
-    t.date "expiration_date"
+    t.datetime "expiration_at"
     t.boolean "reusable", default: true, null: false
     t.index ["organization_id", "code"], name: "index_coupons_on_organization_id_and_code", unique: true, where: "(code IS NOT NULL)"
     t.index ["organization_id"], name: "index_coupons_on_organization_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1477,6 +1477,7 @@ type Coupon {
   """
   customerCount: Int!
   expiration: CouponExpiration!
+  expirationAt: ISO8601DateTime
   expirationDate: ISO8601Date
   frequency: CouponFrequency!
   frequencyDuration: Int
@@ -1512,6 +1513,7 @@ type CouponDetails {
   """
   customerCount: Int!
   expiration: CouponExpiration!
+  expirationAt: ISO8601DateTime
   expirationDate: ISO8601Date
   frequency: CouponFrequency!
   frequencyDuration: Int
@@ -1625,6 +1627,7 @@ input CreateCouponInput {
   code: String
   couponType: CouponTypeEnum!
   expiration: CouponExpiration!
+  expirationAt: ISO8601DateTime
   expirationDate: ISO8601Date
   frequency: CouponFrequency!
   frequencyDuration: Int
@@ -4753,6 +4756,7 @@ input UpdateCouponInput {
   code: String
   couponType: CouponTypeEnum!
   expiration: CouponExpiration!
+  expirationAt: ISO8601DateTime
   expirationDate: ISO8601Date
   frequency: CouponFrequency!
   frequencyDuration: Int

--- a/schema.json
+++ b/schema.json
@@ -3596,6 +3596,20 @@
               ]
             },
             {
+              "name": "expirationAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "expirationDate",
               "description": null,
               "type": {
@@ -3968,6 +3982,20 @@
                   "name": "CouponExpiration",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "expirationAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -4804,6 +4832,18 @@
                   "name": "CouponExpiration",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "expirationAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -18231,6 +18271,18 @@
                   "name": "CouponExpiration",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "expirationAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/mutations/coupons/create_spec.rb
+++ b/spec/graphql/mutations/coupons/create_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Mutations::Coupons::Create, type: :graphql do
   let(:membership) { create(:membership) }
+  let(:expiration_at) { Time.current + 3.days }
   let(:mutation) do
     <<-GQL
       mutation($input: CreateCouponInput!) {
@@ -14,7 +15,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
           amountCents,
           amountCurrency,
           expiration,
-          expirationDate,
+          expirationAt,
           status,
           reusable
         }
@@ -22,7 +23,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
     GQL
   end
 
-  it 'create a coupon' do
+  it 'creates a coupon' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
@@ -36,7 +37,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
           amountCents: 5000,
           amountCurrency: 'EUR',
           expiration: 'time_limit',
-          expirationDate: (Time.current + 3.days).to_date,
+          expirationAt: expiration_at.iso8601,
           reusable: false,
         },
       },
@@ -51,9 +52,44 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
       expect(result_data['amountCents']).to eq(5000)
       expect(result_data['amountCurrency']).to eq('EUR')
       expect(result_data['expiration']).to eq('time_limit')
-      expect(result_data['expirationDate']).to eq (Time.current + 3.days).to_date.to_s
+      expect(result_data['expirationAt']).to eq expiration_at.iso8601
       expect(result_data['status']).to eq('active')
       expect(result_data['reusable']).to eq(false)
+    end
+  end
+
+  context 'with an expiration date' do
+    it 'creates a coupon' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: membership.organization,
+        query: mutation,
+        variables: {
+          input: {
+            name: 'Super Coupon',
+            code: 'free-beer',
+            couponType: 'fixed_amount',
+            frequency: 'once',
+            amountCents: 5000,
+            amountCurrency: 'EUR',
+            expiration: 'time_limit',
+            expirationDate: expiration_at.to_date.iso8601,
+          },
+        },
+      )
+
+      result_data = result['data']['createCoupon']
+
+      aggregate_failures do
+        expect(result_data['id']).to be_present
+        expect(result_data['name']).to eq('Super Coupon')
+        expect(result_data['code']).to eq('free-beer')
+        expect(result_data['amountCents']).to eq(5000)
+        expect(result_data['amountCurrency']).to eq('EUR')
+        expect(result_data['expiration']).to eq('time_limit')
+        expect(result_data['expirationAt']).to eq expiration_at.end_of_day.iso8601
+        expect(result_data['status']).to eq('active')
+      end
     end
   end
 

--- a/spec/graphql/mutations/coupons/update_spec.rb
+++ b/spec/graphql/mutations/coupons/update_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Mutations::Coupons::Update, type: :graphql do
   let(:membership) { create(:membership) }
   let(:coupon) { create(:coupon, organization: membership.organization) }
+  let(:expiration_at) { Time.current + 3.days }
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateCouponInput!) {
@@ -16,7 +17,7 @@ RSpec.describe Mutations::Coupons::Update, type: :graphql do
           amountCents,
           amountCurrency,
           expiration,
-          expirationDate,
+          expirationAt,
           reusable
         }
       }
@@ -37,7 +38,7 @@ RSpec.describe Mutations::Coupons::Update, type: :graphql do
           amountCents: 123,
           amountCurrency: 'USD',
           expiration: 'time_limit',
-          expirationDate: (Time.current + 33.days).to_date,
+          expirationAt: expiration_at.iso8601,
           reusable: false,
         },
       },
@@ -52,8 +53,43 @@ RSpec.describe Mutations::Coupons::Update, type: :graphql do
       expect(result_data['amountCents']).to eq(123)
       expect(result_data['amountCurrency']).to eq('USD')
       expect(result_data['expiration']).to eq('time_limit')
-      expect(result_data['expirationDate']).to eq (Time.current + 33.days).to_date.to_s
+      expect(result_data['expirationAt']).to eq expiration_at.iso8601
       expect(result_data['reusable']).to eq(false)
+    end
+  end
+
+  context 'with an expiration date' do
+    it 'updates a coupon' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query: mutation,
+        variables: {
+          input: {
+            id: coupon.id,
+            name: 'New name',
+            couponType: 'fixed_amount',
+            frequency: 'once',
+            code: 'new_code',
+            amountCents: 123,
+            amountCurrency: 'USD',
+            expiration: 'time_limit',
+            expirationDate: expiration_at.to_date.iso8601,
+            reusable: false,
+          },
+        },
+      )
+
+      result_data = result['data']['updateCoupon']
+
+      aggregate_failures do
+        expect(result_data['name']).to eq('New name')
+        expect(result_data['code']).to eq('new_code')
+        expect(result_data['status']).to eq('active')
+        expect(result_data['amountCents']).to eq(123)
+        expect(result_data['amountCurrency']).to eq('USD')
+        expect(result_data['expiration']).to eq('time_limit')
+        expect(result_data['expirationAt']).to eq expiration_at.end_of_day.iso8601
+      end
     end
   end
 

--- a/spec/serializers/v1/coupon_serializer_spec.rb
+++ b/spec/serializers/v1/coupon_serializer_spec.rb
@@ -17,8 +17,14 @@ RSpec.describe ::V1::CouponSerializer do
       expect(result['coupon']['amount_cents']).to eq(coupon.amount_cents)
       expect(result['coupon']['amount_currency']).to eq(coupon.amount_currency)
       expect(result['coupon']['expiration']).to eq(coupon.expiration)
-      expect(result['coupon']['expiration_date']).to eq(coupon.expiration_date&.iso8601)
+      expect(result['coupon']['expiration_at']).to eq(coupon.expiration_at&.iso8601)
       expect(result['coupon']['created_at']).to eq(coupon.created_at.iso8601)
     end
+  end
+
+  it 'serializes the legacy fields' do
+    result = JSON.parse(serializer.to_json)
+
+    expect(result['coupon']['expiration_date']).to eq(coupon.expiration_at&.to_date&.iso8601)
   end
 end

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Coupons::CreateService, type: :service do
         amount_currency: 'EUR',
         expiration: 'time_limit',
         reusable: false,
-        expiration_date: (Time.current + 3.days).to_date,
+        expiration_at: (Time.current + 3.days).end_of_day,
       }
     end
 

--- a/spec/services/coupons/terminate_service_spec.rb
+++ b/spec/services/coupons/terminate_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Coupons::TerminateService, type: :service do
         organization: organization,
         status: 'active',
         expiration: 'time_limit',
-        expiration_date: (Time.current - 30.days).to_date,
+        expiration_at: Time.current - 30.days,
         created_at: Time.zone.now - 40.days,
       )
     end
@@ -52,7 +52,7 @@ RSpec.describe Coupons::TerminateService, type: :service do
         organization: organization,
         status: 'active',
         expiration: 'time_limit',
-        expiration_date: (Time.current + 15.days).to_date,
+        expiration_at: Time.current + 15.days,
         created_at: Time.zone.now,
       )
     end

--- a/spec/services/coupons/update_service_spec.rb
+++ b/spec/services/coupons/update_service_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Coupons::UpdateService, type: :service do
 
   let(:coupon) { create(:coupon, organization: organization) }
 
+  let(:expiration_at) { Time.current + 30.days }
+
   describe 'update' do
     before { coupon }
 
@@ -23,7 +25,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
         amount_currency: 'EUR',
         expiration: 'time_limit',
         reusable: false,
-        expiration_date: (Time.current + 30.days).to_date,
+        expiration_at: expiration_at,
       }
     end
 
@@ -38,7 +40,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
         expect(result.coupon.amount_currency).to eq('EUR')
         expect(result.coupon.expiration).to eq('time_limit')
         expect(result.coupon.reusable).to eq(false)
-        expect(result.coupon.expiration_date).to eq (Time.current + 30.days).to_date
+        expect(result.coupon.expiration_at.to_s).to eq((Time.current + 30.days).to_s)
       end
     end
 
@@ -53,7 +55,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
           amount_currency: 'EUR',
           reusable: false,
           expiration: 'time_limit',
-          expiration_date: (Time.current + 30.days).to_date,
+          expiration_at: Time.current + 30.days,
         }
       end
 
@@ -81,12 +83,12 @@ RSpec.describe Coupons::UpdateService, type: :service do
         amount_cents: 123,
         amount_currency: 'EUR',
         expiration: 'time_limit',
-        expiration_date: (Time.current + 15.days).to_date,
+        expiration_at: Time.current + 15.days,
       }
     end
 
     it 'updates the coupon' do
-      result = subject.update_from_api(
+      result = update_service.update_from_api(
         organization: organization,
         code: coupon.code,
         params: update_args,
@@ -107,7 +109,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
       let(:name) { nil }
 
       it 'returns an error' do
-        result = subject.update_from_api(
+        result = update_service.update_from_api(
           organization: organization,
           code: coupon.code,
           params: update_args,
@@ -123,7 +125,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
 
     context 'when coupon is not found' do
       it 'returns an error' do
-        result = subject.update_from_api(
+        result = update_service.update_from_api(
           organization: organization,
           code: 'fake_code12345',
           params: update_args,


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR updates the coupon to turn `expiration_date` into `expiration_at`, it is keeping the compatibility with the existing fields.
