### PR TITLE
feat(credit-notes): Disable credit note creation until license management is ready

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -46,6 +46,17 @@ module Api
       )
     end
 
+    def forbidden_error(code:)
+      render(
+        json: {
+          status: 403,
+          error: 'Forbidden',
+          code: code,
+        },
+        status: :forbidden,
+      )
+    end
+
     def method_not_allowed_error(code:)
       render(
         json: {
@@ -65,6 +76,8 @@ module Api
         method_not_allowed_error(code: error_result.error.code)
       when BaseService::ValidationFailure
         validation_errors(errors: error_result.error.messages)
+      when BaseService::ForbiddenFailure
+        forbidden_error(code: error_result.error.code)
       else
         raise(error_result.error)
       end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -62,6 +62,16 @@ class BaseService
     end
   end
 
+  class ForbiddenFailure < FailedResult
+    attr_reader :code
+
+    def initialize(result, code:)
+      @code = code
+
+      super(result, code)
+    end
+  end
+
   class Result < OpenStruct
     attr_reader :error
 
@@ -105,6 +115,10 @@ class BaseService
 
     def service_failure!(code:, message:)
       fail_with_error!(ServiceFailure.new(self, code: code, error_message: message))
+    end
+
+    def forbidden_failure!(code: 'feature_unavailable')
+      fail_with_error!(ServiceFailure.new(self, code: code))
     end
 
     def throw_error

--- a/app/services/credit_notes/create_from_upgrade.rb
+++ b/app/services/credit_notes/create_from_upgrade.rb
@@ -27,6 +27,7 @@ module CreditNotes
           },
         ],
         reason: :order_change,
+        automatic: true,
       ).call
     end
 

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -11,11 +11,14 @@ module CreditNotes
       @credit_amount_cents = args[:credit_amount_cents] || 0
       @refund_amount_cents = args[:refund_amount_cents] || 0
 
+      @automatic = args.key?(:automatic) ? args[:automatic] : false
+
       super
     end
 
     def call
       return result.not_found_failure!(resource: invoice) unless invoice
+      return result.forbidden_failure! unless automatic
 
       ActiveRecord::Base.transaction do
         result.credit_note = CreditNote.create!(
@@ -67,7 +70,13 @@ module CreditNotes
 
     private
 
-    attr_accessor :invoice, :items_attr, :reason, :description, :credit_amount_cents, :refund_amount_cents
+    attr_accessor :invoice,
+                  :items_attr,
+                  :reason,
+                  :description,
+                  :credit_amount_cents,
+                  :refund_amount_cents,
+                  :automatic
 
     delegate :credit_note, to: :result
     delegate :customer, to: :invoice

--- a/spec/controllers/api/v1/credit_notes_controller_spec.rb
+++ b/spec/controllers/api/v1/credit_notes_controller_spec.rb
@@ -231,37 +231,38 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       }
     end
 
-    it 'creates a credit note' do
-      post_with_token(organization, '/api/v1/credit_notes', { credit_note: create_params })
+    # TODO: credit note feature is diabled for now
+    # it 'creates a credit note' do
+    #   post_with_token(organization, '/api/v1/credit_notes', { credit_note: create_params })
 
-      aggregate_failures do
-        expect(response).to have_http_status(:success)
+    #   aggregate_failures do
+    #     expect(response).to have_http_status(:success)
 
