### PR TITLE
feat(invoice_grace_period): Add draft status to credit notes

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -5,7 +5,7 @@ module Api
     class CreditNotesController < Api::BaseController
       def create
         service = CreditNotes::CreateService.new(
-          invoice: current_organization.invoices.finalized.find_by(id: input_params[:invoice_id]),
+          invoice: current_organization.invoices.find_by(id: input_params[:invoice_id]),
           **input_params,
         )
         result = service.call
@@ -37,7 +37,7 @@ module Api
       end
 
       def update
-        credit_note = current_organization.credit_notes.finalized.find_by(id: params[:id])
+        credit_note = current_organization.credit_notes.find_by(id: params[:id])
         return not_found_error(resource: 'credit_note') unless credit_note
 
         result = CreditNotes::UpdateService.new(credit_note:, **update_params).call
@@ -74,7 +74,7 @@ module Api
       end
 
       def void
-        credit_note = current_organization.credit_notes.finalized.find_by(id: params[:id])
+        credit_note = current_organization.credit_notes.find_by(id: params[:id])
         return not_found_error(resource: 'credit_note') unless credit_note
 
         result = CreditNotes::VoidService.new(credit_note:).call

--- a/app/graphql/mutations/credit_notes/create.rb
+++ b/app/graphql/mutations/credit_notes/create.rb
@@ -26,7 +26,7 @@ module Mutations
 
         result = ::CreditNotes::CreateService
           .new(
-            invoice: current_organization.invoices.finalized.find_by(id: args[:invoice_id]),
+            invoice: current_organization.invoices.find_by(id: args[:invoice_id]),
             **args,
           )
           .call

--- a/app/graphql/mutations/credit_notes/create.rb
+++ b/app/graphql/mutations/credit_notes/create.rb
@@ -26,7 +26,7 @@ module Mutations
 
         result = ::CreditNotes::CreateService
           .new(
-            invoice: current_organization.invoices.find_by(id: args[:invoice_id]),
+            invoice: current_organization.invoices.finalized.find_by(id: args[:invoice_id]),
             **args,
           )
           .call

--- a/app/graphql/mutations/credit_notes/download.rb
+++ b/app/graphql/mutations/credit_notes/download.rb
@@ -16,6 +16,7 @@ module Mutations
       def resolve(**args)
         validate_organization!
 
+        # TODO: Security issue here, we can download a credit note from another organization.
         result = ::CreditNotes::GenerateService.new.call(credit_note_id: args[:id])
 
         result.success? ? result.credit_note : result_error(result)

--- a/app/graphql/mutations/credit_notes/update.rb
+++ b/app/graphql/mutations/credit_notes/update.rb
@@ -15,7 +15,7 @@ module Mutations
 
       def resolve(**args)
         result = ::CreditNotes::UpdateService.new(
-          credit_note: context[:current_user].credit_notes.find_by(id: args[:id]),
+          credit_note: context[:current_user].credit_notes.finalized.find_by(id: args[:id]),
           refund_status: args[:refund_status],
         ).call
 

--- a/app/graphql/mutations/credit_notes/update.rb
+++ b/app/graphql/mutations/credit_notes/update.rb
@@ -15,7 +15,7 @@ module Mutations
 
       def resolve(**args)
         result = ::CreditNotes::UpdateService.new(
-          credit_note: context[:current_user].credit_notes.finalized.find_by(id: args[:id]),
+          credit_note: context[:current_user].credit_notes.find_by(id: args[:id]),
           refund_status: args[:refund_status],
         ).call
 

--- a/app/graphql/mutations/credit_notes/void.rb
+++ b/app/graphql/mutations/credit_notes/void.rb
@@ -14,7 +14,7 @@ module Mutations
 
       def resolve(id:)
         result = ::CreditNotes::VoidService.new(
-          credit_note: context[:current_user].credit_notes.finalized.find_by(id:),
+          credit_note: context[:current_user].credit_notes.find_by(id:),
         ).call
 
         result.success? ? result.credit_note : result_error(result)

