### PR TITLE
fix(timezone): Fix GraphQL handling of GMT+12 timezone

### DIFF
--- a/app/graphql/types/timezone_enum.rb
+++ b/app/graphql/types/timezone_enum.rb
@@ -4,11 +4,18 @@ module Types
   class TimezoneEnum < Types::BaseEnum
     ActiveSupport::TimeZone.all
       .uniq { |tz| tz.tzinfo.identifier }
-      .each_with_object([]) { |tz, result| result << [tz.tzinfo.identifier.gsub('Etc/', ''), tz] }
-      .sort_by { |list| list.first.split('/') }
-      .map do |list|
-        symbol = list.first.gsub(/[^_a-zA-Z0-9]/, '_').squeeze('_').upcase
-        value("TZ_#{symbol}", list.first, value: list.first)
+      .each_with_object([]) { |tz, result| result << tz.tzinfo.identifier }
+      .sort_by { |tz| tz.split('/') }
+      .map do |tz|
+        symbol = tz.gsub(/[^_a-zA-Z0-9]/, '_').squeeze('_').upcase
+        value = tz
+
+        if tz == 'Etc/UTC'
+          symbol = 'UTC'
+          value = 'UTC'
+        end
+
+        value("TZ_#{symbol}", value, value:)
       end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4579,6 +4579,11 @@ enum TimezoneEnum {
   TZ_AUSTRALIA_SYDNEY
 
   """
+  Etc/GMT+12
+  """
+  TZ_ETC_GMT_12
+
+  """
   Europe/Amsterdam
   """
   TZ_EUROPE_AMSTERDAM
@@ -4757,11 +4762,6 @@ enum TimezoneEnum {
   Europe/Zurich
   """
   TZ_EUROPE_ZURICH
-
-  """
-  GMT+12
-  """
-  TZ_GMT_12
 
   """
   Pacific/Apia

--- a/schema.json
+++ b/schema.json
@@ -18084,6 +18084,18 @@
               "deprecationReason": null
             },
             {
+              "name": "TZ_ETC_GMT_12",
+              "description": "Etc/GMT+12",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "TZ_UTC",
+              "description": "UTC",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "TZ_EUROPE_AMSTERDAM",
               "description": "Europe/Amsterdam",
               "isDeprecated": false,
@@ -18300,12 +18312,6 @@
               "deprecationReason": null
             },
             {
-              "name": "TZ_GMT_12",
-              "description": "GMT+12",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "TZ_PACIFIC_APIA",
               "description": "Pacific/Apia",
               "isDeprecated": false,
@@ -18386,12 +18392,6 @@
             {
               "name": "TZ_PACIFIC_TONGATAPU",
               "description": "Pacific/Tongatapu",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "TZ_UTC",
-              "description": "UTC",
               "isDeprecated": false,
               "deprecationReason": null
             }

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
   context 'with premium features' do
     around { |test| lago_premium!(&test) }
 
+    let(:timezone) { 'TZ_EUROPE_PARIS' }
+
     it 'updates an organization' do
       result = execute_graphql(
         current_user: membership.user,
@@ -81,7 +83,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
         variables: {
           input: {
             email: 'foo@bar.com',
-            timezone: 'TZ_EUROPE_PARIS',
+            timezone:,
             invoiceGracePeriod: 3,
           },
         },
@@ -90,8 +92,34 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
       result_data = result['data']['updateOrganization']
 
       aggregate_failures do
-        expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
+        expect(result_data['timezone']).to eq(timezone)
         expect(result_data['invoiceGracePeriod']).to eq(3)
+      end
+    end
+
+    context 'with Etc/GMT+12 timezone' do
+      let(:timezone) { 'TZ_ETC_GMT_12' }
+
+      it 'updates an organization' do
+        result = execute_graphql(
+          current_user: membership.user,
+          current_organization: membership.organization,
+          query: mutation,
+          variables: {
+            input: {
+              email: 'foo@bar.com',
+              timezone:,
+              invoiceGracePeriod: 3,
+            },
+          },
+        )
+
+        result_data = result['data']['updateOrganization']
+
+        aggregate_failures do
+          expect(result_data['timezone']).to eq(timezone)
+          expect(result_data['invoiceGracePeriod']).to eq(3)
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

In the user interface, there’s a timezone named `Etc/GMT+12, UTC -12:00`.

- When we select it as the organisation’s timezone, an error message is displayed.
- When creating a new customer with this timezone, the creation process fails.
- When editing the timezone associated with an existing customer, the change is not taken into account.

<img width="689" alt="Screenshot 2023-01-18 at 10 28 40" src="https://user-images.githubusercontent.com/471200/213396898-b49a2f66-dcf5-4dfd-86c6-b11bd09cf179.png">

## Description

This PR fixes the handling of GMT+12 timezone by using the standard `Etc/GMT+12` instead `GMT+12`.

The GraphQL enum value is renamed accordingly into `TZ_ETC_GMT_12`, requiring a refresh of the schema
