### PR TITLE
feat(delete_coupon): Add ability to soft delete a coupon

### DIFF
--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -38,11 +38,8 @@ module Api
       end
 
       def destroy
-        service = Coupons::DestroyService.new
-        result = service.destroy_from_api(
-          organization: current_organization,
-          code: params[:code],
-        )
+        coupon = current_organization.coupons.find_by(code: params[:code])
+        result = Coupons::DestroyService.call(coupon:)
 
         if result.success?
           render_coupon(result.coupon)

--- a/app/graphql/mutations/coupons/destroy.rb
+++ b/app/graphql/mutations/coupons/destroy.rb
@@ -13,7 +13,8 @@ module Mutations
       field :id, ID, null: true
 
       def resolve(id:)
-        result = ::Coupons::DestroyService.new(context[:current_user]).destroy(id)
+        coupon = context[:current_user].coupons.find_by(id:)
+        result = ::Coupons::DestroyService.call(coupon:)
 
         result.success? ? result.coupon : result_error(result)
       end

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -2,6 +2,8 @@
 
 class Coupon < ApplicationRecord
   include Currencies
+  include Discard::Model
+  self.discard_column = :deleted_at
 
   belongs_to :organization
 
@@ -37,11 +39,12 @@ class Coupon < ApplicationRecord
   monetize :amount_cents, disable_validation: true, allow_nil: true
 
   validates :name, presence: true
-  validates :code, uniqueness: { scope: :organization_id, allow_nil: true }
+  validates :code, uniqueness: { conditions: -> { where(deleted_at: nil) }, scope: :organization_id }
 
   validates :amount_cents, numericality: { greater_than: 0 }, allow_nil: true
   validates :amount_currency, inclusion: { in: currency_list }, allow_nil: true
 
+  default_scope -> { kept }
   scope :order_by_status_and_expiration,
         lambda {
           order(

--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -2,8 +2,16 @@
 
 module Coupons
   class DestroyService < BaseService
-    def destroy(id)
-      coupon = result.user.coupons.find_by(id: id)
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(coupon:)
+      @coupon = coupon
+      super
+    end
+
+    def call
       return result.not_found_failure!(resource: 'coupon') unless coupon
       return result.not_allowed_failure!(code: 'attached_to_an_active_customer') unless coupon.deletable?
 
@@ -13,27 +21,8 @@ module Coupons
       result
     end
 
-    def destroy_from_api(organization:, code:)
-      coupon = organization.coupons.find_by(code: code)
-      return result.not_found_failure!(resource: 'coupon') unless coupon
-      return result.not_allowed_failure!(code: 'attached_to_an_active_customer') unless coupon.deletable?
+    private
 
-      coupon.destroy!
-
-      result.coupon = coupon
-      result
-    end
-
-    def terminate(id)
-      coupon = result.user.coupons.find_by(id: id)
-      return result.not_found_failure!(resource: 'coupon') unless coupon
-
-      coupon.mark_as_terminated! unless coupon.terminated?
-
-      result.coupon = coupon
-      result
-    rescue ActiveRecord::RecordInvalid => e
-      result.record_validation_failure!(record: e.record)
-    end
+    attr_reader :coupon
   end
 end

--- a/db/migrate/20230131152047_add_deleted_at_to_coupons.rb
+++ b/db/migrate/20230131152047_add_deleted_at_to_coupons.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToCoupons < ActiveRecord::Migration[7.0]
+  def change
+    add_column :coupons, :deleted_at, :datetime
+    add_index :coupons, :deleted_at
+
+    remove_index :coupons, %i[organization_id code]
+    add_index :coupons, %i[organization_id code], unique: true, where: 'deleted_at IS NULL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_31_144740) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_31_152047) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -134,7 +134,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_31_144740) do
     t.integer "frequency_duration"
     t.datetime "expiration_at"
     t.boolean "reusable", default: true, null: false
-    t.index ["organization_id", "code"], name: "index_coupons_on_organization_id_and_code", unique: true, where: "(code IS NOT NULL)"
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_coupons_on_deleted_at"
+    t.index ["organization_id", "code"], name: "index_coupons_on_organization_id_and_code", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_coupons_on_organization_id"
   end
 

--- a/spec/graphql/mutations/coupons/destroy_spec.rb
+++ b/spec/graphql/mutations/coupons/destroy_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Mutations::Coupons::Destroy, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:coupon) { create(:coupon, organization: organization) }
+  let(:coupon) { create(:coupon, organization:) }
 
   let(:mutation) do
     <<-GQL
@@ -40,5 +40,4 @@ RSpec.describe Mutations::Coupons::Destroy, type: :graphql do
       expect_unauthorized_error(result)
     end
   end
-
 end


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

To allow soft deletion of customers, we first need to be able to soft delete add_ons and coupons

The goal of this PR is to add a `deleted_at` field to the `coupons` table and the Discard logic to allow soft deletion.