### PR TITLE
feat(grace_period): Ability to refresh pay in advance invoices

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -57,6 +57,12 @@ class Invoice < ApplicationRecord
           draft.joins(customer: :organization).where("#{Arel.sql(date)} < ?", Time.current)
         }
 
+  scope :created_before,
+        lambda { |invoice|
+          where.not(id: invoice.id)
+            .where('invoices.created_at < ?', invoice.created_at)
+        }
+
   validates :issuing_date, presence: true
   validates :timezone, timezone: true, allow_nil: true
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -95,10 +95,6 @@ class Subscription < ApplicationRecord
     next_subscriptions.not_canceled.order(created_at: :desc).first
   end
 
-  def fee_exists?(date)
-    fees.subscription_kind.where(created_at: date.beginning_of_day..date.end_of_day).any?
-  end
-
   def already_billed?
     fees.subscription_kind.any?
   end

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -91,6 +91,7 @@ module CreditNotes
     end
 
     def valid_type_or_status?
+      return true if automatic
       return false if invoice.draft?
       return false if invoice.credit?
 

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -84,8 +84,7 @@ module Fees
     #        or when it is payed in advance on an anniversary base
     def should_use_full_amount?
       return true if plan.pay_in_advance? && subscription.anniversary?
-      return true if subscription.fees.subscription_kind.exists?
-
+      return true if subscription.fees.subscription_kind.where('created_at < ?', invoice.created_at).exists?
       return true if subscription.started_in_past? && plan.pay_in_advance?
 
       if subscription.started_in_past? &&

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -97,7 +97,11 @@ module Invoices
     def should_create_subscription_fee?(subscription)
       # NOTE: When plan is pay in advance we generate an invoice upon subscription creation
       # We want to prevent creating subscription fee if subscription creation already happened on billing day
-      return false if subscription.plan.pay_in_advance? && subscription.fee_exists?(issuing_date)
+      fee_exists = subscription.fees.subscription_kind.where(created_at: issuing_date.beginning_of_day..issuing_date.end_of_day)
+        .where.not(invoice_id: invoice.id)
+        .any?
+
+      return false if subscription.plan.pay_in_advance? && fee_exists
       return false unless should_create_yearly_subscription_fee?(subscription)
 
       # NOTE: When a subscription is terminated we still need to charge the subscription

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -126,7 +126,7 @@ module Invoices
 
       # NOTE: Charges should not be billed in advance when we are just upgrading to a new
       #       pay_in_advance subscription
-      return false if subscription.plan.pay_in_advance? && subscription.invoices.where.not(id: invoice.id).count.zero?
+      return false if subscription.plan.pay_in_advance? && subscription.invoices.created_before(invoice).count.zero?
 
       true
     end

--- a/app/services/invoices/finalize_service.rb
+++ b/app/services/invoices/finalize_service.rb
@@ -15,7 +15,7 @@ module Invoices
       return result.not_found_failure!(resource: 'invoice') if invoice.nil?
 
       ActiveRecord::Base.transaction do
-        result = Invoices::RefreshDraftService.call(invoice:)
+        result = Invoices::RefreshDraftService.call(invoice:, context: :finalize)
         result.raise_if_error!
 
         invoice.update!(status: :finalized, issuing_date:)

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -25,12 +25,17 @@ module Invoices
 
         invoice.update!(vat_rate: invoice.customer.applicable_vat_rate)
 
