### PR TITLE
feat(delete_plan): Ability to delete a plan linked to subscriptions

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -32,7 +32,7 @@ module Api
 
       def destroy
         plan = current_organization.plans.find_by(code: params[:code])
-        result = Plans::DestroyService.call(plan:)
+        result = Plans::PrepareDestroyService.call(plan:)
 
         if result.success?
           render_plan(result.plan)

--- a/app/graphql/mutations/plans/destroy.rb
+++ b/app/graphql/mutations/plans/destroy.rb
@@ -14,7 +14,7 @@ module Mutations
 
       def resolve(id:)
         plan = context[:current_user].plans.find_by(id:)
-        result = ::Plans::DestroyService.call(plan:)
+        result = ::Plans::PrepareDestroyService.call(plan:)
 
         result.success? ? result.plan : result_error(result)
       end

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -35,7 +35,6 @@ module Types
       field :subscriptions, [Types::Subscriptions::Object]
       field :invoice_subscriptions, [Types::InvoiceSubscription::Object]
       field :fees, [Types::Fees::Object], null: true
-      field :plan, Types::Plans::Object
       field :credit_notes, [Types::CreditNotes::Object], null: true
 
       field :wallet_transaction_amount_cents, GraphQL::Types::BigInt, null: false

--- a/app/jobs/plans/destroy_job.rb
+++ b/app/jobs/plans/destroy_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Plans
+  class DestroyJob < ApplicationJob
+    queue_as 'default'
+
+    def perform(plan)
+      result = Plans::DestroyService.call(plan:)
+      result.raise_if_error!
+    end
+  end
+end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -25,8 +25,10 @@ class Plan < ApplicationRecord
   monetize :amount_cents
 
   validates :name, presence: true
-  validates :code, presence: true, uniqueness: { scope: :organization_id }
   validates :amount_currency, inclusion: { in: currency_list }
+  validates :code,
+            presence: true,
+            uniqueness: { conditions: -> { where(deleted_at: nil) }, scope: :organization_id }
 
   default_scope -> { kept }
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -2,7 +2,7 @@
 
 class Subscription < ApplicationRecord
   belongs_to :customer
-  belongs_to :plan
+  belongs_to :plan, -> { with_discarded }
   belongs_to :previous_subscription, class_name: 'Subscription', optional: true
 
   has_one :organization, through: :customer

--- a/app/queries/plans_query.rb
+++ b/app/queries/plans_query.rb
@@ -17,7 +17,7 @@ class PlansQuery < BaseQuery
   attr_reader :search_term
 
   def base_scope
-    Plan.where(organization:).ransack(search_params)
+    Plan.where(organization:).where(pending_deletion: false).ransack(search_params)
   end
 
   def search_params

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -23,6 +23,7 @@ module Plans
       invoices = Invoice.draft.joins(:plans).where(plans: { id: plan.id }).distinct
       invoices.each { |invoice| Invoices::FinalizeService.call(invoice:) }
 
+      plan.pending_deletion = false
       plan.discard!
       track_plan_deleted
 

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -14,7 +14,20 @@ module Plans
     def call
       return result.not_found_failure!(resource: 'plan') unless plan
 
-      plan.destroy!
+      draft_invoice_ids = Invoice.draft.joins(:plans)
+        .where(plans: { id: plan.id }).distinct.pluck(:id)
+
+      plan.discard!
+
+      # NOTE: Terminate active subscriptions asynchronously.
+      plan.subscriptions.active do |subscription|
+        Subscriptions::TerminateJob.perform_later(subscription, Time.current.to_i)
+      end
+
+      # NOTE: Refresh all draft invoices asynchronously.
+      Invoices::RefreshBatchJob.perform_later(draft_invoice_ids)
+
+      track_plan_deleted
 
       result.plan = plan
       result
@@ -23,5 +36,29 @@ module Plans
     private
 
     attr_reader :plan
+
+    def track_plan_deleted
+      count_by_charge_model = plan.charges.group(:charge_model).count
+
+      SegmentTrackJob.perform_later(
+        membership_id: CurrentContext.membership,
+        event: 'plan_deleted',
+        properties: {
+          code: plan.code,
+          name: plan.name,
+          description: plan.description,
+          plan_interval: plan.interval,
+          plan_amount_cents: plan.amount_cents,
+          plan_period: plan.pay_in_advance ? 'advance' : 'arrears',
+          trial: plan.trial_period,
+          nb_charges: plan.charges.count,
+          nb_standard_charges: count_by_charge_model['standard'] || 0,
+          nb_percentage_charges: count_by_charge_model['percentage'] || 0,
+          nb_graduated_charges: count_by_charge_model['graduated'] || 0,
+          nb_package_charges: count_by_charge_model['package'] || 0,
+          organization_id: plan.organization_id,
+        },
+      )
+    end
   end
 end

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -16,7 +16,7 @@ module Plans
 
       # NOTE: Terminate active subscriptions.
       plan.subscriptions.active.each do |subscription|
