### PR TITLE
feat(delete_customer): Keep customer visible from invoice

### DIFF
--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -36,6 +36,7 @@ module Types
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :has_active_wallet, Boolean, null: false, description: 'Define if a customer has an active wallet'
       field :has_credit_notes, Boolean, null: false, description: 'Define if a customer has any credit note'

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -7,6 +7,7 @@ class Invoice < ApplicationRecord
   before_save :ensure_number
 
   belongs_to :customer, -> { with_discarded }
+  belongs_to :organization
 
   has_many :fees
   has_many :credits
@@ -122,10 +123,6 @@ class Invoice < ApplicationRecord
     return amount unless wallet_transactions.exists?
 
     amount + wallet_transaction_amount
-  end
-
-  def organization
-    customer&.organization
   end
 
   def invoice_subscription(subscription_id)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -6,7 +6,7 @@ class Invoice < ApplicationRecord
 
   before_save :ensure_number
 
-  belongs_to :customer
+  belongs_to :customer, -> { with_discarded }
 
   has_many :fees
   has_many :credits

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,7 +9,7 @@ class Organization < ApplicationRecord
   has_many :plans
   has_many :customers
   has_many :subscriptions, through: :customers
-  has_many :invoices, through: :customers
+  has_many :invoices
   has_many :credit_notes, through: :customers
   has_many :events
   has_many :coupons

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -13,8 +13,9 @@ module Invoices
     def create
       ActiveRecord::Base.transaction do
         invoice = Invoice.create!(
-          customer: customer,
-          issuing_date: issuing_date,
+          organization: customer.organization,
+          customer:,
+          issuing_date:,
           invoice_type: :add_on,
           payment_status: :pending,
           amount_currency: currency,

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -35,6 +35,7 @@ module Invoices
     def compute_usage
       Rails.cache.fetch(current_cache_key, expires_in: cache_expiration) do
         @invoice = Invoice.new(
+          organization: subscription.organization,
           customer: subscription.customer,
           issuing_date: boundaries[:issuing_date],
           amount_currency: plan.amount_currency,

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -13,8 +13,9 @@ module Invoices
     def create
       ActiveRecord::Base.transaction do
         invoice = Invoice.create!(
-          customer: customer,
-          issuing_date: issuing_date,
+          organization: customer.organization,
+          customer:,
+          issuing_date:,
           invoice_type: :credit,
           payment_status: :pending,
           amount_currency: currency,

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -18,6 +18,7 @@ module Invoices
 
       ActiveRecord::Base.transaction do
         invoice = Invoice.create!(
+          organization: customer.organization,
           customer:,
           issuing_date:,
           invoice_type: :subscription,

--- a/db/migrate/20230202163249_add_organization_id_to_invoices.rb
+++ b/db/migrate/20230202163249_add_organization_id_to_invoices.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToInvoices < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :invoices, :organization, type: :uuid, foreign_key: true, index: true, null: true
+
+    reversible do |dir|
+      dir.up do
+        LagoApi::Application.load_tasks
+        Rake::Task['invoices:fill_organization'].invoke
+      end
+    end
+
+    change_column_null :invoices, :organization_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_02_150407) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_02_163249) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -364,7 +364,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_150407) do
     t.string "timezone", default: "UTC", null: false
     t.integer "payment_attempts", default: 0, null: false
     t.boolean "ready_for_payment_processing", default: true, null: false
+    t.uuid "organization_id", null: false
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
+    t.index ["organization_id"], name: "index_invoices_on_organization_id"
   end
 
   create_table "memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -592,6 +594,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_150407) do
   add_foreign_key "invoice_subscriptions", "invoices"
   add_foreign_key "invoice_subscriptions", "subscriptions"
   add_foreign_key "invoices", "customers"
+  add_foreign_key "invoices", "organizations"
   add_foreign_key "memberships", "organizations"
   add_foreign_key "memberships", "users"
   add_foreign_key "payment_provider_customers", "customers"

--- a/lib/tasks/invoices.rake
+++ b/lib/tasks/invoices.rake
@@ -60,4 +60,11 @@ namespace :invoices do
       )
     end
   end
