### PR TITLE
feat(subscriptions): Add subscriptions count to BM and plan

### DIFF
--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -15,6 +15,7 @@ module Types
       field :field_name, String, null: true
       field :group, GraphQL::Types::JSON, null: true
       field :flat_groups, [Types::Groups::Object], null: true
+      field :subscriptions_count, Integer, null: false
       field :active_subscriptions_count, Integer, null: false
       field :draft_invoices_count, Integer, null: false
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
@@ -27,6 +28,10 @@ module Types
 
       def flat_groups
         object.selectable_groups
+      end
+
+      def subscriptions_count
+        object.plans.joins(:subscriptions).count
       end
 
       def active_subscriptions_count

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -26,6 +26,7 @@ module Types
 
       field :charge_count, Integer, null: false, description: 'Number of charges attached to a plan'
       field :customer_count, Integer, null: false, description: 'Number of customers attached to a plan'
+      field :subscriptions_count, Integer, null: false
       field :active_subscriptions_count, Integer, null: false
       field :draft_invoices_count, Integer, null: false
 
@@ -35,6 +36,10 @@ module Types
 
       def customer_count
         object.subscriptions.active.select(:customer_id).distinct.count
+      end
+
+      def subscriptions_count
+        object.subscriptions.count
       end
 
       def active_subscriptions_count

--- a/schema.graphql
+++ b/schema.graphql
@@ -138,6 +138,7 @@ type BillableMetric {
   id: ID!
   name: String!
   organization: Organization
+  subscriptionsCount: Int!
   updatedAt: ISO8601DateTime!
 }
 
@@ -160,6 +161,7 @@ type BillableMetricDetail {
   id: ID!
   name: String!
   organization: Organization
+  subscriptionsCount: Int!
   updatedAt: ISO8601DateTime!
 }
 
@@ -3629,6 +3631,7 @@ type Plan {
   organization: Organization
   parentId: ID
   payInAdvance: Boolean!
+  subscriptionsCount: Int!
   trialPeriod: Float
   updatedAt: ISO8601DateTime!
 }
@@ -3664,6 +3667,7 @@ type PlanDetails {
   organization: Organization
   parentId: ID
   payInAdvance: Boolean!
+  subscriptionsCount: Int!
   trialPeriod: Float
   updatedAt: ISO8601DateTime!
 }

--- a/schema.json
+++ b/schema.json
@@ -1194,6 +1194,24 @@
               ]
             },
             {
+              "name": "subscriptionsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "updatedAt",
               "description": null,
               "type": {
@@ -1492,6 +1510,24 @@
                 "kind": "OBJECT",
                 "name": "Organization",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "subscriptionsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -14549,6 +14585,24 @@
               ]
             },
             {
+              "name": "subscriptionsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "trialPeriod",
               "description": null,
               "type": {
@@ -14935,6 +14989,24 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "subscriptionsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
                   "ofType": null
                 }
               },

--- a/spec/graphql/resolvers/billable_metric_resolver_spec.rb
+++ b/spec/graphql/resolvers/billable_metric_resolver_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
         billableMetric(id: $billableMetricId) {
           id
           name
+          subscriptionsCount
           activeSubscriptionsCount
           draftInvoicesCount
         }
@@ -34,6 +35,7 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
 
     aggregate_failures do
       expect(metric_response['id']).to eq(billable_metric.id)
+      expect(metric_response['subscriptionsCount']).to eq(0)
       expect(metric_response['activeSubscriptionsCount']).to eq(0)
       expect(metric_response['draftInvoicesCount']).to eq(0)
     end
@@ -47,6 +49,7 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
     create(:standard_charge, plan: subscription.plan, billable_metric:)
 
     metric_response = graphql_request['data']['billableMetric']
+    expect(metric_response['subscriptionsCount']).to eq(2)
     expect(metric_response['activeSubscriptionsCount']).to eq(1)
   end
 

--- a/spec/graphql/resolvers/plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_resolver_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
           id
           name
           customerCount
+          subscriptionsCount
           activeSubscriptionsCount
           draftInvoicesCount
         }
@@ -32,15 +33,14 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
       current_user: membership.user,
       current_organization: organization,
       query:,
-      variables: {
-        planId: plan.id,
-      },
+      variables: { planId: plan.id },
     )
 
     plan_response = result['data']['plan']
 
     aggregate_failures do
       expect(plan_response['id']).to eq(plan.id)
+      expect(plan_response['subscriptionsCount']).to eq(2)
       expect(plan_response['customerCount']).to eq(1)
     end
   end
@@ -49,10 +49,8 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
     it 'returns an error' do
       result = execute_graphql(
         current_user: membership.user,
-        query: query,
-        variables: {
-          planId: plan.id,
-        },
+        query:,
+        variables: { planId: plan.id },
       )
 
       expect_graphql_error(
@@ -68,9 +66,7 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
         current_user: membership.user,
         current_organization: organization,
         query:,
-        variables: {
-          planId: 'foo',
-        },
+        variables: { planId: 'foo' },
       )
 
       expect_graphql_error(


### PR DESCRIPTION
We want to restrict the edition of BM and plan if they are attached to subscriptions.

The goal of this PR is to return:
- number of subscriptions linked to a plan
- number of subscriptions linked to a BM