### PR TITLE
hotfix(timezone): Broken invoice template with subscription fees

### DIFF
--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -514,7 +514,7 @@ html
             h2.invoice-details-title.title-2.mb-24 #{subscription.plan.name} details
           .body-1 Subscription
           .mb-24.body-3
-            | From #{invoice_subscription(subscription.id).from_datetime_in_customer_timezome&.strftime('%b %d, %Y')} to #{invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.strftime('%b %d, %Y')}
+            | From #{invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.strftime('%b %d, %Y')} to #{invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.strftime('%b %d, %Y')}
 
           .invoice-resume.mb-24.overflow-auto
             table.invoice-resume-table width="100%"


### PR DESCRIPTION
## Context

A recent change for handling timezone on invoice introduces an error (a big finger typo...) with subscription fees. Since the test coverage on the invoice template is a bit poor, the typo was not detected

## Description

This PR simply fixes the typo.

NOTE: A next PR will come with an improved test coverage for the PDF template
