### PR TITLE
feat: Remove can_be_deleted on coupons and add_ons

### DIFF
--- a/app/graphql/types/add_ons/object.rb
+++ b/app/graphql/types/add_ons/object.rb
@@ -19,9 +19,14 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       field :customer_count, Integer, null: false, description: 'Number of customers using this add-on'
+      field :applied_add_ons_count, Integer, null: false
 
       def customer_count
         object.applied_add_ons.select(:customer_id).distinct.count
+      end
+
+      def applied_add_ons_count
+        object.applied_add_ons.count
       end
     end
   end

--- a/app/graphql/types/add_ons/object.rb
+++ b/app/graphql/types/add_ons/object.rb
@@ -20,16 +20,8 @@ module Types
 
       field :customer_count, Integer, null: false, description: 'Number of customers using this add-on'
 
-      field :can_be_deleted, Boolean, null: false do
-        description 'Check if add-on is deletable'
-      end
-
       def customer_count
         object.applied_add_ons.select(:customer_id).distinct.count
-      end
-
-      def can_be_deleted
-        object.deletable?
       end
     end
   end

--- a/app/graphql/types/coupons/object.rb
+++ b/app/graphql/types/coupons/object.rb
@@ -28,16 +28,8 @@ module Types
 
       field :customer_count, Integer, null: false, description: 'Number of customers using this coupon'
 
-      field :can_be_deleted, Boolean, null: false do
-        description 'Check if coupon is deletable'
-      end
-
       def customer_count
         object.applied_coupons.active.select(:customer_id).distinct.count
-      end
-
-      def can_be_deleted
-        object.deletable?
       end
     end
   end

--- a/app/graphql/types/coupons/object.rb
+++ b/app/graphql/types/coupons/object.rb
@@ -27,9 +27,14 @@ module Types
       field :terminated_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :customer_count, Integer, null: false, description: 'Number of customers using this coupon'
+      field :applied_coupons_count, Integer, null: false
 
       def customer_count
         object.applied_coupons.active.select(:customer_id).distinct.count
+      end
+
+      def applied_coupons_count
+        object.applied_coupons.count
       end
     end
   end

--- a/app/models/add_on.rb
+++ b/app/models/add_on.rb
@@ -21,12 +21,4 @@ class AddOn < ApplicationRecord
   validates :amount_currency, inclusion: { in: currency_list }
 
   default_scope -> { kept }
