### PR TITLE
feat(timezones): Create and update subscription#subscription_at

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -7,7 +7,10 @@ module Api
         subscription_service = Subscriptions::CreateService.new
         result = subscription_service.create_from_api(
           organization: current_organization,
-          params: create_params,
+          params: SubscriptionLegacyInput.new(
+            current_organization,
+            create_params,
+          ).create_input,
         )
 
         if result.success?
@@ -45,10 +48,12 @@ module Api
       def update
         service = Subscriptions::UpdateService.new
 
-        result = service.update_from_api(
-          organization: current_organization,
-          external_id: params[:external_id],
-          params: update_params,
+        result = service.update(
+          subscription: current_organization.subscriptions.find_by(external_id: params[:external_id]),
+          args: SubscriptionLegacyInput.new(
+            current_organization,
+            update_params,
+          ).update_input,
         )
 
         if result.success?
@@ -86,11 +91,19 @@ module Api
 
       def create_params
         params.require(:subscription)
-          .permit(:external_customer_id, :plan_code, :name, :external_id, :billing_time, :subscription_date)
+          .permit(
+            :external_customer_id,
+            :plan_code,
+            :name,
+            :external_id,
+            :billing_time,
+            :subscription_date,
+            :subscription_at,
+          )
       end
 
       def update_params
-        params.require(:subscription).permit(:name, :subscription_date)
+        params.require(:subscription).permit(:name, :subscription_date, :subscription_at)
       end
     end
   end

--- a/app/graphql/mutations/subscriptions/create.rb
+++ b/app/graphql/mutations/subscriptions/create.rb
@@ -14,6 +14,9 @@ module Mutations
       argument :name, String, required: false
       argument :subscription_id, ID, required: false
       argument :billing_time, Types::Subscriptions::BillingTimeEnum, required: true
+      argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
+
+      # NOTE: LEGACY FIELDS
       argument :subscription_date, GraphQL::Types::ISO8601Date, required: false
 
       type Types::Subscriptions::Object
@@ -23,7 +26,12 @@ module Mutations
 
         result = ::Subscriptions::CreateService
           .new
-          .create(**args.merge(organization_id: current_organization.id))
+          .create(
+            SubscriptionLegacyInput.new(
+              current_organization,
+              args.merge(organization_id: current_organization.id),
+            ).create_input,
+          )
 
         result.success? ? result.subscription : result_error(result)
       end

--- a/app/graphql/mutations/subscriptions/update.rb
+++ b/app/graphql/mutations/subscriptions/update.rb
@@ -10,14 +10,25 @@ module Mutations
 
       argument :id, ID, required: true
       argument :name, String, required: false
+      argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
+
+      # NOTE: LEGACY FIELDS
       argument :subscription_date, GraphQL::Types::ISO8601Date, required: false
 
       type Types::Subscriptions::Object
 
       def resolve(**args)
+        subscription = context[:current_user].subscriptions.find_by(id: args[:id])
+
         result = ::Subscriptions::UpdateService
           .new(context[:current_user])
-          .update(**args)
+          .update(
+            subscription: subscription,
+            args: SubscriptionLegacyInput.new(
+              subscription&.organization,
+              args,
+            ).update_input,
+          )
 
         result.success? ? result.subscription : result_error(result)
       end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -17,7 +17,7 @@ module Types
       field :period_end_date, GraphQL::Types::ISO8601Date
 
       field :billing_time, Types::Subscriptions::BillingTimeEnum
-      field :subscription_date, GraphQL::Types::ISO8601Date
+      field :subscription_at, GraphQL::Types::ISO8601DateTime
       field :canceled_at, GraphQL::Types::ISO8601DateTime
       field :terminated_at, GraphQL::Types::ISO8601DateTime
       field :started_at, GraphQL::Types::ISO8601DateTime
@@ -46,8 +46,11 @@ module Types
           .next_end_of_period
       end
 
+      # NOTE: LEGACY FIELDS
+      field :subscription_date, GraphQL::Types::ISO8601Date
+
       def subscription_date
-        object.subscription_at.to_date
+        object.subscription_at&.to_date
       end
     end
   end

--- a/app/legacy_inputs/subscription_legacy_input.rb
+++ b/app/legacy_inputs/subscription_legacy_input.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SubscriptionLegacyInput < BaseLegacyInput
+  def create_input
+    if args[:subscription_date].present?
+      args[:subscription_at] ||= date_in_organization_timezone(args[:subscription_date], end_of_day: false)
+    end
+
+    args
+  end
+  alias update_input create_input
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_many :add_ons, through: :organizations
   has_many :credit_notes, through: :organizations
   has_many :wallets, through: :organizations
+  has_many :subscriptions, through: :customers
 
   validates :email, presence: true
   validates :password, presence: true

--- a/app/serializers/v1/legacy/subscription_serializer.rb
+++ b/app/serializers/v1/legacy/subscription_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module V1
+  module Legacy
+    class SubscriptionSerializer < ModelSerializer
+      def serialize
+        {
+          subscription_date: model.subscription_at&.to_date,
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -12,7 +12,7 @@ module V1
         plan_code: model.plan.code,
         status: model.status,
         billing_time: model.billing_time,
-        subscription_date: model.subscription_at&.to_date&.iso8601,
+        subscription_at: model.subscription_at&.iso8601,
         started_at: model.started_at&.iso8601,
         terminated_at: model.terminated_at&.iso8601,
         canceled_at: model.canceled_at&.iso8601,
@@ -20,7 +20,13 @@ module V1
         previous_plan_code: model.previous_subscription&.plan&.code,
         next_plan_code: model.next_subscription&.plan&.code,
         downgrade_plan_date: model.downgrade_plan_date&.iso8601,
-      }
+      }.merge(legacy_values)
+    end
+
+    private
+
+    def legacy_values
+      ::V1::Legacy::SubscriptionSerializer.new(model).serialize
     end
   end
 end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -28,7 +28,7 @@ module Subscriptions
       @name = params[:name]&.strip
       @external_id = params[:external_id]&.strip
       @billing_time = params[:billing_time]
