### PR TITLE
fix(subscription): Fix credit note amount validation when terminating

### DIFF
--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -12,7 +12,7 @@ module CreditNotes
     def call
       return result if (last_subscription_fee&.amount_cents || 0).zero?
 
-      amount = compute_amount
+      amount = compute_amount.ceil
       return result unless amount.positive?
 
       # NOTE: if credit notes were already issued on the fee,

--- a/spec/scenarios/invoices_spec.rb
+++ b/spec/scenarios/invoices_spec.rb
@@ -93,12 +93,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           .and change { subscription_invoice.reload.credit_notes.count }.from(0).to(1)
           .and change { subscription.invoices.count }.from(1).to(2)
 
-        # Draft credit note is created (31 - 20) * 548 / 17.0 * 1.2 = 425.
+        # Draft credit note is created (31 - 20) * 548 / 17.0 * 1.2 = 425.5 rounded at 426
         credit_note = subscription_invoice.credit_notes.first
         expect(credit_note).to be_draft
-        expect(credit_note.credit_amount_cents).to eq(425)
-        expect(credit_note.balance_amount_cents).to eq(425)
-        expect(credit_note.total_amount_cents).to eq(425)
+        expect(credit_note.credit_amount_cents).to eq(426)
+        expect(credit_note.balance_amount_cents).to eq(426)
+        expect(credit_note.total_amount_cents).to eq(426)
 
         # Invoice for termination is created
         termination_invoice = subscription.invoices.order(created_at: :desc).first
@@ -112,7 +112,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         expect {
           refresh_invoice(subscription_invoice)
         }.not_to change { subscription_invoice.reload.total_amount_cents }
-        expect(credit_note.reload.total_amount_cents).to eq(425)
+        expect(credit_note.reload.total_amount_cents).to eq(426)
 
         # Refresh termination invoice
         expect {
@@ -132,8 +132,8 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           finalize_invoice(termination_invoice)
         }.to change { termination_invoice.reload.status }.from('draft').to('finalized')
 
-        # Total amount should reflect the credit note 720 - 425
-        expect(termination_invoice.total_amount_cents).to eq(295)
+        # Total amount should reflect the credit note 720 - 426
+        expect(termination_invoice.total_amount_cents).to eq(294)
       end
     end
 
@@ -176,10 +176,10 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           .and change { subscription_invoice.reload.credit_notes.count }.from(0).to(1)
           .and change { subscription.invoices.count }.from(1).to(2)
 
-        # Credit note is created (31 - 20) * 548 / 17.0 * 1.2 = 425.
+        # Credit note is created (31 - 20) * 548 / 17.0 * 1.2 = 425.5 rounded at 426
         credit_note = subscription_invoice.credit_notes.first
-        expect(credit_note.credit_amount_cents).to eq(425)
-        expect(credit_note.balance_amount_cents).to eq(425)
+        expect(credit_note.credit_amount_cents).to eq(426)
+        expect(credit_note.balance_amount_cents).to eq(426)
 
         # Invoice for termination is created
         termination_invoice = subscription.invoices.order(created_at: :desc).first
@@ -193,7 +193,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         expect {
           refresh_invoice(subscription_invoice)
         }.not_to change { subscription_invoice.reload.total_amount_cents }
-        expect(credit_note.reload.credit_amount_cents).to eq(425)
+        expect(credit_note.reload.credit_amount_cents).to eq(426)
 
         # Refresh termination invoice
         expect {


### PR DESCRIPTION
## Context

By terminating a subscription with usage, we got the previous error. Credit note and invoice are not created.

1. Create a plan **************Premium**************
2. Attach 2 usage based charges
3. Ingest usage
4. Terminate subscription
5. >> Bug

```
BaseService::ValidationFailure
Validation errors: {:base=>["does_not_match_item_amounts"]}
```

## Description

The issue is related to the rounding of the credit note amount.
Credit note VAT for `credit_amount_cents` is computed without rounding on the amount but once assigned to the item, the amount rounded down automatically by rails because the field is stored as an integer.
It could leads to an error in validation of the credit_amount_cents against item total_amounts. The fix is to round the amount before computing the `credit_amount_cents` to make sure both credit note and items will use the same amount for VAT computation.