### PR TITLE
feat(delete_plan): Merge API and GraphQL service method to destroy plan

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -31,11 +31,8 @@ module Api
       end
 
       def destroy
-        service = Plans::DestroyService.new
-        result = service.destroy_from_api(
-          organization: current_organization,
-          code: params[:code],
-        )
+        plan = current_organization.plans.find_by(code: params[:code])
+        result = Plans::DestroyService.call(plan:)
 
         if result.success?
           render_plan(result.plan)

--- a/app/graphql/mutations/plans/destroy.rb
+++ b/app/graphql/mutations/plans/destroy.rb
@@ -13,7 +13,8 @@ module Mutations
       field :id, ID, null: true
 
       def resolve(id:)
-        result = ::Plans::DestroyService.new(context[:current_user]).destroy(id)
+        plan = context[:current_user].plans.find_by(id:)
+        result = ::Plans::DestroyService.call(plan:)
 
         result.success? ? result.plan : result_error(result)
       end

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -2,8 +2,16 @@
 
 module Plans
   class DestroyService < BaseService
-    def destroy(id)
-      plan = result.user.plans.find_by(id: id)
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(plan:)
+      @plan = plan
+      super
+    end
+
+    def call
       return result.not_found_failure!(resource: 'plan') unless plan
       return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless plan.deletable?
 
@@ -13,15 +21,8 @@ module Plans
       result
     end
 
-    def destroy_from_api(organization:, code:)
-      plan = organization.plans.find_by(code: code)
-      return result.not_found_failure!(resource: 'plan') unless plan
-      return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless plan.deletable?
+    private
 
-      plan.destroy!
-
-      result.plan = plan
-      result
-    end
+    attr_reader :plan
   end
 end

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Plans::DestroyService, type: :service do
 
   before { plan }
 
-  describe 'destroy' do
+  describe '#call' do
     it 'destroys the plan' do
       expect { plans_service.call }
         .to change(Plan, :count).by(-1)

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -3,73 +3,46 @@
 require 'rails_helper'
 
 RSpec.describe Plans::DestroyService, type: :service do
-  subject(:plans_service) { described_class.new(membership.user) }
+  subject(:plans_service) { described_class.new(plan:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
+  let(:plan) { create(:plan, organization:) }
+
+  before { plan }
+
   describe 'destroy' do
-    let(:plan) { create(:plan, organization: organization) }
-
     it 'destroys the plan' do
-      id = plan.id
-
-      expect { plans_service.destroy(id) }
+      expect { plans_service.call }
         .to change(Plan, :count).by(-1)
     end
 
     context 'when plan is not found' do
-      it 'returns an error' do
-        result = plans_service.destroy(nil)
+      let(:plan) { nil }
 
-        expect(result).not_to be_success
-        expect(result.error.error_code).to eq('plan_not_found')
+      it 'returns an error' do
+        result = plans_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('plan_not_found')
+        end
       end
     end
 
     context 'when plan is attached to subscription' do
       before do
-        create(:subscription, plan: plan)
+        create(:subscription, plan:)
       end
 
       it 'returns an error' do
-        result = plans_service.destroy(plan.id)
+        result = plans_service.call
 
-        expect(result).not_to be_success
-        expect(result.error.code).to eq('attached_to_an_active_subscription')
-      end
-    end
-  end
-
-  describe 'destroy_from_api' do
-    let(:plan) { create(:plan, organization: organization) }
-
-    it 'destroys the plan' do
-      code = plan.code
-
-      expect { plans_service.destroy_from_api(organization: organization, code: code) }
-        .to change(Plan, :count).by(-1)
-    end
-
-    context 'when plan is not found' do
-      it 'returns an error' do
-        result = plans_service.destroy_from_api(organization: organization, code: 'invalid12345')
-
-        expect(result).not_to be_success
-        expect(result.error.error_code).to eq('plan_not_found')
-      end
-    end
-
-    context 'when plan is attached to subscription' do
-      let(:subscription) { create(:subscription, plan: plan) }
-
-      before { subscription }
-
-      it 'returns an error' do
-        result = plans_service.destroy_from_api(organization: organization, code: plan.code)
-
-        expect(result).not_to be_success
-        expect(result.error.code).to eq('attached_to_an_active_subscription')
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.code).to eq('attached_to_an_active_subscription')
+        end
       end
     end
   end


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete/edit plans.

The goal of this feature is to be able to destroy a plans linked to an active or terminated subscription.

## Description

This PR merges `Plans::DestroyService#update` and `Plans::DestroyService#update_from_api` methods into a single one named `Plans::DestroyService#call`. This will reduce the amount of code and test  to maintain and ensure the behavior is the same between API and GraphQL