### PR TITLE
feat(rounding): Add precise amount cents to credit note items

### DIFF
--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -12,7 +12,7 @@ module CreditNotes
     def call
       return result if (last_subscription_fee&.amount_cents || 0).zero?
 
-      amount = compute_amount.round
+      amount = compute_amount
       return result unless amount.positive?
 
       # NOTE: if credit notes were already issued on the fee,
@@ -20,11 +20,11 @@ module CreditNotes
       amount -= last_subscription_fee.credit_note_items.sum(:amount_cents)
       return result unless amount.positive?
 
-      vat_amount = (amount * last_subscription_fee.vat_rate).fdiv(100).round
+      vat_amount = (amount * last_subscription_fee.vat_rate).fdiv(100)
 
       CreditNotes::CreateService.new(
         invoice: last_subscription_fee.invoice,
-        credit_amount_cents: amount + vat_amount,
+        credit_amount_cents: (amount + vat_amount).round,
         refund_amount_cents: 0,
         items: [
           {

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -107,9 +107,12 @@ module CreditNotes
 
     def create_items
       items_attr.each do |item_attr|
+        amount_cents = item_attr[:amount_cents] || 0
+
         item = credit_note.items.new(
           fee: invoice.fees.find_by(id: item_attr[:fee_id]),
-          amount_cents: item_attr[:amount_cents] || 0,
+          amount_cents: amount_cents.round,
+          precise_amount_cents: amount_cents,
           amount_currency: invoice.amount_currency,
         )
         break unless valid_item?(item)

--- a/app/services/credit_notes/validate_service.rb
+++ b/app/services/credit_notes/validate_service.rb
@@ -43,7 +43,7 @@ module CreditNotes
 
     def total_items_amount_cents
       credit_note.items.sum do |item|
-        item.amount_cents + (item.amount_cents * item.fee.vat_rate).fdiv(100)
+        item.precise_amount_cents + (item.precise_amount_cents * item.fee.vat_rate).fdiv(100)
       end.round
     end
 

--- a/db/migrate/20230221102035_add_precise_amount_cents_to_credit_note_items.rb
+++ b/db/migrate/20230221102035_add_precise_amount_cents_to_credit_note_items.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddPreciseAmountCentsToCreditNoteItems < ActiveRecord::Migration[7.0]
+  def change
+    add_column :credit_note_items, :precise_amount_cents, :decimal, precision: 30, scale: 5
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE credit_note_items SET precise_amount_cents = amount_cents;
+        SQL
+      end
+    end
+
+    change_column_null :credit_note_items, :precise_amount_cents, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_21_070501) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_21_102035) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -159,6 +159,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_21_070501) do
     t.string "amount_currency", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.decimal "precise_amount_cents", precision: 30, scale: 5, null: false
     t.index ["credit_note_id"], name: "index_credit_note_items_on_credit_note_id"
     t.index ["fee_id"], name: "index_credit_note_items_on_fee_id"
   end

--- a/spec/factories/credit_note_items.rb
+++ b/spec/factories/credit_note_items.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     credit_note
     fee
     amount_cents { 100 }
+    precise_amount_cents { 100 }
     amount_currency { 'EUR' }
   end
 end

--- a/spec/scenarios/terminate_pay_in_advance_spec.rb
+++ b/spec/scenarios/terminate_pay_in_advance_spec.rb
@@ -37,8 +37,7 @@ describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
       expect(term_invoice.total_amount_cents).to eq(0)
 
       credit_note = sub_invoice.credit_notes.first
-      # TODO: Address rounding issue here as expected amount with VAT is 4286.
-      expect(credit_note.total_amount_cents).to eq(4285) # (50.0 / 28 * 20) + (3571 * 20 / 100)
+      expect(credit_note.total_amount_cents).to eq(4286) # 60.0 / 28 * 20
     end
   end
 
@@ -74,8 +73,7 @@ describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
         expect(term_invoice.total_amount_cents).to eq(0)
 
         credit_note = sub_invoice.credit_notes.first
-        # TODO: Address rounding issue here as expected amount with VAT is 4286.
-        expect(credit_note.total_amount_cents).to eq(4285) # 60.0 / 28 * 20
+        expect(credit_note.total_amount_cents).to eq(4286) # 60.0 / 28 * 20
       end
     end
   end
@@ -148,8 +146,7 @@ describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
         expect(term_invoice.total_amount_cents).to eq(0)
 
         credit_note = sub_invoice.credit_notes.first
-        # TODO: Address rounding issue here as expected amount with VAT is 5786.
-        expect(credit_note.total_amount_cents).to eq(5785)
+        expect(credit_note.total_amount_cents).to eq(5786)
       end
     end
 
@@ -186,8 +183,7 @@ describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
           expect(term_invoice.total_amount_cents).to eq(0)
 
           credit_note = sub_invoice.credit_notes.first
-          # TODO: Address rounding issue here as expected amount with VAT is 5786.
-          expect(credit_note.total_amount_cents).to eq(5785)
+          expect(credit_note.total_amount_cents).to eq(5786)
         end
       end
     end
@@ -225,8 +221,7 @@ describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
           expect(term_invoice.total_amount_cents).to eq(0)
 
           credit_note = sub_invoice.credit_notes.first
-          # TODO: Address rounding issue here as expected amount with VAT is 5786.
-          expect(credit_note.total_amount_cents).to eq(5785)
+          expect(credit_note.total_amount_cents).to eq(5786)
         end
       end
     end

--- a/spec/services/credit_notes/validate_service_spec.rb
+++ b/spec/services/credit_notes/validate_service_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       :credit_note_item,
       credit_note:,
       amount_cents:,
+      precise_amount_cents: amount_cents,
       fee:,
     )
   end


### PR DESCRIPTION
The goal of this PR is to fix rounding issues by using a precise amount cents for credit note items.