### PR TITLE
feat(grace_period): Prevent from downloading a draft invoice

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -49,7 +49,7 @@ module Api
       end
 
       def download
-        invoice = current_organization.invoices.find_by(id: params[:id])
+        invoice = current_organization.invoices.finalized.find_by(id: params[:id])
 
         return not_found_error(resource: 'invoice') unless invoice
 

--- a/app/services/invoices/generate_service.rb
+++ b/app/services/invoices/generate_service.rb
@@ -11,11 +11,11 @@ module Invoices
     def generate(invoice_id:)
       invoice = Invoice.find_by(id: invoice_id)
       return result.not_found_failure!(resource: 'invoice') if invoice.blank?
+      return result.not_allowed_failure!(code: 'is_draft') if invoice.draft?
 
       generate_pdf(invoice) if invoice.file.blank?
 
       result.invoice = invoice
-
       result
     end
 

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::InvoicesController, type: :request do
   let(:organization) { create(:organization) }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:invoice) { create(:invoice, customer: customer) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, customer:, status: :finalized) }
 
   describe 'UPDATE /invoices' do
     let(:update_params) do
@@ -189,6 +189,17 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
 
         expect(response).to have_http_status(:success)
         expect(json[:invoice][:lago_id]).to eq(invoice.id)
+      end
+    end
+  end
+
+  describe 'POST /invoices/:id/download' do
+    let(:invoice) { create(:invoice, customer:, status: :draft) }
+
+    context 'when invoice is draft' do
+      it 'returns not found' do
+        post_with_token(organization, "/api/v1/invoices/#{invoice.id}/download")
+        expect(response).to have_http_status(:not_found)
       end
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to prevent downloading a draft invoice.