### PR TITLE
feat(credit_notes): Add license management and handle grace period

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -150,7 +150,7 @@ class Invoice < ApplicationRecord
   end
 
   def creditable_amount_cents
-    return 0 if legacy? || credit?
+    return 0 if legacy? || credit? || draft?
 
     fees.map do |fee|
       creditable = fee.creditable_amount_cents
@@ -159,7 +159,7 @@ class Invoice < ApplicationRecord
   end
 
   def refundable_amount_cents
-    return 0 if legacy? || credit? || !succeeded?
+    return 0 if legacy? || credit? || draft? || !succeeded?
 
     amount = creditable_amount_cents - credits.sum(:amount_cents) - wallet_transaction_amount_cents
     amount.negative? ? 0 : amount

--- a/spec/controllers/api/v1/credit_notes_controller_spec.rb
+++ b/spec/controllers/api/v1/credit_notes_controller_spec.rb
@@ -231,38 +231,39 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       }
     end
 
-    # TODO: credit note feature is diabled for now
-    # it 'creates a credit note' do
-    #   post_with_token(organization, '/api/v1/credit_notes', { credit_note: create_params })
+    around { |test| lago_premium!(&test) }
 
-    #   aggregate_failures do
-    #     expect(response).to have_http_status(:success)
+    it 'creates a credit note' do
+      post_with_token(organization, '/api/v1/credit_notes', { credit_note: create_params })
 
-    #     expect(json[:credit_note][:lago_id]).to be_present
-    #     expect(json[:credit_note][:credit_status]).to eq('available')
-    #     expect(json[:credit_note][:refund_status]).to eq('pending')
-    #     expect(json[:credit_note][:reason]).to eq('duplicated_charge')
-    #     expect(json[:credit_note][:description]).to eq('Duplicated charge')
-    #     expect(json[:credit_note][:total_amount_cents]).to eq(15)
-    #     expect(json[:credit_note][:total_amount_currency]).to eq('EUR')
-    #     expect(json[:credit_note][:credit_amount_cents]).to eq(10)
-    #     expect(json[:credit_note][:credit_amount_currency]).to eq('EUR')
-    #     expect(json[:credit_note][:balance_amount_cents]).to eq(10)
-    #     expect(json[:credit_note][:balance_amount_currency]).to eq('EUR')
-    #     expect(json[:credit_note][:refund_amount_cents]).to eq(5)
-    #     expect(json[:credit_note][:refund_amount_currency]).to eq('EUR')
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
 
-    #     expect(json[:credit_note][:items][0][:lago_id]).to be_present
-    #     expect(json[:credit_note][:items][0][:amount_cents]).to eq(10)
-    #     expect(json[:credit_note][:items][0][:amount_currency]).to eq('EUR')
-    #     expect(json[:credit_note][:items][0][:fee][:lago_id]).to eq(fee1.id)
+        expect(json[:credit_note][:lago_id]).to be_present
+        expect(json[:credit_note][:credit_status]).to eq('available')
+        expect(json[:credit_note][:refund_status]).to eq('pending')
+        expect(json[:credit_note][:reason]).to eq('duplicated_charge')
+        expect(json[:credit_note][:description]).to eq('Duplicated charge')
+        expect(json[:credit_note][:total_amount_cents]).to eq(15)
+        expect(json[:credit_note][:total_amount_currency]).to eq('EUR')
+        expect(json[:credit_note][:credit_amount_cents]).to eq(10)
+        expect(json[:credit_note][:credit_amount_currency]).to eq('EUR')
+        expect(json[:credit_note][:balance_amount_cents]).to eq(10)
+        expect(json[:credit_note][:balance_amount_currency]).to eq('EUR')
+        expect(json[:credit_note][:refund_amount_cents]).to eq(5)
+        expect(json[:credit_note][:refund_amount_currency]).to eq('EUR')
 
-    #     expect(json[:credit_note][:items][1][:lago_id]).to be_present
-    #     expect(json[:credit_note][:items][1][:amount_cents]).to eq(5)
-    #     expect(json[:credit_note][:items][1][:amount_currency]).to eq('EUR')
-    #     expect(json[:credit_note][:items][1][:fee][:lago_id]).to eq(fee2.id)
-    #   end
-    # end
+        expect(json[:credit_note][:items][0][:lago_id]).to be_present
+        expect(json[:credit_note][:items][0][:amount_cents]).to eq(10)
+        expect(json[:credit_note][:items][0][:amount_currency]).to eq('EUR')
+        expect(json[:credit_note][:items][0][:fee][:lago_id]).to eq(fee1.id)
+
+        expect(json[:credit_note][:items][1][:lago_id]).to be_present
+        expect(json[:credit_note][:items][1][:amount_cents]).to eq(5)
+        expect(json[:credit_note][:items][1][:amount_currency]).to eq('EUR')
+        expect(json[:credit_note][:items][1][:fee][:lago_id]).to eq(fee2.id)
+      end
+    end
 
     context 'when invoice is not found' do
       let(:invoice_id) { 'foo_id' }

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     trait :draft do
       status { :draft }
     end
