### PR TITLE
fix (webhooks): change webhook public key endpoint reponse type

### DIFF
--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -3,7 +3,12 @@
 module Api
   module V1
     class WebhooksController < Api::BaseController
+      # Deprecated method
       def public_key
+        render(plain: Base64.encode64(RsaPublicKey.to_s))
+      end
+
+      def json_public_key
         render(
           json: {
             webhook: {

--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -4,7 +4,14 @@ module Api
   module V1
     class WebhooksController < Api::BaseController
       def public_key
-        render(plain: Base64.encode64(RsaPublicKey.to_s))
+        render(
+          json: {
+            webhook: {
+              public_key: Base64.encode64(RsaPublicKey.to_s),
+            },
+          },
+          status: :ok,
+        )
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
 
       resources :webhooks, only: %i[] do
         get :public_key, on: :collection
+        get :json_public_key, on: :collection
       end
     end
   end

--- a/spec/requests/api/v1/webhooks_spec.rb
+++ b/spec/requests/api/v1/webhooks_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::V1::WebhooksController, type: :request do
       get_with_token(organization, '/api/v1/webhooks/public_key')
 
       expect(response).to have_http_status(:success)
-      expect(response.body).to eq(Base64.encode64(RsaPublicKey.to_s))
+      expect(json[:webhook][:public_key]).to eq(Base64.encode64(RsaPublicKey.to_s))
     end
   end
 end

--- a/spec/requests/api/v1/webhooks_spec.rb
+++ b/spec/requests/api/v1/webhooks_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe Api::V1::WebhooksController, type: :request do
       get_with_token(organization, '/api/v1/webhooks/public_key')
 
       expect(response).to have_http_status(:success)
+      expect(response.body).to eq(Base64.encode64(RsaPublicKey.to_s))
+    end
+  end
+
+  describe 'json_public_key' do
+    it 'returns the public key in JSON response used to verify webhook signatures' do
+      get_with_token(organization, '/api/v1/webhooks/json_public_key')
+
+      expect(response).to have_http_status(:success)
       expect(json[:webhook][:public_key]).to eq(Base64.encode64(RsaPublicKey.to_s))
     end
   end


### PR DESCRIPTION
## Context

In order to be consistent in API response types, this PR changes response type for endpoint to generate webhook public key

## Description

`api/v1/webhooks/public_key` returned text/plain in the past. It's changed now to application/json
