### PR TITLE
feat(delete_coupon): Ability to terminate an applied coupon from the API

### DIFF
--- a/app/controllers/api/v1/customers/applied_coupons_controller.rb
+++ b/app/controllers/api/v1/customers/applied_coupons_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Customers
+      class AppliedCouponsController < Api::BaseController
+        def destroy
+          customer = current_organization.customers.find_by(external_id: params[:customer_external_id])
+          return not_found_error(resource: 'customer') unless customer
+
+          coupon = current_organization.coupons.find_by(code: params[:coupon_code])
+          return not_found_error(resource: 'coupon') unless coupon
+
+          applied_coupon = customer.applied_coupons.find_by(coupon_id: coupon.id)
+          return not_found_error(resource: 'applied_coupon') unless applied_coupon
+
+          result = ::AppliedCoupons::TerminateService.call(applied_coupon:)
+          if result.success?
+            render(json: ::V1::AppliedCouponSerializer.new(result.applied_coupon, root_name: 'applied_coupon'))
+          else
+            render_error_response(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class CustomersController < Api::BaseController
       def create
-        service = Customers::CreateService.new
+        service = ::Customers::CreateService.new
         result = service.create_from_api(
           organization: current_organization,
           params: create_params,
@@ -23,7 +23,7 @@ module Api
       end
 
       def current_usage
-        service = Invoices::CustomerUsageService
+        service = ::Invoices::CustomerUsageService
           .new(
             nil,
             customer_id: params[:customer_external_id],
@@ -75,7 +75,7 @@ module Api
 
       def destroy
         customer = current_organization.customers.find_by(external_id: params[:external_id])
-        result = Customers::DestroyService.call(customer:)
+        result = ::Customers::DestroyService.call(customer:)
 
         if result.success?
           render(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,10 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :customers, param: :external_id, only: %i[create index show destroy] do
         get :current_usage
+
+        scope module: :customers do
+          resources :applied_coupons, param: :coupon_code, only: %i[destroy]
+        end
       end
 
       resources :subscriptions, only: %i[create update index], param: :external_id

--- a/spec/requests/api/v1/customers/applied_coupons_spec.rb
+++ b/spec/requests/api/v1/customers/applied_coupons_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::Customers::AppliedCouponsController, type: :request do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:coupon) { create(:coupon, organization:) }
+
+  describe 'destroy' do
+    let(:applied_coupon) { create(:applied_coupon, customer:, coupon:) }
+
+    before { applied_coupon }
+
+    it 'terminates the applied coupon' do
+      expect do
+        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/#{coupon.code}")
+      end.to change { applied_coupon.reload.status }.from('active').to('terminated')
+    end
+
+    it 'returns the applied_coupon' do
+      delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/#{coupon.code}")
+
+      expect(response).to have_http_status(:success)
+      expect(json[:applied_coupon][:lago_id]).to eq(applied_coupon.id)
+    end
+
+    context 'when customer does not exist' do
+      it 'returns not_found error' do
+        delete_with_token(organization, "/api/v1/customers/unknown/applied_coupons/#{coupon.code}")
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when coupon does not exist' do
+      it 'returns not_found error' do
+        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/unknown")
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when coupon is not applied to customer' do
+      it 'returns not_found error' do
+        other_coupon = create(:coupon, organization:)
+        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/#{other_coupon.code}")
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently, there is no way to delete objects linked to a subscription. This can be a real limitation during PoCs and onboarding, as users have to ping us to delete customers.

The goal of this feature is to be able to soft-delete a customer linked to an active or terminated subscription.

## Description

This PR adds the ability to terminate an applied coupon from the API.