### PR TITLE
feat (coupons): apply coupons with plan limitations on invoice

### DIFF
--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -5,6 +5,8 @@ module Credits
     def initialize(invoice:, applied_coupon:, base_amount_cents:)
       @invoice = invoice
       @applied_coupon = applied_coupon
+      # base_amount_cents represents maximum value that can be credited. It is either equal to invoice
+      # total_amount_cents or sum of the fees related to some plan (for coupons with plan limitations)
       @base_amount_cents = base_amount_cents
 
       super(nil)

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -2,9 +2,10 @@
 
 module Credits
   class AppliedCouponService < BaseService
-    def initialize(invoice:, applied_coupon:)
+    def initialize(invoice:, applied_coupon:, base_amount_cents:)
       @invoice = invoice
       @applied_coupon = applied_coupon
+      @base_amount_cents = base_amount_cents
 
       super(nil)
     end
@@ -36,7 +37,7 @@ module Credits
 
     private
 
-    attr_accessor :invoice, :applied_coupon
+    attr_accessor :invoice, :applied_coupon, :base_amount_cents
 
     delegate :coupon, to: :applied_coupon
 
@@ -46,17 +47,17 @@ module Credits
 
     def compute_amount
       if applied_coupon.coupon.percentage?
-        discounted_value = invoice.total_amount_cents * applied_coupon.percentage_rate.fdiv(100)
+        discounted_value = base_amount_cents * applied_coupon.percentage_rate.fdiv(100)
 
-        return (discounted_value >= invoice.total_amount_cents) ? invoice.total_amount_cents : discounted_value.round
+        return (discounted_value >= base_amount_cents) ? base_amount_cents : discounted_value.round
       end
 
       if applied_coupon.recurring? || applied_coupon.forever?
-        return invoice.total_amount_cents if applied_coupon.amount_cents > invoice.total_amount_cents
+        return base_amount_cents if applied_coupon.amount_cents > base_amount_cents
 
         applied_coupon.amount_cents
       else
-        return invoice.total_amount_cents if remaining_amount > invoice.total_amount_cents
+        return base_amount_cents if remaining_amount > base_amount_cents
 
         remaining_amount
       end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -143,7 +143,12 @@ module Invoices
     def applied_coupons
       return @applied_coupons if @applied_coupons
 
-      @applied_coupons = customer.applied_coupons.active.order(created_at: :asc)
+      with_plan_limit = customer.applied_coupons.active.joins(:coupon).where(coupon: { limited_plans: true })
+        .order(created_at: :asc)
+      applied_to_all = customer.applied_coupons.active.joins(:coupon).where(coupon: { limited_plans: false })
+        .order(created_at: :asc)
+
+      @applied_coupons = with_plan_limit + applied_to_all
     end
 
     def credit_notes
@@ -197,9 +202,17 @@ module Invoices
 
         next if applied_coupon.coupon.fixed_amount? && applied_coupon.amount_currency != currency
 
-        credit_result = Credits::AppliedCouponService.new(
-          invoice:, applied_coupon:,
-        ).create
+        base_amount_cents = if applied_coupon.coupon.limited_plans?
+          coupon_related_fees = coupon_fees(applied_coupon)
+
+          next unless coupon_related_fees.exists?
+
+          coupon_base_amount_cents(coupon_related_fees:)
+        else
+          invoice.total_amount_cents
+        end
+
+        credit_result = Credits::AppliedCouponService.new(invoice:, applied_coupon:, base_amount_cents:).create
         credit_result.raise_if_error!
 
         refresh_amounts(credit_amount_cents: credit_result.credit.amount_cents)
@@ -234,6 +247,26 @@ module Invoices
 
     def not_in_finalizing_process?
       invoice.draft? && context != :finalize
