### PR TITLE
fix: Add unscoped to legacy tasks

### DIFF
--- a/lib/tasks/charges.rake
+++ b/lib/tasks/charges.rake
@@ -7,7 +7,7 @@ namespace :charges do
     # created containing a fixed_amount. All existing charges have fixed_amount
     # and fixed_amount_target with a null value.
 
-    Charge.percentage.where("properties -> 'fixed_amount_target' IS NOT NULL").find_each do |charge|
+    Charge.unscoped.percentage.where("properties -> 'fixed_amount_target' IS NOT NULL").find_each do |charge|
       charge.properties.delete('fixed_amount_target')
       charge.properties['free_units_per_events'] = nil
       charge.properties['free_units_per_total_aggregation'] = nil
@@ -18,13 +18,13 @@ namespace :charges do
   desc 'Set graduated properties to hash and rename volume ranges'
   task update_graduated_properties_to_hash: :environment do
     # Rename existing volume ranges from `ranges: []` to `volume_ranges: []`
-    Charge.volume.find_each do |charge|
+    Charge.unscoped.volume.find_each do |charge|
       charge.properties['volume_ranges'] = charge.properties.delete('ranges')
       charge.save!
     end
 
     # Update graduated charges from array `[]` to hash `graduated_ranges: []`
-    Charge.graduated.find_each do |charge|
+    Charge.unscoped.graduated.find_each do |charge|
       charge.properties = { graduated_ranges: charge.properties }
       charge.save!
     end

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -4,14 +4,14 @@ namespace :events do
   # NOTE: related to https://github.com/getlago/lago-api/issues/317
   desc 'Fill missing timestamps for events'
   task fill_timestamp: :environment do
-    Event.where(timestamp: nil).find_each do |event|
+    Event.unscoped.where(timestamp: nil).find_each do |event|
       event.update!(timestamp: event.created_at)
     end
   end
 
   desc 'Fill missing subscription_id'
   task fill_subscription: :environment do
-    Event.where(subscription_id: nil).find_each do |event|
+    Event.unscoped.where(subscription_id: nil).find_each do |event|
       subscription = event.customer.active_subscription || event.customer.subscriptions.order(:created_at).last
 
       unless subscription
@@ -25,8 +25,8 @@ namespace :events do
 
   desc 'Fill missing properties on persisted_events'
   task fill_persisted_properties: :environment do
-    PersistedEvent.find_each do |persisted_event|
-      event = Event.where(
+    PersistedEvent.unscoped.find_each do |persisted_event|
+      event = Event.unscoped.where(
         organization_id: persisted_event.billable_metric.organization_id,
         customer_id: persisted_event.customer_id,
       ).where(


### PR DESCRIPTION
Resetting the database was not working due to the addition of the default scope on `deleted_at` column.

The goal of this PR is to fix legacy tasks by adding `unscoped`.