-      @subscription_at = params[:subscription_date] || Time.current
+      @subscription_at = params[:subscription_at] || Time.current
       @current_subscription = editable_subscriptions&.find_by(external_id: external_id)
 
       process_create
@@ -38,7 +38,7 @@ module Subscriptions
       e.result
     end
 
-    def create(**args)
+    def create(args)
       @current_customer = Customer.find_by(
         id: args[:customer_id],
         organization_id: args[:organization_id],
@@ -53,7 +53,7 @@ module Subscriptions
       @name = args[:name]&.strip
       @external_id = SecureRandom.uuid
       @billing_time = args[:billing_time]
-      @subscription_at = args[:subscription_date] || Time.current
+      @subscription_at = args[:subscription_at] || Time.current
       @current_subscription = editable_subscriptions&.find_by(id: args[:subscription_id])
 
       process_create
@@ -62,7 +62,7 @@ module Subscriptions
     private
 
     def process_create
-      return result unless valid?(customer: current_customer, plan: current_plan, subscription_date: subscription_at)
+      return result unless valid?(customer: current_customer, plan: current_plan, subscription_at: subscription_at)
 
       ActiveRecord::Base.transaction do
         currency_result = Customers::UpdateService.new(nil).update_currency(

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -2,34 +2,13 @@
 
 module Subscriptions
   class UpdateService < BaseService
-    def update(**args)
-      subscription = Subscription.find_by(id: args[:id])
+    def update(subscription:, args:)
       return result.not_found_failure!(resource: 'subscription') unless subscription
 
       subscription.name = args[:name] if args.key?(:name)
 
-      if subscription.starting_in_the_future? && args.key?(:subscription_date)
-        subscription.subscription_at = args[:subscription_date]
-
-        process_subscription_at_change(subscription)
-      else
-        subscription.save!
-      end
-
-      result.subscription = subscription
-      result
-    rescue ActiveRecord::RecordInvalid => e
-      result.record_validation_failure!(record: e.record)
-    end
-
-    def update_from_api(organization:, external_id:, params:)
-      subscription = organization.subscriptions.find_by(external_id: external_id)
-      return result.not_found_failure!(resource: 'subscription') unless subscription
-
-      subscription.name = params[:name] if params.key?(:name)
-
-      if subscription.starting_in_the_future? && params.key?(:subscription_date)
-        subscription.subscription_at = params[:subscription_date]
+      if subscription.starting_in_the_future? && args.key?(:subscription_at)
+        subscription.subscription_at = args[:subscription_at]
 
         process_subscription_at_change(subscription)
       else

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -6,7 +6,7 @@ module Subscriptions
       return false unless valid_customer?
       return false unless valid_plan?
 
-      valid_subscription_date?
+      valid_subscription_at?
 
       if errors?
         result.validation_failure!(errors: errors)
@@ -34,11 +34,11 @@ module Subscriptions
       false
     end
 
-    def valid_subscription_date?
-      return true if args[:subscription_date].respond_to?(:strftime)
-      return true if args[:subscription_date].is_a?(String) && Date._strptime(args[:subscription_date]).present?
+    def valid_subscription_at?
+      return true if args[:subscription_at].respond_to?(:strftime)
+      return true if args[:subscription_at].is_a?(String) && DateTime._strptime(args[:subscription_at]).present?
 
-      add_error(field: :subscription_date, error_code: 'invalid_date')
+      add_error(field: :subscription_at, error_code: 'invalid_date')
 
       false
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1759,6 +1759,7 @@ input CreateSubscriptionInput {
   customerId: ID!
   name: String
   planId: ID!
+  subscriptionAt: ISO8601DateTime
   subscriptionDate: ISO8601Date
   subscriptionId: ID
 }
@@ -3981,6 +3982,7 @@ type Subscription {
   plan: Plan!
   startedAt: ISO8601DateTime
   status: StatusTypeEnum
+  subscriptionAt: ISO8601DateTime
   subscriptionDate: ISO8601Date
   terminatedAt: ISO8601DateTime
   updatedAt: ISO8601DateTime!
@@ -4892,6 +4894,7 @@ input UpdateSubscriptionInput {
   clientMutationId: String
   id: ID!
   name: String
+  subscriptionAt: ISO8601DateTime
   subscriptionDate: ISO8601Date
 }
 

--- a/schema.json
+++ b/schema.json
@@ -5771,6 +5771,18 @@
               "deprecationReason": null
             },
             {
+              "name": "subscriptionAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "subscriptionDate",
               "description": null,
               "type": {
@@ -16836,6 +16848,20 @@
               ]
             },
             {
+              "name": "subscriptionAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "subscriptionDate",
               "description": null,
               "type": {
@@ -19187,6 +19213,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -11,11 +11,13 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
     <<~GQL
       mutation($input: CreateSubscriptionInput!) {
         createSubscription(input: $input) {
-          id,
-          status,
-          name,
-          startedAt,
-          billingTime,
+          id
+          status
+          name
+          startedAt
+          billingTime
+          subscriptionAt
+          subscriptionDate
           customer {
             id
           },
@@ -52,6 +54,39 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
       expect(result_data['customer']['id']).to eq(customer.id)
       expect(result_data['plan']['id']).to eq(plan.id)
       expect(result_data['billingTime']).to eq('anniversary')
+    end
+  end
+
+  context 'with legacy subscription_date' do
+    it 'creates a subscription' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query: mutation,
+        variables: {
+          input: {
+            customerId: customer.id,
+            planId: plan.id,
+            name: 'invoice display name',
+            billingTime: 'anniversary',
+            subscriptionDate: '2022-12-06',
+          },
+        },
+      )
+
+      result_data = result['data']['createSubscription']
+
+      aggregate_failures do
+        expect(result_data['id']).to be_present
+        expect(result_data['status'].to_sym).to eq(:active)
+        expect(result_data['name']).to eq('invoice display name')
+        expect(result_data['startedAt']).to be_present
+        expect(result_data['customer']['id']).to eq(customer.id)
+        expect(result_data['plan']['id']).to eq(plan.id)
+        expect(result_data['billingTime']).to eq('anniversary')
+        expect(result_data['subscriptionDate']).to eq('2022-12-06')
+        expect(result_data['subscriptionAt']).to eq('2022-12-06T00:00:00Z')
+      end
     end
   end
 

--- a/spec/graphql/mutations/subscriptions/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_spec.rb
@@ -4,13 +4,23 @@ require 'rails_helper'
 
 RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
   let(:membership) { create(:membership) }
-  let(:subscription) { create(:subscription) }
+
+  let(:subscription) do
+    create(
+      :subscription,
+      organization: membership.organization,
+      subscription_at: Time.current + 3.days,
+    )
+  end
+
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateSubscriptionInput!) {
         updateSubscription(input: $input) {
-          id,
+          id
           name
+          subscriptionAt
+          subscriptionDate
         }
       }
     GQL
@@ -23,7 +33,7 @@ RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
       variables: {
         input: {
           id: subscription.id,
-          name: 'New name'
+          name: 'New name',
         },
       },
     )
@@ -35,6 +45,34 @@ RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
     end
   end
 
+  context 'with legacy subscription_date' do
+    let(:subscription_at) { Time.current + 4.days }
+
+    before { subscription.pending! }
+
+    it 'updates an subscription' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query: mutation,
+        variables: {
+          input: {
+            id: subscription.id,
+            name: 'New name',
+            subscriptionDate: subscription_at.to_date.iso8601,
+          },
+        },
+      )
+
+      result_data = result['data']['updateSubscription']
+
+      aggregate_failures do
+        expect(result_data['name']).to eq('New name')
+        expect(result_data['subscriptionDate']).to eq(subscription_at.to_date.iso8601)
+        expect(result_data['subscriptionAt']).to eq(subscription_at.beginning_of_day.iso8601)
+      end
+    end
+  end
+
   context 'without current_user' do
     it 'returns an error' do
       result = execute_graphql(
@@ -42,7 +80,7 @@ RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
         variables: {
           input: {
             id: subscription.id,
-            name: 'New name'
+            name: 'New name',
           },
         },
       )

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
             name: 'invoice display name',
             external_id: external_id,
             billing_time: 'anniversary',
-            subscription_date: (Time.current + 5.days).to_date,
+            subscription_at: Time.current + 5.days,
           }
         end
 
@@ -227,11 +227,11 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           name: 'invoice display name',
           external_id: external_id,
           billing_time: 'anniversary',
-          subscription_date: '2022-99-99',
+          subscription_at: '2022-99-99T00:00:00Z',
         }
       end
 
