### PR TITLE
fix(timezones): Resolve issue with current usage boundaries with old …

### DIFF
--- a/app/serializers/v1/customer_usage_serializer.rb
+++ b/app/serializers/v1/customer_usage_serializer.rb
@@ -5,8 +5,8 @@ module V1
     def serialize
       payload = {
         # TODO: remove || after all cache key expirations
-        from_datetime: model.from_date&.beginning_of_day || model.from_datetime,
-        to_datetime: model.to_date&.end_of_day || model.to_datetime,
+        from_datetime: model.from_date&.to_date&.beginning_of_day&.iso8601 || model.from_datetime,
+        to_datetime: model.to_date&.to_date&.end_of_day&.iso8601 || model.to_datetime,
         issuing_date: model.issuing_date,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,


### PR DESCRIPTION
## Context

A recent changes of the billing period boundaries introduced for the timezone features has led to an issue with the cached result of the customer usage.

## Description

The cache still contains date boundaries when the serializer expects a datetime.
This fix introduce a temporary fallback to deal with the previous fields until all cached expire.

A first fix was issues before: https://github.com/getlago/lago-api/pull/649, but it was not totally resolving the issue
