### PR TITLE
misc: Rename throw_error service method into raise_if_error

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -13,7 +13,7 @@ class WebhooksController < ApplicationController
         return head(:bad_request)
       end
 
-      result.throw_error
+      result.raise_if_error!
     end
 
     head(:ok)
@@ -31,7 +31,7 @@ class WebhooksController < ApplicationController
         return head(:bad_request)
       end
 
-      result.throw_error
+      result.raise_if_error!
     end
 
     head(:ok)

--- a/app/jobs/bill_add_on_job.rb
+++ b/app/jobs/bill_add_on_job.rb
@@ -11,6 +11,6 @@ class BillAddOnJob < ApplicationJob
       datetime: Time.zone.at(timestamp),
     ).create
 
-    raise(result.throw_error) unless result.success?
+    result.raise_if_error!
   end
 end

--- a/app/jobs/bill_paid_credit_job.rb
+++ b/app/jobs/bill_paid_credit_job.rb
@@ -11,6 +11,6 @@ class BillPaidCreditJob < ApplicationJob
       timestamp: timestamp,
     ).create
 
-    raise result.throw_error unless result.success?
+    result.raise_if_error!
   end
 end

--- a/app/jobs/bill_subscription_job.rb
+++ b/app/jobs/bill_subscription_job.rb
@@ -12,6 +12,6 @@ class BillSubscriptionJob < ApplicationJob
       recurring: recurring,
     ).create
 
-    result.throw_error unless result.success?
+    result.raise_if_error!
   end
 end

--- a/app/jobs/create_event_job.rb
+++ b/app/jobs/create_event_job.rb
@@ -11,6 +11,6 @@ class CreateEventJob < ApplicationJob
       metadata: metadata,
     )
 
-    result.throw_error unless result.success?
+    result.raise_if_error!
   end
 end

--- a/app/jobs/credit_notes/refunds/gocardless_create_job.rb
+++ b/app/jobs/credit_notes/refunds/gocardless_create_job.rb
@@ -7,7 +7,7 @@ module CreditNotes
 
       def perform(credit_note)
         result = CreditNotes::Refunds::GocardlessService.new(credit_note).create
-        result.throw_error unless result.success?
+        result.raise_if_error!
       end
     end
   end

--- a/app/jobs/credit_notes/refunds/stripe_create_job.rb
+++ b/app/jobs/credit_notes/refunds/stripe_create_job.rb
@@ -7,7 +7,7 @@ module CreditNotes
 
       def perform(credit_note)
         result = CreditNotes::Refunds::StripeService.new(credit_note).create
-        result.throw_error unless result.success?
+        result.raise_if_error!
       end
     end
   end

--- a/app/jobs/events/create_batch_job.rb
+++ b/app/jobs/events/create_batch_job.rb
@@ -12,7 +12,7 @@ module Events
         metadata: metadata,
       )
 
-      result.throw_error unless result.success?
+      result.raise_if_error!
     end
   end
 end

--- a/app/jobs/invoices/payments/gocardless_create_job.rb
+++ b/app/jobs/invoices/payments/gocardless_create_job.rb
@@ -7,7 +7,7 @@ module Invoices
 
       def perform(invoice)
         result = Invoices::Payments::GocardlessService.new(invoice).create
-        result.throw_error unless result.success?
+        result.raise_if_error!
       end
     end
   end

--- a/app/jobs/invoices/payments/stripe_create_job.rb
+++ b/app/jobs/invoices/payments/stripe_create_job.rb
@@ -7,7 +7,7 @@ module Invoices
 
       def perform(invoice)
         result = Invoices::Payments::StripeService.new(invoice).create
-        result.throw_error unless result.success?
+        result.raise_if_error!
       end
     end
   end

--- a/app/jobs/payment_provider_customers/gocardless_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/gocardless_checkout_url_job.rb
@@ -10,7 +10,7 @@ module PaymentProviderCustomers
 
     def perform(gocardless_customer)
       result = PaymentProviderCustomers::GocardlessService.new(gocardless_customer).generate_checkout_url
-      result.throw_error
+      result.raise_if_error!
     end
   end
 end

--- a/app/jobs/payment_provider_customers/gocardless_create_job.rb
+++ b/app/jobs/payment_provider_customers/gocardless_create_job.rb
@@ -10,7 +10,7 @@ module PaymentProviderCustomers
 
     def perform(gocardless_customer)
       result = PaymentProviderCustomers::GocardlessService.new(gocardless_customer).create
-      result.throw_error
+      result.raise_if_error!
     end
   end
 end

--- a/app/jobs/payment_provider_customers/stripe_create_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_create_job.rb
@@ -10,7 +10,7 @@ module PaymentProviderCustomers
 
     def perform(stripe_customer)
       result = PaymentProviderCustomers::StripeService.new(stripe_customer).create
-      result.throw_error
+      result.raise_if_error!
     end
   end
 end

