### PR TITLE
feat(delete_bm): Add deleted_at and setup discard for soft-delete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'oauth2'
 gem 'rack-cors'
 
 # Database
+gem 'discard', '~> 1.2'
 gem 'kaminari-activerecord'
 gem 'pg'
 gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,8 @@ GEM
     diff-lcs (1.5.0)
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
+    discard (1.2.1)
+      activerecord (>= 4.2, < 8)
     docile (1.4.0)
     dotenv (2.8.1)
     erubi (1.11.0)
@@ -447,6 +449,7 @@ DEPENDENCIES
   coffee-rails
   countries
   debug
+  discard (~> 1.2)
   dotenv
   factory_bot_rails
   faker

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class BillableMetric < ApplicationRecord
+  include Discard::Model
+  self.discard_column = :deleted_at
+
   belongs_to :organization
 
   has_many :charges, dependent: :destroy
@@ -22,6 +25,8 @@ class BillableMetric < ApplicationRecord
   validates :code, presence: true, uniqueness: { scope: :organization_id }
   validates :field_name, presence: true, if: :should_have_field_name?
   validates :aggregation_type, inclusion: { in: AGGREGATION_TYPES.map(&:to_s) }
+
+  default_scope -> { kept }
 
   def attached_to_subscriptions?
     plans.joins(:subscriptions).exists?

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -22,9 +22,11 @@ class BillableMetric < ApplicationRecord
   enum aggregation_type: AGGREGATION_TYPES
 
   validates :name, presence: true
-  validates :code, presence: true, uniqueness: { scope: :organization_id }
   validates :field_name, presence: true, if: :should_have_field_name?
   validates :aggregation_type, inclusion: { in: AGGREGATION_TYPES.map(&:to_s) }
+  validates :code,
+            presence: true,
+            uniqueness: { conditions: -> { where(deleted_at: nil) }, scope: :organization_id }
 
   default_scope -> { kept }
 

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -2,6 +2,8 @@
 
 class Charge < ApplicationRecord
   include Currencies
+  include Discard::Model
+  self.discard_column = :deleted_at
 
   belongs_to :plan, touch: true
   belongs_to :billable_metric
@@ -26,6 +28,8 @@ class Charge < ApplicationRecord
   validate :validate_volume, if: -> { volume? && group_properties.empty? }
 
   validate :validate_group_properties
+
+  default_scope -> { kept }
 
   def properties(group_id: nil)
     group_properties.find_by(group_id: group_id)&.values || read_attribute(:properties)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Event < ApplicationRecord
+  include Discard::Model
+  self.discard_column = :deleted_at
+
   include CustomerTimezone
   include OrganizationTimezone
 
@@ -11,6 +14,7 @@ class Event < ApplicationRecord
   validates :transaction_id, presence: true, uniqueness: { scope: :subscription_id }
   validates :code, presence: true
 
+  default_scope -> { kept }
   scope :from_datetime, ->(from_datetime) { where('events.timestamp::timestamp(0) >= ?', from_datetime) }
   scope :to_datetime, ->(to_datetime) { where('events.timestamp::timestamp(0) <= ?', to_datetime) }
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Group < ApplicationRecord
+  include Discard::Model
+  self.discard_column = :deleted_at
+
   belongs_to :billable_metric
   belongs_to :parent, class_name: 'Group', foreign_key: 'parent_group_id', optional: true
   has_many :children, class_name: 'Group', foreign_key: 'parent_group_id'
@@ -12,6 +15,7 @@ class Group < ApplicationRecord
 
   validates :key, :value, presence: true
 
+  default_scope -> { kept }
   scope :parents, -> { where(parent_group_id: nil) }
   scope :children, -> { where.not(parent_group_id: nil) }
 

--- a/app/models/group_property.rb
+++ b/app/models/group_property.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 class GroupProperty < ApplicationRecord
+  include Discard::Model
+  self.discard_column = :deleted_at
+
   belongs_to :charge
   belongs_to :group
 
   validates :values, presence: true
+
+  default_scope -> { kept }
 end

--- a/app/models/persisted_event.rb
+++ b/app/models/persisted_event.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 class PersistedEvent < ApplicationRecord
+  include Discard::Model
+  self.discard_column = :deleted_at
+
   belongs_to :customer
   belongs_to :billable_metric
 
   validates :external_id, presence: true
   validates :added_at, presence: true
   validates :external_subscription_id, presence: true
+
+  default_scope -> { kept }
 end

--- a/db/migrate/20230118100324_add_deleted_at_to_billable_metrics.rb
+++ b/db/migrate/20230118100324_add_deleted_at_to_billable_metrics.rb
@@ -15,5 +15,8 @@ class AddDeletedAtToBillableMetrics < ActiveRecord::Migration[7.0]
     add_index :group_properties, :deleted_at
     add_index :events, :deleted_at
     add_index :persisted_events, :deleted_at
