### PR TITLE
feat (invoices): add issued_at attribute in graphQL response

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -26,6 +26,7 @@ module Types
       field :vat_rate, Float, null: false
 
       field :issuing_date, GraphQL::Types::ISO8601Date, null: false
+      field :issued_at, GraphQL::Types::ISO8601DateTime, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -120,6 +120,14 @@ class Invoice < ApplicationRecord
     amount + wallet_transaction_amount
   end
 
+  def issued_at
+    issuing_time = created_at.in_time_zone(customer.applicable_timezone)
+
+    return issuing_time unless grace_period?
+
+    issuing_time + customer.applicable_invoice_grace_period.days
+  end
+
   def organization
     customer&.organization
   end
@@ -173,5 +181,9 @@ class Invoice < ApplicationRecord
     formatted_sequential_id = format('%03d', sequential_id)
 
     self.number = "#{customer.slug}-#{formatted_sequential_id}"
+  end
+
+  def grace_period?
+    customer.applicable_invoice_grace_period.positive?
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2996,6 +2996,7 @@ type Invoice {
   id: ID!
   invoiceSubscriptions: [InvoiceSubscription!]
   invoiceType: InvoiceTypeEnum!
+  issuedAt: ISO8601DateTime!
   issuingDate: ISO8601Date!
   legacy: Boolean!
   number: String!

--- a/schema.json
+++ b/schema.json
@@ -11284,6 +11284,24 @@
               ]
             },
             {
+              "name": "issuedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "issuingDate",
               "description": null,
               "type": {

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe Invoice, type: :model do
 
   describe '#issued_at' do
     let(:customer) { create(:customer, timezone: 'America/Los_Angeles') }
-    let(:invoice) { create(:invoice, customer: customer, created_at: DateTime.parse('2022-11-17 23:34:23')) }
+    let(:invoice) { create(:invoice, customer:, created_at: DateTime.parse('2022-11-17 23:34:23')) }
 
     before { invoice }
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -188,6 +188,27 @@ RSpec.describe Invoice, type: :model do
     end
   end
 
+  describe '#issued_at' do
+    let(:customer) { create(:customer, timezone: 'America/Los_Angeles') }
+    let(:invoice) { create(:invoice, customer: customer, created_at: DateTime.parse('2022-11-17 23:34:23')) }
+
+    before { invoice }
+
+    context 'when grace period does not exist' do
+      it 'assigns the issuing date in the customer timezone' do
+        expect(invoice.issued_at).to eq('Sun, 17 Nov 2022 15:34:23.000000000 PST -08:00')
+      end
+    end
+
+    context 'when grace period is set to three' do
+      before { customer.update!(invoice_grace_period: 3) }
+
+      it 'assigns the issuing date in the customer timezone' do
+        expect(invoice.issued_at).to eq('Sun, 20 Nov 2022 15:34:23.000000000 PST -08:00')
+      end
+    end
+  end
+
   describe '#subtotal_before_prepaid_credits' do
     let(:customer) { create(:customer) }
     let(:invoice) { create(:invoice, customer: customer, amount_cents: 555) }


### PR DESCRIPTION
## Context

Add `issued_at` attribute in graphQL response

## Description

UI needs information about timezone so `issuing_date` attribute is not suitable for this case.

This PR adds new attribute called `issued_at` and this attribute is returned in customer timezone. It will be consumed only from the UI
