### PR TITLE
fix: Delete all groups without calling callbacks

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -4,7 +4,7 @@ class BillableMetric < ApplicationRecord
   belongs_to :organization
 
   has_many :charges, dependent: :destroy
-  has_many :groups, dependent: :destroy
+  has_many :groups, dependent: :delete_all
   has_many :plans, through: :charges
   has_many :persisted_events
 


### PR DESCRIPTION
Deleting a BM including 2 levels of dimension was not possible due to `PG::ForeignKeyViolation` on groups.
The goal of this PR is to use `delete_all` when deleting groups, to not hit any callbacks.

<img width="786" alt="Screenshot 2022-12-05 at 10 19 20" src="https://user-images.githubusercontent.com/226046/205609328-62e1dbe7-2fb2-4cfa-a7a5-e2bfff5bf411.png">
