### PR TITLE
feat(credit_notes): add search capability to GraphQl resolver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.10-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.13.10-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -427,6 +429,7 @@ GEM
 
 PLATFORMS
   aarch64-linux-musl
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/graphql/resolvers/customer_credit_notes_resolver.rb
+++ b/app/graphql/resolvers/customer_credit_notes_resolver.rb
@@ -11,24 +11,25 @@ module Resolvers
     argument :customer_id, ID, required: true, description: 'Uniq ID of the customer'
     argument :page, Integer, required: false
     argument :limit, Integer, required: false
+    argument :search_term, String, required: false
 
     type Types::CreditNotes::Object.collection_type, null: true
 
-    def resolve(customer_id: nil, ids: nil, page: nil, limit: nil)
+    def resolve(customer_id: nil, ids: nil, page: nil, limit: nil, search_term: nil)
       validate_organization!
 
-      current_customer = Customer.find(customer_id)
+      query = CustomerCreditNotesQuery.new(organization: current_organization)
+      result = query.call(
+        search_term:,
+        page:,
+        customer_id:,
+        limit:,
+        filters: {
+          ids:,
+        },
+      )
 
-      credit_notes = current_customer
-        .credit_notes
-        .finalized
-        .order(created_at: :desc)
-        .page(page)
-        .per(limit)
-
-      credit_notes = credit_notes.where(id: ids) if ids.present?
-
-      credit_notes
+      result.credit_notes
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'customer')
     end

--- a/app/models/concerns/ransack_uuid_search.rb
+++ b/app/models/concerns/ransack_uuid_search.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module RansackUuidSearch
+  extend ActiveSupport::Concern
+
+  included do
+    ransacker :id do
+      Arel.sql("\"#{table_name}\".\"id\"::varchar")
+    end
+  end
+end

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -2,6 +2,7 @@
 
 class CreditNote < ApplicationRecord
   include Sequenced
+  include RansackUuidSearch
 
   before_save :ensure_number
 