--- a/app/graphql/mutations/credit_notes/void.rb
+++ b/app/graphql/mutations/credit_notes/void.rb
@@ -14,7 +14,7 @@ module Mutations
 
       def resolve(id:)
         result = ::CreditNotes::VoidService.new(
-          credit_note: context[:current_user].credit_notes.find_by(id: id),
+          credit_note: context[:current_user].credit_notes.finalized.find_by(id:),
         ).call
 
         result.success? ? result.credit_note : result_error(result)

--- a/app/graphql/resolvers/credit_note_resolver.rb
+++ b/app/graphql/resolvers/credit_note_resolver.rb
@@ -14,7 +14,7 @@ module Resolvers
     def resolve(id: nil)
       validate_organization!
 
-      current_organization.credit_notes.find(id)
+      current_organization.credit_notes.finalized.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'credit_note')
     end

--- a/app/graphql/resolvers/customer_credit_notes_resolver.rb
+++ b/app/graphql/resolvers/customer_credit_notes_resolver.rb
@@ -21,6 +21,7 @@ module Resolvers
 
       credit_notes = current_customer
         .credit_notes
+        .finalized
         .order(created_at: :desc)
         .page(page)
         .per(limit)

--- a/app/graphql/resolvers/invoice_credit_notes_resolver.rb
+++ b/app/graphql/resolvers/invoice_credit_notes_resolver.rb
@@ -16,8 +16,9 @@ module Resolvers
     def resolve(invoice_id: nil, page: nil, limit: nil)
       validate_organization!
 
-      Invoice.find(invoice_id)
+      Invoice.finalized.find(invoice_id)
         .credit_notes
+        .finalized
         .order(created_at: :desc)
         .page(page)
         .per(limit)

--- a/app/graphql/resolvers/invoice_credit_notes_resolver.rb
+++ b/app/graphql/resolvers/invoice_credit_notes_resolver.rb
@@ -16,7 +16,7 @@ module Resolvers
     def resolve(invoice_id: nil, page: nil, limit: nil)
       validate_organization!
 
-      Invoice.finalized.find(invoice_id)
+      Invoice.find(invoice_id)
         .credit_notes
         .finalized
         .order(created_at: :desc)

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -66,7 +66,7 @@ module Types
       end
 
       def has_credit_notes
-        object.credit_notes.any?
+        object.credit_notes.finalized.any?
       end
 
       def active_subscription_count
@@ -87,11 +87,11 @@ module Types
       end
 
       def credit_notes_credits_available_count
-        object.credit_notes.where('credit_notes.credit_amount_cents > 0').count
+        object.credit_notes.finalized.where('credit_notes.credit_amount_cents > 0').count
       end
 
       def credit_notes_balance_amount_cents
-        object.credit_notes.sum('credit_notes.balance_amount_cents')
+        object.credit_notes.finalized.sum('credit_notes.balance_amount_cents')
       end
     end
   end

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -40,10 +40,12 @@ class CreditNote < ApplicationRecord
   REFUND_STATUS = %i[pending succeeded failed].freeze
 
   REASON = %i[duplicated_charge product_unsatisfactory order_change order_cancellation fraudulent_charge other].freeze
+  STATUS = %i[draft finalized].freeze
 
   enum credit_status: CREDIT_STATUS
   enum refund_status: REFUND_STATUS
   enum reason: REASON
+  enum status: STATUS
 
   sequenced scope: ->(credit_note) { CreditNote.where(invoice_id: credit_note.invoice_id) }
 

--- a/app/services/credit_notes/generate_service.rb
+++ b/app/services/credit_notes/generate_service.rb
@@ -9,7 +9,7 @@ module CreditNotes
     end
 
     def call(credit_note_id:)
-      credit_note = CreditNote.find_by(id: credit_note_id)
+      credit_note = CreditNote.finalized.find_by(id: credit_note_id)
       return result.not_found_failure!(resource: 'credit_note') if credit_note.blank?
 
       generate_pdf(credit_note) if credit_note.file.blank?

--- a/app/services/credit_notes/update_service.rb
+++ b/app/services/credit_notes/update_service.rb
@@ -10,7 +10,7 @@ module CreditNotes
     end
 
     def call
