### PR TITLE
feat(timezones): Prevent overlaping of timezone when customer timezone changes

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -41,6 +41,7 @@ class Invoice < ApplicationRecord
   sequenced scope: ->(invoice) { invoice.customer.invoices }
 
   validates :issuing_date, presence: true
+  validates :timezone, timezone: true, allow_nil: true
 
   def file_url
     return if file.blank?

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -13,17 +13,16 @@ class InvoiceSubscription < ApplicationRecord
   monetize :subscription_amount_cents, disable_validation: true, allow_nil: true
   monetize :total_amount_cents, disable_validation: true, allow_nil: true
 
-  scope :order_by_charges_to_datetime, lambda {
-    condition = ActiveRecord::Base.sanitize_sql_for_conditions(
-      <<-SQL
-        COALESCE(
-          (invoice_subscriptions.properties->>\'to_datetime\')::timestamp, invoice_subscriptions.created_at
-        ) ASC
-      SQL
-    )
+  scope :order_by_charges_to_datetime,
+        lambda {
+          condition = <<-SQL
+            COALESCE(
+              (invoice_subscriptions.properties->>\'to_datetime\')::timestamp, invoice_subscriptions.created_at
+            ) ASC
+          SQL
 
-    order(Arel.sql(condition))
-  }
+          order(Arel.sql(ActiveRecord::Base.sanitize_sql_for_conditions(condition)))
+        }
 
   def fees
     @fees ||= Fee.where(

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -13,6 +13,18 @@ class InvoiceSubscription < ApplicationRecord
   monetize :subscription_amount_cents, disable_validation: true, allow_nil: true
   monetize :total_amount_cents, disable_validation: true, allow_nil: true
 
+  scope :order_by_charges_to_datetime, lambda {
+    condition = ActiveRecord::Base.sanitize_sql_for_conditions(
+      <<-SQL
+        COALESCE(
+          (invoice_subscriptions.properties->>\'to_datetime\')::timestamp, invoice_subscriptions.created_at
+        ) ASC
+      SQL
+    )
+
+    order(Arel.sql(condition))
+  }
+
   def fees
     @fees ||= Fee.where(
       subscription_id: subscription.id,

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -21,19 +21,19 @@ class InvoiceSubscription < ApplicationRecord
   end
 
   def from_datetime
-    fees_datetime('from_datetime')&.to_datetime
+    properties['from_datetime']&.to_datetime
   end
 
   def to_datetime
-    fees_datetime('to_datetime')&.to_datetime
+    properties['to_datetime']&.to_datetime
   end
 
   def charges_from_datetime
-    fees_datetime('charges_from_datetime')&.to_datetime
+    properties['charges_from_datetime']&.to_datetime
   end
 
   def charges_to_datetime
-    fees_datetime('charges_to_datetime')&.to_datetime
+    properties['charges_to_datetime']&.to_datetime
   end
 
   def charge_amount_cents
@@ -54,10 +54,4 @@ class InvoiceSubscription < ApplicationRecord
 
   alias charge_amount_currency total_amount_currency
   alias subscription_amount_currency total_amount_currency
-
-  def fees_datetime(field)
-    return if fees.empty?
-
-    fees.first.properties[field]
-  end
 end

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -22,6 +22,7 @@ module Invoices
           credit_amount_currency: currency,
           total_amount_currency: currency,
           vat_rate: customer.applicable_vat_rate,
+          timezone: customer.applicable_timezone,
         )
 
         create_add_on_fee(invoice)

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -26,10 +26,9 @@ module Invoices
           timezone: customer.applicable_timezone,
         )
 
-        subscriptions.each { |subscription| invoice.subscriptions << subscription }
-
         result = Invoices::CalculateFeesService.new(
           invoice: invoice,
+          subscriptions: subscriptions,
           timestamp: timestamp,
         ).call
 

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -23,6 +23,7 @@ module Invoices
           credit_amount_currency: currency,
           total_amount_currency: currency,
           vat_rate: customer.applicable_vat_rate,
+          timezone: customer.applicable_timezone,
         )
 
         subscriptions.each { |subscription| invoice.subscriptions << subscription }

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -24,6 +24,7 @@ module Invoices
 
           # NOTE: No VAT should be applied on as it can be considered as an advance
           vat_rate: 0,
+          timezone: customer.applicable_timezone,
         )
 
         create_credit_fee(invoice)

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -54,7 +54,13 @@ module Subscriptions
       # NOTE: If customer applicable timezone changes during a billing period, there is a risk to double count events
       #       or to miss some. To prevent it, we have to ensure that invoice bounds does not overlap or that there is no
       #       hole bewtween a charges_from_datetime and the charges_to_datetime of the previous period
-      datetime = previous_charge_to_datetime + 1.second if timezone_has_changed?
+      if timezone_has_changed?
+        new_datetime = previous_charge_to_datetime + 1.second
+
+        # NOTE: Ensure that the invoice is really the previous one
+        #       26 hours is the maximum time difference between two places in the world
+        datetime = new_datetime if ((datetime.in_time_zone - new_datetime.in_time_zone) / 1.hour).abs < 26
+      end
 
       datetime = subscription.started_at if datetime < subscription.started_at
 

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -50,6 +50,12 @@ module Subscriptions
 
     def charges_from_datetime
       datetime = customer_timezone_shift(compute_charges_from_date)
+
+      # NOTE: If customer applicable timezone changes during a billing period, there is a risk to double count events
+      #       or to miss some. To prevent it, we have to ensure that invoice bounds does not overlap or that there is no
+      #       hole bewtween a charges_from_datetime and the charges_to_datetime of the previous period
+      datetime = previous_charge_to_datetime + 1.second if timezone_has_changed?
+
       datetime = subscription.started_at if datetime < subscription.started_at
 
       datetime
@@ -103,6 +109,25 @@ module Subscriptions
       result = date.in_time_zone(customer.applicable_timezone)
       result = result.end_of_day if end_of_day
       result.utc
+    end
+
+    def last_invoice_subscription
+      @last_invoice_subscription ||= subscription
+        .invoice_subscriptions
+        .order_by_charges_to_datetime
+        .first
+    end
+
+    def timezone_has_changed?
+      return false if last_invoice_subscription.blank?
+
+      last_invoice_subscription.invoice.timezone != customer.applicable_timezone
+    end
+
+    def previous_charge_to_datetime
+      return if last_invoice_subscription.blank?
+
+      last_invoice_subscription.charges_to_datetime
     end
 
     def terminated_pay_in_arrear?

--- a/db/migrate/20221208140608_add_timezone_to_invoices.rb
+++ b/db/migrate/20221208140608_add_timezone_to_invoices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTimezoneToInvoices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invoices, :timezone, :string, null: false, default: 'UTC'
+  end
+end

--- a/db/migrate/20221208142739_add_properties_to_invoice_subscriptions.rb
+++ b/db/migrate/20221208142739_add_properties_to_invoice_subscriptions.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddPropertiesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invoice_subscriptions, :properties, :jsonb, null: false, default: '{}'
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE invoice_subscriptions
+          SET properties = COALESCE((
+            SELECT fees.properties
+            FROM fees
+            WHERE fees.subscription_id = invoice_subscriptions.subscription_id
+              AND fees.invoice_id = invoice_subscriptions.invoice_id
+            ORDER BY fees.created_at ASC
+            LIMIT 1
+          ), '{}');
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_08_140608) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_08_142739) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -307,6 +307,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_140608) do
     t.uuid "subscription_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "properties", default: "{}", null: false
     t.index ["invoice_id"], name: "index_invoice_subscriptions_on_invoice_id"
     t.index ["subscription_id"], name: "index_invoice_subscriptions_on_subscription_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -473,10 +473,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_142739) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "previous_subscription_id"