-      it 'returns invalid_date error' do
+      it 'returns invalid_at error' do
         result = create_service.create_from_api(
           organization: organization,
           params: params,
@@ -239,12 +239,13 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error.messages[:subscription_date]).to eq(['invalid_date'])
+          expect(result.error.messages[:subscription_at]).to eq(['invalid_date'])
         end
       end
     end
 
     context 'when subscription_at is given and is in the future' do
+      let(:subscription_at) { Time.current + 5.days }
       let(:params) do
         {
           external_customer_id: customer.external_id,
@@ -252,7 +253,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           name: 'invoice display name',
           external_id: external_id,
           billing_time: 'anniversary',
-          subscription_date: (Time.current + 5.days).to_date,
+          subscription_at: subscription_at,
         }
       end
 
@@ -270,7 +271,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           expect(subscription.customer_id).to eq(customer.id)
           expect(subscription.plan_id).to eq(plan.id)
           expect(subscription.started_at).not_to be_present
-          expect(subscription.subscription_at).to eq((Time.current + 5.days).to_date)
+          expect(subscription.subscription_at.to_s).to eq(subscription_at.to_s)
           expect(subscription.name).to eq('invoice display name')
           expect(subscription).to be_pending
           expect(subscription.external_id).to eq(external_id)
@@ -280,6 +281,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
     end
 
     context 'when subscription_at is given and is in the past' do