+
+    remove_index :billable_metrics, %i[organization_id code]
+    add_index :billable_metrics, %i[organization_id code], unique: true, where: 'deleted_at IS NULL'
   end
 end

--- a/db/migrate/20230118100324_add_deleted_at_to_billable_metrics.rb
+++ b/db/migrate/20230118100324_add_deleted_at_to_billable_metrics.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToBillableMetrics < ActiveRecord::Migration[7.0]
+  def change
+    add_column :billable_metrics, :deleted_at, :datetime
+    add_column :charges, :deleted_at, :datetime
+    add_column :groups, :deleted_at, :datetime
+    add_column :group_properties, :deleted_at, :datetime
+    add_column :events, :deleted_at, :datetime
+    add_column :persisted_events, :deleted_at, :datetime
+
+    add_index :billable_metrics, :deleted_at
+    add_index :charges, :deleted_at
+    add_index :groups, :deleted_at
+    add_index :group_properties, :deleted_at
+    add_index :events, :deleted_at
+    add_index :persisted_events, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_09_095957) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_18_100324) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -95,6 +95,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_09_095957) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "field_name"
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_billable_metrics_on_deleted_at"
     t.index ["organization_id", "code"], name: "index_billable_metrics_on_organization_id_and_code", unique: true
     t.index ["organization_id"], name: "index_billable_metrics_on_organization_id"
   end
@@ -107,7 +109,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_09_095957) do
     t.string "amount_currency"
     t.integer "charge_model", default: 0, null: false
     t.jsonb "properties", default: "{}", null: false
+    t.datetime "deleted_at"
     t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"
+    t.index ["deleted_at"], name: "index_charges_on_deleted_at"
     t.index ["plan_id"], name: "index_charges_on_plan_id"
   end
 
@@ -231,7 +235,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_09_095957) do
     t.datetime "updated_at", null: false
     t.jsonb "metadata", default: {}, null: false
     t.uuid "subscription_id"
+    t.datetime "deleted_at"
     t.index ["customer_id"], name: "index_events_on_customer_id"
+    t.index ["deleted_at"], name: "index_events_on_deleted_at"
     t.index ["organization_id", "code"], name: "index_events_on_organization_id_and_code"
     t.index ["organization_id"], name: "index_events_on_organization_id"
     t.index ["subscription_id", "code"], name: "index_events_on_subscription_id_and_code"
@@ -272,7 +278,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_09_095957) do
     t.jsonb "values", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["charge_id"], name: "index_group_properties_on_charge_id"
+    t.index ["deleted_at"], name: "index_group_properties_on_deleted_at"
     t.index ["group_id"], name: "index_group_properties_on_group_id"
   end
 
@@ -284,7 +292,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_09_095957) do
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["billable_metric_id"], name: "index_groups_on_billable_metric_id"
+    t.index ["deleted_at"], name: "index_groups_on_deleted_at"
     t.index ["parent_group_id"], name: "index_groups_on_parent_group_id"
   end
 
@@ -425,9 +435,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_09_095957) do
     t.datetime "updated_at", null: false
     t.uuid "billable_metric_id"
     t.jsonb "properties", default: {}, null: false
+    t.datetime "deleted_at"
     t.index ["billable_metric_id"], name: "index_persisted_events_on_billable_metric_id"
     t.index ["customer_id", "external_subscription_id", "billable_metric_id"], name: "index_search_persisted_events"
     t.index ["customer_id"], name: "index_persisted_events_on_customer_id"
+    t.index ["deleted_at"], name: "index_persisted_events_on_deleted_at"
     t.index ["external_id"], name: "index_persisted_events_on_external_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,7 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_18_100324) do
     t.string "field_name"
     t.datetime "deleted_at"
     t.index ["deleted_at"], name: "index_billable_metrics_on_deleted_at"
-    t.index ["organization_id", "code"], name: "index_billable_metrics_on_organization_id_and_code", unique: true
+    t.index ["organization_id", "code"], name: "index_billable_metrics_on_organization_id_and_code", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_billable_metrics_on_organization_id"
   end
 
@@ -174,8 +174,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_18_100324) do
     t.string "refund_vat_amount_currency"
     t.bigint "vat_amount_cents", default: 0, null: false
     t.string "vat_amount_currency"
-    t.date "issuing_date", null: false
     t.datetime "refunded_at"
+    t.date "issuing_date", null: false
     t.integer "status", default: 1, null: false
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
@@ -342,9 +342,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_18_100324) do
     t.uuid "customer_id"
     t.boolean "legacy", default: false, null: false
     t.float "vat_rate"
-    t.integer "status", default: 1, null: false
     t.bigint "credit_amount_cents", default: 0, null: false
     t.string "credit_amount_currency"
+    t.integer "status", default: 1, null: false
     t.string "timezone", default: "UTC", null: false
     t.integer "payment_attempts", default: 0, null: false
     t.boolean "ready_for_payment_processing", default: true, null: false