-      return result.not_found_failure!(resource: 'credit_note') if credit_note.nil?
+      return result.not_found_failure!(resource: 'credit_note') if credit_note.nil? || credit_note.draft?
 
       if params.key?(:refund_status)
         credit_note.refund_status = params[:refund_status]

--- a/app/services/credit_notes/validate_item_service.rb
+++ b/app/services/credit_notes/validate_item_service.rb
@@ -31,11 +31,11 @@ module CreditNotes
     end
 
     def refunded_invoice_amount_cents
-      invoice.credit_notes.where.not(id: credit_note.id).sum(:refund_amount_cents)
+      invoice.credit_notes.finalized.where.not(id: credit_note.id).sum(:refund_amount_cents)
     end
 
     def credited_invoice_amount_cents
-      invoice.credit_notes.where.not(id: credit_note.id).sum(:credit_amount_cents)
+      invoice.credit_notes.finalized.where.not(id: credit_note.id).sum(:credit_amount_cents)
     end
 
     def invoice_credit_note_total_amount_cents

--- a/app/services/credit_notes/validate_service.rb
+++ b/app/services/credit_notes/validate_service.rb
@@ -30,11 +30,11 @@ module CreditNotes
     end
 
     def refunded_invoice_amount_cents
-      invoice.credit_notes.where.not(id: credit_note.id).sum(:refund_amount_cents)
+      invoice.credit_notes.finalized.where.not(id: credit_note.id).sum(:refund_amount_cents)
     end
 
     def credited_invoice_amount_cents
-      invoice.credit_notes.where.not(id: credit_note.id).sum(:credit_amount_cents)
+      invoice.credit_notes.finalized.where.not(id: credit_note.id).sum(:credit_amount_cents)
     end
 
     def invoice_credit_note_total_amount_cents

--- a/app/services/credit_notes/void_service.rb
+++ b/app/services/credit_notes/void_service.rb
@@ -9,7 +9,7 @@ module CreditNotes
     end
 
     def call
-      return result.not_found_failure!(resource: 'credit_note') if credit_note.nil?
+      return result.not_found_failure!(resource: 'credit_note') if credit_note.nil? || credit_note.draft?
 
       result.credit_note = credit_note
       return result.not_allowed_failure!(code: 'no_voidable_amount') unless credit_note.voidable?

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -148,7 +148,11 @@ module Invoices
     end
 
     def credit_notes
-      @credit_notes ||= customer.credit_notes.available.where.not(invoice_id: invoice.id).order(created_at: :asc)
+      @credit_notes ||= customer.credit_notes
+        .finalized
+        .available
+        .where.not(invoice_id: invoice.id)
+        .order(created_at: :asc)
     end
 
     def wallet

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -42,7 +42,7 @@ module Invoices
 
         return calculate_result unless calculate_result.success?
 
-        # In case of a refresh the same day of the termination
+        # NOTE: In case of a refresh the same day of the termination.
         invoice.fees.update_all(created_at: invoice.created_at) # rubocop:disable Rails/SkipsModelValidations
       end
 

--- a/db/migrate/20230109095957_add_status_to_credit_notes.rb
+++ b/db/migrate/20230109095957_add_status_to_credit_notes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStatusToCreditNotes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :credit_notes, :status, :integer, null: false, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_06_152449) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_09_095957) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -172,6 +172,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_152449) do
     t.string "vat_amount_currency"
     t.datetime "refunded_at"
     t.date "issuing_date", null: false
+    t.integer "status", default: 1, null: false
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end

--- a/spec/factories/credit_notes.rb
+++ b/spec/factories/credit_notes.rb
@@ -29,5 +29,9 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :draft do
+      status { :draft }
+    end
   end
 end

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -133,32 +133,6 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
     end
   end
 
