### PR TITLE
feat(delete_bm): Expose deleted resources in PDF invoice

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -4,15 +4,15 @@ class Fee < ApplicationRecord
   include Currencies
 
   belongs_to :invoice
-  belongs_to :charge, optional: true
+  belongs_to :charge, -> { with_discarded }, optional: true
   belongs_to :applied_add_on, optional: true
   belongs_to :subscription, optional: true
-  belongs_to :group, optional: true
+  belongs_to :group, -> { with_discarded }, optional: true
   belongs_to :invoiceable, polymorphic: true, optional: true
 
   has_one :customer, through: :subscription
   has_one :organization, through: :invoice
-  has_one :billable_metric, through: :charge
+  has_one :billable_metric, -> { with_discarded }, through: :charge
   has_one :add_on, through: :applied_add_on
 
   has_many :credit_note_items

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -546,7 +546,7 @@ html
                       td width="70%"
                         .body-1 = fee.billable_metric.name
                         .body-3
-                          - if fee.charge.billable_metric.recurring_count_agg?
+                          - if fee.billable_metric.recurring_count_agg?
                             | See breakdown for total unit
                           - elsif fee.charge.percentage?
                             | Total unit: #{fees.sum(&:events_count)} events for #{fees.sum(&:units)}
@@ -558,7 +558,7 @@ html
                       tr
                         td width="70%" style="padding-left: 16px;"
                           .body-1 = fee.group.name
-                          - unless fee.charge.billable_metric.recurring_count_agg?
+                          - unless fee.billable_metric.recurring_count_agg?
                             .body-3
                               - if fee.charge.percentage?
                                 | Total unit: #{fee.events_count} events for #{fee.units}

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -5,16 +5,6 @@ FactoryBot.define do
     billable_metric
     plan
 
-    trait :with_group do
-      after(:build) do |charge|
-        create(
-          :group_property,
-          charge: charge,
-          values: charge.properties,
-        )
-      end
-    end
-
     factory :standard_charge do
       charge_model { 'standard' }
       properties do

--- a/spec/factories/utils.rb
+++ b/spec/factories/utils.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  trait :discarded do
+    deleted_at { Time.current }
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to ensure deleted resource remains visible on PDF invoice