### PR TITLE
feat(delete_coupon): Terminate applied coupons on deletion

### DIFF
--- a/app/graphql/mutations/applied_coupons/terminate.rb
+++ b/app/graphql/mutations/applied_coupons/terminate.rb
@@ -13,9 +13,11 @@ module Mutations
       type Types::AppliedCoupons::Object
 
       def resolve(id:)
-        result = ::AppliedCoupons::TerminateService
-          .new(context[:current_user])
-          .terminate(id)
+        applied_coupon = AppliedCoupon.joins(coupon: :organization)
+          .where(organizations: { id: context[:current_user].organization_ids })
+          .find_by(id:)
+
+        result = ::AppliedCoupons::TerminateService.call(applied_coupon:)
 
         result.success? ? result.applied_coupon : result_error(result)
       end

--- a/app/services/applied_coupons/terminate_service.rb
+++ b/app/services/applied_coupons/terminate_service.rb
@@ -2,12 +2,16 @@
 
 module AppliedCoupons
   class TerminateService < BaseService
-    def terminate(id)
-      applied_coupon = AppliedCoupon
-        .joins(coupon: :organization)
-        .where(organizations: { id: result.user.organization_ids })
-        .find_by(id: id)
+    def self.call(...)
+      new(...).call
+    end
 
+    def initialize(applied_coupon:)
+      @applied_coupon = applied_coupon
+      super
+    end
+
+    def call
       return result.not_found_failure!(resource: 'applied_coupon') unless applied_coupon
 
       applied_coupon.mark_as_terminated! unless applied_coupon.terminated?
@@ -17,5 +21,9 @@ module AppliedCoupons
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     end
+
+    private
+
+    attr_reader :applied_coupon
   end
 end

--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -17,6 +17,10 @@ module Coupons
       ActiveRecord::Base.transaction do
         coupon.discard!
         coupon.coupon_plans.discard_all
+
+        coupon.applied_coupons.active.each do |applied_coupon|
+          AppliedCoupons::TerminateService.call(applied_coupon:)
+        end
       end
 
       result.coupon = coupon

--- a/spec/services/add_ons/destroy_service_spec.rb
+++ b/spec/services/add_ons/destroy_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AddOns::DestroyService, type: :service do
   let(:organization) { membership.organization }
   let(:add_on) { create(:add_on, organization:) }
 
-  describe 'destroy' do
+  describe '#call' do
     before { add_on }
 
     it 'soft deletes the add-on' do

--- a/spec/services/applied_coupons/terminate_service_spec.rb
+++ b/spec/services/applied_coupons/terminate_service_spec.rb
@@ -3,17 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe AppliedCoupons::TerminateService, type: :service do
-  subject(:terminate_service) { described_class.new(membership.user) }
+  subject(:terminate_service) { described_class.new(applied_coupon:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
+  let(:coupon) { create(:coupon, status: 'active', organization:) }
+  let(:applied_coupon) { create(:applied_coupon, coupon:) }
 
-  let(:coupon) { create(:coupon, status: 'active', organization: organization) }
-  let(:applied_coupon) { create(:applied_coupon, coupon: coupon) }
-
-  describe 'terminate' do
+  describe '#call' do
     it 'terminates the applied coupon' do
-      result = terminate_service.terminate(applied_coupon.id)
+      result = terminate_service.call
 
       expect(result).to be_success
       expect(result.applied_coupon).to be_terminated
@@ -24,7 +23,7 @@ RSpec.describe AppliedCoupons::TerminateService, type: :service do
 
       it 'does not impact the applied coupon' do
         terminated_at = applied_coupon.reload.terminated_at
-        result = terminate_service.terminate(applied_coupon.id)
+        result = terminate_service.call
 
         expect(result).to be_success
         expect(result.applied_coupon).to be_terminated

--- a/spec/services/coupons/destroy_service_spec.rb
+++ b/spec/services/coupons/destroy_service_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe Coupons::DestroyService, type: :service do
       end
     end
 
+    context 'with applied coupons' do
+      it 'terminates applied coupons' do
+        applied_coupon = create(:applied_coupon, coupon:)
+        result = destroy_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(applied_coupon.reload).to be_terminated
+        end
+      end
+    end
+
     context 'when coupon is not found' do
       let(:coupon) { nil }
 


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

This PR adds the ability to terminate active applied coupons on coupon deletion.