### PR TITLE
feat: Add resolver for fetching the current organization

### DIFF
--- a/app/graphql/resolvers/organization_resolver.rb
+++ b/app/graphql/resolvers/organization_resolver.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class OrganizationResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description 'Query the current organization'
+
+    type Types::OrganizationType, null: true
+
+    def resolve
+      validate_organization!
+      current_organization
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -23,6 +23,7 @@ module Types
     field :events, resolver: Resolvers::EventsResolver
     field :customer_usage, resolver: Resolvers::Customers::UsageResolver
     field :customer_invoices, resolver: Resolvers::Customers::InvoicesResolver
+    field :organization, resolver: Resolvers::OrganizationResolver
     field :plans, resolver: Resolvers::PlansResolver
     field :plan, resolver: Resolvers::PlanResolver
     field :current_version, resolver: Resolvers::VersionResolver

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -64,7 +64,7 @@ module Customers
         legal_name: args[:legal_name],
         legal_number: args[:legal_number],
         vat_rate: args[:vat_rate],
-        invoice_grace_period: args[:invoice_grace_period] || 0,
+        invoice_grace_period: args[:invoice_grace_period],
         payment_provider: args[:payment_provider],
         currency: args[:currency],
       )

--- a/schema.graphql
+++ b/schema.graphql
@@ -3885,6 +3885,11 @@ type Query {
   memberships(limit: Int, page: Int): MembershipCollection!
 
   """
+  Query the current organization
+  """
+  organization: Organization
+
+  """
   Query a single plan of an organization
   """
   plan(

--- a/schema.json
+++ b/schema.json
@@ -16074,6 +16074,20 @@
               ]
             },
             {
+              "name": "organization",
+              "description": "Query the current organization",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Organization",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "plan",
               "description": "Query a single plan of an organization",
               "type": {

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           paymentProvider: 'stripe',
           currency: 'EUR',
           timezone: 'TZ_EUROPE_PARIS',
-          invoiceGracePeriod: 2,
           providerCustomer: {
             providerCustomerId: 'cu_12345',
           },
@@ -62,7 +61,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
       expect(result_data['currency']).to eq('EUR')
       # TODO(:timezone): Timezone update is turned off for now
       # expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
-      expect(result_data['invoiceGracePeriod']).to eq(2)
+      expect(result_data['invoiceGracePeriod']).to be_nil
       expect(result_data['paymentProvider']).to eq('stripe')
       expect(result_data['providerCustomer']['id']).to be_present
       expect(result_data['providerCustomer']['providerCustomerId']).to eq('cu_12345')

--- a/spec/graphql/resolvers/organization_resolver_spec.rb
+++ b/spec/graphql/resolvers/organization_resolver_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::OrganizationResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query {
+        organization {
+          id
+          name
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+
+  it 'returns the current organization' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+      variables: {},
+    )
+
+    data = result['data']['organization']
+
+    aggregate_failures do
+      expect(data['id']).to eq(organization.id)
+      expect(data['name']).to eq(organization.name)
+    end
+  end
+end


### PR DESCRIPTION
The goal of this PR is to:
- add a resolver for fetching the current organization via graphQL.
_We decided to not put this accessible via the API for now._
- fix an issue for setting invoice_grace_period to `nil` by default on customers

---
