### PR TITLE
feat (locales): Add base setup for localization

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -36,6 +36,8 @@ class Customer < ApplicationRecord
   default_scope -> { kept }
   sequenced scope: ->(customer) { customer.organization.customers.with_discarded }
 
+  enum document_locale: I18n.available_locales
+
   validates :country, country_code: true, unless: -> { country.nil? }
   validates :currency, inclusion: { in: currency_list }, allow_nil: true
   validates :external_id,

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -27,6 +27,8 @@ class Organization < ApplicationRecord
 
   before_create :generate_api_key
 
+  enum document_locale: I18n.available_locales
+
   validates :country, country_code: true, unless: -> { country.nil? }
   validates :email, email: true, if: :email?
   validates :invoice_footer, length: { maximum: 600 }

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,10 @@ module LagoApi
     config.active_record.encryption.deterministic_key = ENV['ENCRYPTION_DETERMINISTIC_KEY']
     config.active_record.encryption.key_derivation_salt = ENV['ENCRYPTION_KEY_DERIVATION_SALT']
 
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+    config.i18n.available_locales = %i[en fr]
+    config.i18n.default_locale = :en
+
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid
     end

--- a/db/migrate/20230207110702_add_document_locale_to_customers_and_organizations.rb
+++ b/db/migrate/20230207110702_add_document_locale_to_customers_and_organizations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDocumentLocaleToCustomersAndOrganizations < ActiveRecord::Migration[7.0]
   def change
     add_column :organizations, :document_locale, :integer, default: 0, null: false

--- a/db/migrate/20230207110702_add_document_locale_to_customers_and_organizations.rb
+++ b/db/migrate/20230207110702_add_document_locale_to_customers_and_organizations.rb
@@ -1,0 +1,6 @@
+class AddDocumentLocaleToCustomersAndOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :document_locale, :integer, default: 0, null: false
+    add_column :customers, :document_locale, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_03_132157) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_07_110702) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -236,6 +236,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_03_132157) do
     t.integer "invoice_grace_period"
     t.string "timezone"
     t.datetime "deleted_at"
+    t.integer "document_locale"
     t.index ["deleted_at"], name: "index_customers_on_deleted_at"
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_customers_on_organization_id"
@@ -403,6 +404,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_03_132157) do
     t.text "invoice_footer"
     t.integer "invoice_grace_period", default: 0, null: false
     t.string "timezone", default: "UTC", null: false
+    t.integer "document_locale", default: 0, null: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"
   end


### PR DESCRIPTION
## Context

For legal reason, some companies had to generate invoices in their own languages. Unfortunately Lago is supporting only one language that do not fit their need.

## Description

This PR adds base DB changes and setup for allowing internalisation on the pdf documents