-        expect(json[:credit_note][:lago_id]).to be_present
-        expect(json[:credit_note][:credit_status]).to eq('available')
-        expect(json[:credit_note][:refund_status]).to eq('pending')
-        expect(json[:credit_note][:reason]).to eq('duplicated_charge')
-        expect(json[:credit_note][:description]).to eq('Duplicated charge')
-        expect(json[:credit_note][:total_amount_cents]).to eq(15)
-        expect(json[:credit_note][:total_amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:credit_amount_cents]).to eq(10)
-        expect(json[:credit_note][:credit_amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:balance_amount_cents]).to eq(10)
-        expect(json[:credit_note][:balance_amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:refund_amount_cents]).to eq(5)
-        expect(json[:credit_note][:refund_amount_currency]).to eq('EUR')
+    #     expect(json[:credit_note][:lago_id]).to be_present
+    #     expect(json[:credit_note][:credit_status]).to eq('available')
+    #     expect(json[:credit_note][:refund_status]).to eq('pending')
+    #     expect(json[:credit_note][:reason]).to eq('duplicated_charge')
+    #     expect(json[:credit_note][:description]).to eq('Duplicated charge')
+    #     expect(json[:credit_note][:total_amount_cents]).to eq(15)
+    #     expect(json[:credit_note][:total_amount_currency]).to eq('EUR')
+    #     expect(json[:credit_note][:credit_amount_cents]).to eq(10)
+    #     expect(json[:credit_note][:credit_amount_currency]).to eq('EUR')
+    #     expect(json[:credit_note][:balance_amount_cents]).to eq(10)
+    #     expect(json[:credit_note][:balance_amount_currency]).to eq('EUR')
+    #     expect(json[:credit_note][:refund_amount_cents]).to eq(5)
+    #     expect(json[:credit_note][:refund_amount_currency]).to eq('EUR')
 
-        expect(json[:credit_note][:items][0][:lago_id]).to be_present
-        expect(json[:credit_note][:items][0][:amount_cents]).to eq(10)
-        expect(json[:credit_note][:items][0][:amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:items][0][:fee][:lago_id]).to eq(fee1.id)
+    #     expect(json[:credit_note][:items][0][:lago_id]).to be_present
+    #     expect(json[:credit_note][:items][0][:amount_cents]).to eq(10)
+    #     expect(json[:credit_note][:items][0][:amount_currency]).to eq('EUR')
+    #     expect(json[:credit_note][:items][0][:fee][:lago_id]).to eq(fee1.id)
 
-        expect(json[:credit_note][:items][1][:lago_id]).to be_present
-        expect(json[:credit_note][:items][1][:amount_cents]).to eq(5)
-        expect(json[:credit_note][:items][1][:amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:items][1][:fee][:lago_id]).to eq(fee2.id)
-      end
-    end
+    #     expect(json[:credit_note][:items][1][:lago_id]).to be_present
+    #     expect(json[:credit_note][:items][1][:amount_cents]).to eq(5)
+    #     expect(json[:credit_note][:items][1][:amount_currency]).to eq('EUR')
+    #     expect(json[:credit_note][:items][1][:fee][:lago_id]).to eq(fee2.id)
+    #   end
+    # end
 
     context 'when invoice is not found' do
       let(:invoice_id) { 'foo_id' }

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -50,60 +50,61 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
     GQL
   end
 
-  it 'creates a credit note' do
-    result = execute_graphql(
-      current_user: membership.user,
-      current_organization: organization,
-      query: mutation,
-      variables: {
-        input: {
-          reason: 'duplicated_charge',
-          invoiceId: invoice.id,
-          description: 'Duplicated charge',
-          creditAmountCents: 10,
-          refundAmountCents: 5,
-          items: [
-            {
-              feeId: fee1.id,
-              amountCents: 10,
-            },
-            {
-              feeId: fee2.id,
-              amountCents: 5,
-            },
-          ],
-        },
-      },
-    )
+  # TODO: credit note feature is diabled for now
+  # it 'creates a credit note' do
+  #   result = execute_graphql(
+  #     current_user: membership.user,
+  #     current_organization: organization,
+  #     query: mutation,
+  #     variables: {
+  #       input: {
+  #         reason: 'duplicated_charge',
+  #         invoiceId: invoice.id,
+  #         description: 'Duplicated charge',
+  #         creditAmountCents: 10,
+  #         refundAmountCents: 5,
+  #         items: [
+  #           {
+  #             feeId: fee1.id,
+  #             amountCents: 10,
+  #           },
+  #           {
+  #             feeId: fee2.id,
+  #             amountCents: 5,
+  #           },
+  #         ],
+  #       },
+  #     },
+  #   )
 
