### PR TITLE
feat(grace_period): Add nullable to invoice_grace_period

### DIFF
--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -25,7 +25,7 @@ module Types
       field :legal_name, String, null: true
       field :legal_number, String, null: true
       field :vat_rate, Float, null: true
-      field :invoice_grace_period, Integer, null: false
+      field :invoice_grace_period, Integer, null: true
       field :currency, Types::CurrencyEnum, null: true
       field :payment_provider, Types::PaymentProviders::ProviderTypeEnum, null: true
       field :timezone, Types::TimezoneEnum, null: true

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -35,7 +35,7 @@ class Customer < ApplicationRecord
   validates :country, country_code: true, unless: -> { country.nil? }
   validates :currency, inclusion: { in: currency_list }, allow_nil: true
   validates :external_id, presence: true, uniqueness: { scope: :organization_id }
-  validates :invoice_grace_period, numericality: { greater_than_or_equal_to: 0 }
+  validates :invoice_grace_period, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validates :payment_provider, inclusion: { in: PAYMENT_PROVIDERS }, allow_nil: true
   validates :timezone, timezone: true, allow_nil: true
   validates :vat_rate, numericality: { less_than_or_equal_to: 100, greater_than_or_equal_to: 0 }, allow_nil: true
@@ -69,7 +69,7 @@ class Customer < ApplicationRecord
   end
 
   def applicable_invoice_grace_period
-    return invoice_grace_period if invoice_grace_period.positive?
+    return invoice_grace_period if invoice_grace_period.present?
 
     organization.invoice_grace_period
   end

--- a/app/services/events/validate_creation_service.rb
+++ b/app/services/events/validate_creation_service.rb
@@ -61,9 +61,8 @@ module Events
 
       return invalid_code_error unless valid_code?
 
-      invalid_persisted_event = persisted_event_validation(
-        customer.active_subscriptions.first || organization.subscriptions.find_by(id: params[:subscription_id]),
-      )
+      subscription = organization.subscriptions.find_by(external_id: params[:external_subscription_id])
+      invalid_persisted_event = persisted_event_validation(subscription || customer.active_subscriptions.first)
       return invalid_persisted_event_error(invalid_persisted_event) if invalid_persisted_event.present?
     end
 

--- a/db/migrate/20221226091020_add_nullable_to_invoice_grace_period.rb
+++ b/db/migrate/20221226091020_add_nullable_to_invoice_grace_period.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddNullableToInvoiceGracePeriod < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :customers, :invoice_grace_period, true
+    change_column_default :customers, :invoice_grace_period, from: 0, to: nil
+
+    reversible do |dir|
+      dir.up do
+        # Update all existing customers to a nil invoice_grace_period.
+        execute <<-SQL
+          UPDATE customers SET invoice_grace_period = NULL;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_22_164226) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_26_091020) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -212,7 +212,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_22_164226) do
     t.string "slug"
     t.bigint "sequential_id"
     t.string "currency"
-    t.integer "invoice_grace_period", default: 0, null: false
+    t.integer "invoice_grace_period"
     t.string "timezone"
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true
     t.index ["organization_id"], name: "index_customers_on_organization_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -2576,7 +2576,7 @@ type Customer {
   """
   hasCreditNotes: Boolean!
   id: ID!
-  invoiceGracePeriod: Int!
+  invoiceGracePeriod: Int
   legalName: String
   legalNumber: String
   logoUrl: String
@@ -2648,7 +2648,7 @@ type CustomerDetails {
   """
   hasCreditNotes: Boolean!
   id: ID!
-  invoiceGracePeriod: Int!
+  invoiceGracePeriod: Int
   invoices: [Invoice!]
   legalName: String
   legalNumber: String

--- a/schema.json
+++ b/schema.json
@@ -7817,13 +7817,9 @@
               "name": "invoiceGracePeriod",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -8497,13 +8493,9 @@
               "name": "invoiceGracePeriod",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Customer, type: :model do
       let(:organization_invoice_grace_period) { 5 }
 
       before do
-        customer.invoice_grace_period = 0
+        customer.invoice_grace_period = nil
         organization.invoice_grace_period = organization_invoice_grace_period
       end
 

--- a/spec/services/customers/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/customers/update_invoice_grace_period_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Customers::UpdateInvoiceGracePeriodService, type: :service do
     end
 
     it 'updates invoice grace period on customer' do
-      expect { update_service.call }.to change { customer.reload.invoice_grace_period }.from(0).to(2)
+      expect { update_service.call }.to change { customer.reload.invoice_grace_period }.from(nil).to(2)
     end
 
     it 'finalizes corresponding draft invoices' do

--- a/spec/services/events/validate_creation_service_spec.rb
+++ b/spec/services/events/validate_creation_service_spec.rb
@@ -227,6 +227,35 @@ RSpec.describe Events::ValidateCreationService, type: :service do
           end
         end
       end
+
+      context 'when event belongs to a recurring persisted event and subscription is terminated' do
+        let(:billable_metric) do
+          create(
+            :billable_metric,
+            organization:,
+            aggregation_type: 'recurring_count_agg',
+            field_name: 'item_id',
+          )
+        end
+
+        let(:subscription) { create(:subscription, customer:, organization:, status: :terminated) }
+        let(:params) do
+          {
+            external_subscription_id: subscription.external_id,
+            code: billable_metric.code,
+            properties: {
+              billable_metric.field_name => 'ext_1234',
+              'operation_type' => 'add',
+            },
+          }
+        end
+
+        it 'returns no error' do
+          validate_event
+
+          expect(result).to be_success
+        end
+      end
     end
 
     context 'when batch is true' do


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to:
- add nullable to invoice grace period column on customers
- be able to create persisted events in a terminated subscription