### PR TITLE
fix(payments): Remove Lago from the payment label

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -124,7 +124,7 @@ module Invoices
           confirm: true,
           off_session: true,
           error_on_requires_action: true,
-          description: "Lago - #{organization.name} - Invoice #{invoice.number}",
+          description: "#{organization.name} - Invoice #{invoice.number}",
           metadata: {
             lago_customer_id: customer.id,
             lago_invoice_id: invoice.id,


### PR DESCRIPTION
## Context

When a payment intent is triggered through integration with Stripe, the payment description currently includes `Lago - {{organization.name}} - Invoice {{invoice.number}`}.

## Description

SInce it can be confusing for customers to see the name of our company as they don’t have any contractual relationship with us. This PR changes the payment description to only show `{{organization.name}} - Invoice {{invoice.number}}`.
