### PR TITLE
feat (coupons): Handle coupon create and update for plan limitation

### DIFF
--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -94,6 +94,9 @@ module Api
           # NOTE: Legacy field
           :expiration_date,
           :reusable,
+          applies_to: [
+            plan_codes: [],
+          ]
         )
       end
 

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -105,6 +105,7 @@ module Api
           json: ::V1::CouponSerializer.new(
             coupon,
             root_name: 'coupon',
+            includes: %i[plans],
           ),
         )
       end

--- a/app/graphql/types/coupons/object.rb
+++ b/app/graphql/types/coupons/object.rb
@@ -22,6 +22,8 @@ module Types
       field :expiration, Types::Coupons::ExpirationEnum, null: false
       field :expiration_at, GraphQL::Types::ISO8601DateTime, null: true
 
+      field :plans, [Types::Plans::Object]
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
       field :terminated_at, GraphQL::Types::ISO8601DateTime, null: true

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -7,7 +7,7 @@ class Coupon < ApplicationRecord
 
   has_many :applied_coupons
   has_many :customers, through: :applied_coupons
-  has_many :coupon_plans
+  has_many :coupon_plans, dependent: :destroy
   has_many :plans, through: :coupon_plans
 
   STATUSES = [

--- a/app/serializers/v1/coupon_serializer.rb
+++ b/app/serializers/v1/coupon_serializer.rb
@@ -3,7 +3,7 @@
 module V1
   class CouponSerializer < ModelSerializer
     def serialize
-      {
+      payload = {
         lago_id: model.id,
         name: model.name,
         code: model.code,
@@ -14,10 +14,15 @@ module V1
         frequency: model.frequency,
         frequency_duration: model.frequency_duration,
         reusable: model.reusable,
+        limited_plans: model.limited_plans,
         created_at: model.created_at.iso8601,
         expiration: model.expiration,
         expiration_at: model.expiration_at&.iso8601,
       }.merge(legacy_values)
+
+      payload = payload.merge(plans) if include?(:plans)
+
+      payload
     end
 
     private
@@ -26,6 +31,11 @@ module V1
       ::V1::Legacy::CouponSerializer.new(
         model,
       ).serialize
+    end
+
+    def plans
+      ::CollectionSerializer
+        .new(model.plans, ::V1::PlanSerializer, collection_name: 'plans').serialize
     end
   end
 end

--- a/app/services/coupons/create_service.rb
+++ b/app/services/coupons/create_service.rb
@@ -5,10 +5,13 @@ module Coupons
     def create(args)
       return result unless valid?(args)
 
+      @limitations = args[:applies_to]&.deep_symbolize_keys || {}
+      @organization_id = args[:organization_id]
+
       reusable = args.key?(:reusable) ? args[:reusable] : true
 
-      coupon = Coupon.create!(
-        organization_id: args[:organization_id],
+      coupon = Coupon.new(
+        organization_id: organization_id,
         name: args[:name],
         code: args[:code],
         coupon_type: args[:coupon_type],
@@ -19,8 +22,21 @@ module Coupons
         frequency_duration: args[:frequency_duration],
         expiration: args[:expiration]&.to_sym,
         expiration_at: args[:expiration_at],
+        limited_plans: plan_identifiers.present?,
         reusable: reusable,
       )
+
+      if plan_identifiers.present?
+        plans = fetch_plans
+
+        return result.not_found_failure!(resource: 'plans') if plans.count != plan_identifiers.count
+      end
+
+      ActiveRecord::Base.transaction do
+        coupon.save!
+
+        plans.each { |plan| CouponPlan.create!(coupon:, plan:) } if plan_identifiers.present?
+      end
 
       result.coupon = coupon
       track_coupon_created(result.coupon)
@@ -31,6 +47,8 @@ module Coupons
 
     private
 
+    attr_reader :limitations, :organization_id
+
     def track_coupon_created(coupon)
       SegmentTrackJob.perform_later(
         membership_id: CurrentContext.membership,
@@ -38,9 +56,23 @@ module Coupons
         properties: {
           coupon_code: coupon.code,
           coupon_name: coupon.name,
-          organization_id: coupon.organization_id,
+          organization_id:,
         },
       )
+    end
+
+    def plan_identifiers
+      if api_context?
+        limitations[:plan_codes]&.uniq
+      else
+        limitations[:plan_ids]&.uniq
+      end
+    end
+
+    def fetch_plans
+      return Plan.where(code: plan_identifiers, organization_id:) if api_context?
+
+      Plan.where(id: plan_identifiers, organization_id:)
     end
 
     def valid?(args)

--- a/schema.graphql
+++ b/schema.graphql
@@ -1481,6 +1481,7 @@ type Coupon {
   name: String!
   organization: Organization
   percentageRate: Float
+  plans: [Plan!]
   reusable: Boolean!
   status: CouponStatusEnum!
   terminatedAt: ISO8601DateTime
@@ -1516,6 +1517,7 @@ type CouponDetails {
   name: String!
   organization: Organization
   percentageRate: Float
+  plans: [Plan!]
   reusable: Boolean!
   status: CouponStatusEnum!
   terminatedAt: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -3784,6 +3784,28 @@
               ]
             },
             {
+              "name": "plans",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Plan",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "reusable",
               "description": null,
               "type": {
@@ -4156,6 +4178,28 @@
                 "kind": "SCALAR",
                 "name": "Float",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "plans",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Plan",
+                    "ofType": null
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/factories/coupon_plans.rb
+++ b/spec/factories/coupon_plans.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :coupon_plan do
+    coupon
+    plan
+  end
+end

--- a/spec/serializers/v1/coupon_serializer_spec.rb
+++ b/spec/serializers/v1/coupon_serializer_spec.rb
@@ -3,9 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe ::V1::CouponSerializer do
-  subject(:serializer) { described_class.new(coupon, root_name: 'coupon') }
+  subject(:serializer) { described_class.new(coupon, root_name: 'coupon', includes: %i[plans]) }
 
-  let(:coupon) { create(:coupon) }
+  let(:coupon_plan) { create(:coupon_plan) }
+  let(:coupon) { coupon_plan.coupon }
+
+  before { coupon_plan }
 
   it 'serializes the object' do
     result = JSON.parse(serializer.to_json)
@@ -16,9 +19,11 @@ RSpec.describe ::V1::CouponSerializer do
       expect(result['coupon']['code']).to eq(coupon.code)
       expect(result['coupon']['amount_cents']).to eq(coupon.amount_cents)
       expect(result['coupon']['amount_currency']).to eq(coupon.amount_currency)
+      expect(result['coupon']['limited_plans']).to eq(coupon.limited_plans)
       expect(result['coupon']['expiration']).to eq(coupon.expiration)
       expect(result['coupon']['expiration_at']).to eq(coupon.expiration_at&.iso8601)
       expect(result['coupon']['created_at']).to eq(coupon.created_at.iso8601)
+      expect(result['coupon']['plans'].first['lago_id']).to eq(coupon_plan.plan.id)
     end
   end
 

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -101,5 +101,71 @@ RSpec.describe Coupons::CreateService, type: :service do
         end
       end
     end
+
+    context 'with plan limitations in graphql context' do
+      let(:plan) { create(:plan, organization:) }
+      let(:create_args) do
+        {
+          name: 'Super Coupon',
+          code: 'free-beer',
+          organization_id: organization.id,
+          coupon_type: 'fixed_amount',
+          frequency: 'once',
+          amount_cents: 100,
+          amount_currency: 'EUR',
+          expiration: 'time_limit',
+          reusable: false,
+          expiration_at:,
+          applies_to: {
+            plan_ids: [plan.id],
+          },
+        }
+      end
+
+      before { CurrentContext.source = 'graphql' }
+
+      it 'creates a coupon' do
+        expect { create_service.create(**create_args) }
+          .to change(Coupon, :count).by(1)
+      end
+
+      it 'creates a coupon plan' do
+        expect { create_service.create(**create_args) }
+          .to change(CouponPlan, :count).by(1)
+      end
+    end
+
+    context 'with plan limitations in api context' do
+      let(:plan) { create(:plan, organization:) }
+      let(:create_args) do
+        {
+          name: 'Super Coupon',
+          code: 'free-beer',
+          organization_id: organization.id,
+          coupon_type: 'fixed_amount',
+          frequency: 'once',
+          amount_cents: 100,
+          amount_currency: 'EUR',
+          expiration: 'time_limit',
+          reusable: false,
+          expiration_at:,
+          applies_to: {
+            plan_codes: [plan.code],
+          },
+        }
+      end
+
+      before { CurrentContext.source = 'api' }
+
+      it 'creates a coupon' do
+        expect { create_service.create(**create_args) }
+          .to change(Coupon, :count).by(1)
+      end
+
+      it 'creates a coupon plan' do
+        expect { create_service.create(**create_args) }
+          .to change(CouponPlan, :count).by(1)
+      end
+    end
   end
 end

--- a/spec/services/coupons/update_service_spec.rb
+++ b/spec/services/coupons/update_service_spec.rb
@@ -69,6 +69,72 @@ RSpec.describe Coupons::UpdateService, type: :service do
         end
       end
     end
+
+    context 'with new plan limitations' do
+      let(:plan) { create(:plan, organization:) }
+      let(:plan_second) { create(:plan, organization:) }
+      let(:coupon_plan) { create(:coupon_plan, coupon:, plan:) }
+      let(:update_args) do
+        {
+          id: coupon.id,
+          name: 'new name',
+          coupon_type: 'fixed_amount',
+          frequency: 'once',
+          amount_cents: 100,
+          amount_currency: 'EUR',
+          expiration: 'time_limit',
+          reusable: false,
+          expiration_at:,
+          applies_to: {
+            plan_ids: [plan.id, plan_second.id],
+          },
+        }
+      end
+
+      before do
+        CurrentContext.source = 'graphql'
+
+        plan_second
+        coupon_plan
+      end
+
+      it 'creates new coupon plans' do
+        expect { update_service.update(**update_args) }
+          .to change(CouponPlan, :count).by(1)
+      end
+    end
+
+    context 'with coupon plans to delete' do
+      let(:plan) { create(:plan, organization:) }
+      let(:coupon_plan) { create(:coupon_plan, coupon:, plan:) }
+      let(:update_args) do
+        {
+          id: coupon.id,
+          name: 'new name',
+          coupon_type: 'fixed_amount',
+          frequency: 'once',
+          amount_cents: 100,
+          amount_currency: 'EUR',
+          expiration: 'time_limit',
+          reusable: false,
+          expiration_at:,
+          applies_to: {
+            plan_ids: [],
+          },
+        }
+      end
+
+      before do
+        CurrentContext.source = 'graphql'
+
+        coupon_plan
+      end
+
+      it 'deletes a coupon plan' do
+        expect { update_service.update(**update_args) }
+          .to change(CouponPlan, :count).by(-1)
+      end
+    end
   end
 
   describe 'update_from_api' do
@@ -133,6 +199,80 @@ RSpec.describe Coupons::UpdateService, type: :service do
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('coupon_not_found')
+      end
+    end
+
+    context 'with new plan limitations' do
+      let(:plan) { create(:plan, organization:) }
+      let(:plan_second) { create(:plan, organization:) }
+      let(:coupon_plan) { create(:coupon_plan, coupon:, plan:) }
+      let(:update_args) do
+        {
+          name: name,
+          code: 'coupon1_code',
+          coupon_type: 'fixed_amount',
+          frequency: 'once',
+          amount_cents: 123,
+          amount_currency: 'EUR',
+          expiration: 'time_limit',
+          expiration_at: Time.current + 15.days,
+          applies_to: {
+            plan_codes: [plan.code, plan_second.code],
+          },
+        }
+      end
+
+      before do
+        CurrentContext.source = 'api'
+
+        plan_second
+        coupon_plan
+      end
+
+      it 'creates a new coupon plan' do
+        expect do
+          update_service.update_from_api(
+            organization:,
+            code: coupon.code,
+            params: update_args,
+          )
+        end.to change(CouponPlan, :count).by(1)
+      end
+    end
+
+    context 'with coupon plans to delete' do
+      let(:plan) { create(:plan, organization:) }
+      let(:coupon_plan) { create(:coupon_plan, coupon:, plan:) }
+      let(:update_args) do
+        {
+          name: name,
+          code: 'coupon1_code',
+          coupon_type: 'fixed_amount',
+          frequency: 'once',
+          amount_cents: 123,
+          amount_currency: 'EUR',
+          expiration: 'time_limit',
+          expiration_at: Time.current + 15.days,
+          applies_to: {
+            plan_codes: [],
+          },
+        }
+      end
+
+      before do
+        CurrentContext.source = 'api'
+
+        coupon_plan
+      end
+
+      it 'deletes a coupon plan' do
+        expect do
+          update_service.update_from_api(
+            organization:,
+            code: coupon.code,
+            params: update_args,
+          )
+        end.to change(CouponPlan, :count).by(-1)
       end
     end
   end


### PR DESCRIPTION
## Context

It’s impossible to assign a coupon only for some dedicated plans. It means that coupons is deducted from total invoice no matter the plans.

## Description

This PR adds logic to handle coupon save and update with given plan limitations
