### PR TITLE
feat(delete_bm): Ensure deleted resources are exposed in Invoice API endpoint

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -43,7 +43,9 @@ class BillableMetric < ApplicationRecord
   end
 
   def active_groups
-    groups.active.order(created_at: :asc)
+    scope = groups.active.order(created_at: :asc)
+    scope = scope.with_discarded if discarded?
+    scope
   end
 
   # NOTE: 1 dimension: all groups, 2 dimensions: all children.

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -5,7 +5,7 @@ module V1
     def serialize
       {
         lago_id: model.id,
-        lago_group_id: model.group&.id,
+        lago_group_id: model.group_id,
         item: {
           type: model.fee_type,
           code: model.item_code,

--- a/spec/factories/utils.rb
+++ b/spec/factories/utils.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  trait :discarded do
+  trait :deleted do
     deleted_at { Time.current }
   end
 end

--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe BillableMetric, type: :model do
         expect(metric.selectable_groups).to match_array([one, second, third])
       end
     end
+
+    context 'when billable metric and group are deleted' do
+      it 'returns all groups' do
+        metric.discard!
+        one = create(:group, :deleted, billable_metric: metric, key: 'country', value: 'france')
+        second = create(:group, :deleted, billable_metric: metric, key: 'country', value: 'italy')
+
+        expect(metric.selectable_groups).to match_array([one, second])
+      end
+    end
   end
 
   describe '#active_groups_as_tree' do

--- a/spec/services/invoices/generate_service_spec.rb
+++ b/spec/services/invoices/generate_service_spec.rb
@@ -76,22 +76,22 @@ RSpec.describe Invoices::GenerateService, type: :service do
       end
     end
 
-    context 'when a billable metric is discarded' do
-      let(:billable_metric) { create(:billable_metric, :discarded) }
-      let(:group) { create(:group, :discarded, billable_metric:) }
+    context 'when a billable metric is deleted' do
+      let(:billable_metric) { create(:billable_metric, :deleted) }
+      let(:group) { create(:group, :deleted, billable_metric:) }
       let(:fees) { [create(:charge_fee, subscription:, invoice:, group:, charge:, amount_cents: 10)] }
 
       let(:group_property) do
         build(
           :group_property,
-          :discarded,
+          :deleted,
           group:,
           values: { amount: '10', amount_currency: 'EUR' },
         )
       end
 
       let(:charge) do
-        create(:standard_charge, :discarded, billable_metric:, group_properties: [group_property])
+        create(:standard_charge, :deleted, billable_metric:, group_properties: [group_property])
       end
 
       it 'generates the invoice synchronously' do


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to ensure deleted resource attached to a fee remain visible in invoice API endpoint