### PR TITLE
feat(delete_customer): Add attributes to allow soft deletion

### DIFF
--- a/db/migrate/20230202150407_add_deleted_at_to_customers.rb
+++ b/db/migrate/20230202150407_add_deleted_at_to_customers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToCustomers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :customers, :deleted_at, :datetime
+    add_index :customers, :deleted_at
+
+    remove_index :customers, %i[external_id organization_id]
+    add_index :customers, %i[external_id organization_id], unique: true, where: 'deleted_at IS NULL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_02_110407) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_02_150407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -233,7 +233,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_110407) do
     t.string "currency"
     t.integer "invoice_grace_period"
     t.string "timezone"
-    t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_customers_on_deleted_at"
+    t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_customers_on_organization_id"
     t.check_constraint "invoice_grace_period >= 0", name: "check_customers_on_invoice_grace_period"
   end

--- a/lib/tasks/customers.rake
+++ b/lib/tasks/customers.rake
@@ -3,7 +3,7 @@
 namespace :customers do
   desc 'Generate Slug for Customers'
   task generate_slug: :environment do
-    Customer.order(:created_at).find_each(&:save)
+    Customer.unscoped.order(:created_at).find_each(&:save)
   end
 
   desc 'Set customer currency from active subscription'


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

The goal of this PR is to add the `deleted_at` column to the `customers` table, to allow soft deletion of customers