### PR TITLE
feat(grace_period): Ability to finalize automatically draft invoices

### DIFF
--- a/app/jobs/clock/finalize_invoices_job.rb
+++ b/app/jobs/clock/finalize_invoices_job.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Clock
+  class FinalizeInvoicesJob < ApplicationJob
+    queue_as 'clock'
+
+    def perform
+      draft_invoices.each do |invoice|
+        Invoices::FinalizeService.call(invoice: invoice)
+      end
+    end
+
+    private
+
+    def draft_invoices
+      Invoice
+        .draft
+        .joins(customer: :organization)
+        .where(
+          "(invoices.created_at + \
+          COALESCE(customers.invoice_grace_period, organizations.invoice_grace_period) * INTERVAL '1 DAY') \
+          < ?",
+          Time.current,
+        )
+    end
+  end
+end

--- a/app/services/invoices/finalize_service.rb
+++ b/app/services/invoices/finalize_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Invoices
+  class FinalizeService < BaseService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(invoice:)
+      @invoice = invoice
+      super
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        result = Invoices::RefreshDraftService.call(invoice: invoice)
+        invoice.finalized!
+        SendWebhookJob.perform_later(:invoice, invoice) if invoice.organization.webhook_url?
+        Invoices::Payments::CreateService.new(invoice).call
+        track_invoice_created(invoice)
+
+        result
+      end
+    end
+
+    private
+
+    attr_accessor :invoice
+
+    def track_invoice_created(invoice)
+      SegmentTrackJob.perform_later(
+        membership_id: CurrentContext.membership,
+        event: 'invoice_created',
+        properties: {
+          organization_id: invoice.organization.id,
+          invoice_id: invoice.id,
+          invoice_type: invoice.invoice_type,
+        },
+      )
+    end
+  end
+end

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -15,10 +15,10 @@ module Invoices
       return result unless invoice.draft?
 
       ActiveRecord::Base.transaction do
-        invoice.fees.destroy_all
         invoice.credit_notes.destroy_all
         invoice.credits.destroy_all
         invoice.wallet_transactions.destroy_all
