### PR TITLE
misc: Disable wrap parameters by default

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::API
+  wrap_parameters false
+
   include ApiResponses
 
   rescue_from ActionController::RoutingError, with: :not_found


### PR DESCRIPTION
We don't want to wrap the parameters hash into a nested hash by default.
This will allow returning a 400 bad request when clients submit requests without specifying root elements.