### PR TITLE
feat(delete_coupon): Add unscoped to legacy coupon's tasks

### DIFF
--- a/lib/tasks/coupons.rake
+++ b/lib/tasks/coupons.rake
@@ -3,11 +3,11 @@
 namespace :coupons do
   desc 'Populate expiration_date for coupons'
   task fill_expiration_date: :environment do
-    Coupon.find_each do |coupon|
+    Coupon.unscoped.find_each do |coupon|
       next unless coupon.expiration_duration
 
       expiration_date = coupon.created_at.to_date + coupon.expiration_duration.days
-      coupon.update!(expiration_date: expiration_date)
+      coupon.update!(expiration_date:)
     end
   end
 end


### PR DESCRIPTION
Resetting the database was not working due to the addition of the default scope on the deleted_at column.

The goal of this PR is to fix legacy tasks by adding unscoped.