### PR TITLE
feat (coupons): coupons v4 db changes

### DIFF
--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -7,6 +7,8 @@ class Coupon < ApplicationRecord
 
   has_many :applied_coupons
   has_many :customers, through: :applied_coupons
+  has_many :coupon_plans
+  has_many :plans, through: :coupon_plans
 
   STATUSES = [
     :active,

--- a/app/models/coupon_plan.rb
+++ b/app/models/coupon_plan.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CouponPlan < ApplicationRecord
+  belongs_to :coupon
+  belongs_to :plan
+end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -11,6 +11,8 @@ class Plan < ApplicationRecord
   has_many :subscriptions
   has_many :customers, through: :subscriptions
   has_many :children, class_name: 'Plan', foreign_key: :parent_id
+  has_many :coupon_plans
+  has_many :coupons, through: :coupon_plans
 
   INTERVALS = %i[
     weekly

--- a/db/migrate/20230125104957_create_coupon_plans.rb
+++ b/db/migrate/20230125104957_create_coupon_plans.rb
@@ -1,0 +1,12 @@
+class CreateCouponPlans < ActiveRecord::Migration[7.0]
+  def change
+    create_table :coupon_plans, id: :uuid do |t|
+      t.references :coupon, type: :uuid, index: true, null: false, foreign_key: true
+      t.references :plan, type: :uuid, index: true, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_column :coupons, :limited_plans, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20230125104957_create_coupon_plans.rb
+++ b/db/migrate/20230125104957_create_coupon_plans.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateCouponPlans < ActiveRecord::Migration[7.0]
   def change
     create_table :coupon_plans, id: :uuid do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_18_100324) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_25_104957) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -115,6 +115,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_18_100324) do
     t.index ["plan_id"], name: "index_charges_on_plan_id"
   end
 
+  create_table "coupon_plans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "coupon_id", null: false
+    t.uuid "plan_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["coupon_id"], name: "index_coupon_plans_on_coupon_id"
+    t.index ["plan_id"], name: "index_coupon_plans_on_plan_id"
+  end
+
   create_table "coupons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "organization_id", null: false
     t.string "name", null: false
@@ -132,6 +141,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_18_100324) do
     t.integer "frequency_duration"
     t.datetime "expiration_at"
     t.boolean "reusable", default: true, null: false
+    t.boolean "limited_plans", default: false, null: false
     t.index ["organization_id", "code"], name: "index_coupons_on_organization_id_and_code", unique: true, where: "(code IS NOT NULL)"
     t.index ["organization_id"], name: "index_coupons_on_organization_id"
   end
@@ -546,6 +556,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_18_100324) do
   add_foreign_key "billable_metrics", "organizations"
   add_foreign_key "charges", "billable_metrics"
   add_foreign_key "charges", "plans"
+  add_foreign_key "coupon_plans", "coupons"
+  add_foreign_key "coupon_plans", "plans"
   add_foreign_key "credit_note_items", "credit_notes"
   add_foreign_key "credit_note_items", "fees"
   add_foreign_key "credit_notes", "customers"


### PR DESCRIPTION
## Context

It’s impossible to assign a coupon only for some dedicated plans. It means that coupons is deducted from total invoice no matter the plans.

## Description

This PR adds basic DB changes needed for this feature
