### PR TITLE
fix(credit_notes): Round VAT at credit note level

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -72,7 +72,9 @@ class Invoice < ApplicationRecord
   end
 
   def fee_total_amount_cents
-    fees.sum(:amount_cents) + fees.sum(:vat_amount_cents)
+    amount_cents = fees.sum(:amount_cents)
+    vat_amount_cents = fees.sum { |f| f.amount_cents * f.vat_rate }.fdiv(100).ceil
+    amount_cents + vat_amount_cents
   end
 
   def currency

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Invoice, type: :model do
     let(:organization) { create(:organization, name: 'LAGO') }
     let(:customer) { create(:customer, organization:) }
     let(:invoice) { create(:invoice, customer:, organization:) }
-    let(:fees) { create_list(:fee, 2, invoice:, amount_cents: 100, vat_amount_cents: 20) }
+    let(:fees) { create_list(:fee, 2, invoice:, amount_cents: 100, vat_rate: 20, vat_amount_cents: 20) }
 
     before { fees }
 

--- a/spec/services/credit_notes/validate_item_service_spec.rb
+++ b/spec/services/credit_notes/validate_item_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CreditNotes::ValidateItemService, type: :service do
-  subject(:validator) { described_class.new(result, item: item) }
+  subject(:validator) { described_class.new(result, item:) }
 
   let(:result) { BaseService::Result.new }
   let(:amount_cents) { 10 }
@@ -12,25 +12,25 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
   let(:credit_note) do
     create(
       :credit_note,
-      invoice: invoice,
-      customer: customer,
-      credit_amount_cents: credit_amount_cents,
-      refund_amount_cents: refund_amount_cents,
+      invoice:,
+      customer:,
+      credit_amount_cents:,
+      refund_amount_cents:,
     )
   end
   let(:item) do
     build(
       :credit_note_item,
-      credit_note: credit_note,
-      amount_cents: amount_cents,
-      fee: fee,
+      credit_note:,
+      amount_cents:,
+      fee:,
     )
   end
 
-  let(:invoice) { create(:invoice, total_amount_cents: 100, amount_cents: 100) }
+  let(:invoice) { create(:invoice, total_amount_cents: 120, amount_cents: 100) }
   let(:customer) { invoice.customer }
 
-  let(:fee) { create(:fee, invoice: invoice, amount_cents: 100) }
+  let(:fee) { create(:fee, invoice:, amount_cents: 100, vat_rate: 20) }
 
   describe '.call' do
     it 'validates the item' do
@@ -67,7 +67,7 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
       let(:amount_cents) { fee.amount_cents + 10 }
 
       before do
-        create(:fee, invoice: invoice, amount_cents: 100, vat_amount_cents: 20)
+        create(:fee, invoice:, amount_cents: 100, vat_rate: 20, vat_amount_cents: 20)
       end
 
       it 'fails the validation' do
@@ -82,8 +82,8 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
 
     context 'when reaching fee creditable amount' do
       before do
-        create(:credit_note_item, fee: fee, amount_cents: 99)
-        create(:fee, invoice: invoice, amount_cents: 100, vat_amount_cents: 20)
+        create(:credit_note_item, fee:, amount_cents: 99)
+        create(:fee, invoice:, amount_cents: 100, vat_rate: 20, vat_amount_cents: 20)
       end
 
       it 'fails the validation' do
@@ -98,7 +98,7 @@ RSpec.describe CreditNotes::ValidateItemService, type: :service do
 
     context 'when reaching invoice creditable amount' do
       before do
-        create(:credit_note, invoice: invoice, total_amount_cents: 99)
+        create(:credit_note, invoice:, total_amount_cents: 99)
       end
 
       it 'fails the validation' do

--- a/spec/services/credit_notes/validate_service_spec.rb
+++ b/spec/services/credit_notes/validate_service_spec.rb
@@ -7,34 +7,36 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
 
   let(:result) { BaseService::Result.new }
   let(:amount_cents) { 10 }
-  let(:credit_amount_cents) { 10 }
+  let(:credit_amount_cents) { 12 }
+  let(:item_amount_cents) { 10 }
   let(:refund_amount_cents) { 0 }
   let(:credit_note) do
     create(
       :credit_note,
-      invoice: invoice,
-      customer: customer,
-      credit_amount_cents: credit_amount_cents,
-      refund_amount_cents: refund_amount_cents,
+      invoice:,
+      customer:,
+      credit_amount_cents:,
+      refund_amount_cents:,
     )
   end
   let(:item) do
     create(
       :credit_note_item,
-      credit_note: credit_note,
-      amount_cents: amount_cents,
-      fee: fee,
+      credit_note:,
+      amount_cents:,
+      fee:,
     )
   end
 
-  let(:invoice) { create(:invoice, total_amount_cents: 100, amount_cents: 100) }
+  let(:invoice) { create(:invoice, total_amount_cents: 120, amount_cents: 100) }
   let(:customer) { invoice.customer }
 
   let(:fee) do
     create(
       :fee,
-      invoice: invoice,
+      invoice:,
       amount_cents: 100,
+      vat_rate: 20,
     )
   end
 
@@ -76,7 +78,7 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       let(:credit_amount_cents) { 250 }
 
       before do
-        create(:fee, invoice: invoice, amount_cents: 100, vat_amount_cents: 20)
+        create(:fee, invoice:, amount_cents: 100, vat_rate: 20, vat_amount_cents: 20)
       end
 
       it 'fails the validation' do
@@ -94,7 +96,7 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
 
       before do
         invoice.succeeded!
-        create(:fee, invoice: invoice, amount_cents: 100, vat_amount_cents: 20)
+        create(:fee, invoice:, amount_cents: 100, vat_rate: 20, vat_amount_cents: 20)
       end
 
       it 'fails the validation' do
@@ -109,7 +111,7 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
 
     context 'when reaching invoice creditable amount' do
       before do
-        create(:credit_note, invoice: invoice, total_amount_cents: 99)
+        create(:credit_note, invoice:, total_amount_cents: 99)
       end
 
       it 'fails the validation' do
@@ -125,7 +127,7 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
     context 'when reaching invoice refundable amount' do
       before do
         invoice.succeeded!
-        create(:credit_note, invoice: invoice, total_amount_cents: 99, refund_amount_cents: 99, credit_amount_cents: 0)
+        create(:credit_note, invoice:, total_amount_cents: 119, refund_amount_cents: 199, credit_amount_cents: 0)
       end
 
       let(:credit_amount_cents) { 0 }
@@ -145,10 +147,10 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       before do
         create(
           :credit_note,
-          invoice: invoice,
-          credit_amount_cents: 66,
+          invoice:,
+          credit_amount_cents: 86,
           refund_amount_cents: 33,
-          total_amount_cents: 99,
+          total_amount_cents: 119,
         )
       end
 


### PR DESCRIPTION
## Context

Lago API performs some math on top of monetary values, to calculate VAT, internal fees, etc.

Since these operations are done using integer amounts in cents and are spread around the codebase, there are some rounding issues and inconsistencies, like off-by-one errors.

## Description

This PR ensure VAT amount computed to validate credit notes is computed based on fee amount without using rounded value stored on fees, in order to prevent rounding issues