+      let(:subscription_at) { Time.current - 5.days }
       let(:params) do
         {
           external_customer_id: customer.external_id,
@@ -287,7 +289,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           name: 'invoice display name',
           external_id: external_id,
           billing_time: 'anniversary',
-          subscription_date: (Time.current - 5.days).to_date,
+          subscription_at: subscription_at,
         }
       end
 
@@ -304,8 +306,8 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         aggregate_failures do
           expect(subscription.customer_id).to eq(customer.id)
           expect(subscription.plan_id).to eq(plan.id)
-          expect(subscription.started_at).to eq((Time.current - 5.days).beginning_of_day)
-          expect(subscription.subscription_at).to eq((Time.current - 5.days).to_date)
+          expect(subscription.started_at.to_s).to eq(subscription_at.to_s)
+          expect(subscription.subscription_at.to_s).to eq(subscription_at.to_s)
           expect(subscription.name).to eq('invoice display name')
           expect(subscription).to be_active
           expect(subscription.external_id).to eq(external_id)
@@ -763,7 +765,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           plan_id: plan.id,
           organization_id: organization.id,
           billing_time: :anniversary,
-          subscription_date: '2022-99-99',
+          subscription_at: '2022-99-99T00:00:00Z',
         }
       end
 
@@ -772,7 +774,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error.messages[:subscription_date]).to eq(['invalid_date'])
+          expect(result.error.messages[:subscription_at]).to eq(['invalid_date'])
         end
       end
     end

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -9,20 +9,19 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
   let(:subscription) { create(:subscription) }
 
   describe 'update' do