-  context 'when invoice is draft' do
-    let(:invoice) { create(:invoice, :draft) }
-
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        query: mutation,
-        variables: {
-          input: {
-            reason: 'duplicated_charge',
-            invoiceId: invoice.id,
-            items: [
-              {
-                feeId: fee1.id,
-                amountCents: 15,
-              },
-            ],
-          },
-        },
-      )
-
-      expect_not_found(result)
-    end
-  end
-
   context 'without current user' do
     it 'returns an error' do
       result = execute_graphql(

--- a/spec/graphql/mutations/credit_notes/update_spec.rb
+++ b/spec/graphql/mutations/credit_notes/update_spec.rb
@@ -39,25 +39,6 @@ RSpec.describe Mutations::CreditNotes::Update, type: :graphql do
     end
   end
 
-  context 'when credit note is draft' do
-    let(:credit_note) { create(:credit_note, :draft, customer:) }
-
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query: mutation,
-        variables: {
-          input: {
-            id: credit_note.id,
-            refundStatus: 'succeeded',
-          },
-        },
-      )
-
-      expect_not_found(result)
-    end
-  end
-
   context 'when credit note is not found' do
     it 'returns an error' do
       result = execute_graphql(

--- a/spec/graphql/mutations/credit_notes/void_spec.rb
+++ b/spec/graphql/mutations/credit_notes/void_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe Mutations::CreditNotes::Void, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:credit_note) { create(:credit_note, customer: customer) }
+  let(:customer) { create(:customer, organization:) }
+  let(:credit_note) { create(:credit_note, customer:) }
 
   let(:mutation) do
     <<~GQL
@@ -48,6 +48,22 @@ RSpec.describe Mutations::CreditNotes::Void, type: :graphql do
           input: {
             id: 'foo_bar',
           },
+        },
+      )
+
+      expect_not_found(result)
+    end
+  end
+
+  context 'when credit note is draft' do
+    let(:credit_note) { create(:credit_note, :draft, customer:) }
+
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query: mutation,
+        variables: {
+          input: { id: credit_note.id },
         },
       )
 

--- a/spec/graphql/mutations/credit_notes/void_spec.rb
+++ b/spec/graphql/mutations/credit_notes/void_spec.rb
@@ -55,22 +55,6 @@ RSpec.describe Mutations::CreditNotes::Void, type: :graphql do
     end
   end
 
-  context 'when credit note is draft' do
-    let(:credit_note) { create(:credit_note, :draft, customer:) }
-
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query: mutation,
-        variables: {
-          input: { id: credit_note.id },
-        },
-      )
-
-      expect_not_found(result)
-    end
-  end
-
   context 'without current user' do
     it 'returns an error' do
       result = execute_graphql(

--- a/spec/graphql/resolvers/invoice_credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_credit_notes_resolver_spec.rb
@@ -91,21 +91,4 @@ RSpec.describe Resolvers::InvoiceCreditNotesResolver, type: :graphql do
       expect_graphql_error(result:, message: 'Resource not found')
     end
   end
-
-  context 'when invoice is draft' do
-    let(:invoice) { create(:invoice, :draft, customer:) }
-
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: organization,
-        query:,
-        variables: {
-          invoiceId: invoice.id,
-        },
-      )
-
-      expect_graphql_error(result:, message: 'Resource not found')
-    end
-  end
 end

--- a/spec/requests/api/v1/credit_notes_spec.rb
+++ b/spec/requests/api/v1/credit_notes_spec.rb
@@ -112,16 +112,6 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       end
     end
 
-    context 'when credit note is draft' do
-      let(:credit_note) { create(:credit_note, :draft) }
-
-      it 'returns not found' do
-        put_with_token(organization, '/api/v1/credit_notes/555', credit_note: update_params)
-
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-
     context 'when provided refund status is invalid' do
       let(:update_params) { { refund_status: 'foo_bar' } }
 
@@ -308,15 +298,6 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
-
-    context 'when invoice is draft' do
-      it 'returns not found' do
-        invoice.update!(status: :draft)
-        post_with_token(organization, '/api/v1/credit_notes', { credit_note: create_params })
-
-        expect(response).to have_http_status(:not_found)
-      end
-    end
   end
 
   describe 'PUT /credit_notes/:id/void' do
