### PR TITLE
misc(redis): Add Redis Password Support

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
     config.cache_store = :mem_cache_store, ENV['LAGO_MEMCACHE_SERVERS'].split(',')
 
   elsif ENV['LAGO_REDIS_CACHE_URL'].present?
-    config.cache_store = :redis_cache_store, {
+    cache_store_config = {
       url: ENV['LAGO_REDIS_CACHE_URL'],
       error_handler: ->(method:, returning:, exception:) {
         Rails.logger.error(exception.message)
@@ -49,5 +49,9 @@ Rails.application.configure do
         Sentry.capture_exception(exception)
       },
     }
+
+    cache_store_config.merge({ password: ENV['LAGO_REDIS_CACHE_PASSWORD'] }) if ENV['LAGO_REDIS_CACHE_PASSWORD'].present?
+
+    config.cache_store = :redis_cache_store, cache_store_config
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,9 @@ Rails.application.configure do
       },
     }
 
-    cache_store_config.merge({ password: ENV['LAGO_REDIS_CACHE_PASSWORD'] }) if ENV['LAGO_REDIS_CACHE_PASSWORD'].present?
+    if ENV['LAGO_REDIS_CACHE_PASSWORD'].present?
+      cache_store_config = cache_store_config.merge({ password: ENV['LAGO_REDIS_CACHE_PASSWORD'] })
+    end
 
     config.cache_store = :redis_cache_store, cache_store_config
   end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,9 +6,7 @@ redis_config = {
   pool_timeout: 5,
 }
 
-if ENV['REDIS_PASSWORD'].present?
-  redis_config = redis_config.merge({ password: ENV['REDIS_PASSWORD'] })
-end
+redis_config = redis_config.merge({ password: ENV['REDIS_PASSWORD'] }) if ENV['REDIS_PASSWORD'].present?
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
+redis_config = {
+  url: ENV['REDIS_URL'],
+  password: ENV['REDIS_PASSWORD'],
+  pool_timeout: 5,
+}
+
+redis_config.merge({ password: ENV['REDIS_PASSWORD'] }) if ENV['REDIS_PASSWORD'].present?
+
 Sidekiq.configure_server do |config|
-  config.redis = { url: ENV['REDIS_URL'], pool_timeout: 5 }
+  config.redis = redis_config
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: ENV['REDIS_URL'], pool_timeout: 5 }
+  config.redis = redis_config
 end
 
 Sidekiq.logger = Rails.logger

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,7 +6,9 @@ redis_config = {
   pool_timeout: 5,
 }
 
-redis_config.merge({ password: ENV['REDIS_PASSWORD'] }) if ENV['REDIS_PASSWORD'].present?
+if ENV['REDIS_PASSWORD'].present?
+  redis_config = redis_config.merge({ password: ENV['REDIS_PASSWORD'] })
+end
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config


### PR DESCRIPTION
## Context

Some users want to be able to use a Redis protected server.

## Description

- Add the support of `REDIS_PASSWORD` for Sidekiq
- Add the support of `LAGO_REDIS_CACHE_PASSWORD` for Cache Store
