### PR TITLE
feat: Restrict add on update if already applied

### DIFF
--- a/app/services/add_ons/update_service.rb
+++ b/app/services/add_ons/update_service.rb
@@ -16,10 +16,13 @@ module AddOns
       return result.not_found_failure!(resource: 'add_on') unless add_on
 
       add_on.name = params[:name]
-      add_on.code = params[:code]
       add_on.description = params[:description]
-      add_on.amount_cents = params[:amount_cents]
-      add_on.amount_currency = params[:amount_currency]
+
+      unless add_on.applied_add_ons.exists?
+        add_on.code = params[:code]
+        add_on.amount_cents = params[:amount_cents]
+        add_on.amount_currency = params[:amount_currency]
+      end
 
       add_on.save!
 

--- a/spec/services/add_ons/update_service_spec.rb
+++ b/spec/services/add_ons/update_service_spec.rb
@@ -56,5 +56,27 @@ RSpec.describe AddOns::UpdateService, type: :service do
         end
       end
     end
+
+    context 'when attached to an applied add on' do
+      let(:update_args) do
+        {
+          id: add_on.id,
+          name: 'new name',
+          description: 'new desc',
+          code: 'new code',
+        }
+      end
+
+      it 'updates only name and description' do
+        create(:applied_add_on, add_on:)
+        result = add_ons_service.call
+
+        aggregate_failures do
+          expect(result.add_on.name).to eq('new name')
+          expect(result.add_on.description).to eq('new desc')
+          expect(result.add_on.code).not_to eq('new code')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
The goal of this PR is to restrict the update of an add_on if already applied to a subscription.