### PR TITLE
feat(delete_customer): Remove delete limitation

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -49,6 +49,7 @@ module Api
             ::V1::InvoiceSerializer,
             collection_name: 'invoices',
             meta: pagination_metadata(invoices),
+            includes: %i[customer],
           ),
         )
       end

--- a/app/graphql/types/add_ons/object.rb
+++ b/app/graphql/types/add_ons/object.rb
@@ -17,6 +17,7 @@ module Types
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :customer_count, Integer, null: false, description: 'Number of customers using this add-on'
       field :applied_add_ons_count, Integer, null: false

--- a/app/graphql/types/applied_add_ons/object.rb
+++ b/app/graphql/types/applied_add_ons/object.rb
@@ -12,6 +12,10 @@ module Types
       field :amount_currency, Types::CurrencyEnum, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      def add_on
+        AddOn.with_discarded.find(object.add_on_id)
+      end
     end
   end
 end

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -50,16 +50,8 @@ module Types
             null: false,
             description: 'Credit notes credits balance available per customer'
 
-      field :can_be_deleted, Boolean, null: false do
-        description 'Check if customer is deletable'
-      end
-
       field :can_edit_attributes, Boolean, null: false do
         description 'Check if customer attributes are editable'
-      end
-
-      def can_be_deleted
-        object.deletable?
       end
 
       def has_active_wallet

--- a/app/jobs/clock/terminate_wallets_job.rb
+++ b/app/jobs/clock/terminate_wallets_job.rb
@@ -5,7 +5,9 @@ module Clock
     queue_as 'clock'
 
     def perform
-      Wallets::TerminateService.new.terminate_all_expired
+      Wallet.active.expired.find_each do |wallet|
+        Wallets::TerminateService.call(wallet:)
+      end
     end
   end
 end

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -6,7 +6,7 @@ class CreditNote < ApplicationRecord
 
   before_save :ensure_number
 
-  belongs_to :customer
+  belongs_to :customer, -> { with_discarded }
   belongs_to :invoice
 
   has_one :organization, through: :customer

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -9,7 +9,7 @@ class CreditNote < ApplicationRecord
   belongs_to :customer, -> { with_discarded }
   belongs_to :invoice
 
-  has_one :organization, through: :customer
+  has_one :organization, through: :invoice
 
   has_many :items, class_name: 'CreditNoteItem', dependent: :destroy
   has_many :fees, through: :items

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -46,14 +46,6 @@ class Customer < ApplicationRecord
   validates :timezone, timezone: true, allow_nil: true
   validates :vat_rate, numericality: { less_than_or_equal_to: 100, greater_than_or_equal_to: 0 }, allow_nil: true
 
-  def attached_to_subscriptions?
-    subscriptions.exists?
-  end
-
-  def deletable?
-    !attached_to_subscriptions? && applied_add_ons.none? && applied_coupons.none? && wallets.none?
-  end
-
   def active_subscription
     subscriptions.active.order(started_at: :desc).first
   end
@@ -81,7 +73,7 @@ class Customer < ApplicationRecord
   end
 
   def editable?
-    !attached_to_subscriptions? &&
+    subscriptions.none? &&
       applied_add_ons.none? &&
       applied_coupons.where.not(amount_currency: nil).none? &&
       wallets.none?

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -53,7 +53,7 @@ class Invoice < ApplicationRecord
             )
           SQL
 
-          draft.joins(customer: :organization).where("#{Arel.sql(date)} < ?", Time.current)
+          draft.joins(:customer, :organization).where("#{Arel.sql(date)} < ?", Time.current)
         }
 
   scope :created_before,

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,7 +10,7 @@ class Organization < ApplicationRecord
   has_many :customers
   has_many :subscriptions, through: :customers
   has_many :invoices
-  has_many :credit_notes, through: :customers
+  has_many :credit_notes, through: :invoices
   has_many :events
   has_many :coupons
   has_many :applied_coupons, through: :coupons

--- a/app/services/customers/destroy_service.rb
+++ b/app/services/customers/destroy_service.rb
@@ -14,7 +14,6 @@ module Customers
 
     def call
       return result.not_found_failure!(resource: 'customer') unless customer
-      return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless customer.deletable?
 
       customer.discard!
       track_customer_deleted