+
+  desc 'Fill invoice organization from customers'
+  task fill_organization: :environment do
+    Invoice.where(organization_id: nil).find_each do |invoice|
+      invoice.update!(organization_id: invoice.customer.organization_id)
+    end
+  end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2547,6 +2547,7 @@ type Customer {
   """
   creditNotesCreditsAvailableCount: Int!
   currency: CurrencyEnum
+  deletedAt: ISO8601DateTime
   email: String
   externalId: String!
 
@@ -2619,6 +2620,7 @@ type CustomerDetails {
   """
   creditNotesCreditsAvailableCount: Int!
   currency: CurrencyEnum
+  deletedAt: ISO8601DateTime
   email: String
   externalId: String!
 

--- a/schema.json
+++ b/schema.json
@@ -7848,6 +7848,20 @@
               ]
             },
             {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "email",
               "description": null,
               "type": {
@@ -8515,6 +8529,20 @@
               "type": {
                 "kind": "ENUM",
                 "name": "CurrencyEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :invoice do
     customer
+    organization
 
     issuing_date { Time.zone.now - 1.day }
     payment_status { 'pending' }

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
+  let(:organization) { create(:organization) }
   let(:membership) { create(:membership, organization:) }
-  let(:organization) { invoice.organization }
+  let(:customer) { create(:customer, organization:) }
 
   let(:fee1) { create(:fee, invoice:) }
   let(:fee2) { create(:charge_fee, invoice:) }
@@ -12,6 +13,8 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
   let(:invoice) do
     create(
       :invoice,
+      customer:,
+      organization:,
       payment_status: 'succeeded',
       amount_cents: 100,
       amount_currency: 'EUR',

--- a/spec/graphql/mutations/invoices/finalize_spec.rb
+++ b/spec/graphql/mutations/invoices/finalize_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mutations::Invoices::Finalize, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, :draft, customer:) }
+  let(:invoice) { create(:invoice, :draft, customer:, organization:) }
 
   let(:mutation) do
     <<~GQL

--- a/spec/graphql/mutations/invoices/refresh_spec.rb
+++ b/spec/graphql/mutations/invoices/refresh_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Mutations::Invoices::Refresh, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
 
   let(:mutation) do
     <<~GQL

--- a/spec/graphql/mutations/invoices/retry_all_payments_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_all_payments_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Mutations::Invoices::RetryAllPayments, type: :graphql do
     let(:invoice_first) do
       create(
         :invoice,
+        organization:,
         customer: customer_first,
         status: 'finalized',
         payment_status: 'failed',
@@ -34,6 +35,7 @@ RSpec.describe Mutations::Invoices::RetryAllPayments, type: :graphql do
     let(:invoice_second) do
       create(
         :invoice,
+        organization:,
         customer: customer_second,
         status: 'finalized',
         payment_status: 'failed',

--- a/spec/graphql/mutations/invoices/retry_payment_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_payment_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Mutations::Invoices::RetryPayment, type: :graphql do
   let(:invoice) do
     create(
       :invoice,
+      organization:,
       customer:,
       status: 'finalized',
       payment_status: 'failed',

--- a/spec/graphql/resolvers/billable_metric_resolver_spec.rb
+++ b/spec/graphql/resolvers/billable_metric_resolver_spec.rb
@@ -60,10 +60,10 @@ RSpec.describe Resolvers::BillableMetricResolver, type: :graphql do
     charge = create(:standard_charge, plan: subscription.plan, billable_metric:)
     charge2 = create(:standard_charge, plan: subscription2.plan, billable_metric:)
 
-    invoice = create(:invoice, customer:)
+    invoice = create(:invoice, customer:, organization: billable_metric.organization)
     create(:fee, invoice:, charge:)
 
-    draft_invoice = create(:invoice, :draft, customer:)
+    draft_invoice = create(:invoice, :draft, customer:, organization: billable_metric.organization)
     create(:fee, invoice: draft_invoice, charge: charge2)
     create(:fee, invoice: draft_invoice, charge: charge2)
 

--- a/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/invoices_resolver_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Resolvers::Customers::InvoicesResolver, type: :graphql do
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:, organization:) }
-  let(:draft_invoice) { create(:invoice, :draft, customer:) }
-  let(:finalized_invoice) { create(:invoice, customer:) }
+  let(:draft_invoice) { create(:invoice, :draft, customer:, organization:) }
+  let(:finalized_invoice) { create(:invoice, customer:, organization:) }
 
   before do
     subscription

--- a/spec/graphql/resolvers/invoice_credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_credit_notes_resolver_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Resolvers::InvoiceCreditNotesResolver, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
   let(:subscription) { create(:subscription, customer:, organization:) }
   let(:credit_note) { create(:credit_note, organization:, customer:, invoice:) }
 

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
-  let(:invoice_subscription) { create(:invoice_subscription, invoice: create(:invoice, customer:)) }
-  let(:invoice) { invoice_subscription.invoice }
+  let(:invoice_subscription) { create(:invoice_subscription, invoice:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
   let(:subscription) { invoice_subscription.subscription }
   let(:fee) { create(:fee, subscription:, invoice:, amount_cents: 10) }
 
-  before { fee }
+  before { fee and invoice }
 
   it 'returns a single invoice' do
     result = execute_graphql(
@@ -168,13 +168,13 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
   end
 
   context 'with an add on invoice' do
-    let(:invoice) { create(:invoice, customer:) }
+    let(:invoice) { create(:invoice, customer:, organization:) }
     let(:add_on) { create(:add_on, organization:) }
     let(:applied_add_on) { create(:applied_add_on, add_on:, customer:) }
     let(:fee) { create(:add_on_fee, invoice:, applied_add_on:) }
 
     it 'returns a single invoice' do
-      esult = execute_graphql(
+      result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
         query:,

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -18,8 +18,12 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
   let(:organization) { membership.organization }
   let(:customer_first) { create(:customer, organization:) }
   let(:customer_second) { create(:customer, organization:) }
-  let(:invoice_first) { create(:invoice, customer: customer_first, payment_status: :pending, status: :finalized) }
-  let(:invoice_second) { create(:invoice, customer: customer_second, payment_status: :succeeded, status: :finalized) }
+  let(:invoice_first) do
+    create(:invoice, customer: customer_first, payment_status: :pending, status: :finalized, organization:)
+  end
+  let(:invoice_second) do
+    create(:invoice, customer: customer_second, payment_status: :succeeded, status: :finalized, organization:)
+  end
 
   before do
     invoice_first
@@ -80,7 +84,7 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
   end
 
   context 'when filtering by draft status' do
-    let(:invoice_third) { create(:invoice, customer: customer_second, status: :draft) }
+    let(:invoice_third) { create(:invoice, customer: customer_second, status: :draft, organization:) }
     let(:query) do
       <<~GQL
         query {

--- a/spec/jobs/clock/finalize_invoices_job_spec.rb
+++ b/spec/jobs/clock/finalize_invoices_job_spec.rb
@@ -8,10 +8,22 @@ describe Clock::FinalizeInvoicesJob, job: true do
   describe '.perform' do
     let(:customer) { create(:customer, invoice_grace_period: 3) }
     let(:draft_invoice) do
-      create(:invoice, status: :draft, created_at: DateTime.parse('20 Jun 2022'), customer:)
+      create(
+        :invoice,
+        status: :draft,
+        created_at: DateTime.parse('20 Jun 2022'),
+        customer:,
+        organization: customer.organization,
+      )
     end
     let(:finalized_invoice) do
-      create(:invoice, status: :finalized, created_at: DateTime.parse('20 Jun 2022'), customer:)
+      create(
+        :invoice,
+        status: :finalized,
+        created_at: DateTime.parse('20 Jun 2022'),
+        customer:,
+        organization: customer.organization,
+      )
     end
 
     before do

--- a/spec/jobs/invoices/payments/retry_all_job_spec.rb
+++ b/spec/jobs/invoices/payments/retry_all_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Invoices::Payments::RetryAllJob, type: :job do
   let(:retry_batch_service) { instance_double(Invoices::Payments::RetryBatchService) }
   let(:result) { BaseService::Result.new }
   let(:organization) { create(:organization) }
-  let(:invoice) { create(:invoice) }
+  let(:invoice) { create(:invoice, organization:) }
 
   before do
     allow(Invoices::Payments::RetryBatchService).to receive(:new)

--- a/spec/jobs/invoices/prepaid_credit_job_spec.rb
+++ b/spec/jobs/invoices/prepaid_credit_job_spec.rb
@@ -3,19 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe Invoices::PrepaidCreditJob, type: :job do
-  let(:invoice) { create(:invoice, customer: customer) }
+  let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
   let(:customer) { create(:customer) }
-  let(:subscription) { create(:subscription, customer: customer) }
-  let(:wallet) { create(:wallet, customer: customer, balance: 10.0, credits_balance: 10.0) }
+  let(:subscription) { create(:subscription, customer:) }
+  let(:wallet) { create(:wallet, customer:, balance: 10.0, credits_balance: 10.0) }
   let(:wallet_transaction) do
-    create(:wallet_transaction, wallet: wallet, amount: 15.0, credit_amount: 15.0, status: 'pending')
+    create(:wallet_transaction, wallet:, amount: 15.0, credit_amount: 15.0, status: 'pending')
   end
   let(:fee) do
-    create(:fee,
+    create(
+      :fee,
       fee_type: 'credit',
       invoiceable_type: 'WalletTransaction',
       invoiceable_id: wallet_transaction.id,
-      invoice: invoice
+      invoice:,
     )
   end
 

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SendWebhookJob, type: :job do
   let(:webhook_add_on_service) { instance_double(Webhooks::AddOnService) }
   let(:webhook_event_service) { instance_double(Webhooks::EventService) }
   let(:organization) { create(:organization, webhook_url: 'http://foo.bar') }
-  let(:invoice) { create(:invoice) }
+  let(:invoice) { create(:invoice, organization:) }
 
   context 'when webhook_type is invoice' do
     before do
@@ -257,7 +257,7 @@ RSpec.describe SendWebhookJob, type: :job do
 
   context 'when webhook_type is invoice.drafted' do
     let(:webhook_service) { instance_double(Webhooks::Invoices::DraftedService) }
-    let(:invoice) { create(:invoice) }
+    let(:invoice) { create(:invoice, organization:) }
 
     before do
       allow(Webhooks::Invoices::DraftedService).to receive(:new)
@@ -301,7 +301,7 @@ RSpec.describe SendWebhookJob, type: :job do
 
   context 'when webhook type is invoice.payment_status_updated' do
     let(:webhook_service) { instance_double(Webhooks::Invoices::PaymentStatusUpdatedService) }
-    let(:invoice) { create(:invoice) }
+    let(:invoice) { create(:invoice, organization:) }
 
     before do
       allow(Webhooks::Invoices::PaymentStatusUpdatedService).to receive(:new)

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CreditNote, type: :model do
     let(:customer) { invoice.customer }
 
     let(:credit_note) do
-      build(:credit_note, invoice: invoice, customer: customer)
+      build(:credit_note, invoice:, customer:)
     end
 
     it 'assigns a sequential_id is present' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -95,10 +95,10 @@ RSpec.describe Invoice, type: :model do
 
   describe '#sub_total_vat_excluded_amount' do
     let(:organization) { create(:organization, name: 'LAGO') }
-    let(:customer) { create(:customer, organization: organization) }
-    let(:subscription) { create(:subscription, organization: organization, customer: customer) }
-    let(:invoice) { create(:invoice, customer: customer, amount_currency: 'EUR') }
-    let(:fees) { create_list(:fee, 3, invoice: invoice, amount_cents: 300) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, organization:, customer:) }
+    let(:invoice) { create(:invoice, customer:, amount_currency: 'EUR', organization:) }
+    let(:fees) { create_list(:fee, 3, invoice:, amount_cents: 300) }
 
     before { fees }
 
@@ -109,10 +109,10 @@ RSpec.describe Invoice, type: :model do
 
   describe '#sub_total_vat_included_amount' do
     let(:organization) { create(:organization, name: 'LAGO') }
-    let(:customer) { create(:customer, organization: organization, vat_rate: 20) }
-    let(:subscription) { create(:subscription, organization: organization, customer: customer) }
-    let(:invoice) { create(:invoice, customer: customer, amount_currency: 'EUR', vat_amount_cents: 180) }
-    let(:fees) { create_list(:fee, 3, invoice: invoice, amount_cents: 300) }
+    let(:customer) { create(:customer, organization:, vat_rate: 20) }
+    let(:subscription) { create(:subscription, organization:, customer:) }
+    let(:invoice) { create(:invoice, customer:, amount_currency: 'EUR', vat_amount_cents: 180, organization:) }
+    let(:fees) { create_list(:fee, 3, invoice:, amount_cents: 300) }
 
     before { fees }
 
@@ -123,10 +123,10 @@ RSpec.describe Invoice, type: :model do
 
   describe '#coupon_total_amount' do
     let(:organization) { create(:organization, name: 'LAGO') }
-    let(:customer) { create(:customer, organization: organization) }
-    let(:subscription) { create(:subscription, organization: organization, customer: customer) }
-    let(:invoice) { create(:invoice, customer: customer) }
-    let(:credit) { create(:credit, invoice: invoice) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, organization:, customer:) }
+    let(:invoice) { create(:invoice, customer:, organization:) }
+    let(:credit) { create(:credit, invoice:) }
 
     before { credit }
 
@@ -137,10 +137,10 @@ RSpec.describe Invoice, type: :model do
 
   describe '#credit_note_total_amount' do
     let(:organization) { create(:organization, name: 'LAGO') }
-    let(:customer) { create(:customer, organization: organization) }
-    let(:subscription) { create(:subscription, organization: organization, customer: customer) }
-    let(:invoice) { create(:invoice, customer: customer) }
-    let(:credit) { create(:credit_note_credit, invoice: invoice) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, organization:, customer:) }
+    let(:invoice) { create(:invoice, customer:, organization:) }
+    let(:credit) { create(:credit_note_credit, invoice:) }
 
     before { credit }
 
@@ -151,10 +151,10 @@ RSpec.describe Invoice, type: :model do
 
   describe '#charge_amount' do
     let(:organization) { create(:organization, name: 'LAGO') }
-    let(:customer) { create(:customer, organization: organization) }
-    let(:subscription) { create(:subscription, organization: organization, customer: customer) }
-    let(:invoice) { create(:invoice, customer: customer) }
-    let(:fees) { create_list(:fee, 3, invoice: invoice) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, organization:, customer:) }
+    let(:invoice) { create(:invoice, customer:, organization:) }
+    let(:fees) { create_list(:fee, 3, invoice:) }
 
     it 'returns the charges amount' do
       expect(invoice.charge_amount.to_s).to eq('0.00')
@@ -163,10 +163,10 @@ RSpec.describe Invoice, type: :model do
 
   describe '#credit_amount' do
     let(:organization) { create(:organization, name: 'LAGO') }
-    let(:customer) { create(:customer, organization: organization) }
-    let(:subscription) { create(:subscription, organization: organization, customer: customer) }
-    let(:invoice) { create(:invoice, customer: customer) }
-    let(:credit) { create(:credit, invoice: invoice) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, organization:, customer:) }
+    let(:invoice) { create(:invoice, customer:, organization:) }
+    let(:credit) { create(:credit, invoice:) }
 
     it 'returns the credits amount' do
       expect(invoice.credit_amount.to_s).to eq('0.00')
@@ -175,10 +175,10 @@ RSpec.describe Invoice, type: :model do
 
   describe '#wallet_transaction_amount' do
     let(:customer) { create(:customer) }
-    let(:invoice) { create(:invoice, customer: customer) }
-    let(:wallet) { create(:wallet, customer: customer, balance: 10.0, credits_balance: 10.0) }
+    let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
+    let(:wallet) { create(:wallet, customer:, balance: 10.0, credits_balance: 10.0) }
     let(:wallet_transaction) do
-      create(:wallet_transaction, invoice: invoice, wallet: wallet, amount: 1, credit_amount: 1)
+      create(:wallet_transaction, invoice:, wallet:, amount: 1, credit_amount: 1)
     end
 
     before { wallet_transaction }
@@ -190,10 +190,10 @@ RSpec.describe Invoice, type: :model do
 
   describe '#subtotal_before_prepaid_credits' do
     let(:customer) { create(:customer) }
-    let(:invoice) { create(:invoice, customer: customer, amount_cents: 555) }
-    let(:wallet) { create(:wallet, customer: customer, balance: 10.0, credits_balance: 10.0) }
+    let(:invoice) { create(:invoice, customer:, amount_cents: 555, organization: customer.organization) }
+    let(:wallet) { create(:wallet, customer:, balance: 10.0, credits_balance: 10.0) }
     let(:wallet_transaction) do
-      create(:wallet_transaction, invoice: invoice, wallet: wallet, amount: 1, credit_amount: 1)
+      create(:wallet_transaction, invoice:, wallet:, amount: 1, credit_amount: 1)
     end
 
     before { wallet_transaction }
@@ -213,9 +213,9 @@ RSpec.describe Invoice, type: :model do
 
   describe '#fee_total_amount_cents' do
     let(:organization) { create(:organization, name: 'LAGO') }
-    let(:customer) { create(:customer, organization: organization) }
-    let(:invoice) { create(:invoice, customer: customer) }
-    let(:fees) { create_list(:fee, 2, invoice: invoice, amount_cents: 100, vat_amount_cents: 20) }
+    let(:customer) { create(:customer, organization:) }
+    let(:invoice) { create(:invoice, customer:, organization:) }
+    let(:fees) { create_list(:fee, 2, invoice:, amount_cents: 100, vat_amount_cents: 20) }
 
     before { fees }
 
@@ -226,15 +226,15 @@ RSpec.describe Invoice, type: :model do
 
   describe '#subscription_amount' do
     let(:organization) { create(:organization, name: 'LAGO') }
-    let(:customer) { create(:customer, organization: organization) }
-    let(:subscription) { create(:subscription, organization: organization, customer: customer) }
-    let(:invoice) { create(:invoice, customer: customer) }
-    let(:fees) { create_list(:fee, 2, invoice: invoice) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, organization:, customer:) }
+    let(:invoice) { create(:invoice, customer:, organization:) }
+    let(:fees) { create_list(:fee, 2, invoice:) }
 
     it 'returns the subscriptions amount' do
-      create(:fee, invoice: invoice, amount_cents: 200)
-      create(:fee, invoice: invoice, amount_cents: 100)
-      create(:fee, invoice: invoice, charge_id: create(:standard_charge).id, fee_type: 'charge')
+      create(:fee, invoice:, amount_cents: 200)
+      create(:fee, invoice:, amount_cents: 100)
+      create(:fee, invoice:, charge_id: create(:standard_charge).id, fee_type: 'charge')
 
       expect(invoice.subscription_amount.to_s).to eq('3.00')
     end

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe InvoicesQuery, type: :query do
   let(:invoice_first) do
     create(
       :invoice,
+      organization:,
       status: 'finalized',
       payment_status: 'succeeded',
       customer: customer_first,
@@ -23,6 +24,7 @@ RSpec.describe InvoicesQuery, type: :query do
   let(:invoice_second) do
     create(
       :invoice,
+      organization:,
       status: 'finalized',
       payment_status: 'pending',
       customer: customer_second,
@@ -32,6 +34,7 @@ RSpec.describe InvoicesQuery, type: :query do
   let(:invoice_third) do
     create(
       :invoice,
+      organization:,
       status: 'finalized',
       payment_status: 'failed',
       customer: customer_first,
@@ -41,6 +44,7 @@ RSpec.describe InvoicesQuery, type: :query do
   let(:invoice_fourth) do
     create(
       :invoice,
+      organization:,
       status: 'draft',
       payment_status: 'pending',
       customer: customer_second,
@@ -50,6 +54,7 @@ RSpec.describe InvoicesQuery, type: :query do
   let(:invoice_fifth) do
     create(
       :invoice,
+      organization:,
       status: 'draft',
       payment_status: 'pending',
       customer: customer_first,

--- a/spec/requests/api/v1/credit_notes_spec.rb
+++ b/spec/requests/api/v1/credit_notes_spec.rb
@@ -3,14 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::CreditNotesController, type: :request do
-  let(:organization) { invoice.organization }
-  let(:customer) { invoice.customer }
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
   let(:credit_note) { create(:credit_note, invoice:, customer:) }
   let(:credit_note_items) { create_list(:credit_note_item, 2, credit_note:) }
 
   let(:invoice) do
     create(
       :invoice,
+      organization:,
+      customer:,
       payment_status: 'succeeded',
       amount_cents: 100,
       amount_currency: 'EUR',
@@ -177,7 +179,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
 
   describe 'GET /credit_notes' do
     let(:second_customer) { create(:customer, organization:) }
-    let(:second_invoice) { create(:invoice, customer: second_customer) }
+    let(:second_invoice) { create(:invoice, customer: second_customer, organization:) }
     let(:second_credit_note) { create(:credit_note, invoice: second_invoice, customer: second_invoice.customer) }
     let(:draft_credit_note) { create(:credit_note, :draft, customer: second_customer) }
 

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::InvoicesController, type: :request do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
 
   describe 'UPDATE /invoices' do
     let(:update_params) do
@@ -112,7 +112,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
   end
 
   describe 'GET /invoices' do
-    let(:invoice) { create(:invoice, :draft, customer:) }
+    let(:invoice) { create(:invoice, :draft, customer:, organization:) }
     let(:customer) { create(:customer, organization:) }
 
     before { invoice }
@@ -128,7 +128,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'with pagination' do
-      let(:invoice2) { create(:invoice, customer:) }
+      let(:invoice2) { create(:invoice, customer:, organization:) }
 
       before { invoice2 }
 
@@ -147,9 +147,9 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'with issuing_date params' do
-      let(:invoice) { create(:invoice, customer:, issuing_date: 5.days.ago.to_date) }
-      let(:invoice2) { create(:invoice, customer:, issuing_date: 3.days.ago.to_date) }
-      let(:invoice3) { create(:invoice, customer:, issuing_date: 1.day.ago.to_date) }
+      let(:invoice) { create(:invoice, customer:, issuing_date: 5.days.ago.to_date, organization:) }
+      let(:invoice2) { create(:invoice, customer:, issuing_date: 3.days.ago.to_date, organization:) }
+      let(:invoice3) { create(:invoice, customer:, issuing_date: 1.day.ago.to_date, organization:) }
 
       before do
         invoice2
@@ -171,7 +171,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     context 'with external_customer_id params' do
       it 'returns invoices of the customer' do
         second_customer = create(:customer, organization:)
-        invoice = create(:invoice, customer: second_customer)
+        invoice = create(:invoice, customer: second_customer, organization:)
 
         get_with_token(organization, "/api/v1/invoices?external_customer_id=#{second_customer.external_id}")
 
@@ -183,7 +183,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
 
     context 'with status params' do
       it 'returns invoices for the given status' do
-        invoice = create(:invoice, customer:)
+        invoice = create(:invoice, customer:, organization:)
 
         get_with_token(organization, '/api/v1/invoices?status=finalized')
 
@@ -194,9 +194,9 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'with payment status param' do
-      let(:invoice) { create(:invoice, customer:, payment_status: :succeeded) }
-      let(:invoice2) { create(:invoice, customer:, payment_status: :failed) }
-      let(:invoice3) { create(:invoice, customer:, payment_status: :pending) }
+      let(:invoice) { create(:invoice, customer:, payment_status: :succeeded, organization:) }
+      let(:invoice2) { create(:invoice, customer:, payment_status: :failed, organization:) }
+      let(:invoice3) { create(:invoice, customer:, payment_status: :pending, organization:) }
 
       before do
         invoice2
@@ -222,7 +222,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'when invoice is draft' do
-      let(:invoice) { create(:invoice, :draft, customer:) }
+      let(:invoice) { create(:invoice, :draft, customer:, organization:) }
 
       it 'updates the invoice' do
         expect {
@@ -239,7 +239,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'when invoice is finalized' do
-      let(:invoice) { create(:invoice, customer:) }
+      let(:invoice) { create(:invoice, customer:, organization:) }
 
       it 'does not update the invoice' do
         expect {
@@ -257,7 +257,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
   end
 
   describe 'PUT /invoices/:id/finalize' do
-    let(:invoice) { create(:invoice, :draft, customer:) }
+    let(:invoice) { create(:invoice, :draft, customer:, organization:) }
 
     context 'when invoice does not exist' do
       it 'returns a not found error' do
@@ -267,7 +267,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'when invoice is not draft' do
-      let(:invoice) { create(:invoice, customer:, status: :finalized) }
+      let(:invoice) { create(:invoice, customer:, status: :finalized, organization:) }
 
       it 'returns a not found error' do
         put_with_token(organization, "/api/v1/invoices/#{invoice.id}/finalize", {})
@@ -290,7 +290,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
   end
 
   describe 'POST /invoices/:id/download' do
-    let(:invoice) { create(:invoice, :draft, customer:) }
+    let(:invoice) { create(:invoice, :draft, customer:, organization:) }
 
     context 'when invoice is draft' do
       it 'returns not found' do
@@ -326,7 +326,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
     end
 
     context 'when invoices belongs to an other organization' do
-      let(:invoice) { create(:invoice) }
+      let(:invoice) { create(:invoice, organization:) }
 
       it 'returns not found' do
         get_with_token(organization, "/api/v1/invoices/#{invoice.id}/retry_payment")

--- a/spec/serializers/v1/billable_metric_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_serializer_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe ::V1::BillableMetricSerializer do
     charge = create(:standard_charge, plan: subscription.plan, billable_metric:)
     charge2 = create(:standard_charge, plan: subscription2.plan, billable_metric:)
 
-    invoice = create(:invoice, customer:)
+    invoice = create(:invoice, customer:, organization: billable_metric.organization)
     create(:fee, invoice:, charge:)
 
-    draft_invoice = create(:invoice, :draft, customer:)
+    draft_invoice = create(:invoice, :draft, customer:, organization: billable_metric.organization)
     create(:fee, invoice: draft_invoice, charge: charge2)
     create(:fee, invoice: draft_invoice, charge: charge2)
 

--- a/spec/services/credit_notes/generate_service_spec.rb
+++ b/spec/services/credit_notes/generate_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CreditNotes::GenerateService, type: :service do
 
   let(:organization) { create(:organization, name: 'LAGO') }
   let(:customer) { create(:customer, organization:) }
-  let(:invoice) { create(:invoice, customer:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
   let(:credit_note) { create(:credit_note, invoice:, customer:) }
   let(:fee) { create(:fee, invoice:) }
   let(:credit_note_item) { create(:credit_note_item, credit_note:, fee:) }

--- a/spec/services/customers/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/customers/update_invoice_grace_period_service_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Customers::UpdateInvoiceGracePeriodService, type: :service do
 
   describe '#call' do
     let(:invoice_to_be_finalized) do
-      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'))
+      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'), organization:)
     end
 
     let(:invoice_to_not_be_finalized) do
-      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'))
+      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'), organization:)
     end
 
     before do

--- a/spec/services/fees/paid_credit_service_spec.rb
+++ b/spec/services/fees/paid_credit_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Fees::PaidCreditService do
   end
 
   let(:customer) { create(:customer) }
-  let(:invoice) { create(:invoice) }
+  let(:invoice) { create(:invoice, organization: customer.organization) }
   let(:subscription) { create(:subscription, customer: customer) }
   let(:wallet) { create(:wallet, customer: customer) }
   let(:wallet_transaction) do

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Fees::SubscriptionService do
       amount_currency: 'EUR',
     )
   end
-  let(:invoice) { create(:invoice) }
+  let(:invoice) { create(:invoice, organization: customer.organization) }
   let(:boundaries) do
     {
       from_datetime: Time.zone.parse('2022-03-01 00:00:00'),
@@ -640,8 +640,8 @@ RSpec.describe Fees::SubscriptionService do
     end
 
     before do
-      other_invoice = create(:invoice)
-      create(:fee, subscription: subscription, invoice: other_invoice)
+      other_invoice = create(:invoice, organization: customer.organization)
+      create(:fee, subscription:, invoice: other_invoice)
     end
 
     it 'creates a fee with full period amount' do

--- a/spec/services/invoices/generate_service_spec.rb
+++ b/spec/services/invoices/generate_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Invoices::GenerateService, type: :service do
   let(:organization) { create(:organization, name: 'LAGO') }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, organization:, customer:) }
-  let(:invoice) { create(:invoice, customer:, status: :finalized) }
+  let(:invoice) { create(:invoice, customer:, status: :finalized, organization:) }
   let(:credit) { create(:credit, invoice:) }
   let(:fees) { create_list(:fee, 3, invoice:) }
   let(:invoice_subscription) { create(:invoice_subscription, invoice:, subscription:) }
@@ -47,7 +47,7 @@ RSpec.describe Invoices::GenerateService, type: :service do
     end
 
     context 'when invoice is draft' do
-      let(:invoice) { create(:invoice, customer:, status: :draft) }
+      let(:invoice) { create(:invoice, customer:, status: :draft, organization:) }
 
       it 'returns a result with error' do
         result = invoice_generate_service.generate(invoice_id: invoice.id)

--- a/spec/services/invoices/payments/create_service_spec.rb
+++ b/spec/services/invoices/payments/create_service_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe Invoices::Payments::CreateService, type: :service do
   subject(:create_service) { described_class.new(invoice) }
 
-  let(:invoice) { create(:invoice, customer: customer) }
-  let(:customer) { create(:customer, payment_provider: payment_provider) }
+  let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
+  let(:customer) { create(:customer, payment_provider:) }
   let(:payment_provider) { 'stripe' }
 
   describe '#call' do

--- a/spec/services/invoices/payments/gocardless_service_spec.rb
+++ b/spec/services/invoices/payments/gocardless_service_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
 
   let(:customer) { create(:customer) }
   let(:organization) { customer.organization }
-  let(:gocardless_payment_provider) { create(:gocardless_provider, organization: organization) }
-  let(:gocardless_customer) { create(:gocardless_customer, customer: customer) }
+  let(:gocardless_payment_provider) { create(:gocardless_provider, organization:) }
+  let(:gocardless_customer) { create(:gocardless_customer, customer:) }
   let(:gocardless_client) { instance_double(GoCardlessPro::Client) }
   let(:gocardless_payments_service) { instance_double(GoCardlessPro::Services::PaymentsService) }
   let(:gocardless_mandates_service) { instance_double(GoCardlessPro::Services::MandatesService) }
@@ -17,7 +17,8 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
   let(:invoice) do
     create(
       :invoice,
-      customer: customer,
+      organization:,
+      customer:,
       total_amount_cents: 200,
       total_amount_currency: 'EUR',
       ready_for_payment_processing: true,
@@ -138,7 +139,8 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
       let(:invoice) do
         create(
           :invoice,
-          customer: customer,
+          organization:,
+          customer:,
           total_amount_cents: 0,
           total_amount_currency: 'EUR',
         )

--- a/spec/services/invoices/payments/retry_service_spec.rb
+++ b/spec/services/invoices/payments/retry_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Invoices::Payments::RetryService, type: :service do
   subject(:retry_service) { described_class.new(invoice:) }
 
-  let(:invoice) { create(:invoice, customer:, status: 'finalized') }
+  let(:invoice) { create(:invoice, customer:, status: 'finalized', organization: customer.organization) }
   let(:customer) { create(:customer, payment_provider:) }
   let(:payment_provider) { 'stripe' }
 
@@ -44,7 +44,15 @@ RSpec.describe Invoices::Payments::RetryService, type: :service do
     end
 
     context 'when invoice payment status is already succeeded' do
-      let(:invoice) { create(:invoice, customer:, status: 'finalized', payment_status: 'succeeded') }
+      let(:invoice) do
+        create(
+          :invoice,
+          customer:,
+          status: 'finalized',
+          payment_status: 'succeeded',
+          organization: customer.organization,
+        )
+      end
 
       it 'returns an error' do
         result = retry_service.call
@@ -56,7 +64,9 @@ RSpec.describe Invoices::Payments::RetryService, type: :service do
     end
 
     context 'when invoice status is draft' do
-      let(:invoice) { create(:invoice, customer:, payment_status: 'pending', status: 'draft') }
+      let(:invoice) do
+        create(:invoice, customer:, payment_status: 'pending', status: 'draft', organization: customer.organization)
+      end
 
       it 'returns an error' do
         result = retry_service.call

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -7,13 +7,14 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
 
   let(:customer) { create(:customer) }
   let(:organization) { customer.organization }
-  let(:stripe_payment_provider) { create(:stripe_provider, organization: organization) }
-  let(:stripe_customer) { create(:stripe_customer, customer: customer, payment_method_id: 'pm_123456') }
+  let(:stripe_payment_provider) { create(:stripe_provider, organization:) }
+  let(:stripe_customer) { create(:stripe_customer, customer:, payment_method_id: 'pm_123456') }
 
   let(:invoice) do
     create(
       :invoice,
-      customer: customer,
+      organization:,
+      customer:,
       total_amount_cents: 200,
       total_amount_currency: 'EUR',
       ready_for_payment_processing: true,
@@ -137,7 +138,8 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       let(:invoice) do
         create(
           :invoice,
-          customer: customer,
+          organization:,
+          customer:,
           total_amount_cents: 0,
           total_amount_currency: 'EUR',
         )

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
   describe '#call' do
     let(:status) { :draft }
     let(:invoice) do
-      create(:invoice, subscriptions: [subscription], status:)
+      create(:invoice, subscriptions: [subscription], status:, organization: subscription.organization)
     end
 
     let(:started_at) { 1.month.ago }

--- a/spec/services/organizations/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/organizations/update_invoice_grace_period_service_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe Organizations::UpdateInvoiceGracePeriodService, type: :service do
 
   describe '#call' do
     let(:invoice_to_be_finalized) do
-      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'))
+      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'), organization:)
     end
 
     let(:invoice_to_not_be_finalized) do
-      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'))
+      create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'), organization:)
     end
 
     before do

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -56,27 +56,27 @@ RSpec.describe Organizations::UpdateService do
 
       context 'when updating invoice grace period' do
         let(:customer) { create(:customer, organization:) }
-  
+
         let(:invoice_to_be_finalized) do
-          create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'))
+          create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'), organization:)
         end
-  
+
         let(:invoice_to_not_be_finalized) do
-          create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'))
+          create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'), organization:)
         end
-  
+
         before do
           invoice_to_be_finalized
           invoice_to_not_be_finalized
           allow(Invoices::FinalizeService).to receive(:call)
         end
-  
+
         it 'finalizes corresponding draft invoices' do
           current_date = DateTime.parse('22 Jun 2022')
-  
+
           travel_to(current_date) do
             result = organization_update_service.update(invoice_grace_period: 2)
-  
+
             expect(result.organization.invoice_grace_period).to eq(2)
             expect(Invoices::FinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
             expect(Invoices::FinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)
@@ -164,29 +164,29 @@ RSpec.describe Organizations::UpdateService do
         let(:update_args) do
           { billing_configuration: { invoice_grace_period: 2 } }
         end
-  
+
         let(:customer) { create(:customer, organization:) }
-  
+
         let(:invoice_to_be_finalized) do
-          create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'))
+          create(:invoice, status: :draft, customer:, created_at: DateTime.parse('19 Jun 2022'), organization:)
         end
-  
+
         let(:invoice_to_not_be_finalized) do
-          create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'))
+          create(:invoice, status: :draft, customer:, created_at: DateTime.parse('21 Jun 2022'), organization:)
         end
-  
+
         before do
           invoice_to_be_finalized
           invoice_to_not_be_finalized
           allow(Invoices::FinalizeService).to receive(:call)
         end
-  
+
         it 'finalizes corresponding draft invoices' do
           current_date = DateTime.parse('22 Jun 2022')
-  
+
           travel_to(current_date) do
             result = organization_update_service.update_from_api(params: update_args)
-  
+
             expect(result.organization.invoice_grace_period).to eq(2)
             expect(Invoices::FinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
             expect(Invoices::FinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)

--- a/spec/services/wallets/apply_paid_credits_service_spec.rb
+++ b/spec/services/wallets/apply_paid_credits_service_spec.rb
@@ -6,19 +6,20 @@ RSpec.describe Wallets::ApplyPaidCreditsService, type: :service do
   subject(:service) { described_class.new }
 
   describe '.call' do
-    let(:invoice) { create(:invoice, customer: customer) }
+    let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
     let(:customer) { create(:customer) }
-    let(:subscription) { create(:subscription, customer: customer) }
-    let(:wallet) { create(:wallet, customer: customer, balance: 10.0, credits_balance: 10.0) }
+    let(:subscription) { create(:subscription, customer:) }
+    let(:wallet) { create(:wallet, customer:, balance: 10.0, credits_balance: 10.0) }
     let(:wallet_transaction) do
-      create(:wallet_transaction, wallet: wallet, amount: 15.0, credit_amount: 15.0, status: 'pending')
+      create(:wallet_transaction, wallet:, amount: 15.0, credit_amount: 15.0, status: 'pending')
     end
     let(:fee) do
-      create(:fee,
+      create(
+        :fee,
         fee_type: 'credit',
         invoiceable_type: 'WalletTransaction',
         invoiceable_id: wallet_transaction.id,
-        invoice: invoice
+        invoice:,
       )
     end
 

--- a/spec/services/webhooks/add_on_service_spec.rb
+++ b/spec/services/webhooks/add_on_service_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe Webhooks::AddOnService do
   subject(:webhook_add_on_service) { described_class.new(invoice) }
 
-  let(:organization) { create(:organization, webhook_url: webhook_url) }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:subscription) { create(:subscription, organization: organization) }
-  let(:invoice) { create(:invoice, customer: customer) }
+  let(:organization) { create(:organization, webhook_url:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
   let(:webhook_url) { 'http://foo.bar' }
 
   describe '.call' do

--- a/spec/services/webhooks/invoices/drafted_service_spec.rb
+++ b/spec/services/webhooks/invoices/drafted_service_spec.rb
@@ -5,15 +5,15 @@ require 'rails_helper'
 RSpec.describe Webhooks::Invoices::DraftedService do
   subject(:webhook_invoice_service) { described_class.new(invoice) }
 
-  let(:organization) { create(:organization, webhook_url: webhook_url) }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:subscription) { create(:subscription, organization: organization) }
-  let(:invoice) { create(:invoice, customer: customer) }
+  let(:organization) { create(:organization, webhook_url:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
   let(:webhook_url) { 'http://foo.bar' }
 
   before do
-    create_list(:fee, 2, invoice: invoice)
-    create_list(:credit, 2, invoice: invoice)
+    create_list(:fee, 2, invoice:)
+    create_list(:credit, 2, invoice:)
   end
 
   describe '.call' do

--- a/spec/services/webhooks/invoices/generated_service_spec.rb
+++ b/spec/services/webhooks/invoices/generated_service_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe Webhooks::Invoices::GeneratedService do
   subject(:webhook_service) { described_class.new(invoice) }
 
-  let(:customer) { create(:customer, organization: organization) }
-  let(:subscription) { create(:subscription, organization: organization, customer: customer) }
-  let(:invoice) { create(:invoice, customer: customer) }
-  let(:organization) { create(:organization, webhook_url: webhook_url) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, organization:, customer:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:organization) { create(:organization, webhook_url:) }
   let(:webhook_url) { 'http://foo.bar' }
 
   describe '.call' do

--- a/spec/services/webhooks/invoices/payment_status_updated_service_spec.rb
+++ b/spec/services/webhooks/invoices/payment_status_updated_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Webhooks::Invoices::PaymentStatusUpdatedService do
   let(:organization) { create(:organization, webhook_url:) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, organization:, customer:) }
-  let(:invoice) { create(:invoice, customer:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
 
   describe '.call' do
     let(:lago_client) { instance_double(LagoHttpClient::Client) }

--- a/spec/services/webhooks/invoices_service_spec.rb
+++ b/spec/services/webhooks/invoices_service_spec.rb
@@ -5,15 +5,15 @@ require 'rails_helper'
 RSpec.describe Webhooks::InvoicesService do
   subject(:webhook_invoice_service) { described_class.new(invoice) }
 
-  let(:organization) { create(:organization, webhook_url: webhook_url) }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:subscription) { create(:subscription, organization: organization) }
-  let(:invoice) { create(:invoice, customer: customer) }
+  let(:organization) { create(:organization, webhook_url:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
   let(:webhook_url) { 'http://foo.bar' }
 
   before do
-    create_list(:fee, 4, invoice: invoice)
-    create_list(:credit, 4, invoice: invoice)
+    create_list(:fee, 4, invoice:)
+    create_list(:credit, 4, invoice:)
   end
 
   describe '.call' do

--- a/spec/services/webhooks/payment_providers/invoice_payment_failure_service_spec.rb
+++ b/spec/services/webhooks/payment_providers/invoice_payment_failure_service_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe Webhooks::PaymentProviders::InvoicePaymentFailureService do
   subject(:webhook_service) { described_class.new(invoice, webhook_options) }
 
-  let(:invoice) { create(:invoice, customer: customer) }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:subscription) { create(:subscription, organization: organization) }
-  let(:organization) { create(:organization, webhook_url: webhook_url) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, organization:) }
+  let(:organization) { create(:organization, webhook_url:) }
   let(:webhook_url) { 'http://foo.bar' }
 
   let(:webhook_options) { { provider_error: { message: 'message', error_code: 'code' } } }


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

This PR adds two changes:
- It creates a direct relation between `invoice` and `organization` models, rather than going through `customer`
- It ensure soft deleted customers remains visible from an invoice perspective