### PR TITLE
feat(delete_bm): Track metric and refresh draft invoices

### DIFF
--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -34,8 +34,8 @@ module Types
       end
 
       def draft_invoices_count
-        object.plans
-          .joins(subscriptions: [:invoices])
+        object.charges
+          .joins(fees: [:invoice])
           .merge(Invoice.draft)
           .select(:invoice_id)
           .distinct

--- a/app/jobs/billable_metrics/delete_events_job.rb
+++ b/app/jobs/billable_metrics/delete_events_job.rb
@@ -9,9 +9,10 @@ module BillableMetrics
 
       deleted_at = Time.current
 
-      Event.joins(subscription: [:plan])
-        .where(code: metric.code, plan: { id: metric.plans.pluck(:id) })
-        .update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
+      Event.joins(subscription: [:plan]).where(
+        code: metric.code,
+        plan: { id: Charge.with_discarded.where(billable_metric_id: metric.id).pluck(:plan_id) },
+      ).update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
 
       metric.persisted_events.update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
     end

--- a/app/jobs/invoices/refresh_batch_job.rb
+++ b/app/jobs/invoices/refresh_batch_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Invoices
+  class RefreshBatchJob < ApplicationJob
+    queue_as 'invoices'
+
+    def perform(invoice_ids)
+      Invoice.find(invoice_ids).each do |invoice|
+        ::Invoices::RefreshDraftService.call(invoice:)
+      end
+    end
+  end
+end

--- a/app/serializers/v1/billable_metric_serializer.rb
+++ b/app/serializers/v1/billable_metric_serializer.rb
@@ -24,8 +24,8 @@ module V1
     end
 
     def draft_invoices_count
-      model.plans
-        .joins(subscriptions: [:invoices])
+      model.charges
+        .joins(fees: [:invoice])
         .merge(Invoice.draft)
         .select(:invoice_id)
         .distinct

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -29,12 +29,10 @@ module BillableMetrics
       # NOTE: Discard all related events asynchronously.
       BillableMetrics::DeleteEventsJob.perform_later(metric)
 
-      track_billable_metric_deleted
+      # NOTE: Refresh all draft invoices asynchronously.
+      Invoices::RefreshBatchJob.perform_later(draft_invoice_ids)
 
-      # NOTE: Refresh all invoices linked to the billable metric.
-      Invoice.find(draft_invoice_ids).each do |invoice|
-        ::Invoices::RefreshDraftService.call(invoice:)
-      end
+      track_billable_metric_deleted
 
       result.billable_metric = metric
       result

--- a/spec/graphql/resolvers/billable_metric_resolver_spec.rb
+++ b/spec/graphql/resolvers/billable_metric_resolver_spec.rb
@@ -51,17 +51,18 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
   end
 
   it 'returns the count number of draft invoices' do
-    customer = create(:customer, organization:)
+    customer = create(:customer, organization: billable_metric.organization)
     subscription = create(:subscription)
     subscription2 = create(:subscription)
-    create(:standard_charge, plan: subscription.plan, billable_metric:)
-    create(:standard_charge, plan: subscription2.plan, billable_metric:)
+    charge = create(:standard_charge, plan: subscription.plan, billable_metric:)
+    charge2 = create(:standard_charge, plan: subscription2.plan, billable_metric:)
 
     invoice = create(:invoice, customer:)
-    create(:invoice_subscription, subscription:, invoice:)
+    create(:fee, invoice:, charge:)
+
     draft_invoice = create(:invoice, :draft, customer:)
-    create(:invoice_subscription, subscription:, invoice: draft_invoice)
-    create(:invoice_subscription, subscription: subscription2, invoice: draft_invoice)
+    create(:fee, invoice: draft_invoice, charge: charge2)
+    create(:fee, invoice: draft_invoice, charge: charge2)
 
     metric_response = graphql_request['data']['billableMetric']
     expect(metric_response['draftInvoicesCount']).to eq(1)

--- a/spec/serializers/v1/billable_metric_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_serializer_spec.rb
@@ -37,14 +37,15 @@ RSpec.describe ::V1::BillableMetricSerializer do
     customer = create(:customer, organization: billable_metric.organization)
     subscription = create(:subscription)
     subscription2 = create(:subscription)
-    create(:standard_charge, plan: subscription.plan, billable_metric:)
-    create(:standard_charge, plan: subscription2.plan, billable_metric:)
+    charge = create(:standard_charge, plan: subscription.plan, billable_metric:)
+    charge2 = create(:standard_charge, plan: subscription2.plan, billable_metric:)
 
     invoice = create(:invoice, customer:)
-    create(:invoice_subscription, subscription:, invoice:)
+    create(:fee, invoice:, charge:)
+
     draft_invoice = create(:invoice, :draft, customer:)
-    create(:invoice_subscription, subscription:, invoice: draft_invoice)
-    create(:invoice_subscription, subscription: subscription2, invoice: draft_invoice)
+    create(:fee, invoice: draft_invoice, charge: charge2)
+    create(:fee, invoice: draft_invoice, charge: charge2)
 
     expect(result['billable_metric']['draft_invoices_count']).to eq(1)
   end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             .to match_datetime((timestamp - 1.day).end_of_day)
           expect(result.invoice.fees.first.properties['from_datetime'])
             .to match_datetime((timestamp - 1.month).beginning_of_day)
-          expect(result.invoice.subscriptions).to eq(subscriptions)
+          expect(result.invoice.subscriptions.to_a).to match_array(subscriptions)
           expect(result.invoice.payment_status).to eq('pending')
           expect(result.invoice.fees.subscription_kind.count).to eq(2)
           expect(result.invoice.fees.charge_kind.count).to eq(2)


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/179

## Context

As a user, I want to be able to delete a billable metric that is linked to a subscription in case of a change of pricing (e.g. we no longer charge customers based on the number of API calls).

Once deleted, the corresponding charges will be removed from the plans and from all draft invoices.

Deleted metrics will still be included in past invoices (i.e. finalized invoices).

## Description

The goal of this PR is to:
- Track metric deletion on Segment
- Refresh linked draft invoices