### PR TITLE
fix (applied coupons): fix delete applied coupon logic by using lago id as identifier

### DIFF
--- a/app/controllers/api/v1/customers/applied_coupons_controller.rb
+++ b/app/controllers/api/v1/customers/applied_coupons_controller.rb
@@ -8,10 +8,7 @@ module Api
           customer = current_organization.customers.find_by(external_id: params[:customer_external_id])
           return not_found_error(resource: 'customer') unless customer
 
-          coupon = current_organization.coupons.find_by(code: params[:coupon_code])
-          return not_found_error(resource: 'coupon') unless coupon
-
-          applied_coupon = customer.applied_coupons.find_by(coupon_id: coupon.id)
+          applied_coupon = customer.applied_coupons.find_by(id: params[:id])
           return not_found_error(resource: 'applied_coupon') unless applied_coupon
 
           result = ::AppliedCoupons::TerminateService.call(applied_coupon:)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
         get :current_usage
 
         scope module: :customers do
-          resources :applied_coupons, param: :coupon_code, only: %i[destroy]
+          resources :applied_coupons, only: %i[destroy]
         end
       end
 

--- a/spec/requests/api/v1/customers/applied_coupons_spec.rb
+++ b/spec/requests/api/v1/customers/applied_coupons_spec.rb
@@ -5,21 +5,21 @@ require 'rails_helper'
 RSpec.describe Api::V1::Customers::AppliedCouponsController, type: :request do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:coupon) { create(:coupon, organization:) }
 
   describe 'destroy' do
-    let(:applied_coupon) { create(:applied_coupon, customer:, coupon:) }
+    let(:applied_coupon) { create(:applied_coupon, customer:) }
+    let(:identifier) { applied_coupon.id }
 
     before { applied_coupon }
 
     it 'terminates the applied coupon' do
       expect do
-        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/#{coupon.code}")
+        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/#{identifier}")
       end.to change { applied_coupon.reload.status }.from('active').to('terminated')
     end
 
     it 'returns the applied_coupon' do
-      delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/#{coupon.code}")
+      delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/#{identifier}")
 
       expect(response).to have_http_status(:success)
       expect(json[:applied_coupon][:lago_id]).to eq(applied_coupon.id)
@@ -27,24 +27,28 @@ RSpec.describe Api::V1::Customers::AppliedCouponsController, type: :request do
 
     context 'when customer does not exist' do
       it 'returns not_found error' do
-        delete_with_token(organization, "/api/v1/customers/unknown/applied_coupons/#{coupon.code}")
+        delete_with_token(organization, "/api/v1/customers/unknown/applied_coupons/#{identifier}")
 
         expect(response).to have_http_status(:not_found)
       end
     end
 
-    context 'when coupon does not exist' do
+    context 'when applied coupon does not exist' do
+      let(:identifier) { 'unknown' }
+
       it 'returns not_found error' do
-        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/unknown")
+        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/#{identifier}")
 
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context 'when coupon is not applied to customer' do
+      let(:other_applied_coupon) { create(:applied_coupon) }
+      let(:identifier) { other_applied_coupon.id }
+
       it 'returns not_found error' do
-        other_coupon = create(:coupon, organization:)
-        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/#{other_coupon.code}")
+        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_coupons/#{identifier}")
 
         expect(response).to have_http_status(:not_found)
       end


### PR DESCRIPTION
## Description

Currently we can assign multiple coupons of a same type on a customer. That being said we need to remove applied coupon by unique identifier.
