### PR TITLE
feat(delete_add_on): Process soft deletion

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -13,7 +13,7 @@ class Fee < ApplicationRecord
   has_one :customer, through: :subscription
   has_one :organization, through: :invoice
   has_one :billable_metric, -> { with_discarded }, through: :charge
-  has_one :add_on, through: :applied_add_on
+  has_one :add_on, -> { with_discarded }, through: :applied_add_on
 
   has_many :credit_note_items
   has_many :credit_notes, through: :credit_note_items

--- a/app/services/add_ons/destroy_service.rb
+++ b/app/services/add_ons/destroy_service.rb
@@ -15,7 +15,7 @@ module AddOns
     def call
       return result.not_found_failure!(resource: 'add_on') unless add_on
 
-      add_on.destroy!
+      add_on.discard!
 
       result.add_on = add_on
       result

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -38,6 +38,7 @@ FactoryBot.define do
 
   factory :add_on_fee, class: 'Fee' do
     invoice
+    applied_add_on
     fee_type { 'add_on' }
 
     amount_cents { 200 }

--- a/spec/models/add_on_spec.rb
+++ b/spec/models/add_on_spec.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe AddOn, type: :model do
-end

--- a/spec/services/add_ons/destroy_service_spec.rb
+++ b/spec/services/add_ons/destroy_service_spec.rb
@@ -13,9 +13,13 @@ RSpec.describe AddOns::DestroyService, type: :service do
   describe 'destroy' do
     before { add_on }
 
-    it 'destroys the add-on' do
-      expect { destroy_service.call }
-        .to change(AddOn, :count).by(-1)
+    it 'soft deletes the add-on' do
+      aggregate_failures do
+        expect { destroy_service.call }
+          .to change(AddOn, :count).by(-1)
+
+        expect(add_on.reload.deleted_at).to be_present
+      end
     end
 
     context 'when add-on is not found' do


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

To allow soft deletion of customers, we first need to be able to soft delete add_ons and coupons

The goal of this PR add the soft deletion logic for add_ons