### PR TITLE
fix(usage): Round VAT at invoice level

### DIFF
--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -98,7 +98,7 @@ module Invoices
 
     def compute_amounts
       invoice.amount_cents = invoice.fees.sum(&:amount_cents)
-      invoice.vat_amount_cents = invoice.fees.sum(&:vat_amount_cents)
+      invoice.vat_amount_cents = invoice.fees.sum { |f| f.amount_cents * f.vat_rate }.fdiv(100).ceil
       invoice.total_amount_cents = invoice.amount_cents + invoice.vat_amount_cents
     end
 

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
         )
       end
 
-      it 'initialize an invoice' do
+      it 'initializes an invoice' do
         travel_to(current_date) do
           result = usage_service.usage
 

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
       end.to change { cache.exist?(key) }.from(false).to(true)
     end
 
-    it 'initialize an invoice' do
+    it 'initializes an invoice' do
       result = usage_service.usage
 
       aggregate_failures do

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -3,44 +3,61 @@
 require 'rails_helper'
 
 RSpec.describe Invoices::CustomerUsageService, type: :service do
-  subject(:invoice_service) do
-    described_class.new(membership.user, customer_id: customer_id, subscription_id: subscription_id)
+  subject(:usage_service) do
+    described_class.new(membership.user, customer_id:, subscription_id:)
   end
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer_id) {}
-  let(:subscription_id) { nil }
+  let(:customer) { create(:customer, organization:, vat_rate: 20) }
+  let(:customer_id) { customer&.id }
+  let(:subscription_id) { subscription&.id }
+  let(:plan) { create(:plan, interval: 'monthly') }
+  let(:timestamp) { Time.current }
 
-  describe '.usage' do
-    let(:billable_metric) do
-      create(:billable_metric, aggregation_type: 'count_agg')
-    end
+  let(:subscription) do
+    create(
+      :subscription,
+      plan:,
+      customer:,
+      started_at: Time.zone.now - 2.years,
+    )
+  end
 
-    let(:customer) { create(:customer, organization: organization) }
-    let(:customer_id) { customer.id }
-    let(:subscription_id) { subscription&.id }
-    let(:subscription) do
-      create(
-        :subscription,
-        plan: plan,
-        customer: customer,
-        started_at: Time.zone.now - 2.years,
-      )
-    end
-    let(:plan) { create(:plan, interval: 'monthly') }
-    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
-    let(:cache) { Rails.cache }
+  let(:billable_metric) do
+    create(:billable_metric, aggregation_type: 'count_agg')
+  end
 
+  let(:events) do
+    create_list(
+      :event,
+      2,
+      organization:,
+      subscription:,
+      customer:,
+      code: billable_metric.code,
+      timestamp:,
+    )
+  end
+
+  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+  let(:cache) { Rails.cache }
+
+  describe '#usage' do
     before do
-      subscription
-      create(:standard_charge, plan: plan, charge_model: 'standard')
+      events if subscription
+      create(
+        :standard_charge,
+        plan:,
+        billable_metric:,
+        properties: { amount: '12.66' },
+      )
       allow(Rails).to receive(:cache).and_return(memory_store)
       Rails.cache.clear
     end
 
     it 'uses the Rails cache' do
-      to_date = invoice_service.__send__(:boundaries)[:charges_to_datetime].to_date
+      to_date = usage_service.__send__(:boundaries)[:charges_to_datetime].to_date
       key = [
         'current_usage',
         "#{subscription.id}-#{to_date.iso8601}-#{subscription.created_at.iso8601}",
@@ -48,213 +65,82 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
       ].join('/')
 
       expect do
-        invoice_service.usage
+        usage_service.usage
       end.to change { cache.exist?(key) }.from(false).to(true)
     end
 
-    context 'when billed monthly' do
-      it 'initialize an invoice' do
-        result = invoice_service.usage
+    it 'initialize an invoice' do
+      result = usage_service.usage
+
+      aggregate_failures do
+        expect(result).to be_success
+
+        expect(result.usage.id).to be_nil
+        expect(result.usage.from_datetime).to eq(Time.current.beginning_of_month.iso8601)
+        expect(result.usage.to_datetime).to eq(Time.current.end_of_month.iso8601)
+        expect(result.usage.issuing_date).to eq(Time.zone.today.end_of_month.iso8601)
+        expect(result.usage.fees.size).to eq(1)
+
+        expect(result.usage.amount_cents).to eq(2532) # 1266 * 2
+        expect(result.usage.amount_currency).to eq('EUR')
+        expect(result.usage.vat_amount_cents).to eq(507) # 1266 * 2 * 0.2 = 506.4
+        expect(result.usage.vat_amount_currency).to eq('EUR')
+        expect(result.usage.total_amount_cents).to eq(3039)
+        expect(result.usage.total_amount_currency).to eq('EUR')
+      end
+    end
+
+    context 'with subscription started in current billing period' do
+      before { subscription.update!(started_at: Time.zone.today) }
+
+      it 'changes the from date of the invoice' do
+        result = usage_service.usage
 
         aggregate_failures do
           expect(result).to be_success
 
           expect(result.usage.id).to be_nil
