### PR TITLE
feat(delete_plan): Add subscription and invoice counters to plans

### DIFF
--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -26,6 +26,8 @@ module Types
 
       field :charge_count, Integer, null: false, description: 'Number of charges attached to a plan'
       field :customer_count, Integer, null: false, description: 'Number of customers attached to a plan'
+      field :active_subscriptions_count, Integer, null: false
+      field :draft_invoices_count, Integer, null: false
 
       field :can_be_deleted, Boolean, null: false do
         description 'Check if plan is deletable'
@@ -41,6 +43,18 @@ module Types
 
       def can_be_deleted
         object.deletable?
+      end
+
+      def active_subscriptions_count
+        object.subscriptions.active.count
+      end
+
+      def draft_invoices_count
+        object.subscriptions.joins(:invoices)
+          .merge(Invoice.draft)
+          .select(:invoice_id)
+          .distinct
+          .count
       end
     end
   end

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -15,6 +15,8 @@ module V1
         trial_period: model.trial_period,
         pay_in_advance: model.pay_in_advance,
         bill_charges_monthly: model.bill_charges_monthly,
+        active_subscriptions_count:,
+        draft_invoices_count:,
       }
 
       payload = payload.merge(charges) if include?(:charges)
@@ -26,6 +28,19 @@ module V1
 
     def charges
       ::CollectionSerializer.new(model.charges, ::V1::ChargeSerializer, collection_name: 'charges').serialize
+    end
+
+    def active_subscriptions_count
+      model.subscriptions.active.count
+    end
+
+    def draft_invoices_count
+      model.subscriptions
+        .joins(:invoices)
+        .merge(Invoice.draft)
+        .select(:invoice_id)
+        .distinct
+        .count
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3605,6 +3605,7 @@ type Organization {
 }
 
 type Plan {
+  activeSubscriptionsCount: Int!
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   billChargesMonthly: Boolean
@@ -3627,6 +3628,7 @@ type Plan {
   """
   customerCount: Int!
   description: String
+  draftInvoicesCount: Int!
   id: ID!
   interval: PlanInterval!
   name: String!
@@ -3643,6 +3645,7 @@ type PlanCollection {
 }
 
 type PlanDetails {
+  activeSubscriptionsCount: Int!
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   billChargesMonthly: Boolean
@@ -3665,6 +3668,7 @@ type PlanDetails {
   """
   customerCount: Int!
   description: String
+  draftInvoicesCount: Int!
   id: ID!
   interval: PlanInterval!
   name: String!

--- a/schema.json
+++ b/schema.json
@@ -14269,6 +14269,24 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "activeSubscriptionsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "amountCents",
               "description": null,
               "type": {
@@ -14437,6 +14455,24 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "draftInvoicesCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -14647,6 +14683,24 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "activeSubscriptionsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "amountCents",
               "description": null,
               "type": {
@@ -14815,6 +14869,24 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "draftInvoicesCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/resolvers/plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_resolver_spec.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: true
 
 require 'rails_helper'
 
@@ -7,7 +7,11 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
     <<~GQL
       query($planId: ID!) {
         plan(id: $planId) {
-          id name customerCount
+          id
+          name
+          customerCount
+          activeSubscriptionsCount
+          draftInvoicesCount
         }
       }
     GQL
@@ -15,24 +19,19 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:plan) do
-    create(:plan, organization: organization)
-  end
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
 
   before do
     customer
-
-    2.times do
-      create(:subscription, customer: customer, plan: plan)
-    end
+    create_list(:subscription, 2, customer:, plan:)
   end
 
   it 'returns a single plan' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
-      query: query,
+      query:,
       variables: {
         planId: plan.id,
       },
@@ -57,7 +56,7 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
       )
 
       expect_graphql_error(
-        result: result,
+        result:,
         message: 'Missing organization id',
       )
     end
@@ -68,14 +67,14 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
-        query: query,
+        query:,
         variables: {
           planId: 'foo',
         },
       )
 
       expect_graphql_error(
-        result: result,
+        result:,
         message: 'Resource not found',
       )
     end

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ::V1::PlanSerializer do
   subject(:serializer) { described_class.new(plan, root_name: 'plan', includes: %i[charges]) }
 
   let(:plan) { create(:plan) }
-  let(:charge) { create(:standard_charge, plan: plan) }
+  let(:charge) { create(:standard_charge, plan:) }
 
   before { charge }
 
@@ -25,6 +25,8 @@ RSpec.describe ::V1::PlanSerializer do
       expect(result['plan']['trial_period']).to eq(plan.trial_period)
       expect(result['plan']['pay_in_advance']).to eq(plan.pay_in_advance)
       expect(result['plan']['bill_charges_monthly']).to eq(plan.bill_charges_monthly)
+      expect(result['plan']['active_subscriptions_count']).to eq(0)
+      expect(result['plan']['draft_invoices_count']).to eq(0)
       expect(result['plan']['charges'].first['lago_id']).to eq(charge.id)
       expect(result['plan']['charges'].first['group_properties']).to eq([])
     end


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete plans.

The goal of this feature is to be able to soft-delete a plan linked to an active or terminated subscription.

## Description

The goal of this PR is to add two counters in the `V1::PlanSerializer` and `Plan` GraphQL type:
- `active_subscription_count`
- `draft_invoice_count`