-    result_data = result['data']['createCreditNote']
+  #   result_data = result['data']['createCreditNote']
 
-    aggregate_failures do
-      expect(result_data['id']).to be_present
-      expect(result_data['creditStatus']).to eq('available')
-      expect(result_data['refundStatus']).to eq('pending')
-      expect(result_data['reason']).to eq('duplicated_charge')
-      expect(result_data['description']).to eq('Duplicated charge')
-      expect(result_data['totalAmountCents']).to eq('15')
-      expect(result_data['totalAmountCurrency']).to eq('EUR')
-      expect(result_data['creditAmountCents']).to eq('10')
-      expect(result_data['creditAmountCurrency']).to eq('EUR')
-      expect(result_data['balanceAmountCents']).to eq('10')
-      expect(result_data['balanceAmountCurrency']).to eq('EUR')
-      expect(result_data['refundAmountCents']).to eq('5')
-      expect(result_data['refundAmountCurrency']).to eq('EUR')
+  #   aggregate_failures do
+  #     expect(result_data['id']).to be_present
+  #     expect(result_data['creditStatus']).to eq('available')
+  #     expect(result_data['refundStatus']).to eq('pending')
+  #     expect(result_data['reason']).to eq('duplicated_charge')
+  #     expect(result_data['description']).to eq('Duplicated charge')
+  #     expect(result_data['totalAmountCents']).to eq('15')
+  #     expect(result_data['totalAmountCurrency']).to eq('EUR')
+  #     expect(result_data['creditAmountCents']).to eq('10')
+  #     expect(result_data['creditAmountCurrency']).to eq('EUR')
+  #     expect(result_data['balanceAmountCents']).to eq('10')
+  #     expect(result_data['balanceAmountCurrency']).to eq('EUR')
+  #     expect(result_data['refundAmountCents']).to eq('5')
+  #     expect(result_data['refundAmountCurrency']).to eq('EUR')
 
-      expect(result_data['items'][0]['id']).to be_present
-      expect(result_data['items'][0]['amountCents']).to eq('10')
-      expect(result_data['items'][0]['amountCurrency']).to eq('EUR')
-      expect(result_data['items'][0]['fee']['id']).to eq(fee1.id)
+  #     expect(result_data['items'][0]['id']).to be_present
+  #     expect(result_data['items'][0]['amountCents']).to eq('10')
+  #     expect(result_data['items'][0]['amountCurrency']).to eq('EUR')
+  #     expect(result_data['items'][0]['fee']['id']).to eq(fee1.id)
 
-      expect(result_data['items'][1]['id']).to be_present
-      expect(result_data['items'][1]['amountCents']).to eq('5')
-      expect(result_data['items'][1]['amountCurrency']).to eq('EUR')
-      expect(result_data['items'][1]['fee']['id']).to eq(fee2.id)
-    end
-  end
+  #     expect(result_data['items'][1]['id']).to be_present
+  #     expect(result_data['items'][1]['amountCents']).to eq('5')
+  #     expect(result_data['items'][1]['amountCurrency']).to eq('EUR')
+  #     expect(result_data['items'][1]['fee']['id']).to eq(fee2.id)
+  #   end
+  # end
 
   context 'when invoice is not found' do
     it 'returns an error' do

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       description: nil,
       credit_amount_cents: credit_amount_cents,
       refund_amount_cents: refund_amount_cents,
+      automatic: true, # TODO: credit note feature is diabled for now
     )
   end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The objective of this feature is to introduce a new concept of credit notes.

The main reason behind this need is to handle the following case:
- If an overdue has been paid because a customer passes from a yearly plan to a monthly plan (`in_advance`), we charge the customer as if the remainder does not exist.

## Description

This PR disable the manual credit note creation for API and GraphQL until we release the license management system