### PR TITLE
feat(timezones): Prevent double billing

### DIFF
--- a/app/jobs/bill_subscription_job.rb
+++ b/app/jobs/bill_subscription_job.rb
@@ -5,10 +5,11 @@ class BillSubscriptionJob < ApplicationJob
 
   retry_on Sequenced::SequenceError
 
-  def perform(subscriptions, timestamp)
-    result = Invoices::CreateService.new(
+  def perform(subscriptions, timestamp, invoice_source: :initial)
+    result = Invoices::SubscriptionService.new(
       subscriptions: subscriptions,
       timestamp: timestamp,
+      invoice_source: invoice_source,
     ).create
 
     result.throw_error unless result.success?

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -13,6 +13,13 @@ class InvoiceSubscription < ApplicationRecord
   monetize :subscription_amount_cents, disable_validation: true, allow_nil: true
   monetize :total_amount_cents, disable_validation: true, allow_nil: true
 
+  SOURCES = [
+    :recurring, # Created by the billing service
+    :initial, # Created by the creation or the start of a subscription
+  ].freeze
+
+  enum source: SOURCES
+
   scope :order_by_charges_to_datetime,
         lambda {
           condition = <<-SQL

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -40,18 +40,25 @@ class Subscription < ApplicationRecord
     SQL
   end
 
-  def mark_as_active!(timestamp = Time.zone.now)
+  def self.started_at_in_timezone_sql
+    <<-SQL
+      subscriptions.started_at::timestamptz AT TIME ZONE
+      COALESCE(customers.timezone, organizations.timezone, 'UTC')
+    SQL
+  end
+
+  def mark_as_active!(timestamp = Time.current)
     self.started_at ||= timestamp
     active!
   end
 
-  def mark_as_terminated!(timestamp = Time.zone.now)
+  def mark_as_terminated!(timestamp = Time.current)
     self.terminated_at ||= timestamp
     terminated!
   end
 
   def mark_as_canceled!
-    self.canceled_at ||= Time.zone.now
+    self.canceled_at ||= Time.current
     canceled!
   end
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -6,10 +6,11 @@ module Invoices
       new(...).call
     end
 
-    def initialize(invoice:, subscriptions:, timestamp:)
+    def initialize(invoice:, subscriptions:, timestamp:, invoice_source:)
       @invoice = invoice
       @subscriptions = subscriptions
       @timestamp = timestamp
+      @invoice_source = invoice_source
 
       super
     end
@@ -23,6 +24,7 @@ module Invoices
             invoice: invoice,
             subscription: subscription,
             properties: boundaries,
+            source: invoice_source,
           )
 
           create_subscription_fee(subscription, boundaries) if should_create_subscription_fee?(subscription)
@@ -47,7 +49,7 @@ module Invoices
 
     private
 
-    attr_accessor :invoice, :subscriptions, :timestamp
+    attr_accessor :invoice, :subscriptions, :timestamp, :invoice_source
 
     delegate :customer, :currency, to: :invoice
 

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 module Invoices
-  class CreateService < BaseService
-    def initialize(subscriptions:, timestamp:)
+  class SubscriptionService < BaseService
+    def initialize(subscriptions:, timestamp:, invoice_source:)
       @subscriptions = subscriptions
       @timestamp = timestamp
+      @invoice_source = invoice_source
       @customer = subscriptions&.first&.customer
       @currency = subscriptions&.first&.plan&.amount_currency
 
@@ -33,6 +34,7 @@ module Invoices
           invoice: invoice,
           subscriptions: subscriptions,
           timestamp: timestamp,
+          invoice_source: invoice_source,
         ).call
       end
 
@@ -47,7 +49,7 @@ module Invoices
 
     private
 
-    attr_accessor :subscriptions, :timestamp, :customer, :currency
+    attr_accessor :subscriptions, :timestamp, :invoice_source, :customer, :currency
 
     def issuing_date
       Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone).to_date

--- a/clock.rb
+++ b/clock.rb
@@ -16,14 +16,13 @@ module Clockwork
     Sentry.capture_exception(error)
   end
 
-  # NOTE: Run every hour to take customer timezone into account
+  # NOTE: All clocks run every hour to take customer timezones into account
+
   every(1.hour, 'schedule:activate_subscriptions', at: '**:30') do
     Clock::ActivateSubscriptionsJob.perform_later
   end
 
-  # NOTE: Keep "at" >= 1 to prevent double billing on "time change" day
-  #       for countries located on an UTC-1 timezone
-  every(1.day, 'schedule:bill_customers', at: '01:00') do
+  every(1.hour, 'schedule:bill_customers', at: '*:10') do
     Clock::SubscriptionsBillerJob.perform_later
   end
 

