### PR TITLE
feat (localization): update org document locale from the API

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -38,6 +38,7 @@ module Api
             :invoice_footer,
             :invoice_grace_period,
             :vat_rate,
+            :document_locale,
           ],
         )
       end

--- a/app/serializers/v1/organization_serializer.rb
+++ b/app/serializers/v1/organization_serializer.rb
@@ -22,6 +22,7 @@ module V1
           invoice_footer: model.invoice_footer,
           invoice_grace_period: model.invoice_grace_period,
           vat_rate: model.vat_rate,
+          document_locale: model.document_locale,
         },
       }
     end

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -56,6 +56,7 @@ module Organizations
         billing = params[:billing_configuration]
         organization.invoice_footer = billing[:invoice_footer] if billing.key?(:invoice_footer)
         organization.vat_rate = billing[:vat_rate] if billing.key?(:vat_rate)
+        organization.document_locale = billing[:document_locale] if billing.key?(:document_locale)
 
         if License.premium? && billing.key?(:invoice_grace_period)
           Organizations::UpdateInvoiceGracePeriodService.call(

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
           invoice_footer: 'footer',
           invoice_grace_period: 3,
           vat_rate: 20,
+          document_locale: 'fr',
         },
       }
     end
@@ -45,6 +46,7 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
 
         billing = json[:organization][:billing_configuration]
         expect(billing[:invoice_footer]).to eq('footer')
+        expect(billing[:document_locale]).to eq('fr')
         expect(billing[:vat_rate]).to eq(20)
       end
     end

--- a/spec/serializers/v1/organization_serializer_spec.rb
+++ b/spec/serializers/v1/organization_serializer_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe ::V1::OrganizationSerializer do
       expect(result['organization']['billing_configuration']['invoice_footer']).to eq(org.invoice_footer)
       expect(result['organization']['billing_configuration']['invoice_grace_period']).to eq(org.invoice_grace_period)
       expect(result['organization']['billing_configuration']['vat_rate']).to eq(org.vat_rate)
+      expect(result['organization']['billing_configuration']['document_locale']).to eq(org.document_locale)
       expect(result['organization']['timezone']).to eq(org.timezone)
     end
   end


### PR DESCRIPTION
## Context

For legal reason, some companies had to generate invoices in their own languages. Unfortunately Lago is supporting only one language that do not fit their need.

## Description

This PR handles updating organization document locale from the API