+
+    trait :credit do
+      invoice_type { :credit }
+    end
   end
 end

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -50,61 +50,62 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
     GQL
   end
 
-  # TODO: credit note feature is diabled for now
-  # it 'creates a credit note' do
-  #   result = execute_graphql(
-  #     current_user: membership.user,
-  #     current_organization: organization,
-  #     query: mutation,
-  #     variables: {
-  #       input: {
-  #         reason: 'duplicated_charge',
-  #         invoiceId: invoice.id,
-  #         description: 'Duplicated charge',
-  #         creditAmountCents: 10,
-  #         refundAmountCents: 5,
-  #         items: [
-  #           {
-  #             feeId: fee1.id,
-  #             amountCents: 10,
-  #           },
-  #           {
-  #             feeId: fee2.id,
-  #             amountCents: 5,
-  #           },
-  #         ],
-  #       },
-  #     },
-  #   )
+  around { |test| lago_premium!(&test) }
 
-  #   result_data = result['data']['createCreditNote']
+  it 'creates a credit note' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query: mutation,
+      variables: {
+        input: {
+          reason: 'duplicated_charge',
+          invoiceId: invoice.id,
+          description: 'Duplicated charge',
+          creditAmountCents: 10,
+          refundAmountCents: 5,
+          items: [
+            {
+              feeId: fee1.id,
+              amountCents: 10,
+            },
+            {
+              feeId: fee2.id,
+              amountCents: 5,
+            },
+          ],
+        },
+      },
+    )
 
-  #   aggregate_failures do
-  #     expect(result_data['id']).to be_present
-  #     expect(result_data['creditStatus']).to eq('available')
-  #     expect(result_data['refundStatus']).to eq('pending')
-  #     expect(result_data['reason']).to eq('duplicated_charge')
-  #     expect(result_data['description']).to eq('Duplicated charge')
-  #     expect(result_data['totalAmountCents']).to eq('15')
-  #     expect(result_data['totalAmountCurrency']).to eq('EUR')
-  #     expect(result_data['creditAmountCents']).to eq('10')
-  #     expect(result_data['creditAmountCurrency']).to eq('EUR')
-  #     expect(result_data['balanceAmountCents']).to eq('10')
-  #     expect(result_data['balanceAmountCurrency']).to eq('EUR')
-  #     expect(result_data['refundAmountCents']).to eq('5')
-  #     expect(result_data['refundAmountCurrency']).to eq('EUR')
+    result_data = result['data']['createCreditNote']
 
-  #     expect(result_data['items'][0]['id']).to be_present
-  #     expect(result_data['items'][0]['amountCents']).to eq('10')
-  #     expect(result_data['items'][0]['amountCurrency']).to eq('EUR')
-  #     expect(result_data['items'][0]['fee']['id']).to eq(fee1.id)
+    aggregate_failures do
+      expect(result_data['id']).to be_present
+      expect(result_data['creditStatus']).to eq('available')
+      expect(result_data['refundStatus']).to eq('pending')
+      expect(result_data['reason']).to eq('duplicated_charge')
+      expect(result_data['description']).to eq('Duplicated charge')
+      expect(result_data['totalAmountCents']).to eq('15')
+      expect(result_data['totalAmountCurrency']).to eq('EUR')
+      expect(result_data['creditAmountCents']).to eq('10')
+      expect(result_data['creditAmountCurrency']).to eq('EUR')
+      expect(result_data['balanceAmountCents']).to eq('10')
+      expect(result_data['balanceAmountCurrency']).to eq('EUR')
+      expect(result_data['refundAmountCents']).to eq('5')
+      expect(result_data['refundAmountCurrency']).to eq('EUR')
 
-  #     expect(result_data['items'][1]['id']).to be_present
-  #     expect(result_data['items'][1]['amountCents']).to eq('5')
-  #     expect(result_data['items'][1]['amountCurrency']).to eq('EUR')
-  #     expect(result_data['items'][1]['fee']['id']).to eq(fee2.id)
-  #   end
-  # end
+      expect(result_data['items'][0]['id']).to be_present
+      expect(result_data['items'][0]['amountCents']).to eq('10')
+      expect(result_data['items'][0]['amountCurrency']).to eq('EUR')
+      expect(result_data['items'][0]['fee']['id']).to eq(fee1.id)
+
+      expect(result_data['items'][1]['id']).to be_present
+      expect(result_data['items'][1]['amountCents']).to eq('5')
+      expect(result_data['items'][1]['amountCurrency']).to eq('EUR')
+      expect(result_data['items'][1]['fee']['id']).to eq(fee2.id)
+    end
+  end
 
   context 'when invoice is not found' do
     it 'returns an error' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,6 +39,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include GraphQLHelper, type: :graphql
   config.include ApiHelper, type: :request