-        Invoices::CalculateFeesService.call(
+        calculate_result = Invoices::CalculateFeesService.call(
           invoice:,
           subscriptions: Subscription.find(subscription_ids),
           timestamp: invoice.created_at.to_i,
         )
+        return calculate_result unless calculate_result.success?
+
+        invoice.fees.update_all(created_at: invoice.created_at) # rubocop:disable Rails/SkipsModelValidations
       end
+
+      result
     end
 
     private

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -6,9 +6,10 @@ module Invoices
       new(...).call
     end
 
-    def initialize(invoice:)
+    def initialize(invoice:, context: :refresh)
       @invoice = invoice
       @subscription_ids = invoice.subscriptions.pluck(:id)
+      @context = context
       super
     end
 
@@ -17,21 +18,31 @@ module Invoices
       return result unless invoice.draft?
 
       ActiveRecord::Base.transaction do
-        invoice.credit_notes.destroy_all
-        invoice.credits.destroy_all
-        invoice.wallet_transactions.destroy_all
+        cn_subscription_ids = invoice.credit_notes.map do |cn|
+          { credit_note_id: cn.id, subscription_id: cn.fees.pick(:subscription_id) }
+        end
+        invoice.credit_notes.each { |cn| cn.items.update_all(fee_id: nil) } # rubocop:disable Rails/SkipsModelValidations
+
         invoice.fees.destroy_all
         invoice.invoice_subscriptions.destroy_all
-
         invoice.update!(vat_rate: invoice.customer.applicable_vat_rate)
 
         calculate_result = Invoices::CalculateFeesService.call(
           invoice:,
           subscriptions: Subscription.find(subscription_ids),
           timestamp: invoice.created_at.to_i,
+          context:,
         )
+
+        invoice.credit_notes.each do |credit_note|
+          subscription_id = cn_subscription_ids.find { |h| h[:credit_note_id] == credit_note.id }[:subscription_id]
+          fee = invoice.fees.subscription.find_by(subscription_id:)
+          credit_note.items.update_all(fee_id: fee.id) # rubocop:disable Rails/SkipsModelValidations
+        end
+
         return calculate_result unless calculate_result.success?
 
+        # In case of a refresh the same day of the termination
         invoice.fees.update_all(created_at: invoice.created_at) # rubocop:disable Rails/SkipsModelValidations
       end
 
@@ -40,6 +51,6 @@ module Invoices
 
     private
 
-    attr_accessor :invoice, :subscription_ids
+    attr_accessor :invoice, :subscription_ids, :context
   end
 end

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -10,7 +10,7 @@ module Subscriptions
     end
 
     def terminate_from_api(organization:, external_id:)
-      subscription = organization.subscriptions.active.find_by(external_id: external_id)
+      subscription = organization.subscriptions.active.find_by(external_id:)
       return result.not_found_failure!(resource: 'subscription') if subscription.blank?
 
       process_terminate(subscription)

--- a/db/migrate/20230105094302_add_nullable_to_fee_id_on_credit_note_items.rb
+++ b/db/migrate/20230105094302_add_nullable_to_fee_id_on_credit_note_items.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNullableToFeeIdOnCreditNoteItems < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :credit_note_items, :fee_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -134,7 +134,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_152449) do
 
   create_table "credit_note_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "credit_note_id", null: false
-    t.uuid "fee_id", null: false
+    t.uuid "fee_id"
     t.bigint "amount_cents", default: 0, null: false
     t.string "amount_currency", null: false
     t.datetime "created_at", null: false

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -267,27 +267,6 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
-  describe '#fee_exists??' do
-    let(:subscription) { create(:subscription) }
-    let(:current_date) { Time.current.to_date }
-
-    context 'without subscriptions fees that are created today' do
-      before { create(:fee, subscription: subscription, created_at: Time.current - 2.days) }
-
-      it 'returns false' do
-        expect(subscription.fee_exists?(current_date)).to be false
-      end
-    end
-
-    context 'with subscription fees that are created today' do
-      before { create(:fee, subscription: subscription) }
-
-      it 'returns true' do
-        expect(subscription.fee_exists?(current_date)).to be true
-      end
-    end
-  end
-
   describe '#starting_in_the_future?' do
     context 'when subscription is active' do
       let(:subscription) { create(:active_subscription) }

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
   describe 'GET /invoices/:id' do
     it 'returns a invoice' do
       group = create(:group)
-      create(:fee, invoice_id: invoice.id, group: group)
+      create(:fee, invoice_id: invoice.id, group:)
 
       get_with_token(organization, "/api/v1/invoices/#{invoice.id}")
 
@@ -67,9 +67,9 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
   end
 
-  describe 'index' do
+  describe 'GET /invoices' do
     let(:invoice) { create(:invoice, :draft, customer:) }
-    let(:customer) { create(:customer, organization: organization) }
+    let(:customer) { create(:customer, organization:) }
 
     before { invoice }
 
@@ -84,7 +84,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'with pagination' do
-      let(:invoice2) { create(:invoice, customer: customer) }
+      let(:invoice2) { create(:invoice, customer:) }
 
       before { invoice2 }
 
