### PR TITLE
fix(credit_notes): Fix downgrade credit notes when timezone

### DIFF
--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -58,16 +58,12 @@ module CreditNotes
       )
     end
 
-    def from_date
-      date_service.previous_beginning_of_period(current_period: true)
-    end
-
     def to_date
       date_service.next_end_of_period.to_date
     end
 
     def day_price
-      date_service.single_day_price(optional_from_date: from_date)
+      date_service.single_day_price
     end
 
     def terminated_at_in_timezone

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -71,7 +71,7 @@ module CreditNotes
     end
 
     def remaining_duration
-      billed_from = terminated_at_in_timezone.to_date
+      billed_from = terminated_at_in_timezone.end_of_day.utc.to_date
 
       if plan.has_trial? && subscription.trial_end_date >= billed_from
         billed_from = if subscription.trial_end_date > to_date

--- a/spec/scenarios/terminate_pay_in_advance_spec.rb
+++ b/spec/scenarios/terminate_pay_in_advance_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 5000) }
+  let(:metric) { create(:billable_metric, organization:) }
+
+  it 'creates expected credit note and invoice' do
+    ### 8 Feb: Create and terminate subscription
+    feb8 = DateTime.new(2023, 2, 8)
+
+    travel_to(feb8) do
+      expect {
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+      }.to change(Invoice, :count).by(1)
+
+      subscription = customer.subscriptions.find_by(external_id: customer.external_id)
+      sub_invoice = subscription.invoices.first
+      expect(sub_invoice.total_amount_cents).to eq(4500) # 60 / 28 * 21
+
+      expect {
+        terminate_subscription(subscription)
+      }.to change { subscription.reload.status }.from('active').to('terminated')
+        .and change { subscription.invoices.count }.from(1).to(2)
+        .and change { sub_invoice.reload.credit_notes.count }.from(0).to(1)
+
+      term_invoice = subscription.invoices.order(sequential_id: :desc).first
+      expect(term_invoice.total_amount_cents).to eq(0)
+
+      credit_note = sub_invoice.credit_notes.first
+      # TODO: Rounding issue here.
+      # expect(credit_note.total_amount_cents).to eq(4286) # 60.0 / 28 * 20
+    end
+  end
+end

--- a/spec/scenarios/terminate_pay_in_advance_spec.rb
+++ b/spec/scenarios/terminate_pay_in_advance_spec.rb
@@ -37,8 +37,45 @@ describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
       expect(term_invoice.total_amount_cents).to eq(0)
 
       credit_note = sub_invoice.credit_notes.first
-      # TODO: Rounding issue here.
-      # expect(credit_note.total_amount_cents).to eq(4286) # 60.0 / 28 * 20
+      # TODO: Address rounding issue here as expected amount with VAT is 4286.
+      expect(credit_note.total_amount_cents).to eq(4287) # 60.0 / 28 * 20
+    end
+  end
+
+  context 'when subscription billing is anniversary' do
+    it 'creates expected credit note and invoice' do
+      ### 8 Feb: Create and terminate subscription
+      feb8 = DateTime.new(2023, 2, 8)
+
+      travel_to(feb8) do
+        expect {
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code,
+              billing_time: 'anniversary',
+            },
+          )
+        }.to change(Invoice, :count).by(1)
+
+        subscription = customer.subscriptions.find_by(external_id: customer.external_id)
+        sub_invoice = subscription.invoices.first
+        expect(sub_invoice.total_amount_cents).to eq(6000) # Full period is billed
+
+        expect {
+          terminate_subscription(subscription)
+        }.to change { subscription.reload.status }.from('active').to('terminated')
+          .and change { subscription.invoices.count }.from(1).to(2)
+          .and change { sub_invoice.reload.credit_notes.count }.from(0).to(1)
+
+        term_invoice = subscription.invoices.order(sequential_id: :desc).first
+        expect(term_invoice.total_amount_cents).to eq(0)
+
+        credit_note = sub_invoice.credit_notes.first
+        # TODO: Address rounding issue here as expected amount with VAT is 5786.
+        expect(credit_note.total_amount_cents).to eq(5787) # 60.0 / 28 * 27
+      end
     end
   end
 end

--- a/spec/scenarios/terminate_pay_in_advance_spec.rb
+++ b/spec/scenarios/terminate_pay_in_advance_spec.rb
@@ -42,6 +42,82 @@ describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
     end
   end
 