+  config.include LicenseHelper
   config.include ActiveSupport::Testing::TimeHelpers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -5,12 +5,12 @@ require 'rails_helper'
 RSpec.describe CreditNotes::CreateService, type: :service do
   subject(:create_service) do
     described_class.new(
-      invoice: invoice,
-      items: items,
+      invoice:,
+      items:,
       description: nil,
-      credit_amount_cents: credit_amount_cents,
-      refund_amount_cents: refund_amount_cents,
-      automatic: true, # TODO: credit note feature is diabled for now
+      credit_amount_cents:,
+      refund_amount_cents:,
+      automatic:,
     )
   end
 
@@ -25,6 +25,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
     )
   end
 
+  let(:automatic) { true }
   let(:fee1) { create(:fee, invoice: invoice, amount_cents: 10, vat_amount_cents: 2, vat_rate: 20) }
   let(:fee2) { create(:fee, invoice: invoice, amount_cents: 10, vat_amount_cents: 2, vat_rate: 20) }
   let(:credit_amount_cents) { 12 }
@@ -193,6 +194,123 @@ RSpec.describe CreditNotes::CreateService, type: :service do
           result = create_service.call
 
           expect(result.credit_note.issuing_date.to_s).to eq('2022-11-24')
+        end
+      end
+    end
+
+    context 'when invoice is not found' do
+      let(:invoice) { nil }
+      let(:items) { [] }
+
+      it 'returns a failure' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('invoice_not_found')
+        end
+      end
+    end
+
+    context 'when invoice is not automatic' do
+      let(:automatic) { false }
+
+      it 'returns a failure' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+
+          expect(result.error).to be_a(BaseService::ForbiddenFailure)
+          expect(result.error.code).to eq('feature_unavailable')
+        end
+      end
+
+      context 'with a valid license' do
+        before { License.instance_variable_set(:@premium, true) }
+
+        after { License.instance_variable_set(:@premium, false) }
+
+        it 'returns a success' do
+          result = create_service.call
+          expect(result).to be_success
+        end
+
+        context 'when invoice is draft' do
+          let(:invoice) do
+            create(
+              :invoice,
+              :draft,
+              amount_currency: 'EUR',
+              amount_cents: 20,
+              total_amount_cents: 24,
+              payment_status: :succeeded,
+              vat_rate: 20,
+            )
+          end
+
+          it 'returns a failure' do
+            result = create_service.call
+
+            aggregate_failures do
+              expect(result).not_to be_success
+
+              expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+              expect(result.error.code).to eq('invalid_type_or_status')
+            end
+          end
+        end
+
+        context 'when invoice is a prepaid credit invoice' do
+          let(:invoice) do
+            create(
+              :invoice,
+              :credit,
+              amount_currency: 'EUR',
+              amount_cents: 20,
+              total_amount_cents: 24,
+              payment_status: :succeeded,
+              vat_rate: 20,
+            )
+          end
+
+          it 'returns a failure' do
+            result = create_service.call
+
+            aggregate_failures do
+              expect(result).not_to be_success
+
+              expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+              expect(result.error.code).to eq('invalid_type_or_status')
+            end
+          end
+        end
+
+        context 'when invoice is legacy' do
+          let(:invoice) do
+            create(
+              :invoice,
+              amount_currency: 'EUR',
+              amount_cents: 20,
+              total_amount_cents: 24,
+              payment_status: :succeeded,
+              vat_rate: 20,
+              legacy: true,
+            )
+          end
+
+          it 'returns a failure' do
+            result = create_service.call
+
+            aggregate_failures do
+              expect(result).not_to be_success
+
+              expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+              expect(result.error.code).to eq('invalid_type_or_status')
+            end
+          end
         end
       end
     end

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -229,9 +229,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       end
 
       context 'with a valid license' do
-        before { License.instance_variable_set(:@premium, true) }
-
-        after { License.instance_variable_set(:@premium, false) }
+        around { |test| lago_premium!(&test) }
 
         it 'returns a success' do
           result = create_service.call

--- a/spec/support/license_helper.rb
+++ b/spec/support/license_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module LicenseHelper
+  def lago_premium!
+    License.instance_variable_set(:@premium, true)
+    yield
+    License.instance_variable_set(:@premium, false)
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Context

The license management was recently introduce. Since credit note feature is supposed to be a premium one, it is impacted

## Description

This PR adds:
- the premium flag handling to unblock the feature
- Prevents the manual creation of credit notes on `draft`, `credit` or `legacy` invoices