+    t.date "subscription_date"
     t.string "name"
     t.string "external_id", null: false
     t.integer "billing_time", default: 0, null: false
-    t.datetime "subscription_at"
     t.index ["customer_id"], name: "index_subscriptions_on_customer_id"
     t.index ["external_id"], name: "index_subscriptions_on_external_id"
     t.index ["plan_id"], name: "index_subscriptions_on_plan_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_05_112007) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_08_140608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -332,6 +332,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_05_112007) do
     t.bigint "credit_amount_cents", default: 0, null: false
     t.string "credit_amount_currency"
     t.integer "status", default: 0, null: false
+    t.string "timezone", default: "UTC", null: false
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
   end
 
@@ -471,10 +472,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_05_112007) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "previous_subscription_id"
-    t.date "subscription_date"
     t.string "name"
     t.string "external_id", null: false
     t.integer "billing_time", default: 0, null: false
+    t.datetime "subscription_at"
     t.index ["customer_id"], name: "index_subscriptions_on_customer_id"
     t.index ["external_id"], name: "index_subscriptions_on_external_id"
     t.index ["plan_id"], name: "index_subscriptions_on_plan_id"

--- a/db/seeds/groups.rb
+++ b/db/seeds/groups.rb
@@ -161,6 +161,7 @@ Charge.create_with(
 )
 
 2.times do