+    end
+
+    def coupon_fees(applied_coupon)
+      invoice
+        .fees
+        .joins(subscription: :plan)
+        .where(plan: { id: applied_coupon.coupon.coupon_plans.select(:plan_id) })
+    end
+
+    def coupon_base_amount_cents(coupon_related_fees:)
+      fee_amounts = coupon_related_fees.select(:amount_cents, :vat_amount_cents)
+
+      fees_amount_cents = fee_amounts.sum(&:amount_cents)
+      fees_vat_amount_cents = fee_amounts.sum(&:vat_amount_cents)
+
+      total_fees_amount_cents = fees_amount_cents + fees_vat_amount_cents
+
+      # In some cases when credit note is already applied sum from above
+      # can be greater than invoice total_amount_cents
+      total_fees_amount_cents > invoice.total_amount_cents ? invoice.total_amount_cents : total_fees_amount_cents
     end
   end
 end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -266,7 +266,7 @@ module Invoices
 
       # In some cases when credit note is already applied sum from above
       # can be greater than invoice total_amount_cents
-      total_fees_amount_cents > invoice.total_amount_cents ? invoice.total_amount_cents : total_fees_amount_cents
+      (total_fees_amount_cents > invoice.total_amount_cents) ? invoice.total_amount_cents : total_fees_amount_cents
     end
   end
 end

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -3,18 +3,21 @@
 require 'rails_helper'
 
 RSpec.describe Credits::AppliedCouponService do
-  subject(:credit_service) { described_class.new(invoice: invoice, applied_coupon: applied_coupon) }
+  subject(:credit_service) do
+    described_class.new(invoice:, applied_coupon:, base_amount_cents:)
+  end
 
   let(:invoice) do
     create(
       :invoice,
-      amount_cents: amount_cents,
+      amount_cents:,
       amount_currency: 'EUR',
       total_amount_cents: amount_cents,
       total_amount_currency: 'EUR',
     )
   end
   let(:amount_cents) { 123 }
+  let(:base_amount_cents) { invoice.total_amount_cents }
 
   let(:applied_coupon) { create(:applied_coupon, amount_cents: 12) }
 
@@ -60,8 +63,8 @@ RSpec.describe Credits::AppliedCouponService do
       before do
         create(
           :credit,
-          invoice: invoice,
-          applied_coupon: applied_coupon,
+          invoice:,
+          applied_coupon:,
           amount_cents: 12,
           amount_currency: 'EUR',
         )
@@ -77,7 +80,7 @@ RSpec.describe Credits::AppliedCouponService do
       before do
         create(
           :credit,
-          applied_coupon: applied_coupon,
+          applied_coupon:,
           amount_cents: 10,
         )
       end
@@ -106,7 +109,7 @@ RSpec.describe Credits::AppliedCouponService do
       let(:coupon) { create(:coupon, coupon_type: 'percentage') }
 
       let(:applied_coupon) do
-        create(:applied_coupon, coupon: coupon, percentage_rate: 20.00)
+        create(:applied_coupon, coupon:, percentage_rate: 20.00)
       end
 
       it 'creates a credit' do
@@ -135,7 +138,7 @@ RSpec.describe Credits::AppliedCouponService do
       let(:applied_coupon) do
         create(
           :applied_coupon,
-          coupon: coupon,
+          coupon:,
           frequency: 'recurring',
           frequency_duration: 3,
           frequency_duration_remaining: 3,
@@ -229,7 +232,7 @@ RSpec.describe Credits::AppliedCouponService do
       let(:applied_coupon) do
         create(
           :applied_coupon,
-          coupon: coupon,
+          coupon:,
           frequency: 'recurring',
           frequency_duration: 3,
           frequency_duration_remaining: 3,
@@ -262,7 +265,7 @@ RSpec.describe Credits::AppliedCouponService do
         let(:applied_coupon) do
           create(
             :applied_coupon,
-            coupon: coupon,
+            coupon:,
             frequency: 'recurring',
             frequency_duration: 3,
             frequency_duration_remaining: 1,


### PR DESCRIPTION
## Context

It’s impossible to assign a coupon only for some dedicated plans. It means that coupons is deducted from total invoice no matter the plans.

## Description

This PR handles applying coupons with plan limitations on invoice
