### PR TITLE
feat(delete_bm): Ensure deleted resources are exposed in Invoice GrahQL type

### DIFF
--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -13,6 +13,18 @@ module Types
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      def billable_metric
+        return object.billable_metric unless object.discarded?
+
+        BillableMetric.with_discarded.find_by(id: object.billable_metric_id)
+      end
+
+      def group_properties
+        scope = object.group_properties
+        scope = scope.with_discarded if object.discarded?
+        scope
+      end
     end
   end
 end

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -43,7 +43,9 @@ class BillableMetric < ApplicationRecord
   end
 
   def active_groups
-    groups.active.order(created_at: :asc)
+    scope = groups.active.order(created_at: :asc)
+    scope = scope.with_discarded if discarded?
+    scope
   end
 
   # NOTE: 1 dimension: all groups, 2 dimensions: all children.


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to ensure deleted resource attached to a fee remain visible in invoice GraphQL type