### PR TITLE
feat(delete_bm): Merge destroy method used by API and GraphQL

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -46,9 +46,8 @@ module Api
 
       def destroy
         service = ::BillableMetrics::DestroyService.new
-        result = service.destroy_from_api(
-          organization: current_organization,
-          code: params[:code],
+        result = service.destroy(
+          metric: current_organization.billable_metrics.find_by(code: params[:code]),
         )
 
         if result.success?

--- a/app/graphql/mutations/billable_metrics/destroy.rb
+++ b/app/graphql/mutations/billable_metrics/destroy.rb
@@ -13,7 +13,11 @@ module Mutations
       field :id, ID, null: true
 
       def resolve(id:)
-        result = ::BillableMetrics::DestroyService.new(context[:current_user]).destroy(id)
+        result = ::BillableMetrics::DestroyService
+          .new
+          .destroy(
+            metric: context[:current_user].billable_metrics.find_by(id:),
+          )
 
         result.success? ? result.billable_metric : result_error(result)
       end

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -2,19 +2,7 @@
 
 module BillableMetrics
   class DestroyService < BaseService
-    def destroy(id)
-      metric = result.user.billable_metrics.find_by(id: id)
-      return result.not_found_failure!(resource: 'billable_metric') unless metric
-      return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless metric.deletable?
-
-      metric.destroy!
-
-      result.billable_metric = metric
-      result
-    end
-
-    def destroy_from_api(organization:, code:)
-      metric = organization.billable_metrics.find_by(code: code)
+    def destroy(metric:)
       return result.not_found_failure!(resource: 'billable_metric') unless metric
       return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless metric.deletable?
 

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -9,18 +9,18 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
   let(:organization) { membership.organization }
 
   describe 'destroy' do
-    let(:billable_metric) { create(:billable_metric, organization: organization) }
+    let(:billable_metric) { create(:billable_metric, organization:) }
+
+    before { billable_metric }
 
     it 'destroys the billable metric' do
-      id = billable_metric.id
-
-      expect { destroy_service.destroy(id) }
+      expect { destroy_service.destroy(metric: billable_metric) }
         .to change(BillableMetric, :count).by(-1)
     end
 
     context 'when billable metric is not found' do
       it 'returns an error' do
-        result = destroy_service.destroy(nil)
+        result = destroy_service.destroy(metric: nil)
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('billable_metric_not_found')
@@ -31,44 +31,11 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
       let(:subscription) { create(:subscription) }
 
       before do
-        create(:standard_charge, plan: subscription.plan, billable_metric: billable_metric)
+        create(:standard_charge, plan: subscription.plan, billable_metric:)
       end
 
       it 'returns an error' do
-        result = destroy_service.destroy(billable_metric.id)
-
-        expect(result).not_to be_success
-        expect(result.error.code).to eq('attached_to_an_active_subscription')
-      end
-    end
-  end
-
-  describe 'destroy_from_api' do
-    let(:billable_metric) { create(:billable_metric, organization: organization) }
-
-    it 'destroys the billable metric' do
-      code = billable_metric.code
-
-      expect { destroy_service.destroy_from_api(organization: organization, code: code) }
-        .to change(BillableMetric, :count).by(-1)
-    end
-
-    context 'when billable metric is not found' do
-      it 'returns an error' do
-        result = destroy_service.destroy_from_api(organization: organization, code: 'invalid12345')
-
-        expect(result).not_to be_success
-        expect(result.error.error_code).to eq('billable_metric_not_found')
-      end
-    end
-
-    context 'when billable metric is attached to subscription' do
-      let(:subscription) { create(:subscription) }
-
-      before { create(:standard_charge, plan: subscription.plan, billable_metric: billable_metric) }
-
-      it 'returns an error' do
-        result = destroy_service.destroy_from_api(organization: organization, code: billable_metric.code)
+        result = destroy_service.destroy(metric: billable_metric)
 
         expect(result).not_to be_success
         expect(result.error.code).to eq('attached_to_an_active_subscription')


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to merge `BillableMetrics::DestroyService#destroy` and `BillableMetrics::DestroyService#destroy_from_api` method to reduce code duplication and pave the way for soft deletion logic