### PR TITLE
misc: Merge API and GraphQL BillableMetric update services

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -25,12 +25,12 @@ module Api
       end
 
       def update
-        service = ::BillableMetrics::UpdateService.new
-        result = service.update_from_api(
-          organization: current_organization,
+        billable_metric = BillableMetric.find_by(
           code: params[:code],
-          params: input_params.to_h,
+          organization_id: current_organization.id,
         )
+
+        result = ::BillableMetrics::UpdateService.call(billable_metric:, params: input_params.to_h)
 
         if result.success?
           render(

--- a/app/graphql/mutations/billable_metrics/update.rb
+++ b/app/graphql/mutations/billable_metrics/update.rb
@@ -19,8 +19,8 @@ module Mutations
       type Types::BillableMetrics::Object
 
       def resolve(**args)
-        result = ::BillableMetrics::UpdateService.new(context[:current_user]).update(**args)
-
+        billable_metric = context[:current_user].billable_metrics.find_by(id: args[:id])
+        result = ::BillableMetrics::UpdateService.call(billable_metric:, params: args)
         result.success? ? result.billable_metric : result_error(result)
       end
     end

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -2,61 +2,43 @@
 
 module BillableMetrics
   class UpdateService < BaseService
-    def update(**args)
-      metric = result.user.billable_metrics.find_by(id: args[:id])
-      return result.not_found_failure!(resource: 'billable_metric') unless metric
+    def initialize(billable_metric:, params:)
+      @billable_metric = billable_metric
+      @params = params
 
-      metric.name = args[:name]
-      metric.description = args[:description] if args[:description]
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'billable_metric') unless billable_metric
+
+      billable_metric.name = params[:name] if params.key?(:name)
+      billable_metric.description = params[:description] if params.key?(:description)
 
       # NOTE: Only name and description are editable if billable metric
       #       is attached to subscriptions
-      unless metric.attached_to_subscriptions?
-        metric.code = args[:code]
-        metric.aggregation_type = args[:aggregation_type]&.to_sym
-        metric.field_name = args[:field_name]
-
-        if args.key?(:group)
-          group_result = update_groups(metric, args[:group])
-          return group_result if group_result.error
-        end
-      end
-
-      metric.save!
-
-      result.billable_metric = metric
-      result
-    rescue ActiveRecord::RecordInvalid => e
-      result.record_validation_failure!(record: e.record)
-    end
-
-    def update_from_api(organization:, code:, params:)
-      metric = organization.billable_metrics.find_by(code: code)
-      return result.not_found_failure!(resource: 'billable_metric') unless metric
-
-      metric.name = params[:name] if params.key?(:name)
-      metric.description = params[:description] if params.key?(:description)
-
-      unless metric.attached_to_subscriptions?
-        metric.code = params[:code] if params.key?(:code)
-        metric.aggregation_type = params[:aggregation_type] if params.key?(:aggregation_type)
-        metric.field_name = params[:field_name] if params.key?(:field_name)
+      unless billable_metric.attached_to_subscriptions?
+        billable_metric.code = params[:code] if params.key?(:code)
+        billable_metric.aggregation_type = params[:aggregation_type]&.to_sym if params.key?(:aggregation_type)
+        billable_metric.field_name = params[:field_name] if params.key?(:field_name)
 
         if params.key?(:group)
-          group_result = update_groups(metric, params[:group])
+          group_result = update_groups(billable_metric, params[:group])
           return group_result if group_result.error
         end
       end
 
-      metric.save!
+      billable_metric.save!
 
-      result.billable_metric = metric
+      result.billable_metric = billable_metric
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     end
 
     private
+
+    attr_reader :billable_metric, :params
 
     def update_groups(metric, group_params)
       ActiveRecord::Base.transaction do


### PR DESCRIPTION
## Description

This PR merges `BillableMetrics::UpdateService#update` and `BillableMetrics::UpdateService#update_from_api` methods into a single one named `BillableMetrics::UpdateService#call`. 

This will reduce the amount of code and test to maintain and ensure the behavior is the same between API and GraphQL
