### PR TITLE
fix (coupons): validate expiration_at field on create and update

### DIFF
--- a/app/services/coupons/create_service.rb
+++ b/app/services/coupons/create_service.rb
@@ -3,6 +3,8 @@
 module Coupons
   class CreateService < BaseService
     def create(args)
+      return result unless valid?(args)
+
       reusable = args.key?(:reusable) ? args[:reusable] : true
 
       coupon = Coupon.create!(
@@ -39,6 +41,10 @@ module Coupons
           organization_id: coupon.organization_id,
         },
       )
+    end
+
+    def valid?(args)
+      Coupons::ValidateService.new(result, **args).valid?
     end
   end
 end

--- a/app/services/coupons/update_service.rb
+++ b/app/services/coupons/update_service.rb
@@ -33,6 +33,8 @@ module Coupons
       coupon = organization.coupons.find_by(code: code)
       return result.not_found_failure!(resource: 'coupon') unless coupon
 
+      return result unless valid?(params)
+
       coupon.name = params[:name] if params.key?(:name)
       coupon.expiration = params[:expiration] if params.key?(:expiration)
       coupon.expiration_at = params[:expiration_at] if params.key?(:expiration_at)
@@ -54,6 +56,12 @@ module Coupons
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    def valid?(args)
+      Coupons::ValidateService.new(result, **args).valid?
     end
   end
 end

--- a/app/services/coupons/validate_service.rb
+++ b/app/services/coupons/validate_service.rb
@@ -26,7 +26,7 @@ module Coupons
 
       return true if expiration_at && expiration_at.to_date >= Time.current.to_date
 
-      add_error(field: :expiration_at, error_code: 'invalid_value')
+      add_error(field: :expiration_at, error_code: 'invalid_date')
 
       false
     end

--- a/app/services/coupons/validate_service.rb
+++ b/app/services/coupons/validate_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Coupons
+  class ValidateService < BaseValidator
+    def valid?
+      valid_expiration_at?
+
+      if errors?
+        result.validation_failure!(errors: errors)
+        return false
+      end
+
+      true
+    end
+
+    private
+
+    def valid_expiration_at?
+      return true if args[:expiration_at].blank?
+
+      expiration_at = if args[:expiration_at].is_a?(Time)
+        args[:expiration_at]
+      elsif args[:expiration_at].is_a?(String) && Date._strptime(args[:expiration_at]).present?
+        Date.strptime(args[:expiration_at])
+      end
+
+      return true if expiration_at && expiration_at.to_date >= Time.current.to_date
+
+      add_error(field: :expiration_at, error_code: 'invalid_value')
+
+      false
+    end
+  end
+end

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Coupons::CreateService, type: :service do
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:expiration_at]).to eq(['invalid_value'])
+          expect(result.error.messages[:expiration_at]).to eq(['invalid_date'])
         end
       end
     end

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Coupons::CreateService, type: :service do
   let(:organization) { membership.organization }
 
   describe 'create' do
+    let(:expiration_at) { (Time.current + 3.days).end_of_day }
     let(:create_args) do
       {
         name: 'Super Coupon',
@@ -20,7 +21,7 @@ RSpec.describe Coupons::CreateService, type: :service do
         amount_currency: 'EUR',
         expiration: 'time_limit',
         reusable: false,
-        expiration_at: (Time.current + 3.days).end_of_day,
+        expiration_at: expiration_at,
       }
     end
 
@@ -83,6 +84,20 @@ RSpec.describe Coupons::CreateService, type: :service do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages[:code]).to eq(['value_already_exist'])
+        end
+      end
+    end
+
+    context 'with invalid expiration_at' do
+      let(:expiration_at) { (Time.current - 3.days).end_of_day }
+
+      it 'returns an error' do
+        result = create_service.create(**create_args)
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:expiration_at]).to eq(['invalid_value'])
         end
       end
     end

--- a/spec/services/coupons/validate_service_spec.rb
+++ b/spec/services/coupons/validate_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Coupons::ValidateService, type: :service do
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
-        expect(result.error.messages[:expiration_at]).to eq(['invalid_value'])
+        expect(result.error.messages[:expiration_at]).to eq(['invalid_date'])
       end
     end
   end

--- a/spec/services/coupons/validate_service_spec.rb
+++ b/spec/services/coupons/validate_service_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Coupons::ValidateService, type: :service do
+  subject(:validate_service) { described_class.new(result, **args) }
+
+  let(:result) { BaseService::Result.new }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:expiration_at) { Time.current + 10.days }
+  let(:args) do
+    {
+      organization_id: organization.id,
+      name: 'name',
+      code: 'code',
+      coupon_type: 'fixed_amount',
+      amount_cents: 100,
+      amount_currency: 'EUR',
+      frequency: 'once',
+      expiration: 'time_limit',
+      expiration_at: expiration_at,
+    }
+  end
+
+  describe '#valid?' do
+    it 'returns true' do
+      expect(validate_service).to be_valid
+    end
+
+    context 'when expiration_at is invalid' do
+      let(:expiration_at) { Time.current - 10.days }
+
+      it 'returns false and result has errors' do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:expiration_at]).to eq(['invalid_value'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
When creating/updating coupon from the API we need to validate expiration_at field. Currently, we don't validate it and coupon can be created even with `expiration_at` field set in the past