-
-  def attached_to_customers?
-    applied_add_ons.exists?
-  end
-
-  def deletable?
-    !attached_to_customers?
-  end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -30,11 +30,6 @@ input AddGocardlessPaymentProviderInput {
 type AddOn {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
-
-  """
-  Check if add-on is deletable
-  """
-  canBeDeleted: Boolean!
   code: String!
   createdAt: ISO8601DateTime!
 
@@ -57,11 +52,6 @@ type AddOnCollection {
 type AddOnDetails {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
-
-  """
-  Check if add-on is deletable
-  """
-  canBeDeleted: Boolean!
   code: String!
   createdAt: ISO8601DateTime!
 
@@ -1462,11 +1452,6 @@ enum CountryCode {
 type Coupon {
   amountCents: BigInt
   amountCurrency: CurrencyEnum
-
-  """
-  Check if coupon is deletable
-  """
-  canBeDeleted: Boolean!
   code: String
   couponType: CouponTypeEnum!
   createdAt: ISO8601DateTime!
@@ -1497,11 +1482,6 @@ type CouponCollection {
 type CouponDetails {
   amountCents: BigInt
   amountCurrency: CurrencyEnum
-
-  """
-  Check if coupon is deletable
-  """
-  canBeDeleted: Boolean!
   code: String
   couponType: CouponTypeEnum!
   createdAt: ISO8601DateTime!

--- a/schema.graphql
+++ b/schema.graphql
@@ -30,6 +30,7 @@ input AddGocardlessPaymentProviderInput {
 type AddOn {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
+  appliedAddOnsCount: Int!
   code: String!
   createdAt: ISO8601DateTime!
 
@@ -52,6 +53,7 @@ type AddOnCollection {
 type AddOnDetails {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
+  appliedAddOnsCount: Int!
   code: String!
   createdAt: ISO8601DateTime!
 
@@ -1452,6 +1454,7 @@ enum CountryCode {
 type Coupon {
   amountCents: BigInt
   amountCurrency: CurrencyEnum
+  appliedCouponsCount: Int!
   code: String
   couponType: CouponTypeEnum!
   createdAt: ISO8601DateTime!
@@ -1482,6 +1485,7 @@ type CouponCollection {
 type CouponDetails {
   amountCents: BigInt
   amountCurrency: CurrencyEnum
+  appliedCouponsCount: Int!
   code: String
   couponType: CouponTypeEnum!
   createdAt: ISO8601DateTime!

--- a/schema.json
+++ b/schema.json
@@ -161,24 +161,6 @@
               ]
             },
             {
-              "name": "canBeDeleted",
-              "description": "Check if add-on is deletable",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "code",
               "description": null,
               "type": {
@@ -411,24 +393,6 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "CurrencyEnum",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "canBeDeleted",
-              "description": "Check if add-on is deletable",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
                   "ofType": null
                 }
               },
@@ -3606,24 +3570,6 @@
               ]
             },
             {
-              "name": "canBeDeleted",
-              "description": "Check if coupon is deletable",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "code",
               "description": null,
               "type": {
@@ -3978,24 +3924,6 @@
                 "kind": "ENUM",
                 "name": "CurrencyEnum",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "canBeDeleted",
-              "description": "Check if coupon is deletable",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/schema.json
+++ b/schema.json
@@ -161,6 +161,24 @@
               ]
             },
             {
+              "name": "appliedAddOnsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "code",
               "description": null,
               "type": {
@@ -393,6 +411,24 @@
                 "ofType": {
                   "kind": "ENUM",
                   "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "appliedAddOnsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
                   "ofType": null
                 }
               },
@@ -3570,6 +3606,24 @@
               ]
             },
             {
+              "name": "appliedCouponsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "code",
               "description": null,
               "type": {
@@ -3924,6 +3978,24 @@
                 "kind": "ENUM",
                 "name": "CurrencyEnum",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "appliedCouponsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/resolvers/add_on_resolver_spec.rb
+++ b/spec/graphql/resolvers/add_on_resolver_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Resolvers::AddOnResolver, type: :graphql do
     <<~GQL
       query($addOnId: ID!) {
         addOn(id: $addOnId) {
-          id, name, customerCount
+          id name customerCount appliedAddOnsCount
         }
       }
     GQL
@@ -15,11 +15,11 @@ RSpec.describe Resolvers::AddOnResolver, type: :graphql do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:add_on) { create(:add_on, organization: organization) }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:customer2) { create(:customer, organization: organization) }
-  let(:applied_add_on_list) { create_list(:applied_add_on, 3, add_on: add_on, customer: customer) }
-  let(:applied_add_on) { create(:applied_add_on, add_on: add_on, customer: customer2) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:customer2) { create(:customer, organization:) }
+  let(:applied_add_on_list) { create_list(:applied_add_on, 3, add_on:, customer:) }
+  let(:applied_add_on) { create(:applied_add_on, add_on:, customer: customer2) }
 
   before do
     customer
@@ -28,7 +28,7 @@ RSpec.describe Resolvers::AddOnResolver, type: :graphql do
     applied_add_on
 
     3.times do
-      create(:subscription, customer: customer)
+      create(:subscription, customer:)
     end
   end
 
@@ -36,10 +36,8 @@ RSpec.describe Resolvers::AddOnResolver, type: :graphql do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
-      query: query,
-      variables: {
-        addOnId: add_on.id,
-      },
+      query:,
+      variables: { addOnId: add_on.id },
     )
 
     add_on_response = result['data']['addOn']
@@ -48,6 +46,7 @@ RSpec.describe Resolvers::AddOnResolver, type: :graphql do
       expect(add_on_response['id']).to eq(add_on.id)
       expect(add_on_response['name']).to eq(add_on.name)
       expect(add_on_response['customerCount']).to eq(2)
+      expect(add_on_response['appliedAddOnsCount']).to eq(4)
     end
   end
 
@@ -55,16 +54,11 @@ RSpec.describe Resolvers::AddOnResolver, type: :graphql do
     it 'returns an error' do
       result = execute_graphql(
         current_user: membership.user,
-        query: query,
-        variables: {
-          addOnId: add_on.id,
-        },
+        query:,
+        variables: { addOnId: add_on.id },
       )
 
-      expect_graphql_error(
-        result: result,
-        message: 'Missing organization id',
-        )
+      expect_graphql_error(result:, message: 'Missing organization id')
     end
   end
 
@@ -73,16 +67,11 @@ RSpec.describe Resolvers::AddOnResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
-        query: query,
-        variables: {
-          addOnId: 'invalid',
-        },
+        query:,
+        variables: { addOnId: 'invalid' },
       )
 
-      expect_graphql_error(
-        result: result,
-        message: 'Resource not found',
-      )
+      expect_graphql_error(result:, message: 'Resource not found')
     end
   end
 end

--- a/spec/graphql/resolvers/coupons_resolver_spec.rb
+++ b/spec/graphql/resolvers/coupons_resolver_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Resolvers::CouponsResolver, type: :graphql do
     <<~GQL
       query {
         coupons(limit: 5, status: active) {
-          collection { id canBeDeleted }
+          collection { id }
           metadata { currentPage, totalCount }
         }
       }
@@ -36,7 +36,6 @@ RSpec.describe Resolvers::CouponsResolver, type: :graphql do
     aggregate_failures do
       expect(coupons_response['collection'].count).to eq(organization.coupons.active.count)
       expect(coupons_response['collection'].first['id']).to eq(coupon.id)
-      expect(coupons_response['collection'].first['canBeDeleted']).to be_truthy
 
       expect(coupons_response['metadata']['currentPage']).to eq(1)
       expect(coupons_response['metadata']['totalCount']).to eq(1)

--- a/spec/models/add_on_spec.rb
+++ b/spec/models/add_on_spec.rb
@@ -3,27 +3,4 @@
 require 'rails_helper'
 
 RSpec.describe AddOn, type: :model do
-  describe 'attached_to_customers?' do
-    let(:add_on) { create(:add_on) }
-
-    it { expect(add_on).not_to be_attached_to_customers }
-
-    context 'with attached customers' do
-      before { create(:applied_add_on, add_on: add_on) }
-
-      it { expect(add_on).to be_attached_to_customers }
-    end
-  end
-
-  describe 'deletable?' do
-    let(:add_on) { create(:add_on) }
-
-    it { expect(add_on).to be_deletable }
-
-    context 'with attached customers' do
-      before { create(:applied_add_on, add_on: add_on) }
-
-      it { expect(add_on).not_to be_deletable }
-    end
-  end
 end


### PR DESCRIPTION
The goal of this PR is to:
- Remove `can_be_deleted` on `coupons` and `add_ons`
- Add `appliedCouponsCount` and `appliedAddOnsCount`

In order to know if a specific coupon or add_on can be updated or deleted.