### PR TITLE
feat (localization): add document_locale support in graphQL for organization

### DIFF
--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -31,6 +31,7 @@ module Types
         vat_rate: object&.vat_rate,
         invoice_footer: object&.invoice_footer,
         invoice_grace_period: object&.invoice_grace_period,
+        document_locale: object&.document_locale,
       }
     end
   end

--- a/app/graphql/types/organizations/billing_configuration.rb
+++ b/app/graphql/types/organizations/billing_configuration.rb
@@ -9,6 +9,7 @@ module Types
       field :vat_rate, Float, null: false
       field :invoice_footer, String
       field :invoice_grace_period, Integer, null: false
+      field :document_locale, String
     end
   end
 end

--- a/app/graphql/types/organizations/billing_configuration_input.rb
+++ b/app/graphql/types/organizations/billing_configuration_input.rb
@@ -8,6 +8,7 @@ module Types
       argument :invoice_footer, String, required: false
       argument :invoice_grace_period, Integer, required: false
       argument :vat_rate, Float, required: false
+      argument :document_locale, String, required: false
     end
   end
 end

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -23,6 +23,10 @@ module Organizations
       organization.city = args[:city] if args.key?(:city)
       organization.country = args[:country] if args.key?(:country)
 
+      if billing_configuration.key?(:document_locale)
+        organization.document_locale = billing_configuration[:document_locale]
+      end
+
       if billing_configuration.key?(:invoice_footer)
         organization.invoice_footer = billing_configuration[:invoice_footer]
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3591,6 +3591,7 @@ type Organization {
 }
 
 type OrganizationBillingConfiguration {
+  documentLocale: String
   id: ID!
   invoiceFooter: String
   invoiceGracePeriod: Int!
@@ -3598,6 +3599,7 @@ type OrganizationBillingConfiguration {
 }
 
 input OrganizationBillingConfigurationInput {
+  documentLocale: String
   invoiceFooter: String
   invoiceGracePeriod: Int
   vatRate: Float

--- a/schema.json
+++ b/schema.json
@@ -14398,6 +14398,20 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "documentLocale",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -14507,6 +14521,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Float",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "documentLocale",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           city
           country
           timezone
-          billingConfiguration { vatRate, invoiceFooter, invoiceGracePeriod }
+          billingConfiguration { vatRate, invoiceFooter, invoiceGracePeriod, documentLocale }
         }
       }
     GQL
@@ -45,6 +45,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           billingConfiguration: {
             vatRate: 12.5,
             invoiceFooter: 'invoice footer',
+            documentLocale: 'fr',
           },
         },
       },
@@ -66,6 +67,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
       expect(result_data['billingConfiguration']['invoiceFooter']).to eq('invoice footer')
       expect(result_data['billingConfiguration']['invoiceGracePeriod']).to eq(0)
       expect(result_data['billingConfiguration']['vatRate']).to eq(12.5)
+      expect(result_data['billingConfiguration']['documentLocale']).to eq('fr')
       expect(result_data['timezone']).to eq('TZ_UTC')
     end
   end

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Organizations::UpdateService do
         billing_configuration: {
           vat_rate: 12.5,
           invoice_footer: 'invoice footer',
+          document_locale: 'fr',
         },
       )
 
@@ -40,6 +41,7 @@ RSpec.describe Organizations::UpdateService do
         expect(result.organization.country).to eq('FR')
         expect(result.organization.timezone).to eq('UTC')
         expect(result.organization.invoice_footer).to eq('invoice footer')
+        expect(result.organization.document_locale).to eq('fr')
       end
     end
 


### PR DESCRIPTION
## Context

For legal reason, some companies had to generate invoices in their own languages. Unfortunately Lago is supporting only one language that do not fit their need.

## Description

This PR handles updating organization document locale from the graphQL
