### PR TITLE
fix(credit-notes): Return the right type of error on creation

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -118,7 +118,7 @@ class BaseService
     end
 
     def forbidden_failure!(code: 'feature_unavailable')
-      fail_with_error!(ServiceFailure.new(self, code: code))
+      fail_with_error!(ForbiddenFailure.new(self, code: code))
     end
 
     def throw_error


### PR DESCRIPTION
## Context

Related to https://github.com/getlago/lago-api/pull/663

## Description

The error returned by the service was a `ServiceFailure` when it should be a `ForbiddenFailure`.

Note: this code is not yet covered by tests because it will change soon with the premium/oss separation