### PR TITLE
feat(invoices): add search capability to GraphQl resolver

### DIFF
--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -12,23 +12,33 @@ module Resolvers
     argument :limit, Integer, required: false
     argument :status, Types::Invoices::StatusTypeEnum, required: false
     argument :payment_status, [Types::Invoices::PaymentStatusTypeEnum], required: false
+    argument :search_term, String, required: false
 
     type Types::Invoices::Object.collection_type, null: false
 
-    def resolve(ids: nil, page: nil, limit: nil, payment_status: nil, status: nil)
+    def resolve( # rubocop:disable Metrics/ParameterLists
+      ids: nil,
+      page: nil,
+      limit: nil,
+      payment_status: nil,
+      status: nil,
+      search_term: nil
+    )
       validate_organization!
 
-      invoices = current_organization
-        .invoices
-        .order(issuing_date: :desc, created_at: :desc)
-        .page(page)
-        .per(limit)
+      query = InvoicesQuery.new(organization: current_organization)
+      result = query.call(
+        search_term:,
+        page:,
+        limit:,
+        payment_status:,
+        status:,
+        filters: {
+          ids:,
+        },
+      )
 
-      invoices = invoices.where(status:) if status.present?
-      invoices = invoices.where(payment_status:) if payment_status.present?
-      invoices = invoices.where(id: ids) if ids.present?
-
-      invoices
+      result.invoices
     end
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -2,6 +2,7 @@
 
 class Invoice < ApplicationRecord
   include Sequenced
+  include RansackUuidSearch
 
   before_save :ensure_number
 

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class InvoicesQuery < BaseQuery
+  def call(search_term:, status:, payment_status:, page:, limit:, filters: {}) # rubocop:disable Metrics/ParameterLists
+    @search_term = search_term
+
+    invoices = base_scope.result.includes(:customer)
+    invoices = invoices.where(id: filters[:ids]) if filters[:ids].present?
+    invoices = invoices.where(status:) if status.present?
+    invoices = invoices.where(payment_status:) if payment_status.present?
+    invoices = invoices.order(issuing_date: :desc, created_at: :desc).page(page).per(limit)
+
+    result.invoices = invoices
+    result
+  end
+
+  private
+
+  attr_reader :search_term
+
+  def base_scope
+    organization.invoices.ransack(search_params)
+  end
+
+  def search_params
+    return nil if search_term.blank?
+
+    {
+      m: 'or',
+      id_cont: search_term,
+      number_cont: search_term,
+      customer_name_cont: search_term,
+      customer_external_id_cont: search_term,
+      customer_email_cont: search_term,
+    }
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3915,6 +3915,7 @@ type Query {
     limit: Int
     page: Int
     paymentStatus: [InvoicePaymentStatusTypeEnum!]
+    searchTerm: String
     status: InvoiceStatusTypeEnum
   ): InvoiceCollection!
 

