### PR TITLE
fix(payment_provider): Prevent duplicated payment provider customers

### DIFF
--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -10,6 +10,8 @@ module PaymentProviderCustomers
     has_many :payments
     has_many :refunds, foreign_key: :payment_provider_customer_id
 
+    validates :customer_id, uniqueness: { scope: :type }
+
     def push_to_settings(key:, value:)
       self.settings ||= {}
       settings[key] = value

--- a/db/migrate/20230202110407_add_index_to_payment_provider_customers.rb
+++ b/db/migrate/20230202110407_add_index_to_payment_provider_customers.rb
@@ -2,6 +2,24 @@
 
 class AddIndexToPaymentProviderCustomers < ActiveRecord::Migration[7.0]
   def change
+    reversible do |dir|
+      dir.up do
+        # Remove duplicated customers before adding new index
+        payment_customers = PaymentProviderCustomers::BaseCustomer.group(:customer_id, :type)
+          .having('COUNT(id) > 1')
+          .select('COUNT(id) AS customer_count, customer_id, type')
+
+        payment_customers.each do |payment_customer|
+          customers = PaymentProviderCustomers::BaseCustomer.where(
+            customer_id: payment_customer.customer_id,
+            type: payment_customer.type,
+          ).order(updated_at: :desc)
+
+          customers[1..].each(&:destroy)
+        end
+      end
+    end
+
     add_index :payment_provider_customers, %i[customer_id type], unique: true
     remove_index :payment_provider_customers, :customer_id
   end

--- a/db/migrate/20230202110407_add_index_to_payment_provider_customers.rb
+++ b/db/migrate/20230202110407_add_index_to_payment_provider_customers.rb
@@ -13,7 +13,7 @@ class AddIndexToPaymentProviderCustomers < ActiveRecord::Migration[7.0]
           customers = PaymentProviderCustomers::BaseCustomer.where(
             customer_id: payment_customer.customer_id,
             type: payment_customer.type,
-          ).order(updated_at: :desc)
+          ).order('payment_provider_id ASC NULLS LAST, updated_at desc')
 
           customers[1..].each(&:destroy)
         end

--- a/db/migrate/20230202110407_add_index_to_payment_provider_customers.rb
+++ b/db/migrate/20230202110407_add_index_to_payment_provider_customers.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIndexToPaymentProviderCustomers < ActiveRecord::Migration[7.0]
+  def change
+    add_index :payment_provider_customers, %i[customer_id type], unique: true
+    remove_index :payment_provider_customers, :customer_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_31_152047) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_02_110407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -409,7 +409,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_31_152047) do
     t.jsonb "settings", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["customer_id"], name: "index_payment_provider_customers_on_customer_id"
+    t.index ["customer_id", "type"], name: "index_payment_provider_customers_on_customer_id_and_type", unique: true
     t.index ["payment_provider_id"], name: "index_payment_provider_customers_on_payment_provider_id"
     t.index ["provider_customer_id"], name: "index_payment_provider_customers_on_provider_customer_id"
   end


### PR DESCRIPTION
## Context

In production, two users have duplicated Stripe customers. The reason why is still unclear, but it leads to unpredictable behaviors when trying to update the stripe customer id.

## Description

To prevent duplication of payment provider customer, this PR adds a validation rule to ensure each customer can have only one PaymentProviderCustomer per type of provider.
