### PR TITLE
feat(grace_period): Finalize invoices if grace period is updated

### DIFF
--- a/app/graphql/mutations/customers/update_invoice_grace_period.rb
+++ b/app/graphql/mutations/customers/update_invoice_grace_period.rb
@@ -14,10 +14,7 @@ module Mutations
       type Types::Customers::SingleObject
 
       def resolve(id:, invoice_grace_period:)
-        result = ::Customers::UpdateService.new(context[:current_user]).update(
-          id: id,
-          invoice_grace_period: invoice_grace_period,
-        )
+        result = ::Customers::UpdateService.new(context[:current_user]).update(id:, invoice_grace_period:)
 
         result.success? ? result.customer : result_error(result)
       end

--- a/app/jobs/clock/finalize_invoices_job.rb
+++ b/app/jobs/clock/finalize_invoices_job.rb
@@ -5,23 +5,9 @@ module Clock
     queue_as 'clock'
 
     def perform
-      draft_invoices.each do |invoice|
-        Invoices::FinalizeService.call(invoice: invoice)
+      Invoice.ready_to_be_finalized.each do |invoice|
+        Invoices::FinalizeService.call(invoice:)
       end
-    end
-
-    private
-
-    def draft_invoices
-      Invoice
-        .draft
-        .joins(customer: :organization)
-        .where(
-          "(invoices.created_at + \
-          COALESCE(customers.invoice_grace_period, organizations.invoice_grace_period) * INTERVAL '1 DAY') \
-          < ?",
-          Time.current,
-        )
     end
   end
 end

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -101,7 +101,9 @@ module Customers
       return unless params.key?(:billing_configuration)
 
       billing = params[:billing_configuration]
-      customer.invoice_grace_period = billing[:invoice_grace_period] if billing.key?(:invoice_grace_period)
+      if billing.key?(:invoice_grace_period)
+        Customers::UpdateInvoiceGracePeriodService.call(customer:, grace_period: billing[:invoice_grace_period])
+      end
       customer.vat_rate = billing[:vat_rate] if billing.key?(:vat_rate)
 
       if new_customer

--- a/app/services/customers/update_invoice_grace_period_service.rb
+++ b/app/services/customers/update_invoice_grace_period_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Customers
+  class UpdateInvoiceGracePeriodService < BaseService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(customer:, grace_period:)
+      @customer = customer
+      @grace_period = grace_period
+      super
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        customer.update!(invoice_grace_period: grace_period)
+
+        # NOTE: Finalize related draft invoices.
+        customer.invoices.ready_to_be_finalized.each do |invoice|
+          Invoices::FinalizeService.call(invoice:)
+        end
+
+        # NOTE: Update issuing_date on draft invoices.
+        customer.invoices.draft.each do |invoice|
+          invoice.update!(issuing_date: grace_period_issuing_date(invoice))
+        end
+
+        result.customer = customer
+        result
+      end
+    end
+
+    private
+
+    attr_reader :customer, :grace_period
+
+    def invoice_created_at(invoice)
+      invoice.created_at.in_time_zone(customer.applicable_timezone).to_date
+    end
+
+    def grace_period_issuing_date(invoice)
+      invoice_created_at(invoice) + customer.applicable_invoice_grace_period.days
+    end
+  end
+end

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -34,18 +34,21 @@ module Customers
         customer.vat_rate = args[:vat_rate] if args.key?(:vat_rate)
         customer.payment_provider = args[:payment_provider] if args.key?(:payment_provider)
         customer.invoice_footer = args[:invoice_footer] if args.key?(:invoice_footer)
-        customer.invoice_grace_period = args[:invoice_grace_period] if args.key?(:invoice_grace_period)
+        if args.key?(:invoice_grace_period)
+          Customers::UpdateInvoiceGracePeriodService.call(customer:, grace_period: args[:invoice_grace_period])
+        end
 
         if args.key?(:billing_configuration)
           billing = args[:billing_configuration]
           customer.invoice_footer = billing[:invoice_footer] if billing.key?(:invoice_footer)
-          customer.invoice_grace_period = billing[:invoice_grace_period] if billing.key?(:invoice_grace_period)
           customer.vat_rate = billing[:vat_rate] if billing.key?(:vat_rate)
+          if billing.key?(:invoice_grace_period)
+            Customers::UpdateInvoiceGracePeriodService.call(customer:, grace_period: billing[:invoice_grace_period])
+          end
         end
 
         # NOTE: external_id is not editable if customer is attached to subscriptions
         customer.external_id = args[:external_id] if customer.editable? && args.key?(:external_id)
