### PR TITLE
fix(s3): Add compatible S3 Bucket Region

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -19,6 +19,7 @@ amazon_compatible_endpoint:
   secret_access_key: <%= ENV['LAGO_AWS_S3_SECRET_ACCESS_KEY'] %>
   endpoint: <%= ENV['LAGO_AWS_S3_ENDPOINT'] %>
   bucket: <%= ENV['LAGO_AWS_S3_BUCKET'] %>
+  region: <%= ENV['LAGO_AWS_S3_REGION'] %>
 
 google:
   service: GCS


### PR DESCRIPTION
## Context

S3 Endpoints (not AWS) do not use `region` but it's mandatory for the `aws-sdk` gem

## Description

- Add the `region` env var support for S3 endpoints
