### PR TITLE
feat(delete_coupon): Soft delete coupon and coupon plans

### DIFF
--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -62,14 +62,6 @@ class Coupon < ApplicationRecord
 
   scope :expired, -> { where('coupons.expiration_at::timestamp(0) < ?', Time.current) }
 
-  def attached_to_customers?
-    applied_coupons.exists?
-  end
-
-  def deletable?
-    !attached_to_customers?
-  end
-
   def mark_as_terminated!(timestamp = Time.zone.now)
     self.terminated_at ||= timestamp
     terminated!

--- a/app/models/coupon_plan.rb
+++ b/app/models/coupon_plan.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class CouponPlan < ApplicationRecord
+  include Discard::Model
+  self.discard_column = :deleted_at
+
   belongs_to :coupon
   belongs_to :plan
+
+  default_scope -> { kept }
 end

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -7,7 +7,7 @@ class Credit < ApplicationRecord
   belongs_to :applied_coupon, optional: true
   belongs_to :credit_note, optional: true
 
-  has_one :coupon, through: :applied_coupon
+  has_one :coupon, -> { with_discarded }, through: :applied_coupon
 
   monetize :amount_cents, disable_validation: true, allow_nil: true
 

--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -14,7 +14,10 @@ module Coupons
     def call
       return result.not_found_failure!(resource: 'coupon') unless coupon
 
-      coupon.discard!
+      ActiveRecord::Base.transaction do
+        coupon.discard!
+        coupon.coupon_plans.discard_all
+      end
 
       result.coupon = coupon
       result

--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -13,7 +13,6 @@ module Coupons
 
     def call
       return result.not_found_failure!(resource: 'coupon') unless coupon
-      return result.not_allowed_failure!(code: 'attached_to_an_active_customer') unless coupon.deletable?
 
       coupon.destroy!
 

--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -14,7 +14,7 @@ module Coupons
     def call
       return result.not_found_failure!(resource: 'coupon') unless coupon
 
-      coupon.destroy!
+      coupon.discard!
 
       result.coupon = coupon
       result

--- a/app/services/coupons/update_service.rb
+++ b/app/services/coupons/update_service.rb
@@ -10,7 +10,7 @@ module Coupons
       coupon.expiration = args[:expiration]&.to_sym
       coupon.expiration_at = args[:expiration_at]
 
-      unless coupon.attached_to_customers?
+      unless coupon.applied_coupons.exists?
         coupon.code = args[:code]
         coupon.coupon_type = args[:coupon_type]
         coupon.amount_cents = args[:amount_cents]
@@ -39,7 +39,7 @@ module Coupons
       coupon.expiration = params[:expiration] if params.key?(:expiration)
       coupon.expiration_at = params[:expiration_at] if params.key?(:expiration_at)
 
-      unless coupon.attached_to_customers?
+      unless coupon.applied_coupons.exists?
         coupon.code = params[:code] if params.key?(:code)
         coupon.coupon_type = params[:coupon_type] if params.key?(:coupon_type)
         coupon.amount_cents = params[:amount_cents] if params.key?(:amount_cents)

--- a/db/migrate/20230203132157_add_deleted_at_to_coupon_plans.rb
+++ b/db/migrate/20230203132157_add_deleted_at_to_coupon_plans.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToCouponPlans < ActiveRecord::Migration[7.0]
+  def change
+    add_column :coupon_plans, :deleted_at, :datetime
+    add_index :coupon_plans, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_02_163249) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_03_132157) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -122,7 +122,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_163249) do
     t.uuid "plan_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["coupon_id"], name: "index_coupon_plans_on_coupon_id"
+    t.index ["deleted_at"], name: "index_coupon_plans_on_deleted_at"
     t.index ["plan_id"], name: "index_coupon_plans_on_plan_id"
   end
 

