### PR TITLE
feat(timezone): Wallet expiration date

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -6,11 +6,12 @@ module Api
       def create
         service = Wallets::CreateService.new
         result = service.create(
-          **input_params
-            .merge(organization_id: current_organization.id)
-            .merge(customer: customer)
-            .to_h
-            .symbolize_keys,
+          WalletLegacyInput.new(
+            current_organization,
+            input_params
+              .merge(organization_id: current_organization.id)
+              .merge(customer: customer),
+          ).create_input,
         )
 
         if result.success?
@@ -23,9 +24,11 @@ module Api
       def update
         service = Wallets::UpdateService.new
         result = service.update(
-          **update_params.merge(id: params[:id])
-            .to_h
-            .symbolize_keys,
+          wallet: current_organization.wallets.find_by(id: params[:id]),
+          args: WalletLegacyInput.new(
+            current_organization,
+            update_params.merge(id: params[:id]),
+          ).update_input,
         )
 
         if result.success?
@@ -84,6 +87,8 @@ module Api
           :currency,
           :paid_credits,
           :granted_credits,
+          :expiration_at,
+          # NOTE: Legacy field
           :expiration_date,
         )
       end
@@ -95,6 +100,8 @@ module Api
       def update_params
         params.require(:wallet).permit(
           :name,
+          :expiration_at,
+          # NOTE: Legacy field
           :expiration_date,
         )
       end

--- a/app/graphql/mutations/wallets/update.rb
+++ b/app/graphql/mutations/wallets/update.rb
@@ -11,14 +11,25 @@ module Mutations
 
       argument :id, ID, required: true
       argument :name, String, required: false
+      argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
+
+      # NOTE: Legacy fields, will be removed when releasing the timezone feature
       argument :expiration_date, GraphQL::Types::ISO8601Date, required: false
 
       type Types::Wallets::Object
 
       def resolve(**args)
+        wallet = context[:current_user].wallets.find_by(id: args[:id])
+
         result = ::Wallets::UpdateService
           .new(context[:current_user])
-          .update(**args)
+          .update(
+            wallet: wallet,
+            args: WalletLegacyInput.new(
+              wallet&.organization,
+              args,
+            ).update_input,
+          )
 
         result.success? ? result.wallet : result_error(result)
       end

--- a/app/graphql/types/wallets/object.rb
+++ b/app/graphql/types/wallets/object.rb
@@ -17,13 +17,20 @@ module Types
       field :consumed_amount, String, null: false
       field :consumed_credits, String, null: false
 
-      field :expiration_date, GraphQL::Types::ISO8601Date, null: true
+      field :expiration_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
       field :terminated_at, GraphQL::Types::ISO8601DateTime, null: true
       field :last_balance_sync_at, GraphQL::Types::ISO8601DateTime, null: true
       field :last_consumed_credit_at, GraphQL::Types::ISO8601DateTime, null: true
+
+      # NOTE: Legacy fields, will be removed when releasing the timezone feature
+      field :expiration_date, GraphQL::Types::ISO8601Date, null: true
+
+      def expiration_date
+        object.expiration_at&.to_date
+      end
     end
   end
 end

--- a/app/legacy_inputs/base_legacy_input.rb
+++ b/app/legacy_inputs/base_legacy_input.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class BaseLegacyInput
+  def initialize(organization, args)
+    @organization = organization
+    @args = args&.to_h&.symbolize_keys
+  end
+
+  protected
+
+  attr_reader :organization, :args
+
+  def date_in_organization_timezone(date, end_of_day: false)
+    return if date.blank?
+
+    result = date.to_date.in_time_zone(organization&.timezone || 'UTC')
+    result = result.end_of_day if end_of_day
+    result.utc
+  end
+end

--- a/app/legacy_inputs/wallet_legacy_input.rb
+++ b/app/legacy_inputs/wallet_legacy_input.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class WalletLegacyInput < BaseLegacyInput
+  def create_input
+    if args[:expiration_date].present?
+      args[:expiration_at] ||= date_in_organization_timezone(args[:expiration_date], end_of_day: true)
+    end
+
+    args
+  end
+  alias update_input create_input
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :coupons, through: :organizations
   has_many :add_ons, through: :organizations
   has_many :credit_notes, through: :organizations
+  has_many :wallets, through: :organizations
 
   validates :email, presence: true
   validates :password, presence: true

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -19,5 +19,5 @@ class Wallet < ApplicationRecord
     terminated!
   end
 
-  scope :expired, -> { where('wallets.expiration_date < ?', Time.current.beginning_of_day) }
+  scope :expired, -> { where('wallets.expiration_at::timestamp(0) <= ?', Time.current) }
 end

