### PR TITLE
feat(delete_bm): Add deleted_at field in GraphQL schema

### DIFF
--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -15,8 +15,10 @@ module Types
       field :field_name, String, null: true
       field :group, GraphQL::Types::JSON, null: true
       field :flat_groups, [Types::Groups::Object], null: true
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :can_be_deleted, Boolean, null: false do
         description 'Check if billable metric is deletable'

--- a/app/graphql/types/charges/group_properties.rb
+++ b/app/graphql/types/charges/group_properties.rb
@@ -7,6 +7,8 @@ module Types
 
       field :group_id, ID, null: false
       field :values, Types::Charges::Properties, null: false
+
+      field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
     end
   end
 end

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -13,6 +13,7 @@ module Types
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
 
       def billable_metric
         return object.billable_metric unless object.discarded?

--- a/app/graphql/types/events/object.rb
+++ b/app/graphql/types/events/object.rb
@@ -12,6 +12,7 @@ module Types
 
       field :timestamp, GraphQL::Types::ISO8601DateTime, null: true
       field :received_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
       field :customer_timezone, Types::TimezoneEnum, null: false
 
       field :api_client, String, null: true

--- a/app/graphql/types/groups/object.rb
+++ b/app/graphql/types/groups/object.rb
@@ -9,6 +9,8 @@ module Types
       field :key, String, null: true
       field :value, String, null: false
 
+      field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
+
       def key
         object.parent&.value
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -133,6 +133,7 @@ type BillableMetric {
   canBeDeleted: Boolean!
   code: String!
   createdAt: ISO8601DateTime!
+  deletedAt: ISO8601DateTime
   description: String
   fieldName: String
   flatGroups: [Group!]
@@ -157,6 +158,7 @@ type BillableMetricDetail {
   canBeDeleted: Boolean!
   code: String!
   createdAt: ISO8601DateTime!
+  deletedAt: ISO8601DateTime
   description: String
   fieldName: String
   flatGroups: [Group!]
@@ -176,6 +178,7 @@ type Charge {
   billableMetric: BillableMetric!
   chargeModel: ChargeModelEnum!
   createdAt: ISO8601DateTime!
+  deletedAt: ISO8601DateTime
   groupProperties: [GroupProperties!]
   id: ID!
   properties: Properties
@@ -2849,6 +2852,7 @@ type Event {
   billableMetricName: String
   code: String!
   customerTimezone: TimezoneEnum!
+  deletedAt: ISO8601DateTime
   externalCustomerId: String!
   externalSubscriptionId: String!
   id: ID!
@@ -2924,12 +2928,14 @@ input GraduatedRangeInput {
 }
 
 type Group {
+  deletedAt: ISO8601DateTime
   id: ID!
   key: String
   value: String!
 }
 
 type GroupProperties {
+  deletedAt: ISO8601DateTime
   groupId: ID!
   values: Properties!
 }

--- a/schema.json
+++ b/schema.json
@@ -1048,6 +1048,20 @@
               ]
             },
             {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "description",
               "description": null,
               "type": {
@@ -1322,6 +1336,20 @@
               ]
             },
             {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "description",
               "description": null,
               "type": {
@@ -1546,6 +1574,20 @@
                   "name": "ISO8601DateTime",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -9629,6 +9671,20 @@
               ]
             },
             {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "externalCustomerId",
               "description": null,
               "type": {
@@ -10451,6 +10507,20 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -10513,6 +10583,20 @@
           ],
           "possibleTypes": null,
           "fields": [
+            {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
             {
               "name": "groupId",
               "description": null,


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to expose the `deletedAt` field in the GraphQL schema for:
- BillableMetric
- Charge
- Group
- GroupProperty
- Event