### PR TITLE
feat (coupons): coupon overlapping plans validation

### DIFF
--- a/app/services/applied_coupons/create_service.rb
+++ b/app/services/applied_coupons/create_service.rb
@@ -49,6 +49,7 @@ module AppliedCoupons
     def check_preconditions
       return result.not_found_failure!(resource: 'customer') unless customer
       return result.not_found_failure!(resource: 'coupon') unless coupon
+      return result.not_allowed_failure!(code: 'plan_overlapping') if plan_limitation_overlapping?
       return if reusable_coupon?
 
       result.single_validation_failure!(field: 'coupon', error_code: 'coupon_is_not_reusable')
@@ -94,6 +95,16 @@ module AppliedCoupons
       return true if coupon.reusable?
 
       customer.applied_coupons.where(coupon_id: coupon.id).none?
+    end
+
+    def plan_limitation_overlapping?
+      return false unless coupon.limited_plans?
+
+      related_plans = coupon.coupon_plans.pluck(:plan_id)
+
+      active_coupons_ids = customer.applied_coupons.active.pluck(:coupon_id)
+
+      CouponPlan.where(coupon_id: active_coupons_ids, plan_id: related_plans).exists?
     end
 
     def track_applied_coupon_created(applied_coupon)

--- a/app/services/applied_coupons/create_service.rb
+++ b/app/services/applied_coupons/create_service.rb
@@ -100,11 +100,12 @@ module AppliedCoupons
     def plan_limitation_overlapping?
       return false unless coupon.limited_plans?
 
-      related_plans = coupon.coupon_plans.pluck(:plan_id)
-
-      active_coupons_ids = customer.applied_coupons.active.pluck(:coupon_id)
-
-      CouponPlan.where(coupon_id: active_coupons_ids, plan_id: related_plans).exists?
+      customer
+        .applied_coupons
+        .active
+        .joins(coupon: :coupon_plans)
+        .where(coupon_plans: { plan_id: coupon.coupon_plans.select(:plan_id) })
+        .exists?
     end
 
     def track_applied_coupon_created(applied_coupon)

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -177,6 +177,28 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
       end
     end
 
+    context 'when coupon is already applied with the same plan limitation' do
+      let(:plan) { create(:plan, organization:) }
+      let(:coupon_old) { create(:coupon, status: 'active', organization:, limited_plans: true) }
+      let(:coupon) { create(:coupon, status: 'active', organization:, limited_plans: true) }
+      let(:coupon_plan_old) { create(:coupon_plan, coupon: coupon_old, plan:) }
+      let(:coupon_plan) { create(:coupon_plan, coupon:, plan:) }
+
+      before do
+        coupon_plan_old
+        coupon_plan
+        create(:applied_coupon, customer:, coupon: coupon_old)
+      end
+
+      it 'fails' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(create_result.error.code).to eq('plan_overlapping')
+        end
+      end
+    end
+
     context 'when coupon is inactive' do
       before { coupon.terminated! }
 
@@ -325,6 +347,28 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
           expect(create_result.error).to be_a(BaseService::ValidationFailure)
           expect(create_result.error.messages.keys).to include(:coupon)
           expect(create_result.error.messages[:coupon]).to include('coupon_is_not_reusable')
+        end
+      end
+    end
+
+    context 'when coupon is already applied with the same plan limitation' do
+      let(:plan) { create(:plan, organization:) }
+      let(:coupon_old) { create(:coupon, status: 'active', organization:, limited_plans: true) }
+      let(:coupon) { create(:coupon, status: 'active', organization:, limited_plans: true) }
+      let(:coupon_plan_old) { create(:coupon_plan, coupon: coupon_old, plan:) }
+      let(:coupon_plan) { create(:coupon_plan, coupon:, plan:) }
+
+      before do
+        coupon_plan_old
+        coupon_plan
+        create(:applied_coupon, customer:, coupon: coupon_old)
+      end
+
+      it 'fails' do
+        aggregate_failures do
+          expect(create_result).not_to be_success
+          expect(create_result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(create_result.error.code).to eq('plan_overlapping')
         end
       end
     end


### PR DESCRIPTION
## Context

It’s impossible to assign a coupon only for some dedicated plans. It means that coupons is deducted from total invoice no matter the plans.

## Description

This PR adds validation that prevent adding plan limitation only if there is plan limitation already added on previous coupon (that is applied on customer)
