### PR TITLE
fix: Ability to create an event without a given timestamp

### DIFF
--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: true
 
 module Events
   class CreateService < BaseService
@@ -33,9 +33,10 @@ module Events
       Events::ValidateCreationService.call(organization:, params:, customer:, result:)
       return result unless result.success?
 
+      event_timestamp = Time.zone.at(params[:timestamp] || timestamp)
       subscription = Subscription
         .where(external_id: params[:external_subscription_id])
-        .where('started_at <= ?', Time.zone.at(params[:timestamp]))
+        .where('started_at <= ?', event_timestamp)
         .order(started_at: :desc)
         .first || customer&.active_subscriptions&.first
 
@@ -54,9 +55,7 @@ module Events
         event.subscription_id = subscription.id
         event.properties = params[:properties] || {}
         event.metadata = metadata || {}
-
-        event.timestamp = Time.zone.at(params[:timestamp]) if params[:timestamp]
-        event.timestamp ||= timestamp
+        event.timestamp = event_timestamp
 
         event.save!
 

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -111,6 +111,24 @@ RSpec.describe Events::CreateService, type: :service do
 
     before { subscription }
 
+    context 'when timestamp is not present in the payload' do
+      let(:create_args) do
+        {
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          properties: { foo: 'bar' },
+        }
+      end
+
+      it 'creates an event by setting the timestamp to the current datetime' do
+        result = create_service.call(organization:, params: create_args, timestamp:, metadata: {})
+
+        expect(result).to be_success
+        expect(result.event.timestamp).to eq(Time.zone.at(timestamp))
+      end
+    end
+
     context 'when creating an event to a terminated subscription' do
       let(:subscription) do
         create(:subscription, customer:, organization:, status: :terminated, started_at: 1.month.ago)


### PR DESCRIPTION
We currently have an issue when trying to create an event without a given timestamp in the payload.

The goal of this PR is to fix this issue by assigning the current timestamp.