### PR TITLE
feat (localization): support managing customer document locale through the API

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -116,6 +116,7 @@ module Api
             :sync,
             :sync_with_provider,
             :vat_rate,
+            :document_locale,
           ],
         )
       end

--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -36,6 +36,7 @@ module V1
         invoice_grace_period: model.invoice_grace_period,
         payment_provider: model.payment_provider,
         vat_rate: model.vat_rate,
+        document_locale: model.document_locale,
       }
 
       if model.payment_provider&.to_sym == :stripe

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -112,6 +112,7 @@ module Customers
       end
 
       customer.vat_rate = billing[:vat_rate] if billing.key?(:vat_rate)
+      customer.document_locale = billing[:document_locale] if billing.key?(:document_locale)
 
       if new_customer
         create_billing_configuration(customer, billing)

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
             payment_provider: 'stripe',
             provider_customer_id: 'stripe_id',
             vat_rate: 20,
+            document_locale: 'fr',
           },
         }
       end
@@ -81,6 +82,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
           expect(billing[:provider_customer_id]).to eq('stripe_id')
           expect(billing[:invoice_grace_period]).to eq(3)
           expect(billing[:vat_rate]).to eq(20)
+          expect(billing[:document_locale]).to eq('fr')
         end
       end
     end

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe ::V1::CustomerSerializer do
       expect(result['customer']['billing_configuration']['payment_provider']).to eq(customer.payment_provider)
       expect(result['customer']['billing_configuration']['invoice_grace_period']).to eq(customer.invoice_grace_period)
       expect(result['customer']['billing_configuration']['vat_rate']).to eq(customer.vat_rate)
+      expect(result['customer']['billing_configuration']['document_locale']).to eq(customer.document_locale)
     end
   end
 end

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Customers::CreateService, type: :service do
         currency: 'EUR',
         billing_configuration: {
           vat_rate: 20,
+          document_locale: 'fr',
         },
       }
     end
@@ -46,6 +47,7 @@ RSpec.describe Customers::CreateService, type: :service do
 
         billing = create_args[:billing_configuration]
         expect(customer.vat_rate).to eq(billing[:vat_rate])
+        expect(customer.document_locale).to eq(billing[:document_locale])
         expect(customer.invoice_grace_period).to be_nil
       end
     end


### PR DESCRIPTION
## Context

For legal reason, some companies had to generate invoices in their own languages. Unfortunately Lago is supporting only one language that do not fit their need.

## Description

This PR handles updating customer document locale from the API
