### PR TITLE
fix(invoices): Fix prepaid credit invoices to hide tax related items

### DIFF
--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -18,6 +18,10 @@ module Invoices
           invoice_type: :credit,
           status: :pending,
 
+          amount_currency: currency,
+          vat_amount_currency: currency,
+          total_amount_currency: currency,
+
           # NOTE: Apply credits before VAT, will be changed with credit note feature
           legacy: true,
           vat_rate: customer.applicable_vat_rate,
@@ -28,7 +32,6 @@ module Invoices
         compute_amounts(invoice)
 
         invoice.total_amount_cents = invoice.amount_cents + invoice.vat_amount_cents
-        invoice.total_amount_currency = currency
         invoice.save!
 
         track_invoice_created(invoice)

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -455,15 +455,16 @@ html
               td.body-2 Total due
               td.body-1 = total_amount.format
           - else
-            tr
-              td.body-1 width="70%" Sub total (excl. tax)
-              td.body-1 width="30%" = sub_total_vat_excluded_amount.format
-            tr
-              td.body-2 Tax (#{vat_rate || 0})%
-              td.body-1 = vat_amount.format
-            tr
-              td.body-1 Sub total (incl. tax)
-              td.body-1 = sub_total_vat_included_amount.format
+            - unless credit?
+              tr
+                td.body-1 width="70%" Sub total (excl. tax)
+                td.body-1 width="30%" = sub_total_vat_excluded_amount.format
+              tr
+                td.body-2 Tax (#{vat_rate || 0})%
+                td.body-1 = vat_amount.format
+              tr
+                td.body-1 Sub total (incl. tax)
+                td.body-1 = sub_total_vat_included_amount.format
             - if credits.credit_note_kind.any?
               tr
                 td.body-2 Credit Notes

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -169,8 +169,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_25_111605) do
     t.string "refund_vat_amount_currency"
     t.bigint "vat_amount_cents", default: 0, null: false
     t.string "vat_amount_currency"
-    t.date "issuing_date", null: false
     t.datetime "refunded_at"
+    t.date "issuing_date", null: false
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The PR is related to the credit note feature and especially the changes regarding VAT

## Description

Since Prepaid credit will not handle VAT anymore, this PR removes the tax related items from the prepaid credit invoices when they are not legacy.