+  context 'when customer is in UTC+ timezone' do
+    let(:customer) { create(:customer, organization:, timezone: 'Asia/Tokyo') }
+
+    it 'creates expected credit note and invoice' do
+      ### 8 Feb: Create and terminate subscription
+      feb8 = DateTime.new(2023, 2, 8)
+
+      travel_to(feb8) do
+        expect {
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code,
+            },
+          )
+        }.to change(Invoice, :count).by(1)
+
+        subscription = customer.subscriptions.find_by(external_id: customer.external_id)
+        sub_invoice = subscription.invoices.first
+        expect(sub_invoice.total_amount_cents).to eq(4500) # 60 / 28 * 21
+
+        expect {
+          terminate_subscription(subscription)
+        }.to change { subscription.reload.status }.from('active').to('terminated')
+          .and change { subscription.invoices.count }.from(1).to(2)
+          .and change { sub_invoice.reload.credit_notes.count }.from(0).to(1)
+
+        term_invoice = subscription.invoices.order(sequential_id: :desc).first
+        expect(term_invoice.total_amount_cents).to eq(0)
+
+        credit_note = sub_invoice.credit_notes.first
+        # TODO: Address rounding issue here as expected amount with VAT is 4286.
+        expect(credit_note.total_amount_cents).to eq(4287) # 60.0 / 28 * 20
+      end
+    end
+  end
+
+  context 'when customer is in UTC- timezone' do
+    let(:customer) { create(:customer, organization:, timezone: 'America/Los_Angeles') }
+
+    it 'creates expected credit note and invoice' do
+      ### 8 Feb: Create and terminate subscription
+      feb8 = DateTime.new(2023, 2, 8)
+
+      travel_to(feb8) do
+        expect {
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code,
+            },
+          )
+        }.to change(Invoice, :count).by(1)
+
+        subscription = customer.subscriptions.find_by(external_id: customer.external_id)
+        sub_invoice = subscription.invoices.first
+        expect(sub_invoice.total_amount_cents).to eq(4715) # 60 / 28 * 22
+
+        expect {
+          terminate_subscription(subscription)
+        }.to change { subscription.reload.status }.from('active').to('terminated')
+          .and change { subscription.invoices.count }.from(1).to(2)
+          .and change { sub_invoice.reload.credit_notes.count }.from(0).to(1)
+
+        term_invoice = subscription.invoices.order(sequential_id: :desc).first
+        expect(term_invoice.total_amount_cents).to eq(0)
+
+        credit_note = sub_invoice.credit_notes.first
+        # TODO: Address rounding issue here as expected amount with VAT is 4500.
+        expect(credit_note.total_amount_cents).to eq(4502) # 60.0 / 28 * 21
+      end
+    end
+  end
+
   context 'when subscription billing is anniversary' do
     it 'creates expected credit note and invoice' do
       ### 8 Feb: Create and terminate subscription
@@ -75,6 +151,84 @@ describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
         credit_note = sub_invoice.credit_notes.first
         # TODO: Address rounding issue here as expected amount with VAT is 5786.
         expect(credit_note.total_amount_cents).to eq(5787) # 60.0 / 28 * 27
+      end
+    end
+
+    context 'when customer is in UTC+ timezone' do
+      let(:customer) { create(:customer, organization:, timezone: 'Asia/Tokyo') }
+
+      it 'creates expected credit note and invoice' do
+        ### 8 Feb: Create and terminate subscription
+        feb8 = DateTime.new(2023, 2, 8)
+
+        travel_to(feb8) do
+          expect {
+            create_subscription(
+              {
+                external_customer_id: customer.external_id,
+                external_id: customer.external_id,
+                plan_code: plan.code,
+                billing_time: 'anniversary',
+              },
+            )
+          }.to change(Invoice, :count).by(1)
+
+          subscription = customer.subscriptions.find_by(external_id: customer.external_id)
+          sub_invoice = subscription.invoices.first
+          expect(sub_invoice.total_amount_cents).to eq(6000) # Full period is billed
+
+          expect {
+            terminate_subscription(subscription)
+          }.to change { subscription.reload.status }.from('active').to('terminated')
+            .and change { subscription.invoices.count }.from(1).to(2)
+            .and change { sub_invoice.reload.credit_notes.count }.from(0).to(1)
+
+          term_invoice = subscription.invoices.order(sequential_id: :desc).first
+          expect(term_invoice.total_amount_cents).to eq(0)
+
+          credit_note = sub_invoice.credit_notes.first
+          # TODO: Address rounding issue here as expected amount with VAT is 5786.
+          expect(credit_note.total_amount_cents).to eq(5787) # 60.0 / 28 * 27
+        end
+      end
+    end
+
+    context 'when customer is in UTC- timezone' do
+      let(:customer) { create(:customer, organization:, timezone: 'America/Los_Angeles') }
+
+      it 'creates expected credit note and invoice' do
+        ### 8 Feb: Create and terminate subscription
+        feb8 = DateTime.new(2023, 2, 8)
+
+        travel_to(feb8) do
+          expect {
+            create_subscription(
+              {
+                external_customer_id: customer.external_id,
+                external_id: customer.external_id,
+                plan_code: plan.code,
+                billing_time: 'anniversary',
+              },
+            )
+          }.to change(Invoice, :count).by(1)
+
+          subscription = customer.subscriptions.find_by(external_id: customer.external_id)
+          sub_invoice = subscription.invoices.first
+          expect(sub_invoice.total_amount_cents).to eq(6000) # Full period is billed
+
+          expect {
+            terminate_subscription(subscription)
+          }.to change { subscription.reload.status }.from('active').to('terminated')
+            .and change { subscription.invoices.count }.from(1).to(2)
+            .and change { sub_invoice.reload.credit_notes.count }.from(0).to(1)
+
+          term_invoice = subscription.invoices.order(sequential_id: :desc).first
+          expect(term_invoice.total_amount_cents).to eq(0)
+
+          credit_note = sub_invoice.credit_notes.first
+          # TODO: Address rounding issue here as expected amount with VAT is 5786.
+          expect(credit_note.total_amount_cents).to eq(5787) # 60.0 / 28 * 27
+        end
       end
     end
   end

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -201,11 +201,11 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
             credit_note = result.credit_note
             expect(credit_note).to be_available
             expect(credit_note).to be_order_change
