### PR TITLE
feat(applied coupons): extend applied coupon serializer

### DIFF
--- a/app/controllers/api/v1/applied_coupons_controller.rb
+++ b/app/controllers/api/v1/applied_coupons_controller.rb
@@ -45,6 +45,7 @@ module Api
             ::V1::AppliedCouponSerializer,
             collection_name: 'applied_coupons',
             meta: pagination_metadata(applied_coupons),
+            includes: %i[credits],
           ),
         )
       end

--- a/app/serializers/v1/credit_serializer.rb
+++ b/app/serializers/v1/credit_serializer.rb
@@ -16,7 +16,7 @@ module V1
         invoice: {
           lago_id: model.invoice_id,
           payment_status: model.invoice.payment_status,
-        }
+        },
       }
     end
   end

--- a/app/serializers/v1/credit_serializer.rb
+++ b/app/serializers/v1/credit_serializer.rb
@@ -13,6 +13,10 @@ module V1
           code: model.item_code,
           name: model.item_name,
         },
+        invoice: {
+          lago_id: model.invoice_id,
+          payment_status: model.invoice.payment_status,
+        }
       }
     end
   end

--- a/spec/serializers/v1/applied_coupon_serializer_spec.rb
+++ b/spec/serializers/v1/applied_coupon_serializer_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::AppliedCouponSerializer do
+  subject(:serializer) { described_class.new(applied_coupon, root_name: 'applied_coupon', includes: %i[credits]) }
+
+  let(:applied_coupon) { create(:applied_coupon) }
+  let(:credit) { create(:credit, amount_cents: 50, applied_coupon:) }
+
+  before { credit }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+    credit = applied_coupon.credits.first
+
+    aggregate_failures do
+      expect(result['applied_coupon']['lago_id']).to eq(applied_coupon.id)
+      expect(result['applied_coupon']['lago_coupon_id']).to eq(applied_coupon.coupon.id)
+      expect(result['applied_coupon']['coupon_code']).to eq(applied_coupon.coupon.code)
+      expect(result['applied_coupon']['lago_customer_id']).to eq(applied_coupon.customer.id)
+      expect(result['applied_coupon']['external_customer_id']).to eq(applied_coupon.customer.external_id)
+      expect(result['applied_coupon']['status']).to eq(applied_coupon.status)
+      expect(result['applied_coupon']['amount_cents']).to eq(applied_coupon.amount_cents)
+      expect(result['applied_coupon']['amount_cents_remaining'])
+        .to eq(applied_coupon.amount_cents - applied_coupon.credits.sum(:amount_cents))
+      expect(result['applied_coupon']['amount_currency']).to eq(applied_coupon.amount_currency)
+      expect(result['applied_coupon']['percentage_rate']).to eq(applied_coupon.percentage_rate)
+      expect(result['applied_coupon']['frequency']).to eq(applied_coupon.frequency)
+      expect(result['applied_coupon']['frequency_duration']).to eq(applied_coupon.frequency_duration)
+      expect(result['applied_coupon']['frequency_duration_remaining'])
+        .to eq(applied_coupon.frequency_duration_remaining)
+      expect(result['applied_coupon']['expiration_at']).to eq(applied_coupon.coupon.expiration_at&.iso8601)
+      expect(result['applied_coupon']['created_at']).to eq(applied_coupon.created_at&.iso8601)
+      expect(result['applied_coupon']['terminated_at']).to eq(applied_coupon.terminated_at&.iso8601)
+
+      expect(result['applied_coupon']['credits'].first['lago_id']).to eq(credit.id)
+      expect(result['applied_coupon']['credits'].first['amount_cents']).to eq(credit.amount_cents)
+      expect(result['applied_coupon']['credits'].first['amount_currency']).to eq(credit.amount_currency)
+      expect(result['applied_coupon']['credits'].first['item']['lago_id']).to eq(credit.item_id)
+      expect(result['applied_coupon']['credits'].first['item']['type']).to eq(credit.item_type)
+      expect(result['applied_coupon']['credits'].first['item']['code']).to eq(credit.item_code)
+      expect(result['applied_coupon']['credits'].first['item']['name']).to eq(credit.item_name)
+      expect(result['applied_coupon']['credits'].first['invoice']['payment_status'])
+        .to eq(credit.invoice.payment_status)
+      expect(result['applied_coupon']['credits'].first['invoice']['lago_id']).to eq(credit.invoice.id)
+    end
+  end
+end

--- a/spec/serializers/v1/credit_serializer_spec.rb
+++ b/spec/serializers/v1/credit_serializer_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe ::V1::CreditSerializer do
       expect(result['credit']['item']['type']).to eq(credit.item_type)
       expect(result['credit']['item']['code']).to eq(credit.item_code)
       expect(result['credit']['item']['name']).to eq(credit.item_name)
+      expect(result['credit']['invoice']['payment_status']).to eq(credit.invoice.payment_status)
+      expect(result['credit']['invoice']['lago_id']).to eq(credit.invoice.id)
     end
   end
 end


### PR DESCRIPTION
## Context

Some clients requested extension for applied coupons serializer. They want to see on which invoices coupon was spent and the amount that is used. This can be achieved by extending credit serializer and returning list of credits with each applied coupon.