--- a/db/migrate/20221212153810_add_source_to_invoice_subscriptions.rb
+++ b/db/migrate/20221212153810_add_source_to_invoice_subscriptions.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddSourceToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invoice_subscriptions, :source, :integer
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE invoice_subscriptions
+          SET source = 0;
+        SQL
+      end
+    end
+
+    change_column_null :invoice_subscriptions, :source, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_08_142739) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_12_153810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -308,6 +308,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_142739) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "properties", default: "{}", null: false
+    t.integer "source", null: false
     t.index ["invoice_id"], name: "index_invoice_subscriptions_on_invoice_id"
     t.index ["subscription_id"], name: "index_invoice_subscriptions_on_subscription_id"
   end

--- a/db/seeds/invoices.rb
+++ b/db/seeds/invoices.rb
@@ -2,9 +2,10 @@
 
 # NOTE: Generate invoices for the customers
 Subscription.all.find_each do |subscription|
-  Invoices::CreateService.new(
+  Invoices::SubscriptionService.new(
     subscriptions: [subscription],
     timestamp: Time.zone.now - 2.months,
+    invoice_source: :initial,
   ).create
 end
 

--- a/spec/factories/invoice_subscriptions.rb
+++ b/spec/factories/invoice_subscriptions.rb
@@ -4,5 +4,7 @@ FactoryBot.define do
   factory :invoice_subscription do
     subscription
     invoice
+
+    source { :initial }
   end
 end

--- a/spec/jobs/bill_subscription_job_spec.rb
+++ b/spec/jobs/bill_subscription_job_spec.rb
@@ -6,19 +6,19 @@ RSpec.describe BillSubscriptionJob, type: :job do
   let(:subscription) { create(:subscription) }
   let(:timestamp) { Time.zone.now.to_i }
 
-  let(:invoice_service) { instance_double(Invoices::CreateService) }
+  let(:invoice_service) { instance_double(Invoices::SubscriptionService) }
   let(:result) { BaseService::Result.new }
 
   it 'calls the invoices create service' do
-    allow(Invoices::CreateService).to receive(:new)
-      .with(subscriptions: [subscription], timestamp: timestamp)
+    allow(Invoices::SubscriptionService).to receive(:new)
+      .with(subscriptions: [subscription], timestamp: timestamp, invoice_source: :initial)
       .and_return(invoice_service)
     allow(invoice_service).to receive(:create)
       .and_return(result)
 
     described_class.perform_now([subscription], timestamp)
 
-    expect(Invoices::CreateService).to have_received(:new)
+    expect(Invoices::SubscriptionService).to have_received(:new)
     expect(invoice_service).to have_received(:create)
   end
 
@@ -28,8 +28,8 @@ RSpec.describe BillSubscriptionJob, type: :job do
     end
 
     it 'raises an error' do
-      allow(Invoices::CreateService).to receive(:new)
-        .with(subscriptions: [subscription], timestamp: timestamp)
+      allow(Invoices::SubscriptionService).to receive(:new)
+        .with(subscriptions: [subscription], timestamp: timestamp, invoice_source: :initial)
         .and_return(invoice_service)
       allow(invoice_service).to receive(:create)
         .and_return(result)
@@ -38,7 +38,7 @@ RSpec.describe BillSubscriptionJob, type: :job do
         described_class.perform_now([subscription], timestamp)
       end.to raise_error(BaseService::FailedResult)
 
-      expect(Invoices::CreateService).to have_received(:new)
+      expect(Invoices::SubscriptionService).to have_received(:new)
       expect(invoice_service).to have_received(:create)
     end
   end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -4,8 +4,15 @@ require 'rails_helper'
 
 RSpec.describe Invoices::CalculateFeesService, type: :service do
   subject(:invoice_service) do
-    described_class.new(invoice: invoice, subscriptions: subscriptions, timestamp: timestamp.to_i)
+    described_class.new(
+      invoice: invoice,
+      subscriptions: subscriptions,
+      timestamp: timestamp.to_i,
+      invoice_source: invoice_source,
+    )
   end
+
+  let(:invoice_source) { :initial }
 
   describe '#call' do
     let(:invoice) do
@@ -58,6 +65,9 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           aggregate_failures do
             expect(result).to be_success
             expect(result.invoice.fees.subscription_kind.count).to eq(0)
+
+            expect(result.invoice.invoice_subscriptions.count).to eq(1)
+            expect(result.invoice.invoice_subscriptions.first).to be_initial
           end
         end
       end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -2,9 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe Invoices::CreateService, type: :service do
+RSpec.describe Invoices::SubscriptionService, type: :service do
   subject(:invoice_service) do
-    described_class.new(subscriptions: subscriptions, timestamp: timestamp.to_i)
+    described_class.new(
+      subscriptions: subscriptions,
+      timestamp: timestamp.to_i,
+      invoice_source: :initial,
+    )
   end
 
   describe 'create' do


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR ensure that a subscription cannot is not billed twice on its creation date or the billing date
