### PR TITLE
feat(coupons): add search capability to GraphQl resolver

### DIFF
--- a/app/graphql/resolvers/coupons_resolver.rb
+++ b/app/graphql/resolvers/coupons_resolver.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal
+# frozen_string_literal: true
 
 module Resolvers
   class CouponsResolver < GraphQL::Schema::Resolver
@@ -11,22 +11,25 @@ module Resolvers
     argument :page, Integer, required: false
     argument :limit, Integer, required: false
     argument :status, Types::Coupons::StatusEnum, required: false
+    argument :search_term, String, required: false
 
     type Types::Coupons::Object.collection_type, null: false
 
-    def resolve(ids: nil, page: nil, limit: nil, status: nil)
+    def resolve(ids: nil, page: nil, limit: nil, status: nil, search_term: nil)
       validate_organization!
 
-      coupons = current_organization
-        .coupons
-        .order_by_status_and_expiration
-        .page(page)
-        .per(limit)
+      query = CouponsQuery.new(organization: current_organization)
+      result = query.call(
+        search_term:,
+        page:,
+        limit:,
+        status:,
+        filters: {
+          ids:,
+        },
+      )
 
-      coupons = coupons.where(status: status) if status.present?
-      coupons = coupons.where(id: ids) if ids.present?
-
-      coupons
+      result.coupons
     end
   end
 end

--- a/app/queries/coupons_query.rb
+++ b/app/queries/coupons_query.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class CouponsQuery < BaseQuery
+  def call(search_term:, page:, limit:, status:, filters: {})
+    @search_term = search_term
+
+    coupons = base_scope.result
+    coupons = coupons.where(id: filters[:ids]) if filters[:ids].present?
+    coupons = coupons.where(status:) if status.present?
+    coupons = coupons.order_by_status_and_expiration.page(page).per(limit)
+
+    result.coupons = coupons
+    result
+  end
+
+  private
+
+  attr_reader :search_term
+
+  def base_scope
+    Coupon.where(organization:).ransack(search_params)
+  end
+
+  def search_params
+    return nil if search_term.blank?
+
+    {
+      m: 'or',
+      name_cont: search_term,
+      code_cont: search_term,
+    }
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3767,6 +3767,7 @@ type Query {
     ids: [ID!]
     limit: Int
     page: Int
+    searchTerm: String
     status: CouponStatusEnum
   ): CouponCollection!
 

--- a/schema.json
+++ b/schema.json
@@ -15522,6 +15522,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },

--- a/spec/queries/coupons_query_spec.rb
+++ b/spec/queries/coupons_query_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CouponsQuery, type: :query do
+  subject(:coupon_query) do
+    described_class.new(organization:)
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:coupon_first) { create(:coupon, organization:, status: 'active', name: 'defgh', code: '11') }
+  let(:coupon_second) { create(:coupon, organization:, status: 'terminated',  name: 'abcde', code: '22') }
+  let(:coupon_third) { create(:coupon, organization:, status: 'active', name: 'presuv', code: '33') }
+
+  before do
+    coupon_first
+    coupon_second
+    coupon_third
+  end
+
+  it 'returns all coupons' do
+    result = coupon_query.call(
+      search_term: nil,
+      status: nil,
+      page: 1,
+      limit: 10,
+    )
+
+    returned_ids = result.coupons.pluck(:id)
+
+    aggregate_failures do
+      expect(result.coupons.count).to eq(3)
+      expect(returned_ids).to include(coupon_first.id)
+      expect(returned_ids).to include(coupon_second.id)
+      expect(returned_ids).to include(coupon_third.id)
+    end
+  end
+
+  context 'when searching for /de/ term' do
+    it 'returns only two coupons' do
+      result = coupon_query.call(
+        search_term: 'de',
+        status: nil,
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.coupons.pluck(:id)
+
+      aggregate_failures do
+        expect(result.coupons.count).to eq(2)
+        expect(returned_ids).to include(coupon_first.id)
+        expect(returned_ids).to include(coupon_second.id)
+        expect(returned_ids).not_to include(coupon_third.id)
+      end
+    end
+  end
+
+  context 'when searching for /de/ term and filtering by id' do
+    it 'returns only one coupon' do
+      result = coupon_query.call(
+        search_term: 'de',
+        status: nil,
+        page: 1,
+        limit: 10,
+        filters: {
+          ids: [coupon_second.id],
+        },
+      )
+
+      returned_ids = result.coupons.pluck(:id)
+
+      aggregate_failures do
+        expect(result.coupons.count).to eq(1)
+        expect(returned_ids).not_to include(coupon_first.id)
+        expect(returned_ids).to include(coupon_second.id)
+        expect(returned_ids).not_to include(coupon_third.id)
+      end
+    end
+  end
+
+  context 'when searching for terminated status' do
+    it 'returns only two coupons' do
+      result = coupon_query.call(
+        search_term: nil,
+        status: 'terminated',
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.coupons.pluck(:id)
+
+      aggregate_failures do
+        expect(result.coupons.count).to eq(1)
+        expect(returned_ids).not_to include(coupon_first.id)
+        expect(returned_ids).to include(coupon_second.id)
+        expect(returned_ids).not_to include(coupon_third.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/156

## Context

It’s hard for our user to find a specific objects when there’s more than 10 objects in a list view.

## Description

This PR adds the ability to search on a specific search query agains Coupons `name` and `code`