### PR TITLE
fix(stripe): Ignore not found payment webhook when not created with lago

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -41,15 +41,20 @@ module Invoices
         result
       end
 
-      def update_payment_status(provider_payment_id:, status:)
-        payment = Payment.find_by(provider_payment_id: provider_payment_id)
-        return result.not_found_failure!(resource: 'stripe_payment') unless payment
+      def update_payment_status(provider_payment_id:, status:, metadata: {})
+        payment = Payment.find_by(provider_payment_id:)
+        unless payment
+          # NOTE: Payment was not initiated by lago
+          return result unless metadata&.key?(:lago_invoice_id)
+
+          return result.not_found_failure!(resource: 'stripe_payment')
+        end
 
         result.payment = payment
         result.invoice = payment.invoice
         return result if payment.invoice.succeeded?
 
-        payment.update!(status: status)
+        payment.update!(status:)
         payment.invoice.update!(payment_status: status, ready_for_payment_processing: status != 'succeeded')
         handle_prepaid_credits(payment.invoice, status)
 

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -115,7 +115,8 @@ module PaymentProviders
         Invoices::Payments::StripeService
           .new.update_payment_status(
             provider_payment_id: event.data.object.id,
-            status: status,
+            status:,
+            metadata: event.data.object.metadata.to_h.symbolize_keys,
           )
       when 'payment_method.detached'
         result = PaymentProviderCustomers::StripeService

--- a/spec/fixtures/stripe/payment_intent_event.json
+++ b/spec/fixtures/stripe/payment_intent_event.json
@@ -34,7 +34,9 @@
       "invoice": null,
       "last_payment_error": null,
       "livemode": false,
-      "metadata": {},
+      "metadata": {
+        "lago_invoice_id": "a587e552-36bc-4334-81f2-abcbf034ad3f"
+      },
       "next_action": null,
       "on_behalf_of": null,
       "payment_method": null,

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -345,5 +345,37 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         end
       end
     end
+
+    context 'when payment is not found' do
+      let(:payment) { nil }
+
+      it 'returns an empty result' do
+        result = stripe_service.update_payment_status(
+          provider_payment_id: 'ch_123456',
+          status: 'succeeded',
+        )
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.payment).to be_nil
+        end
+      end
+
+      context 'with invoice id in metadata' do
+        it 'returns a not found failure' do
+          result = stripe_service.update_payment_status(
+            provider_payment_id: 'ch_123456',
+            status: 'succeeded',
+            metadata: { lago_invoice_id: SecureRandom.uuid },
+          )
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq('stripe_payment_not_found')
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -241,6 +241,13 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
 
         expect(Invoices::Payments::StripeService).to have_received(:new)
         expect(payment_service).to have_received(:update_payment_status)
+          .with(
+            provider_payment_id: 'pi_1JKS2Y2VYugoKSBzNHPFBNj9',
+            status: 'succeeded',
+            metadata: {
+              lago_invoice_id: 'a587e552-36bc-4334-81f2-abcbf034ad3f',
+            },
+          )
       end
     end
 


### PR DESCRIPTION
## Context

This fix is related to the following error:
```
BaseService::NotFoundFailure
stripe_payment_not_found
```
We have A LOT of them in sentry and A LOT of related dead jobs.

The issue is that we are receiving stripe webhooks for all payment executed by Stripe, even those not initiated by Lago, leading to a failure because the app is unable to find a matching payment.

## Description

Since we are sending the invoice ID in the metadata when initiating the payment, to we should be looking for the presence of this id in the hook object metadata and ignore the hook if the field is not present.