### PR TITLE
feat(grace_period): Add 1 second to timestamp before billing

### DIFF
--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -30,7 +30,7 @@ module Invoices
         calculate_result = Invoices::CalculateFeesService.call(
           invoice:,
           subscriptions: Subscription.find(subscription_ids),
-          timestamp: invoice.created_at.to_i,
+          timestamp: invoice.created_at.to_i + 1.second, # NOTE: Adding 1 second because of to_i rounding.
           context:,
         )
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -176,7 +176,7 @@ module Subscriptions
       BillSubscriptionJob.set(wait: 2.seconds)
         .perform_later(
           [current_subscription],
-          Time.zone.now.to_i,
+          Time.zone.now.to_i + 1.second, # NOTE: Adding 1 second because of to_i rounding.
         )
 
       if current_plan.pay_in_advance?
@@ -186,7 +186,7 @@ module Subscriptions
           .set(wait: 2.seconds)
           .perform_later(
             [new_subscription],
-            Time.zone.now.to_i,
+            Time.zone.now.to_i + 1.second, # NOTE: Adding 1 second because of to_i rounding.
           )
       end
 


### PR DESCRIPTION
As we're not handling milliseconds, we can have issues where `terminated_at` is set before the timestamp sent to the billing job (on upgrade for instance).

The goal of this PR is to fix this by adding one second to the timestamp. The ideal solution would be to handle correctly milliseconds in the future.