### PR TITLE
fix: Spec failure on CurrentContext.source

### DIFF
--- a/spec/requests/api/base_spec.rb
+++ b/spec/requests/api/base_spec.rb
@@ -9,15 +9,17 @@ RSpec.describe Api::BaseController, type: :controller do
     end
   end
 
+  let(:organization) { create(:organization) }
+
   it 'sets the context source to api' do
+    request.headers['Authorization'] = "Bearer #{organization.api_key}"
+
     get :index
 
     expect(CurrentContext.source).to eq 'api'
   end
 
   describe 'authenticate' do
-    let(:organization) { create(:organization) }
-
     it 'validates the organization api key' do
       request.headers['Authorization'] = "Bearer #{organization.api_key}"
 


### PR DESCRIPTION
## Before 

```
 1) Api::BaseController sets the context source to api
     Failure/Error: expect(CurrentContext.source).to eq 'api'

       expected: "api"
            got: nil

       (compared using ==)
     # ./spec/requests/api/base_spec.rb:15:in `block (2 levels) in <top (required)>'
```