--- a/spec/requests/api/v1/billable_metrics_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
         post_with_token(
           organization,
           '/api/v1/billable_metrics',
-          { billable_metric: create_params.merge(group: group) },
+          { billable_metric: create_params.merge(group:) },
         )
 
         expect(json[:billable_metric][:group]).to eq(group)
@@ -66,12 +66,12 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
   end
 
   describe 'update' do
-    let(:billable_metric) { create(:billable_metric, organization: organization) }
+    let(:billable_metric) { create(:billable_metric, organization:) }
     let(:code) { 'BM1_code' }
     let(:update_params) do
       {
         name: 'BM1',
-        code: code,
+        code:,
         description: 'description',
         aggregation_type: 'sum_agg',
         field_name: 'amount_sum',
@@ -92,12 +92,12 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
 
     context 'with group parameter' do
       it 'updates billable metric\'s group' do
-        create(:group, billable_metric: billable_metric)
+        create(:group, billable_metric:)
 
         put_with_token(
           organization,
           "/api/v1/billable_metrics/#{billable_metric.code}",
-          { billable_metric: update_params.merge(group: group) },
+          { billable_metric: update_params.merge(group:) },
         )
 
         expect(json[:billable_metric][:group]).to eq(group)
@@ -128,7 +128,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
     end
 
     context 'when billable metric code already exists in organization scope (validation error)' do
-      let(:billable_metric2) { create(:billable_metric, organization: organization) }
+      let(:billable_metric2) { create(:billable_metric, organization:) }
       let(:code) { billable_metric2.code }
 
       before { billable_metric2 }
@@ -146,13 +146,10 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
   end
 
   describe 'show' do
-    let(:billable_metric) { create(:billable_metric, organization: organization) }
+    let(:billable_metric) { create(:billable_metric, organization:) }
 
     it 'returns a billable metric' do
-      get_with_token(
-        organization,
-        "/api/v1/billable_metrics/#{billable_metric.code}",
-      )
+      get_with_token(organization, "/api/v1/billable_metrics/#{billable_metric.code}")
 
       expect(response).to have_http_status(:success)
       expect(json[:billable_metric][:lago_id]).to eq(billable_metric.id)
@@ -161,10 +158,16 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
 
     context 'when billable metric does not exist' do
       it 'returns not found' do
-        get_with_token(
-          organization,
-          '/api/v1/billable_metrics/555',
-        )
+        get_with_token(organization, '/api/v1/billable_metrics/555')
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when billable metric is deleted' do
+      it 'returns not found' do
+        billable_metric.discard
+        get_with_token(organization, "/api/v1/billable_metrics/#{billable_metric.code}")
 
         expect(response).to have_http_status(:not_found)
       end
@@ -172,7 +175,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
   end
 
   describe 'destroy' do
-    let(:billable_metric) { create(:billable_metric, organization: organization) }
+    let(:billable_metric) { create(:billable_metric, organization:) }
 
     before { billable_metric }
 
@@ -199,8 +202,8 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
 
     context 'when billable metric is attached to active subscription' do
       let(:subscription) { create(:subscription) }
-      let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric: billable_metric) }
-      let(:billable_metric) { create(:billable_metric, organization: organization) }
+      let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:) }
+      let(:billable_metric) { create(:billable_metric, organization:) }
 
       before do
         charge
@@ -221,7 +224,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
   end
 
   describe 'index' do
-    let(:billable_metric) { create(:billable_metric, organization: organization) }
+    let(:billable_metric) { create(:billable_metric, organization:) }
 
     before { billable_metric }
 
@@ -235,7 +238,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
     end
 
     context 'with pagination' do
-      let(:billable_metric2) { create(:billable_metric, organization: organization) }
+      let(:billable_metric2) { create(:billable_metric, organization:) }
 
       before { billable_metric2 }
 

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -92,10 +92,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
     let(:event) { create(:event) }
 
     it 'returns an event' do
-      get_with_token(
-        event.organization,
-        '/api/v1/events/' + event.transaction_id
-      )
+      get_with_token(event.organization, "/api/v1/events/#{event.transaction_id}")
 
       expect(response).to have_http_status(:ok)
 
@@ -109,10 +106,16 @@ RSpec.describe Api::V1::EventsController, type: :request do
 
     context 'with a non-existing transaction_id' do
       it 'returns not found' do
-        get_with_token(
-          organization,
-          "/api/v1/events/#{SecureRandom.uuid}",
-        )
+        get_with_token(organization, "/api/v1/events/#{SecureRandom.uuid}")
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when event is deleted' do
+      it 'returns not found' do
+        event.discard
+        get_with_token(event.organization, "/api/v1/events/#{event.transaction_id}")
 
         expect(response).to have_http_status(:not_found)
       end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to:
- Add `deleted_at` to all affected tables
- Setup discard gem with `deleted_at` column and default scope `kept`
- Ensure code uniqueness validation does not take into account deleted billable metrics