### PR TITLE
fix(redis): Password is defaulted to empty string by docker compose

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
       },
     }
 
-    if ENV['LAGO_REDIS_CACHE_PASSWORD'].present?
+    unless ENV['LAGO_REDIS_CACHE_PASSWORD'].empty?
       cache_store_config = cache_store_config.merge({ password: ENV['LAGO_REDIS_CACHE_PASSWORD'] })
     end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
       },
     }
 
-    unless ENV['LAGO_REDIS_CACHE_PASSWORD'].empty?
+    if ENV['LAGO_REDIS_CACHE_PASSWORD'].present? && !ENV['LAGO_REDIS_CACHE_PASSWORD'].empty?
       cache_store_config = cache_store_config.merge({ password: ENV['LAGO_REDIS_CACHE_PASSWORD'] })
     end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,7 +6,9 @@ redis_config = {
   pool_timeout: 5,
 }
 
-redis_config = redis_config.merge({ password: ENV['REDIS_PASSWORD'] }) unless ENV['REDIS_PASSWORD'].empty?
+if ENV['REDIS_PASSWORD'].present? && !ENV['REDIS_PASSWORD'].empty?
+  redis_config = redis_config.merge({ password: ENV['REDIS_PASSWORD'] })
+end
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -6,7 +6,7 @@ redis_config = {
   pool_timeout: 5,
 }
 
-redis_config = redis_config.merge({ password: ENV['REDIS_PASSWORD'] }) if ENV['REDIS_PASSWORD'].present?
+redis_config = redis_config.merge({ password: ENV['REDIS_PASSWORD'] }) unless ENV['REDIS_PASSWORD'].empty?
 
 Sidekiq.configure_server do |config|
   config.redis = redis_config


### PR DESCRIPTION
- Docker Compose is using blank string instead of `nil` values for ENV VAR that are not defined