--- a/app/serializers/v1/legacy/wallet_serializer.rb
+++ b/app/serializers/v1/legacy/wallet_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module V1
+  module Legacy
+    class WalletSerializer < ModelSerializer
+      def serialize
+        {
+          expiration_date: model.expiration_at&.to_date&.iso8601,
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/v1/wallet_serializer.rb
+++ b/app/serializers/v1/wallet_serializer.rb
@@ -15,11 +15,17 @@ module V1
         balance: model.balance,
         consumed_credits: model.consumed_credits,
         created_at: model.created_at&.iso8601,
-        expiration_date: model.expiration_date&.iso8601,
+        expiration_at: model.expiration_at&.iso8601,
         last_balance_sync_at: model.last_balance_sync_at&.iso8601,
         last_consumed_credit_at: model.last_consumed_credit_at&.iso8601,
-        terminated_at: model.terminated_at
-      }
+        terminated_at: model.terminated_at,
+      }.merge(legacy_values)
+    end
+
+    def legacy_values
+      ::V1::Legacy::WalletSerializer.new(
+        model,
+      ).serialize
     end
   end
 end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -2,14 +2,14 @@
 
 module Wallets
   class CreateService < BaseService
-    def create(**args)
+    def create(args)
       return result unless valid?(**args)
 
       wallet = Wallet.new(
         customer_id: result.current_customer.id,
         name: args[:name],
         rate_amount: args[:rate_amount],
-        expiration_date: args[:expiration_date],
+        expiration_at: args[:expiration_at],
         status: :active,
       )
 

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -2,12 +2,11 @@
 
 module Wallets
   class UpdateService < BaseService
-    def update(**args)
-      wallet = Wallet.find_by(id: args[:id])
+    def update(wallet:, args:)
       return result.not_found_failure!(resource: 'wallet') unless wallet
 
       wallet.name = args[:name] if args.key?(:name)
-      wallet.expiration_date = args[:expiration_date] if args.key?(:expiration_date)
+      wallet.expiration_at = args[:expiration_at] if args.key?(:expiration_at)
 
       wallet.save!
 

--- a/clock.rb
+++ b/clock.rb
@@ -31,7 +31,7 @@ module Clockwork
     Clock::TerminateCouponsJob.perform_later
   end
 
-  every(1.day, 'schedule:terminate_wallets', at: '4:00') do
+  every(1.hour, 'schedule:terminate_wallets', at: '*:45') do
     Clock::TerminateWalletsJob.perform_later
   end
 end

--- a/db/migrate/20221202130126_rename_wallets_expiration_date.rb
+++ b/db/migrate/20221202130126_rename_wallets_expiration_date.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class RenameWalletsExpirationDate < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :wallets, :expiration_date, :expiration_at
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE wallets SET expiration_at = (date_trunc('day', expiration_at) + interval '1 day' - interval '1 second')::timestamp;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_28_132620) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_02_130126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -509,7 +509,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_132620) do
     t.decimal "credits_balance", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "balance", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "consumed_credits", precision: 30, scale: 5, default: "0.0", null: false
-    t.datetime "expiration_date", precision: nil
+    t.datetime "expiration_at", precision: nil
     t.datetime "last_balance_sync_at", precision: nil
     t.datetime "last_consumed_credit_at", precision: nil
     t.datetime "terminated_at", precision: nil

--- a/schema.graphql
+++ b/schema.graphql
@@ -1686,6 +1686,7 @@ input CreateCustomerWalletInput {
   clientMutationId: String
   currency: CurrencyEnum!
   customerId: ID!
+  expirationAt: ISO8601DateTime
   expirationDate: ISO8601Date
   grantedCredits: String!
   name: String
@@ -4820,6 +4821,7 @@ input UpdateCustomerWalletInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  expirationAt: ISO8601DateTime
   expirationDate: ISO8601Date
   id: ID!
   name: String
@@ -4926,6 +4928,7 @@ type Wallet {
   creditsBalance: String!
   currency: CurrencyEnum!
   customer: Customer
+  expirationAt: ISO8601DateTime
   expirationDate: ISO8601Date
   id: ID!
   lastBalanceSyncAt: ISO8601DateTime
@@ -4950,6 +4953,7 @@ type WalletDetails {
   creditsBalance: String!
   currency: CurrencyEnum!
   customer: Customer
+  expirationAt: ISO8601DateTime
   expirationDate: ISO8601Date
   id: ID!
   lastBalanceSyncAt: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -5247,11 +5247,11 @@
               "deprecationReason": null
             },
             {
-              "name": "expirationDate",
+              "name": "expirationAt",
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "ISO8601Date",
+                "name": "ISO8601DateTime",
                 "ofType": null
               },
               "defaultValue": null,
@@ -5269,6 +5269,18 @@
                   "name": "CurrencyEnum",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "expirationDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -18609,6 +18621,18 @@
               "deprecationReason": null
             },
             {
+              "name": "expirationAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "expirationDate",
               "description": null,
               "type": {
@@ -19498,6 +19522,20 @@
               ]
             },
             {
+              "name": "expirationAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "expirationDate",
               "description": null,
               "type": {
@@ -19823,6 +19861,20 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Customer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "expirationAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
   let(:customer) { create(:customer, organization: organization) }
   let(:subscription) { create(:subscription, customer: customer) }
   let(:wallet) { create(:wallet, customer: customer) }
+  let(:expiration_at) { DateTime.parse('2022-01-01 23:59:59') }
 
   let(:mutation) do
     <<-GQL
@@ -16,7 +17,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
           id,
           name,
           status,
-          expirationDate,
+          expirationAt,
         }
       }
     GQL
@@ -32,7 +33,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
         input: {
           id: wallet.id,
           name: 'New name',
-          expirationDate: '2022-01-01',
+          expirationAt: expiration_at.iso8601,
         },
       },
     )
