### PR TITLE
feat: add hasCreditNotes attribute invoice graphQL resolver

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -31,6 +31,7 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       field :legacy, Boolean, null: false
+      field :has_credit_notes, Boolean, null: false
 
       field :subscriptions, [Types::Subscriptions::Object]
       field :invoice_subscriptions, [Types::InvoiceSubscription::Object]
@@ -48,6 +49,10 @@ module Types
 
       field :refundable_amount_cents, Integer, null: false
       field :creditable_amount_cents, Integer, null: false
+
+      def has_credit_notes
+        object.credit_notes.any?
+      end
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2993,6 +2993,7 @@ type Invoice {
   customer: Customer!
   fees: [Fee!]
   fileUrl: String
+  hasCreditNotes: Boolean!
   id: ID!
   invoiceSubscriptions: [InvoiceSubscription!]
   invoiceType: InvoiceTypeEnum!

--- a/schema.json
+++ b/schema.json
@@ -11226,6 +11226,24 @@
               ]
             },
             {
+              "name": "hasCreditNotes",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {


### PR DESCRIPTION
## Context

Draft invoice with no credit notes related should not allow to access the list of credit notes nor create one (manually)

## Description

This PR adds the information if an invoice has credit notes or not for the Front-End to hide the credit notes secitons