### PR TITLE
fix(invoices): race conditions for wbehook

### DIFF
--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -45,6 +45,7 @@ module Invoices
     private
 
     attr_accessor :subscriptions, :timestamp, :customer, :currency
+    delegate :invoice, to: :result
 
     def issuing_date
       Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone).to_date
@@ -66,8 +67,4 @@ module Invoices
       )
     end
   end
-
-  private
-
-  delegate :invoice, to: :resul
 end

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -12,8 +12,11 @@ module Invoices
     end
 
     def create
+      result = nil
+      invoice = nil
+
       ActiveRecord::Base.transaction do
-        result.invoice = Invoice.create!(
+        invoice = Invoice.create!(
           customer: customer,
           issuing_date: issuing_date,
           invoice_type: :subscription,
@@ -26,7 +29,7 @@ module Invoices
           timezone: customer.applicable_timezone,
         )
 
-        self.result = Invoices::CalculateFeesService.new(
+        result = Invoices::CalculateFeesService.new(
           invoice: invoice,
           subscriptions: subscriptions,
           timestamp: timestamp,
@@ -45,7 +48,6 @@ module Invoices
     private
 
     attr_accessor :subscriptions, :timestamp, :customer, :currency
-    delegate :invoice, to: :result
 
     def issuing_date
       Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone).to_date

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -12,11 +12,8 @@ module Invoices
     end
 
     def create
-      invoice = nil
-      result = nil
-
       ActiveRecord::Base.transaction do
-        invoice = Invoice.create!(
+        result.invoice = Invoice.create!(
           customer: customer,
           issuing_date: issuing_date,
           invoice_type: :subscription,
@@ -29,7 +26,7 @@ module Invoices
           timezone: customer.applicable_timezone,
         )
 
-        result = Invoices::CalculateFeesService.new(
+        self.result = Invoices::CalculateFeesService.new(
           invoice: invoice,
           subscriptions: subscriptions,
           timestamp: timestamp,
@@ -69,4 +66,8 @@ module Invoices
       )
     end
   end
+
+  private
+
+  delegate :invoice, to: :resul
 end

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -32,12 +32,13 @@ module Invoices
           timestamp: timestamp,
         ).call
 
-        SendWebhookJob.perform_later(:invoice, invoice) if should_deliver_webhook?
         Invoices::Payments::CreateService.new(invoice).call
         track_invoice_created(invoice)
 
         result
       end
+
+      SendWebhookJob.perform_later(:invoice, invoice) if should_deliver_webhook?
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     end

--- a/app/services/invoices/create_service.rb
+++ b/app/services/invoices/create_service.rb
@@ -12,6 +12,9 @@ module Invoices
     end
 
     def create
+      invoice = nil
+      result = nil
+
       ActiveRecord::Base.transaction do
         invoice = Invoice.create!(
           customer: customer,
@@ -31,14 +34,13 @@ module Invoices
           subscriptions: subscriptions,
           timestamp: timestamp,
         ).call
-
-        Invoices::Payments::CreateService.new(invoice).call
-        track_invoice_created(invoice)
-
-        result
       end
 
       SendWebhookJob.perform_later(:invoice, invoice) if should_deliver_webhook?
+      Invoices::Payments::CreateService.new(invoice).call
+      track_invoice_created(invoice)
+
+      result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     end


### PR DESCRIPTION
## Context

- we had a race condition that was sending the webhook for a invoice before closing the transaction DB for it.

## Description

- Call the webhook job after the invoice DB transaction
