### PR TITLE
feat(invoices): Add second order on created_at on resolver to make order predictable

### DIFF
--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -20,7 +20,7 @@ module Resolvers
 
       invoices = current_organization
         .invoices
-        .order(issuing_date: :desc)
+        .order(issuing_date: :desc, created_at: :desc)
         .page(page)
         .per(limit)
 


### PR DESCRIPTION
## Description

This PR intends to fix invoice ordering in invoices resolver.

Since current order relies only on `issuing_date` the order could be unpredictable if some invoices share the same issuing date.

The `created_at` is now used as a second param for ordering.