-          expect(result.usage.from_datetime).to eq(Time.current.beginning_of_month.iso8601)
-          expect(result.usage.to_datetime).to eq(Time.current.end_of_month.iso8601)
-          expect(result.usage.issuing_date).to eq(Time.zone.today.end_of_month.iso8601)
-          expect(result.usage.fees.size).to eq(1)
-
-          expect(result.usage.amount_cents).to eq(0)
-          expect(result.usage.amount_currency).to eq('EUR')
-          expect(result.usage.vat_amount_cents).to eq(0)
-          expect(result.usage.vat_amount_currency).to eq('EUR')
-          expect(result.usage.total_amount_cents).to eq(0)
-          expect(result.usage.total_amount_currency).to eq('EUR')
+          expect(result.usage.from_datetime).to eq(subscription.started_at.iso8601)
         end
       end
+    end
 
-      context 'with subscription started in current billing period' do
-        before { subscription.update!(started_at: Time.zone.today) }
+    context 'when subscription is billed on anniversary date' do
+      let(:current_date) { DateTime.parse('2022-06-22') }
+      let(:started_at) { DateTime.parse('2022-03-07') }
+      let(:subscription_at) { started_at }
+      let(:timestamp) { current_date }
 
-        it 'changes the from date of the invoice' do
-          result = invoice_service.usage
+      let(:subscription) do
+        create(
+          :subscription,
+          plan:,
+          customer:,
+          subscription_at:,
+          started_at:,
+          billing_time: :anniversary,
+        )
+      end
+
+      it 'initialize an invoice' do
+        travel_to(current_date) do
+          result = usage_service.usage
 
           aggregate_failures do
             expect(result).to be_success
 
             expect(result.usage.id).to be_nil
-            expect(result.usage.from_datetime).to eq(subscription.started_at.iso8601)
-          end
-        end
-      end
+            expect(result.usage.from_datetime.to_date.to_s).to eq('2022-06-07')
+            expect(result.usage.to_datetime.to_date.to_s).to eq('2022-07-06')
+            expect(result.usage.issuing_date).to eq('2022-07-06')
+            expect(result.usage.fees.size).to eq(1)
 