--- a/app/jobs/payment_providers/gocardless/handle_event_job.rb
+++ b/app/jobs/payment_providers/gocardless/handle_event_job.rb
@@ -7,7 +7,7 @@ module PaymentProviders
 
       def perform(events_json:)
         result = PaymentProviders::GocardlessService.new.handle_event(events_json: events_json)
-        result.throw_error if result.present?
+        result.raise_if_error!
       end
     end
   end

--- a/app/jobs/payment_providers/stripe/handle_event_job.rb
+++ b/app/jobs/payment_providers/stripe/handle_event_job.rb
@@ -10,7 +10,7 @@ module PaymentProviders
           organization: organization,
           event_json: event,
         )
-        result.throw_error
+        result.raise_if_error!
       end
     end
   end

--- a/app/jobs/payment_providers/stripe/refresh_webhook_job.rb
+++ b/app/jobs/payment_providers/stripe/refresh_webhook_job.rb
@@ -9,7 +9,7 @@ module PaymentProviders
         result = PaymentProviders::StripeService.new.refresh_webhook(
           stripe_provider: stripe_provider,
         )
-        result.throw_error
+        result.raise_if_error!
       end
     end
   end

--- a/app/jobs/payment_providers/stripe/register_webhook_job.rb
+++ b/app/jobs/payment_providers/stripe/register_webhook_job.rb
@@ -7,7 +7,7 @@ module PaymentProviders
 
       def perform(stripe_provider)
         result = PaymentProviders::StripeService.new.register_webhook(stripe_provider)
-        result.throw_error
+        result.raise_if_error!
       end
     end
   end

--- a/app/jobs/subscriptions/terminate_job.rb
+++ b/app/jobs/subscriptions/terminate_job.rb
@@ -10,7 +10,7 @@ module Subscriptions
         timestamp: timestamp,
       )
 
-      result.throw_error unless result.success?
+      result.raise_if_error!
     end
   end
 end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -121,7 +121,7 @@ class BaseService
       fail_with_error!(ForbiddenFailure.new(self, code: code))
     end
 
-    def throw_error
+    def raise_if_error!
       return if success?
 
       raise(error)

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -43,7 +43,7 @@ module CreditNotes
         return result unless result.success?
 
         valid_credit_note?
-        result.throw_error unless result.success?
+        result.raise_if_error!
 
         credit_note.credit_status = 'available' if credit_note.credited?
         credit_note.refund_status = 'pending' if credit_note.refunded?

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -133,7 +133,7 @@ module Customers
         async: !(billing_configuration || {})[:sync],
       )
 
-      create_result.throw_error unless create_result.success?
+      create_result.raise_if_error!
     end
 
     def track_customer_created(customer)

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -112,7 +112,7 @@ module Customers
         payment_provider_id: customer.organization.stripe_payment_provider&.id,
         params: billing_configuration,
       )
-      return create_result.throw_error unless create_result.success?
+      create_result.raise_if_error!
 
       # NOTE: Create service is modifying an other instance of the provider customer
       customer.stripe_customer&.reload
@@ -124,7 +124,7 @@ module Customers
         payment_provider_id: customer.organization.gocardless_payment_provider&.id,
         params: billing_configuration,
       )
-      return create_result.throw_error unless create_result.success?
+      create_result.raise_if_error!
 
       # NOTE: Create service is modifying an other instance of the provider customer
       customer.gocardless_customer&.reload

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -77,7 +77,7 @@ module Events
       return unless persisted_service.matching_billable_metric?
 
       service_result = persisted_service.call
-      service_result.throw_error unless service_result.success?
+      service_result.raise_if_error!
     end
   end
 end

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -89,7 +89,7 @@ module Events
 
     def handle_persisted_event
       service_result = persisted_event_service.call
-      service_result.throw_error unless service_result.success?
+      service_result.raise_if_error!
     end
   end
 end

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -61,8 +61,8 @@ module Invoices
 
     def create_add_on_fee(invoice)
       fee_result = Fees::AddOnService
-        .new(invoice: invoice, applied_add_on: applied_add_on).create
-      raise(fee_result.throw_error) unless fee_result.success?
+        .new(invoice:, applied_add_on:).create
+      fee_result.raise_if_error!
     end
 
     def should_deliver_webhook?

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -78,24 +78,19 @@ module Invoices
 
     def create_subscription_fee(subscription, boundaries)
       fee_result = Fees::SubscriptionService.new(
-        invoice: invoice,
-        subscription: subscription,
-        boundaries: boundaries,
+        invoice:, subscription:, boundaries:,
       ).create
 
-      fee_result.throw_error unless fee_result.success?
+      fee_result.raise_if_error!
     end
 
     def create_charges_fees(subscription, boundaries)
       subscription.plan.charges.each do |charge|
         fee_result = Fees::ChargeService.new(
-          invoice: invoice,
-          charge: charge,
-          subscription: subscription,
-          boundaries: boundaries,
+          invoice:, charge:, subscription:, boundaries:,
         ).create
 
-        fee_result.throw_error unless fee_result.success?
+        fee_result.raise_if_error!
       end
     end
 
