### PR TITLE
fix(timezones): Prevent error with cached boundaries

### DIFF
--- a/app/serializers/v1/customer_usage_serializer.rb
+++ b/app/serializers/v1/customer_usage_serializer.rb
@@ -4,8 +4,9 @@ module V1
   class CustomerUsageSerializer < ModelSerializer
     def serialize
       payload = {
-        from_datetime: model.from_datetime,
-        to_datetime: model.to_datetime,
+        # TODO: remove || after all cache key expirations
+        from_datetime: model.from_date&.beginning_of_day || model.from_datetime,
+        to_datetime: model.to_date&.end_of_day || model.to_datetime,
         issuing_date: model.issuing_date,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,

--- a/app/serializers/v1/legacy/customer_usage_serializer.rb
+++ b/app/serializers/v1/legacy/customer_usage_serializer.rb
@@ -5,8 +5,9 @@ module V1
     class CustomerUsageSerializer < ModelSerializer
       def serialize
         {
-          from_date: model.from_datetime.to_date,
-          to_date: model.to_datetime.to_date,
+          # TODO: remove || after all cache key expirations
+          from_date: model.from_date || model.from_datetime&.to_date,
+          to_date: model.to_date || model.to_datetime&.to_date,
         }
       end
     end


### PR DESCRIPTION
## Context

A recent changes of the billing period boundaries introduced for the timezone features has led to an issue with the cached result of the customer usage.

## Description

The cache still contains date boundaries when the serializer expects a datetime.
This fix introduce a temporary fallback to deal with the previous fields until all cached expire.
