### PR TITLE
feat(delete_charge): Refact plan update service to merge api and graphql

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -20,12 +20,8 @@ module Api
       end
 
       def update
-        service = Plans::UpdateService.new
-        result = service.update_from_api(
-          organization: current_organization,
-          code: params[:code],
-          params: input_params,
-        )
+        plan = current_organization.plans.find_by(code: params[:code])
+        result = Plans::UpdateService.call(plan:, params: input_params)
 
         if result.success?
           render_plan(result.plan)

--- a/app/graphql/mutations/plans/update.rb
+++ b/app/graphql/mutations/plans/update.rb
@@ -25,8 +25,9 @@ module Mutations
 
       def resolve(**args)
         args[:charges].map!(&:to_h)
+        plan = context[:current_user].plans.find_by(id: args[:id])
 
-        result = ::Plans::UpdateService.new(context[:current_user]).update(**args)
+        result = ::Plans::UpdateService.call(plan:, params: args)
         result.success? ? result.plan : result_error(result)
       end
     end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -3,19 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe Plans::UpdateService, type: :service do
-  subject(:plans_service) { described_class.new(membership.user) }
+  subject(:plans_service) { described_class.new(plan:, params: update_args) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:plan) { create(:plan, organization: organization) }
+  let(:plan) { create(:plan, organization:) }
   let(:plan_name) { 'Updated plan name' }
-  let(:billable_metrics) do
-    create_list(:billable_metric, 2, organization: organization)
-  end
   let(:group) { create(:group, billable_metric: billable_metrics.first) }
+
+  let(:billable_metrics) do
+    create_list(:billable_metric, 2, organization:)
+  end
+
   let(:update_args) do
     {
-      id: plan.id,
       name: plan_name,
       code: 'new_plan',
       interval: 'monthly',
@@ -57,9 +58,9 @@ RSpec.describe Plans::UpdateService, type: :service do
     }
   end
 
-  describe 'update' do
+  describe 'call' do
     it 'updates a plan' do
-      result = plans_service.update(**update_args)
+      result = plans_service.call
 
       updated_plan = result.plan
       aggregate_failures do
@@ -68,11 +69,24 @@ RSpec.describe Plans::UpdateService, type: :service do
       end
     end
 
+    context 'when plan is not found' do
+      let(:plan) { nil }
+
+      it 'returns an error' do
+        result = plans_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('plan_not_found')
+        end
+      end
+    end
+
     context 'with validation error' do
       let(:plan_name) { nil }
 
       it 'returns an error' do
-        result = plans_service.update(**update_args)
+        result = plans_service.call
 
         aggregate_failures do
           expect(result).not_to be_success
@@ -86,10 +100,12 @@ RSpec.describe Plans::UpdateService, type: :service do
       let(:billable_metrics) { create_list(:billable_metric, 2) }
 
       it 'returns an error' do
-        result = plans_service.update(**update_args)
+        result = plans_service.call
 
-        expect(result).not_to be_success
-        expect(result.error.error_code).to eq('billable_metrics_not_found')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('billable_metrics_not_found')
+        end
       end
     end
 
@@ -139,12 +155,12 @@ RSpec.describe Plans::UpdateService, type: :service do
       end
 
       it 'updates existing charge and creates an other one' do
-        expect { plans_service.update(**update_args) }
+        expect { plans_service.call }
           .to change(Charge, :count).by(1)
       end
 
       it 'updates group properties' do
