### PR TITLE
feat(delete_customer): Terminate all customer resources

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -39,8 +39,8 @@ module Api
       end
 
       def terminate
-        service = Wallets::TerminateService.new
-        result = service.terminate(organization: current_organization, id: params[:id])
+        wallet = current_organization.wallets.find_by(id: params[:id])
+        result = Wallets::TerminateService.call(wallet:)
 
         if result.success?
           render_wallet(result.wallet)

--- a/app/graphql/mutations/wallets/terminate.rb
+++ b/app/graphql/mutations/wallets/terminate.rb
@@ -14,10 +14,8 @@ module Mutations
       type Types::Wallets::Object
 
       def resolve(id:)
-        result = ::Wallets::TerminateService.new(context[:current_user]).terminate(
-          organization: current_organization,
-          id:,
-        )
+        wallet = current_organization.wallets.find_by(id:)
+        result = ::Wallets::TerminateService.call(wallet:)
 
         result.success? ? result.wallet : result_error(result)
       end

--- a/app/jobs/customers/terminate_relations_job.rb
+++ b/app/jobs/customers/terminate_relations_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Customers
+  class TerminateRelationsJob < ApplicationJob
+    def perform(customer_id:)
+      customer = Customer.with_discarded.find_by(id: customer_id)
+
+      result = Customers::TerminateRelationsService.call(customer:)
+      result.raise_if_error!
+    end
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Subscription < ApplicationRecord
-  belongs_to :customer
+  belongs_to :customer, -> { with_discarded }
   belongs_to :plan, -> { with_discarded }
   belongs_to :previous_subscription, class_name: 'Subscription', optional: true
 

--- a/app/services/customers/destroy_service.rb
+++ b/app/services/customers/destroy_service.rb
@@ -17,9 +17,11 @@ module Customers
       return result.not_allowed_failure!(code: 'attached_to_an_active_subscription') unless customer.deletable?
 
       customer.discard!
+      track_customer_deleted
+
+      Customers::TerminateRelationsJob.perform_later(customer_id: customer.id)
 
       result.customer = customer
-      track_customer_deleted
       result
     end
 

--- a/app/services/customers/terminate_relations_service.rb
+++ b/app/services/customers/terminate_relations_service.rb
@@ -34,5 +34,9 @@ module Customers
       result.customer = customer
       result
     end
+
+    private
+
+    attr_reader :customer
   end
 end

--- a/app/services/customers/terminate_relations_service.rb
+++ b/app/services/customers/terminate_relations_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Customers
+  class TerminateRelationsService < BaseService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(customer:)
+      @customer = customer
+      super
+    end
+
+    def call
+      return result.not_allowed_failure!(resource: 'customer') unless customer
+
+      # NOTE: Terminate active subscriptions.
+      customer.subscriptions.active.each do |subscription|
+        Subscriptions::TerminateService.call(subscription:)
+      end
+
+      # NOTE: Cancel pending subscriptions
+      customer.subscriptions.pending.each(&:mark_as_canceled!)
+
+      # NOTE: Finalize all draft invoices.
+      customer.invoices.draft.each { |invoice| Invoices::FinalizeService.call(invoice:) }
+
+      # NOTE: Terminate applied coupons
+      customer.applied_coupons.active.each { |applied_coupon| AppliedCoupons::TerminateService.call(applied_coupon:) }
+
+      # NOTE: Terminate wallets
+      customer.wallets.active.each { |wallet| Wallets::TerminateService.call(wallet:) }
+
+      result.customer = customer
+      result
+    end
+  end
+end

--- a/app/services/wallets/terminate_service.rb
+++ b/app/services/wallets/terminate_service.rb
@@ -2,8 +2,16 @@
 
 module Wallets
   class TerminateService < BaseService
-    def terminate(organization:, id:)
-      wallet = organization.wallets.find_by(id:)
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(wallet:)
+      @wallet = wallet
+      super
+    end
+
+    def call
       return result.not_found_failure!(resource: 'wallet') unless wallet
 
       wallet.mark_as_terminated! if wallet.active?
@@ -17,5 +25,9 @@ module Wallets
     def terminate_all_expired
       Wallet.active.expired.find_each(&:mark_as_terminated!)
     end
+
+    private
+
+    attr_reader :wallet
   end
 end

