### PR TITLE
misc: Merge API and GraphQL Subscription create services

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -4,9 +4,19 @@ module Api
   module V1
     class SubscriptionsController < Api::BaseController
       def create
-        subscription_service = Subscriptions::CreateService.new
-        result = subscription_service.create_from_api(
-          organization: current_organization,
+        customer = Customer.find_or_initialize_by(
+          external_id: create_params[:external_customer_id]&.strip,
+          organization_id: current_organization.id,
+        )
+
+        plan = Plan.find_by(
+          code: create_params[:plan_code],
+          organization_id: current_organization.id,
+        )
+
+        result = Subscriptions::CreateService.call(
+          customer:,
+          plan:,
           params: SubscriptionLegacyInput.new(
             current_organization,
             create_params,

--- a/app/graphql/mutations/subscriptions/create.rb
+++ b/app/graphql/mutations/subscriptions/create.rb
@@ -21,9 +21,21 @@ module Mutations
       def resolve(**args)
         validate_organization!
 
-        result = ::Subscriptions::CreateService
-          .new
-          .create(args.merge(organization_id: current_organization.id))
+        customer = Customer.find_by(
+          id: args[:customer_id],
+          organization_id: current_organization.id,
+        )
+
+        plan = Plan.find_by(
+          id: args[:plan_id],
+          organization_id: current_organization.id,
+        )
+
+        result = ::Subscriptions::CreateService.call(
+          customer:,
+          plan:,
+          params: args.merge(external_id: SecureRandom.uuid),
+        )
 
         result.success? ? result.subscription : result_error(result)
       end


### PR DESCRIPTION
## Description

This PR merges `Subscriptions::CreateService#create` and `Subscriptions::CreateService#create_from_api` methods into a single one named `Subscriptions::CreateService#call`. 

This will reduce the amount of code and test to maintain and ensure the behavior is the same between API and GraphQL