### PR TITLE
feat(timezones): Turn source into a reccuring flag

### DIFF
--- a/app/jobs/bill_subscription_job.rb
+++ b/app/jobs/bill_subscription_job.rb
@@ -5,11 +5,11 @@ class BillSubscriptionJob < ApplicationJob
 
   retry_on Sequenced::SequenceError
 
-  def perform(subscriptions, timestamp, invoice_source: :initial)
+  def perform(subscriptions, timestamp, recurring: false)
     result = Invoices::SubscriptionService.new(
       subscriptions: subscriptions,
       timestamp: timestamp,
-      invoice_source: invoice_source,
+      recurring: recurring,
     ).create
 
     result.throw_error unless result.success?

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -13,13 +13,6 @@ class InvoiceSubscription < ApplicationRecord
   monetize :subscription_amount_cents, disable_validation: true, allow_nil: true
   monetize :total_amount_cents, disable_validation: true, allow_nil: true
 
-  SOURCES = [
-    :recurring, # Created by the billing service
-    :initial, # Created by the creation or the start of a subscription
-  ].freeze
-
-  enum source: SOURCES
-
   scope :order_by_charges_to_datetime,
         lambda {
           condition = <<-SQL
@@ -30,6 +23,8 @@ class InvoiceSubscription < ApplicationRecord
 
           order(Arel.sql(ActiveRecord::Base.sanitize_sql_for_conditions(condition)))
         }
+
+  scope :recurring, -> { where(recurring: true) }
 
   def fees
     @fees ||= Fee.where(

--- a/app/services/billing_service.rb
+++ b/app/services/billing_service.rb
@@ -165,8 +165,20 @@ class BillingService
   end
 
   def already_billed_filter_sql
+    # TODO: A migration to unify type of the timestamp property must performed
+    timestamp_condition = <<-SQL
+      CASE
+        WHEN invoice_subscriptions.properties->>'timestamp' ~ '^[0-9\.]+$'
+        THEN
+          to_timestamp((invoice_subscriptions.properties->>'timestamp')::integer)::timestamptz
+        ELSE
+          (invoice_subscriptions.properties->>'timestamp')::timestamptz
+      END
+    SQL
+
     InvoiceSubscription
-      .where("DATE(invoice_subscriptions.properties->>'timestamp') = DATE(?)", today.to_date)
+      .where("invoice_subscriptions.properties->>'timestamp' IS NOT NULL")
+      .where("DATE(#{Arel.sql(timestamp_condition)}) = DATE(?)", today.to_date)
       .recurring
       .group(:subscription_id)
       .select('invoice_subscriptions.subscription_id, COUNT(invoice_subscriptions.id) AS invoiced_count')

--- a/app/services/billing_service.rb
+++ b/app/services/billing_service.rb
@@ -21,7 +21,7 @@ class BillingService
 
       BillSubscriptionJob
         .set(wait: rand(50).minutes)
-        .perform_later(billing_subscriptions, billing_timestamp, invoice_source: :recurring)
+        .perform_later(billing_subscriptions, billing_timestamp, recurring: true)
     end
   end
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -6,11 +6,11 @@ module Invoices
       new(...).call
     end
 
-    def initialize(invoice:, subscriptions:, timestamp:, invoice_source:)
+    def initialize(invoice:, subscriptions:, timestamp:, recurring: false)
       @invoice = invoice
       @subscriptions = subscriptions
       @timestamp = timestamp
-      @invoice_source = invoice_source
+      @recurring = recurring
 
       super
     end
@@ -24,7 +24,7 @@ module Invoices
             invoice: invoice,
             subscription: subscription,
             properties: boundaries,
-            source: invoice_source,
+            recurring: recurring,
           )
 
           create_subscription_fee(subscription, boundaries) if should_create_subscription_fee?(subscription)
@@ -49,7 +49,7 @@ module Invoices
 
     private
 
-    attr_accessor :invoice, :subscriptions, :timestamp, :invoice_source
+    attr_accessor :invoice, :subscriptions, :timestamp, :recurring
 
     delegate :customer, :currency, to: :invoice
 

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -2,10 +2,10 @@
 
 module Invoices
   class SubscriptionService < BaseService
-    def initialize(subscriptions:, timestamp:, invoice_source:)
+    def initialize(subscriptions:, timestamp:, recurring:)
       @subscriptions = subscriptions
       @timestamp = timestamp
