### PR TITLE
feat(delete_plan): Merge subscription terminate methods

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -27,11 +27,8 @@ module Api
 
       # NOTE: We can't destroy a subscription, it will terminate it
       def terminate
-        result = Subscriptions::TerminateService.new
-          .terminate_from_api(
-            organization: current_organization,
-            external_id: params[:external_id],
-          )
+        subscription = current_organization.subscriptions.active.find_by(external_id: params[:external_id])
+        result = Subscriptions::TerminateService.call(subscription:)
 
         if result.success?
           render(

--- a/app/graphql/mutations/subscriptions/terminate.rb
+++ b/app/graphql/mutations/subscriptions/terminate.rb
@@ -16,7 +16,8 @@ module Mutations
       def resolve(**args)
         validate_organization!
 
-        result = ::Subscriptions::TerminateService.new.terminate(args[:id])
+        subscription = current_organization.subscriptions.find_by(id: args[:id])
+        result = ::Subscriptions::TerminateService.call(subscription:)
 
         result.success? ? result.subscription : result_error(result)
       end

--- a/app/jobs/subscriptions/terminate_job.rb
+++ b/app/jobs/subscriptions/terminate_job.rb
@@ -5,10 +5,8 @@ module Subscriptions
     queue_as 'billing'
 
     def perform(subscription, timestamp)
-      result = Subscriptions::TerminateService.new.terminate_and_start_next(
-        subscription: subscription,
-        timestamp: timestamp,
-      )
+      result = Subscriptions::TerminateService.new(subscription:)
+        .terminate_and_start_next(timestamp:)
 
       result.raise_if_error!
     end

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -2,22 +2,51 @@
 
 module Subscriptions
   class TerminateService < BaseService
-    def terminate(subscription_id)
-      subscription = Subscription.find_by(id: subscription_id)
-      return result.not_found_failure!(resource: 'subscription') if subscription.blank?
-
-      process_terminate(subscription)
+    def self.call(...)
+      new(...).call
     end
 
-    def terminate_from_api(organization:, external_id:)
-      subscription = organization.subscriptions.active.find_by(external_id:)
+    def initialize(subscription:)
+      @subscription = subscription
+
+      super
+    end
+
+    def call
       return result.not_found_failure!(resource: 'subscription') if subscription.blank?
 
-      process_terminate(subscription)
+      if subscription.starting_in_the_future?
+        subscription.mark_as_terminated!
+      elsif !subscription.terminated?
+        subscription.mark_as_terminated!
+
+        if subscription.plan.pay_in_advance?
+          # NOTE: As subscription was payed in advance and terminated before the end of the period,
+          #       we have to create a credit note for the days that were not consumed
+          credit_note_result = CreditNotes::CreateFromTermination.new(
+            subscription:,
+            reason: 'order_cancellation',
+          ).call
+          credit_note_result.raise_if_error!
+        end
+
+        BillSubscriptionJob.perform_later([subscription], subscription.terminated_at)
+      end
+
+      # NOTE: Pending next subscription should be canceled as well
+      subscription.next_subscription&.mark_as_canceled!
+
+      SendWebhookJob.perform_later(
+        'subscription.terminated',
+        subscription,
+      )
+
+      result.subscription = subscription
+      result
     end
 
     # NOTE: Called to terminate a downgraded subscription
-    def terminate_and_start_next(subscription:, timestamp:)
+    def terminate_and_start_next(timestamp:)
       next_subscription = subscription.next_subscription
       return result unless next_subscription
       return result unless next_subscription.pending?
@@ -57,35 +86,6 @@ module Subscriptions
 
     private
 
-    def process_terminate(subscription)
-      if subscription.starting_in_the_future?
-        subscription.mark_as_terminated!
-      elsif !subscription.terminated?
-        subscription.mark_as_terminated!
-
-        if subscription.plan.pay_in_advance?
-          # NOTE: As subscription was payed in advance and terminated before the end of the period,
-          #       we have to create a credit note for the days that were not consumed
-          credit_note_result = CreditNotes::CreateFromTermination.new(
-            subscription:,
-            reason: 'order_cancellation',
-          ).call
-          credit_note_result.raise_if_error!
-        end
-
-        BillSubscriptionJob.perform_later([subscription], subscription.terminated_at)
-      end
-
-      # NOTE: Pending next subscription should be canceled as well
-      subscription.next_subscription&.mark_as_canceled!
-
-      SendWebhookJob.perform_later(
-        'subscription.terminated',
-        subscription,
-      )
-
-      result.subscription = subscription
-      result
-    end
+    attr_reader :subscription
   end
 end

--- a/spec/graphql/mutations/subscriptions/terminate_spec.rb
+++ b/spec/graphql/mutations/subscriptions/terminate_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Mutations::Subscriptions::Terminate, type: :graphql do
   let(:membership) { create(:membership) }
-  let(:subscription) { create(:subscription) }
+  let(:subscription) { create(:subscription, organization: membership.organization) }
   let(:mutation) do
     <<~GQL
       mutation($input: TerminateSubscriptionInput!) {

--- a/spec/jobs/subscriptions/terminate_job_spec.rb
+++ b/spec/jobs/subscriptions/terminate_job_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe Subscriptions::TerminateJob, type: :job do
   let(:result) { BaseService::Result.new }
 
   it 'calls the subscription service' do
-    allow(Subscriptions::TerminateService).to receive(:new).and_return(subscription_service)
+    allow(Subscriptions::TerminateService).to receive(:new)
+      .with(subscription:)
+      .and_return(subscription_service)
     allow(subscription_service).to receive(:terminate_and_start_next)
-      .with(subscription: subscription, timestamp: timestamp)
+      .with(timestamp:)
       .and_return(result)
 
     described_class.perform_now(subscription, timestamp)
@@ -27,9 +29,11 @@ RSpec.describe Subscriptions::TerminateJob, type: :job do
     end
 
     it 'raises an error' do
-      allow(Subscriptions::TerminateService).to receive(:new).and_return(subscription_service)
+      allow(Subscriptions::TerminateService).to receive(:new)
+        .with(subscription:)
+        .and_return(subscription_service)
       allow(subscription_service).to receive(:terminate_and_start_next)
-        .with(subscription: subscription, timestamp: timestamp)
+        .with(timestamp:)
         .and_return(result)
 
       expect do


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete plans.

The goal of this feature is to be able to soft-delete a plan linked to an active or terminated subscription.

## Description

The goal of this PR is to merge `Subscriptions::TerminateService#terminate` and `Subscriptions::TerminateService#terminate_from_api` into a single one named `call`.
This will reduce the amount of code and test to maintain and ensure the behavior is the same between API and GraphQL