### PR TITLE
feat(grace_period): Ability to create events on terminated subscription

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -10,7 +10,7 @@ class CreditNote < ApplicationRecord
 
   has_one :organization, through: :customer
 
-  has_many :items, class_name: 'CreditNoteItem'
+  has_many :items, class_name: 'CreditNoteItem', dependent: :destroy
   has_many :fees, through: :items
   has_many :refunds
 

--- a/app/services/events/validate_creation_service.rb
+++ b/app/services/events/validate_creation_service.rb
@@ -91,7 +91,7 @@ module Events
     end
 
     def customer_external_subscription_ids
-      @customer_external_subscription_ids ||= customer&.active_subscriptions&.pluck(:external_id)
+      @customer_external_subscription_ids ||= customer&.subscriptions&.pluck(:external_id)
     end
 
     def missing_subscription_error

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -39,7 +39,7 @@ module Invoices
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
         invoice.save!
 
-        result.invoice = invoice
+        result.invoice = invoice.reload
       end
 
       result

--- a/spec/services/events/validate_creation_service_spec.rb
+++ b/spec/services/events/validate_creation_service_spec.rb
@@ -135,6 +135,30 @@ RSpec.describe Events::ValidateCreationService, type: :service do
         end
       end
 
+      context 'when there is one active subscription with the same external_id' do
+        let(:subscription) do
+          create(:subscription, customer:, organization:, external_id:, status: :terminated)
+        end
+        let(:external_id) { SecureRandom.uuid }
+        let(:params) do
+          {
+            code: billable_metric.code,
+            external_subscription_id: external_id,
+            external_customer_id: customer.external_id,
+          }
+        end
+
+        before do
+          subscription
+          create(:active_subscription, customer:, organization:, external_id:)
+        end
+
+        it 'does not return any validation errors' do
+          expect(validate_event).to be_nil
+          expect(result).to be_success
+        end
+      end
+
       context 'when code does not exist' do
         let(:params) do
           { external_customer_id: customer.external_id, code: 'event_code' }


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to be able to create events on a terminated subscription.