### PR TITLE
feat (metadata): add basic model setup for customer metadata

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -17,6 +17,7 @@ class Customer < ApplicationRecord
   has_many :events
   has_many :invoices
   has_many :applied_coupons
+  has_many :metadata, class_name: 'Metadata::CustomerMetadata', dependent: :destroy
   has_many :coupons, through: :applied_coupons
   has_many :credit_notes
   has_many :applied_add_ons

--- a/app/models/metadata/customer_metadata.rb
+++ b/app/models/metadata/customer_metadata.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Metadata
+  class CustomerMetadata < ApplicationRecord
+    belongs_to :customer
+
+    validates :key, presence: true, uniqueness: { scope: :customer_id }, length: { maximum: 20 }
+    validates :value, presence: true, length: { maximum: 40 }
+  end
+end

--- a/db/migrate/20230221070501_create_customer_metadata.rb
+++ b/db/migrate/20230221070501_create_customer_metadata.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateCustomerMetadata < ActiveRecord::Migration[7.0]
+  def change
+    create_table :customer_metadata, id: :uuid do |t|
+      t.references :customer, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.string :key, null: false
+      t.string :value, null: false
+      t.boolean :display_in_invoice, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230221070501_create_customer_metadata.rb
+++ b/db/migrate/20230221070501_create_customer_metadata.rb
@@ -10,6 +10,8 @@ class CreateCustomerMetadata < ActiveRecord::Migration[7.0]
       t.boolean :display_in_invoice, default: false, null: false
 
       t.timestamps
+
+      t.index %w[customer_id key], name: 'index_customer_metadata_on_customer_id_and_key', unique: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -217,6 +217,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_21_070501) do
     t.boolean "display_in_invoice", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["customer_id", "key"], name: "index_customer_metadata_on_customer_id_and_key", unique: true
     t.index ["customer_id"], name: "index_customer_metadata_on_customer_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_14_145444) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_21_070501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -208,6 +208,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_145444) do
     t.index ["applied_coupon_id"], name: "index_credits_on_applied_coupon_id"
     t.index ["credit_note_id"], name: "index_credits_on_credit_note_id"
     t.index ["invoice_id"], name: "index_credits_on_invoice_id"
+  end
+
+  create_table "customer_metadata", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "customer_id", null: false
+    t.string "key", null: false
+    t.string "value", null: false
+    t.boolean "display_in_invoice", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_customer_metadata_on_customer_id"
   end
 
   create_table "customers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -597,6 +607,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_14_145444) do
   add_foreign_key "credits", "applied_coupons"
   add_foreign_key "credits", "credit_notes"
   add_foreign_key "credits", "invoices"
+  add_foreign_key "customer_metadata", "customers"
   add_foreign_key "customers", "organizations"
   add_foreign_key "events", "customers"
   add_foreign_key "events", "organizations"

--- a/spec/factories/customer_metadata.rb
+++ b/spec/factories/customer_metadata.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :customer_metadata, class: 'Metadata::CustomerMetadata' do
+    customer
+
+    key { 'lead_name' }
+    value { 'John Doe' }
+    display_in_invoice { true }
+  end
+end

--- a/spec/models/metadata/customer_metadata_spec.rb
+++ b/spec/models/metadata/customer_metadata_spec.rb
@@ -13,10 +13,8 @@ RSpec.describe Metadata::CustomerMetadata, type: :model do
   end
 
   describe 'key validations' do
-    context 'when uniqueness condition is valid' do
-      it 'validates the key' do
-        expect(metadata).to be_valid
-      end
+    context 'when uniqueness condition is satisfied', :tag do
+      it { expect(metadata).to be_valid }
     end
 
     context 'when key is not unique' do
@@ -24,39 +22,29 @@ RSpec.describe Metadata::CustomerMetadata, type: :model do
 
       before { old_metadata }
 
-      it 'validates the key' do
-        expect(metadata).not_to be_valid
-      end
+      it { expect(metadata).not_to be_valid }
     end
 
-    context 'when length constraint is satisfied' do
-      it 'validates the key' do
-        expect(metadata).to be_valid
-      end
+    context 'when length constraint is satisfied', :tag do
+      it { expect(metadata).to be_valid }
     end
 
     context 'when key length is invalid' do
       let(:key) { 'hello-hello-hello-hello-hello' }
 
-      it 'validates the key' do
-        expect(metadata).not_to be_valid
-      end
+      it { expect(metadata).not_to be_valid }
     end
   end
 
   describe 'value validations' do
