### PR TITLE
feat(timezones): Turn subscription#subscription_date into subscription_at

### DIFF
--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -45,6 +45,10 @@ module Types
         ::Subscriptions::DatesService.new_instance(object, Time.current)
           .next_end_of_period
       end
+
+      def subscription_date
+        object.subscription_at.to_date
+      end
     end
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -32,10 +32,10 @@ class Subscription < ApplicationRecord
 
   scope :starting_in_the_future, -> { pending.where(previous_subscription: nil) }
 
-  # NOTE: SQL query to get subscription_date into customer timezone
-  def self.subscription_date_in_timezone_sql
+  # NOTE: SQL query to get subscription_at into customer timezone
+  def self.subscription_at_in_timezone_sql
     <<-SQL
-      subscriptions.subscription_date::timestamptz AT TIME ZONE
+      subscriptions.subscription_at::timestamptz AT TIME ZONE
       COALESCE(customers.timezone, organizations.timezone, 'UTC')
     SQL
   end
@@ -81,7 +81,7 @@ class Subscription < ApplicationRecord
     customer.subscriptions
       .where(external_id: external_id)
       .where.not(started_at: nil)
-      .order(started_at: :asc).first&.started_at || subscription_date
+      .order(started_at: :asc).first&.started_at || subscription_at
   end
 
   def next_subscription

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -12,7 +12,7 @@ module V1
         plan_code: model.plan.code,
         status: model.status,
         billing_time: model.billing_time,
-        subscription_date: model.subscription_date&.iso8601,
+        subscription_date: model.subscription_at&.to_date&.iso8601,
         started_at: model.started_at&.iso8601,
         terminated_at: model.terminated_at&.iso8601,
         canceled_at: model.canceled_at&.iso8601,

--- a/app/services/billing_service.rb
+++ b/app/services/billing_service.rb
@@ -101,7 +101,7 @@ class BillingService
       .joins(:plan, customer: :organization)
       .anniversary
       .merge(Plan.weekly)
-      .where("EXTRACT(ISODOW FROM (#{Subscription.subscription_date_in_timezone_sql})) = ?", today.wday)
+      .where("EXTRACT(ISODOW FROM (#{Subscription.subscription_at_in_timezone_sql})) = ?", today.wday)
       .select(:id).to_sql
   end
 
@@ -117,7 +117,7 @@ class BillingService
       .joins(:plan, customer: :organization)
       .anniversary
       .merge(Plan.monthly)
-      .where("DATE_PART('day', (#{Subscription.subscription_date_in_timezone_sql})) IN (?)", days)
+      .where("DATE_PART('day', (#{Subscription.subscription_at_in_timezone_sql})) IN (?)", days)
       .select(:id).to_sql
   end
 
@@ -133,8 +133,8 @@ class BillingService
       .joins(:plan, customer: :organization)
       .anniversary
       .merge(Plan.yearly)
-      .where("DATE_PART('month', (#{Subscription.subscription_date_in_timezone_sql})) = ?", today.month)
-      .where("DATE_PART('day', (#{Subscription.subscription_date_in_timezone_sql})) IN (?)", days)
+      .where("DATE_PART('month', (#{Subscription.subscription_at_in_timezone_sql})) = ?", today.month)
+      .where("DATE_PART('day', (#{Subscription.subscription_at_in_timezone_sql})) IN (?)", days)
       .select(:id).to_sql
   end
 
@@ -150,7 +150,7 @@ class BillingService
       .joins(:plan, customer: :organization)
       .anniversary
       .merge(Plan.yearly.where(bill_charges_monthly: true))
-      .where("DATE_PART('day', (#{Subscription.subscription_date_in_timezone_sql})) IN (?)", days)
+      .where("DATE_PART('day', (#{Subscription.subscription_at_in_timezone_sql})) IN (?)", days)
       .select(:id).to_sql
   end
 

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -13,7 +13,7 @@ module Subscriptions
         .joins(customer: :organization)
         .pending
         .where(previous_subscription: nil)
-        .where("DATE(#{Subscription.subscription_date_in_timezone_sql}) = ?", Time.zone.at(timestamp).to_date)
+        .where("DATE(#{Subscription.subscription_at_in_timezone_sql}) = ?", Time.zone.at(timestamp).to_date)
         .find_each do |subscription|
           subscription.mark_as_active!(Time.zone.at(timestamp))
 

--- a/app/services/subscriptions/dates/monthly_service.rb
+++ b/app/services/subscriptions/dates/monthly_service.rb
@@ -44,11 +44,11 @@ module Subscriptions
       end
 
       def compute_to_date(from_date = compute_from_date)
-        return from_date.end_of_month if subscription.calendar? || subscription_date.day == 1
+        return from_date.end_of_month if subscription.calendar? || subscription_at.day == 1
 
         year = from_date.year
         month = from_date.month + 1
-        day = subscription_date.day - 1
+        day = subscription_at.day - 1
 
         if month > 12
           month = 1
@@ -63,7 +63,7 @@ module Subscriptions
 
         year = billing_date.year
         month = billing_date.month
-        day = subscription_date.day
+        day = subscription_at.day
 
         # NOTE: we need the last day of the period, and not the first of the next one
         result_date = build_date(year, month, day) - 1.day
@@ -87,7 +87,7 @@ module Subscriptions
       def previous_anniversary_day(date)
         year = nil
         month = nil
-        day = subscription_date.day
+        day = subscription_at.day
 
         if date.day < day
           year = date.month == 1 ? date.year - 1 : date.year

--- a/app/services/subscriptions/dates/weekly_service.rb
+++ b/app/services/subscriptions/dates/weekly_service.rb
@@ -45,7 +45,7 @@ module Subscriptions
 
       def compute_next_end_of_period
         return billing_date.end_of_week if calendar?
-        return billing_date if billing_date.wday == (subscription_date - 1.day).wday
+        return billing_date if billing_date.wday == (subscription_at - 1.day).wday
 
         # NOTE: we need the last day of the period, and not the first of the next one
         billing_date.next_occurring(subscription_day_name) - 1.day
@@ -58,13 +58,13 @@ module Subscriptions
       end
 
       def previous_anniversary_day(date)
-        return date if date.wday == subscription_date.wday
+        return date if date.wday == subscription_at.wday
 
         date.prev_occurring(subscription_day_name)
       end
 
       def subscription_day_name
-        @subscription_day_name ||= subscription_date.strftime('%A').downcase.to_sym
+        @subscription_day_name ||= subscription_at.strftime('%A').downcase.to_sym
       end
 
       def compute_duration(*)

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -6,7 +6,7 @@ module Subscriptions
       def first_month_in_yearly_period?
         return billing_date.month == 1 if calendar?
 