--- a/app/services/customers/terminate_relations_service.rb
+++ b/app/services/customers/terminate_relations_service.rb
@@ -16,7 +16,7 @@ module Customers
 
       # NOTE: Terminate active subscriptions.
       customer.subscriptions.active.each do |subscription|
-        Subscriptions::TerminateService.call(subscription:)
+        Subscriptions::TerminateService.call(subscription:, async: false)
       end
 
       # NOTE: Cancel pending subscriptions

--- a/app/services/wallets/terminate_service.rb
+++ b/app/services/wallets/terminate_service.rb
@@ -22,10 +22,6 @@ module Wallets
       result.record_validation_failure!(record: e.record)
     end
 
-    def terminate_all_expired
-      Wallet.active.expired.find_each(&:mark_as_terminated!)
-    end
-
     private
 
     attr_reader :wallet

--- a/schema.graphql
+++ b/schema.graphql
@@ -38,6 +38,7 @@ type AddOn {
   Number of customers using this add-on
   """
   customerCount: Int!
+  deletedAt: ISO8601DateTime
   description: String
   id: ID!
   name: String!
@@ -61,6 +62,7 @@ type AddOnDetails {
   Number of customers using this add-on
   """
   customerCount: Int!
+  deletedAt: ISO8601DateTime
   description: String
   id: ID!
   name: String!

--- a/schema.graphql
+++ b/schema.graphql
@@ -2530,11 +2530,6 @@ type Customer {
   applicableTimezone: TimezoneEnum!
 
   """
-  Check if customer is deletable
-  """
-  canBeDeleted: Boolean!
-
-  """
   Check if customer attributes are editable
   """
   canEditAttributes: Boolean!
@@ -2600,11 +2595,6 @@ type CustomerDetails {
   applicableTimezone: TimezoneEnum!
   appliedAddOns: [AppliedAddOn!]
   appliedCoupons: [AppliedCoupon!]
-
-  """
-  Check if customer is deletable
-  """
-  canBeDeleted: Boolean!
 
   """
   Check if customer attributes are editable

--- a/schema.json
+++ b/schema.json
@@ -7808,24 +7808,6 @@
               ]
             },
             {
-              "name": "canBeDeleted",
-              "description": "Check if customer is deletable",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "canEditAttributes",
               "description": "Check if customer attributes are editable",
               "type": {
@@ -8467,24 +8449,6 @@
                     "name": "AppliedCoupon",
                     "ofType": null
                   }
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "canBeDeleted",
-              "description": "Check if customer is deletable",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
                 }
               },
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -233,6 +233,20 @@
               ]
             },
             {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "description",
               "description": null,
               "type": {
@@ -485,6 +499,20 @@
                   "name": "Int",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/mutations/credit_notes/update_spec.rb
+++ b/spec/graphql/mutations/credit_notes/update_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Mutations::CreditNotes::Update, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
-  let(:credit_note) { create(:credit_note, customer:) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
+  let(:credit_note) { create(:credit_note, customer:, invoice:) }
 
   let(:mutation) do
     <<~GQL

--- a/spec/graphql/mutations/credit_notes/void_spec.rb
+++ b/spec/graphql/mutations/credit_notes/void_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Mutations::CreditNotes::Void, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
-  let(:credit_note) { create(:credit_note, customer:) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
+  let(:credit_note) { create(:credit_note, customer:, invoice:) }
 
   let(:mutation) do
     <<~GQL

--- a/spec/graphql/resolvers/credit_note_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_note_resolver_spec.rb
@@ -44,13 +44,14 @@ RSpec.describe Resolvers::CreditNoteResolver, type: :graphql do
   let(:membership) { create(:membership) }
 
   let(:customer) { create(:customer, organization: membership.organization) }
-  let(:credit_note) { create(:credit_note, customer: customer) }
+  let(:invoice) { create(:invoice, organization: membership.organization, customer:) }
+  let(:credit_note) { create(:credit_note, customer:, invoice:) }
 
   it 'returns a single credit note' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: customer.organization,
-      query: query,
+      query:,
       variables: {
         creditNoteId: credit_note.id,
       },

--- a/spec/jobs/clock/terminate_wallets_job_spec.rb
+++ b/spec/jobs/clock/terminate_wallets_job_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Clock::TerminateWalletsJob, job: true do
+  let(:to_expire_wallet) do
+    create(
+      :wallet,
+      status: 'active',
+      expiration_at: Time.zone.now - 40.days,
+    )
+  end
+
+  let(:to_keep_active_wallet) do
+    create(
+      :wallet,
+      status: 'active',
+      expiration_at: Time.zone.now + 40.days,
+    )
+  end
+
+  before do
+    to_expire_wallet
+    to_keep_active_wallet
+  end
+
+  it 'terminates the expired wallets' do
+    described_class.perform_now
+
+    expect(to_expire_wallet.reload.status).to eq('terminated')
+    expect(to_keep_active_wallet.reload.status).to eq('active')
+  end
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -178,34 +178,4 @@ RSpec.describe Customer, type: :model do
       end
     end
   end
-
-  describe 'deletable?' do
-    let(:customer) { create(:customer) }
-
-    it { expect(customer).to be_deletable }
-
-    context 'when attached to a subscription' do
-      before { create(:subscription, customer: customer) }
-
-      it { expect(customer).not_to be_deletable }
-    end
-
-    context 'when attached to an add-on' do
-      before { create(:applied_add_on, customer: customer) }
-
-      it { expect(customer).not_to be_deletable }
-    end
-
-    context 'when attached to a coupon' do
-      before { create(:applied_coupon, customer: customer) }
-
-      it { expect(customer).not_to be_deletable }
-    end
-
-    context 'when attached to a wallet' do
-      before { create(:wallet, customer: customer) }
-
-      it { expect(customer).not_to be_deletable }
-    end
-  end
 end

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -179,6 +179,21 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         expect(json[:invoices].count).to eq(1)
         expect(json[:invoices].first[:lago_id]).to eq(invoice.id)
       end
+
+      context 'with deleted customer' do
+        let(:customer) { create(:customer, :deleted, organization:) }
+
+        it 'returns the invoices of the customer' do
+          get_with_token(organization, "/api/v1/invoices?external_customer_id=#{customer.external_id}")
+
+          aggregate_failures do
+            expect(response).to have_http_status(:success)
+            expect(json[:invoices].count).to eq(1)
+            expect(json[:invoices].first[:lago_id]).to eq(invoice.id)
+            expect(json[:invoices].first[:customer][:lago_id]).to eq(customer.id)
+          end
+        end
+      end
     end
 
     context 'with status params' do

--- a/spec/scenarios/delete_customer_spec.rb
+++ b/spec/scenarios/delete_customer_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Delete Customer Scenarios', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
+  let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 1000) }
+  let(:metric) { create(:billable_metric, organization:) }
+
+  it 'deletes the customer and terminate relations' do
+    ### 15 Dec: Create subscription + charge.
+    dec15 = DateTime.new(2022, 12, 15)
+
+    travel_to(dec15) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+        },
+      )
+
+      create(:standard_charge, plan:, billable_metric: metric, properties: { amount: '3' })
+    end
+
+    subscription = customer.subscriptions.find_by(external_id: customer.external_id)
+    dec_invoice = subscription.invoices.first
+    expect(dec_invoice).to be_draft
+
+    ### 1 Jan: Billing
+    jan1 = DateTime.new(2023, 1, 1)
+
+    travel_to(jan1) do
+      perform_billing
+      expect(subscription.invoices.count).to eq(2)
+    end
+
+    jan_invoice = subscription.invoices.order(created_at: :desc).first
+    expect(jan_invoice).to be_draft
+
+    ### 10 Jan: Delete Plan
+    jan20 = DateTime.new(2023, 1, 20)
+
+    travel_to(jan20) do
+      # Downgrade subscription
+      downgrade_plan = create(:plan, organization:, amount_cents: 500)
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: downgrade_plan.code,
+          subscription_at: '2023-02-01T00:00:00Z',
+        },
+      )
+      pending_subscription = customer.subscriptions.pending.first
+
+      # Create coupon and apply it to customer
+      create_coupon(
+        {
+          name: 'coupon1',
+          code: 'coupon1_code',
+          coupon_type: 'fixed_amount',
+          frequency: 'once',
+          amount_cents: 123,
+          amount_currency: 'EUR',
+          expiration: 'time_limit',
+          expiration_at: Time.current + 15.days,
+          reusable: false,
+        },
+      )
+      apply_coupon(
+        {
+          external_customer_id: customer.external_id,
+          coupon_code: 'coupon1_code',
+        },
+      )
+      applied_coupon = customer.applied_coupons.active.first
+
+      # Create wallet
+      create_wallet(
+        {
+          external_customer_id: customer.external_id,
+          rate_amount: '1',
+          name: 'Wallet1',
+          currency: 'EUR',
+          paid_credits: '10',
+          granted_credits: '10',
+          expiration_at: Time.current + 15.days,
+        },
+      )
+      wallet = customer.wallets.active.first
+
+      delete_customer(customer)
+
+      # Customer is discarded
+      expect(customer.reload).to be_discarded
+
+      perform_all_enqueued_jobs
+
+      # Subscription is terminated
+      expect(subscription.reload).to be_terminated
+
+      # Pending subscription is canceled
+      expect(pending_subscription.reload).to be_canceled
+
+      # Applied coupon is terminated
+      expect(applied_coupon.reload).to be_terminated
+
+      # Wallet is terminated
+      expect(wallet.reload).to be_terminated
+
+      # A new termination invoice has been created
+      expect(subscription.invoices.count).to eq(3)
+      term_invoice = subscription.invoices.order(created_at: :desc).first
+      expect(term_invoice).to be_finalized
+
+      # Draft invoices are now finalized
+      expect(dec_invoice.reload).to be_finalized
+      expect(jan_invoice.reload).to be_finalized
+    end
+  end
+end

--- a/spec/services/credit_notes/refunds/gocardless_service_spec.rb
+++ b/spec/services/credit_notes/refunds/gocardless_service_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
   subject(:gocardless_service) { described_class.new(credit_note) }
 
   let(:customer) { create(:customer) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
   let(:organization) { customer.organization }
-  let(:gocardless_payment_provider) { create(:gocardless_provider, organization: organization) }
-  let(:gocardless_customer) { create(:gocardless_customer, customer: customer) }
+  let(:gocardless_payment_provider) { create(:gocardless_provider, organization:) }
+  let(:gocardless_customer) { create(:gocardless_customer, customer:) }
   let(:gocardless_client) { instance_double(GoCardlessPro::Client) }
   let(:gocardless_refunds_service) { instance_double(GoCardlessPro::Services::RefundsService) }
   let(:payment) do
@@ -25,7 +26,8 @@ RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
   let(:credit_note) do
     create(
       :credit_note,
-      customer: customer,
+      customer:,
+      invoice:,
       refund_amount_cents: 134,
       refund_amount_currency: 'CHF',
       refund_status: :pending,

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
 
   let(:customer) { create(:customer) }
   let(:organization) { customer.organization }
-  let(:stripe_payment_provider) { create(:stripe_provider, organization: organization) }
-  let(:stripe_customer) { create(:stripe_customer, customer: customer) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:stripe_payment_provider) { create(:stripe_provider, organization:) }
+  let(:stripe_customer) { create(:stripe_customer, customer:) }
   let(:payment) do
     create(
       :payment,
@@ -23,7 +24,8 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
   let(:credit_note) do
     create(
       :credit_note,
-      customer: customer,
+      customer:,
+      invoice:,
       refund_amount_cents: 134,
       refund_amount_currency: 'CHF',
       refund_status: :pending,

--- a/spec/services/customers/destroy_service_spec.rb
+++ b/spec/services/customers/destroy_service_spec.rb
@@ -52,18 +52,5 @@ RSpec.describe Customers::DestroyService, type: :service do
         expect(result.error.error_code).to eq('customer_not_found')
       end
     end
-
-    context 'when customer is attached to subscription' do
-      before do
-        create(:subscription, customer:)
-      end
-
-      it 'returns an error' do
-        result = destroy_service.call
-
-        expect(result).not_to be_success
-        expect(result.error.code).to eq('attached_to_an_active_subscription')
-      end
-    end
   end
 end

--- a/spec/services/wallets/terminate_service_spec.rb
+++ b/spec/services/wallets/terminate_service_spec.rb
@@ -38,34 +38,4 @@ RSpec.describe Wallets::TerminateService, type: :service do
       end
     end
   end
-
-  describe 'terminate_all_expired' do
-    let(:to_expire_wallet) do
-      create(
-        :wallet,
-        status: 'active',
-        expiration_at: Time.zone.now - 40.days,
-      )
-    end
-
-    let(:to_keep_active_wallet) do
-      create(
-        :wallet,
-        status: 'active',
-        expiration_at: Time.zone.now + 40.days,
-      )
-    end
-
-    before do
-      to_expire_wallet
-      to_keep_active_wallet
-    end
-
-    it 'terminates the expired wallets' do
-      terminate_service.terminate_all_expired
-
-      expect(to_expire_wallet.reload.status).to eq('terminated')
-      expect(to_keep_active_wallet.reload.status).to eq('active')
-    end
-  end
 end

--- a/spec/services/webhooks/credit_notes/created_service_spec.rb
+++ b/spec/services/webhooks/credit_notes/created_service_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe Webhooks::CreditNotes::CreatedService do
   subject(:webhook_service) { described_class.new(credit_note) }
 
-  let(:credit_note) { create(:credit_note, customer: customer) }
-
-  let(:organization) { create(:organization, webhook_url: webhook_url) }
-  let(:customer) { create(:customer, organization: organization) }
+  let(:organization) { create(:organization, webhook_url:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
+  let(:credit_note) { create(:credit_note, customer:, invoice:) }
   let(:webhook_url) { 'http://foo.bar' }
 
   describe '.call' do

--- a/spec/services/webhooks/credit_notes/generated_service_spec.rb
+++ b/spec/services/webhooks/credit_notes/generated_service_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe Webhooks::CreditNotes::GeneratedService do
   subject(:webhook_service) { described_class.new(credit_note) }
 
-  let(:credit_note) { create(:credit_note, customer: customer) }
-
-  let(:organization) { create(:organization, webhook_url: webhook_url) }
-  let(:customer) { create(:customer, organization: organization) }
+  let(:organization) { create(:organization, webhook_url:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
+  let(:credit_note) { create(:credit_note, customer:, invoice:) }
   let(:webhook_url) { 'http://foo.bar' }
 
   describe '.call' do

--- a/spec/services/webhooks/credit_notes/payment_provider_refund_failure_service_spec.rb
+++ b/spec/services/webhooks/credit_notes/payment_provider_refund_failure_service_spec.rb
@@ -5,9 +5,10 @@ require 'rails_helper'
 RSpec.describe Webhooks::CreditNotes::PaymentProviderRefundFailureService do
   subject(:webhook_service) { described_class.new(credit_note, webhook_options) }
 
-  let(:credit_note) { create(:credit_note, customer: customer) }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:organization) { create(:organization, webhook_url: webhook_url) }
+  let(:organization) { create(:organization, webhook_url:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
+  let(:credit_note) { create(:credit_note, customer:, invoice:) }
   let(:webhook_url) { 'http://foo.bar' }
 
   let(:webhook_options) { { provider_error: { message: 'message', error_code: 'code' } } }

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -8,6 +8,10 @@ module ScenariosHelper
     perform_all_enqueued_jobs
   end
 
+  def delete_customer(customer)
+    delete_with_token(organization, "/api/v1/customers/#{customer.external_id}")
+  end
+
   ### Plans
 
   def delete_plan(plan)
@@ -34,6 +38,22 @@ module ScenariosHelper
 
   def finalize_invoice(invoice)
     put_with_token(organization, "/api/v1/invoices/#{invoice.id}/finalize", {})
+  end
+
+  ### Coupons
+
+  def create_coupon(params)
+    post_with_token(organization, '/api/v1/coupons', { coupon: params })
+  end
+
+  def apply_coupon(params)
+    post_with_token(organization, '/api/v1/applied_coupons', { applied_coupon: params })
+  end
+
+  ### Wallets
+
+  def create_wallet(params)
+    post_with_token(organization, '/api/v1/wallets', { wallet: params })
   end
 
   # This performs any enqueued-jobs, and continues doing so until the queue is empty.


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

This PR adds two changes:
- It removes the not allowed error when trying to delete a plan attached to a subscription
- It removes the `canBeDeleted` attribute from the `Customer` GraphQL type