### PR TITLE
feat(delete_bm): Discard metric and associations

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -45,10 +45,8 @@ module Api
       end
 
       def destroy
-        service = ::BillableMetrics::DestroyService.new
-        result = service.destroy_from_api(
-          organization: current_organization,
-          code: params[:code],
+        result = ::BillableMetrics::DestroyService.call(
+          metric: current_organization.billable_metrics.find_by(code: params[:code]),
         )
 
         if result.success?

--- a/app/graphql/mutations/billable_metrics/destroy.rb
+++ b/app/graphql/mutations/billable_metrics/destroy.rb
@@ -13,7 +13,8 @@ module Mutations
       field :id, ID, null: true
 
       def resolve(id:)
-        result = ::BillableMetrics::DestroyService.new(context[:current_user]).destroy(id)
+        metric = context[:current_user].billable_metrics.find_by(id:)
+        result = ::BillableMetrics::DestroyService.call(metric:)
 
         result.success? ? result.billable_metric : result_error(result)
       end

--- a/app/jobs/billable_metrics/delete_events_job.rb
+++ b/app/jobs/billable_metrics/delete_events_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module BillableMetrics
+  class DeleteEventsJob < ApplicationJob
+    queue_as :default
+
+    def perform(metric)
+      return unless metric.discarded?
+
+      deleted_at = Time.current
+
+      Event.joins(subscription: [:plan])
+        .where(code: metric.code, plan: { id: metric.plans.pluck(:id) })
+        .update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
+
+      metric.persisted_events.update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+end

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -2,24 +2,25 @@
 
 module BillableMetrics
   class DestroyService < BaseService
-    def destroy(id)
-      metric = result.user.billable_metrics.find_by(id:)
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(metric:)
+      @metric = metric
+      super
+    end
+
+    def call
       return result.not_found_failure!(resource: 'billable_metric') unless metric
 
       metric.destroy!
-
       result.billable_metric = metric
       result
     end
 
-    def destroy_from_api(organization:, code:)
-      metric = organization.billable_metrics.find_by(code:)
-      return result.not_found_failure!(resource: 'billable_metric') unless metric
+    private
 
-      metric.destroy!
-
-      result.billable_metric = metric
-      result
-    end
+    attr_reader :metric
   end
 end

--- a/spec/graphql/mutations/billable_metrics/destroy_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/destroy_spec.rb
@@ -21,9 +21,7 @@ RSpec.describe Mutations::BillableMetrics::Destroy, type: :graphql do
     result = execute_graphql(
       current_user: membership.user,
       query: mutation,
-      variables: {
-        input: { id: billable_metric.id }
-      }
+      variables: { input: { id: billable_metric.id } },
     )
 
     data = result['data']['destroyBillableMetric']
@@ -34,9 +32,7 @@ RSpec.describe Mutations::BillableMetrics::Destroy, type: :graphql do
     it 'returns an error' do
       result = execute_graphql(
         query: mutation,
-        variables: {
-          input: { id: billable_metric.id }
-        }
+        variables: { input: { id: billable_metric.id } },
       )
 
       expect_unauthorized_error(result)

--- a/spec/jobs/billable_metrics/delete_events_job_spec.rb
+++ b/spec/jobs/billable_metrics/delete_events_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetrics::DeleteEventsJob, type: :job do
+  let(:billable_metric) { create(:billable_metric, :deleted) }
+  let(:subscription) { create(:subscription) }
+
+  it 'deletes related events' do
+    create(:standard_charge, plan: subscription.plan, billable_metric:)
+    event = create(:event, code: billable_metric.code, subscription:)
+    persisted_event = create(:persisted_event, billable_metric:)
+
+    freeze_time do
+      expect { described_class.perform_now(billable_metric) }
+        .to change { event.reload.deleted_at }.from(nil).to(Time.current)
+        .and change { persisted_event.reload.deleted_at }.from(nil).to(Time.current)
+    end
+  end
+end

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -3,44 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe BillableMetrics::DestroyService, type: :service do
-  subject(:destroy_service) { described_class.new(membership.user) }
+  subject(:destroy_service) { described_class.new(metric:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
+  let(:metric) { create(:billable_metric, organization:) }
 
-  describe 'destroy' do
-    let(:billable_metric) { create(:billable_metric, organization:) }
+  before { metric }
 
+  describe '#call' do
     it 'destroys the billable metric' do
-      id = billable_metric.id
-
-      expect { destroy_service.destroy(id) }
-        .to change(BillableMetric, :count).by(-1)
+      expect { destroy_service.call }.to change(BillableMetric, :count).by(-1)
     end
 
     context 'when billable metric is not found' do
+      let(:metric) { nil }
+
       it 'returns an error' do
-        result = destroy_service.destroy(nil)
-
-        expect(result).not_to be_success
-        expect(result.error.error_code).to eq('billable_metric_not_found')
-      end
-    end
-  end
-
-  describe 'destroy_from_api' do
-    let(:billable_metric) { create(:billable_metric, organization:) }
-
-    it 'destroys the billable metric' do
-      code = billable_metric.code
-
-      expect { destroy_service.destroy_from_api(organization:, code:) }
-        .to change(BillableMetric, :count).by(-1)
-    end
-
-    context 'when billable metric is not found' do
-      it 'returns an error' do
-        result = destroy_service.destroy_from_api(organization:, code: 'invalid12345')
+        result = destroy_service.call
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('billable_metric_not_found')

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -3,24 +3,52 @@
 require 'rails_helper'
 
 RSpec.describe BillableMetrics::DestroyService, type: :service do
-  subject(:destroy_service) { described_class.new(metric:) }
+  subject(:destroy_service) { described_class.new(metric: billable_metric) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:metric) { create(:billable_metric, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:subscription) { create(:subscription) }
+  let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:) }
+  let(:group) { create(:group, billable_metric:) }
+  let(:group_property) { create(:group_property, group:, charge:) }
 
-  before { metric }
+  before do
+    charge
+    group_property
+
+    allow(BillableMetrics::DeleteEventsJob).to receive(:perform_later).and_call_original
+  end
 
   describe '#call' do
-    it 'destroys the billable metric' do
-      expect { destroy_service.call }.to change(BillableMetric, :count).by(-1)
+    it 'discards the billable metric' do
+      freeze_time do
+        expect { destroy_service.call }.to change { billable_metric.reload.deleted_at }.from(nil).to(Time.current)
+      end
+    end
+
+    it 'discards all the related charges' do
+      freeze_time do
+        expect { destroy_service.call }.to change { charge.reload.deleted_at }.from(nil).to(Time.current)
+      end
+    end
+
+    it 'discards all the related groups' do
+      freeze_time do
+        expect { destroy_service.call }.to change { group.reload.deleted_at }.from(nil).to(Time.current)
+          .and change { group_property.reload.deleted_at }.from(nil).to(Time.current)
+      end
+    end
+
+    it 'enqueues a DeleteEventsJob' do
+      expect do
+        destroy_service.call
+      end.to have_enqueued_job(BillableMetrics::DeleteEventsJob).with(billable_metric)
     end
 
     context 'when billable metric is not found' do
-      let(:metric) { nil }
-
       it 'returns an error' do
-        result = destroy_service.call
+        result = described_class.new(metric: nil).call
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('billable_metric_not_found')


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to:
- Refactor bm destroy service
- Discard metric and associations (charges, groups, group properties, events and persisted events)