### PR TITLE
fix: Accept timestamp as string

### DIFF
--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -18,7 +18,7 @@ module Events
       Events::ValidateCreationService.call(organization:, params:, customer:, result:)
       return result unless result.success?
 
-      event_timestamp = Time.zone.at(params[:timestamp] || timestamp)
+      event_timestamp = Time.zone.at(params[:timestamp] ? params[:timestamp].to_i : timestamp)
       subscription = Subscription
         .where(external_id: params[:external_subscription_id])
         .where('started_at <= ?', event_timestamp)

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe Events::CreateService, type: :service do
       end
     end
 
+    context 'when timestamp is given as string' do
+      it 'creates an event by setting timestamp' do
+        create_args[:timestamp] = create_args[:timestamp].to_s
+
+        result = create_service.call(organization:, params: create_args, timestamp:, metadata: {})
+        expect(result).to be_success
+        expect(result.event.timestamp).to eq(Time.zone.at(create_args[:timestamp].to_i))
+      end
+    end
+
     context 'when creating an event to a terminated subscription' do
       let(:subscription) do
         create(:subscription, customer:, organization:, status: :terminated, started_at: 1.month.ago)


### PR DESCRIPTION
The goal of this PR is to not raise an exception is someone is creating an event by using a string for the timestamp.