--- a/spec/factories/coupon_plans.rb
+++ b/spec/factories/coupon_plans.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :coupon_plan do
+    coupon
+    plan
+  end
+end

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -3,30 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Coupon, type: :model do
-  describe 'attached_to_customers?' do
-    let(:coupon) { create(:coupon) }
-
-    it { expect(coupon).not_to be_attached_to_customers }
-
-    context 'with attached customers' do
-      before { create(:applied_coupon, coupon: coupon) }
-
-      it { expect(coupon).to be_attached_to_customers }
-    end
-  end
-
-  describe 'deletable?' do
-    let(:coupon) { create(:coupon) }
-
-    it { expect(coupon).to be_deletable }
-
-    context 'with attached customers' do
-      before { create(:applied_coupon, coupon: coupon) }
-
-      it { expect(coupon).not_to be_deletable }
-    end
-  end
-
   describe '.mark_as_terminated' do
     let(:coupon) { create(:coupon) }
 

--- a/spec/requests/api/v1/coupons_spec.rb
+++ b/spec/requests/api/v1/coupons_spec.rb
@@ -53,19 +53,19 @@ RSpec.describe Api::V1::CouponsController, type: :request do
   end
 
   describe 'update' do
-    let(:coupon) { create(:coupon, organization: organization) }
+    let(:coupon) { create(:coupon, organization:) }
     let(:code) { 'coupon_code' }
     let(:expiration_at) { Time.current + 15.days }
     let(:update_params) do
       {
         name: 'coupon1',
-        code: code,
+        code:,
         coupon_type: 'fixed_amount',
         frequency: 'once',
         amount_cents: 123,
         amount_currency: 'EUR',
         expiration: 'time_limit',
-        expiration_at: expiration_at,
+        expiration_at:,
       }
     end
 
@@ -111,7 +111,7 @@ RSpec.describe Api::V1::CouponsController, type: :request do
     end
 
     context 'when coupon code already exists in organization scope (validation error)' do
-      let(:coupon2) { create(:coupon, organization: organization) }
+      let(:coupon2) { create(:coupon, organization:) }
       let(:code) { coupon2.code }
 
       before { coupon2 }
@@ -129,7 +129,7 @@ RSpec.describe Api::V1::CouponsController, type: :request do
   end
 
   describe 'show' do
