### PR TITLE
feat(webhooks): Add invoice payment status updated webhook

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -44,6 +44,8 @@ class SendWebhookJob < ApplicationJob
       Webhooks::Invoices::GeneratedService.new(object).call
     when 'invoice.drafted'
       Webhooks::Invoices::DraftedService.new(object).call
+    when 'invoice.payment_status_updated'
+      Webhooks::Invoices::PaymentStatusUpdatedService.new(object).call
     when 'subscription.terminated'
       Webhooks::Subscriptions::TerminatedService.new(object).call
     else

--- a/app/services/invoices/payments/gocardless_service.rb
+++ b/app/services/invoices/payments/gocardless_service.rb
@@ -63,6 +63,8 @@ module Invoices
           ready_for_payment_processing: invoice_payment_status != 'succeeded',
         )
         handle_prepaid_credits(payment.invoice, invoice_payment_status)
+
+        SendWebhookJob.perform_later('invoice.payment_status_updated', payment.invoice)
         track_payment_status_changed(payment.invoice)
 
         result

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -52,6 +52,8 @@ module Invoices
         payment.update!(status: status)
         payment.invoice.update!(payment_status: status, ready_for_payment_processing: status != 'succeeded')
         handle_prepaid_credits(payment.invoice, status)
+
+        SendWebhookJob.perform_later('invoice.payment_status_updated', payment.invoice)
         track_payment_status_changed(payment.invoice)
 
         result

--- a/app/services/webhooks/invoices/payment_status_updated_service.rb
+++ b/app/services/webhooks/invoices/payment_status_updated_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Invoices
+    class PaymentStatusUpdatedService < Webhooks::BaseService
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::InvoiceSerializer.new(
+          object,
+          root_name: 'invoice',
+        )
+      end
+
+      def webhook_type
+        'invoice.payment_status_updated'
+      end
+
+      def object_type
+        'invoice'
+      end
+    end
+  end
+end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -299,6 +299,28 @@ RSpec.describe SendWebhookJob, type: :job do
     end
   end
 
+  context 'when webhook type is invoice.payment_status_updated' do
+    let(:webhook_service) { instance_double(Webhooks::Invoices::PaymentStatusUpdatedService) }
+    let(:invoice) { create(:invoice) }
+
+    before do
+      allow(Webhooks::Invoices::PaymentStatusUpdatedService).to receive(:new)
+        .with(invoice)
+        .and_return(webhook_service)
+      allow(webhook_service).to receive(:call)
+    end
+
+    it 'calls the webhook service' do
+      send_webhook_job.perform_now(
+        'invoice.payment_status_updated',
+        invoice,
+      )
+
+      expect(Webhooks::Invoices::PaymentStatusUpdatedService).to have_received(:new)
+      expect(webhook_service).to have_received(:call)
+    end
+  end
+
   context 'with not implemented webhook type' do
     it 'raises a NotImplementedError' do
       expect { send_webhook_job.perform_now(:subscription, invoice) }

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -257,6 +257,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
 
     before do
       allow(SegmentTrackJob).to receive(:perform_later)
+      allow(SendWebhookJob).to receive(:perform_later)
       payment
     end
 
@@ -286,6 +287,18 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
           invoice_id: invoice.id,
           payment_status: invoice.payment_status,
         },
+      )
+    end
+
+    it 'calls the SendWebhook job' do
+      invoice = stripe_service.update_payment_status(
+        provider_payment_id: 'ch_123456',
+        status: 'succeeded',
+      ).payment.invoice
+      
+      expect(SendWebhookJob).to have_received(:perform_later).with(
+        'invoice.payment_status_updated',
+        invoice,
       )
     end
 

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         provider_payment_id: 'ch_123456',
         status: 'succeeded',
       ).payment.invoice
-      
+
       expect(SendWebhookJob).to have_received(:perform_later).with(
         'invoice.payment_status_updated',
         invoice,

--- a/spec/services/webhooks/invoices/payment_status_updated_service_spec.rb
+++ b/spec/services/webhooks/invoices/payment_status_updated_service_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Invoices::PaymentStatusUpdatedService do
+  subject(:webhook_service) { described_class.new(invoice) }
+
+  let(:webhook_url) { 'http://foo.bar' }
+  let(:organization) { create(:organization, webhook_url: webhook_url) }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:subscription) { create(:subscription, organization: organization, customer: customer) }
+  let(:invoice) { create(:invoice, customer: customer) }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post)
+    end
+
+    it 'calls the organization webhook url' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post)
+    end
+
+    it 'builds payload with invoice.payment_status_updated webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post) do |payload|
+        expect(payload[:webhook_type]).to eq('invoice.payment_status_updated')
+        expect(payload[:object_type]).to eq('invoice')
+      end
+    end
+  end
+end

--- a/spec/services/webhooks/invoices/payment_status_updated_service_spec.rb
+++ b/spec/services/webhooks/invoices/payment_status_updated_service_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe Webhooks::Invoices::PaymentStatusUpdatedService do
   subject(:webhook_service) { described_class.new(invoice) }
 
   let(:webhook_url) { 'http://foo.bar' }
-  let(:organization) { create(:organization, webhook_url: webhook_url) }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:subscription) { create(:subscription, organization: organization, customer: customer) }
-  let(:invoice) { create(:invoice, customer: customer) }
+  let(:organization) { create(:organization, webhook_url:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, organization:, customer:) }
+  let(:invoice) { create(:invoice, customer:) }
 
   describe '.call' do
     let(:lago_client) { instance_double(LagoHttpClient::Client) }


### PR DESCRIPTION
## Context

Customers are not notified when a payment status is updated on an invoice when using payment providers

## Description

- Add a `invoice.payment_status_updated` webhook