-
         customer.save!
 
         # NOTE: if payment provider is updated, we need to create/update the provider customer

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -23,10 +23,7 @@ module Invoices
         invoice.fees.destroy_all
         invoice.invoice_subscriptions.destroy_all
 
-        invoice.update!(
-          issuing_date:,
-          vat_rate: invoice.customer.applicable_vat_rate,
-        )
+        invoice.update!(vat_rate: invoice.customer.applicable_vat_rate)
 
         Invoices::CalculateFeesService.call(
           invoice:,
@@ -39,9 +36,5 @@ module Invoices
     private
 
     attr_accessor :invoice, :subscription_ids
-
-    def issuing_date
-      @issuing_date ||= Time.current.in_time_zone(invoice.customer.applicable_timezone).to_date
-    end
   end
 end

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -56,7 +56,10 @@ module Invoices
     attr_accessor :subscriptions, :timestamp, :recurring, :customer, :currency
 
     def issuing_date
-      Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone).to_date
+      issuing_date = Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone).to_date
+      return issuing_date unless grace_period?
+
+      issuing_date + customer.applicable_invoice_grace_period.days
     end
 
     def grace_period?

--- a/app/services/organizations/update_invoice_grace_period_service.rb
+++ b/app/services/organizations/update_invoice_grace_period_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Organizations
+  class UpdateInvoiceGracePeriodService < BaseService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(organization:, grace_period:)
+      @organization = organization
+      @grace_period = grace_period
+      super
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        organization.update!(invoice_grace_period: grace_period)
+
+        # NOTE: Finalize related draft invoices.
+        organization.invoices.ready_to_be_finalized.each do |invoice|
+          Invoices::FinalizeService.call(invoice:)
+        end
+
+        # NOTE: Update issuing_date on draft invoices.
+        organization.invoices.draft.each do |invoice|
+          invoice.update!(issuing_date: grace_period_issuing_date(invoice))
+        end
+
+        result.organization = organization
+        result
+      end
+    end
+
+    private
+
+    attr_reader :organization, :grace_period
+
+    def invoice_created_at(invoice)
+      invoice.created_at.in_time_zone(invoice.customer.applicable_timezone).to_date
+    end
+
+    def grace_period_issuing_date(invoice)
+      invoice_created_at(invoice) + invoice.customer.applicable_invoice_grace_period.days
+    end
+  end
+end

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -21,7 +21,9 @@ module Organizations
       organization.city = args[:city] if args.key?(:city)
       organization.country = args[:country] if args.key?(:country)
       organization.invoice_footer = args[:invoice_footer] if args.key?(:invoice_footer)
-      organization.invoice_grace_period = args[:invoice_grace_period] if args.key?(:invoice_grace_period)
+      if args.key?(:invoice_grace_period)
+        Organizations::UpdateInvoiceGracePeriodService.call(organization:, grace_period: args[:invoice_grace_period])
+      end
 
       # TODO(:timezone): Timezone update is turned off for now
       # organization.timezone = args[:timezone] if args.key?(:timezone)
@@ -31,7 +33,6 @@ module Organizations
       organization.save!
 
       result.organization = organization
-
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
@@ -55,8 +56,10 @@ module Organizations
       if params.key?(:billing_configuration)
         billing = params[:billing_configuration]
         organization.invoice_footer = billing[:invoice_footer] if billing.key?(:invoice_footer)
-        organization.invoice_grace_period = billing[:invoice_grace_period] if billing.key?(:invoice_grace_period)
         organization.vat_rate = billing[:vat_rate] if billing.key?(:vat_rate)
+        if billing.key?(:invoice_grace_period)
+          Organizations::UpdateInvoiceGracePeriodService.call(organization:, grace_period: billing[:invoice_grace_period])
+        end
       end
 
       organization.save!

--- a/spec/graphql/mutations/invoices/refresh_spec.rb
+++ b/spec/graphql/mutations/invoices/refresh_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Mutations::Invoices::Refresh, type: :graphql do
       mutation($input: RefreshInvoiceInput!) {
         refreshInvoice(input: $input) {
           id
-          issuingDate
+          updatedAt
         }
       }
     GQL
@@ -34,7 +34,7 @@ RSpec.describe Mutations::Invoices::Refresh, type: :graphql do
 
       aggregate_failures do
         expect(result_data['id']).to be_present
