### PR TITLE
misc: Merge API and GraphQL AppliedCoupon create services

### DIFF
--- a/app/controllers/api/v1/applied_coupons_controller.rb
+++ b/app/controllers/api/v1/applied_coupons_controller.rb
@@ -4,11 +4,17 @@ module Api
   module V1
     class AppliedCouponsController < Api::BaseController
       def create
-        service = AppliedCoupons::CreateService.new
-        result = service.create_from_api(
-          organization: current_organization,
-          args: create_params,
+        customer = Customer.find_by(
+          external_id: create_params[:external_customer_id],
+          organization_id: current_organization.id,
         )
+
+        coupon = Coupon.find_by(
+          code: create_params[:coupon_code],
+          organization_id: current_organization.id,
+        )
+
+        result = AppliedCoupons::CreateService.call(customer:, coupon:, params: create_params)
 
         if result.success?
           render(

--- a/app/graphql/mutations/applied_coupons/create.rb
+++ b/app/graphql/mutations/applied_coupons/create.rb
@@ -23,10 +23,17 @@ module Mutations
       def resolve(**args)
         validate_organization!
 
-        result = ::AppliedCoupons::CreateService
-          .new(context[:current_user])
-          .create(**args.merge(organization_id: current_organization.id))
+        customer = Customer.find_by(
+          id: args[:customer_id],
+          organization_id: current_organization.id,
+        )
 
+        coupon = Coupon.find_by(
+          id: args[:coupon_id],
+          organization_id: current_organization.id,
+        )
+
+        result = ::AppliedCoupons::CreateService.call(customer:, coupon:, params: args)
         result.success? ? result.applied_coupon : result_error(result)
       end
     end


### PR DESCRIPTION
## Description

This PR merges `AppliedCoupons::CreateService#create` and `AppliedCoupons::CreateService#create_from_api` methods into a single one named `AppliedCoupons::CreateService#call`. 

This will reduce the amount of code and test to maintain and ensure the behavior is the same between API and GraphQL