-        Subscriptions::TerminateService.new.terminate(subscription.id, async: false)
+        Subscriptions::TerminateService.call(subscription:, async: false)
       end
 
       # NOTE: Finalize all draft invoices.

--- a/app/services/plans/prepare_destroy_service.rb
+++ b/app/services/plans/prepare_destroy_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Plans
+  class PrepareDestroyService < BaseService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(plan:)
+      @plan = plan
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'plan') unless plan
+
+      plan.update!(pending_deletion: true)
+      Plans::DestroyJob.perform_later(plan)
+
+      result.plan = plan
+      result
+    end
+
+    private
+
+    attr_reader :plan
+  end
+end

--- a/db/migrate/20230127140904_add_pending_deletion_to_plans.rb
+++ b/db/migrate/20230127140904_add_pending_deletion_to_plans.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPendingDeletionToPlans < ActiveRecord::Migration[7.0]
+  def change
+    add_column :plans, :pending_deletion, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_26_103454) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_27_140904) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -458,6 +458,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_26_103454) do
     t.boolean "bill_charges_monthly"
     t.uuid "parent_id"
     t.datetime "deleted_at"
+    t.boolean "pending_deletion", default: false, null: false
     t.index ["deleted_at"], name: "index_plans_on_deleted_at"
     t.index ["organization_id", "code"], name: "index_plans_on_organization_id_and_code", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_plans_on_organization_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -3001,7 +3001,6 @@ type Invoice {
   legacy: Boolean!
   number: String!
   paymentStatus: InvoicePaymentStatusTypeEnum!
-  plan: Plan
   refundableAmountCents: BigInt!
   sequentialId: ID!
   status: InvoiceStatusTypeEnum!

--- a/schema.json
+++ b/schema.json
@@ -11482,20 +11482,6 @@
               ]
             },
             {
-              "name": "plan",
-              "description": null,
-              "type": {
-                "kind": "OBJECT",
-                "name": "Plan",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "refundableAmountCents",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/plans/destroy_spec.rb
+++ b/spec/graphql/mutations/plans/destroy_spec.rb
@@ -3,6 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe Mutations::Plans::Destroy, type: :graphql do
+  subject(:graphql_request) do
+    execute_graphql(
+      current_user: membership.user,
+      query: mutation,
+      variables: { input: { id: plan.id } },
+    )
+  end
+
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization: membership.organization) }
@@ -17,16 +25,12 @@ RSpec.describe Mutations::Plans::Destroy, type: :graphql do
     GQL
   end
 
-  it 'deletes a plan' do
-    result = execute_graphql(
-      current_user: membership.user,
-      query: mutation,
-      variables: {
-        input: { id: plan.id }
-      }
-    )
+  it 'marks plan as pending_deletion' do
+    expect { graphql_request }.to change { plan.reload.pending_deletion }.from(false).to(true)
+  end
 
-    data = result['data']['destroyPlan']
+  it 'returns the deleted plan' do
+    data = graphql_request['data']['destroyPlan']
     expect(data['id']).to eq(plan.id)
   end
 
@@ -34,9 +38,7 @@ RSpec.describe Mutations::Plans::Destroy, type: :graphql do
     it 'returns an error' do
       result = execute_graphql(
         query: mutation,
-        variables: {
-          input: { id: plan.id }
-        }
+        variables: { input: { id: plan.id } },
       )
 
       expect_unauthorized_error(result)

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::PlansController, type: :request do
   let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization: organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
 
   describe 'create' do
     let(:create_params) do
@@ -91,7 +91,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
     end
 
     context 'with group properties on charges' do
