### PR TITLE
fix(credit-notes): Fix credit note amount for terminate with previous credit note

### DIFF
--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -16,9 +16,9 @@ module CreditNotes
       return result unless amount.positive?
 
       # NOTE: if credit notes were already issued on the fee,
-      #       we take the remaining creditable amount
-      amount = last_subscription_fee.creditable_amount_cents if amount > last_subscription_fee.creditable_amount_cents
-      return result if amount.zero?
+      #       we have to deduct them from the prorated amount
+      amount -= last_subscription_fee.credit_note_items.sum(:amount_cents)
+      return result unless amount.positive?
 
       vat_amount = (amount * last_subscription_fee.vat_rate).fdiv(100).ceil
 
@@ -41,7 +41,7 @@ module CreditNotes
 
     attr_accessor :subscription, :reason
 
-    delegate :plan, :terminated_at, to: :subscription
+    delegate :plan, :terminated_at, :customer, to: :subscription
 
     def last_subscription_fee
       @last_subscription_fee ||= subscription.fees.order(created_at: :desc).last
@@ -63,15 +63,19 @@ module CreditNotes
     end
 
     def to_date
-      date_service.next_end_of_period.to_date # TODO: deal with timezone
+      date_service.next_end_of_period.to_date
     end
 
     def day_price
       date_service.single_day_price(optional_from_date: from_date)
     end
 
+    def terminated_at_in_timezone
+      terminated_at.in_time_zone(customer.applicable_timezone)
+    end
+
     def remaining_duration
-      billed_from = terminated_at.to_date
+      billed_from = terminated_at_in_timezone.to_date
 
       if plan.has_trial? && subscription.trial_end_date >= billed_from
         billed_from = if subscription.trial_end_date > to_date

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -15,6 +15,11 @@ module CreditNotes
       amount = compute_amount
       return result unless amount.positive?
 
+      # NOTE: if credit notes were already issued on the fee,
+      #       we take the remaining creditable amount
+      amount = last_subscription_fee.creditable_amount_cents if amount > last_subscription_fee.creditable_amount_cents
+      return result if amount.zero?
+
       vat_amount = (amount * last_subscription_fee.vat_rate).fdiv(100).ceil
 
       CreditNotes::CreateService.new(

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -96,6 +96,49 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
       end
     end
 
+    context 'when existing credit notes on the fee' do
+      let(:credit_note) do
+        create(
+          :credit_note,
+          customer: subscription.customer,
+          invoice: subscription_fee.invoice,
+          credit_amount_cents: 90,
+        )
+      end
+
+      let(:credit_note_item) do
+        create(
+          :credit_note_item,
+          credit_note:,
+          fee: subscription_fee,
+          amount_cents: 90,
+        )
+      end
+
+      before { credit_note_item }
+
+      it 'takes the remaining creditable amount' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          credit_note = result.credit_note
+          expect(credit_note).to be_available
+          expect(credit_note).to be_order_change
+          expect(credit_note.total_amount_cents).to eq(12)
+          expect(credit_note.total_amount_currency).to eq('EUR')
+          expect(credit_note.credit_amount_cents).to eq(12)
+          expect(credit_note.credit_amount_currency).to eq('EUR')
+          expect(credit_note.balance_amount_cents).to eq(12)
+          expect(credit_note.balance_amount_currency).to eq('EUR')
+          expect(credit_note.reason).to eq('order_change')
+
+          expect(credit_note.items.count).to eq(1)
+        end
+      end
+    end
+
     context 'when plan has trial period ending after terminated_at' do
       let(:plan) do
         create(


### PR DESCRIPTION
## Context

We have an issue with the subscription termination in the following case:

1. I apply a pay in advance plan to a customer (subscription A)
2. Invoice is finalized and I applied a credit note covering the 100% of invoice
3. I decided to terminate the subscription A
4. I’ve this error, the terminate does not lead to an invoice creation

It fails with a validation failure:

```
Validation errors: {:amount_cents=>["higher_than_remaining_fee_amount", "higher_than_remaining_invoice_amount"]}
```
The reason is that when terminating the subscription, we try to emit a credit note for the overpaid amount (at prorata of the period duration) targeting the subscription fee of the last invoice. Since this fee has been already re-credited, the validation fails as there is no remaining creditable amount.

## Description

The PR fixes the issue by taking the max creditable amount on the last subscription fee if the pro-rata amount is higher than the remaining amount.

NOTE: this amount could be 0, in that case, no credit note will be emitted.