@@ -42,7 +43,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
     aggregate_failures do
       expect(result_data['name']).to eq('New name')
       expect(result_data['status']).to eq('active')
-      expect(result_data['expirationDate']).to eq('2022-01-01')
+      expect(result_data['expirationAt']).to eq('2022-01-01T23:59:59Z')
     end
   end
 

--- a/spec/serializers/v1/wallet_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_serializer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::WalletSerializer do
+  subject(:serializer) { described_class.new(wallet, root_name: 'wallet') }
+
+  let(:wallet) { create(:wallet) }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['wallet']['lago_id']).to eq(wallet.id)
+      expect(result['wallet']['lago_customer_id']).to eq(wallet.customer_id)
+      expect(result['wallet']['external_customer_id']).to eq(wallet.customer.external_id)
+      expect(result['wallet']['status']).to eq(wallet.status)
+      expect(result['wallet']['currency']).to eq(wallet.currency)
+      expect(result['wallet']['name']).to eq(wallet.name)
+      expect(result['wallet']['rate_amount']).to eq(wallet.rate_amount.to_s)
+      expect(result['wallet']['credits_balance']).to eq(wallet.credits_balance.to_s)
+      expect(result['wallet']['balance']).to eq(wallet.balance.to_s)
+      expect(result['wallet']['consumed_credits']).to eq(wallet.consumed_credits.to_s)
+      expect(result['wallet']['created_at']).to eq(wallet.created_at.iso8601)
+      expect(result['wallet']['expiration_at']).to eq(wallet.expiration_at&.iso8601)
+      expect(result['wallet']['last_balance_sync_at']).to eq(wallet.last_balance_sync_at&.iso8601)
+      expect(result['wallet']['last_consumed_credit_at']).to eq(wallet.last_consumed_credit_at&.iso8601)
+      expect(result['wallet']['terminated_at']).to eq(wallet.terminated_at)
+    end
+  end
+end

--- a/spec/services/wallets/terminate_service_spec.rb
+++ b/spec/services/wallets/terminate_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Wallets::TerminateService, type: :service do
       create(
         :wallet,
         status: 'active',
-        expiration_date: Time.zone.now - 40.days,
+        expiration_at: Time.zone.now - 40.days,
       )
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Wallets::TerminateService, type: :service do
       create(
         :wallet,
         status: 'active',
-        expiration_date: Time.zone.now + 40.days,
+        expiration_at: Time.zone.now + 40.days,
       )
     end
 

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -21,18 +21,18 @@ RSpec.describe Wallets::UpdateService, type: :service do
       {
         id: wallet.id,
         name: 'new name',
-        expiration_date: '2022-01-01',
+        expiration_at: DateTime.parse('2022-01-01 23:59:59'),
       }
     end
 
     it 'updates the wallet' do
-      result = update_service.update(**update_args)
+      result = update_service.update(wallet: wallet, args: update_args)
 
       expect(result).to be_success
 
       aggregate_failures do
         expect(result.wallet.name).to eq('new name')
-        expect(result.wallet.expiration_date).to eq('2022-01-01')
+        expect(result.wallet.expiration_at.iso8601).to eq('2022-01-01T23:59:59Z')
       end
     end
 
@@ -46,7 +46,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
       end
 
       it 'returns an error' do
-        result = update_service.update(**update_args)
+        result = update_service.update(wallet: nil, args: update_args)
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('wallet_not_found')


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR updates the wallet to turn `expiration_date` into `expiration_at`, it is keeping the compatibility with the existing fields.
