### PR TITLE
fix(stripe): Ignore not found refund webhook

### DIFF
--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -34,15 +34,15 @@ module CreditNotes
         result
       end
 
-      def update_status(provider_refund_id:, status:)
-        refund = Refund.find_by(provider_refund_id: provider_refund_id)
-        return result.not_found_failure!(resource: 'stripe_refund') unless refund
+      def update_status(provider_refund_id:, status:, metadata: {})
+        refund = Refund.find_by(provider_refund_id:)
+        return handle_missing_refund(metadata) unless refund
 
         result.refund = refund
         @credit_note = result.credit_note = refund.credit_note
         return result if refund.credit_note.succeeded?
 
-        refund.update!(status: status)
+        refund.update!(status:)
         update_credit_note_status(status)
         track_refund_status_changed(status)
 
@@ -146,6 +146,16 @@ module CreditNotes
             refund_status: status,
           },
         )
+      end
+
+      def handle_missing_refund(metadata)
+        # NOTE: Refund was not initiated by lago
+        return result unless metadata&.key?(:lago_invoice_id)
+
+        # NOTE: Invoice does not belongs to this lago instance
+        return result if Invoice.find_by(id: metadata[:lago_invoice_id]).nil?
+
+        result.not_found_failure!(resource: 'stripe_refund')
       end
     end
   end

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -134,6 +134,7 @@ module PaymentProviders
           .new.update_status(
             provider_refund_id: event.data.object.id,
             status: event.data.object.status,
+            metadata: event.data.object.metadata.to_h.symbolize_keys,
           )
       end
     end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/845

This fix is related to the following error:
```
BaseService::NotFoundFailure
stripe_refund_not_found
```
We have a lot of them in sentry and a lot of related dead jobs.

The issue is that we are receiving stripe webhooks for all refund executed by Stripe, even those not initiated by the receiving lago instance, leading to a failure because the app is unable to find a matching refund.

## Description

Since we are sending the invoice ID in the metadata when initiating the refund, to we should be looking for the presence of this invoice in the database and ignore the hook if the invoice is not found.