@@ -172,10 +167,9 @@ module Invoices
 
     def create_credit_note_credit
       credit_result = Credits::CreditNoteService.new(
-        invoice: invoice,
-        credit_notes: credit_notes,
+        invoice:, credit_notes:,
       ).call
-      credit_result.throw_error unless credit_result.success?
+      credit_result.raise_if_error!
 
       refresh_amounts(credit_amount_cents: credit_result.credits.sum(&:amount_cents))
     end
@@ -187,10 +181,9 @@ module Invoices
         next if applied_coupon.coupon.fixed_amount? && applied_coupon.amount_currency != currency
 
         credit_result = Credits::AppliedCouponService.new(
-          invoice: invoice,
-          applied_coupon: applied_coupon,
+          invoice:, applied_coupon:,
         ).create
-        credit_result.throw_error unless credit_result.success?
+        credit_result.raise_if_error!
 
         refresh_amounts(credit_amount_cents: credit_result.credit.amount_cents)
       end
@@ -198,7 +191,7 @@ module Invoices
 
     def create_applied_prepaid_credit
       prepaid_credit_result = Credits::AppliedPrepaidCreditService.new(invoice: invoice, wallet: wallet).create
-      prepaid_credit_result.throw_error unless prepaid_credit_result.success?
+      prepaid_credit_result.raise_if_error!
 
       refresh_amounts(credit_amount_cents: prepaid_credit_result.prepaid_credit_amount_cents)
     end
@@ -218,7 +211,7 @@ module Invoices
         to_datetime: date_service.to_datetime,
         charges_from_datetime: date_service.charges_from_datetime,
         charges_to_datetime: date_service.charges_to_datetime,
-        timestamp: timestamp,
+        timestamp:,
       }
     end
   end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -68,13 +68,10 @@ module Invoices
 
       query.each do |charge|
         fees_result = Fees::ChargeService.new(
-          invoice: invoice,
-          charge: charge,
-          subscription: subscription,
-          boundaries: boundaries,
+          invoice:, charge:, subscription:, boundaries:,
         ).current_usage
 
-        fees_result.throw_error unless fees_result.success?
+        fees_result.raise_if_error!
 
         invoice.fees << fees_result.fees
       end

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -65,9 +65,9 @@ module Invoices
 
     def create_credit_fee(invoice)
       fee_result = Fees::PaidCreditService
-        .new(invoice: invoice, wallet_transaction: wallet_transaction, customer: customer).create
+        .new(invoice:, wallet_transaction:, customer:).create
 
-      raise(fee_result.throw_error) unless fee_result.success?
+      fee_result.raise_if_error!
     end
 
     def should_deliver_webhook?

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -18,8 +18,8 @@ module Invoices
 
       ActiveRecord::Base.transaction do
         invoice = Invoice.create!(
-          customer: customer,
-          issuing_date: issuing_date,
+          customer:,
+          issuing_date:,
           invoice_type: :subscription,
 
           amount_currency: currency,
@@ -32,14 +32,11 @@ module Invoices
         )
 
         result = Invoices::CalculateFeesService.new(
-          invoice: invoice,
-          subscriptions: subscriptions,
-          timestamp: timestamp,
-          recurring: recurring,
+          invoice:, subscriptions:, timestamp:, recurring:,
         ).call
       end
 
-      result.throw_error unless result.success?
+      result.raise_if_error!
 
       if grace_period?
         SendWebhookJob.perform_later('invoice.drafted', invoice) if should_deliver_webhook?

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -108,7 +108,7 @@ module PaymentProviders
             stripe_customer_id: event.data.object.customer,
             payment_method_id: event.data.object.payment_method,
           )
-        result.throw_error || result
+        result.raise_if_error! || result
       when 'payment_intent.payment_failed', 'payment_intent.succeeded'
         status = event.type == 'payment_intent.succeeded' ? 'succeeded' : 'failed'
 
@@ -125,7 +125,7 @@ module PaymentProviders
             stripe_customer_id: event.data.object.customer,
             payment_method_id: event.data.object.id,
           )
-        result.throw_error || result
+        result.raise_if_error! || result
       when 'charge.refund.updated'
         CreditNotes::Refunds::StripeService
           .new.update_status(

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -167,7 +167,7 @@ module Subscriptions
         # NOTE: As subscription was payed in advance and terminated before the end of the period,
         #       we have to create a credit note for the days that were not consumed
         credit_note_result = CreditNotes::CreateFromUpgrade.new(subscription: current_subscription).call
-        credit_note_result.throw_error unless credit_note_result.success?
+        credit_note_result.raise_if_error!
       end
 
       # NOTE: Create an invoice for the terminated subscription


### PR DESCRIPTION
## Context

Today result objects expose a `throw_error` that raise a `FailedResult` (or a subclass) if the result is not a success.

```ruby
  def throw_error
    return if success?

    raise(error)
  end
```

Since the naming of this method does not make obvious that it will not raise if the result is a success, the code end-up with things like:

```ruby
raise(result.throw_error) unless result.success?
```
It's seems a bit confusing :exploding_head: 

## Description

This PR simply renames `throw_error` into `raise_if_error!` and clean all the related code.