@@ -103,9 +103,9 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'with issuing_date params' do
-      let(:invoice) { create(:invoice, customer: customer, issuing_date: 5.days.ago.to_date) }
-      let(:invoice2) { create(:invoice, customer: customer, issuing_date: 3.days.ago.to_date) }
-      let(:invoice3) { create(:invoice, customer: customer, issuing_date: 1.day.ago.to_date) }
+      let(:invoice) { create(:invoice, customer:, issuing_date: 5.days.ago.to_date) }
+      let(:invoice2) { create(:invoice, customer:, issuing_date: 3.days.ago.to_date) }
+      let(:invoice3) { create(:invoice, customer:, issuing_date: 1.day.ago.to_date) }
 
       before do
         invoice2
@@ -126,7 +126,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
 
     context 'with external_customer_id params' do
       it 'returns invoices of the customer' do
-        second_customer = create(:customer, organization: organization)
+        second_customer = create(:customer, organization:)
         invoice = create(:invoice, customer: second_customer)
 
         get_with_token(organization, "/api/v1/invoices?external_customer_id=#{second_customer.external_id}")
@@ -176,7 +176,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'when invoice is finalized' do
-      let(:invoice) { create(:invoice, customer:, status: :finalized) }
+      let(:invoice) { create(:invoice, customer:) }
 
       it 'does not update the invoice' do
         expect {

--- a/spec/scenarios/invoices_spec.rb
+++ b/spec/scenarios/invoices_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Invoices Scenarios', :invoices_scenarios, type: :request do
+  # This performs any enqueued-jobs, and continues doing so until the queue is empty.
+  # Lots of the jobs enqueue other jobs as part of their work, and this ensures that
+  # everything that's supposed to happen, happens.
+  def perform_all_enqueued_jobs
+    # Drain ActiveJobs and Sidekiq jobs
+    until enqueued_jobs.empty?
+      perform_enqueued_jobs
+      Sidekiq::Worker.drain_all
+    end
+  end
+
+  let(:organization) { create(:organization, webhook_url: nil) }
+
+  context 'when invoice is paid in advance and grace period' do
+    let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
+    let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 1000) }
+    let(:datetime) { DateTime.new(2022, 12, 15) }
+    let(:metric) { create(:billable_metric, organization:) }
+
+    before do
+      subscription_service = Subscriptions::CreateService.new
+      subscription_service.create_from_api(
+        organization:,
+        params: {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          started_at: datetime,
+          subscription_at: datetime,
+        },
+      )
+
+      subscription = Subscription.order(created_at: :desc).first
+      subscription.update!(created_at: datetime)
+
+      Invoices::SubscriptionService.new(
+        subscriptions: [subscription],
+        timestamp: datetime.to_i,
+        recurring: false,
+      ).create
+
+      invoice = Invoice.order(created_at: :desc).first
+      invoice.update!(created_at: datetime)
+
+      create(:standard_charge, plan:, billable_metric: metric, properties: { amount: '1' })
+    end
+
+    it 'terminates the pay in advance subscription' do
+      invoice = Invoice.order(created_at: :desc).first
+      subscription = invoice.subscriptions.first
+
+      # 17 days - From 15th Dec. to 31st Dec.
+      expect(invoice).to be_draft
+      expect(invoice.total_amount_cents).to eq(658)
+
+      # Terminate subscription on Dec. 20th
+      current_date = DateTime.parse('20 Dec 2022')
+
+      travel_to(current_date) do
+        expect {
+          delete_with_token(organization, "/api/v1/subscriptions/#{subscription.external_id}")
+        }.to change { subscription.reload.status }.from('active').to('terminated')
+      end
+
+      perform_all_enqueued_jobs
+
+      binding.break
+    end
+
+    it 'refreshes and finalizes invoices' do
+      invoice = Invoice.order(created_at: :desc).first
+      subscription = invoice.subscriptions.first
+
+      # 17 days - From 15th Dec. to 31st Dec.
+      expect(invoice.total_amount_cents).to eq(658)
+
+      # Create an event for the subscription
+      create(:event, subscription:, code: metric.code, timestamp: datetime + 1.day)
+
+      # Paid in advance invoice amount should not change
+      expect {
+        put_with_token(organization, "/api/v1/invoices/#{invoice.id}/refresh", {})
+      }.not_to change { invoice.reload.total_amount_cents }
+
+      # Create an event for the subscription
+      create(:event, subscription:, timestamp: datetime + 2.days, code: metric.code)
+
+      # Paid in advance invoice should not change
+      expect {
+        put_with_token(organization, "/api/v1/invoices/#{invoice.id}/refresh", {})
+      }.not_to change { invoice.reload.total_amount_cents }
+
+      # Next month: Billing
+      new_datetime = DateTime.new(2023, 1, 1)
+
+      Invoices::SubscriptionService.new(
+        subscriptions: [subscription],
+        timestamp: new_datetime.to_i,
+        recurring: false,
+      ).create
+
+      expect(subscription.invoices.count).to eq(2)
+      new_invoice = subscription.invoices.order(created_at: :desc).first
+      expect(new_invoice.total_amount_cents).to eq(1440) # (1000 + 200) * 1.2
+
+      # Create event
+      create(:event, subscription:, timestamp: datetime + 3.days, code: metric.code)
+
+      # Nothing change in the invoice for the pay in advance subscription
+      expect {
+        put_with_token(organization, "/api/v1/invoices/#{invoice.id}/refresh", {})
+      }.not_to change { invoice.reload.total_amount_cents }
+
+      expect {
+        put_with_token(organization, "/api/v1/invoices/#{new_invoice.id}/refresh", {})
+      }.to change { new_invoice.reload.total_amount_cents }.from(1440).to(1560) # (1000 + 200 + 100) * 1.2
+
+      # Finalize invoices
+      expect {
+        put_with_token(organization, "/api/v1/invoices/#{invoice.id}/finalize", {})
+      }.to change { invoice.reload.status }.from('draft').to('finalized')
+
+      expect {
+        put_with_token(organization, "/api/v1/invoices/#{new_invoice.id}/finalize", {})
+      }.to change { new_invoice.reload.status }.from('draft').to('finalized')
+
+      expect(invoice.total_amount_cents).to eq(658)
+      expect(new_invoice.total_amount_cents).to eq(1560)
+    end
+  end
+end

