### PR TITLE
feat(add_ons): add search capability to GraphQl resolver

### DIFF
--- a/app/graphql/resolvers/add_ons_resolver.rb
+++ b/app/graphql/resolvers/add_ons_resolver.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal
+# frozen_string_literal: true
 
 module Resolvers
   class AddOnsResolver < GraphQL::Schema::Resolver
@@ -10,21 +10,24 @@ module Resolvers
     argument :ids, [ID], required: false, description: 'List of add-ons IDs to fetch'
     argument :page, Integer, required: false
     argument :limit, Integer, required: false
+    argument :search_term, String, required: false
 
     type Types::AddOns::Object.collection_type, null: false
 
-    def resolve(ids: nil, page: nil, limit: nil)
+    def resolve(ids: nil, page: nil, limit: nil, search_term: nil)
       validate_organization!
 
-      add_ons = current_organization
-        .add_ons
-        .order(created_at: :desc)
-        .page(page)
-        .per(limit)
+      query = ::AddOnsQuery.new(organization: current_organization)
+      result = query.call(
+        search_term:,
+        page:,
+        limit:,
+        filters: {
+          ids:,
+        },
+      )
 
-      add_ons = add_ons.where(id: ids) if ids.present?
-
-      add_ons
+      result.add_ons
     end
   end
 end

--- a/app/queries/add_ons_query.rb
+++ b/app/queries/add_ons_query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class AddOnsQuery < BaseQuery
+  def call(search_term:, page:, limit:, filters: {})
+    @search_term = search_term
+
+    add_ons = base_scope.result
+    add_ons = add_ons.where(id: filters[:ids]) if filters[:ids].present?
+    add_ons = add_ons.order(created_at: :desc).page(page).per(limit)
+
+    result.add_ons = add_ons
+    result
+  end
+
+  private
+
+  attr_reader :search_term
+
+  def base_scope
+    AddOn.where(organization:).ransack(search_params)
+  end
+
+  def search_params
+    return nil if search_term.blank?
+
+    {
+      m: 'or',
+      name_cont: search_term,
+      code_cont: search_term,
+    }
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3721,6 +3721,7 @@ type Query {
     ids: [ID!]
     limit: Int
     page: Int
+    searchTerm: String
   ): AddOnCollection!
 
   """

--- a/schema.json
+++ b/schema.json
@@ -15306,6 +15306,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },

--- a/spec/queries/add_ons_query_spec.rb
+++ b/spec/queries/add_ons_query_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AddOnsQuery, type: :query do
+  subject(:add_ons_query) do
+    described_class.new(organization:)
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:add_on_first) { create(:add_on, organization:, name: 'defgh', code: '11') }
+  let(:add_on_second) { create(:add_on, organization:, name: 'abcde', code: '22') }
+  let(:add_on_third) { create(:add_on, organization:, name: 'presuv', code: '33') }
+
+  before do
+    add_on_first
+    add_on_second
+    add_on_third
+  end
+
+  it 'returns all add_ons' do
+    result = add_ons_query.call(
+      search_term: nil,
+      page: 1,
+      limit: 10,
+    )
+
+    returned_ids = result.add_ons.pluck(:id)
+
+    aggregate_failures do
+      expect(result.add_ons.count).to eq(3)
+      expect(returned_ids).to include(add_on_first.id)
+      expect(returned_ids).to include(add_on_second.id)
+      expect(returned_ids).to include(add_on_third.id)
+    end
+  end
+
+  context 'when searching for /de/ term' do
+    it 'returns only two add_ons' do
+      result = add_ons_query.call(
+        search_term: 'de',
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.add_ons.pluck(:id)
+
+      aggregate_failures do
+        expect(result.add_ons.count).to eq(2)
+        expect(returned_ids).to include(add_on_first.id)
+        expect(returned_ids).to include(add_on_second.id)
+        expect(returned_ids).not_to include(add_on_third.id)
+      end
+    end
+  end
+
+  context 'when searching for /de/ term and filtering by id' do
+    it 'returns only one add_on' do
+      result = add_ons_query.call(
+        search_term: 'de',
+        page: 1,
+        limit: 10,
+        filters: {
+          ids: [add_on_second.id],
+        },
+      )
+
+      returned_ids = result.add_ons.pluck(:id)
+
+      aggregate_failures do
+        expect(result.add_ons.count).to eq(1)
+        expect(returned_ids).not_to include(add_on_first.id)
+        expect(returned_ids).to include(add_on_second.id)
+        expect(returned_ids).not_to include(add_on_third.id)
+      end
+    end
+  end
+
+  context 'when searching for /1/ term' do
+    it 'returns only two add_ons' do
+      result = add_ons_query.call(
+        search_term: '1',
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.add_ons.pluck(:id)
+
+      aggregate_failures do
+        expect(result.add_ons.count).to eq(1)
+        expect(returned_ids).to include(add_on_first.id)
+        expect(returned_ids).not_to include(add_on_second.id)
+        expect(returned_ids).not_to include(add_on_third.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/156

## Context

It’s hard for our user to find a specific objects when there’s more than 10 objects in a list view.

## Description

This PR adds the ability to search on a specific search query agains AddOns `name` and `code`