@@ -335,16 +316,6 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
     context 'when credit note does not exist' do
       it 'returns a not found error' do
         put_with_token(organization, '/api/v1/credit_notes/555/void')
-
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-
-    context 'when credit note is draft' do
-      let(:credit_note) { create(:credit_note, :draft) }
-
-      it 'returns not found' do
-        put_with_token(organization, "/api/v1/credit_notes/#{credit_note.id}/void")
 
         expect(response).to have_http_status(:not_found)
       end

--- a/spec/scenarios/invoices_spec.rb
+++ b/spec/scenarios/invoices_spec.rb
@@ -24,14 +24,11 @@ describe 'Invoices Scenarios', :invoices_scenarios, type: :request do
         )
 
         create(:standard_charge, plan:, billable_metric: metric, properties: { amount: '3' })
-
-        subscription_invoice = Invoice.order(created_at: :desc).first
-        expect(subscription_invoice).to be_draft
-        expect(subscription_invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
       end
 
-      subscription = Subscription.order(created_at: :desc).first
-      subscription_invoice = subscription.invoices.first
+      subscription_invoice = Invoice.draft.first
+      subscription = subscription_invoice.subscriptions.first
+      expect(subscription_invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
 
       ### 17 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 17)) do
@@ -107,14 +104,11 @@ describe 'Invoices Scenarios', :invoices_scenarios, type: :request do
         )
 
         create(:standard_charge, plan:, billable_metric: metric, properties: { amount: '1' })
-
-        subscription_invoice = Invoice.order(created_at: :desc).first
-        expect(subscription_invoice).to be_draft
-        expect(subscription_invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
       end
 
-      subscription = Subscription.order(created_at: :desc).first
-      subscription_invoice = subscription.invoices.first
+      subscription_invoice = Invoice.draft.first
+      subscription = subscription_invoice.subscriptions.first
+      expect(subscription_invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
 
       ### 17 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 17)) do
@@ -189,13 +183,11 @@ describe 'Invoices Scenarios', :invoices_scenarios, type: :request do
         )
 
         create(:standard_charge, plan:, billable_metric: metric, properties: { amount: '1' })
-
-        invoice = Invoice.order(created_at: :desc).first
-        expect(invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
       end
 
-      subscription = Subscription.order(created_at: :desc).first
-      invoice = subscription.invoices.first
+      invoice = Invoice.draft.first
+      subscription = invoice.subscriptions.first
+      expect(invoice.total_amount_cents).to eq(658) # 17 days - From 15th Dec. to 31st Dec.
 
       ### 16 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 16)) do

--- a/spec/services/credit_notes/update_service_spec.rb
+++ b/spec/services/credit_notes/update_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CreditNotes::UpdateService, type: :service do
-  subject(:credit_note_service) { described_class.new(credit_note: credit_note, **params) }
+  subject(:credit_note_service) { described_class.new(credit_note:, **params) }
 
   let(:credit_note) { create(:credit_note) }
 
@@ -50,6 +50,20 @@ RSpec.describe CreditNotes::UpdateService, type: :service do
         expect(result.error).to be_a(BaseService::ValidationFailure)
         expect(result.error.messages.keys).to include(:refund_status)
         expect(result.error.messages[:refund_status]).to include('value_is_invalid')
+      end
+    end
+  end
+
+  context 'when credit_note is draft' do
+    let(:credit_note) { create(:credit_note, :draft) }
+
+    it 'returns a failure' do
+      result = credit_note_service.call
+
+      aggregate_failures do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq('credit_note_not_found')
       end
     end
   end

--- a/spec/services/credit_notes/void_service_spec.rb
+++ b/spec/services/credit_notes/void_service_spec.rb
@@ -35,6 +35,20 @@ RSpec.describe CreditNotes::VoidService, type: :service do
       end
     end
 
+    context 'when credit note is draft' do
+      let(:credit_note) { create(:credit_note, :draft) }
+
+      it 'returns a failure' do
+        result = void_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq('credit_note')
+        end
+      end
+    end
+
     context 'when the credit note is not voidable' do
       let(:credit_note) { create(:credit_note, credit_status: :voided) }
 

--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Invoices::FinalizeService, type: :service do
     let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
     let(:timestamp) { Time.zone.now.beginning_of_month }
     let(:started_at) { Time.zone.now - 2.years }
+    let(:credit_note) { create(:credit_note, :draft, invoice:) }
 
     let(:plan) { create(:plan, interval: 'monthly') }
 

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -115,12 +115,12 @@ RSpec.describe Subscriptions::TerminateService do
   describe '.terminate_from_api' do
     let(:membership) { create(:membership) }
     let(:organization) { membership.organization }
-    let(:customer) { create(:customer, organization: organization) }
-    let(:subscription) { create(:subscription, customer: customer) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, customer:) }
 
     it 'terminates a subscription' do
       result = terminate_service.terminate_from_api(
-        organization: organization,
+        organization:,
         external_id: subscription.external_id,
       )
 
@@ -134,7 +134,7 @@ RSpec.describe Subscriptions::TerminateService do
     it 'enqueues a BillSubscriptionJob' do
       expect do
         terminate_service.terminate_from_api(
-          organization: organization,
+          organization:,
           external_id: subscription.external_id,
         )
       end.to have_enqueued_job(BillSubscriptionJob)
@@ -143,8 +143,8 @@ RSpec.describe Subscriptions::TerminateService do
     context 'when subscription is not found' do
       it 'returns an error' do
         result = terminate_service.terminate_from_api(
-          organization: organization,
-          external_id: subscription.external_id + '123',
+          organization:,
+          external_id: "#{subscription.external_id}123",
         )
 
         expect(result.error.error_code).to eq('subscription_not_found')
@@ -156,7 +156,7 @@ RSpec.describe Subscriptions::TerminateService do
 
       it 'returns an error' do
         result = terminate_service.terminate_from_api(
-          organization: organization,
+          organization:,
           external_id: subscription.external_id,
         )
 
@@ -173,10 +173,7 @@ RSpec.describe Subscriptions::TerminateService do
     before { next_subscription }
 
     it 'terminates the subscription' do
-      result = terminate_service.terminate_and_start_next(
-        subscription: subscription,
-        timestamp: timestamp,
-      )
+      result = terminate_service.terminate_and_start_next(subscription:, timestamp:)
 
       aggregate_failures do
         expect(result).to be_success
@@ -185,10 +182,7 @@ RSpec.describe Subscriptions::TerminateService do
     end
 
     it 'starts the next subscription' do
-      result = terminate_service.terminate_and_start_next(
-        subscription: subscription,
-        timestamp: timestamp,
-      )
+      result = terminate_service.terminate_and_start_next(subscription:, timestamp:)
 
       aggregate_failures do
         expect(result).to be_success
@@ -202,10 +196,7 @@ RSpec.describe Subscriptions::TerminateService do
 
       it 'enqueues a job to bill the existing subscription' do
         expect do
-          terminate_service.terminate_and_start_next(
-            subscription: subscription,
-            timestamp: timestamp,
-          )
+          terminate_service.terminate_and_start_next(subscription:, timestamp:)
         end.to have_enqueued_job(BillSubscriptionJob)
       end
     end
@@ -216,7 +207,7 @@ RSpec.describe Subscriptions::TerminateService do
         create(
           :subscription,
           previous_subscription_id: subscription.id,
-          plan: plan,
+          plan:,
           status: :pending,
         )
       end
@@ -225,10 +216,7 @@ RSpec.describe Subscriptions::TerminateService do
 
       it 'enqueues a job to bill the existing subscription' do
         expect do
-          terminate_service.terminate_and_start_next(
-            subscription: subscription,
-            timestamp: timestamp,
-          )
+          terminate_service.terminate_and_start_next(subscription:, timestamp:)
         end.to have_enqueued_job(BillSubscriptionJob).twice
       end
     end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to add a new field status to credit notes (`draft` or `finalized`).
This is useful when creating a draft invoice, draft credit note can also be created.
Then, when we're finalizing an invoice the goal of the next PR is to also finalize credit notes.