-      @invoice_source = invoice_source
+      @recurring = recurring
       @customer = subscriptions&.first&.customer
       @currency = subscriptions&.first&.plan&.amount_currency
 
@@ -34,7 +34,7 @@ module Invoices
           invoice: invoice,
           subscriptions: subscriptions,
           timestamp: timestamp,
-          invoice_source: invoice_source,
+          recurring: recurring,
         ).call
       end
 
@@ -49,7 +49,7 @@ module Invoices
 
     private
 
-    attr_accessor :subscriptions, :timestamp, :invoice_source, :customer, :currency
+    attr_accessor :subscriptions, :timestamp, :recurring, :customer, :currency
 
     def issuing_date
       Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone).to_date

--- a/db/migrate/20221219111209_change_invoice_subscription_source.rb
+++ b/db/migrate/20221219111209_change_invoice_subscription_source.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ChangeInvoiceSubscriptionSource < ActiveRecord::Migration[7.0]
+  def up
+    change_table :invoice_subscriptions, bulk: true do |t|
+      t.remove :source
+
+      t.boolean :recurring, null: true
+    end
+
+    execute <<-SQL
+      UPDATE invoice_subscriptions
+      SET recurring = true;
+    SQL
+
+    change_column_null :invoice_subscriptions, :recurring, null: false
+  end
+
+  def down
+    change_table :invoice_subscriptions, bulk: true do |t|
+      t.integer :source
+      t.remove :recurring
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_12_153810) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_19_111209) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -308,7 +308,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_12_153810) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "properties", default: "{}", null: false
-    t.integer "source", null: false
+    t.boolean "recurring"
     t.index ["invoice_id"], name: "index_invoice_subscriptions_on_invoice_id"
     t.index ["subscription_id"], name: "index_invoice_subscriptions_on_subscription_id"
   end

--- a/db/seeds/invoices.rb
+++ b/db/seeds/invoices.rb
@@ -5,7 +5,7 @@ Subscription.all.find_each do |subscription|
   Invoices::SubscriptionService.new(
     subscriptions: [subscription],
     timestamp: Time.zone.now - 2.months,
-    invoice_source: :initial,
+    recurring: true,
   ).create
 end
 

--- a/spec/factories/invoice_subscriptions.rb
+++ b/spec/factories/invoice_subscriptions.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     subscription
     invoice
 
-    source { :initial }
+    recurring { false }
   end
 end

--- a/spec/jobs/bill_subscription_job_spec.rb
+++ b/spec/jobs/bill_subscription_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BillSubscriptionJob, type: :job do
 
   it 'calls the invoices create service' do
     allow(Invoices::SubscriptionService).to receive(:new)
-      .with(subscriptions: [subscription], timestamp: timestamp, invoice_source: :initial)
+      .with(subscriptions: [subscription], timestamp: timestamp, recurring: false)
       .and_return(invoice_service)
     allow(invoice_service).to receive(:create)
       .and_return(result)
@@ -29,7 +29,7 @@ RSpec.describe BillSubscriptionJob, type: :job do
 
     it 'raises an error' do
       allow(Invoices::SubscriptionService).to receive(:new)
-        .with(subscriptions: [subscription], timestamp: timestamp, invoice_source: :initial)
+        .with(subscriptions: [subscription], timestamp: timestamp, recurring: false)
         .and_return(invoice_service)
       allow(invoice_service).to receive(:create)
         .and_return(result)

--- a/spec/services/billing_service_spec.rb
+++ b/spec/services/billing_service_spec.rb
@@ -69,10 +69,10 @@ RSpec.describe BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with(match_array([subscription1, subscription2]), current_date.to_i, invoice_source: :recurring)
+            .with(match_array([subscription1, subscription2]), current_date.to_i, recurring: true)
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription3], current_date.to_i, invoice_source: :recurring)
+            .with([subscription3], current_date.to_i, recurring: true)
         end
       end
 
@@ -96,7 +96,7 @@ RSpec.describe BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, invoice_source: :recurring)
+            .with([subscription], current_date.to_i, recurring: true)
         end
       end
 
@@ -120,7 +120,7 @@ RSpec.describe BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, invoice_source: :recurring)
+            .with([subscription], current_date.to_i, recurring: true)
         end
       end
 
