### PR TITLE
fix(stripe): prevent issue with payment method update

### DIFF
--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -25,9 +25,9 @@ module PaymentProviderCustomers
     end
 
     def update_payment_method(organization_id:, stripe_customer_id:, payment_method_id:)
-      stripe_customer = PaymentProviderCustomers::StripeCustomer
+      @stripe_customer = PaymentProviderCustomers::StripeCustomer
         .joins(:customer)
-        .where(customers: { organization_id: organization_id })
+        .where(customers: { organization_id: })
         .find_by(provider_customer_id: stripe_customer_id)
       return result.not_found_failure!(resource: 'stripe_customer') unless stripe_customer
 
@@ -43,9 +43,9 @@ module PaymentProviderCustomers
     end
 
     def delete_payment_method(organization_id:, stripe_customer_id:, payment_method_id:)
-      stripe_customer = PaymentProviderCustomers::StripeCustomer
+      @stripe_customer = PaymentProviderCustomers::StripeCustomer
         .joins(:customer)
-        .where(customers: { organization_id: organization_id })
+        .where(customers: { organization_id: })
         .find_by(provider_customer_id: stripe_customer_id)
       return result.not_found_failure!(resource: 'stripe_customer') unless stripe_customer
 

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -75,8 +75,10 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
   end
 
   describe '.update_payment_method' do
+    subject(:stripe_service) { described_class.new }
+
     let(:stripe_customer) do
-      create(:stripe_customer, customer: customer, provider_customer_id: 'cus_123456')
+      create(:stripe_customer, customer:, provider_customer_id: 'cus_123456')
     end
 
     it 'updates the customer payment method' do
@@ -96,7 +98,7 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
       let(:invoice) do
         create(
           :invoice,
-          customer: customer,
+          customer:,
           total_amount_cents: 200,
           total_amount_currency: 'EUR',
         )
@@ -122,6 +124,8 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
   end
 
   describe '.delete_payment_method' do
+    subject(:stripe_service) { described_class.new }
+
     let(:payment_method_id) { 'card_12345' }
 
     let(:stripe_customer) do


### PR DESCRIPTION
## Context

Fix for the following error:

```
Module::DelegationError
PaymentProviderCustomers::StripeService#customer delegated to stripe_customer.customer, but stripe_customer is nil
```

The issue happen because, `PaymentProviderCustomers::StripeService#update_payment_method` is expecting for a `customer` attribute when trying to refresh the pending invoices.
This attribute is delegated to a `stripe_customer` instance variable, but it was not set in this context.

## Description

The fix is simple as we only need to set the `stripe_customer` instance variable.

A proper test coverage was also added

