### PR TITLE
fix(invoices): invoice status should be finalized by default

### DIFF
--- a/db/migrate/20230102150636_change_invoices_default_status.rb
+++ b/db/migrate/20230102150636_change_invoices_default_status.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ChangeInvoicesDefaultStatus < ActiveRecord::Migration[7.0]
+  def up
+    change_column_default :invoices, :status, 1
+
+    execute <<-SQL
+      UPDATE invoices SET status = 1;
+    SQL
+  end
+
+  def down
+    change_column_default :invoices, :status, 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_26_091020) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_02_150636) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -170,8 +170,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_091020) do
     t.string "refund_vat_amount_currency"
     t.bigint "vat_amount_cents", default: 0, null: false
     t.string "vat_amount_currency"
-    t.date "issuing_date", null: false
     t.datetime "refunded_at"
+    t.date "issuing_date", null: false
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end
@@ -331,9 +331,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_26_091020) do
     t.uuid "customer_id"
     t.boolean "legacy", default: false, null: false
     t.float "vat_rate"
-    t.integer "status", default: 0, null: false
     t.bigint "credit_amount_cents", default: 0, null: false
     t.string "credit_amount_currency"
+    t.integer "status", default: 1, null: false
     t.string "timezone", default: "UTC", null: false
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
   end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     payment_status { 'pending' }
     amount_currency { 'EUR' }
     total_amount_currency { 'EUR' }
+
+    trait :draft do
+      status { :draft }
+    end
   end
 end

--- a/spec/graphql/mutations/invoices/finalize_spec.rb
+++ b/spec/graphql/mutations/invoices/finalize_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mutations::Invoices::Finalize, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:) }
+  let(:invoice) { create(:invoice, :draft, customer:) }
 
   let(:mutation) do
     <<~GQL

--- a/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe Resolvers::Customers::InvoicesResolver, type: :graphql do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:subscription) { create(:subscription, customer: customer, organization: organization) }
-  let(:draft_invoice) { create(:invoice, customer: customer) }
-  let(:finalized_invoice) { create(:invoice, status: :finalized, customer: customer) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:, organization:) }
+  let(:draft_invoice) { create(:invoice, :draft, customer:) }
+  let(:finalized_invoice) { create(:invoice, customer:) }
 
   before do
     subscription

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::InvoicesController, type: :request do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:, status: :finalized) }
+  let(:invoice) { create(:invoice, customer:) }
 
   describe 'UPDATE /invoices' do
     let(:update_params) do
@@ -68,7 +68,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
   end
 
   describe 'index' do
-    let(:invoice) { create(:invoice, customer: customer) }
+    let(:invoice) { create(:invoice, :draft, customer:) }
     let(:customer) { create(:customer, organization: organization) }
 
     before { invoice }
@@ -139,7 +139,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
 
     context 'with status params' do
       it 'returns invoices for the given status' do
-        invoice = create(:invoice, customer: customer, status: :finalized)
+        invoice = create(:invoice, customer:)
 
         get_with_token(organization, '/api/v1/invoices?status=finalized')
 
@@ -159,7 +159,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'when invoice is draft' do
-      let(:invoice) { create(:invoice, customer:) }
+      let(:invoice) { create(:invoice, :draft, customer:) }
 
       it 'updates the invoice' do
         expect {
@@ -194,7 +194,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
   end
 
   describe 'PUT /invoices/:id/finalize' do
-    let(:invoice) { create(:invoice, customer:, status: :draft) }
+    let(:invoice) { create(:invoice, :draft, customer:) }
 
     context 'when invoice does not exist' do
       it 'returns a not found error' do
@@ -227,7 +227,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
   end
 
   describe 'POST /invoices/:id/download' do
-    let(:invoice) { create(:invoice, customer:, status: :draft) }
+    let(:invoice) { create(:invoice, :draft, customer:) }
 
     context 'when invoice is draft' do
       it 'returns not found' do

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe Invoices::AddOnService, type: :service do
         expect(result.invoice.vat_rate).to eq(20)
         expect(result.invoice.total_amount_cents).to eq(240)
         expect(result.invoice.total_amount_currency).to eq('EUR')
+
+        expect(result.invoice).to be_finalized
       end
     end
 

--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Invoices::FinalizeService, type: :service do
     let(:invoice) do
       create(
         :invoice,
+        :draft,
         subscriptions: [subscription],
         amount_currency: 'EUR',
         vat_amount_currency: 'EUR',

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
         expect(result.invoice.vat_rate).to eq(0)
         expect(result.invoice.total_amount_cents).to eq(1500)
         expect(result.invoice.total_amount_currency).to eq('EUR')
+
+        expect(result.invoice).to be_finalized
       end
     end
 


### PR DESCRIPTION
## Context

Add on and prepaid credit invoices are created in draft but they should not

## Description

This PR changes default invoice status from `draft` to `finalized` to make sure this types of invoice are not impacted by the grace period feature.
