### PR TITLE
fix(credit-notes): Take max creditable amount when terminating subscription

### DIFF
--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -44,7 +44,7 @@ module CreditNotes
     delegate :plan, :terminated_at, :customer, to: :subscription
 
     def last_subscription_fee
-      @last_subscription_fee ||= subscription.fees.order(created_at: :desc).last
+      @last_subscription_fee ||= subscription.fees.order(created_at: :desc).first
     end
 
     def compute_amount


### PR DESCRIPTION
## Context

This PR is a fix for some validation errors when creating credit notes for terminated subscription:
```
Validation errors: {:amount_cents=>["higher_than_remaining_fee_amount", "higher_than_remaining_invoice_amount"]}
```

## Description

Order of the query to fetch the last subscription fee as target of the credit note item, was always returning the first fee created on the subscription...
