### PR TITLE
feat(delete_plan): Add deleted_at on plans

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -2,6 +2,8 @@
 
 class Plan < ApplicationRecord
   include Currencies
+  include Discard::Model
+  self.discard_column = :deleted_at
 
   belongs_to :organization
   belongs_to :parent, class_name: 'Plan', optional: true
@@ -25,6 +27,8 @@ class Plan < ApplicationRecord
   validates :name, presence: true
   validates :code, presence: true, uniqueness: { scope: :organization_id }
   validates :amount_currency, inclusion: { in: currency_list }
+
+  default_scope -> { kept }
 
   def pay_in_arrear?
     !pay_in_advance

--- a/db/migrate/20230126103454_add_deleted_at_to_plans.rb
+++ b/db/migrate/20230126103454_add_deleted_at_to_plans.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToPlans < ActiveRecord::Migration[7.0]
+  def change
+    add_column :plans, :deleted_at, :datetime
+    add_index :plans, :deleted_at
+
+    remove_index :plans, %i[code organization_id]
+    add_index :plans, %i[organization_id code], unique: true, where: 'deleted_at IS NULL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_18_100324) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_103454) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -457,7 +457,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_18_100324) do
     t.boolean "pay_in_advance", default: false, null: false
     t.boolean "bill_charges_monthly"
     t.uuid "parent_id"
-    t.index ["code", "organization_id"], name: "index_plans_on_code_and_organization_id", unique: true
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_plans_on_deleted_at"
+    t.index ["organization_id", "code"], name: "index_plans_on_organization_id_and_code", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_plans_on_organization_id"
     t.index ["parent_id"], name: "index_plans_on_parent_id"
   end


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete plans.

The goal of this feature is to be able to soft-delete a plan linked to an active or terminated subscription.

## Description

The goal of this PR is to add `deleted_at` on plans.