+  time = Time.current
   Event.create!(
     customer: customer,
     subscription: subscription,

--- a/spec/models/invoice_subscription_spec.rb
+++ b/spec/models/invoice_subscription_spec.rb
@@ -3,93 +3,79 @@
 require 'rails_helper'
 
 RSpec.describe InvoiceSubscription, type: :model do
-  let(:invoice_subscription) { create(:invoice_subscription) }
+  let(:invoice_subscription) { create(:invoice_subscription, properties: properties) }
   let(:invoice) { invoice_subscription.invoice }
   let(:subscription) { invoice_subscription.subscription }
+
+  let(:from_datetime) { '2022-01-01 00:00:00' }
+  let(:to_datetime) { '2022-01-31 23:59:59' }
+  let(:charges_from_datetime) { '2022-01-01 00:00:00' }
+  let(:charges_to_datetime) { '2022-01-31 23:59:59' }
+
+  let(:properties) do
+    {
+      from_datetime: from_datetime,
+      to_datetime: to_datetime,
+      charges_from_datetime: charges_from_datetime,
+      charges_to_datetime: charges_to_datetime,
+    }
+  end
 
   describe '#fees' do
     it 'returns corresponding fees' do
       first_fee = create(:fee, subscription_id: subscription.id, invoice_id: invoice.id)
-      second_fee = create(:fee, subscription_id: subscription.id)
-      third_fee = create(:fee, invoice_id: invoice.id)
+      create(:fee, subscription_id: subscription.id)
+      create(:fee, invoice_id: invoice.id)
 
       expect(invoice_subscription.fees).to eq([first_fee])
     end
   end
 
   describe '#from_datetime' do
-    it 'returns first fee from_date' do
-      create(
-        :fee,
-        subscription_id: subscription.id,
-        invoice_id: invoice.id,
-        properties: { from_datetime: '2022-01-01 00:00:00' },
-      )
-
+    it 'returns properties from_datetime' do
       expect(invoice_subscription.from_datetime).to match_datetime('2022-01-01 00:00:00')
     end
 
-    context 'when fees are empty' do
-      it 'returns nil' do
-        expect(invoice_subscription.from_datetime).to be_nil
-      end
+    context 'when properties from_datetime is empty' do
+      let(:from_datetime) { nil }
+
+      it { expect(invoice_subscription.from_datetime).to be_nil }
     end
   end
 
   describe '#to_datetime' do
-    it 'returns first fee to_date' do
-      create(
-        :fee,
-        subscription_id: subscription.id,
-        invoice_id: invoice.id,
-        properties: { to_datetime: '2022-01-31 23:59:59' },
-      )
-
+    it 'returns properties to_datetime' do
       expect(invoice_subscription.to_datetime).to match_datetime('2022-01-31 12 23:59:59')
     end
 
-    context 'when fees are empty' do
-      it 'returns nil' do
-        expect(invoice_subscription.to_datetime).to be_nil
-      end
+    context 'when properties to_datetime is empty' do
+      let(:to_datetime) { nil }
+
+      it { expect(invoice_subscription.to_datetime).to be_nil }
     end
   end
 
   describe '#charges_from_datetime' do
-    it 'returns first fee charges_from_date' do
-      create(
-        :fee,
-        subscription_id: subscription.id,
-        invoice_id: invoice.id,
-        properties: { charges_from_datetime: '2022-01-01 00:00:00' },
-      )
-
+    it 'returns properties charges_from_datetime' do
       expect(invoice_subscription.charges_from_datetime).to match_datetime('2022-01-01 00:00:00')
     end
 
-    context 'when fees are empty' do
-      it 'returns nil' do
-        expect(invoice_subscription.charges_from_datetime).to be_nil
-      end
+    context 'when properties charges_from_datetime is empty' do
+      let(:charges_from_datetime) { nil }
+
+      it { expect(invoice_subscription.charges_from_datetime).to be_nil }
     end
   end
 
   describe '#charges_to_datetime' do
-    it 'returns first fee charges_to_date' do
-      create(
-        :fee,
-        subscription_id: subscription.id,
-        invoice_id: invoice.id,
-        properties: { charges_to_datetime: '2022-01-31 23:59:59' },
-      )
-
+    it 'returns properties charges_to_datetime' do
       expect(invoice_subscription.charges_to_datetime).to match_datetime('2022-01-31 23:59:59')
     end
 
-    context 'when fees are empty' do
-      it 'returns nil' do
-        expect(invoice_subscription.charges_to_datetime).to be_nil
-      end
+    context 'when properties charges_to_datetime is empty' do
+      let(:charges_to_datetime) { nil }
+
+      it { expect(invoice_subscription.charges_to_datetime).to be_nil }
     end
   end
 

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -4,18 +4,18 @@ require 'rails_helper'
 
 RSpec.describe Invoices::CalculateFeesService, type: :service do
   subject(:invoice_service) do
-    described_class.new(invoice: invoice, timestamp: timestamp.to_i)
+    described_class.new(invoice: invoice, subscriptions: subscriptions, timestamp: timestamp.to_i)
   end
 
   describe '#call' do
     let(:invoice) do
       create(
         :invoice,
-        subscriptions: subscriptions,
         amount_currency: 'EUR',
         vat_amount_currency: 'EUR',
         total_amount_currency: 'EUR',
         issuing_date: Time.zone.at(timestamp).to_date,
+        customer: subscription.customer,
       )
     end
 

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe Invoices::CreateService, type: :service do
       aggregate_failures do
         expect(result).to be_success
 
-        expect(result.invoice.fees.first.properties['to_datetime'])
+        expect(result.invoice.invoice_subscriptions.first.properties['to_datetime'])
           .to eq (timestamp - 1.day).end_of_day.as_json
-        expect(result.invoice.fees.first.properties['from_datetime'])
+        expect(result.invoice.invoice_subscriptions.first.properties['from_datetime'])
           .to eq (timestamp - 1.month).beginning_of_day.as_json
 
         expect(result.invoice.subscriptions.first).to eq(subscription)

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -260,6 +260,29 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         it 'takes customer timezone into account' do
           expect(result).to eq(date_service.from_datetime.to_s)
         end
+
+        context 'when timezone has changed' do
+          let(:billing_at) { DateTime.parse('02 Mar 2022') }
+
+          let(:previous_invoice_subscription) do
+            create(
+              :invoice_subscription,
+              subscription: subscription,
+              properties: {
+                charges_to_datetime: '2022-01-31T23:59:59Z',
+              },
+            )
+          end
+
+          before do
+            previous_invoice_subscription
+            subscription.customer.update!(timezone: 'America/Los_Angeles')
+          end
+
+          it 'takes previous invoice into account' do
+            expect(result).to match_datetime('2022-02-01 00:00:00')
+          end
+        end
       end
 
       context 'when subscription started in the middle of a period' do

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -219,6 +219,29 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
         it 'takes customer timezone into account' do
           expect(result).to eq(date_service.from_datetime.to_s)
         end
+
+        context 'when timezone has changed' do
+          let(:billing_at) { DateTime.parse('08 Mar 2022') }
+
+          let(:previous_invoice_subscription) do
+            create(
+              :invoice_subscription,
+              subscription: subscription,
+              properties: {
+                charges_to_datetime: '2022-02-27T22:59:59Z',
+              },
+            )
+          end
+
+          before do
+            previous_invoice_subscription
+            subscription.customer.update!(timezone: 'America/Los_Angeles')
+          end
+
+          it 'takes previous invoice into account' do
+            expect(result).to match_datetime('2022-02-27 23:00:00')
+          end
+        end
       end
 
       context 'when subscription started in the middle of a period' do

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -259,6 +259,29 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         it 'takes customer timezone into account' do
           expect(result).to eq(date_service.from_datetime.to_s)
         end
+
+        context 'when timezone has changed' do
+          let(:billing_at) { DateTime.parse('02 Jan 2022') }
+
+          let(:previous_invoice_subscription) do
+            create(
+              :invoice_subscription,
+              subscription: subscription,
+              properties: {
+                charges_to_datetime: '2020-12-31T22:59:59Z',
+              },
+            )
+          end
+
+          before do
+            previous_invoice_subscription
+            subscription.customer.update!(timezone: 'America/Los_Angeles')
+          end
+
+          it 'takes previous invoice into account' do
+            expect(result).to match_datetime('2020-12-31 23:00:00')
+          end
+        end
       end
 
       context 'when subscription started in the middle of a period' do


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR ensure that charges billed on a period does not overlap with a previous invoice or that no holes appears between 2 consecutive invoices in case of a change of time zone at customer or organization level.
Timezone will be stored at invoice level to ensure we are not loosing the timezone information
