### PR TITLE
feat(delete_customer): Add API delete route and improve services

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -73,6 +73,22 @@ module Api
         )
       end
 
+      def destroy
+        customer = current_organization.customers.find_by(external_id: params[:external_id])
+        result = Customers::DestroyService.call(customer:)
+
+        if result.success?
+          render(
+            json: ::V1::CustomerSerializer.new(
+              result.customer,
+              root_name: 'customer',
+            ),
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
       private
 
       def create_params

--- a/app/graphql/mutations/customers/destroy.rb
+++ b/app/graphql/mutations/customers/destroy.rb
@@ -13,7 +13,8 @@ module Mutations
       field :id, ID, null: true
 
       def resolve(id:)
-        result = ::Customers::DestroyService.new(context[:current_user]).destroy(id: id)
+        customer = context[:current_user].customers.find_by(id:)
+        result = ::Customers::DestroyService.call(customer:)
 
         result.success? ? result.customer : result_error(result)
       end

--- a/app/services/customers/destroy_service.rb
+++ b/app/services/customers/destroy_service.rb
@@ -2,8 +2,17 @@
 
 module Customers
   class DestroyService < BaseService
-    def destroy(id:)
-      customer = result.user.customers.find_by(id: id)
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(customer:)
+      @customer = customer
+
+      super
+    end
+
+    def call
       return result.not_found_failure!(resource: 'customer') unless customer
       return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless customer.deletable?
 
@@ -12,5 +21,9 @@ module Customers
       result.customer = customer
       result
     end
+
+    private
+
+    attr_reader :customer
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :customers, param: :external_id, only: %i[create index show] do
+      resources :customers, param: :external_id, only: %i[create index show destroy] do
         get :current_usage
       end
 

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -398,4 +398,35 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       end
     end
   end
+
+  describe 'DELETE /customers/:customer_id' do
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+
+    before { customer }
+
+    it 'deletes a customer' do
+      expect { delete_with_token(organization, "/api/v1/customers/#{customer.external_id}") }
+        .to change(Customer, :count).by(-1)
+    end
+
+    it 'returns deleted customer' do
+      delete_with_token(organization, "/api/v1/customers/#{customer.external_id}")
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+
+        expect(json[:customer][:lago_id]).to eq(customer.id)
+        expect(json[:customer][:external_id]).to eq(customer.external_id)
+      end
+    end
+
+    context 'when customer does not exist' do
+      it 'returns not_found error' do
+        delete_with_token(organization, '/api/v1/customers/invalid')
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end

--- a/spec/services/customers/destroy_service_spec.rb
+++ b/spec/services/customers/destroy_service_spec.rb
@@ -3,34 +3,29 @@
 require 'rails_helper'
 
 RSpec.describe Customers::DestroyService, type: :service do
-  subject(:customers_service) { described_class.new(user) }
+  subject(:customers_service) { described_class.new(customer:) }
 
-  let(:user) { nil }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
   describe 'destroy' do
-    subject(:customers_service) { described_class.new(membership.user) }
-
     let(:membership) { create(:membership) }
     let(:organization) { membership.organization }
-    let(:customer) { create(:customer, organization: organization) }
+    let(:customer) { create(:customer, organization:) }
+
+    before { customer }
 
     it 'destroys the customer' do
-      id = customer.id
-
       expect do
-        customers_service.destroy(
-          id: id,
-        )
+        customers_service.call
       end.to change(Customer, :count).by(-1)
     end
 
     context 'when customer is not found' do
+      let(:customer) { nil }
+
       it 'returns an error' do
-        result = customers_service.destroy(
-          id: nil,
-        )
+        result = customers_service.call
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('customer_not_found')
@@ -39,13 +34,11 @@ RSpec.describe Customers::DestroyService, type: :service do
 
     context 'when customer is attached to subscription' do
       before do
-        create(:subscription, customer: customer)
+        create(:subscription, customer:)
       end
 
       it 'returns an error' do
-        result = customers_service.destroy(
-          id: customer.id,
-        )
+        result = customers_service.call
 
         expect(result).not_to be_success
         expect(result.error.code).to eq('attached_to_an_active_subscription')


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

The goal of this PR is to add the missing route `DELETE /api/v1/customers/:external_id` and to improve the `Customers::DestroyService`