-            expect(credit_note.total_amount_cents).to eq(22)
+            expect(credit_note.total_amount_cents).to eq(21)
             expect(credit_note.total_amount_currency).to eq('EUR')
-            expect(credit_note.credit_amount_cents).to eq(22)
+            expect(credit_note.credit_amount_cents).to eq(21)
             expect(credit_note.credit_amount_currency).to eq('EUR')
-            expect(credit_note.balance_amount_cents).to eq(22)
+            expect(credit_note.balance_amount_cents).to eq(21)
             expect(credit_note.balance_amount_currency).to eq('EUR')
             expect(credit_note.reason).to eq('order_change')
 

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -189,26 +189,53 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
       let(:started_at) { Time.zone.parse('2022-09-01 12:00') }
       let(:terminated_at) { Time.zone.parse('2022-10-15 01:00') }
 
-      before { subscription.customer.update!(timezone: 'America/Los_Angeles') }
+      context 'when timezone shift is UTC -' do
+        before { subscription.customer.update!(timezone: 'America/Los_Angeles') }
 
-      it 'takes the timezone into account' do
-        result = create_service.call
+        it 'takes the timezone into account' do
+          result = create_service.call
 
-        aggregate_failures do
-          expect(result).to be_success
+          aggregate_failures do
+            expect(result).to be_success
 
-          credit_note = result.credit_note
-          expect(credit_note).to be_available
-          expect(credit_note).to be_order_change
-          expect(credit_note.total_amount_cents).to eq(22)
-          expect(credit_note.total_amount_currency).to eq('EUR')
-          expect(credit_note.credit_amount_cents).to eq(22)
-          expect(credit_note.credit_amount_currency).to eq('EUR')
-          expect(credit_note.balance_amount_cents).to eq(22)
-          expect(credit_note.balance_amount_currency).to eq('EUR')
-          expect(credit_note.reason).to eq('order_change')
+            credit_note = result.credit_note
+            expect(credit_note).to be_available
+            expect(credit_note).to be_order_change
+            expect(credit_note.total_amount_cents).to eq(22)
+            expect(credit_note.total_amount_currency).to eq('EUR')
+            expect(credit_note.credit_amount_cents).to eq(22)
+            expect(credit_note.credit_amount_currency).to eq('EUR')
+            expect(credit_note.balance_amount_cents).to eq(22)
+            expect(credit_note.balance_amount_currency).to eq('EUR')
+            expect(credit_note.reason).to eq('order_change')
 
-          expect(credit_note.items.count).to eq(1)
+            expect(credit_note.items.count).to eq(1)
+          end
+        end
+      end
+
+      context 'when timezone shift is UTC +' do
+        before { subscription.customer.update!(timezone: 'Europe/Paris') }
+
+        it 'takes the timezone into account' do
+          result = create_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            credit_note = result.credit_note
+            expect(credit_note).to be_available
+            expect(credit_note).to be_order_change
+            expect(credit_note.total_amount_cents).to eq(20)
+            expect(credit_note.total_amount_currency).to eq('EUR')
+            expect(credit_note.credit_amount_cents).to eq(20)
+            expect(credit_note.credit_amount_currency).to eq('EUR')
+            expect(credit_note.balance_amount_cents).to eq(20)
+            expect(credit_note.balance_amount_currency).to eq('EUR')
+            expect(credit_note.reason).to eq('order_change')
+
+            expect(credit_note.items.count).to eq(1)
+          end
         end
       end
     end


### PR DESCRIPTION
## Context

As a user with a specific time zone, when terminating a subscription pay in advance, the amount of the credit note is not accurate.

## Description

The issue was related to the `optional_from_date` passed to the method used to compute the single day price on a period. In the case of a positive time shift with UTC, the wrong day was used as the beginning of the period, leading to a wrong single day price.
