### PR TITLE
feat(timezones): Handle customer and organization timezones

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -92,6 +92,7 @@ module Api
           :legal_name,
           :legal_number,
           :currency,
+          :timezone,
           billing_configuration: [
             :invoice_grace_period,
             :payment_provider,

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -33,6 +33,7 @@ module Api
           :city,
           :legal_name,
           :legal_number,
+          :timezone,
           billing_configuration: [
             :invoice_footer,
             :invoice_grace_period,

--- a/app/graphql/mutations/coupons/create.rb
+++ b/app/graphql/mutations/coupons/create.rb
@@ -22,9 +22,6 @@ module Mutations
       argument :expiration, Types::Coupons::ExpirationEnum, required: true
       argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
 
-      # NOTE: Legacy fields, will be removed when releasing the timezone feature
-      argument :expiration_date, GraphQL::Types::ISO8601Date, required: false
-
       type Types::Coupons::Object
 
       def resolve(**args)
@@ -32,12 +29,7 @@ module Mutations
 
         result = ::Coupons::CreateService
           .new(context[:current_user])
-          .create(
-            CouponLegacyInput.new(
-              current_organization,
-              args.merge(organization_id: current_organization.id),
-            ).create_input,
-          )
+          .create(args.merge(organization_id: current_organization.id))
 
         result.success? ? result.coupon : result_error(result)
       end

--- a/app/graphql/mutations/coupons/update.rb
+++ b/app/graphql/mutations/coupons/update.rb
@@ -22,21 +22,11 @@ module Mutations
       argument :expiration, Types::Coupons::ExpirationEnum, required: true
       argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
 
-      # NOTE: Legacy fields, will be removed when releasing the timezone feature
-      argument :expiration_date, GraphQL::Types::ISO8601Date, required: false
-
       type Types::Coupons::Object
 
       def resolve(**args)
-        coupon = context[:current_user].coupons.find_by(id: args[:id])
-
         result = ::Coupons::UpdateService.new(context[:current_user])
-          .update(
-            CouponLegacyInput.new(
-              coupon&.organization,
-              args,
-            ).update_input,
-          )
+          .update(args)
 
         result.success? ? result.coupon : result_error(result)
       end

--- a/app/graphql/mutations/customers/create.rb
+++ b/app/graphql/mutations/customers/create.rb
@@ -26,6 +26,7 @@ module Mutations
       argument :vat_rate, Float, required: false
       argument :invoice_grace_period, Integer, required: false
       argument :currency, Types::CurrencyEnum, required: false
+      argument :timezone, Types::TimezoneEnum, required: false
 
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false

--- a/app/graphql/mutations/customers/update.rb
+++ b/app/graphql/mutations/customers/update.rb
@@ -26,6 +26,7 @@ module Mutations
       argument :vat_rate, Float, required: false
       argument :invoice_grace_period, Integer, required: false
       argument :currency, Types::CurrencyEnum, required: false
+      argument :timezone, Types::TimezoneEnum, required: false
 
       argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false

--- a/app/graphql/mutations/organizations/update.rb
+++ b/app/graphql/mutations/organizations/update.rb
@@ -23,6 +23,7 @@ module Mutations
       argument :country, Types::CountryCodeEnum, required: false
       argument :invoice_footer, String, required: false
       argument :invoice_grace_period, Integer, required: false
+      argument :timezone, Types::TimezoneEnum, required: false
 
       type Types::OrganizationType
 

--- a/app/graphql/mutations/subscriptions/create.rb
+++ b/app/graphql/mutations/subscriptions/create.rb
@@ -23,12 +23,7 @@ module Mutations
 
         result = ::Subscriptions::CreateService
           .new
-          .create(
-            SubscriptionLegacyInput.new(
-              current_organization,
-              args.merge(organization_id: current_organization.id),
-            ).create_input,
-          )
+          .create(args.merge(organization_id: current_organization.id))
 
         result.success? ? result.subscription : result_error(result)
       end

--- a/app/graphql/mutations/subscriptions/create.rb
+++ b/app/graphql/mutations/subscriptions/create.rb
@@ -16,9 +16,6 @@ module Mutations
       argument :billing_time, Types::Subscriptions::BillingTimeEnum, required: true
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
 
-      # NOTE: LEGACY FIELDS
-      argument :subscription_date, GraphQL::Types::ISO8601Date, required: false
-
       type Types::Subscriptions::Object
 
       def resolve(**args)

--- a/app/graphql/mutations/subscriptions/update.rb
+++ b/app/graphql/mutations/subscriptions/update.rb
@@ -21,10 +21,7 @@ module Mutations
           .new(context[:current_user])
           .update(
             subscription: subscription,
-            args: SubscriptionLegacyInput.new(
-              subscription&.organization,
-              args,
-            ).update_input,
+            args: args,
           )
 
         result.success? ? result.subscription : result_error(result)

--- a/app/graphql/mutations/subscriptions/update.rb
+++ b/app/graphql/mutations/subscriptions/update.rb
@@ -12,9 +12,6 @@ module Mutations
       argument :name, String, required: false
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
 
-      # NOTE: LEGACY FIELDS
-      argument :subscription_date, GraphQL::Types::ISO8601Date, required: false
-
       type Types::Subscriptions::Object
 
       def resolve(**args)

--- a/app/graphql/mutations/wallets/create.rb
+++ b/app/graphql/mutations/wallets/create.rb
@@ -17,9 +17,6 @@ module Mutations
       argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :currency, Types::CurrencyEnum, required: true
 
-      # NOTE: Legacy fields, will be removed when releasing the timezone feature
-      argument :expiration_date, GraphQL::Types::ISO8601Date, required: false
-
       type Types::Wallets::Object
 
       def resolve(**args)
@@ -28,13 +25,10 @@ module Mutations
         result = ::Wallets::CreateService
           .new(context[:current_user])
           .create(
-            WalletLegacyInput.new(
-              current_organization,
-              args
-                .merge(organization_id: current_organization.id)
-                .merge(customer: current_customer(args[:customer_id]))
-                .except(:customer_id),
-            ).create_input,
+            args
+              .merge(organization_id: current_organization.id)
+              .merge(customer: current_customer(args[:customer_id]))
+              .except(:customer_id),
           )
 
         result.success? ? result.wallet : result_error(result)

--- a/app/graphql/mutations/wallets/update.rb
+++ b/app/graphql/mutations/wallets/update.rb
@@ -13,9 +13,6 @@ module Mutations
       argument :name, String, required: false
       argument :expiration_at, GraphQL::Types::ISO8601DateTime, required: false
 
-      # NOTE: Legacy fields, will be removed when releasing the timezone feature
-      argument :expiration_date, GraphQL::Types::ISO8601Date, required: false
-
       type Types::Wallets::Object
 
       def resolve(**args)
@@ -25,10 +22,7 @@ module Mutations
           .new(context[:current_user])
           .update(
             wallet: wallet,
-            args: WalletLegacyInput.new(
-              wallet&.organization,
-              args,
-            ).update_input,
+            args: args,
           )
 
         result.success? ? result.wallet : result_error(result)

--- a/app/graphql/types/coupons/object.rb
+++ b/app/graphql/types/coupons/object.rb
@@ -39,13 +39,6 @@ module Types
       def can_be_deleted
         object.deletable?
       end
-
-      # NOTE: Legacy fields, will be removed when releasing the timezone feature
-      field :expiration_date, GraphQL::Types::ISO8601Date, null: true
-
-      def expiration_date
-        object.expiration_at&.to_date
-      end
     end
   end
 end

--- a/app/graphql/types/events/object.rb
+++ b/app/graphql/types/events/object.rb
@@ -11,10 +11,8 @@ module Types
       field :transaction_id, String, null: true
 
       field :timestamp, GraphQL::Types::ISO8601DateTime, null: true
-      field :timestamp_in_customer_timezone, GraphQL::Types::ISO8601DateTime, null: true
-
       field :received_at, GraphQL::Types::ISO8601DateTime, null: false
-      field :received_at_in_customer_timezone, GraphQL::Types::ISO8601DateTime, null: false
+      field :customer_timezone, Types::TimezoneEnum, null: false
 
       field :api_client, String, null: true
       field :ip_address, String, null: true
@@ -60,10 +58,8 @@ module Types
         object.properties.key?(object.billable_metric_field_name)
       end
 
-      delegate :timestamp_in_customer_timezone, to: :object
-
-      def received_at_in_customer_timezone
-        object.created_at_in_customer_timezone
+      def customer_timezone
+        object.customer.applicable_timezone
       end
     end
   end

--- a/app/graphql/types/invoice_subscription/object.rb
+++ b/app/graphql/types/invoice_subscription/object.rb
@@ -15,18 +15,6 @@ module Types
       field :fees, [Types::Fees::Object], null: true
       field :from_datetime, GraphQL::Types::ISO8601DateTime, null: true
       field :to_datetime, GraphQL::Types::ISO8601DateTime, null: true
-
-      # NOTE: LEGACY FIELDS
-      field :from_date, GraphQL::Types::ISO8601Date, null: true
-      field :to_date, GraphQL::Types::ISO8601Date, null: true
-
-      def from_date
-        object.from_datetime&.to_date
-      end
-
-      def to_date
-        object.to_datetime&.to_date
-      end
     end
   end
 end

--- a/app/graphql/types/invoices/usage.rb
+++ b/app/graphql/types/invoices/usage.rb
@@ -22,18 +22,6 @@ module Types
       def charges_usage
         object.fees
       end
-
-      # NOTE: LEGACY FIELDS
-      field :from_date, GraphQL::Types::ISO8601Date, null: false
-      field :to_date, GraphQL::Types::ISO8601Date, null: false
-
-      def from_date
-        object.from_datetime.to_date
-      end
-
-      def to_date
-        object.to_datetime.to_date
-      end
     end
   end
 end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -45,13 +45,6 @@ module Types
         ::Subscriptions::DatesService.new_instance(object, Time.current)
           .next_end_of_period
       end
-
-      # NOTE: LEGACY FIELDS
-      field :subscription_date, GraphQL::Types::ISO8601Date
-
-      def subscription_date
-        object.subscription_at&.to_date
-      end
     end
   end
 end

--- a/app/graphql/types/wallets/object.rb
+++ b/app/graphql/types/wallets/object.rb
@@ -24,13 +24,6 @@ module Types
       field :terminated_at, GraphQL::Types::ISO8601DateTime, null: true
       field :last_balance_sync_at, GraphQL::Types::ISO8601DateTime, null: true
       field :last_consumed_credit_at, GraphQL::Types::ISO8601DateTime, null: true
-
-      # NOTE: Legacy fields, will be removed when releasing the timezone feature
-      field :expiration_date, GraphQL::Types::ISO8601Date, null: true
-
-      def expiration_date
-        object.expiration_at&.to_date
-      end
     end
   end
 end

--- a/app/legacy_inputs/base_legacy_input.rb
+++ b/app/legacy_inputs/base_legacy_input.rb
@@ -13,7 +13,11 @@ class BaseLegacyInput
   def date_in_organization_timezone(date, end_of_day: false)
     return if date.blank?
 
+<<<<<<< HEAD
     result = date.to_date.in_time_zone(organization&.timezone || 'UTC')
+=======
+    result = date.to_date.in_time_zone(organization.timezone)
+>>>>>>> ccc2cd9e (feat(timezones): Coupon expiration date)
     result = result.end_of_day if end_of_day
     result.utc
   end

--- a/app/legacy_inputs/base_legacy_input.rb
+++ b/app/legacy_inputs/base_legacy_input.rb
@@ -13,11 +13,7 @@ class BaseLegacyInput
   def date_in_organization_timezone(date, end_of_day: false)
     return if date.blank?
 
-<<<<<<< HEAD
     result = date.to_date.in_time_zone(organization&.timezone || 'UTC')
-=======
-    result = date.to_date.in_time_zone(organization.timezone)
->>>>>>> ccc2cd9e (feat(timezones): Coupon expiration date)
     result = result.end_of_day if end_of_day
     result.utc
   end

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -20,6 +20,7 @@ module Customers
         customer.logo_url = params[:logo_url] if params.key?(:logo_url)
         customer.legal_name = params[:legal_name] if params.key?(:legal_name)
         customer.legal_number = params[:legal_number] if params.key?(:legal_number)
+        customer.timezone = params[:timezone] if params.key?(:timezone)
 
         if params.key?(:currency)
           currency_result = Customers::UpdateService.new(nil).update_currency(
@@ -64,6 +65,7 @@ module Customers
         invoice_grace_period: args[:invoice_grace_period] || 0,
         payment_provider: args[:payment_provider],
         currency: args[:currency],
+        timezone: args[:timezone],
       )
 
       # NOTE: handle configuration for configured payment providers

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -20,7 +20,9 @@ module Customers
         customer.logo_url = params[:logo_url] if params.key?(:logo_url)
         customer.legal_name = params[:legal_name] if params.key?(:legal_name)
         customer.legal_number = params[:legal_number] if params.key?(:legal_number)
-        customer.timezone = params[:timezone] if params.key?(:timezone)
+
+        # TODO(:timezone): Timezone update is turned off for now
+        # customer.timezone = params[:timezone] if params.key?(:timezone)
 
         if params.key?(:currency)
           currency_result = Customers::UpdateService.new(nil).update_currency(
@@ -65,8 +67,10 @@ module Customers
         invoice_grace_period: args[:invoice_grace_period] || 0,
         payment_provider: args[:payment_provider],
         currency: args[:currency],
-        timezone: args[:timezone],
       )
+      # TODO(:timezone): Timezone update is turned off for now
+      #   timezone: args[:timezone],
+      # )
 
       # NOTE: handle configuration for configured payment providers
       billing_configuration = args[:provider_customer]&.to_h&.merge(payment_provider: args[:payment_provider])

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -26,7 +26,9 @@ module Customers
         customer.logo_url = args[:logo_url] if args.key?(:logo_url)
         customer.legal_name = args[:legal_name] if args.key?(:legal_name)
         customer.legal_number = args[:legal_number] if args.key?(:legal_number)
-        customer.timezone = args[:timezone] if args.key?(:timezone)
+
+        # TODO(:timezone): Timezone update is turned off for now
+        # customer.timezone = args[:timezone] if args.key?(:timezone)
 
         # TODO: delete this when GraphQL will use billing_configuration.
         customer.vat_rate = args[:vat_rate] if args.key?(:vat_rate)

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -26,6 +26,7 @@ module Customers
         customer.logo_url = args[:logo_url] if args.key?(:logo_url)
         customer.legal_name = args[:legal_name] if args.key?(:legal_name)
         customer.legal_number = args[:legal_number] if args.key?(:legal_number)
+        customer.timezone = args[:timezone] if args.key?(:timezone)
 
         # TODO: delete this when GraphQL will use billing_configuration.
         customer.vat_rate = args[:vat_rate] if args.key?(:vat_rate)

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -22,6 +22,7 @@ module Organizations
       organization.country = args[:country] if args.key?(:country)
       organization.invoice_footer = args[:invoice_footer] if args.key?(:invoice_footer)
       organization.invoice_grace_period = args[:invoice_grace_period] if args.key?(:invoice_grace_period)
+      organization.timezone = args[:timezone] if args.key?(:timezone)
 
       handle_base64_logo(args[:logo]) if args.key?(:logo)
 
@@ -45,6 +46,7 @@ module Organizations
       organization.city = params[:city] if params.key?(:city)
       organization.legal_name = params[:legal_name] if params.key?(:legal_name)
       organization.legal_number = params[:legal_number] if params.key?(:legal_number)
+      organization.timezone = params[:timezone] if params.key?(:timezone)
 
       if params.key?(:billing_configuration)
         billing = params[:billing_configuration]

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -22,7 +22,9 @@ module Organizations
       organization.country = args[:country] if args.key?(:country)
       organization.invoice_footer = args[:invoice_footer] if args.key?(:invoice_footer)
       organization.invoice_grace_period = args[:invoice_grace_period] if args.key?(:invoice_grace_period)
-      organization.timezone = args[:timezone] if args.key?(:timezone)
+
+      # TODO(:timezone): Timezone update is turned off for now
+      # organization.timezone = args[:timezone] if args.key?(:timezone)
 
       handle_base64_logo(args[:logo]) if args.key?(:logo)
 
@@ -46,7 +48,9 @@ module Organizations
       organization.city = params[:city] if params.key?(:city)
       organization.legal_name = params[:legal_name] if params.key?(:legal_name)
       organization.legal_number = params[:legal_number] if params.key?(:legal_number)
-      organization.timezone = params[:timezone] if params.key?(:timezone)
+
+      # TODO(:timezone): Timezone update is turned off for now
+      # organization.timezone = params[:timezone] if params.key?(:timezone)
 
       if params.key?(:billing_configuration)
         billing = params[:billing_configuration]

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -78,7 +78,7 @@ module Subscriptions
       end
 
       def previous_anniversary_day(date)
-        year = (date.month < subscription_at.month) ? (date.year - 1) : date.year
+        year = (date.month < subscription_at.month) ? date.year - 1 : date.year
         month = subscription_at.month
         day = subscription_at.day
 

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -78,7 +78,7 @@ module Subscriptions
       end
 
       def previous_anniversary_day(date)
-        year = (date.month < subscription_at.month) ? date.year - 1 : date.year
+        year = (date.month < subscription_at.month) ? (date.year - 1) : date.year
         month = subscription_at.month
         day = subscription_at.day
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -474,10 +474,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_12_153810) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "previous_subscription_id"
-    t.date "subscription_date"
     t.string "name"
     t.string "external_id", null: false
     t.integer "billing_time", default: 0, null: false
+    t.datetime "subscription_at"
     t.index ["customer_id"], name: "index_subscriptions_on_customer_id"
     t.index ["external_id"], name: "index_subscriptions_on_external_id"
     t.index ["plan_id"], name: "index_subscriptions_on_plan_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -474,10 +474,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_12_153810) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "previous_subscription_id"
+    t.date "subscription_date"
     t.string "name"
     t.string "external_id", null: false
     t.integer "billing_time", default: 0, null: false
-    t.datetime "subscription_at"
     t.index ["customer_id"], name: "index_subscriptions_on_customer_id"
     t.index ["external_id"], name: "index_subscriptions_on_external_id"
     t.index ["plan_id"], name: "index_subscriptions_on_plan_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -2843,6 +2843,7 @@ type Event {
   apiClient: String
   billableMetricName: String
   code: String!
+  customerTimezone: TimezoneEnum!
   externalCustomerId: String!
   externalSubscriptionId: String!
   id: ID!
@@ -2851,9 +2852,7 @@ type Event {
   matchCustomField: Boolean!
   payload: JSON!
   receivedAt: ISO8601DateTime!
-  receivedAtInCustomerTimezone: ISO8601DateTime!
   timestamp: ISO8601DateTime
-  timestampInCustomerTimezone: ISO8601DateTime
   transactionId: String
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1677,6 +1677,7 @@ input CreateCustomerInput {
   phone: String
   providerCustomer: ProviderCustomerInput
   state: String
+  timezone: TimezoneEnum
   url: String
   vatRate: Float
   zipcode: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -4859,6 +4859,7 @@ input UpdateOrganizationInput {
   legalNumber: String
   logo: String
   state: String
+  timezone: TimezoneEnum
   vatRate: Float
   webhookUrl: String
   zipcode: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -1478,7 +1478,6 @@ type Coupon {
   customerCount: Int!
   expiration: CouponExpiration!
   expirationAt: ISO8601DateTime
-  expirationDate: ISO8601Date
   frequency: CouponFrequency!
   frequencyDuration: Int
   id: ID!
@@ -1514,7 +1513,6 @@ type CouponDetails {
   customerCount: Int!
   expiration: CouponExpiration!
   expirationAt: ISO8601DateTime
-  expirationDate: ISO8601Date
   frequency: CouponFrequency!
   frequencyDuration: Int
   id: ID!
@@ -1628,7 +1626,6 @@ input CreateCouponInput {
   couponType: CouponTypeEnum!
   expiration: CouponExpiration!
   expirationAt: ISO8601DateTime
-  expirationDate: ISO8601Date
   frequency: CouponFrequency!
   frequencyDuration: Int
   name: String!
@@ -1694,7 +1691,6 @@ input CreateCustomerWalletInput {
   currency: CurrencyEnum!
   customerId: ID!
   expirationAt: ISO8601DateTime
-  expirationDate: ISO8601Date
   grantedCredits: String!
   name: String
   paidCredits: String!
@@ -2681,10 +2677,8 @@ type CustomerUsage {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   chargesUsage: [ChargeUsage!]!
-  fromDate: ISO8601Date!
   fromDatetime: ISO8601DateTime!
   issuingDate: ISO8601Date!
-  toDate: ISO8601Date!
   toDatetime: ISO8601DateTime!
   totalAmountCents: BigInt!
   totalAmountCurrency: CurrencyEnum!
@@ -3030,12 +3024,10 @@ enum InvoicePaymentStatusTypeEnum {
 type InvoiceSubscription {
   chargeAmountCents: Int!
   fees: [Fee!]
-  fromDate: ISO8601Date
   fromDatetime: ISO8601DateTime
   invoice: Invoice!
   subscription: Subscription!
   subscriptionAmountCents: Int!
-  toDate: ISO8601Date
   toDatetime: ISO8601DateTime
   totalAmountCents: Int!
 }
@@ -4760,7 +4752,6 @@ input UpdateCouponInput {
   couponType: CouponTypeEnum!
   expiration: CouponExpiration!
   expirationAt: ISO8601DateTime
-  expirationDate: ISO8601Date
   frequency: CouponFrequency!
   frequencyDuration: Int
   id: String!
@@ -4834,7 +4825,6 @@ input UpdateCustomerWalletInput {
   """
   clientMutationId: String
   expirationAt: ISO8601DateTime
-  expirationDate: ISO8601Date
   id: ID!
   name: String
 }
@@ -4943,7 +4933,6 @@ type Wallet {
   currency: CurrencyEnum!
   customer: Customer
   expirationAt: ISO8601DateTime
-  expirationDate: ISO8601Date
   id: ID!
   lastBalanceSyncAt: ISO8601DateTime
   lastConsumedCreditAt: ISO8601DateTime
@@ -4968,7 +4957,6 @@ type WalletDetails {
   currency: CurrencyEnum!
   customer: Customer
   expirationAt: ISO8601DateTime
-  expirationDate: ISO8601Date
   id: ID!
   lastBalanceSyncAt: ISO8601DateTime
   lastConsumedCreditAt: ISO8601DateTime

--- a/schema.graphql
+++ b/schema.graphql
@@ -4807,6 +4807,7 @@ input UpdateCustomerInput {
   phone: String
   providerCustomer: ProviderCustomerInput
   state: String
+  timezone: TimezoneEnum
   url: String
   vatRate: Float
   zipcode: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -1757,7 +1757,6 @@ input CreateSubscriptionInput {
   name: String
   planId: ID!
   subscriptionAt: ISO8601DateTime
-  subscriptionDate: ISO8601Date
   subscriptionId: ID
 }
 
@@ -3976,7 +3975,6 @@ type Subscription {
   startedAt: ISO8601DateTime
   status: StatusTypeEnum
   subscriptionAt: ISO8601DateTime
-  subscriptionDate: ISO8601Date
   terminatedAt: ISO8601DateTime
   updatedAt: ISO8601DateTime!
 }
@@ -4888,7 +4886,6 @@ input UpdateSubscriptionInput {
   id: ID!
   name: String
   subscriptionAt: ISO8601DateTime
-  subscriptionDate: ISO8601Date
 }
 
 type User {

--- a/schema.json
+++ b/schema.json
@@ -5741,18 +5741,6 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "subscriptionDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
             }
           ],
           "enumValues": null
@@ -16758,20 +16746,6 @@
               ]
             },
             {
-              "name": "subscriptionDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "terminatedAt",
               "description": null,
               "type": {
@@ -19121,18 +19095,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "ISO8601DateTime",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "subscriptionDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
                 "ofType": null
               },
               "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -3610,20 +3610,6 @@
               ]
             },
             {
-              "name": "expirationDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "frequency",
               "description": null,
               "type": {
@@ -3995,20 +3981,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "ISO8601DateTime",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "expirationDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -4848,18 +4820,6 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "expirationDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
             }
           ],
           "enumValues": null
@@ -5369,18 +5329,6 @@
                   "name": "CurrencyEnum",
                   "ofType": null
                 }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "expirationDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -8934,24 +8882,6 @@
               ]
             },
             {
-              "name": "fromDate",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601Date",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "fromDatetime",
               "description": null,
               "type": {
@@ -8971,24 +8901,6 @@
             },
             {
               "name": "issuingDate",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601Date",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "toDate",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -11908,20 +11820,6 @@
               ]
             },
             {
-              "name": "fromDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "fromDatetime",
               "description": null,
               "type": {
@@ -11982,20 +11880,6 @@
                   "name": "Int",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "toDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -18325,18 +18209,6 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "expirationDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
             }
           ],
           "enumValues": null
@@ -18788,18 +18660,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "ISO8601DateTime",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "expirationDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
                 "ofType": null
               },
               "defaultValue": null,
@@ -19722,20 +19582,6 @@
               ]
             },
             {
-              "name": "expirationDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "id",
               "description": null,
               "type": {
@@ -20061,20 +19907,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "ISO8601DateTime",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "expirationDate",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -5212,6 +5212,18 @@
               "deprecationReason": null
             },
             {
+              "name": "timezone",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "TimezoneEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "paymentProvider",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -18645,6 +18645,18 @@
               "deprecationReason": null
             },
             {
+              "name": "timezone",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "TimezoneEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "paymentProvider",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -18996,6 +18996,18 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "timezone",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "TimezoneEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "enumValues": null

--- a/schema.json
+++ b/schema.json
@@ -9613,6 +9613,24 @@
               ]
             },
             {
+              "name": "customerTimezone",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "TimezoneEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "externalCustomerId",
               "description": null,
               "type": {
@@ -9753,39 +9771,7 @@
               ]
             },
             {
-              "name": "receivedAtInCustomerTimezone",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ISO8601DateTime",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "timestamp",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601DateTime",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "timestampInCustomerTimezone",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/spec/graphql/mutations/coupons/create_spec.rb
+++ b/spec/graphql/mutations/coupons/create_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
             amountCents: 5000,
             amountCurrency: 'EUR',
             expiration: 'time_limit',
-            expirationDate: expiration_at.to_date.iso8601,
+            expirationAt: expiration_at.iso8601,
           },
         },
       )
@@ -87,7 +87,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
         expect(result_data['amountCents']).to eq(5000)
         expect(result_data['amountCurrency']).to eq('EUR')
         expect(result_data['expiration']).to eq('time_limit')
-        expect(result_data['expirationAt']).to eq expiration_at.end_of_day.iso8601
+        expect(result_data['expirationAt']).to eq(expiration_at.iso8601)
         expect(result_data['status']).to eq('active')
       end
     end

--- a/spec/graphql/mutations/coupons/create_spec.rb
+++ b/spec/graphql/mutations/coupons/create_spec.rb
@@ -93,41 +93,6 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
     end
   end
 
-  context 'with an expiration date' do
-    it 'creates a coupon' do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            name: 'Super Coupon',
-            code: 'free-beer',
-            couponType: 'fixed_amount',
-            frequency: 'once',
-            amountCents: 5000,
-            amountCurrency: 'EUR',
-            expiration: 'time_limit',
-            expirationDate: expiration_at.to_date.iso8601,
-          },
-        },
-      )
-
-      result_data = result['data']['createCoupon']
-
-      aggregate_failures do
-        expect(result_data['id']).to be_present
-        expect(result_data['name']).to eq('Super Coupon')
-        expect(result_data['code']).to eq('free-beer')
-        expect(result_data['amountCents']).to eq(5000)
-        expect(result_data['amountCurrency']).to eq('EUR')
-        expect(result_data['expiration']).to eq('time_limit')
-        expect(result_data['expirationAt']).to eq expiration_at.end_of_day.iso8601
-        expect(result_data['status']).to eq('active')
-      end
-    end
-  end
-
   context 'without current user' do
     it 'returns an error' do
       result = execute_graphql(
@@ -142,7 +107,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
             amountCents: 5000,
             amountCurrency: 'EUR',
             expiration: 'time_limit',
-            expirationDate: (Time.current + 3.days).to_date,
+            expirationAt: (Time.current + 3.days).iso8601,
           },
         },
       )
@@ -165,7 +130,7 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
             amountCents: 5000,
             amountCurrency: 'EUR',
             expiration: 'time_limit',
-            expirationDate: (Time.current + 3.days).to_date,
+            expirationAt: (Time.current + 3.days).iso8601,
           },
         },
       )

--- a/spec/graphql/mutations/coupons/update_spec.rb
+++ b/spec/graphql/mutations/coupons/update_spec.rb
@@ -58,41 +58,6 @@ RSpec.describe Mutations::Coupons::Update, type: :graphql do
     end
   end
 
-  context 'with an expiration date' do
-    it 'updates a coupon' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query: mutation,
-        variables: {
-          input: {
-            id: coupon.id,
-            name: 'New name',
-            couponType: 'fixed_amount',
-            frequency: 'once',
-            code: 'new_code',
-            amountCents: 123,
-            amountCurrency: 'USD',
-            expiration: 'time_limit',
-            expirationDate: expiration_at.to_date.iso8601,
-            reusable: false,
-          },
-        },
-      )
-
-      result_data = result['data']['updateCoupon']
-
-      aggregate_failures do
-        expect(result_data['name']).to eq('New name')
-        expect(result_data['code']).to eq('new_code')
-        expect(result_data['status']).to eq('active')
-        expect(result_data['amountCents']).to eq(123)
-        expect(result_data['amountCurrency']).to eq('USD')
-        expect(result_data['expiration']).to eq('time_limit')
-        expect(result_data['expirationAt']).to eq expiration_at.end_of_day.iso8601
-      end
-    end
-  end
-
   context 'without current_user' do
     it 'returns an error' do
       result = execute_graphql(
@@ -107,7 +72,7 @@ RSpec.describe Mutations::Coupons::Update, type: :graphql do
             amountCents: 123,
             amountCurrency: 'USD',
             expiration: 'time_limit',
-            expirationDate: (Time.current + 33.days).to_date,
+            expirationAt: (Time.current + 33.days).iso8601,
           },
         },
       )

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           paymentProvider
           providerCustomer { id, providerCustomerId }
           currency
+          timezone
           canEditAttributes
           invoiceGracePeriod
         }
@@ -41,6 +42,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           country: 'GB',
           paymentProvider: 'stripe',
           currency: 'EUR',
+          timezone: 'TZ_EUROPE_PARIS',
           invoiceGracePeriod: 2,
           providerCustomer: {
             providerCustomerId: 'cu_12345',
@@ -58,6 +60,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
       expect(result_data['city']).to eq('London')
       expect(result_data['country']).to eq('GB')
       expect(result_data['currency']).to eq('EUR')
+      expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
       expect(result_data['invoiceGracePeriod']).to eq(2)
       expect(result_data['paymentProvider']).to eq('stripe')
       expect(result_data['providerCustomer']['id']).to be_present

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
       expect(result_data['city']).to eq('London')
       expect(result_data['country']).to eq('GB')
       expect(result_data['currency']).to eq('EUR')
-      expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
+      # TODO(:timezone): Timezone update is turned off for now
+      # expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
       expect(result_data['invoiceGracePeriod']).to eq(2)
       expect(result_data['paymentProvider']).to eq('stripe')
       expect(result_data['providerCustomer']['id']).to be_present

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           externalId
           paymentProvider
           currency
+          timezone
           canEditAttributes
           invoiceGracePeriod
           providerCustomer { id, providerCustomerId }
@@ -39,6 +40,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           externalId: external_id,
           paymentProvider: 'stripe',
           currency: 'EUR',
+          timezone: 'TZ_EUROPE_PARIS',
           invoiceGracePeriod: 2,
           providerCustomer: {
             providerCustomerId: 'cu_12345',
@@ -55,6 +57,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       expect(result_data['externalId']).to eq(external_id)
       expect(result_data['paymentProvider']).to eq('stripe')
       expect(result_data['currency']).to eq('EUR')
+      expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
       expect(result_data['invoiceGracePeriod']).to eq(2)
       expect(result_data['providerCustomer']['id']).to be_present
       expect(result_data['providerCustomer']['providerCustomerId']).to eq('cu_12345')

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       expect(result_data['externalId']).to eq(external_id)
       expect(result_data['paymentProvider']).to eq('stripe')
       expect(result_data['currency']).to eq('EUR')
-      expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
+      # TODO(:timezone): Timezone update is turned off for now
+      # expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
       expect(result_data['invoiceGracePeriod']).to eq(2)
       expect(result_data['providerCustomer']['id']).to be_present
       expect(result_data['providerCustomer']['providerCustomerId']).to eq('cu_12345')

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           zipcode: 'FOO1234',
           city: 'Foobar',
           country: 'FR',
+          timezone: 'TZ_EUROPE_PARIS',
           invoiceFooter: 'invoice footer',
           invoiceGracePeriod: 3,
         },
@@ -67,7 +68,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
       expect(result_data['country']).to eq('FR')
       expect(result_data['invoiceFooter']).to eq('invoice footer')
       expect(result_data['invoiceGracePeriod']).to eq(3)
-      expect(result_data['timezone']).to eq('TZ_UTC')
+      expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
     end
   end
 

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
       expect(result_data['country']).to eq('FR')
       expect(result_data['invoiceFooter']).to eq('invoice footer')
       expect(result_data['invoiceGracePeriod']).to eq(3)
-      expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
+      # TODO(:timezone): Timezone update is turned off for now
+      # expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
     end
   end
 

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
           startedAt
           billingTime
           subscriptionAt
-          subscriptionDate
           customer {
             id
           },
@@ -54,39 +53,6 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
       expect(result_data['customer']['id']).to eq(customer.id)
       expect(result_data['plan']['id']).to eq(plan.id)
       expect(result_data['billingTime']).to eq('anniversary')
-    end
-  end
-
-  context 'with legacy subscription_date' do
-    it 'creates a subscription' do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        query: mutation,
-        variables: {
-          input: {
-            customerId: customer.id,
-            planId: plan.id,
-            name: 'invoice display name',
-            billingTime: 'anniversary',
-            subscriptionDate: '2022-12-06',
-          },
-        },
-      )
-
-      result_data = result['data']['createSubscription']
-
-      aggregate_failures do
-        expect(result_data['id']).to be_present
-        expect(result_data['status'].to_sym).to eq(:active)
-        expect(result_data['name']).to eq('invoice display name')
-        expect(result_data['startedAt']).to be_present
-        expect(result_data['customer']['id']).to eq(customer.id)
-        expect(result_data['plan']['id']).to eq(plan.id)
-        expect(result_data['billingTime']).to eq('anniversary')
-        expect(result_data['subscriptionDate']).to eq('2022-12-06')
-        expect(result_data['subscriptionAt']).to eq('2022-12-06T00:00:00Z')
-      end
     end
   end
 

--- a/spec/graphql/mutations/subscriptions/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
           id
           name
           subscriptionAt
-          subscriptionDate
         }
       }
     GQL
@@ -42,34 +41,6 @@ RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
 
     aggregate_failures do
       expect(result_data['name']).to eq('New name')
-    end
-  end
-
-  context 'with legacy subscription_date' do
-    let(:subscription_at) { Time.current + 4.days }
-
-    before { subscription.pending! }
-
-    it 'updates an subscription' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query: mutation,
-        variables: {
-          input: {
-            id: subscription.id,
-            name: 'New name',
-            subscriptionDate: subscription_at.to_date.iso8601,
-          },
-        },
-      )
-
-      result_data = result['data']['updateSubscription']
-
-      aggregate_failures do
-        expect(result_data['name']).to eq('New name')
-        expect(result_data['subscriptionDate']).to eq(subscription_at.to_date.iso8601)
-        expect(result_data['subscriptionAt']).to eq(subscription_at.beginning_of_day.iso8601)
-      end
     end
   end
 

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -49,35 +49,6 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
     end
   end
 
-  context 'with expiration date' do
-    it 'create a wallet' do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            customerId: customer.id,
-            name: 'First Wallet',
-            rateAmount: '1',
-            paidCredits: '0.00',
-            grantedCredits: '0.00',
-            expirationDate: expiration_at.to_date.iso8601,
-            currency: 'EUR',
-          },
-        },
-      )
-
-      result_data = result['data']['createCustomerWallet']
-
-      aggregate_failures do
-        expect(result_data['id']).to be_present
-        expect(result_data['name']).to eq('First Wallet')
-        expect(result_data['expirationAt']).to eq(expiration_at.end_of_day.iso8601)
-      end
-    end
-  end
-
   context 'when name is not present' do
     it 'creates a wallet' do
       result = execute_graphql(
@@ -91,7 +62,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
             rateAmount: '1',
             paidCredits: '0.00',
             grantedCredits: '0.00',
-            expirationDate: (Time.zone.now + 1.year).to_date,
+            expirationAt: (Time.zone.now + 1.year).iso8601,
             currency: 'EUR',
           },
         },
@@ -118,7 +89,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
             rateAmount: '1',
             paidCredits: '0.00',
             grantedCredits: '0.00',
-            expirationDate: (Time.zone.now + 1.year).to_date,
+            expirationAt: (Time.zone.now + 1.year).iso8601,
             currency: 'EUR',
           },
         },
@@ -140,7 +111,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
             rateAmount: '1',
             paidCredits: '0.00',
             grantedCredits: '0.00',
-            expirationDate: (Time.zone.now + 1.year).to_date,
+            expirationAt: (Time.zone.now + 1.year).iso8601,
             currency: 'EUR',
           },
         },

--- a/spec/graphql/resolvers/coupon_resolver_spec.rb
+++ b/spec/graphql/resolvers/coupon_resolver_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Resolvers::CouponResolver, type: :graphql do
     <<~GQL
       query($couponId: ID!) {
         coupon(id: $couponId) {
-          id name customerCount expirationDate
+          id name customerCount expirationAt
         }
       }
     GQL

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
       query($customerId: ID!, $subscriptionId: ID!) {
         customerUsage(customerId: $customerId, subscriptionId: $subscriptionId) {
           fromDatetime
-          fromDate
           toDatetime
-          toDate
           issuingDate
           amountCents
           amountCurrency
@@ -93,8 +91,6 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
     usage_response = result['data']['customerUsage']
 
     aggregate_failures do
-      expect(usage_response['fromDate']).to eq(Time.zone.today.beginning_of_month.iso8601)
-      expect(usage_response['toDate']).to eq(Time.zone.today.end_of_month.iso8601)
       expect(usage_response['fromDatetime']).to eq(Time.current.beginning_of_month.iso8601)
       expect(usage_response['toDatetime']).to eq(Time.current.end_of_month.iso8601)
       expect(usage_response['issuingDate']).to eq(Time.zone.today.end_of_month.iso8601)

--- a/spec/graphql/resolvers/events_resolver_spec.rb
+++ b/spec/graphql/resolvers/events_resolver_spec.rb
@@ -8,19 +8,18 @@ RSpec.describe Resolvers::EventsResolver, type: :graphql do
       query {
         events(limit: 5) {
           collection {
-            id,
-            code,
-            externalCustomerId,
-            transactionId,
-            timestamp,
-            timestampInCustomerTimezone,
-            receivedAt,
-            receivedAtInCustomerTimezone,
-            ipAddress,
-            apiClient,
-            payload,
-            billableMetricName,
-            matchBillableMetric,
+            id
+            code
+            externalCustomerId
+            transactionId
+            timestamp
+            receivedAt
+            customerTimezone
+            ipAddress
+            apiClient
+            payload
+            billableMetricName
+            matchBillableMetric
             matchCustomField
           }
           metadata { currentPage, totalCount }
@@ -64,6 +63,7 @@ RSpec.describe Resolvers::EventsResolver, type: :graphql do
       expect(events_response['collection'].first['transactionId']).to eq(event.transaction_id)
       expect(events_response['collection'].first['timestamp']).to eq(event.timestamp.iso8601)
       expect(events_response['collection'].first['receivedAt']).to eq(event.created_at.iso8601)
+      expect(events_response['collection'].first['customerTimezone']).to eq('TZ_UTC')
       expect(events_response['collection'].first['ipAddress']).to eq(event.metadata['ip_address'])
       expect(events_response['collection'].first['apiClient']).to eq(event.metadata['user_agent'])
       expect(events_response['collection'].first['payload']).to be_present

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
           invoiceSubscriptions {
             fromDatetime
             toDatetime
-            fromDate
-            toDate
             subscription {
               id
             }

--- a/spec/graphql/resolvers/wallet_resolver_spec.rb
+++ b/spec/graphql/resolvers/wallet_resolver_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Resolvers::WalletResolver, type: :graphql do
     <<~GQL
       query($walletId: ID!) {
         wallet(id: $walletId) {
-          id, name, expirationDate
+          id name expirationAt
         }
       }
     GQL

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         external_id: SecureRandom.uuid,
         name: 'Foo Bar',
         currency: 'EUR',
+        timezone: 'America/New_York',
       }
     end
 
@@ -24,6 +25,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         expect(json[:customer][:name]).to eq(create_params[:name])
         expect(json[:customer][:created_at]).to be_present
         expect(json[:customer][:currency]).to eq(create_params[:currency])
+        expect(json[:customer][:timezone]).to eq(create_params[:timezone])
       end
     end
 
@@ -225,8 +227,12 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       let(:aws) { create(:group, billable_metric: metric, key: 'cloud', value: 'aws') }
       let(:google) { create(:group, billable_metric: metric, key: 'cloud', value: 'google') }
       let(:aws_usa) { create(:group, billable_metric: metric, key: 'region', value: 'usa', parent_group_id: aws.id) }
-      let(:aws_france) { create(:group, billable_metric: metric, key: 'region', value: 'france', parent_group_id: aws.id) }
-      let(:google_usa) { create(:group, billable_metric: metric, key: 'region', value: 'usa', parent_group_id: google.id) }
+      let(:aws_france) do
+        create(:group, billable_metric: metric, key: 'region', value: 'france', parent_group_id: aws.id)
+      end
+      let(:google_usa) do
+        create(:group, billable_metric: metric, key: 'region', value: 'usa', parent_group_id: google.id)
+      end
 
       let(:charge) do
         create(

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         expect(json[:customer][:name]).to eq(create_params[:name])
         expect(json[:customer][:created_at]).to be_present
         expect(json[:customer][:currency]).to eq(create_params[:currency])
-        expect(json[:customer][:timezone]).to eq(create_params[:timezone])
+        # TODO(:timezone): Timezone update is turned off for now
+        # expect(json[:customer][:timezone]).to eq(create_params[:timezone])
       end
     end
 

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
         expect(json[:organization][:name]).to eq(organization.name)
         expect(json[:organization][:webhook_url]).to eq(update_params[:webhook_url])
         expect(json[:organization][:vat_rate]).to eq(update_params[:vat_rate])
-        expect(json[:organization][:timezone]).to eq(update_params[:timezone])
+        # TODO(:timezone): Timezone update is turned off for now
+        # expect(json[:organization][:timezone]).to eq(update_params[:timezone])
 
         billing = json[:organization][:billing_configuration]
         expect(billing[:invoice_footer]).to eq('footer')

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
         city: 'test_city',
         legal_name: 'test1',
         legal_number: '123',
+        timezone: 'Europe/Paris',
         billing_configuration: {
           invoice_footer: 'footer',
           invoice_grace_period: 3,
@@ -39,6 +40,7 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
         expect(json[:organization][:name]).to eq(organization.name)
         expect(json[:organization][:webhook_url]).to eq(update_params[:webhook_url])
         expect(json[:organization][:vat_rate]).to eq(update_params[:vat_rate])
+        expect(json[:organization][:timezone]).to eq(update_params[:timezone])
 
         billing = json[:organization][:billing_configuration]
         expect(billing[:invoice_footer]).to eq('footer')

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Customers::CreateService, type: :service do
         expect(customer.external_id).to eq(create_args[:external_id])
         expect(customer.name).to eq(create_args[:name])
         expect(customer.currency).to eq(create_args[:currency])
-        expect(customer.timezone).to eq(create_args[:timezone])
+        # TODO(:timezone): Timezone update is turned off for now
+        # expect(customer.timezone).to eq(create_args[:timezone])
 
         billing = create_args[:billing_configuration]
         expect(customer.invoice_grace_period).to eq(billing[:invoice_grace_period])
@@ -328,7 +329,8 @@ RSpec.describe Customers::CreateService, type: :service do
         expect(customer.external_id).to eq(create_args[:external_id])
         expect(customer.name).to eq(create_args[:name])
         expect(customer.currency).to eq('EUR')
-        expect(customer.timezone).to eq('Europe/Paris')
+        # TODO(:timezone): Timezone update is turned off for now
+        # expect(customer.timezone).to eq('Europe/Paris')
         expect(customer.invoice_grace_period).to eq(2)
       end
     end

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Customers::CreateService, type: :service do
         external_id: SecureRandom.uuid,
         name: 'Foo Bar',
         currency: 'EUR',
+        timezone: 'Europe/Paris',
         billing_configuration: {
           invoice_grace_period: 3,
           vat_rate: 20,
@@ -42,6 +43,7 @@ RSpec.describe Customers::CreateService, type: :service do
         expect(customer.external_id).to eq(create_args[:external_id])
         expect(customer.name).to eq(create_args[:name])
         expect(customer.currency).to eq(create_args[:currency])
+        expect(customer.timezone).to eq(create_args[:timezone])
 
         billing = create_args[:billing_configuration]
         expect(customer.invoice_grace_period).to eq(billing[:invoice_grace_period])
@@ -304,6 +306,7 @@ RSpec.describe Customers::CreateService, type: :service do
         name: 'Foo Bar',
         organization_id: organization.id,
         currency: 'EUR',
+        timezone: 'Europe/Paris',
         invoice_grace_period: 2,
       }
     end
@@ -325,6 +328,7 @@ RSpec.describe Customers::CreateService, type: :service do
         expect(customer.external_id).to eq(create_args[:external_id])
         expect(customer.name).to eq(create_args[:name])
         expect(customer.currency).to eq('EUR')
+        expect(customer.timezone).to eq('Europe/Paris')
         expect(customer.invoice_grace_period).to eq(2)
       end
     end

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe Customers::UpdateService, type: :service do
       updated_customer = result.customer
       aggregate_failures do
         expect(updated_customer.name).to eq('Updated customer name')
-        expect(updated_customer.timezone).to eq('Europe/Paris')
+        # TODO(:timezone): Timezone update is turned off for now
+        # expect(updated_customer.timezone).to eq('Europe/Paris')
 
         billing = update_args[:billing_configuration]
         expect(updated_customer.invoice_grace_period).to eq(billing[:invoice_grace_period])

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Customers::UpdateService, type: :service do
         id: customer.id,
         name: 'Updated customer name',
         external_id: external_id,
+        timezone: 'Europe/Paris',
         billing_configuration: {
           invoice_grace_period: 3,
           vat_rate: 20,
@@ -33,6 +34,7 @@ RSpec.describe Customers::UpdateService, type: :service do
       updated_customer = result.customer
       aggregate_failures do
         expect(updated_customer.name).to eq('Updated customer name')
+        expect(updated_customer.timezone).to eq('Europe/Paris')
 
         billing = update_args[:billing_configuration]
         expect(updated_customer.invoice_grace_period).to eq(billing[:invoice_grace_period])

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Organizations::UpdateService do
         zipcode: 'FOO1234',
         city: 'Foobar',
         country: 'FR',
+        timezone: 'Europe/Paris',
         invoice_footer: 'invoice footer',
         invoice_grace_period: 3,
       )
@@ -37,6 +38,7 @@ RSpec.describe Organizations::UpdateService do
         expect(result.organization.zipcode).to eq('FOO1234')
         expect(result.organization.city).to eq('Foobar')
         expect(result.organization.country).to eq('FR')
+        expect(result.organization.timezone).to eq('Europe/Paris')
         expect(result.organization.invoice_footer).to eq('invoice footer')
         expect(result.organization.invoice_grace_period).to eq(3)
       end
@@ -74,6 +76,7 @@ RSpec.describe Organizations::UpdateService do
         city: 'test_city',
         legal_name: 'test1',
         legal_number: '123',
+        timezone: 'Europe/Paris',
         billing_configuration: {
           invoice_footer: 'footer',
           invoice_grace_period: 3,
@@ -83,7 +86,7 @@ RSpec.describe Organizations::UpdateService do
     end
 
     it 'updates an organization' do
-      result = subject.update_from_api(params: update_args)
+      result = organization_update_service.update_from_api(params: update_args)
 
       aggregate_failures do
         expect(result).to be_success
@@ -91,6 +94,7 @@ RSpec.describe Organizations::UpdateService do
         organization_response = result.organization
         expect(organization_response.name).to eq(organization.name)
         expect(organization_response.webhook_url).to eq(update_args[:webhook_url])
+        expect(organization_response.timezone).to eq(update_args[:timezone])
 
         billing = update_args[:billing_configuration]
         expect(organization_response.invoice_footer).to eq(billing[:invoice_footer])
@@ -103,7 +107,7 @@ RSpec.describe Organizations::UpdateService do
       let(:country) { '---' }
 
       it 'returns an error' do
-        result = subject.update_from_api(params: update_args)
+        result = organization_update_service.update_from_api(params: update_args)
 
         aggregate_failures do
           expect(result).not_to be_success

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Organizations::UpdateService do
         expect(result.organization.zipcode).to eq('FOO1234')
         expect(result.organization.city).to eq('Foobar')
         expect(result.organization.country).to eq('FR')
-        expect(result.organization.timezone).to eq('Europe/Paris')
+        # TODO(:timezone): Timezone update is turned off for now
+        # expect(result.organization.timezone).to eq('Europe/Paris')
         expect(result.organization.invoice_footer).to eq('invoice footer')
         expect(result.organization.invoice_grace_period).to eq(3)
       end
@@ -94,7 +95,8 @@ RSpec.describe Organizations::UpdateService do
         organization_response = result.organization
         expect(organization_response.name).to eq(organization.name)
         expect(organization_response.webhook_url).to eq(update_args[:webhook_url])
-        expect(organization_response.timezone).to eq(update_args[:timezone])
+        # TODO(:timezone): Timezone update is turned off for now
+        # expect(organization_response.timezone).to eq(update_args[:timezone])
 
         billing = update_args[:billing_configuration]
         expect(organization_response.invoice_footer).to eq(billing[:invoice_footer])


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR is the "Final" one for the feature, it contains all breaking changes that cannot be merged before the feature delivery