-        monthly_service.compute_from_date(billing_date).month == subscription_date.month
+        monthly_service.compute_from_date(billing_date).month == subscription_at.month
       end
 
       private
@@ -28,11 +28,11 @@ module Subscriptions
       end
 
       def compute_to_date(from_date = compute_from_date)
-        return from_date.end_of_year if subscription.calendar? || subscription_date.yday == 1
+        return from_date.end_of_year if subscription.calendar? || subscription_at.yday == 1
 
         year = from_date.year + 1
         month = from_date.month
-        day = subscription_date.day - 1
+        day = subscription_at.day - 1
 
         build_date(year, month, day)
       end
@@ -61,8 +61,8 @@ module Subscriptions
         return billing_date.end_of_year if calendar?
 
         year = billing_date.year
-        month = subscription_date.month
-        day = subscription_date.day
+        month = subscription_at.month
+        day = subscription_at.day
 
         # NOTE: we need the last day of the period, and not the first of the next one
         result_date = build_date(year, month, day) - 1.day
@@ -78,9 +78,9 @@ module Subscriptions
       end
 
       def previous_anniversary_day(date)
-        year = date.month < subscription_date.month ? date.year - 1 : date.year
-        month = subscription_date.month
-        day = subscription_date.day
+        year = (date.month < subscription_at.month) ? (date.year - 1) : date.year
+        month = subscription_at.month
+        day = subscription_at.day
 
         build_date(year, month, day)
       end

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -101,7 +101,7 @@ module Subscriptions
 
     attr_accessor :subscription, :billing_at, :current_usage
 
-    delegate :plan, :subscription_date, :calendar?, :customer, to: :subscription
+    delegate :plan, :subscription_at, :calendar?, :customer, to: :subscription
 
     def billing_date
       @billing_date ||= billing_at.in_time_zone(customer.applicable_timezone).to_date

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -101,7 +101,7 @@ module Subscriptions
 
     attr_accessor :subscription, :billing_at, :current_usage
 
-    delegate :plan, :subscription_at, :calendar?, :customer, to: :subscription
+    delegate :plan, :calendar?, :customer, to: :subscription
 
     def billing_date
       @billing_date ||= billing_at.in_time_zone(customer.applicable_timezone).to_date
@@ -109,6 +109,10 @@ module Subscriptions
 
     def base_date
       @base_date ||= current_usage ? billing_date : compute_base_date
+    end
+
+    def subscription_at
+      subscription.subscription_at.in_time_zone(customer.applicable_timezone)
     end
 
     def customer_timezone_shift(date, end_of_day: false)

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -9,9 +9,9 @@ module Subscriptions
       subscription.name = args[:name] if args.key?(:name)
 
       if subscription.starting_in_the_future? && args.key?(:subscription_date)
-        subscription.subscription_date = args[:subscription_date]
+        subscription.subscription_at = args[:subscription_date]
 
-        process_subscription_date_change(subscription)
+        process_subscription_at_change(subscription)
       else
         subscription.save!
       end
@@ -29,9 +29,9 @@ module Subscriptions
       subscription.name = params[:name] if params.key?(:name)
 
       if subscription.starting_in_the_future? && params.key?(:subscription_date)
-        subscription.subscription_date = params[:subscription_date]
+        subscription.subscription_at = params[:subscription_date]
 
-        process_subscription_date_change(subscription)
+        process_subscription_at_change(subscription)
       else
         subscription.save!
       end
@@ -44,14 +44,14 @@ module Subscriptions
 
     private
 
-    def process_subscription_date_change(subscription)
-      if subscription.subscription_date <= Time.current.to_date
-        subscription.mark_as_active!(subscription.subscription_date.beginning_of_day)
+    def process_subscription_at_change(subscription)
+      if subscription.subscription_at <= Time.current
+        subscription.mark_as_active!(subscription.subscription_at)
       else
         subscription.save!
       end
 
-      return unless subscription.plan.pay_in_advance? && subscription.subscription_date.today?
+      return unless subscription.plan.pay_in_advance? && subscription.subscription_at.today?
 
       BillSubscriptionJob.perform_later([subscription], Time.current.to_i)
     end

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -35,7 +35,7 @@ module Subscriptions
     end
 
     def valid_subscription_date?
-      return true if args[:subscription_date].is_a?(Date)
+      return true if args[:subscription_date].respond_to?(:strftime)
       return true if args[:subscription_date].is_a?(String) && Date._strptime(args[:subscription_date]).present?
 
       add_error(field: :subscription_date, error_code: 'invalid_date')

--- a/db/migrate/20221206094412_change_subscription_date_type.rb
+++ b/db/migrate/20221206094412_change_subscription_date_type.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ChangeSubscriptionDateType < ActiveRecord::Migration[7.0]
+  def up
+    add_column :subscriptions, :subscription_at, :datetime
+
+    execute <<-SQL
+      UPDATE subscriptions
+      SET subscription_at = subscription_date::timestamp
+      WHERE subscription_date IS NOT NULL;
+    SQL
+
+    remove_column :subscriptions, :subscription_date
+  end
+
+  def down
+    add_column :subscriptions, :subscription_date, :date
+
+    execute <<-SQL
+      UPDATE subscriptions
+      SET subscription_date = DATE(subscription_at)
+      WHERE subscription_at IS NOT NULL;
+      WHERE
+    SQL
+
+    remove_column :subscriptions, :subscription_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -473,10 +473,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_142739) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "previous_subscription_id"
-    t.date "subscription_date"
     t.string "name"
     t.string "external_id", null: false
     t.integer "billing_time", default: 0, null: false
+    t.datetime "subscription_at"
     t.index ["customer_id"], name: "index_subscriptions_on_customer_id"
     t.index ["external_id"], name: "index_subscriptions_on_external_id"
     t.index ["plan_id"], name: "index_subscriptions_on_plan_id"

