### PR TITLE
feat(delete_charge): Discard charge, properties and refresh invoices

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -32,7 +32,7 @@ class Charge < ApplicationRecord
   default_scope -> { kept }
 
   def properties(group_id: nil)
-    group_properties.find_by(group_id: group_id)&.values || read_attribute(:properties)
+    group_properties.find_by(group_id:)&.values || read_attribute(:properties)
   end
 
   private

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -100,9 +100,13 @@ module Plans
     def sanitize_charges(plan, args_charges, created_charges_ids)
       args_charges_ids = args_charges.reject { |c| c[:id].nil? }.map { |c| c[:id] }
       charges_ids = plan.charges.pluck(:id) - args_charges_ids - created_charges_ids
-      charges_ids.each do |charge_id|
-        Charge.find_by(id: charge_id).destroy!
-      end
+      charges_ids.each { |id| discard_charge!(id) }
+    end
+
+    def discard_charge!(id)
+      charge = Charge.find_by(id:)
+      charge.discard!
+      charge.group_properties.discard_all
     end
   end
 end

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
     it 'enqueues a Invoices::RefreshBatchJob' do
       invoice = create(:invoice, :draft)
       create(:invoice_subscription, subscription:, invoice:)
-      subscription.invoices << invoice
 
       expect do
         destroy_service.call


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete/edit charges.

The goal of this feature is to be able to destroy a charge linked to an active or terminated subscription.

## Description

Objective:
- discard charge 
- discard group properties
- refresh related draft invoices