--- a/app/queries/customer_credit_notes_query.rb
+++ b/app/queries/customer_credit_notes_query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class CustomerCreditNotesQuery < BaseQuery
+  def call(customer_id:, search_term:, page:, limit:, filters: {})
+    @search_term = search_term
+
+    credit_notes = base_scope(customer_id:).result
+    credit_notes = credit_notes.where(id: filters[:ids]) if filters[:ids].present?
+    credit_notes = credit_notes.order(issuing_date: :desc).page(page).per(limit)
+
+    result.credit_notes = credit_notes
+    result
+  end
+
+  private
+
+  attr_reader :search_term
+
+  def base_scope(customer_id:)
+    Customer.find(customer_id).credit_notes.finalized.ransack(search_params)
+  end
+
+  def search_params
+    return nil if search_term.blank?
+
+    {
+      m: 'or',
+      number_cont: search_term,
+      id_cont: search_term,
+    }
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3815,6 +3815,7 @@ type Query {
     ids: [String!]
     limit: Int
     page: Int
+    searchTerm: String
   ): CreditNoteCollection
 
   """

--- a/schema.json
+++ b/schema.json
@@ -15689,6 +15689,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },

--- a/spec/queries/customer_credit_notes_query_spec.rb
+++ b/spec/queries/customer_credit_notes_query_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CustomerCreditNotesQuery, type: :query do
+  subject(:customer_credit_notes_query) do
+    described_class.new(organization:)
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:credit_note_first) { create(:credit_note, organization:, customer:, number: '11imthefirstone') }
+  let(:credit_note_second) { create(:credit_note, organization:, customer:, number: '22imthesecondone') }
+  let(:credit_note_third) { create(:credit_note, organization:, customer:, number: '33imthethirdone') }
+  let(:credit_note_fourth) { create(:credit_note, organization:, number: '44imthefourthone') }
+
+  before do
+    credit_note_first
+    credit_note_second
+    credit_note_third
+    credit_note_fourth
+  end
+
+  it 'returns all credit_notes of the customer' do
+    result = customer_credit_notes_query.call(
+      search_term: nil,
+      customer_id: customer.id,
+      page: 1,
+      limit: 10,
+    )
+
+    returned_ids = result.credit_notes.pluck(:id)
+
+    aggregate_failures do
+      expect(result.credit_notes.count).to eq(3)
+      expect(returned_ids).to include(credit_note_first.id)
+      expect(returned_ids).to include(credit_note_second.id)
+      expect(returned_ids).to include(credit_note_third.id)
+      expect(returned_ids).not_to include(credit_note_fourth.id)
+    end
+  end
+
+  context 'when searching for /imthe/ term' do
+    it 'returns three credit_notes' do
+      result = customer_credit_notes_query.call(
+        search_term: 'imthe',
+        customer_id: customer.id,
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.credit_notes.pluck(:id)
+
+      aggregate_failures do
+        expect(result.credit_notes.count).to eq(3)
+        expect(returned_ids).to include(credit_note_first.id)
+        expect(returned_ids).to include(credit_note_second.id)
+        expect(returned_ids).to include(credit_note_third.id)
+        expect(returned_ids).not_to include(credit_note_fourth.id)
+      end
+    end
+  end
+
+  context 'when searching for /done/ term' do
+    it 'returns two credit_notes' do
+      result = customer_credit_notes_query.call(
+        search_term: 'done',
+        customer_id: customer.id,
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.credit_notes.pluck(:id)
+
+      aggregate_failures do
+        expect(result.credit_notes.count).to eq(2)
+        expect(returned_ids).not_to include(credit_note_first.id)
+        expect(returned_ids).to include(credit_note_second.id)
+        expect(returned_ids).to include(credit_note_third.id)
+        expect(returned_ids).not_to include(credit_note_fourth.id)
+      end
+    end
+  end
+
+  context 'when searching for an id' do
+    it 'returns only one credit_notes' do
+      result = customer_credit_notes_query.call(
+        search_term: credit_note_second.id.scan(/.{10}/).first,
+        customer_id: customer.id,
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.credit_notes.pluck(:id)
+
+      aggregate_failures do
+        expect(result.credit_notes.count).to eq(1)
+        expect(returned_ids).not_to include(credit_note_first.id)
+        expect(returned_ids).to include(credit_note_second.id)
+        expect(returned_ids).not_to include(credit_note_third.id)
+        expect(returned_ids).not_to include(credit_note_fourth.id)
+      end
+    end
+  end
+
+  context 'when filtering by id' do
+    it 'returns only one credit_note' do
+      result = customer_credit_notes_query.call(
+        search_term: nil,
+        customer_id: customer.id,
+        page: 1,
+        limit: 10,
+        filters: {
+          ids: [credit_note_second.id],
+        },
+      )
+
+      returned_ids = result.credit_notes.pluck(:id)
+
+      aggregate_failures do
+        expect(result.credit_notes.count).to eq(1)
+        expect(returned_ids).not_to include(credit_note_first.id)
+        expect(returned_ids).to include(credit_note_second.id)
+        expect(returned_ids).not_to include(credit_note_third.id)
+        expect(returned_ids).not_to include(credit_note_fourth.id)
+      end
+    end
+  end
+
+  context 'when searching for a random user' do
+    it 'returns no credit_note' do
+      result = customer_credit_notes_query.call(
+        search_term: nil,
+        customer_id: create(:customer, organization:).id,
+        page: 1,
+        limit: 10,
+      )
+
+      aggregate_failures do
+        expect(result.credit_notes.count).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/156

## Context

It’s hard for our user to find a specific objects when there’s more than 10 objects in a list view.

## Description

This PR adds the ability to search on a specific search query agains CreditNotes `number` and `id`

Note that Ransack needs the ID value to be a varchar in order to perform a `_cont` on it.
This PR adds an helper to transform the ID type during ransack search