### PR TITLE
fix(invoices): Round VAT at invoice level

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -67,14 +67,7 @@ module Invoices
     end
 
     def compute_amounts
-      fee_amounts = invoice.fees.select(:amount_cents, :vat_amount_cents)
-
-      invoice.amount_cents = fee_amounts.sum(&:amount_cents)
-      invoice.vat_amount_cents = fee_amounts.sum(&:vat_amount_cents)
-
-      invoice.credit_amount_cents = 0 if invoice.credits.empty?
-
-      invoice.total_amount_cents = invoice.amount_cents + invoice.vat_amount_cents - invoice.credit_amount_cents
+      Invoices::ComputeAmountsFromFees.call(invoice:)
     end
 
     def create_subscription_fee(subscription, boundaries)

--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Invoices
+  class ComputeAmountsFromFees < BaseService
+    def self.call(...)
+      new(...).call
+    end
+
+    def initialize(invoice:)
+      @invoice = invoice
+      super
+    end
+
+    def call
+      invoice.amount_cents = invoice.fees.sum(:amount_cents)
+      invoice.vat_amount_cents = invoice.fees.sum { |f| f.amount_cents * f.vat_rate }.fdiv(100).ceil
+      invoice.credit_amount_cents = 0 if invoice.credits.empty?
+      invoice.total_amount_cents = invoice.amount_cents + invoice.vat_amount_cents - invoice.credit_amount_cents
+
+      result.invoice = invoice
+      result
+    end
+
+    private
+
+    attr_reader :invoice
+  end
+end

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -28,7 +28,7 @@ module Invoices
         invoice.update!(vat_rate: invoice.customer.applicable_vat_rate)
 
         calculate_result = Invoices::CalculateFeesService.call(
-          invoice:,
+          invoice: invoice.reload,
           subscriptions: Subscription.find(subscription_ids),
           timestamp: invoice.created_at.to_i + 1.second, # NOTE: Adding 1 second because of to_i rounding.
           context:,

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::ComputeAmountsFromFees, type: :service do
+  subject(:compute_amounts) { described_class.new(invoice:) }
+
+  let(:invoice) { create(:invoice, credit_amount_cents: 100) }
+
+  before do
+    create(:fee, invoice:, amount_cents: 151, vat_rate: 10)
+    create(:fee, invoice:, amount_cents: 379, vat_rate: 20)
+  end
+
+  it 'sets amount_cents from the list of fees' do
+    expect { compute_amounts.call }.to change(invoice, :amount_cents).from(0).to(530)
+  end
+
+  it 'sets vat_amount_cents from the list of fees' do
+    expect { compute_amounts.call }.to change(invoice, :vat_amount_cents).from(0).to(91)
+  end
+
+  it 'sets zero to credit_amount_cents' do
+    expect { compute_amounts.call }.to change(invoice, :credit_amount_cents).from(100).to(0)
+  end
+
+  it 'sets total_amount_cents' do
+    expect { compute_amounts.call }.to change(invoice, :total_amount_cents).from(0).to(621)
+  end
+
+  context 'when credits on invoice' do
+    it 'does not set credit_amount_cents' do
+      create(:credit, invoice:)
+      expect { compute_amounts.call }.not_to change(invoice, :credit_amount_cents).from(100)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Lago API performs some math on top of monetary values, to calculate VAT, internal fees, etc.

Since these operations are done using integer amounts in cents and are spread around the codebase, there are some rounding issues and inconsistencies, like off-by-one errors.

## Description

This PR ensure VAT amount stored at invoice level is computed based on fee amount without using rounded value stored at fee level, to prevent rounding issues
