### PR TITLE
clean(timezones): Remove useless fallback into usage serializer

### DIFF
--- a/app/serializers/v1/customer_usage_serializer.rb
+++ b/app/serializers/v1/customer_usage_serializer.rb
@@ -4,9 +4,8 @@ module V1
   class CustomerUsageSerializer < ModelSerializer
     def serialize
       payload = {
-        # TODO: remove || after all cache key expirations
-        from_datetime: model.from_date&.to_date&.beginning_of_day&.iso8601 || model.from_datetime,
-        to_datetime: model.to_date&.to_date&.end_of_day&.iso8601 || model.to_datetime,
+        from_datetime: model.from_datetime,
+        to_datetime: model.to_datetime,
         issuing_date: model.issuing_date,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,

--- a/app/serializers/v1/legacy/customer_usage_serializer.rb
+++ b/app/serializers/v1/legacy/customer_usage_serializer.rb
@@ -5,9 +5,8 @@ module V1
     class CustomerUsageSerializer < ModelSerializer
       def serialize
         {
-          # TODO: remove || after all cache key expirations
-          from_date: model.from_date || model.from_datetime&.to_date,
-          to_date: model.to_date || model.to_datetime&.to_date,
+          from_date: model.from_datetime&.to_date,
+          to_date: model.to_datetime&.to_date,
         }
       end
     end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR reverts the changes of https://github.com/getlago/lago-api/pull/651 and https://github.com/getlago/lago-api/pull/649 as the issue is now fixed (all cache have expired)
