### PR TITLE
fix(subscriptions): Fix invoice subscriptions order

### DIFF
--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -18,7 +18,7 @@ class InvoiceSubscription < ApplicationRecord
           condition = <<-SQL
             COALESCE(
               (invoice_subscriptions.properties->>\'to_datetime\')::timestamp, invoice_subscriptions.created_at
-            ) ASC
+            ) DESC
           SQL
 
           order(Arel.sql(ActiveRecord::Base.sanitize_sql_for_conditions(condition)))


### PR DESCRIPTION
## Context

- The order is wrong on the `order_by_charges_to_datetime` since it's `ASC` and we want a `DESC` to use it for the `Subscriptions::DateService#last_invoice_subscription`.

## Description

- change the order to `DESC`