-    let(:subscription_date) { '2022-07-07' }
+    let(:subscription_at) { '2022-07-07T00:00:00Z' }
 
     let(:update_args) do
       {
-        id: subscription.id,
         name: 'new name',
-        subscription_date: subscription_date,
+        subscription_at: subscription_at,
       }
     end
 
     before { subscription }
 
     it 'updates the subscription' do
-      result = update_service.update(**update_args)
+      result = update_service.update(subscription: subscription, args: update_args)
 
       expect(result).to be_success
 
@@ -35,13 +34,12 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
     context 'when subscription_at is not passed at all' do
       let(:update_args) do
         {
-          id: subscription.id,
           name: 'new name',
         }
       end
 
       it 'updates the subscription' do
-        result = update_service.update(**update_args)
+        result = update_service.update(subscription: subscription, args: update_args)
 
         expect(result).to be_success
 
@@ -56,7 +54,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
       let(:subscription) { create(:pending_subscription) }
 
       it 'updates the subscription_at as well' do
-        result = update_service.update(**update_args)
+        result = update_service.update(subscription: subscription, args: update_args)
 
         expect(result).to be_success
 
@@ -67,12 +65,12 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
       end
 
       context 'when subscription date is set to today' do
-        let(:subscription_date) { Time.current.to_date }
+        let(:subscription_at) { Time.current }
 
         before { subscription.plan.update!(pay_in_advance: true) }
 
         it 'activates subscription' do
-          result = update_service.update(**update_args)
+          result = update_service.update(subscription: subscription, args: update_args)
 
           expect(result).to be_success
 
@@ -84,83 +82,21 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
 
         it 'enqueues a job to bill the subscription' do
           expect do
