### PR TITLE
fix: Flaky test on finalizing invoices

### DIFF
--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Invoices::FinalizeService, type: :service do
     end
 
     let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
-    let(:timestamp) { Time.zone.now.beginning_of_month }
+    let(:timestamp) { Time.zone.now - 1.year }
     let(:started_at) { Time.zone.now - 2.years }
     let(:fee) { create(:fee, invoice:, subscription:) }
     let(:plan) { create(:plan, interval: 'monthly') }


### PR DESCRIPTION
The goal of this PR is to fix the following flaky test:

```
Invoices::FinalizeService#call updates the issuing date
     Failure/Error:
       expect { finalize_service.call }
         .to change { invoice.reload.issuing_date }.to(Time.current.to_date)

       expected `invoice.reload.issuing_date` to have changed to Wed, 01 Feb 2023, but did not change
```