### PR TITLE
feat(grace_period): Finalize credit notes

### DIFF
--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -57,9 +57,11 @@ module CreditNotes
         )
       end
 
-      track_credit_note_created
-      deliver_webhook
-      handle_refund if should_handle_refund?
+      if credit_note.finalized?
+        track_credit_note_created
+        deliver_webhook
+        handle_refund if should_handle_refund?
+      end
 
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -38,6 +38,7 @@ module CreditNotes
           reason:,
           description:,
           credit_status: 'available',
+          status: invoice.status,
         )
 
         create_items
@@ -92,7 +93,6 @@ module CreditNotes
 
     def valid_type_or_status?
       return true if automatic
-      return false if invoice.draft?
       return false if invoice.credit?
 
       !invoice.legacy?

--- a/app/services/invoices/finalize_service.rb
+++ b/app/services/invoices/finalize_service.rb
@@ -19,6 +19,7 @@ module Invoices
         result.raise_if_error!
 
         invoice.update!(status: :finalized, issuing_date:)
+        invoice.credit_notes.each(&:finalized!)
         SendWebhookJob.perform_later(:invoice, invoice) if invoice.organization.webhook_url?
         Invoices::Payments::CreateService.new(invoice).call
         track_invoice_created(invoice)

--- a/app/services/invoices/finalize_service.rb
+++ b/app/services/invoices/finalize_service.rb
@@ -54,14 +54,6 @@ module Invoices
     end
 
     def track_credit_note_created(credit_note)
-      types = if credit_note.credited? && credit_note.refunded?
-        'both'
-      elsif credit_note.credited?
-        'credit'
-      elsif credit_note.refunded?
-        'refund'
-      end
-
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
         event: 'credit_note_issued',
@@ -69,7 +61,7 @@ module Invoices
           organization_id: credit_note.organization.id,
           credit_note_id: credit_note.id,
           invoice_id: credit_note.invoice_id,
-          credit_note_method: types,
+          credit_note_method: 'credit',
         },
       )
     end

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -249,14 +249,12 @@ RSpec.describe CreditNotes::CreateService, type: :service do
             )
           end
 
-          it 'returns a failure' do
+          it 'creates a draft credit note' do
             result = create_service.call
 
             aggregate_failures do
-              expect(result).not_to be_success
-
-              expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-              expect(result.error.code).to eq('invalid_type_or_status')
+              expect(result).to be_success
+              expect(result.credit_note).to be_draft
             end
           end
         end

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -257,6 +257,17 @@ RSpec.describe CreditNotes::CreateService, type: :service do
               expect(result.credit_note).to be_draft
             end
           end
+
+          it 'does not deliver a webhook' do
+            create_service.call
+            expect(SendWebhookJob).not_to have_been_enqueued.with('credit_note.created', CreditNote)
+          end
+
+          it 'does not call SegmentTrackJob' do
+            allow(SegmentTrackJob).to receive(:perform_later)
+            create_service.call
+            expect(SegmentTrackJob).not_to have_received(:perform_later)
+          end
         end
 
         context 'when invoice is a prepaid credit invoice' do

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -230,7 +230,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         before do
           subscription.update!(
             status: :terminated,
-            terminated_at: DateTime.parse('02 Mar 2022'),
+            terminated_at: DateTime.parse('02 Jan 2022'),
           )
         end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/99

## Context

When a billing period is over, users don’t want to invoice straight away.

They want a defined number of days to:
- Collect delayed events for usage
- Adjust invoice amounts for items

## Description

The goal of this PR is to also finalize credit notes when finalizing invoices.