--- a/db/seeds/base.rb
+++ b/db/seeds/base.rb
@@ -64,7 +64,7 @@ Charge.create_with(
 
   sub = Subscription.create_with(
     started_at: Time.current - 3.months,
-    subscription_date: (Time.current - 3.months).to_date,
+    subscription_at: Time.current - 3.months,
     status: :active,
   ).find_or_create_by!(
     customer: customer,

--- a/db/seeds/groups.rb
+++ b/db/seeds/groups.rb
@@ -35,7 +35,7 @@ customer = Customer.create_with(
 
 subscription = Subscription.create_with(
   started_at: Time.current - 3.months,
-  subscription_date: (Time.current - 3.months).to_date,
+  subscription_at: Time.current - 3.months,
   status: :active,
 ).find_or_create_by!(
   customer: customer,

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
     create(
       :subscription,
       started_at: started_at,
-      subscription_date: subscription_date,
+      subscription_at: subscription_at,
       billing_time: :anniversary,
     )
   end
 
-  let(:subscription_date) { DateTime.parse('2022-06-09') }
-  let(:started_at) { subscription_date }
+  let(:subscription_at) { DateTime.parse('2022-06-09') }
+  let(:started_at) { subscription_at }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:group) { nil }
@@ -66,7 +66,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
           create(
             :subscription,
             started_at: started_at,
-            subscription_date: subscription_date,
+            subscription_at: subscription_at,
             billing_time: :anniversary,
             terminated_at: to_datetime,
             status: :terminated,
@@ -84,7 +84,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
           create(
             :subscription,
             started_at: started_at,
-            subscription_date: subscription_date,
+            subscription_at: subscription_at,
             billing_time: :anniversary,
             terminated_at: to_datetime,
             status: :terminated,
@@ -200,7 +200,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
           create(
             :subscription,
             started_at: started_at,
-            subscription_date: subscription_date,
+            subscription_at: subscription_at,
             billing_time: :anniversary,
             terminated_at: to_datetime,
             status: :terminated,
@@ -227,7 +227,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
           create(
             :subscription,
             started_at: started_at,
-            subscription_date: subscription_date,
+            subscription_at: subscription_at,
             billing_time: :anniversary,
             terminated_at: to_datetime,
             status: :terminated,

--- a/spec/services/billing_service_spec.rb
+++ b/spec/services/billing_service_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe BillingService, type: :service do
   describe '.call' do
     let(:plan) { create(:plan, interval: interval, bill_charges_monthly: bill_charges_monthly) }
     let(:bill_charges_monthly) { false }
-    let(:subscription_date) { DateTime.parse('20 Feb 2021') }
+    let(:subscription_at) { DateTime.parse('20 Feb 2021') }
     let(:customer) { create(:customer) }
 
     let(:subscription) do
       create(
         :subscription,
         plan: plan,
-        subscription_date: subscription_date,
+        subscription_at: subscription_at,
         started_at: Time.zone.now,
         billing_time: billing_time,
       )
@@ -32,7 +32,7 @@ RSpec.describe BillingService, type: :service do
           :subscription,
           customer: customer,
           plan: plan,
-          subscription_date: subscription_date,
+          subscription_at: subscription_at,
           started_at: Time.zone.now,
         )
       end
@@ -42,7 +42,7 @@ RSpec.describe BillingService, type: :service do
           :subscription,
           customer: customer,
           plan: plan,
-          subscription_date: subscription_date,
+          subscription_at: subscription_at,
           started_at: Time.zone.now,
         )
       end
@@ -51,7 +51,7 @@ RSpec.describe BillingService, type: :service do
         create(
           :subscription,
           plan: plan,
-          subscription_date: subscription_date,
+          subscription_at: subscription_at,
           started_at: Time.zone.now,
         )
       end
@@ -152,10 +152,10 @@ RSpec.describe BillingService, type: :service do
       let(:interval) { :weekly }
       let(:billing_time) { :anniversary }
 
-      let(:subscription_date) { DateTime.now.prev_occurring(DateTime.now.strftime('%A').downcase.to_sym) }
+      let(:subscription_at) { DateTime.now.prev_occurring(DateTime.now.strftime('%A').downcase.to_sym) }
 
       let(:current_date) do
-        DateTime.parse('20 Jun 2022').prev_occurring(subscription_date.strftime('%A').downcase.to_sym)
+        DateTime.parse('20 Jun 2022').prev_occurring(subscription_at.strftime('%A').downcase.to_sym)
       end
 
       it 'enqueues a job on billing day' do
@@ -177,7 +177,7 @@ RSpec.describe BillingService, type: :service do
     context 'when billed monthly with anniversary billing time' do
       let(:interval) { :monthly }
       let(:billing_time) { :anniversary }
-      let(:current_date) { subscription_date.next_month }
+      let(:current_date) { subscription_at.next_month }
 
       it 'enqueues a job on billing day' do
         travel_to(current_date) do
@@ -195,7 +195,7 @@ RSpec.describe BillingService, type: :service do
       end
 
       context 'when subscription anniversary is on a 31st' do
-        let(:subscription_date) { DateTime.parse('31 Mar 2021') }
+        let(:subscription_at) { DateTime.parse('31 Mar 2021') }
         let(:current_date) { DateTime.parse('28 Feb 2022') }
 
         it 'enqueues a job if the month count less than 31 days' do
@@ -213,7 +213,7 @@ RSpec.describe BillingService, type: :service do
       let(:interval) { :yearly }
       let(:billing_time) { :anniversary }
 
-      let(:current_date) { subscription_date.next_year }
+      let(:current_date) { subscription_at.next_year }
 
       it 'enqueues a job on billing day' do
         travel_to(current_date) do
@@ -231,7 +231,7 @@ RSpec.describe BillingService, type: :service do
       end
 
       context 'when subscription anniversary is on 29th of february' do
-        let(:subscription_date) { DateTime.parse('29 Feb 2020') }
+        let(:subscription_at) { DateTime.parse('29 Feb 2020') }
         let(:current_date) { DateTime.parse('28 Feb 2022') }
 
         it 'enqueues a job on 28th of february when year is not a leap year' do
@@ -246,7 +246,7 @@ RSpec.describe BillingService, type: :service do
 
       context 'when charges are billed monthly' do
         let(:bill_charges_monthly) { true }
-        let(:current_date) { subscription_date.next_month }
+        let(:current_date) { subscription_at.next_month }
 
         it 'enqueues a job on billing day' do
           travel_to(current_date.next_month) do
@@ -258,7 +258,7 @@ RSpec.describe BillingService, type: :service do
         end
 
         context 'when subscription anniversary is on a 31st' do
-          let(:subscription_date) { DateTime.parse('31 Mar 2021') }
+          let(:subscription_at) { DateTime.parse('31 Mar 2021') }
           let(:current_date) { DateTime.parse('28 Feb 2022') }
 
           it 'enqueues a job if the month count less than 31 days' do
@@ -277,7 +277,7 @@ RSpec.describe BillingService, type: :service do
       let(:subscription) do
         create(
           :subscription,
-          subscription_date: subscription_date,
+          subscription_at: subscription_at,
           started_at: Time.zone.now,
           previous_subscription: previous_subscription,
           status: :pending,
@@ -287,7 +287,7 @@ RSpec.describe BillingService, type: :service do
       let(:previous_subscription) do
         create(
           :subscription,
-          subscription_date: subscription_date,
+          subscription_at: subscription_at,
           started_at: Time.zone.now,
           billing_time: :anniversary,
         )

--- a/spec/services/credit_notes/create_from_upgrade_spec.rb
+++ b/spec/services/credit_notes/create_from_upgrade_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CreditNotes::CreateFromUpgrade, type: :service do
   subject(:create_service) { described_class.new(subscription: subscription) }
 
   let(:started_at) { Time.zone.parse('2022-09-01 10:00') }
-  let(:subscription_date) { Time.zone.parse('2022-09-01 10:00') }
+  let(:subscription_at) { Time.zone.parse('2022-09-01 10:00') }
   let(:terminated_at) { Time.zone.parse('2022-10-15 10:00') }
 
   let(:subscription) do
@@ -14,7 +14,7 @@ RSpec.describe CreditNotes::CreateFromUpgrade, type: :service do
       :subscription,
       plan: plan,
       status: :terminated,
-      subscription_date: subscription_date,
+      subscription_at: subscription_at,
       started_at: started_at,
       terminated_at: terminated_at,
       billing_time: :calendar,

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Fees::SubscriptionService do
 
   let(:started_at) { Time.zone.parse('2022-01-01 00:01') }
   let(:created_at) { started_at }
-  let(:subscription_date) { started_at }
+  let(:subscription_at) { started_at }
 
   let(:plan) do
     create(
@@ -38,7 +38,7 @@ RSpec.describe Fees::SubscriptionService do
       :subscription,
       plan: plan,
       started_at: started_at,
-      subscription_date: subscription_date,
+      subscription_at: subscription_at,
       customer: customer,
       created_at: created_at,
       external_id: 'sub_id',
@@ -279,7 +279,7 @@ RSpec.describe Fees::SubscriptionService do
 
         context 'when subscription is created in the past' do
           context 'when plan is pay in advance' do
-            let(:created_at) { subscription_date + 2.days }
+            let(:created_at) { subscription_at + 2.days }
 
             before { plan.update(pay_in_advance: true) }
 
@@ -291,7 +291,7 @@ RSpec.describe Fees::SubscriptionService do
           end
 
           context 'when subscription has started before previous billing period' do
-            let(:created_at) { subscription_date + 8.days }
+            let(:created_at) { subscription_at + 8.days }
 
             let(:boundaries) do
               {
@@ -507,7 +507,7 @@ RSpec.describe Fees::SubscriptionService do
             :subscription,
             plan: plan,
             started_at: started_at,
-            subscription_date: DateTime.parse('2022-08-31'),
+            subscription_at: DateTime.parse('2022-08-31'),
             billing_time: :anniversary,
             customer: customer,
             external_id: 'sub_id',
@@ -780,7 +780,7 @@ RSpec.describe Fees::SubscriptionService do
         plan: plan,
         status: :terminated,
         started_at: started_at,
-        subscription_date: subscription_date,
+        subscription_at: subscription_at,
         customer: customer,
         external_id: 'sub_id',
       )
@@ -907,7 +907,7 @@ RSpec.describe Fees::SubscriptionService do
         :subscription,
         plan: plan,
         started_at: started_at,
-        subscription_date: subscription_date,
+        subscription_at: subscription_at,
         previous_subscription: previous_subscription,
         customer: customer,
         external_id: 'sub_id',

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       create(
         :subscription,
         plan: plan,
-        subscription_date: started_at.to_date,
+        subscription_at: started_at.to_date,
         started_at: started_at,
         created_at: started_at,
       )
@@ -69,7 +69,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           create(
             :subscription,
             plan: plan,
-            subscription_date: started_at.to_date,
+            subscription_at: started_at.to_date,
             started_at: started_at,
             created_at: timestamp,
           )
@@ -101,13 +101,13 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       context 'when subscription is billed on anniversary date' do
         let(:timestamp) { DateTime.parse('07 Mar 2022') }
         let(:started_at) { DateTime.parse('06 Jun 2021').to_date }
-        let(:subscription_date) { started_at }
+        let(:subscription_at) { started_at }
 
         let(:subscription) do
           create(
             :subscription,
             plan: plan,
-            subscription_date: subscription_date,
+            subscription_at: subscription_at,
             started_at: started_at,
             billing_time: :anniversary,
             created_at: started_at,
@@ -162,7 +162,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           :subscription,
           plan: plan,
           customer: subscription.customer,
-          subscription_date: (Time.zone.now - 2.years).to_date,
+          subscription_at: (Time.zone.now - 2.years).to_date,
           started_at: Time.zone.now - 2.years,
         )
       end
@@ -197,7 +197,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         create(
           :subscription,
           plan: plan,
-          subscription_date: started_at.to_date,
+          subscription_at: started_at.to_date,
           started_at: started_at,
           created_at: started_at,
         )
@@ -216,7 +216,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           expect(result.invoice.fees.first.properties['to_datetime'])
             .to match_datetime((timestamp - 1.day).end_of_day)
           expect(result.invoice.fees.first.properties['from_datetime'])
-            .to match_datetime(subscription.subscription_date.beginning_of_day)
+            .to match_datetime(subscription.subscription_at.beginning_of_day)
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
@@ -250,13 +250,13 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       context 'when subscription is billed on anniversary date' do
         let(:timestamp) { DateTime.parse('07 Mar 2022') }
         let(:started_at) { DateTime.parse('06 Jun 2021').to_date }
-        let(:subscription_date) { started_at }
+        let(:subscription_at) { started_at }
 
         let(:subscription) do
           create(
             :subscription,
             plan: plan,
-            subscription_date: subscription_date,
+            subscription_at: subscription_at,
             started_at: started_at,
             billing_time: :anniversary,
             created_at: started_at,
@@ -305,7 +305,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         create(
           :subscription,
           plan: plan,
-          subscription_date: started_at.to_date,
+          subscription_at: started_at.to_date,
           started_at: started_at,
           created_at: started_at,
         )
@@ -324,7 +324,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           expect(result.invoice.fees.first.properties['to_datetime'])
             .to match_datetime((timestamp - 1.day).end_of_day)
           expect(result.invoice.fees.first.properties['from_datetime'])
-            .to match_datetime(subscription.subscription_date.beginning_of_day)
+            .to match_datetime(subscription.subscription_at.beginning_of_day)
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
@@ -358,13 +358,13 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       context 'when subscription is billed on anniversary date' do
         let(:timestamp) { DateTime.parse('07 Jun 2022') }
         let(:started_at) { DateTime.parse('06 Jun 2020').to_date }
-        let(:subscription_date) { started_at }
+        let(:subscription_at) { started_at }
 
         let(:subscription) do
           create(
             :subscription,
             plan: plan,
-            subscription_date: subscription_date,
+            subscription_at: subscription_at,
             started_at: started_at,
             billing_time: :anniversary,
             created_at: started_at,
@@ -416,7 +416,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         create(
           :subscription,
           plan: plan,
-          subscription_date: started_at.to_date,
+          subscription_at: started_at.to_date,
           started_at: started_at,
           created_at: started_at,
         )
@@ -430,7 +430,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
           expect(result.invoice.fees.first.properties['to_datetime']).to match_datetime((timestamp - 1.day).end_of_day)
           expect(result.invoice.fees.first.properties['from_datetime'])
-            .to match_datetime(subscription.subscription_date.beginning_of_day)
+            .to match_datetime(subscription.subscription_at.beginning_of_day)
           expect(result.invoice.subscriptions.first).to eq(subscription)
           expect(result.invoice.fees.subscription_kind.count).to eq(1)
           expect(result.invoice.fees.charge_kind.count).to eq(1)
@@ -450,7 +450,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         create(
           :subscription,
           plan: plan,
-          subscription_date: started_at.to_date,
+          subscription_at: started_at.to_date,
           started_at: started_at,
           status: :terminated,
           terminated_at: terminated_at,
@@ -473,13 +473,13 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       context 'when subscription is billed on anniversary date' do
         let(:timestamp) { DateTime.parse('07 Mar 2022') }
         let(:started_at) { DateTime.parse('06 Jun 2021').to_date }
-        let(:subscription_date) { started_at }
+        let(:subscription_at) { started_at }
 
         let(:subscription) do
           create(
             :subscription,
             plan: plan,
-            subscription_date: subscription_date,
+            subscription_at: subscription_at,
             started_at: started_at,
             status: :terminated,
             billing_time: :anniversary,
@@ -516,7 +516,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         create(
           :subscription,
           plan: previous_plan,
-          subscription_date: started_at.to_date,
+          subscription_at: started_at.to_date,
           started_at: started_at,
           status: :terminated,
           terminated_at: terminated_at,
@@ -528,7 +528,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           :subscription,
           plan: plan,
           previous_subscription: previous_subscription,
-          subscription_date: started_at.to_date,
+          subscription_at: started_at.to_date,
           started_at: terminated_at + 1.day,
           created_at: terminated_at + 1.day,
         )
@@ -559,7 +559,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         create(
           :subscription,
           plan: next_plan,
-          subscription_date: started_at.to_date,
+          subscription_at: started_at.to_date,
           started_at: terminated_at,
           status: :active,
           billing_time: :calendar,
@@ -576,7 +576,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         create(
           :subscription,
           plan: plan,
-          subscription_date: started_at.to_date,
+          subscription_at: started_at.to_date,
           started_at: started_at,
           status: :terminated,
           terminated_at: terminated_at,

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Invoices::CreateService, type: :service do
       create(
         :subscription,
         plan: plan,
-        subscription_date: started_at.to_date,
+        subscription_at: started_at.to_date,
         started_at: started_at,
         created_at: started_at,
       )

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -92,14 +92,14 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
       context 'when subscription is billed on anniversary date' do
         let(:current_date) { DateTime.parse('2022-06-22') }
         let(:started_at) { DateTime.parse('2022-03-07') }
-        let(:subscription_date) { started_at }
+        let(:subscription_at) { started_at }
 
         let(:subscription) do
           create(
             :subscription,
             plan: plan,
             customer: customer,
-            subscription_date: subscription_date,
+            subscription_at: subscription_at,
             started_at: started_at,
             billing_time: :anniversary,
           )
@@ -157,14 +157,14 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
       context 'when subscription is billed on anniversary date' do
         let(:current_date) { DateTime.parse('2022-06-22') }
         let(:started_at) { DateTime.parse('2022-03-07') }
-        let(:subscription_date) { started_at }
+        let(:subscription_at) { started_at }
 
         let(:subscription) do
           create(
             :subscription,
             plan: plan,
             customer: customer,
-            subscription_date: subscription_date,
+            subscription_at: subscription_at,
             started_at: started_at,
             billing_time: :anniversary,
           )
@@ -222,14 +222,14 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
       context 'when subscription is billed on anniversary date' do
         let(:current_date) { DateTime.parse('2022-06-22') }
         let(:started_at) { DateTime.parse('2021-03-07') }
-        let(:subscription_date) { started_at }
+        let(:subscription_at) { started_at }
 
         let(:subscription) do
           create(
             :subscription,
             plan: plan,
             customer: customer,
-            subscription_date: subscription_date,
+            subscription_at: subscription_at,
             started_at: started_at,
             billing_time: :anniversary,
           )

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Subscriptions::ActivateService, type: :service do
 
   describe 'activate_all_expired' do
     let(:active_subscription) { create(:active_subscription) }
-    let(:pending_subscriptions) { create_list(:pending_subscription, 3, subscription_date: timestamp.to_date) }
+    let(:pending_subscriptions) { create_list(:pending_subscription, 3, subscription_at: timestamp) }
 
     let(:future_pending_subscriptions) do
-      create_list(:pending_subscription, 2, subscription_date: (timestamp + 10.days).to_date)
+      create_list(:pending_subscription, 2, subscription_at: (timestamp + 10.days))
     end
 
     before do
@@ -36,7 +36,7 @@ RSpec.describe Subscriptions::ActivateService, type: :service do
         future_pending_subscriptions
 
         pending_subscription.customer.update!(timezone: 'America/New_York')
-        pending_subscription.update!(subscription_date: DateTime.parse('2022-10-21').to_date)
+        pending_subscription.update!(subscription_at: DateTime.parse('2022-10-21'))
       end
 
       it 'takes timezone into account' do

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         expect(subscription.customer_id).to eq(customer.id)
         expect(subscription.plan_id).to eq(plan.id)
         expect(subscription.started_at).to be_present
-        expect(subscription.subscription_date).to be_present
+        expect(subscription.subscription_at).to be_present
         expect(subscription.name).to eq('invoice display name')
         expect(subscription).to be_active
         expect(subscription.external_id).to eq(external_id)
@@ -130,12 +130,12 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           expect(subscription.customer.external_id).to eq(params[:external_customer_id])
           expect(subscription.plan_id).to eq(plan.id)
           expect(subscription.started_at).to be_present
-          expect(subscription.subscription_date).to be_present
+          expect(subscription.subscription_at).to be_present
           expect(subscription).to be_active
         end
       end
 
-      context 'when plan is pay_in_advance and subscription_date is current date' do
+      context 'when plan is pay_in_advance and subscription_at is current date' do
         before { plan.update(pay_in_advance: true) }
 
         it 'enqueued a job to bill the subscription' do
@@ -148,7 +148,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         end
       end
 
-      context 'when plan is pay_in_advance and subscription_date is in the future' do
+      context 'when plan is pay_in_advance and subscription_at is in the future' do
         let(:params) do
           {
             external_customer_id: customer.external_id,
@@ -219,7 +219,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
       end
     end
 
-    context 'when subscription_date is given and is invalid' do
+    context 'when subscription_at is given and is invalid' do
       let(:params) do
         {
           external_customer_id: customer.external_id,
@@ -244,7 +244,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
       end
     end
 
-    context 'when subscription_date is given and is in the future' do
+    context 'when subscription_at is given and is in the future' do
       let(:params) do
         {
           external_customer_id: customer.external_id,
@@ -270,7 +270,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           expect(subscription.customer_id).to eq(customer.id)
           expect(subscription.plan_id).to eq(plan.id)
           expect(subscription.started_at).not_to be_present
-          expect(subscription.subscription_date).to eq((Time.current + 5.days).to_date)
+          expect(subscription.subscription_at).to eq((Time.current + 5.days).to_date)
           expect(subscription.name).to eq('invoice display name')
           expect(subscription).to be_pending
           expect(subscription.external_id).to eq(external_id)
@@ -279,7 +279,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
       end
     end
 
-    context 'when subscription_date is given and is in the past' do
+    context 'when subscription_at is given and is in the past' do
       let(:params) do
         {
           external_customer_id: customer.external_id,
@@ -305,7 +305,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           expect(subscription.customer_id).to eq(customer.id)
           expect(subscription.plan_id).to eq(plan.id)
           expect(subscription.started_at).to eq((Time.current - 5.days).beginning_of_day)
-          expect(subscription.subscription_date).to eq((Time.current - 5.days).to_date)
+          expect(subscription.subscription_at).to eq((Time.current - 5.days).to_date)
           expect(subscription.name).to eq('invoice display name')
           expect(subscription).to be_active
           expect(subscription.external_id).to eq(external_id)
@@ -353,7 +353,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           customer: customer,
           plan: plan,
           status: :active,
-          subscription_date: Time.zone.now.to_date,
+          subscription_at: Time.current,
           started_at: Time.zone.now,
         )
       end
@@ -449,7 +449,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
               expect(result.subscription.name).to eq('invoice display name new')
               expect(result.subscription.plan.id).to eq(higher_plan.id)
               expect(result.subscription.previous_subscription_id).to eq(subscription.id)
-              expect(result.subscription.subscription_date).to eq(subscription.subscription_date)
+              expect(result.subscription.subscription_at).to eq(subscription.subscription_at)
             end
           end
 
@@ -516,7 +516,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
               subscription.update!(
                 billing_time: :anniversary,
                 started_at: Time.zone.now - 40.days,
-                subscription_date: Time.zone.now - 40.days,
+                subscription_at: Time.zone.now - 40.days,
               )
 
               last_subscription_fee
@@ -599,7 +599,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
               expect(next_subscription).to be_pending
               expect(next_subscription.name).to eq('invoice display name new')
               expect(next_subscription.plan_id).to eq(lower_plan.id)
-              expect(next_subscription.subscription_date).to eq(subscription.subscription_date)
+              expect(next_subscription.subscription_at).to eq(subscription.subscription_at)
               expect(next_subscription.previous_subscription).to eq(subscription)
             end
           end
@@ -692,7 +692,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         expect(subscription.customer_id).to eq(customer.id)
         expect(subscription.plan_id).to eq(plan.id)
         expect(subscription.started_at).to be_present
-        expect(subscription.subscription_date).to be_present
+        expect(subscription.subscription_at).to be_present
         expect(subscription).to be_active
         expect(subscription).to be_anniversary
       end
@@ -756,7 +756,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
       end
     end
 
-    context 'when subscription_date is given and is invalid' do
+    context 'when subscription_at is given and is invalid' do
       let(:params) do
         {
           customer_id: customer.id,

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -429,7 +429,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2022-04-02 03:59:59 UTC')
+          expect(result).to eq('2022-04-01 03:59:59 UTC')
         end
       end
 
@@ -489,7 +489,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2022-02-02 05:00:00 UTC')
+          expect(result).to eq('2022-02-01 05:00:00 UTC')
         end
       end
 

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       :subscription,
       plan: plan,
       customer: customer,
-      subscription_date: subscription_date,
+      subscription_at: subscription_at,
       billing_time: billing_time,
       started_at: started_at,
     )
@@ -20,9 +20,9 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
   let(:plan) { create(:plan, interval: :monthly, pay_in_advance: pay_in_advance) }
   let(:pay_in_advance) { false }
 
-  let(:subscription_date) { DateTime.parse('02 Feb 2021') }
+  let(:subscription_at) { DateTime.parse('02 Feb 2021') }
   let(:billing_at) { DateTime.parse('07 Mar 2022') }
-  let(:started_at) { subscription_date }
+  let(:started_at) { subscription_at }
   let(:timezone) { 'UTC' }
 
   describe 'from_datetime' do
@@ -114,7 +114,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
         context 'when billing day after last day of billing month' do
           let(:billing_at) { DateTime.parse('29 Mar 2022') }
-          let(:subscription_date) { DateTime.parse('31 Mar 2021') }
+          let(:subscription_at) { DateTime.parse('31 Mar 2021') }
 
           it 'returns the previous month last day' do
             expect(result).to eq('2022-02-28 00:00:00 UTC')
@@ -123,7 +123,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
         context 'when billing day on first month of the year' do
           let(:billing_at) { DateTime.parse('28 Jan 2022') }
-          let(:subscription_date) { DateTime.parse('29 Mar 2021') }
+          let(:subscription_at) { DateTime.parse('29 Mar 2021') }
 
           it 'returns the previous month last day' do
             expect(result).to eq('2021-12-29 00:00:00 UTC')
@@ -201,7 +201,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when billing subscription day does not exist in the month' do
-        let(:subscription_date) { DateTime.parse('31 Jan 2022') }
+        let(:subscription_at) { DateTime.parse('31 Jan 2022') }
         let(:billing_at) { DateTime.parse('01 Mar 2022') }
 
         it 'returns the last day of the month' do
@@ -210,7 +210,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when anniversary date is first day of the month' do
-        let(:subscription_date) { DateTime.parse('01 Jan 2022') }
+        let(:subscription_at) { DateTime.parse('01 Jan 2022') }
         let(:billing_at) { DateTime.parse('02 Mar 2022') }
 
         it 'returns the last day of the month' do
@@ -295,7 +295,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       context 'when plan is pay in advance' do
         let(:pay_in_advance) { true }
-        let(:subscription_date) { DateTime.parse('02 Feb 2020') }
+        let(:subscription_at) { DateTime.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
           expect(result).to eq('2022-02-01 00:00:00 UTC')
@@ -321,7 +321,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       context 'when plan is pay in advance' do
         let(:pay_in_advance) { true }
-        let(:subscription_date) { DateTime.parse('02 Feb 2020') }
+        let(:subscription_at) { DateTime.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
           expect(result).to eq('2022-02-02 00:00:00 UTC')
@@ -514,7 +514,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_date) { DateTime.parse('28 Feb 2019') }
+        let(:subscription_at) { DateTime.parse('28 Feb 2019') }
         let(:billing_at) { DateTime.parse('01 Mar 2020') }
 
         it 'returns the price of single day' do
@@ -531,7 +531,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_date) { DateTime.parse('02 Feb 2019') }
+        let(:subscription_at) { DateTime.parse('02 Feb 2019') }
         let(:billing_at) { DateTime.parse('08 Mar 2020') }
 
         it 'returns the price of single day' do
@@ -552,7 +552,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_date) { DateTime.parse('28 Feb 2019') }
+        let(:subscription_at) { DateTime.parse('28 Feb 2019') }
         let(:billing_at) { DateTime.parse('01 Mar 2020') }
 
         it 'returns the month duration' do
@@ -569,7 +569,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_date) { DateTime.parse('02 Feb 2019') }
+        let(:subscription_at) { DateTime.parse('02 Feb 2019') }
         let(:billing_at) { DateTime.parse('08 Mar 2020') }
 
         it 'returns the month duration' do

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       :subscription,
       plan: plan,
       customer: customer,
-      subscription_date: subscription_date,
+      subscription_at: subscription_at,
       billing_time: billing_time,
       started_at: started_at,
     )
@@ -20,9 +20,9 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
   let(:plan) { create(:plan, interval: :weekly, pay_in_advance: pay_in_advance) }
   let(:pay_in_advance) { false }
 
-  let(:subscription_date) { DateTime.parse('02 Feb 2021') }
+  let(:subscription_at) { DateTime.parse('02 Feb 2021') }
   let(:billing_at) { DateTime.parse('07 Mar 2022') }
-  let(:started_at) { subscription_date }
+  let(:started_at) { subscription_at }
   let(:timezone) { 'UTC' }
 
   describe 'from_datetime' do
@@ -87,7 +87,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
       it 'returns the previous week week day' do
         expect(result).to eq('2022-03-01 00:00:00 UTC')
-        expect(Time.zone.parse(result).wday).to eq(subscription_date.wday)
+        expect(Time.zone.parse(result).wday).to eq(subscription_at.wday)
       end
 
       context 'when date is before the start date' do
@@ -95,7 +95,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
         it 'returns the start date' do
           expect(result).to eq(started_at.utc.to_s)
-          expect(Time.zone.parse(result).wday).to eq(subscription_date.wday)
+          expect(Time.zone.parse(result).wday).to eq(subscription_at.wday)
         end
       end
 
@@ -104,7 +104,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
         it 'returns the previous week day' do
           expect(result).to eq('2022-03-08 00:00:00 UTC')
-          expect(Time.zone.parse(result).wday).to eq(subscription_date.wday)
+          expect(Time.zone.parse(result).wday).to eq(subscription_at.wday)
         end
 
         context 'when plan is pay in advance' do
@@ -112,7 +112,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
 
           it 'returns the current week week day' do
             expect(result).to eq('2022-03-08 00:00:00 UTC')
-            expect(Time.zone.parse(result).wday).to eq(subscription_date.wday)
+            expect(Time.zone.parse(result).wday).to eq(subscription_at.wday)
           end
         end
       end

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -387,7 +387,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2022-03-15 03:59:59 UTC')
+          expect(result).to eq('2022-03-14 03:59:59 UTC')
         end
       end
 
@@ -441,7 +441,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2022-02-22 05:00:00 UTC')
+          expect(result).to eq('2022-02-21 05:00:00 UTC')
         end
       end
 

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -493,7 +493,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2023-02-02 04:59:59 UTC')
+          expect(result).to eq('2023-02-01 04:59:59 UTC')
         end
       end
 
@@ -547,7 +547,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:timezone) { 'America/New_York' }
 
         it 'takes customer timezone into account' do
-          expect(result).to eq('2021-02-02 05:00:00 UTC')
+          expect(result).to eq('2021-02-01 05:00:00 UTC')
         end
       end
 

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       :subscription,
       plan: plan,
       customer: customer,
-      subscription_date: subscription_date,
+      subscription_at: subscription_at,
       billing_time: billing_time,
       started_at: started_at,
     )
@@ -20,9 +20,9 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
   let(:plan) { create(:plan, interval: :yearly, pay_in_advance: pay_in_advance) }
   let(:pay_in_advance) { false }
 
-  let(:subscription_date) { DateTime.parse('02 Feb 2021') }
+  let(:subscription_at) { DateTime.parse('02 Feb 2021') }
   let(:billing_at) { DateTime.parse('07 Mar 2022') }
-  let(:started_at) { subscription_date }
+  let(:started_at) { subscription_at }
   let(:timezone) { 'UTC' }
 
   describe 'from_datetime' do
@@ -31,7 +31,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
       let(:billing_at) { DateTime.parse('01 Jan 2022') }
-      let(:subscription_date) { DateTime.parse('02 Feb 2019') }
+      let(:subscription_at) { DateTime.parse('02 Feb 2019') }
 
       it 'returns the beginning of the previous year' do
         expect(result).to eq('2021-01-01 00:00:00 UTC')
@@ -112,7 +112,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         context 'when subscription date on 29/02 of a leap year' do
-          let(:subscription_date) { DateTime.parse('29 Feb 2020') }
+          let(:subscription_at) { DateTime.parse('29 Feb 2020') }
           let(:billing_at) { DateTime.parse('28 Mar 2022') }
 
           it 'returns the previous month last day' do
@@ -137,7 +137,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
       let(:billing_at) { DateTime.parse('01 Jan 2022') }
-      let(:subscription_date) { DateTime.parse('02 Feb 2020') }
+      let(:subscription_at) { DateTime.parse('02 Feb 2020') }
 
       it 'returns the end of the previous year' do
         expect(result).to eq('2021-12-31 23:59:59 UTC')
@@ -192,7 +192,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when subscription date on 29/02 of a leap year' do
-        let(:subscription_date) { DateTime.parse('29 Feb 2020') }
+        let(:subscription_at) { DateTime.parse('29 Feb 2020') }
         let(:billing_at) { DateTime.parse('01 Mar 2022') }
 
         it 'returns the previous month last day' do
@@ -201,7 +201,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when anniversary date is first day of the year' do
-        let(:subscription_date) { DateTime.parse('01 Jan 2021') }
+        let(:subscription_at) { DateTime.parse('01 Jan 2021') }
         let(:billing_at) { DateTime.parse('02 Mar 2022') }
 
         it 'returns the last day of the year' do
@@ -210,7 +210,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when anniversary date is first day of a month' do
-        let(:subscription_date) { DateTime.parse('01 Dec 2022') }
+        let(:subscription_at) { DateTime.parse('01 Dec 2022') }
         let(:billing_at) { DateTime.parse('02 Jan 2024') }
 
         it 'returns the last day of the previous month on next year' do
@@ -247,7 +247,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
       let(:billing_at) { DateTime.parse('01 Jan 2022') }
-      let(:subscription_date) { DateTime.parse('02 Feb 2020') }
+      let(:subscription_at) { DateTime.parse('02 Feb 2020') }
 
       it 'returns from_date' do
         expect(result).to eq(date_service.from_datetime.to_s)
@@ -294,7 +294,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when plan is pay in advance' do
         let(:pay_in_advance) { true }
-        let(:subscription_date) { DateTime.parse('02 Feb 2020') }
+        let(:subscription_at) { DateTime.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
           expect(result).to eq('2021-01-01 00:00:00 UTC')
@@ -336,7 +336,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       context 'when plan is pay in advance' do
         let(:pay_in_advance) { true }
-        let(:subscription_date) { DateTime.parse('02 Feb 2020') }
+        let(:subscription_at) { DateTime.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
           expect(result).to eq('2021-02-02 00:00:00 UTC')
@@ -423,7 +423,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
         context 'when plan is pay in advance' do
           let(:pay_in_advance) { true }
-          let(:subscription_date) { DateTime.parse('02 Feb 2020') }
+          let(:subscription_at) { DateTime.parse('02 Feb 2020') }
           let(:billing_at) { DateTime.parse('07 Mar 2022') }
 
           it 'returns the end of the current period' do
@@ -572,7 +572,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_date) { DateTime.parse('28 Feb 2019') }
+        let(:subscription_at) { DateTime.parse('28 Feb 2019') }
         let(:billing_at) { DateTime.parse('01 Jan 2021') }
 
         it 'returns the price of single day' do
@@ -589,7 +589,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_date) { DateTime.parse('02 Feb 2019') }
+        let(:subscription_at) { DateTime.parse('02 Feb 2019') }
         let(:billing_at) { DateTime.parse('08 Mar 2021') }
 
         it 'returns the price of single day' do
@@ -610,7 +610,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_date) { DateTime.parse('28 Feb 2019') }
+        let(:subscription_at) { DateTime.parse('28 Feb 2019') }
         let(:billing_at) { DateTime.parse('01 Jan 2021') }
 
         it 'returns the year duration' do
@@ -635,7 +635,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when on a leap year' do
-        let(:subscription_date) { DateTime.parse('02 Feb 2019') }
+        let(:subscription_at) { DateTime.parse('02 Feb 2019') }
         let(:billing_at) { DateTime.parse('08 Mar 2021') }
 
         it 'returns the year duration' do

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Subscriptions::DatesService, type: :service do
     create(
       :subscription,
       plan: plan,
-      subscription_date: subscription_date,
+      subscription_at: subscription_at,
       billing_time: :anniversary,
       started_at: started_at,
     )
@@ -18,9 +18,9 @@ RSpec.describe Subscriptions::DatesService, type: :service do
   let(:plan) { create(:plan, interval: interval, pay_in_advance: pay_in_advance) }
   let(:pay_in_advance) { false }
 
-  let(:subscription_date) { DateTime.parse('02 Feb 2021') }
+  let(:subscription_at) { DateTime.parse('02 Feb 2021') }
   let(:billing_date) { DateTime.parse('07 Mar 2022') }
-  let(:started_at) { subscription_date }
+  let(:started_at) { subscription_at }
   let(:interval) { :monthly }
 
   describe '#instance' do

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
   describe 'update' do
     let(:subscription_date) { '2022-07-07' }
 
-    before { subscription }
-
     let(:update_args) do
       {
         id: subscription.id,
@@ -21,6 +19,8 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
       }
     end
 
+    before { subscription }
+
     it 'updates the subscription' do
       result = update_service.update(**update_args)
 
@@ -28,11 +28,11 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
 
       aggregate_failures do
         expect(result.subscription.name).to eq('new name')
-        expect(result.subscription.subscription_date.to_s).not_to eq('2022-07-07')
+        expect(result.subscription.subscription_at.to_s).not_to eq('2022-07-07')
       end
     end
 
-    context 'when subscription_date is not passed at all' do
+    context 'when subscription_at is not passed at all' do
       let(:update_args) do
         {
           id: subscription.id,
@@ -47,7 +47,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
 
         aggregate_failures do
           expect(result.subscription.name).to eq('new name')
-          expect(result.subscription.subscription_date.to_s).not_to eq('2022-07-07')
+          expect(result.subscription.subscription_at.to_s).not_to eq('2022-07-07')
         end
       end
     end
@@ -55,14 +55,14 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
     context 'when subscription is starting in the future' do
       let(:subscription) { create(:pending_subscription) }
 
-      it 'updates the subscription_date as well' do
+      it 'updates the subscription_at as well' do
         result = update_service.update(**update_args)
 
         expect(result).to be_success
 
         aggregate_failures do
           expect(result.subscription.name).to eq('new name')
-          expect(result.subscription.subscription_date.to_s).to eq('2022-07-07')
+          expect(result.subscription.subscription_at.to_s).to eq('2022-07-07 00:00:00 UTC')
         end
       end
 
@@ -93,7 +93,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
     context 'with invalid id' do
       let(:update_args) do
         {
-          id: subscription.id + '123',
+          id: "#{subscription.id}123",
           name: 'new name',
         }
       end
@@ -131,14 +131,14 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
 
       aggregate_failures do
         expect(result.subscription.name).to eq('new name')
-        expect(result.subscription.subscription_date.to_s).not_to eq('2022-07-07')
+        expect(result.subscription.subscription_at.to_s).not_to eq('2022-07-07')
       end
     end
 
     context 'when subscription is starting in the future' do
       let(:subscription) { create(:pending_subscription, customer: customer) }
 
-      it 'updates the subscription_date as well' do
+      it 'updates the subscription_at as well' do
         result = update_service.update_from_api(
           organization: organization,
           external_id: subscription.external_id,
@@ -149,7 +149,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
 
         aggregate_failures do
           expect(result.subscription.name).to eq('new name')
-          expect(result.subscription.subscription_date.to_s).to eq('2022-07-07')
+          expect(result.subscription.subscription_at.to_s).to eq('2022-07-07 00:00:00 UTC')
         end
       end
     end
@@ -158,7 +158,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
       it 'returns an error' do
         result = update_service.update_from_api(
           organization: organization,
-          external_id: subscription.external_id + '123',
+          external_id: "#{subscription.external_id}123",
           params: update_args,
         )
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR turn the `subscription_date` (`date`) field into a `subscription_at` (`datetime`) for subscriptions.
For now, it does not changes the API contract, it will be handled in a new PR
