### PR TITLE
fix(credit_note): Fix item label when related to an add on invoice

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -90,6 +90,12 @@ class CreditNote < ApplicationRecord
       .includes(:fee)
   end
 
+  def add_on_items
+    items.joins(:fee)
+      .merge(Fee.add_on)
+      .includes(:fee)
+  end
+
   def voidable?
     return false if voided?
 

--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -350,9 +350,10 @@ html
                   td.body-1 width="30%" style="text-align: right;"
                     = item.amount.format
             - else
-              - subscription_charge_items(nil).each do |item|
+              - add_on_items.each do |item|
                 tr
-                  td.body-1 = item.fee.item_name
+                  td.body-1
+                    | Add-on - #{item.fee.item_name}
                   td.body-1 width="30%" style="text-align: right;"
                     = item.amount.format
 

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe CreditNote, type: :model do
 
     before { credit_note_item }
 
-    it 'returns the item for ad on' do
+    it 'returns items of the add-on' do
       expect(credit_note.add_on_items).to eq([credit_note_item])
     end
   end

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -218,6 +218,21 @@ RSpec.describe CreditNote, type: :model do
     end
   end
 
+  describe '#add_on_items' do
+    let(:credit_note) { create(:credit_note) }
+    let(:invoice) { credit_note.invoice }
+    let(:add_on) { create(:add_on, organization: credit_note.organization) }
+    let(:applied_add_on) { create(:applied_add_on, add_on:) }
+    let(:credit_note_item) { create(:credit_note_item, credit_note:, fee: add_on_fee) }
+    let(:add_on_fee) { create(:add_on_fee, invoice:, applied_add_on:) }
+
+    before { credit_note_item }
+
+    it 'returns the item for ad on' do
+      expect(credit_note.add_on_items).to eq([credit_note_item])
+    end
+  end
+
   describe '#voidable?' do
     let(:credit_note) do
       create(:credit_note, balance_amount_cents: balance_amount_cents, credit_status: credit_status)


### PR DESCRIPTION
## Context

We have an issue with the PDF for credit notes on add_on invoice:

To reproduce:
1. I apply a credit note to an add-invoice
2. I’m in the credit note and I download the .pdf of credit note
3. There’s no details line in the invoice

## Description

This PR fixes PDF by ensuring add on label is displayed when initial fee was for an add_on