-        expect { plans_service.update(**update_args) }
+        expect { plans_service.call }
           .to change(GroupProperty, :count).by(1)
 
         expect(existing_charge.reload.group_properties.first).to have_attributes(
@@ -182,7 +198,7 @@ RSpec.describe Plans::UpdateService, type: :service do
       before { charge }
 
       it 'destroys the unattached charge' do
-        expect { plans_service.update(**update_args) }
+        expect { plans_service.call }
           .to change { plan.charges.count }.by(-1)
       end
     end
@@ -229,193 +245,17 @@ RSpec.describe Plans::UpdateService, type: :service do
       end
 
       before do
-        create(:subscription, plan: plan)
+        create(:subscription, plan:)
       end
 
       it 'updates only name description and new charges' do
-        result = plans_service.update(**update_args)
+        result = plans_service.call
 
         updated_plan = result.plan
         aggregate_failures do
           expect(updated_plan.name).to eq('Updated plan name')
           expect(plan.charges.count).to eq(2)
         end
-      end
-    end
-  end
-
-  describe 'update_from_api' do
-    it 'updates the plan' do
-      result = plans_service.update_from_api(
-        organization: organization,
-        code: plan.code,
-        params: update_args,
-      )
-
-      aggregate_failures do
-        expect(result).to be_success
-
-        plan_result = result.plan
-        expect(plan_result.id).to eq(plan.id)
-        expect(plan_result.name).to eq(update_args[:name])
-        expect(plan_result.code).to eq(update_args[:code])
-        expect(plan_result.charges.count).to eq(2)
-      end
-    end
-
-    context 'with validation errors' do
-      let(:plan_name) { nil }
-
-      it 'returns an error' do
-        result = plans_service.update_from_api(
-          organization: organization,
-          code: plan.code,
-          params: update_args,
-        )
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages[:name]).to eq(['value_is_mandatory'])
-        end
-      end
-    end
-
-    context 'with metrics from other organization' do
-      let(:billable_metrics) { create_list(:billable_metric, 2) }
-
-      it 'returns an error' do
-        result = plans_service.update_from_api(
-          organization: organization,
-          code: plan.code,
-          params: update_args,
-        )
-
-        expect(result).not_to be_success
-        expect(result.error.error_code).to eq('plan_not_found')
-      end
-    end
-
-    context 'when plan is not found' do
-      it 'returns an error' do
-        result = plans_service.update_from_api(
-          organization: organization,
-          code: 'fake_code12345',
-          params: update_args,
-        )
-
-        expect(result).not_to be_success
-        expect(result.error.error_code).to eq('plan_not_found')
-      end
-    end
-
-    context 'when attached to a subscription' do
-      before { create(:subscription, plan: plan) }
-
-      it 'updates only name and description' do
-        result = plans_service.update_from_api(
-          organization: organization,
-          code: plan.code,
-          params: update_args,
-        )
-
-        plan_result = result.plan
-        aggregate_failures do
-          expect(plan_result.name).to eq(update_args[:name])
-          expect(plan_result.description).to eq(update_args[:description])
-          expect(plan_result.amount_cents).not_to eq(update_args[:amount_cents])
-          expect(plan.charges.count).to eq(2)
-        end
-      end
-    end
-
-    context 'with existing charges' do
-      let(:existing_charge) do
-        create(
-          :standard_charge,
-          plan_id: plan.id,
-          billable_metric_id: billable_metrics.first.id,
-          properties: {
-            amount: '300',
-          },
-        )
-      end
-      let(:update_args) do
-        {
-          id: plan.id,
-          name: plan_name,
-          code: 'new_plan',
-          interval: 'monthly',
-          pay_in_advance: false,
-          amount_cents: 200,
-          amount_currency: 'EUR',
-          charges: [
-            {
-              id: existing_charge.id,
-              billable_metric_id: billable_metrics.first.id,
-              charge_model: 'standard',
-              properties: {
-                amount: '100',
-              },
-            },
-            {
-              billable_metric_id: billable_metrics.last.id,
-              charge_model: 'standard',
-              properties: {
-                amount: '300',
-              },
-            },
-          ],
-        }
-      end
-
-      before { existing_charge }
-
-      it 'updates existing charge and creates an other one' do
-        expect do
-          plans_service.update_from_api(
-            organization: organization,
-            code: plan.code,
-            params: update_args,
-          )
-        end.to change(Charge, :count).by(1)
-      end
-    end
-
-    context 'with charge to delete' do
-      let(:existing_charge) do
-        create(
-          :standard_charge,
-          plan_id: plan.id,
-          billable_metric_id: billable_metrics.first.id,
-          properties: {
-            amount: '300',
-          },
-        )
-      end
-      let(:update_args) do
-        {
-          id: plan.id,
-          name: plan_name,
-          code: 'new_plan',
-          interval: 'monthly',
-          pay_in_advance: false,
-          amount_cents: 200,
-          amount_currency: 'EUR',
-          charges: [],
-        }
-      end
-
-      before { existing_charge }
-
-      it 'destroys the unattached charge' do
-        expect do
-          plans_service.update_from_api(
-            organization: organization,
-            code: plan.code,
-            params: update_args,
-          )
-        end.to change { plan.charges.count }.by(-1)
       end
     end
   end


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete/edit charges.

The goal of this feature is to be able to destroy a charge linked to an active or terminated subscription.

## Description

This PR merges `Plans::UpdateService#update` and `Plans::UpdateService#update_from_api` methods into a single one named `Plans::UpdateService#call`. This will reduce the amount of code to maintain and test and ensure the behavior is the same between API and GraphQL