@@ -142,7 +142,7 @@ RSpec.describe BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with([subscription], current_date.to_i, invoice_source: :recurring)
+              .with([subscription], current_date.to_i, recurring: true)
           end
         end
       end
@@ -163,7 +163,7 @@ RSpec.describe BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, invoice_source: :recurring)
+            .with([subscription], current_date.to_i, recurring: true)
         end
       end
 
@@ -184,7 +184,7 @@ RSpec.describe BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, invoice_source: :recurring)
+            .with([subscription], current_date.to_i, recurring: true)
         end
       end
 
@@ -203,7 +203,7 @@ RSpec.describe BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with([subscription], current_date.to_i, invoice_source: :recurring)
+              .with([subscription], current_date.to_i, recurring: true)
           end
         end
       end
@@ -220,7 +220,7 @@ RSpec.describe BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, invoice_source: :recurring)
+            .with([subscription], current_date.to_i, recurring: true)
         end
       end
 
@@ -239,7 +239,7 @@ RSpec.describe BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with([subscription], current_date.to_i, invoice_source: :recurring)
+              .with([subscription], current_date.to_i, recurring: true)
           end
         end
       end
@@ -253,7 +253,7 @@ RSpec.describe BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with([subscription], current_date.next_month.to_i, invoice_source: :recurring)
+              .with([subscription], current_date.next_month.to_i, recurring: true)
           end
         end
 
@@ -266,7 +266,7 @@ RSpec.describe BillingService, type: :service do
               billing_service.call
 
               expect(BillSubscriptionJob).to have_been_enqueued
-                .with([subscription], current_date.to_i, invoice_source: :recurring)
+                .with([subscription], current_date.to_i, recurring: true)
             end
           end
         end
@@ -353,7 +353,7 @@ RSpec.describe BillingService, type: :service do
         create(
           :invoice_subscription,
           subscription: subscription,
-          source: :recurring,
+          recurring: true,
           properties: {
             timestamp: subscription_at - 1.hour,
           },

--- a/spec/services/billing_service_spec.rb
+++ b/spec/services/billing_service_spec.rb
@@ -367,6 +367,25 @@ RSpec.describe BillingService, type: :service do
           expect { billing_service.call }.not_to have_enqueued_job
         end
       end
+
+      context 'when timestamp is an integer' do
+        let(:invoice_subscription) do
+          create(
+            :invoice_subscription,
+            subscription: subscription,
+            recurring: true,
+            properties: {
+              timestamp: (subscription_at - 1.hour).to_i,
+            },
+          )
+        end
+
+        it 'does not enqueue a job' do
+          travel_to(subscription_at) do
+            expect { billing_service.call }.not_to have_enqueued_job
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       invoice: invoice,
       subscriptions: subscriptions,
       timestamp: timestamp.to_i,
-      invoice_source: invoice_source,
+      recurring: recurring,
     )
   end
 
-  let(:invoice_source) { :initial }
+  let(:recurring) { false }
 
   describe '#call' do
     let(:invoice) do
@@ -67,7 +67,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             expect(result.invoice.fees.subscription_kind.count).to eq(0)
 
             expect(result.invoice.invoice_subscriptions.count).to eq(1)
-            expect(result.invoice.invoice_subscriptions.first).to be_initial
+            expect(result.invoice.invoice_subscriptions.first.recurring).to be_false
           end
         end
       end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             expect(result.invoice.fees.subscription_kind.count).to eq(0)
 
             expect(result.invoice.invoice_subscriptions.count).to eq(1)
-            expect(result.invoice.invoice_subscriptions.first.recurring).to be_false
+            expect(result.invoice.invoice_subscriptions.first.recurring).to be_falsey
           end
         end
       end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
     described_class.new(
       subscriptions: subscriptions,
       timestamp: timestamp.to_i,
-      invoice_source: :initial,
+      recurring: true,
     )
   end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/61

## Context

It’s impossible to bill a customer following its own timezone.
Lago ingests events, creates subscription boundaries and trigger invoices on a UTC timezone, which is the same for everyone.

This feature adds the possibility to choose the timezone an organization or a customer should be billed in.

## Description

This PR follows https://github.com/getlago/lago-api/pull/662 but turn `source` into a boolean flag `recurring` on `InvoiceSubscription` model
