### PR TITLE
feat(credit_notes): Update Segment payload

### DIFF
--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -109,17 +109,22 @@ module CreditNotes
     end
 
     def track_credit_note_created
-      types = []
-      types << 'credit' if credit_note.credited?
-      types << 'refund' if credit_note.refunded?
+      types = if credit_note.credited? && credit_note.refunded?
+        'both'
+      elsif credit_note.credited?
+        'credit'
+      elsif credit_note.refunded?
+        'refund'
+      end
 
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
-        event: 'credit_note_created',
+        event: 'credit_note_issued',
         properties: {
           organization_id: credit_note.organization.id,
           credit_note_id: credit_note.id,
-          credit_note_type: types.join('_and_'),
+          invoice_id: credit_note.invoice_id,
+          credit_note_method: types,
         },
       )
     end

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -92,11 +92,12 @@ RSpec.describe CreditNotes::CreateService, type: :service do
 
       expect(SegmentTrackJob).to have_received(:perform_later).with(
         membership_id: CurrentContext.membership,
-        event: 'credit_note_created',
+        event: 'credit_note_issued',
         properties: {
           organization_id: credit_note.organization.id,
           credit_note_id: credit_note.id,
-          credit_note_type: 'credit_and_refund',
+          invoice_id: credit_note.invoice_id,
+          credit_note_method: 'both',
         },
       )
     end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR updates the Segment tracking payload to match the specs