--- a/spec/scenarios/invoices_spec.rb
+++ b/spec/scenarios/invoices_spec.rb
@@ -3,134 +3,286 @@
 require 'rails_helper'
 
 describe 'Invoices Scenarios', :invoices_scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+
+  context 'when invoice is paid in advance and grace period' do
+    let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
+    let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 1000) }
+    let(:metric) { create(:billable_metric, organization:) }
+
+    it 'terminates the pay in advance subscription with credit note lesser than amount' do
+      ### 15 Dec: Create subscription + charge.
+      dec15 = DateTime.new(2022, 12, 15)
+
+      travel_to(dec15) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+
+        create(:standard_charge, plan:, billable_metric: metric, properties: { amount: '3' })
+
+        subscription_invoice = Invoice.order(created_at: :desc).first
+        expect(subscription_invoice).to be_draft
+        expect(subscription_invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
+      end
+
+      subscription = Subscription.order(created_at: :desc).first
+      subscription_invoice = subscription.invoices.first
+
+      ### 17 Dec: Create event + refresh.
+      travel_to(DateTime.new(2022, 12, 17)) do
+        create(:event, subscription:, code: metric.code)
+        create(:event, subscription:, code: metric.code)
+
+        expect {
+          refresh_invoice(subscription_invoice)
+        }.not_to change { subscription_invoice.reload.total_amount_cents }
+      end
+
+      ### 20 Dec: Terminate subscription + refresh.
+      dec20 = DateTime.new(2022, 12, 20)
+
+      travel_to(dec20) do
+        expect {
+          terminate_subscription(subscription)
+        }.to change { subscription.reload.status }.from('active').to('terminated')
+          .and change { subscription_invoice.reload.credit_notes.count }.from(0).to(1)
+          .and change { subscription.invoices.count }.from(1).to(2)
+
+        # Credit note is created (31 - 20) * 548 / 17.0 * 1.2 = 425.
+        credit_note = subscription_invoice.credit_notes.first
+        expect(credit_note.credit_amount_cents).to eq(425)
+        expect(credit_note.balance_amount_cents).to eq(0) # 425 - 600
+
+        # Invoice for termination is created
+        termination_invoice = subscription.invoices.order(created_at: :desc).first
+
+        # Total amount should reflect the credit note (720 - 425)
+        expect(termination_invoice.total_amount_cents).to eq(295)
+        expect(termination_invoice.credits.first.amount_cents).to eq(425)
+        expect(termination_invoice.credit_notes.count).to eq(0)
+
+        # Refresh pay in advance invoice
+        expect {
+          refresh_invoice(subscription_invoice)
+        }.not_to change { subscription_invoice.reload.total_amount_cents }
+        expect(credit_note.reload.credit_amount_cents).to eq(425)
+
+        # Refresh termination invoice
+        expect {
+          refresh_invoice(termination_invoice)
+        }.not_to change { termination_invoice.reload.total_amount_cents }
+
+        # Finalize pay in advance invoice
+        expect {
+          finalize_invoice(subscription_invoice)
+        }.to change { subscription_invoice.reload.status }.from('draft').to('finalized')
+        expect(subscription_invoice.total_amount_cents).to eq(658)
+
+        # Finalize termination invoice
+        expect {
+          finalize_invoice(termination_invoice)
+        }.to change { termination_invoice.reload.status }.from('draft').to('finalized')
+
+        # Total amount should reflect the credit note
+        expect(termination_invoice.total_amount_cents).to eq(295)
+      end
+    end
+
+    it 'terminates the pay in advance subscription with credit note greater than amount' do
+      ### 15 Dec: Create subscription + charge.
+      dec15 = DateTime.new(2022, 12, 15)
+
+      travel_to(dec15) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+
+        create(:standard_charge, plan:, billable_metric: metric, properties: { amount: '1' })
+
+        subscription_invoice = Invoice.order(created_at: :desc).first
+        expect(subscription_invoice).to be_draft
+        expect(subscription_invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
+      end
+
+      subscription = Subscription.order(created_at: :desc).first
+      subscription_invoice = subscription.invoices.first
+
+      ### 17 Dec: Create event + refresh.
+      travel_to(DateTime.new(2022, 12, 17)) do
+        create(:event, subscription:, code: metric.code)
+
+        expect {
+          refresh_invoice(subscription_invoice)
+        }.not_to change { subscription_invoice.reload.total_amount_cents }
+      end
+
+      ### 20 Dec: Terminate subscription + refresh.
+      dec20 = DateTime.new(2022, 12, 20)
+
+      travel_to(dec20) do
+        expect {
+          terminate_subscription(subscription)
+        }.to change { subscription.reload.status }.from('active').to('terminated')
+          .and change { subscription_invoice.reload.credit_notes.count }.from(0).to(1)
+          .and change { subscription.invoices.count }.from(1).to(2)
+
+        # Credit note is created (31 - 20) * 548 / 17.0 * 1.2 = 425.
+        credit_note = subscription_invoice.credit_notes.first
+        expect(credit_note.credit_amount_cents).to eq(425)
+        expect(credit_note.balance_amount_cents).to eq(305) # 425 - 120
+
+        # Invoice for termination is created
+        termination_invoice = subscription.invoices.order(created_at: :desc).first
+
+        # Total amount should reflect the credit note (120 - 425)
+        expect(termination_invoice.total_amount_cents).to eq(0)
+        expect(termination_invoice.credits.first.amount_cents).to eq(120)
+        expect(termination_invoice.credit_notes.count).to eq(0)
+
+        # Refresh pay in advance invoice
+        expect {
+          refresh_invoice(subscription_invoice)
+        }.not_to change { subscription_invoice.reload.total_amount_cents }
+        expect(credit_note.reload.credit_amount_cents).to eq(425)
+
+        # Refresh termination invoice
+        expect {
+          refresh_invoice(termination_invoice)
+        }.not_to change { termination_invoice.reload.total_amount_cents }
+
+        # Finalize pay in advance invoice
+        expect {
+          finalize_invoice(subscription_invoice)
+        }.to change { subscription_invoice.reload.status }.from('draft').to('finalized')
+        expect(subscription_invoice.total_amount_cents).to eq(658)
+
+        # Finalize termination invoice
+        expect {
+          finalize_invoice(termination_invoice)
+        }.to change { termination_invoice.reload.status }.from('draft').to('finalized')
+
+        # Total amount should reflect the credit note (120 - 425)
+        expect(termination_invoice.total_amount_cents).to eq(0)
+      end
+    end
+
+    it 'refreshes and finalizes invoices' do
+      ### 15 Dec: Create subscription + charge.
+      dec15 = DateTime.new(2022, 12, 15)
+
+      travel_to(dec15) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+
+        create(:standard_charge, plan:, billable_metric: metric, properties: { amount: '1' })
+
+        invoice = Invoice.order(created_at: :desc).first
+        expect(invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
+      end
+
+      subscription = Subscription.order(created_at: :desc).first
+      invoice = subscription.invoices.first
+
+      ### 16 Dec: Create event + refresh.
+      travel_to(DateTime.new(2022, 12, 16)) do
+        create(:event, subscription:, code: metric.code)
+
+        # Paid in advance invoice amount does not change.
+        expect {
+          refresh_invoice(invoice)
+        }.not_to change { invoice.reload.total_amount_cents }
+      end
+
+      ### 17 Dec: Create event + refresh.
+      travel_to(DateTime.new(2022, 12, 17)) do
+        create(:event, subscription:, code: metric.code)
+
+        # Paid in advance invoice amount does not change.
+        expect {
+          refresh_invoice(invoice)
+        }.not_to change { invoice.reload.total_amount_cents }
+      end
+
+      ### 1 Jan: Billing + refresh + finalize.
+      travel_to(DateTime.new(2023, 1, 1)) do
+        perform_billing
+
+        expect(subscription.invoices.count).to eq(2)
+        new_invoice = subscription.invoices.order(created_at: :desc).first
+        expect(new_invoice.total_amount_cents).to eq(1440) # (1000 + 200) * 1.2
+
+        # Create event for Dec 18.
+        create(:event, subscription:, timestamp: DateTime.new(2022, 12, 18), code: metric.code)
+
+        # Paid in advance invoice amount does not change.
+        expect {
+          refresh_invoice(invoice)
+        }.not_to change { invoice.reload.total_amount_cents }
+
+        # Usage invoice amount is updated.
+        expect {
+          refresh_invoice(new_invoice)
+        }.to change { new_invoice.reload.total_amount_cents }.from(1440).to(1560) # (1000 + 200 + 100) * 1.2
+
+        # Finalize invoices.
+        expect {
+          finalize_invoice(invoice)
+        }.to change { invoice.reload.status }.from('draft').to('finalized')
+
+        expect {
+          finalize_invoice(new_invoice)
+        }.to change { new_invoice.reload.status }.from('draft').to('finalized')
+
+        expect(invoice.total_amount_cents).to eq(658)
+        expect(new_invoice.total_amount_cents).to eq(1560)
+      end
+    end
+  end
+
   # This performs any enqueued-jobs, and continues doing so until the queue is empty.
   # Lots of the jobs enqueue other jobs as part of their work, and this ensures that
   # everything that's supposed to happen, happens.
   def perform_all_enqueued_jobs
-    # Drain ActiveJobs and Sidekiq jobs
     until enqueued_jobs.empty?
       perform_enqueued_jobs
       Sidekiq::Worker.drain_all
     end
   end
 
-  let(:organization) { create(:organization, webhook_url: nil) }
+  def create_subscription(params)
+    post_with_token(organization, '/api/v1/subscriptions', { subscription: params })
+    perform_all_enqueued_jobs
+  end
 
-  context 'when invoice is paid in advance and grace period' do
-    let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
-    let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 1000) }
-    let(:datetime) { DateTime.new(2022, 12, 15) }
-    let(:metric) { create(:billable_metric, organization:) }
+  def perform_billing
+    Clock::SubscriptionsBillerJob.perform_later
+    perform_all_enqueued_jobs
+  end
 
-    before do
-      subscription_service = Subscriptions::CreateService.new
-      subscription_service.create_from_api(
-        organization:,
-        params: {
-          external_customer_id: customer.external_id,
-          external_id: customer.external_id,
-          plan_code: plan.code,
-          started_at: datetime,
-          subscription_at: datetime,
-        },
-      )
+  def refresh_invoice(invoice)
+    put_with_token(organization, "/api/v1/invoices/#{invoice.id}/refresh", {})
+  end
 
-      subscription = Subscription.order(created_at: :desc).first
-      subscription.update!(created_at: datetime)
+  def finalize_invoice(invoice)
+    put_with_token(organization, "/api/v1/invoices/#{invoice.id}/finalize", {})
+  end
 
-      Invoices::SubscriptionService.new(
-        subscriptions: [subscription],
-        timestamp: datetime.to_i,
-        recurring: false,
-      ).create
-
-      invoice = Invoice.order(created_at: :desc).first
-      invoice.update!(created_at: datetime)
-
-      create(:standard_charge, plan:, billable_metric: metric, properties: { amount: '1' })
-    end
-
-    it 'terminates the pay in advance subscription' do
-      invoice = Invoice.order(created_at: :desc).first
-      subscription = invoice.subscriptions.first
-
-      # 17 days - From 15th Dec. to 31st Dec.
-      expect(invoice).to be_draft
-      expect(invoice.total_amount_cents).to eq(658)
-
-      # Terminate subscription on Dec. 20th
-      current_date = DateTime.parse('20 Dec 2022')
-
-      travel_to(current_date) do
-        expect {
-          delete_with_token(organization, "/api/v1/subscriptions/#{subscription.external_id}")
-        }.to change { subscription.reload.status }.from('active').to('terminated')
-      end
-
-      perform_all_enqueued_jobs
-
-      binding.break
-    end
-
-    it 'refreshes and finalizes invoices' do
-      invoice = Invoice.order(created_at: :desc).first
-      subscription = invoice.subscriptions.first
-
-      # 17 days - From 15th Dec. to 31st Dec.
-      expect(invoice.total_amount_cents).to eq(658)
-
-      # Create an event for the subscription
-      create(:event, subscription:, code: metric.code, timestamp: datetime + 1.day)
-
-      # Paid in advance invoice amount should not change
-      expect {
-        put_with_token(organization, "/api/v1/invoices/#{invoice.id}/refresh", {})
-      }.not_to change { invoice.reload.total_amount_cents }
-
-      # Create an event for the subscription
-      create(:event, subscription:, timestamp: datetime + 2.days, code: metric.code)
-
-      # Paid in advance invoice should not change
-      expect {
-        put_with_token(organization, "/api/v1/invoices/#{invoice.id}/refresh", {})
-      }.not_to change { invoice.reload.total_amount_cents }
-
-      # Next month: Billing
-      new_datetime = DateTime.new(2023, 1, 1)
-
-      Invoices::SubscriptionService.new(
-        subscriptions: [subscription],
-        timestamp: new_datetime.to_i,
-        recurring: false,
-      ).create
-
-      expect(subscription.invoices.count).to eq(2)
-      new_invoice = subscription.invoices.order(created_at: :desc).first
-      expect(new_invoice.total_amount_cents).to eq(1440) # (1000 + 200) * 1.2
-
-      # Create event
-      create(:event, subscription:, timestamp: datetime + 3.days, code: metric.code)
-
-      # Nothing change in the invoice for the pay in advance subscription
-      expect {
-        put_with_token(organization, "/api/v1/invoices/#{invoice.id}/refresh", {})
-      }.not_to change { invoice.reload.total_amount_cents }
-
-      expect {
-        put_with_token(organization, "/api/v1/invoices/#{new_invoice.id}/refresh", {})
-      }.to change { new_invoice.reload.total_amount_cents }.from(1440).to(1560) # (1000 + 200 + 100) * 1.2
-
-      # Finalize invoices
-      expect {
-        put_with_token(organization, "/api/v1/invoices/#{invoice.id}/finalize", {})
-      }.to change { invoice.reload.status }.from('draft').to('finalized')
-
-      expect {
-        put_with_token(organization, "/api/v1/invoices/#{new_invoice.id}/finalize", {})
-      }.to change { new_invoice.reload.status }.from('draft').to('finalized')
-
-      expect(invoice.total_amount_cents).to eq(658)
-      expect(new_invoice.total_amount_cents).to eq(1560)
-    end
+  def terminate_subscription(subscription)
+    delete_with_token(organization, "/api/v1/subscriptions/#{subscription.external_id}")
+    perform_all_enqueued_jobs
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to be able to pay in advance invoices.