### PR TITLE
Add autoprovisioning of member & orgs

### DIFF
--- a/lib/tasks/signup.rake
+++ b/lib/tasks/signup.rake
@@ -1,21 +1,21 @@
 namespace :signup do
   desc "This task seeds lago with an organisation & a user for on premise deployment"
   task seed_organization: :environment do
-    if ENV['CREATE_ORG'].present? && ENV['CREATE_ORG'] == 'true'
+    if ENV['LAGO_CREATE_ORG'].present? && ENV['LAGO_CREATE_ORG'] == 'true'
       pp "starting seeding environment"
-      if ENV['ORG_USER_PASSWORD'].present? && ENV['ORG_USER_EMAIL'].present? && ENV['ORG_NAME'].present?
-        user = User.create_with(password: ENV['ORG_USER_PASSWORD'])
-          .find_or_create_by(email: ENV['ORG_USER_EMAIL'])
-        organization = Organization.find_or_create_by!(name: ENV['ORG_NAME'])
-        if ENV['ORG_API_KEY'].present?
-          organization.api_key = ENV['ORG_API_KEY']
-          organization.save
+      if ENV['LAGO_ORG_USER_PASSWORD'].present? && ENV['LAGO_ORG_USER_EMAIL'].present? && ENV['LAGO_ORG_NAME'].present?
+        user = User.create_with(password: ENV['LAGO_ORG_USER_PASSWORD'])
+          .find_or_create_by!(email: ENV['LAGO_ORG_USER_EMAIL'])
+        organization = Organization.find_or_create_by!(name: ENV['LAGO_ORG_NAME'])
+        if ENV['LAGO_ORG_API_KEY'].present?
+          organization.api_key = ENV['LAGO_ORG_API_KEY']
+          organization.save!
           Membership.find_or_create_by!(user: user, organization: organization, role: :admin)
         else
-          raise "Couldn't find ORG_API_KEY in environement variables"
+          raise "Couldn't find LAGO_ORG_API_KEY in environement variables"
         end
       else
-        raise "Couldn't find ORG_USER_PASSWORD, ORG_USER_EMAIL or ORG_NAME in environement variables"
+        raise "Couldn't find LAGO_ORG_USER_PASSWORD, LAGO_ORG_USER_EMAIL or LAGO_ORG_NAME in environement variables"
       end
       pp "ending seeding environment"
     end

--- a/lib/tasks/signup.rake
+++ b/lib/tasks/signup.rake
@@ -1,0 +1,23 @@
+namespace :signup do
+  desc "This task seeds lago with an organisation & a user for on premise deployment"
+  task seed_organization: :environment do
+    if ENV['CREATE_ORG'].present? && ENV['CREATE_ORG'] == 'true'
+      pp "starting seeding environment"
+      if ENV['ORG_USER_PASSWORD'].present? && ENV['ORG_USER_EMAIL'].present? && ENV['ORG_NAME'].present?
+        user = User.create_with(password: ENV['ORG_USER_PASSWORD'])
+          .find_or_create_by(email: ENV['ORG_USER_EMAIL'])
+        organization = Organization.find_or_create_by!(name: ENV['ORG_NAME'])
+        if ENV['ORG_API_KEY'].present?
+          organization.api_key = ENV['ORG_API_KEY']
+          organization.save
+          Membership.find_or_create_by!(user: user, organization: organization, role: :admin)
+        else
+          raise "Couldn't find ORG_API_KEY in environement variables"
+        end
+      else
+        raise "Couldn't find ORG_USER_PASSWORD, ORG_USER_EMAIL or ORG_NAME in environement variables"
+      end
+      pp "ending seeding environment"
+    end
+  end
+end

--- a/scripts/start.dev.sh
+++ b/scripts/start.dev.sh
@@ -6,4 +6,5 @@ rm -f ./tmp/pids/server.pid
 bundle install
 
 rake db:prepare
+bundle exec rails signup:seed_organization
 rails s -b 0.0.0.0

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,4 +7,5 @@ fi
 
 rm -f ./tmp/pids/server.pid
 bundle exec rake db:migrate
+bundle exec rails signup:seed_organization
 bundle exec rails s -b ::


### PR DESCRIPTION
## Context

Lago by design is used to push events using one of its clients to the api server. As a developper, often times, the event collection happens on a different app than Lago. In a modern dev environment where apps are deployed at the same time this can lead to a confusing developer experience. Let's take an example where `app_1` is used to collect billable metrics and `lago_api` is used to store it. A developper will boot both app in its cluster (docker-compose, k8s, ...). Since `app_1` is requesting lago client to be able to work the developper has to inject the lago url as well as the token in then ENV variables of `app_1`. But those credentials only exists when the developer logs in to the newly deployed instance of lago, signs up for an account and get his/her api key, then proceed to update the conf of `app_1` and reboot `app_1`. Then the whole cluster can work. This is a suitable experience when developping with Lago Cloud, but it doesn't scale when using the on premise version.   

## Description

The idea of this pull request is to introduce a new way to provision Lago in a local cluster. This will ensure that the api key is deterministic and can be injected in all dependencies (app_1) at boot time without having to manually fetch it. In order to do so I have introduced an optionnal `Rake task`that is called on:
- start.sh
- start.dev.sh

This task will run as follow:
- Check if the developer has injected the required environment variables to create an org, a user and the api_key of the org
- If none of the parameters are passed the task will do nothing thus following the standard way to deploy Lago
- If the parameters are passed it will create or update the org, user and api_key allowing the developer to be able to log in right away when Lago is deployed.
- If all parameters are not properly passed then it will throw an error to guide the developer in the right direction

This fixes the issues raised above. 