-      context 'when subscription is billed on anniversary date' do
-        let(:current_date) { DateTime.parse('2022-06-22') }
-        let(:started_at) { DateTime.parse('2022-03-07') }
-        let(:subscription_at) { started_at }
-
-        let(:subscription) do
-          create(
-            :subscription,
-            plan: plan,
-            customer: customer,
-            subscription_at: subscription_at,
-            started_at: started_at,
-            billing_time: :anniversary,
-          )
-        end
-
-        it 'initialize an invoice' do
-          travel_to(current_date) do
-            result = invoice_service.usage
-
-            aggregate_failures do
-              expect(result).to be_success
-
-              expect(result.usage.id).to be_nil
-              expect(result.usage.from_datetime.to_date.to_s).to eq('2022-06-07')
-              expect(result.usage.to_datetime.to_date.to_s).to eq('2022-07-06')
-              expect(result.usage.issuing_date).to eq('2022-07-06')
-              expect(result.usage.fees.size).to eq(1)
-
-              expect(result.usage.amount_cents).to eq(0)
-              expect(result.usage.amount_currency).to eq('EUR')
-              expect(result.usage.vat_amount_cents).to eq(0)
-              expect(result.usage.vat_amount_currency).to eq('EUR')
-              expect(result.usage.total_amount_cents).to eq(0)
-              expect(result.usage.total_amount_currency).to eq('EUR')
-            end
-          end
-        end
-      end
-    end
-
-    context 'when billed weekly' do
-      let(:plan) { create(:plan, interval: 'weekly') }
-
-      it 'intialize an invoice' do
-        result = invoice_service.usage
-
-        aggregate_failures do
-          expect(result).to be_success
-
-          expect(result.usage.id).to be_nil
-          expect(result.usage.from_datetime).to eq(Time.current.beginning_of_week.iso8601)
-          expect(result.usage.to_datetime).to eq(Time.current.end_of_week.iso8601)
-          expect(result.usage.issuing_date).to eq(Time.zone.today.end_of_week.iso8601)
-          expect(result.usage.fees.size).to eq(1)
-
-          expect(result.usage.amount_cents).to eq(0)
-          expect(result.usage.amount_currency).to eq('EUR')
-          expect(result.usage.vat_amount_cents).to eq(0)
-          expect(result.usage.vat_amount_currency).to eq('EUR')
-          expect(result.usage.total_amount_cents).to eq(0)
-          expect(result.usage.total_amount_currency).to eq('EUR')
-        end
-      end
-
-      context 'when subscription is billed on anniversary date' do
-        let(:current_date) { DateTime.parse('2022-06-22') }
-        let(:started_at) { DateTime.parse('2022-03-07') }
-        let(:subscription_at) { started_at }
-
-        let(:subscription) do
-          create(
-            :subscription,
-            plan: plan,
-            customer: customer,
-            subscription_at: subscription_at,
-            started_at: started_at,
-            billing_time: :anniversary,
-          )
-        end
-
-        it 'initialize an invoice' do
-          travel_to(current_date) do
-            result = invoice_service.usage
-
-            aggregate_failures do
-              expect(result).to be_success
-
-              expect(result.usage.id).to be_nil
-              expect(result.usage.from_datetime.to_date.to_s).to eq('2022-06-20')
-              expect(result.usage.to_datetime.to_date.to_s).to eq('2022-06-26')
-              expect(result.usage.issuing_date).to eq('2022-06-26')
-              expect(result.usage.fees.size).to eq(1)
-
-              expect(result.usage.amount_cents).to eq(0)
-              expect(result.usage.amount_currency).to eq('EUR')
-              expect(result.usage.vat_amount_cents).to eq(0)
-              expect(result.usage.vat_amount_currency).to eq('EUR')
-              expect(result.usage.total_amount_cents).to eq(0)
-              expect(result.usage.total_amount_currency).to eq('EUR')
-            end
-          end
-        end
-      end
-    end
-
-    context 'when billed yearly' do
-      let(:plan) { create(:plan, interval: 'yearly') }
-
-      it 'intialize an invoice' do
-        result = invoice_service.usage
-
-        aggregate_failures do
-          expect(result).to be_success
-
-          expect(result.usage.id).to be_nil
-          expect(result.usage.from_datetime).to eq(Time.current.beginning_of_year.iso8601)
-          expect(result.usage.to_datetime).to eq(Time.current.end_of_year.iso8601)
-          expect(result.usage.issuing_date).to eq(Time.zone.today.end_of_year.iso8601)
-          expect(result.usage.fees.size).to eq(1)
-
-          expect(result.usage.amount_cents).to eq(0)
-          expect(result.usage.amount_currency).to eq('EUR')
-          expect(result.usage.vat_amount_cents).to eq(0)
-          expect(result.usage.vat_amount_currency).to eq('EUR')
-          expect(result.usage.total_amount_cents).to eq(0)
-          expect(result.usage.total_amount_currency).to eq('EUR')
-        end
-      end
-
-      context 'when subscription is billed on anniversary date' do
-        let(:current_date) { DateTime.parse('2022-06-22') }
-        let(:started_at) { DateTime.parse('2021-03-07') }
-        let(:subscription_at) { started_at }
-
-        let(:subscription) do
-          create(
-            :subscription,
-            plan: plan,
-            customer: customer,
-            subscription_at: subscription_at,
-            started_at: started_at,
-            billing_time: :anniversary,
-          )
-        end
-
-        it 'initialize an invoice' do
-          travel_to(current_date) do
-            result = invoice_service.usage
-
-            aggregate_failures do
-              expect(result).to be_success
-
-              expect(result.usage.id).to be_nil
-              expect(result.usage.from_datetime.to_date.to_s).to eq('2022-03-07')
-              expect(result.usage.to_datetime.to_date.to_s).to eq('2023-03-06')
-              expect(result.usage.issuing_date).to eq('2023-03-06')
-              expect(result.usage.fees.size).to eq(1)
-
-              expect(result.usage.amount_cents).to eq(0)
-              expect(result.usage.amount_currency).to eq('EUR')
-              expect(result.usage.vat_amount_cents).to eq(0)
-              expect(result.usage.vat_amount_currency).to eq('EUR')
-              expect(result.usage.total_amount_cents).to eq(0)
-              expect(result.usage.total_amount_currency).to eq('EUR')
-            end
+            expect(result.usage.amount_cents).to eq(2532) # 1266 * 2
+            expect(result.usage.amount_currency).to eq('EUR')
+            expect(result.usage.vat_amount_cents).to eq(507) # 1266 * 2 * 0.2 = 506.4
+            expect(result.usage.vat_amount_currency).to eq('EUR')
+            expect(result.usage.total_amount_cents).to eq(3039)
+            expect(result.usage.total_amount_currency).to eq('EUR')
           end
         end
       end
@@ -264,7 +150,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
       let(:customer_id) { 'foo' }
 
       it 'returns an error' do
-        result = invoice_service.usage
+        result = usage_service.usage
 
         expect(result).not_to be_success
         expect(result.error.error_code).to eq('customer_not_found')
@@ -275,7 +161,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
       let(:subscription) { nil }
 
       it 'fails' do
-        result = invoice_service.usage
+        result = usage_service.usage
 
         aggregate_failures do
           expect(result).not_to be_success


### PR DESCRIPTION
## Context

Lago API performs some math on top of monetary values, to calculate VAT, internal fees, etc.

Since these operations are done using integer amounts in cents and are spread around the codebase, there are some rounding issues and inconsistencies, like off-by-one errors.

## Description

This PR ensure VAT amount computed at invoice level on customer current usage is computed based on fee amount without using rounded value computed at fee level, to prevent rounding issues