--- a/spec/jobs/customers/terminate_relations_job_spec.rb
+++ b/spec/jobs/customers/terminate_relations_job_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Customers::TerminateRelationsJob, type: :job do
+  let(:customer) { create(:customer, :deleted) }
+
+  it 'calls the service' do
+    allow(Customers::TerminateRelationsService)
+      .to receive(:call)
+      .with(customer:)
+      .and_return(BaseService::Result.new)
+
+    described_class.perform_now(customer_id: customer.id)
+
+    expect(Customers::TerminateRelationsService)
+      .to have_received(:call)
+  end
+end

--- a/spec/services/customers/destroy_service_spec.rb
+++ b/spec/services/customers/destroy_service_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe Customers::DestroyService, type: :service do
       end
     end
 
+    it 'enqueues a job to terminates the customer resources' do
+      destroy_service.call
+
+      expect(Customers::TerminateRelationsJob).to have_been_enqueued
+        .with(customer_id: customer.id)
+    end
+
     it 'calls SegmentTrackJob' do
       allow(SegmentTrackJob).to receive(:perform_later)
 

--- a/spec/services/customers/terminate_relations_service_spec.rb
+++ b/spec/services/customers/terminate_relations_service_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Customers::TerminateRelationsService, type: :service do
+  subject(:terminate_service) { described_class.new(customer:) }
+
+  let(:customer) { create(:customer, :deleted) }
+
+  context 'with an active subscription' do
+    let(:subscription) { create(:active_subscription, customer:) }
+
+    before { subscription }
+
+    it 'terminates the subscription' do
+      freeze_time do
+        expect { terminate_service.call }
+          .to change { subscription.reload.status }.from('active').to('terminated')
+          .and change(subscription, :terminated_at).from(nil).to(Time.current)
+      end
+    end
+  end
+
+  context 'with a pending subscription' do
+    let(:subscription) { create(:pending_subscription, customer:) }
+
+    before { subscription }
+
+    it 'cancels the subscription' do
+      freeze_time do
+        expect { terminate_service.call }
+          .to change { subscription.reload.status }.from('pending').to('canceled')
+          .and change(subscription, :canceled_at).from(nil).to(Time.current)
+      end
+    end
+  end
+
+  context 'with draft invoices' do
+    let(:subscription) { create(:active_subscription, customer:) }
+    let(:invoices) { create_list(:invoice, 2, :draft, customer:) }
+
+    before do
+      invoices.each do |invoice|
+        create(:invoice_subscription, invoice:, subscription:)
+      end
+    end
+
+    it 'finalizes draft invoices' do
+      terminate_service.call
+
+      invoices.each { |i| expect(i.reload).to be_finalized }
+    end
+  end
+
+  context 'with an applied coupon' do
+    let(:applied_coupon) { create(:applied_coupon, customer:) }
+
+    before { applied_coupon }
+
+    it 'terminates the applied coupon' do
+      terminate_service.call
+
+      expect(applied_coupon.reload).to be_terminated
+    end
+  end
+
+  context 'with an active wallet' do
+    let(:wallet) { create(:wallet, customer:) }
+
+    before { wallet }
+
+    it 'terminates the wallet' do
+      terminate_service.call
+
+      expect(wallet.reload).to be_terminated
+    end
+  end
+end

--- a/spec/services/wallets/terminate_service_spec.rb
+++ b/spec/services/wallets/terminate_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Wallets::TerminateService, type: :service do
-  subject(:terminate_service) { described_class.new(membership.user) }
+  subject(:terminate_service) { described_class.new(wallet:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
@@ -11,14 +11,14 @@ RSpec.describe Wallets::TerminateService, type: :service do
   let(:subscription) { create(:subscription, customer:) }
   let(:wallet) { create(:wallet, customer:) }
 
-  describe 'terminate' do
+  describe '#call' do
     before do
       subscription
       wallet
     end
 
     it 'terminates the wallet' do
-      result = terminate_service.terminate(organization:, id: wallet.id)
+      result = terminate_service.call
 
       expect(result).to be_success
       expect(result.wallet).to be_terminated
@@ -30,7 +30,7 @@ RSpec.describe Wallets::TerminateService, type: :service do
       it 'does not impact the wallet' do
         wallet.reload
         terminated_at = wallet.terminated_at
-        result = terminate_service.terminate(organization:, id: wallet.id)
+        result = terminate_service.call
 
         expect(result).to be_success
         expect(result.wallet).to be_terminated


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

This PR add the logic to:
- Terminate the active subscription
- Finalize the draft invoices
- Cancel the pending subscription
- Terminate the active wallets
- Terminate the active applied coupons
when soft deleting a customer