### PR TITLE
fix(stripe): Ignore not found payment webhook when no invoice

### DIFF
--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       end
 
       context 'with invoice id in metadata' do
-        it 'returns a not found failure' do
+        it 'returns an empty result' do
           result = stripe_service.update_payment_status(
             provider_payment_id: 'ch_123456',
             status: 'succeeded',
@@ -372,9 +372,26 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
           )
 
           aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq('stripe_payment_not_found')
+            expect(result).to be_success
+            expect(result.payment).to be_nil
+          end
+        end
+
+        context 'when invoice belongs to lago' do
+          let(:invoice) { create(:invoice) }
+
+          it 'returns a not found failure' do
+            result = stripe_service.update_payment_status(
+              provider_payment_id: 'ch_123456',
+              status: 'succeeded',
+              metadata: { lago_invoice_id: invoice.id },
+            )
+
+            aggregate_failures do
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::NotFoundFailure)
+              expect(result.error.message).to eq('stripe_payment_not_found')
+            end
           end
         end
       end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/773

This fix is related to the following error:
```
BaseService::NotFoundFailure
stripe_payment_not_found
```
We have A LOT of them in sentry and A LOT of related dead jobs.

The issue is that we are receiving stripe webhooks for all payment executed by Stripe, even those not initiated by the receiving lago instance, leading to a failure because the app is unable to find a matching payment.

## Description

Since we are sending the invoice ID in the metadata when initiating the payment, to we should be looking for the presence of this invoice in the database and ignore the hook if the invoice is not found.