### PR TITLE
fix (events): add validation for invalid event field_name value

### DIFF
--- a/spec/factories/billable_metrics.rb
+++ b/spec/factories/billable_metrics.rb
@@ -14,4 +14,9 @@ FactoryBot.define do
     aggregation_type { 'recurring_count_agg' }
     field_name { 'item_id' }
   end
+
+  factory :sum_billable_metric, parent: :billable_metric do
+    aggregation_type { 'sum_agg' }
+    field_name { 'item_id' }
+  end
 end

--- a/spec/services/events/validate_creation_service_spec.rb
+++ b/spec/services/events/validate_creation_service_spec.rb
@@ -179,6 +179,34 @@ RSpec.describe Events::ValidateCreationService, type: :service do
         end
       end
 
+      context 'when field_name value is not a number' do
+        let(:billable_metric) { create(:sum_billable_metric, organization: organization) }
+        let(:params) do
+          {
+            code: billable_metric.code,
+            external_customer_id: customer.external_id,
+            properties: {
+              item_id: 'test'
+            },
+          }
+        end
+
+        it 'returns an value_is_not_valid_number error' do
+          validate_event
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages.keys).to include(:properties)
+            expect(result.error.messages[:properties]).to include('value_is_not_valid_number')
+          end
+        end
+
+        it 'enqueues a SendWebhookJob' do
+          expect { validate_event }.to have_enqueued_job(SendWebhookJob)
+        end
+      end
+
       context 'when event belongs to a recurring persisted event' do
         let(:billable_metric) do
           create(

--- a/spec/services/events/validate_creation_service_spec.rb
+++ b/spec/services/events/validate_creation_service_spec.rb
@@ -180,13 +180,13 @@ RSpec.describe Events::ValidateCreationService, type: :service do
       end
 
       context 'when field_name value is not a number' do
-        let(:billable_metric) { create(:sum_billable_metric, organization: organization) }
+        let(:billable_metric) { create(:sum_billable_metric, organization:) }
         let(:params) do
           {
             code: billable_metric.code,
             external_customer_id: customer.external_id,
             properties: {
-              item_id: 'test'
+              item_id: 'test',
             },
           }
         end


### PR DESCRIPTION
For billable metric that is `sum_agg` or `max_agg` we need to check if event's field_name value is integer/float.
For invalid values, validation message should be raised and event should not be persisted