### PR TITLE
fix(stripe): Capture error when removing webhook url

### DIFF
--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -153,7 +153,7 @@ module PaymentProviders
       Rails.logger.error(e.message)
       Rails.logger.error(e.backtrace.join("\n"))
 
-      Sentry.capture_exception(error)
+      Sentry.capture_exception(e)
     end
 
     def reattach_provider_customers(organization_id:, stripe_provider:)


### PR DESCRIPTION
## Description

This PR fixes a typo in the error capture when removing a webhook URL from Stripe API. 