### PR TITLE
fix: Trial period set to zero should not be considered as present

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -39,7 +39,7 @@ class Plan < ApplicationRecord
   end
 
   def has_trial?
-    trial_period.present?
+    trial_period.present? && trial_period.positive?
   end
 
   # NOTE: Method used to compare plan for upgrade / downgrade on

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -4,10 +4,18 @@ require 'rails_helper'
 
 RSpec.describe Plan, type: :model do
   describe '.has_trial?' do
-    let(:plan) { create(:plan, trial_period: 3) }
+    let(:plan) { build(:plan, trial_period: 3) }
 
     it 'returns true when trial_period' do
       expect(plan).to have_trial
+    end
+
+    context 'when value is 0' do
+      let(:plan) { build(:plan, trial_period: 0) }
+
+      it 'returns false' do
+        expect(plan).not_to have_trial
+      end
     end
   end
 


### PR DESCRIPTION
## Context

When setting a trial period at `0` the first subscription of a paid in advance calendar plan is wrongly billed at 0 when created on the last day of the period

## Description

The issue is related to a wrong assumption of the behavior of the rails `present?` method:
```ruby
0.0.present?
# => true
```