-    context 'when length constraint is satisfied' do
-      it 'validates the key' do
-        expect(metadata).to be_valid
-      end
+    context 'when length constraint is satisfied', :tag do
+      it { expect(metadata).to be_valid }
     end
 
     context 'when value length is invalid' do
       let(:value) { 'abcde-abcde-abcde-abcde-abcde-abcde' }
 
-      it 'validates the key' do
-        expect(metadata).to be_valid
-      end
+      it { expect(metadata).to be_valid }
     end
   end
 end

--- a/spec/models/metadata/customer_metadata_spec.rb
+++ b/spec/models/metadata/customer_metadata_spec.rb
@@ -9,18 +9,18 @@ RSpec.describe Metadata::CustomerMetadata, type: :model do
   let(:key) { 'hello' }
   let(:value) { 'abcdef' }
   let(:attributes) do
-    { key: key, value: value, customer: customer, display_in_invoice: true }
+    { key:, value:, customer:, display_in_invoice: true }
   end
 
-  describe 'validations' do
-    context 'when key is unique' do
+  describe 'key validations' do
+    context 'when uniqueness is satisfied' do
       it 'validates the key' do
         expect(metadata).to be_valid
       end
     end
 
     context 'when key is not unique' do
-      let(:old_metadata) { create(:customer_metadata, customer: customer, key: 'hello') }
+      let(:old_metadata) { create(:customer_metadata, customer:, key: 'hello') }
 
       before { old_metadata }
 
@@ -29,27 +29,29 @@ RSpec.describe Metadata::CustomerMetadata, type: :model do
       end
     end
 
-    context 'when key length is valid' do
+    context 'when length constraint is satisfied' do
       it 'validates the key' do
         expect(metadata).to be_valid
       end
     end
 
-    context 'when key length is not valid' do
+    context 'when key length is invalid' do
       let(:key) { 'hello-hello-hello-hello-hello' }
 
       it 'validates the key' do
         expect(metadata).not_to be_valid
       end
     end
+  end
 
-    context 'when value length is valid' do
+  describe 'value validations' do
+    context 'when length constraint is satisfied' do
       it 'validates the key' do
         expect(metadata).to be_valid
       end
     end
 
-    context 'when value length is not valid' do
+    context 'when value length is invalid' do
       let(:value) { 'abcde-abcde-abcde-abcde-abcde-abcde' }
 
       it 'validates the key' do

--- a/spec/models/metadata/customer_metadata_spec.rb
+++ b/spec/models/metadata/customer_metadata_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Metadata::CustomerMetadata, type: :model do
   end
 
   describe 'key validations' do
-    context 'when uniqueness is satisfied' do
+    context 'when uniqueness condition is valid' do
       it 'validates the key' do
         expect(metadata).to be_valid
       end

--- a/spec/models/metadata/customer_metadata_spec.rb
+++ b/spec/models/metadata/customer_metadata_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Metadata::CustomerMetadata, type: :model do
+  subject(:metadata) { described_class.new(attributes) }
+
+  let(:customer) { create(:customer) }
+  let(:key) { 'hello' }
+  let(:value) { 'abcdef' }
+  let(:attributes) do
+    { key: key, value: value, customer: customer, display_in_invoice: true }
+  end
+
+  describe 'validations' do
+    context 'when key is unique' do
+      it 'validates the key' do
+        expect(metadata).to be_valid
+      end
+    end
+
+    context 'when key is not unique' do
+      let(:old_metadata) { create(:customer_metadata, customer: customer, key: 'hello') }
+
+      before { old_metadata }
+
+      it 'validates the key' do
+        expect(metadata).not_to be_valid
+      end
+    end
+
+    context 'when key length is valid' do
+      it 'validates the key' do
+        expect(metadata).to be_valid
+      end
+    end
+
+    context 'when key length is not valid' do
+      let(:key) { 'hello-hello-hello-hello-hello' }
+
+      it 'validates the key' do
+        expect(metadata).not_to be_valid
+      end
+    end
+
+    context 'when value length is valid' do
+      it 'validates the key' do
+        expect(metadata).to be_valid
+      end
+    end
+
+    context 'when value length is not valid' do
+      let(:value) { 'abcde-abcde-abcde-abcde-abcde-abcde' }
+
+      it 'validates the key' do
+        expect(metadata).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/metadata/customer_metadata_spec.rb
+++ b/spec/models/metadata/customer_metadata_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Metadata::CustomerMetadata, type: :model do
       it { expect(metadata).not_to be_valid }
     end
 
-    context 'when length constraint is satisfied', :tag do
+    context 'when length constraint passes', :tag do
       it { expect(metadata).to be_valid }
     end
 


### PR DESCRIPTION
## Context

Creating a customer with Lago’s basic information is not enough to bring context.

## Description

This PR adds customer metadata table and model relations/validations