### PR TITLE
feat (coupons): add logic for handling forever coupons

### DIFF
--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -16,6 +16,7 @@ class AppliedCoupon < ApplicationRecord
   FREQUENCIES = [
     :once,
     :recurring,
+    :forever,
   ].freeze
 
   enum status: STATUSES

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -26,6 +26,7 @@ class Coupon < ApplicationRecord
   FREQUENCIES = [
     :once,
     :recurring,
+    :forever,
   ].freeze
 
   enum status: STATUSES

--- a/app/serializers/v1/applied_coupon_serializer.rb
+++ b/app/serializers/v1/applied_coupon_serializer.rb
@@ -26,7 +26,7 @@ module V1
     private
 
     def amount_cents_remaining
-      return nil if model.recurring?
+      return nil if model.recurring? || model.forever?
       return nil if model.coupon.percentage?
 
       model.amount_cents - model.credits.sum(:amount_cents)

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -51,7 +51,7 @@ module Credits
         return (discounted_value >= invoice.total_amount_cents) ? invoice.total_amount_cents : discounted_value.round
       end
 
-      if applied_coupon.recurring?
+      if applied_coupon.recurring? || applied_coupon.forever?
         return invoice.total_amount_cents if applied_coupon.amount_cents > invoice.total_amount_cents
 
         applied_coupon.amount_cents
@@ -70,6 +70,8 @@ module Credits
     end
 
     def should_terminate_applied_coupon?(credit_amount)
+      return false if applied_coupon.forever?
+
       if applied_coupon.once?
         applied_coupon.coupon.percentage? || credit_amount >= remaining_amount
       else

--- a/schema.graphql
+++ b/schema.graphql
@@ -1531,6 +1531,7 @@ enum CouponExpiration {
 }
 
 enum CouponFrequency {
+  forever
   once
   recurring
 }

--- a/schema.json
+++ b/schema.json
@@ -4200,6 +4200,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "forever",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -176,6 +176,53 @@ RSpec.describe Credits::AppliedCouponService do
       end
     end
 
+    context 'when coupon is forever and fixed amount' do
+      let(:coupon) { create(:coupon, frequency: 'forever', frequency_duration: 0) }
+
+      let(:applied_coupon) do
+        create(
+          :applied_coupon,
+          coupon: coupon,
+          frequency: 'forever',
+          frequency_duration: 0,
+          frequency_duration_remaining: 0,
+          amount_cents: 12,
+        )
+      end
+
+      it 'creates a credit' do
+        result = credit_service.create
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.credit.amount_cents).to eq(12)
+          expect(result.credit.amount_currency).to eq('EUR')
+          expect(result.credit.invoice).to eq(invoice)
+          expect(result.credit.applied_coupon).to eq(applied_coupon)
+          expect(result.credit.applied_coupon.frequency_duration).to eq(0)
+          expect(result.credit.applied_coupon.frequency_duration_remaining).to eq(0)
+        end
+      end
+
+      it 'does not terminate the applied coupon' do
+        result = credit_service.create
+
+        expect(result).to be_success
+        expect(applied_coupon.reload).not_to be_terminated
+      end
+
+      context 'when coupon amount is higher than invoice amount' do
+        let(:amount_cents) { 10 }
+
+        it 'limits the credit amount to the invoice amount' do
+          result = credit_service.create
+
+          expect(result).to be_success
+          expect(result.credit.amount_cents).to eq(10)
+        end
+      end
+    end
+
     context 'when coupon is recurring and percentage' do
       let(:coupon) { create(:coupon, frequency: 'recurring', frequency_duration: 3, coupon_type: 'percentage') }
 

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe Credits::AppliedCouponService do
       let(:applied_coupon) do
         create(
           :applied_coupon,
-          coupon: coupon,
+          coupon:,
           frequency: 'forever',
           frequency_duration: 0,
           frequency_duration_remaining: 0,


### PR DESCRIPTION
## Context

Add logic for handling forever coupons

## Description

Forever coupons are applied indefinitely, no matter if percentage or fixed amount
