### PR TITLE
fix(credit_notes): Enforce security on PDF generation from GraphQL

### DIFF
--- a/app/graphql/mutations/credit_notes/download.rb
+++ b/app/graphql/mutations/credit_notes/download.rb
@@ -16,8 +16,9 @@ module Mutations
       def resolve(**args)
         validate_organization!
 
-        # TODO: Security issue here, we can download a credit note from another organization.
-        result = ::CreditNotes::GenerateService.new.call(credit_note_id: args[:id])
+        result = ::CreditNotes::GenerateService.new(
+          credit_note: context[:current_user].credit_notes.find_by(id: args[:id]),
+        ).call
 
         result.success? ? result.credit_note : result_error(result)
       end

--- a/app/jobs/credit_notes/generate_pdf_job.rb
+++ b/app/jobs/credit_notes/generate_pdf_job.rb
@@ -5,7 +5,8 @@ module CreditNotes
     queue_as 'invoices'
 
     def perform(credit_note)
-      CreditNotes::GenerateService.new.call_from_api(credit_note: credit_note)
+      result = CreditNotes::GenerateService.new(credit_note:, context: 'api').call
+      result.raise_if_error!
     end
   end
 end

--- a/app/services/credit_notes/generate_service.rb
+++ b/app/services/credit_notes/generate_service.rb
@@ -2,23 +2,28 @@
 
 module CreditNotes
   class GenerateService < BaseService
-    def call_from_api(credit_note:)
-      generate_pdf(credit_note)
+    def initialize(credit_note:, context: nil)
+      @credit_note = credit_note
+      @context = context
 
-      SendWebhookJob.perform_later('credit_note.generated', credit_note)
+      super
     end
 
-    def call(credit_note_id:)
-      credit_note = CreditNote.finalized.find_by(id: credit_note_id)
+    def call
       return result.not_found_failure!(resource: 'credit_note') if credit_note.blank?
+      return result.not_found_failure!(resource: 'credit_note') unless credit_note.finalized?
 
       generate_pdf(credit_note) if credit_note.file.blank?
+
+      SendWebhookJob.perform_later('credit_note.generated', credit_note) if should_send_webhook?
 
       result.credit_note = credit_note
       result
     end
 
     private
+
+    attr_reader :credit_note, :context
 
     def generate_pdf(credit_note)
       pdf_service = Utils::PdfGenerator.new(template: 'credit_note', context: credit_note)
@@ -31,6 +36,10 @@ module CreditNotes
       )
 
       credit_note.save!
+    end
+
+    def should_send_webhook?
+      context == 'api'
     end
   end
 end

--- a/spec/jobs/credit_notes/generate_pdf_job_spec.rb
+++ b/spec/jobs/credit_notes/generate_pdf_job_spec.rb
@@ -5,19 +5,22 @@ require 'rails_helper'
 RSpec.describe CreditNotes::GeneratePdfJob, type: :job do
   let(:credit_note) { create(:credit_note) }
 
+  let(:result) { BaseService::Result.new }
+
   let(:generate_service) do
     instance_double(CreditNotes::GenerateService)
   end
 
   it 'delegates to the Generate service' do
     allow(CreditNotes::GenerateService).to receive(:new)
+      .with(credit_note:, context: 'api')
       .and_return(generate_service)
-    allow(generate_service).to receive(:call_from_api)
-      .with(credit_note: credit_note)
+    allow(generate_service).to receive(:call)
+      .and_return(result)
 
     described_class.perform_now(credit_note)
 
     expect(CreditNotes::GenerateService).to have_received(:new)
-    expect(generate_service).to have_received(:call_from_api)
+    expect(generate_service).to have_received(:call)
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/59

## Description

The objective of this PR is to enforce the security of the credit note generation in GraphQL API by scopping the lookup to the connected user