### PR TITLE
misc: Merge API and GraphQL Coupons update services

### DIFF
--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -20,10 +20,10 @@ module Api
       end
 
       def update
-        service = Coupons::UpdateService.new
-        result = service.update_from_api(
-          organization: current_organization,
-          code: params[:code],
+        coupon = current_organization.coupons.find_by(code: params[:code])
+
+        result = Coupons::UpdateService.call(
+          coupon:,
           params: CouponLegacyInput.new(
             current_organization,
             input_params,

--- a/app/graphql/mutations/coupons/update.rb
+++ b/app/graphql/mutations/coupons/update.rb
@@ -27,9 +27,8 @@ module Mutations
       type Types::Coupons::Object
 
       def resolve(**args)
-        result = ::Coupons::UpdateService.new(context[:current_user])
-          .update(args)
-
+        coupon = context[:current_user].coupons.find_by(id: args[:id])
+        result = ::Coupons::UpdateService.call(coupon:, params: args)
         result.success? ? result.coupon : result_error(result)
       end
     end


### PR DESCRIPTION
## Description

This PR merges `Coupons::UpdateService#update` and `Coupons::UpdateService#update_from_api` methods into a single one named `Coupons::UpdateService#call`. 

This will reduce the amount of code and test to maintain and ensure the behavior is the same between API and GraphQL