### PR TITLE
feat(delete_bm): Add activeSubscriptionsCount and draftInvoicesCount

### DIFF
--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -34,7 +34,12 @@ module Types
       end
 
       def draft_invoices_count
-        object.plans.joins(subscriptions: [:invoices]).merge(Invoice.draft).count
+        object.plans
+          .joins(subscriptions: [:invoices])
+          .merge(Invoice.draft)
+          .select(:invoice_id)
+          .distinct
+          .count
       end
     end
   end

--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -15,7 +15,8 @@ module Types
       field :field_name, String, null: true
       field :group, GraphQL::Types::JSON, null: true
       field :flat_groups, [Types::Groups::Object], null: true
-
+      field :active_subscriptions_count, Integer, null: false
+      field :draft_invoices_count, Integer, null: false
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
       field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
@@ -26,6 +27,14 @@ module Types
 
       def flat_groups
         object.selectable_groups
+      end
+
+      def active_subscriptions_count
+        object.plans.joins(:subscriptions).merge(Subscription.active).count
+      end
+
+      def draft_invoices_count
+        object.plans.joins(subscriptions: [:invoices]).merge(Invoice.draft).count
       end
     end
   end

--- a/app/serializers/v1/billable_metric_serializer.rb
+++ b/app/serializers/v1/billable_metric_serializer.rb
@@ -12,7 +12,24 @@ module V1
         created_at: model.created_at.iso8601,
         field_name: model.field_name,
         group: model.active_groups_as_tree,
+        active_subscriptions_count:,
+        draft_invoices_count:,
       }
+    end
+
+    private
+
+    def active_subscriptions_count
+      model.plans.joins(:subscriptions).merge(Subscription.active).count
+    end
+
+    def draft_invoices_count
+      model.plans
+        .joins(subscriptions: [:invoices])
+        .merge(Invoice.draft)
+        .select(:invoice_id)
+        .distinct
+        .count
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -125,11 +125,13 @@ exceed the size of a 32-bit integer, it's encoded as a string.
 scalar BigInt
 
 type BillableMetric {
+  activeSubscriptionsCount: Int!
   aggregationType: AggregationTypeEnum!
   code: String!
   createdAt: ISO8601DateTime!
   deletedAt: ISO8601DateTime
   description: String
+  draftInvoicesCount: Int!
   fieldName: String
   flatGroups: [Group!]
   group: JSON
@@ -145,11 +147,13 @@ type BillableMetricCollection {
 }
 
 type BillableMetricDetail {
+  activeSubscriptionsCount: Int!
   aggregationType: AggregationTypeEnum!
   code: String!
   createdAt: ISO8601DateTime!
   deletedAt: ISO8601DateTime
   description: String
+  draftInvoicesCount: Int!
   fieldName: String
   flatGroups: [Group!]
   group: JSON

--- a/schema.json
+++ b/schema.json
@@ -976,6 +976,24 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "activeSubscriptionsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "aggregationType",
               "description": null,
               "type": {
@@ -1050,6 +1068,24 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "draftInvoicesCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -1246,6 +1282,24 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "activeSubscriptionsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "aggregationType",
               "description": null,
               "type": {
@@ -1320,6 +1374,24 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "draftInvoicesCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/resolvers/billable_metric_resolver_spec.rb
+++ b/spec/graphql/resolvers/billable_metric_resolver_spec.rb
@@ -53,12 +53,15 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
   it 'returns the count number of draft invoices' do
     customer = create(:customer, organization:)
     subscription = create(:subscription)
+    subscription2 = create(:subscription)
     create(:standard_charge, plan: subscription.plan, billable_metric:)
+    create(:standard_charge, plan: subscription2.plan, billable_metric:)
 
     invoice = create(:invoice, customer:)
     create(:invoice_subscription, subscription:, invoice:)
     draft_invoice = create(:invoice, :draft, customer:)
     create(:invoice_subscription, subscription:, invoice: draft_invoice)
+    create(:invoice_subscription, subscription: subscription2, invoice: draft_invoice)
 
     metric_response = graphql_request['data']['billableMetric']
     expect(metric_response['draftInvoicesCount']).to eq(1)


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to add on the billable metric object:
- `activeSubscriptionsCount`
- `draftInvoicesCount`

These fields are used to know the impact of deleting billable metric.