+        invoice.fees.destroy_all
 
         invoice.update!(
           issuing_date: issuing_date,

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Invoices
+  class RefreshDraftService < BaseService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(invoice:)
+      @invoice = invoice
+      super
+    end
+
+    def call
+      return result unless invoice.draft?
+
+      ActiveRecord::Base.transaction do
+        invoice.fees.destroy_all
+        invoice.credit_notes.destroy_all
+        invoice.credits.destroy_all
+        invoice.wallet_transactions.destroy_all
+
+        invoice.update!(
+          issuing_date: issuing_date,
+          vat_rate: invoice.customer.applicable_vat_rate,
+        )
+
+        Invoices::CalculateFeesService.call(
+          invoice: invoice,
+          timestamp: invoice.created_at.to_i,
+        )
+      end
+    end
+
+    private
+
+    attr_accessor :invoice
+
+    def issuing_date
+      @issuing_date ||= Time.current.in_time_zone(invoice.customer.applicable_timezone).to_date
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -27,6 +27,10 @@ module Clockwork
     Clock::SubscriptionsBillerJob.perform_later
   end
 
+  every(1.hour, 'schedule:finalize_invoices') do
+    Clock::FinalizeInvoicesJob.perform_later
+  end
+
   every(1.day, 'schedule:terminate_coupons', at: '5:00') do
     Clock::TerminateCouponsJob.perform_later
   end

--- a/spec/jobs/clock/finalize_invoices_job_spec.rb
+++ b/spec/jobs/clock/finalize_invoices_job_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Clock::FinalizeInvoicesJob, job: true do
+  subject { described_class }
+
+  describe '.perform' do
+    let(:customer) { create(:customer, invoice_grace_period: 3) }
+    let(:draft_invoice) do
+      create(:invoice, status: :draft, created_at: DateTime.parse('20 Jun 2022'), customer: customer)
+    end
+    let(:finalized_invoice) do
+      create(:invoice, status: :finalized, created_at: DateTime.parse('20 Jun 2022'), customer: customer)
+    end
+
+    before do
+      draft_invoice
+      finalized_invoice
+      allow(Invoices::FinalizeService).to receive(:call)
+    end
+
+    context 'when during the grace period' do
+      it 'does not call the finalize service' do
+        current_date = DateTime.parse('22 Jun 2022')
+
+        travel_to(current_date) do
+          described_class.perform_now
+          expect(Invoices::FinalizeService).not_to have_received(:call).with(invoice: draft_invoice)
+          expect(Invoices::FinalizeService).not_to have_received(:call).with(invoice: finalized_invoice)
+        end
+      end
+    end
+
+    context 'when after the grace period' do
+      it 'calls the finalize service' do
+        current_date = DateTime.parse('24 Jun 2022')
+
+        travel_to(current_date) do
+          described_class.perform_now
+          expect(Invoices::FinalizeService).to have_received(:call).with(invoice: draft_invoice)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::FinalizeService, type: :service do
+  subject(:finalize_service) { described_class.new(invoice: invoice) }
+
+  describe '#call' do
+    let(:invoice) do
+      create(
+        :invoice,
+        subscriptions: [subscription],
+        amount_currency: 'EUR',
+        vat_amount_currency: 'EUR',
+        total_amount_currency: 'EUR',
+        issuing_date: Time.zone.at(timestamp).to_date,
+      )
+    end
+
+    let(:subscription) do
+      create(
+        :subscription,
+        plan: plan,
+        subscription_date: started_at.to_date,
+        started_at: started_at,
+        created_at: started_at,
+      )
+    end
+
+    let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
+    let(:timestamp) { Time.zone.now.beginning_of_month }
+    let(:started_at) { Time.zone.now - 2.years }
+
+    let(:plan) { create(:plan, interval: 'monthly') }
+
+    before do
+      create(:standard_charge, plan: subscription.plan, charge_model: 'standard')
+
+      allow(SegmentTrackJob).to receive(:perform_later)
+      allow(Invoices::Payments::StripeCreateJob).to receive(:perform_later).and_call_original
+      allow(Invoices::Payments::GocardlessCreateJob).to receive(:perform_later).and_call_original
+    end
+
+    it 'marks the invoice as finalized' do
+      expect { finalize_service.call }
+        .to change(invoice, :status).from('draft').to('finalized')
+    end
+
+    it 'generates expected fees' do
+      result = finalize_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.invoice.fees.charge_kind.count).to eq(1)
+        expect(result.invoice.fees.subscription_kind.count).to eq(1)
+      end
+    end
+
+    it 'enqueues a SendWebhookJob' do
+      expect do
+        finalize_service.call
+      end.to have_enqueued_job(SendWebhookJob).with(:invoice, Invoice)
+    end
+
+    it 'calls SegmentTrackJob' do
+      invoice = finalize_service.call.invoice
+
+      expect(SegmentTrackJob).to have_received(:perform_later).with(
+        membership_id: CurrentContext.membership,
+        event: 'invoice_created',
+        properties: {
+          organization_id: invoice.organization.id,
+          invoice_id: invoice.id,
+          invoice_type: invoice.invoice_type,
+        },
+      )
+    end
+
+    it 'creates a payment' do
+      payment_create_service = instance_double(Invoices::Payments::CreateService)
+      allow(Invoices::Payments::CreateService).to receive(:new).and_return(payment_create_service)
+      allow(payment_create_service).to receive(:call)
+
+      finalize_service.call
+      expect(Invoices::Payments::CreateService).to have_received(:new)
+      expect(payment_create_service).to have_received(:call)
+    end
+
+    context 'when organization does not have a webhook url' do
+      before { invoice.organization.update!(webhook_url: nil) }
+
+      it 'does not enqueue a SendWebhookJob' do
+        expect do
+          finalize_service.call
+        end.not_to have_enqueued_job(SendWebhookJob)
+      end
+    end
+
+    context 'when fees already exist' do
+      it 'regenerates them' do
+        create(:fee, invoice: invoice)
+        result = finalize_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice.fees.charge_kind.count).to eq(1)
+          expect(result.invoice.fees.subscription_kind.count).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::RefreshDraftService, type: :service do
+  subject(:refresh_service) { described_class.new(invoice: invoice) }
+
+  describe '#call' do
+    let(:status) { :draft }
+    let(:invoice) do
+      create(:invoice, subscriptions: [subscription], status: status)
+    end
+
+    let(:started_at) { 1.month.ago }
+    let(:subscription) do
+      create(
+        :subscription,
+        subscription_date: started_at.to_date,
+        started_at: started_at,
+        created_at: started_at,
+      )
+    end
+
+    before do
+      allow(Invoices::CalculateFeesService).to receive(:call).and_call_original
+    end
+
+    context 'when invoice is finalized' do
+      let(:status) { :finalized }
+
+      it 'does not refresh it' do
+        result = refresh_service.call
+        expect(Invoices::CalculateFeesService).not_to have_received(:call)
+        expect(result).to be_success
+      end
+    end
+
+    it 'regenerates fees' do
+      fee = create(:fee, invoice: invoice)
+      create(:standard_charge, plan: subscription.plan, charge_model: 'standard')
+
+      expect { refresh_service.call }
+        .to change { invoice.reload.fees.count }.from(1).to(2)
+        .and change { invoice.reload.fees.pluck(:id).include?(fee.id) }.from(true).to(false)
+    end
+
+    it 'regenerates credits' do
+      create(:credit, invoice: invoice)
+
+      expect { refresh_service.call }
+        .to change { invoice.reload.credits.count }.from(1).to(0)
+    end
+
+    it 'regenerates credit notes' do
+      create(:credit_note, invoice: invoice)
+
+      expect { refresh_service.call }
+        .to change { invoice.reload.credit_notes.count }.from(1).to(0)
+    end
+
+    it 'regenerates wallet transactions' do
+      create(:wallet_transaction, invoice: invoice)
+
+      expect { refresh_service.call }
+        .to change { invoice.reload.wallet_transactions.count }.from(1).to(0)
+    end
+
+    it 'updates issuing_date' do
+      invoice.customer.update(timezone: 'America/New_York')
+
+      freeze_time do
+        expect { refresh_service.call }
+          .to change { invoice.reload.issuing_date }.to(Time.current.to_date)
+      end
+    end
+
+    it 'updates vat_rate' do
+      invoice.customer.update(vat_rate: 15)
+
+      expect { refresh_service.call }
+        .to change { invoice.reload.vat_rate }.from(nil).to(15)
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to be able to finalize automatically draft invoices.
