### PR TITLE
feat(invoices): Lock invoice payment jobs for 1 hour

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '3.1.3'
 
 gem 'activejob-traceable'
+gem 'activejob-uniqueness', require: 'active_job/uniqueness/sidekiq_patch'
 gem 'analytics-ruby', '~> 2.4.0', require: 'segment/analytics'
 gem 'bcrypt'
 gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,9 @@ GEM
     activejob-traceable (0.3.5)
       activejob
       activesupport
+    activejob-uniqueness (0.2.4)
+      activejob (>= 4.2, < 7.1)
+      redlock (>= 1.2, < 2)
     activemodel (7.0.3.1)
       activesupport (= 7.0.3.1)
     activerecord (7.0.3.1)
@@ -323,6 +326,8 @@ GEM
       activesupport (>= 6.1.5)
       i18n
     redis (4.7.1)
+    redlock (1.3.2)
+      redis (>= 3.0.0, < 6.0)
     reline (0.3.1)
       io-console (~> 0.5)
     representable (3.2.0)
@@ -434,6 +439,7 @@ PLATFORMS
 
 DEPENDENCIES
   activejob-traceable
+  activejob-uniqueness
   analytics-ruby (~> 2.4.0)
   aws-sdk-s3
   bcrypt

--- a/app/jobs/invoices/payments/gocardless_create_job.rb
+++ b/app/jobs/invoices/payments/gocardless_create_job.rb
@@ -5,6 +5,8 @@ module Invoices
     class GocardlessCreateJob < ApplicationJob
       queue_as 'providers'
 
+      unique :until_executed
+
       def perform(invoice)
         result = Invoices::Payments::GocardlessService.new(invoice).create
         result.raise_if_error!

--- a/app/jobs/invoices/payments/stripe_create_job.rb
+++ b/app/jobs/invoices/payments/stripe_create_job.rb
@@ -5,6 +5,8 @@ module Invoices
     class StripeCreateJob < ApplicationJob
       queue_as 'providers'
 
+      unique :until_executed
+
       def perform(invoice)
         result = Invoices::Payments::StripeService.new(invoice).create
         result.raise_if_error!

--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+ActiveJob::Uniqueness.configure do |config|
+  config.lock_ttl = 1.hour
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 require 'sidekiq/testing'
 Sidekiq::Testing.fake!
+ActiveJob::Uniqueness.test_mode!
 
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/709 and in particular the retry logic.

## Description

It take advantage of `activejob-uniqueness` gem to ensure that only one payment processing job can be processed for an invoice at a time.

Note: lock is release automatically when the job finish it's execution