-        expect(result_data['issuingDate']).to eq(Time.current.to_date.to_s)
+        expect(result_data['updatedAt']).to eq(Time.current.iso8601)
       end
     end
   end

--- a/spec/jobs/clock/finalize_invoices_job_spec.rb
+++ b/spec/jobs/clock/finalize_invoices_job_spec.rb
@@ -8,10 +8,10 @@ describe Clock::FinalizeInvoicesJob, job: true do
   describe '.perform' do
     let(:customer) { create(:customer, invoice_grace_period: 3) }
     let(:draft_invoice) do
-      create(:invoice, status: :draft, created_at: DateTime.parse('20 Jun 2022'), customer: customer)
+      create(:invoice, status: :draft, created_at: DateTime.parse('20 Jun 2022'), customer:)
     end
     let(:finalized_invoice) do
-      create(:invoice, status: :finalized, created_at: DateTime.parse('20 Jun 2022'), customer: customer)
+      create(:invoice, status: :finalized, created_at: DateTime.parse('20 Jun 2022'), customer:)
     end
 
     before do

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -159,12 +159,12 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'when invoice is draft' do
-      let(:invoice) { create(:invoice, customer:, issuing_date: 2.days.ago) }
+      let(:invoice) { create(:invoice, customer:) }
 
       it 'updates the invoice' do
         expect {
           put_with_token(organization, "/api/v1/invoices/#{invoice.id}/refresh", {})
-        }.to change { invoice.reload.issuing_date }
+        }.to change { invoice.reload.updated_at }
       end
 
       it 'returns the invoice' do
@@ -181,7 +181,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       it 'does not update the invoice' do
         expect {
           put_with_token(organization, "/api/v1/invoices/#{invoice.id}/refresh", {})
-        }.not_to change { invoice.reload.issuing_date }
+        }.not_to change { invoice.reload.updated_at }
       end
 
       it 'returns the invoice' do

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -136,6 +136,24 @@ RSpec.describe Customers::CreateService, type: :service do
           end
         end
       end
+
+      context 'when updating invoice grace period' do
+        let(:create_args) do
+          {
+            external_id: SecureRandom.uuid,
+            billing_configuration: { invoice_grace_period: 2 },
+          }
+        end
+
+        before do
+          allow(Customers::UpdateInvoiceGracePeriodService).to receive(:call)
+        end
+
+        it 'calls UpdateInvoiceGracePeriodService' do
+          customers_service.create_from_api(organization:, params: create_args)
+          expect(Customers::UpdateInvoiceGracePeriodService).to have_received(:call).with(customer:, grace_period: 2)
+        end
+      end
     end
 
     context 'with validation error' do