-      let(:group) { create(:group, billable_metric: billable_metric) }
+      let(:group) { create(:group, billable_metric:) }
       let(:create_params) do
         {
           name: 'P1',
@@ -164,12 +164,12 @@ RSpec.describe Api::V1::PlansController, type: :request do
   end
 
   describe 'update' do
-    let(:plan) { create(:plan, organization: organization) }
+    let(:plan) { create(:plan, organization:) }
     let(:code) { 'plan_code' }
     let(:update_params) do
       {
         name: 'P1',
-        code: code,
+        code:,
         interval: 'weekly',
         description: 'description',
         amount_cents: 100,
@@ -209,7 +209,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
     end
 
     context 'when plan code already exists in organization scope (validation error)' do
-      let(:plan2) { create(:plan, organization: organization) }
+      let(:plan2) { create(:plan, organization:) }
       let(:code) { plan2.code }
 
       before { plan2 }
@@ -226,7 +226,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
     end
 
     context 'with group properties on charges' do
-      let(:group) { create(:group, billable_metric: billable_metric) }
+      let(:group) { create(:group, billable_metric:) }
       let(:update_params) do
         {
           name: 'P1',
@@ -272,7 +272,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
   end
 
   describe 'show' do
-    let(:plan) { create(:plan, organization: organization) }
+    let(:plan) { create(:plan, organization:) }
 
     it 'returns a plan' do
       get_with_token(
@@ -298,13 +298,11 @@ RSpec.describe Api::V1::PlansController, type: :request do
   end
 
   describe 'destroy' do
-    let(:plan) { create(:plan, organization: organization) }
+    let(:plan) { create(:plan, organization:) }
 
-    before { plan }
-
-    it 'deletes a plan' do
+    it 'marks plan as pending_deletion' do
       expect { delete_with_token(organization, "/api/v1/plans/#{plan.code}") }
-        .to change(Plan, :count).by(-1)
+        .to change { plan.reload.pending_deletion }.from(false).to(true)
     end
 
     it 'returns deleted plan' do
@@ -325,7 +323,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
   end
 
   describe 'index' do
-    let(:plan) { create(:plan, organization: organization) }
+    let(:plan) { create(:plan, organization:) }
 
     before { plan }
 
@@ -340,7 +338,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
     end
 
     context 'with pagination' do
-      let(:plan2) { create(:plan, organization: organization) }
+      let(:plan2) { create(:plan, organization:) }
 
       before { plan2 }
 

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -93,6 +93,18 @@ RSpec.describe Plans::CreateService, type: :service do
       )
     end
 
+    context 'with code already used by a deleted plan' do
+      it 'creates a plan with the same code' do
+        create(:plan, organization:, code: 'new_plan', deleted_at: Time.current)
+
+        expect { plans_service.create(**create_args) }.to change(Plan, :count).by(1)
+
+        plans = organization.plans.with_discarded
+        expect(plans.count).to eq(2)
+        expect(plans.pluck(:code).uniq).to eq(['new_plan'])
+      end
+    end
+
     context 'with validation error' do
       let(:plan_name) { nil }
 

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -30,5 +30,72 @@ RSpec.describe Plans::DestroyService, type: :service do
         end
       end
     end
+
+    it 'calls SegmentTrackJob' do
+      allow(SegmentTrackJob).to receive(:perform_later)
+
+      plans_service.call
+
+      expect(SegmentTrackJob).to have_received(:perform_later).with(
+        membership_id: CurrentContext.membership,
+        event: 'plan_deleted',
+        properties: {
+          code: plan.code,
+          name: plan.name,
+          description: plan.description,
+          plan_interval: plan.interval,
+          plan_amount_cents: plan.amount_cents,
+          plan_period: 'arrears',
+          trial: plan.trial_period,
+          nb_charges: plan.charges.count,
+          nb_standard_charges: 0,
+          nb_percentage_charges: 0,
+          nb_graduated_charges: 0,
+          nb_package_charges: 0,
+          organization_id: plan.organization_id,
+        },
+      )
+    end
+
+    context 'with active subscriptions' do
+      let(:subscriptions) { create_list(:active_subscription, 2, plan:) }
+
+      before { subscriptions }
+
+      it 'terminates the subscriptions' do
+        result = plans_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          subscriptions.each do |subscription|
+            expect(subscription.reload).to be_terminated
+          end
+        end
+      end
+    end
+
+    context 'with draft invoices' do
+      let(:subscription) { create(:active_subscription, plan:) }
+      let(:invoices) { create_list(:invoice, 2, :draft) }
+
+      before do
+        invoices.each do |invoice|
+          create(:invoice_subscription, invoice:, subscription:)
+        end
+      end
+
+      it 'finalizes draft invoices' do
+        result = plans_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          invoices.each do |invoice|
+            expect(invoice.reload).to be_finalized
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Plans::DestroyService, type: :service do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
-  let(:plan) { create(:plan, organization:) }
+  let(:plan) { create(:plan, organization:, pending_deletion: true) }
 
   before { plan }
 
@@ -16,6 +16,10 @@ RSpec.describe Plans::DestroyService, type: :service do
     it 'destroys the plan' do
       expect { plans_service.call }
         .to change(Plan, :count).by(-1)
+    end
+
+    it 'sets pending_deletion to false' do
+      expect { plans_service.call }.to change { plan.reload.pending_deletion }.from(true).to(false)
     end
 
     context 'when plan is not found' do

--- a/spec/services/plans/prepare_destroy_service_spec.rb
+++ b/spec/services/plans/prepare_destroy_service_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Plans::PrepareDestroyService, type: :service do
+  subject(:prepare_destroy_service) { described_class.new(plan:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:plan) { create(:plan, organization:) }
+
+  describe '#call' do
+    it 'sets pending_deletion to true' do
+      expect { prepare_destroy_service.call }.to change { plan.reload.pending_deletion }
+        .from(false).to(true)
+    end
+
+    it 'enqueues a Plans::DestroyJob' do
+      prepare_destroy_service.call
+      expect(Plans::DestroyJob).to have_been_enqueued.with(plan)
+    end
+
+    it 'returns plan in the result' do
+      result = prepare_destroy_service.call
+      expect(result.plan).to eq(plan)
+    end
+
+    context 'when plan is not found' do
+      let(:plan) { nil }
+
+      it 'returns an error' do
+        result = prepare_destroy_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('plan_not_found')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete plans.

The goal of this feature is to be able to soft-delete a plan linked to an active or terminated subscription.

## Description

The goal of this PR is to be able to remove plans even if they are linked to active subscriptions.