### PR TITLE
feat (invoices): Turn off GCL auto retries

### DIFF
--- a/app/services/invoices/payments/gocardless_service.rb
+++ b/app/services/invoices/payments/gocardless_service.rb
@@ -115,7 +115,7 @@ module Invoices
           params: {
             amount: invoice.total_amount_cents,
             currency: invoice.total_amount_currency.upcase,
-            retry_if_possible: true,
+            retry_if_possible: false,
             metadata: {
               lago_customer_id: customer.id,
               lago_invoice_id: invoice.id,


### PR DESCRIPTION
## Context

In order to prevent conflicts with retry feature, we should turn off GCL auto retries.

## Description

We should prevent double charging the same invoice. It can happen in the edge case when payment first failed and after that manual retry is triggered. In the same time auto-retry started and double charge could happen. GCL also suggested to not have both mechanisms in the same time