--- a/spec/services/customers/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/customers/update_invoice_grace_period_service_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Customers::UpdateInvoiceGracePeriodService, type: :service do
+  subject(:update_service) { described_class.new(customer:, grace_period:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:grace_period) { 2 }
+
+  describe '#call' do
+    let(:invoice_to_be_finalized) do
+      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'))
+    end
+
+    let(:invoice_to_not_be_finalized) do
+      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'))
+    end
+
+    before do
+      invoice_to_be_finalized
+      invoice_to_not_be_finalized
+      allow(Invoices::FinalizeService).to receive(:call)
+    end
+
+    it 'updates invoice grace period on customer' do
+      expect { update_service.call }.to change { customer.reload.invoice_grace_period }.from(0).to(2)
+    end
+
+    it 'finalizes corresponding draft invoices' do
+      current_date = DateTime.parse('22 Jun 2022')
+
+      travel_to(current_date) do
+        result = update_service.call
+
+        expect(result.customer.invoice_grace_period).to eq(2)
+        expect(Invoices::FinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
+        expect(Invoices::FinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)
+      end
+    end
+
+    it 'updates issuing_date on draft invoices' do
+      current_date = DateTime.parse('22 Jun 2022')
+
+      travel_to(current_date) do
+        expect { update_service.call }.to change { invoice_to_not_be_finalized.reload.issuing_date }
+          .to(DateTime.parse('23 Jun 2022'))
+      end
+    end
+  end
+end

--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe Invoices::FinalizeService, type: :service do
         .to change(invoice, :status).from('draft').to('finalized')
     end
 
+    it 'updates the issuing date' do
+      invoice.customer.update(timezone: 'America/New_York')
+
+      freeze_time do
+        expect { finalize_service.call }
+          .to change { invoice.reload.issuing_date }.to(Time.current.to_date)
+      end
+    end
+
     it 'generates expected fees' do
       result = finalize_service.call
 

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Invoices::RefreshDraftService, type: :service do
-  subject(:refresh_service) { described_class.new(invoice: invoice) }
+  subject(:refresh_service) { described_class.new(invoice:) }
 
   describe '#call' do
     let(:status) { :draft }
     let(:invoice) do
-      create(:invoice, subscriptions: [subscription], status: status)
+      create(:invoice, subscriptions: [subscription], status:)
     end
 
     let(:started_at) { 1.month.ago }
@@ -16,7 +16,7 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
       create(
         :subscription,
         subscription_at: started_at,
-        started_at: started_at,
+        started_at:,
         created_at: started_at,
       )
     end
@@ -36,7 +36,7 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
     end
 
     it 'regenerates fees' do
-      fee = create(:fee, invoice: invoice)
+      fee = create(:fee, invoice:)
       create(:standard_charge, plan: subscription.plan, charge_model: 'standard')
 
       expect { refresh_service.call }
@@ -45,33 +45,24 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
     end
 
     it 'regenerates credits' do
-      create(:credit, invoice: invoice)
+      create(:credit, invoice:)
 
       expect { refresh_service.call }
         .to change { invoice.reload.credits.count }.from(1).to(0)
     end
 
     it 'regenerates credit notes' do
-      create(:credit_note, invoice: invoice)
+      create(:credit_note, invoice:)
 
       expect { refresh_service.call }
         .to change { invoice.reload.credit_notes.count }.from(1).to(0)
     end
 
     it 'regenerates wallet transactions' do
-      create(:wallet_transaction, invoice: invoice)
+      create(:wallet_transaction, invoice:)
 
       expect { refresh_service.call }
         .to change { invoice.reload.wallet_transactions.count }.from(1).to(0)
-    end
-
-    it 'updates issuing_date' do
-      invoice.customer.update(timezone: 'America/New_York')
-
-      freeze_time do
-        expect { refresh_service.call }
-          .to change { invoice.reload.issuing_date }.to(Time.current.to_date)
-      end
     end
 
     it 'updates vat_rate' do

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -114,14 +114,14 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
     end
 
     context 'with customer timezone' do
-      before { subscription.customer.update!(timezone: 'America/Los_Angeles') }
+      before { subscription.customer.update!(timezone: 'America/Los_Angeles', invoice_grace_period: 3) }
 
       let(:timestamp) { DateTime.parse('2022-11-25 01:00:00') }
 
       it 'assigns the issuing date in the customer timezone' do
         result = invoice_service.create
 
-        expect(result.invoice.issuing_date.to_s).to eq('2022-11-24')
+        expect(result.invoice.issuing_date.to_s).to eq('2022-11-27')
       end
     end
 

--- a/spec/services/organizations/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/organizations/update_invoice_grace_period_service_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Organizations::UpdateInvoiceGracePeriodService, type: :service do
+  subject(:update_service) { described_class.new(organization:, grace_period:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:grace_period) { 2 }
+
+  describe '#call' do
+    let(:invoice_to_be_finalized) do
+      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'))
+    end
+
+    let(:invoice_to_not_be_finalized) do
+      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'))
+    end
+
+    before do
+      invoice_to_be_finalized
+      invoice_to_not_be_finalized
+      allow(Invoices::FinalizeService).to receive(:call)
+    end
+
+    it 'updates invoice grace period on organization' do
+      expect { update_service.call }.to change { organization.reload.invoice_grace_period }.from(0).to(2)
+    end
+
+    it 'finalizes corresponding draft invoices' do
+      current_date = DateTime.parse('22 Jun 2022')
+
+      travel_to(current_date) do
+        result = update_service.call
+
+        expect(result.organization.invoice_grace_period).to eq(2)
+        expect(Invoices::FinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
+        expect(Invoices::FinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)
+      end
+    end
+
+    it 'updates issuing_date on draft invoices' do
+      current_date = DateTime.parse('22 Jun 2022')
+
+      travel_to(current_date) do
+        expect { update_service.call }.to change { invoice_to_not_be_finalized.reload.issuing_date }
+          .to(DateTime.parse('23 Jun 2022'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to be able to finalize invoices when updating grace period on customer or organization.