-            update_service.update(**update_args)
+            update_service.update(subscription: subscription, args: update_args)
           end.to have_enqueued_job(BillSubscriptionJob)
         end
       end
     end
 
-    context 'with invalid id' do
+    context 'when subscription is nil' do
       let(:update_args) do
         {
-          id: "#{subscription.id}123",
           name: 'new name',
         }
       end
 
       it 'returns an error' do
-        result = update_service.update(**update_args)
-
-        expect(result).not_to be_success
-        expect(result.error.error_code).to eq('subscription_not_found')
-      end
-    end
-  end
-
-  describe 'update_from_api' do
-    let(:organization) { membership.organization }
-    let(:update_args) do
-      {
-        name: 'new name',
-        subscription_date: '2022-07-07',
-      }
-    end
-    let(:customer) { create(:customer, organization: organization) }
-    let(:subscription) { create(:subscription, customer: customer) }
-
-    before { subscription }
-
-    it 'updates the subscription' do
-      result = update_service.update_from_api(
-        organization: organization,
-        external_id: subscription.external_id,
-        params: update_args,
-      )
-
-      expect(result).to be_success
-
-      aggregate_failures do
-        expect(result.subscription.name).to eq('new name')
-        expect(result.subscription.subscription_at.to_s).not_to eq('2022-07-07')
-      end
-    end
-
-    context 'when subscription is starting in the future' do
-      let(:subscription) { create(:pending_subscription, customer: customer) }
-
-      it 'updates the subscription_at as well' do
-        result = update_service.update_from_api(
-          organization: organization,
-          external_id: subscription.external_id,
-          params: update_args,
-        )
-
-        expect(result).to be_success
-
-        aggregate_failures do
-          expect(result.subscription.name).to eq('new name')
-          expect(result.subscription.subscription_at.to_s).to eq('2022-07-07 00:00:00 UTC')
-        end
-      end
-    end
-
-    context 'with invalid external_id' do
-      it 'returns an error' do
-        result = update_service.update_from_api(
-          organization: organization,
-          external_id: "#{subscription.external_id}123",
-          params: update_args,
-        )
+        result = update_service.update(subscription: nil, args: update_args)
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('subscription_not_found')

--- a/spec/services/subscriptions/validate_service_spec.rb
+++ b/spec/services/subscriptions/validate_service_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization: organization) }
   let(:plan) { create(:plan, organization: organization) }
-  let(:subscription_date) { '2022-07-07' }
+  let(:subscription_at) { '2022-07-07T00:00:00Z' }
 
   let(:args) do
     {
       customer: customer,
       plan: plan,
-      subscription_date: subscription_date,
+      subscription_at: subscription_at,
     }
   end
 
@@ -51,22 +51,22 @@ RSpec.describe Subscriptions::ValidateService, type: :service do
       end
     end
 
-    context 'with invalid subscription_date' do
+    context 'with invalid subscription_at' do
       context 'when string cannot be parsed to date' do
-        let(:subscription_date) { 'invalid' }
+        let(:subscription_at) { 'invalid' }
 
         it 'returns false and result has errors' do
           expect(validate_service).not_to be_valid
-          expect(result.error.messages[:subscription_date]).to eq(['invalid_date'])
+          expect(result.error.messages[:subscription_at]).to eq(['invalid_date'])
         end
       end
 
-      context 'when subscription_date is integer' do
-        let(:subscription_date) { 123 }
+      context 'when subscription_at is integer' do
+        let(:subscription_at) { 123 }
 
         it 'returns false and result has errors' do
           expect(validate_service).not_to be_valid
-          expect(result.error.messages[:subscription_date]).to eq(['invalid_date'])
+          expect(result.error.messages[:subscription_at]).to eq(['invalid_date'])
         end
       end
     end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR follows https://github.com/getlago/lago-api/pull/655 and allow the creation and update of subscriptions using the `subscription_at` fields instead of the `subscription_date`.

NOTE: it is keeping the compatibility with the existing fields