--- a/schema.json
+++ b/schema.json
@@ -16240,6 +16240,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InvoicesQuery, type: :query do
+  subject(:invoice_query) do
+    described_class.new(organization:)
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer_first) { create(:customer, organization:, name: 'Rick Sanchez', email: 'pickle@hotmail.com') }
+  let(:customer_second) { create(:customer, organization:, name: 'Morty Smith', email: 'ilovejessica@gmail.com') }
+  let(:invoice_first) do
+    create(
+      :invoice,
+      status: 'finalized',
+      payment_status: 'succeeded',
+      customer: customer_first,
+    )
+  end
+  let(:invoice_second) do
+    create(
+      :invoice,
+      status: 'finalized',
+      payment_status: 'pending',
+      customer: customer_second,
+    )
+  end
+  let(:invoice_third) do
+    create(
+      :invoice,
+      status: 'finalized',
+      payment_status: 'failed',
+      customer: customer_first,
+    )
+  end
+  let(:invoice_fourth) do
+    create(
+      :invoice,
+      status: 'draft',
+      payment_status: 'pending',
+      customer: customer_second,
+    )
+  end
+  let(:invoice_fifth) do
+    create(
+      :invoice,
+      status: 'draft',
+      payment_status: 'pending',
+      customer: customer_first,
+    )
+  end
+
+  before do
+    invoice_first
+    invoice_second
+    invoice_third
+    invoice_fourth
+    invoice_fifth
+  end
+
+  it 'returns all invoices' do
+    result = invoice_query.call(
+      search_term: nil,
+      status: nil,
+      payment_status: nil,
+      page: 1,
+      limit: 10,
+    )
+
+    returned_ids = result.invoices.pluck(:id)
+
+    aggregate_failures do
+      expect(result.invoices.count).to eq(5)
+      expect(returned_ids).to include(invoice_first.id)
+      expect(returned_ids).to include(invoice_second.id)
+      expect(returned_ids).to include(invoice_third.id)
+      expect(returned_ids).to include(invoice_fourth.id)
+      expect(returned_ids).to include(invoice_fifth.id)
+    end
+  end
+
+  context 'when filtering by id' do
+    it 'returns only invoices specified' do
+      result = invoice_query.call(
+        search_term: nil,
+        status: nil,
+        payment_status: nil,
+        page: 1,
+        limit: 10,
+        filters: {
+          ids: [invoice_second.id, invoice_fifth.id],
+        },
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(result.invoices.count).to eq(2)
+        expect(returned_ids).not_to include(invoice_first.id)
+        expect(returned_ids).to include(invoice_second.id)
+        expect(returned_ids).not_to include(invoice_third.id)
+        expect(returned_ids).not_to include(invoice_fourth.id)
+        expect(returned_ids).to include(invoice_fifth.id)
+      end
+    end
+  end
+
+  context 'when filtering by draft status' do
+    it 'returns 2 invoices' do
+      result = invoice_query.call(
+        search_term: nil,
+        status: 'draft',
+        payment_status: nil,
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(result.invoices.count).to eq(2)
+        expect(returned_ids).not_to include(invoice_first.id)
+        expect(returned_ids).not_to include(invoice_second.id)
+        expect(returned_ids).not_to include(invoice_third.id)
+        expect(returned_ids).to include(invoice_fourth.id)
+        expect(returned_ids).to include(invoice_fifth.id)
+      end
+    end
+  end
+
+  context 'when filtering by failed payment_status' do
+    it 'returns 1 invoices' do
+      result = invoice_query.call(
+        search_term: nil,
+        status: nil,
+        payment_status: 'failed',
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(result.invoices.count).to eq(1)
+        expect(returned_ids).not_to include(invoice_first.id)
+        expect(returned_ids).not_to include(invoice_second.id)
+        expect(returned_ids).to include(invoice_third.id)
+        expect(returned_ids).not_to include(invoice_fourth.id)
+        expect(returned_ids).not_to include(invoice_fifth.id)
+      end
+    end
+  end
+
+  context 'when searching for a part of an invoice id' do
+    it 'returns 1 invoices' do
+      result = invoice_query.call(
+        search_term: invoice_fourth.id.scan(/.{10}/).first,
+        status: nil,
+        payment_status: nil,
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(result.invoices.count).to eq(1)
+        expect(returned_ids).not_to include(invoice_first.id)
+        expect(returned_ids).not_to include(invoice_second.id)
+        expect(returned_ids).not_to include(invoice_third.id)
+        expect(returned_ids).to include(invoice_fourth.id)
+        expect(returned_ids).not_to include(invoice_fifth.id)
+      end
+    end
+  end
+
+  context 'when searching an invoice number' do
+    it 'returns 1 invoices' do
+      result = invoice_query.call(
+        search_term: invoice_first.number,
+        status: nil,
+        payment_status: nil,
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(result.invoices.count).to eq(1)
+        expect(returned_ids).to include(invoice_first.id)
+        expect(returned_ids).not_to include(invoice_second.id)
+        expect(returned_ids).not_to include(invoice_third.id)
+        expect(returned_ids).not_to include(invoice_fourth.id)
+        expect(returned_ids).not_to include(invoice_fifth.id)
+      end
+    end
+  end
+
+  context 'when searching a customer external id' do
+    it 'returns 2 invoices' do
+      result = invoice_query.call(
+        search_term: customer_second.external_id,
+        status: nil,
+        payment_status: nil,
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(result.invoices.count).to eq(2)
+        expect(returned_ids).not_to include(invoice_first.id)
+        expect(returned_ids).to include(invoice_second.id)
+        expect(returned_ids).not_to include(invoice_third.id)
+        expect(returned_ids).to include(invoice_fourth.id)
+        expect(returned_ids).not_to include(invoice_fifth.id)
+      end
+    end
+  end
+
+  context 'when searching for /rick/ term' do
+    it 'returns 3 invoices' do
+      result = invoice_query.call(
+        search_term: 'rick',
+        status: nil,
+        payment_status: nil,
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(result.invoices.count).to eq(3)
+        expect(returned_ids).to include(invoice_first.id)
+        expect(returned_ids).not_to include(invoice_second.id)
+        expect(returned_ids).to include(invoice_third.id)
+        expect(returned_ids).not_to include(invoice_fourth.id)
+        expect(returned_ids).to include(invoice_fifth.id)
+      end
+    end
+  end
+
+  context 'when searching for /gmail/ term' do
+    it 'returns 2 invoices' do
+      result = invoice_query.call(
+        search_term: 'gmail',
+        status: nil,
+        payment_status: nil,
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(result.invoices.count).to eq(2)
+        expect(returned_ids).not_to include(invoice_first.id)
+        expect(returned_ids).to include(invoice_second.id)
+        expect(returned_ids).not_to include(invoice_third.id)
+        expect(returned_ids).to include(invoice_fourth.id)
+        expect(returned_ids).not_to include(invoice_fifth.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/156

## Context

It’s hard for our user to find a specific objects when there’s more than 10 objects in a list view.

## Description

This PR adds the ability to search on specific attributes of an invoice

- id
- number
- customer_name
- customer_external_id
- customer_email