-    let(:coupon) { create(:coupon, organization: organization) }
+    let(:coupon) { create(:coupon, organization:) }
 
     it 'returns a coupon' do
       get_with_token(
@@ -155,7 +155,7 @@ RSpec.describe Api::V1::CouponsController, type: :request do
   end
 
   describe 'destroy' do
-    let(:coupon) { create(:coupon, organization: organization) }
+    let(:coupon) { create(:coupon, organization:) }
 
     before { coupon }
 
@@ -179,27 +179,10 @@ RSpec.describe Api::V1::CouponsController, type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
-
-    context 'when coupon is attached to customer' do
-      let(:applied_coupon) { create(:applied_coupon, coupon: coupon) }
-
-      before { applied_coupon }
-
-      it 'returns forbidden error' do
-        delete_with_token(organization, "/api/v1/coupons/#{coupon.code}")
-
-        aggregate_failures do
-          expect(response).to have_http_status(:method_not_allowed)
-          expect(json[:status]).to eq(405)
-          expect(json[:error]).to eq('Method Not Allowed')
-          expect(json[:code]).to eq('attached_to_an_active_customer')
-        end
-      end
-    end
   end
 
   describe 'index' do
-    let(:coupon) { create(:coupon, organization: organization) }
+    let(:coupon) { create(:coupon, organization:) }
 
     before { coupon }
 
@@ -213,7 +196,7 @@ RSpec.describe Api::V1::CouponsController, type: :request do
     end
 
     context 'with pagination' do
-      let(:coupon2) { create(:coupon, organization: organization) }
+      let(:coupon2) { create(:coupon, organization:) }
 
       before { coupon2 }
 

--- a/spec/services/add_ons/destroy_service_spec.rb
+++ b/spec/services/add_ons/destroy_service_spec.rb
@@ -15,10 +15,8 @@ RSpec.describe AddOns::DestroyService, type: :service do
 
     it 'soft deletes the add-on' do
       aggregate_failures do
-        expect { destroy_service.call }
-          .to change(AddOn, :count).by(-1)
-
-        expect(add_on.reload.deleted_at).to be_present
+        expect { destroy_service.call }.to change(AddOn, :count).by(-1)
+          .and change { add_on.reload.deleted_at }.from(nil)
       end
     end
 

--- a/spec/services/add_ons/destroy_service_spec.rb
+++ b/spec/services/add_ons/destroy_service_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe AddOns::DestroyService, type: :service do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-
   let(:add_on) { create(:add_on, organization:) }
 
   describe 'destroy' do

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -23,19 +23,20 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
   end
 
   describe '#call' do
-    it 'discards the billable metric' do
+    it 'soft deletes the billable metric' do
       freeze_time do
-        expect { destroy_service.call }.to change { billable_metric.reload.deleted_at }.from(nil).to(Time.current)
+        expect { destroy_service.call }.to change(BillableMetric, :count).by(-1)
+          .and change { billable_metric.reload.deleted_at }.from(nil).to(Time.current)
       end
     end
 
-    it 'discards all the related charges' do
+    it 'soft deletes all the related charges' do
       freeze_time do
         expect { destroy_service.call }.to change { charge.reload.deleted_at }.from(nil).to(Time.current)
       end
     end
 
-    it 'discards all the related groups' do
+    it 'soft deletes all the related groups' do
       freeze_time do
         expect { destroy_service.call }.to change { group.reload.deleted_at }.from(nil).to(Time.current)
           .and change { group_property.reload.deleted_at }.from(nil).to(Time.current)

--- a/spec/services/coupons/destroy_service_spec.rb
+++ b/spec/services/coupons/destroy_service_spec.rb
@@ -8,14 +8,22 @@ RSpec.describe Coupons::DestroyService, type: :service do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:coupon) { create(:coupon, organization:) }
+  let(:coupon_plan) { create(:coupon_plan, coupon:) }
 
   describe '#call' do
     before { coupon }
 
     it 'soft deletes the coupon' do
-      aggregate_failures do
+      freeze_time do
         expect { destroy_service.call }.to change(Coupon, :count).by(-1)
-          .and change { coupon.reload.deleted_at }.from(nil)
+          .and change { coupon.reload.deleted_at }.from(nil).to(Time.current)
+      end
+    end
+
+    it 'soft deletes all the related coupon_plans' do
+      freeze_time do
+        expect { destroy_service.call }.to change { coupon_plan.reload.deleted_at }
+          .from(nil).to(Time.current)
       end
     end
 

--- a/spec/services/coupons/destroy_service_spec.rb
+++ b/spec/services/coupons/destroy_service_spec.rb
@@ -7,14 +7,16 @@ RSpec.describe Coupons::DestroyService, type: :service do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-
   let(:coupon) { create(:coupon, organization:) }
 
   describe '#call' do
     before { coupon }
 
-    it 'destroys the coupon' do
-      expect { destroy_service.call }.to change(Coupon, :count).by(-1)
+    it 'soft deletes the coupon' do
+      aggregate_failures do
+        expect { destroy_service.call }.to change(Coupon, :count).by(-1)
+          .and change { coupon.reload.deleted_at }.from(nil)
+      end
     end
 
     context 'when coupon is not found' do

--- a/spec/services/coupons/destroy_service_spec.rb
+++ b/spec/services/coupons/destroy_service_spec.rb
@@ -29,20 +29,5 @@ RSpec.describe Coupons::DestroyService, type: :service do
         end
       end
     end
-
-    context 'when coupon is attached to customer' do
-      let(:applied_coupon) { create(:applied_coupon, coupon:) }
-
-      before { applied_coupon }
-
-      it 'returns an error' do
-        result = destroy_service.call
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error.code).to eq('attached_to_an_active_customer')
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

This PR adds the ability to soft-delete a coupon and coupon plans.