### PR TITLE
feat(delete_plan): Remove plan canBeDeleted

### DIFF
--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -29,20 +29,12 @@ module Types
       field :active_subscriptions_count, Integer, null: false
       field :draft_invoices_count, Integer, null: false
 
-      field :can_be_deleted, Boolean, null: false do
-        description 'Check if plan is deletable'
-      end
-
       def charge_count
         object.charges.count
       end
 
       def customer_count
         object.subscriptions.active.select(:customer_id).distinct.count
-      end
-
-      def can_be_deleted
-        object.deletable?
       end
 
       def active_subscriptions_count

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -38,10 +38,6 @@ class Plan < ApplicationRecord
     subscriptions.exists?
   end
 
-  def deletable?
-    !attached_to_subscriptions?
-  end
-
   def has_trial?
     trial_period.present? && trial_period.positive?
   end

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -13,7 +13,6 @@ module Plans
 
     def call
       return result.not_found_failure!(resource: 'plan') unless plan
-      return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless plan.deletable?
 
       plan.destroy!
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -3611,11 +3611,6 @@ type Plan {
   billChargesMonthly: Boolean
 
   """
-  Check if plan is deletable
-  """
-  canBeDeleted: Boolean!
-
-  """
   Number of charges attached to a plan
   """
   chargeCount: Int!
@@ -3649,11 +3644,6 @@ type PlanDetails {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   billChargesMonthly: Boolean
-
-  """
-  Check if plan is deletable
-  """
-  canBeDeleted: Boolean!
 
   """
   Number of charges attached to a plan

--- a/schema.json
+++ b/schema.json
@@ -14337,24 +14337,6 @@
               ]
             },
             {
-              "name": "canBeDeleted",
-              "description": "Check if plan is deletable",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "chargeCount",
               "description": "Number of charges attached to a plan",
               "type": {
@@ -14743,24 +14725,6 @@
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "canBeDeleted",
-              "description": "Check if plan is deletable",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -322,25 +322,6 @@ RSpec.describe Api::V1::PlansController, type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
-
-    context 'when plan is attached to active subscription' do
-      let(:subscription) { create(:subscription, plan: plan) }
-      let(:plan) { create(:plan, organization: organization) }
-
-      before { subscription }
-
-      it 'returns forbidden error' do
-        delete_with_token(organization, "/api/v1/plans/#{plan.code}")
-
-        aggregate_failures do
-          expect(response).to have_http_status(:method_not_allowed)
-
-          expect(json[:status]).to eq(405)
-          expect(json[:error]).to eq('Method Not Allowed')
-          expect(json[:code]).to eq('attached_to_an_active_subscription')
-        end
-      end
-    end
   end
 
   describe 'index' do

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -30,20 +30,5 @@ RSpec.describe Plans::DestroyService, type: :service do
         end
       end
     end
-
-    context 'when plan is attached to subscription' do
-      before do
-        create(:subscription, plan:)
-      end
-
-      it 'returns an error' do
-        result = plans_service.call
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error.code).to eq('attached_to_an_active_subscription')
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete plans.

The goal of this feature is to be able to soft-delete a plan linked to an active or terminated subscription.

## Description

The goal of this PR is to remove `canBeDeleted` from plans.