### PR TITLE
fix(stripe): Ignore not found customer webhook when no customer

### DIFF
--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -107,6 +107,7 @@ module PaymentProviders
             organization_id: organization.id,
             stripe_customer_id: event.data.object.customer,
             payment_method_id: event.data.object.payment_method,
+            metadata: event.data.object.metadata.to_h.symbolize_keys,
           )
         result.raise_if_error! || result
       when 'payment_intent.payment_failed', 'payment_intent.succeeded'
@@ -125,6 +126,7 @@ module PaymentProviders
             organization_id: organization.id,
             stripe_customer_id: event.data.object.customer,
             payment_method_id: event.data.object.id,
+            metadata: event.data.object.metadata.to_h.symbolize_keys,
           )
         result.raise_if_error! || result
       when 'charge.refund.updated'

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -121,6 +121,58 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
         end
       end
     end
+
+    context 'when customer is not found' do
+      it 'returns an empty result' do
+        result = stripe_service.update_payment_method(
+          organization_id: organization.id,
+          stripe_customer_id: 'cus_InvaLid',
+          payment_method_id: 'pm_123456',
+        )
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.stripe_customer).to be_nil
+        end
+      end
+
+      context 'when customer in metadata is not found' do
+        it 'returns an empty response' do
+          result = stripe_service.update_payment_method(
+            organization_id: organization.id,
+            stripe_customer_id: 'cus_InvaLid',
+            payment_method_id: 'pm_123456',
+            metadata: {
+              lago_customer_id: SecureRandom.uuid,
+            },
+          )
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.stripe_customer).to be_nil
+          end
+        end
+      end
+
+      context 'when customer in metadata exists' do
+        it 'returns a not found error' do
+          result = stripe_service.update_payment_method(
+            organization_id: organization.id,
+            stripe_customer_id: 'cus_InvaLid',
+            payment_method_id: 'pm_123456',
+            metadata: {
+              lago_customer_id: customer.id,
+            },
+          )
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq('stripe_customer_not_found')
+          end
+        end
+      end
+    end
   end
 
   describe '.delete_payment_method' do
@@ -161,6 +213,58 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
         aggregate_failures do
           expect(result).to be_success
           expect(result.stripe_customer.payment_method_id).to eq(payment_method_id)
+        end
+      end
+    end
+
+    context 'when customer is not found' do
+      it 'returns an empty result' do
+        result = stripe_service.delete_payment_method(
+          organization_id: organization.id,
+          stripe_customer_id: 'cus_InvaLid',
+          payment_method_id: 'pm_123456',
+        )
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.stripe_customer).to be_nil
+        end
+      end
+
+      context 'when customer in metadata is not found' do
+        it 'returns an empty response' do
+          result = stripe_service.delete_payment_method(
+            organization_id: organization.id,
+            stripe_customer_id: 'cus_InvaLid',
+            payment_method_id: 'pm_123456',
+            metadata: {
+              lago_customer_id: SecureRandom.uuid,
+            },
+          )
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.stripe_customer).to be_nil
+          end
+        end
+      end
+
+      context 'when customer in metadata exists' do
+        it 'returns a not found error' do
+          result = stripe_service.delete_payment_method(
+            organization_id: organization.id,
+            stripe_customer_id: 'cus_InvaLid',
+            payment_method_id: 'pm_123456',
+            metadata: {
+              lago_customer_id: customer.id,
+            },
+          )
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq('stripe_customer_not_found')
+          end
         end
       end
     end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/845

This fix is related to the following error:
```
BaseService::NotFoundFailure
stripe_customer_not_found
```
We have A LOT of them in sentry and A LOT of related dead jobs.

The issue is that we are receiving stripe webhooks for all customer changes executed by Stripe, even those not initiated by the receiving lago instance, leading to a failure because the app is unable to find a matching customer.

## Description

Since we are sending the customer ID in the metadata when initiating creating a customer, we should be looking for the presence of this customer in the database and ignore the hook if the customer is not found.
