### PR TITLE
fix: Turn integer amount fields into bigint

### DIFF
--- a/db/migrate/20230106152449_turn_all_amount_cents_to_bigint.rb
+++ b/db/migrate/20230106152449_turn_all_amount_cents_to_bigint.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TurnAllAmountCentsToBigint < ActiveRecord::Migration[7.0]
+  def up
+    change_column :applied_add_ons, :amount_cents, :bigint, null: false
+    change_column :applied_coupons, :amount_cents, :bigint, null: true
+  end
+
+  def down
+    change_column :applied_add_ons, :amount_cents, :integer, null: false
+    change_column :applied_coupons, :amount_cents, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_150636) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_06_152449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -59,7 +59,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_150636) do
   create_table "applied_add_ons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "add_on_id", null: false
     t.uuid "customer_id", null: false
-    t.integer "amount_cents", null: false
+    t.bigint "amount_cents", null: false
     t.string "amount_currency", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -72,7 +72,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_150636) do
     t.uuid "coupon_id", null: false
     t.uuid "customer_id", null: false
     t.integer "status", default: 0, null: false
-    t.integer "amount_cents"
+    t.bigint "amount_cents"
     t.string "amount_currency"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## Context

In current database schema, `applied_add_ons#amount_cents` and `applied_coupons#amount_cents` are stored as integer. 

This is not a good datatype to store amount in cents as max value for an integer is `2147483648` witch could be an issue for some currency.

For example: 2'147'483'648 VND ≃ 86'433 EUR

## Description

This PR intent to turn these field into the bigint datatype allowing values up to 9'223'372'036'854'775'807

**NOTE**: a next PR will turn the GraphQL types for amount_cents fields into bigint to fix issues with large amounts
