### PR TITLE
feat (customer_metadata): handle customer metadata create and update for API

### DIFF
--- a/app/serializers/v1/customer_serializer.rb
+++ b/app/serializers/v1/customer_serializer.rb
@@ -3,7 +3,7 @@
 module V1
   class CustomerSerializer < ModelSerializer
     def serialize
-      {
+      payload = {
         lago_id: model.id,
         external_id: model.external_id,
         name: model.name,
@@ -27,9 +27,21 @@ module V1
         applicable_timezone: model.applicable_timezone,
         billing_configuration: billing_configuration,
       }
+
+      payload = payload.merge(metadata) if include?(:metadata)
+
+      payload
     end
 
     private
+
+    def metadata
+      ::CollectionSerializer.new(
+        model.metadata,
+        ::V1::Customers::MetadataSerializer,
+        collection_name: 'metadata',
+      ).serialize
+    end
 
     def billing_configuration
       configuration = {

--- a/app/serializers/v1/customers/metadata_serializer.rb
+++ b/app/serializers/v1/customers/metadata_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module V1
+  module Customers
+    class MetadataSerializer < ModelSerializer
+      def serialize
+        {
+          lago_id: model.id,
+          key: model.key,
+          value: model.value,
+          display_in_invoice: model.display_in_invoice,
+          created_at: model.created_at.iso8601,
+        }
+      end
+    end
+  end
+end

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -38,7 +38,7 @@ module Customers
           if new_customer && params[:metadata]
             params[:metadata].each { |m| create_metadata(customer:, args: m) }
           elsif params[:metadata]
-            Customers::Metadata::UpdateService.new(customer:).call(params: params[:metadata])
+            Customers::Metadata::UpdateService.call(customer:, params: params[:metadata])
           end
         end
       end

--- a/app/services/customers/metadata/update_service.rb
+++ b/app/services/customers/metadata/update_service.rb
@@ -3,12 +3,13 @@
 module Customers
   module Metadata
     class UpdateService < BaseService
-      def initialize(customer:)
+      def initialize(customer:, params:)
         @customer = customer
+        @params = params
         super
       end
 
-      def call(params:)
+      def call
         created_metadata_ids = []
 
         hash_metadata = params.map { |m| m.to_h.deep_symbolize_keys }
@@ -34,13 +35,13 @@ module Customers
 
       private
 
-      attr_reader :customer
+      attr_reader :customer, :params
 
-      def create_metadata(params)
+      def create_metadata(payload)
         customer.metadata.create!(
-          key: params[:key],
-          value: params[:value],
-          display_in_invoice: params[:display_in_invoice],
+          key: payload[:key],
+          value: payload[:value],
+          display_in_invoice: payload[:display_in_invoice],
         )
       end
 

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -59,7 +59,7 @@ module Customers
         ActiveRecord::Base.transaction do
           customer.save!
 
-          Customers::Metadata::UpdateService.new(customer:).call(params: args[:metadata]) if args[:metadata]
+          Customers::Metadata::UpdateService.call(customer:, params: args[:metadata]) if args[:metadata]
         end
 
         # NOTE: if payment provider is updated, we need to create/update the provider customer

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -87,6 +87,39 @@ RSpec.describe Api::V1::CustomersController, type: :request do
       end
     end
 
+    context 'with metadata' do
+      let(:create_params) do
+        {
+          external_id: SecureRandom.uuid,
+          name: 'Foo Bar',
+          metadata: [
+            {
+              key: 'Hello',
+              value: 'Hi',
+              display_in_invoice: true,
+            },
+          ],
+        }
+      end
+
+      it 'returns a success' do
+        post_with_token(organization, '/api/v1/customers', { customer: create_params })
+
+        expect(response).to have_http_status(:success)
+
+        expect(json[:customer][:lago_id]).to be_present
+        expect(json[:customer][:external_id]).to eq(create_params[:external_id])
+
+        metadata = json[:customer][:metadata]
+        aggregate_failures do
+          expect(metadata).to be_present
+          expect(metadata.first[:key]).to eq('Hello')
+          expect(metadata.first[:value]).to eq('Hi')
+          expect(metadata.first[:display_in_invoice]).to eq(true)
+        end
+      end
+    end
+
     context 'with invalid params' do
       let(:create_params) do
         { name: 'Foo Bar', currency: 'invalid' }

--- a/spec/serializers/v1/customer_serializer_spec.rb
+++ b/spec/serializers/v1/customer_serializer_spec.rb
@@ -3,9 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe ::V1::CustomerSerializer do
-  subject(:serializer) { described_class.new(customer, root_name: 'customer') }
+  subject(:serializer) { described_class.new(customer, root_name: 'customer', includes: %i[metadata]) }
 
   let(:customer) { create(:customer) }
+  let(:metadata) { create(:customer_metadata, customer:) }
+
+  before { metadata }
 
   it 'serializes the object' do
     result = JSON.parse(serializer.to_json)
@@ -36,6 +39,10 @@ RSpec.describe ::V1::CustomerSerializer do
       expect(result['customer']['billing_configuration']['invoice_grace_period']).to eq(customer.invoice_grace_period)
       expect(result['customer']['billing_configuration']['vat_rate']).to eq(customer.vat_rate)
       expect(result['customer']['billing_configuration']['document_locale']).to eq(customer.document_locale)
+      expect(result['customer']['metadata'].first['lago_id']).to eq(metadata.id)
+      expect(result['customer']['metadata'].first['key']).to eq(metadata.key)
+      expect(result['customer']['metadata'].first['value']).to eq(metadata.value)
+      expect(result['customer']['metadata'].first['display_in_invoice']).to eq(metadata.display_in_invoice)
     end
   end
 end

--- a/spec/serializers/v1/customers/metadata_serializer_spec.rb
+++ b/spec/serializers/v1/customers/metadata_serializer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::Customers::MetadataSerializer do
+  subject(:serializer) { described_class.new(metadata, root_name: 'metadata') }
+
+  let(:metadata) { create(:customer_metadata) }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['metadata']['lago_id']).to eq(metadata.id)
+      expect(result['metadata']['key']).to eq(metadata.key)
+      expect(result['metadata']['value']).to eq(metadata.value)
+      expect(result['metadata']['display_in_invoice']).to eq(metadata.display_in_invoice)
+      expect(result['metadata']['created_at']).to eq(metadata.created_at.iso8601)
+    end
+  end
+end

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -85,6 +85,46 @@ RSpec.describe Customers::CreateService, type: :service do
       end
     end
 
+    context 'with metadata' do
+      let(:create_args) do
+        {
+          external_id:,
+          name: 'Foo Bar',
+          currency: 'EUR',
+          billing_configuration: {
+            vat_rate: 20,
+            document_locale: 'fr',
+          },
+          metadata: [
+            {
+              key: 'manager name',
+              value: 'John',
+              display_in_invoice: true,
+            },
+            {
+              key: 'manager address',
+              value: 'Test',
+              display_in_invoice: false,
+            },
+          ],
+        }
+      end
+
+      it 'creates customer with metadata' do
+        result = customers_service.create_from_api(
+          organization:,
+          params: create_args,
+        )
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          customer = result.customer
+          expect(customer.metadata.count).to eq(2)
+        end
+      end
+    end
+
     context 'with premium features' do
       around { |test| lago_premium!(&test) }
 
@@ -118,14 +158,16 @@ RSpec.describe Customers::CreateService, type: :service do
     end
 
     context 'when customer already exists' do
-      let!(:customer) do
+      let(:customer) do
         create(
           :customer,
           organization:,
-          external_id: create_args[:external_id],
+          external_id:,
           email: 'foo@bar.com',
         )
       end
+
+      before { customer }
 
       it 'updates the customer' do
         result = customers_service.create_from_api(
@@ -155,10 +197,59 @@ RSpec.describe Customers::CreateService, type: :service do
         end
       end
 
+      context 'with metadata' do
+        let(:customer_metadata) { create(:customer_metadata, customer:) }
+        let(:another_customer_metadata) { create(:customer_metadata, customer:, key: 'test', value: '1') }
+        let(:create_args) do
+          {
+            external_id:,
+            name: 'Foo Bar',
+            currency: 'EUR',
+            billing_configuration: {
+              vat_rate: 20,
+              document_locale: 'fr',
+            },
+            metadata: [
+              {
+                id: customer_metadata.id,
+                key: 'new key',
+                value: 'new value',
+                display_in_invoice: true,
+              },
+              {
+                key: 'Added key',
+                value: 'Added value',
+                display_in_invoice: true,
+              },
+            ],
+          }
+        end
+
+        before do
+          customer_metadata
+          another_customer_metadata
+        end
+
+        it 'updates metadata' do
+          result = customers_service.create_from_api(
+            organization:,
+            params: create_args,
+          )
+
+          metadata_keys = result.customer.metadata.pluck(:key)
+          metadata_ids = result.customer.metadata.pluck(:id)
+
+          expect(result.customer.metadata.count).to eq(2)
+          expect(metadata_keys).to eq(['new key', 'Added key'])
+          expect(metadata_ids).to include(customer_metadata.id)
+          expect(metadata_ids).not_to include(another_customer_metadata.id)
+        end
+      end
+
       context 'when attached to a subscription' do
         let(:create_args) do
           {
-            external_id: SecureRandom.uuid,
+            external_id:,
             name: 'Foo Bar',
             currency: 'CAD',
           }
@@ -189,7 +280,7 @@ RSpec.describe Customers::CreateService, type: :service do
 
         let(:create_args) do
           {
-            external_id: SecureRandom.uuid,
+            external_id:,
             billing_configuration: { invoice_grace_period: 2 },
           }
         end

--- a/spec/services/customers/metadata/update_service_spec.rb
+++ b/spec/services/customers/metadata/update_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Customers::Metadata::UpdateService do
-  subject(:update_service) { described_class.new(customer:) }
+  subject(:update_service) { described_class.new(customer:, params:) }
 
   let(:customer) { create(:customer) }
   let(:customer_metadata) { create(:customer_metadata, customer:) }
@@ -31,7 +31,7 @@ RSpec.describe Customers::Metadata::UpdateService do
     end
 
     it 'updates existing metadata' do
-      result = update_service.call(params:)
+      result = update_service.call
 
       metadata_keys = result.customer.metadata.pluck(:key)
       metadata_ids = result.customer.metadata.pluck(:id)
@@ -42,7 +42,7 @@ RSpec.describe Customers::Metadata::UpdateService do
     end
 
     it 'adds new metadata' do
-      result = update_service.call(params:)
+      result = update_service.call
 
       metadata_keys = result.customer.metadata.pluck(:key)
 
@@ -51,7 +51,7 @@ RSpec.describe Customers::Metadata::UpdateService do
     end
 
     it 'sanitizes not needed metadata' do
-      result = update_service.call(params:)
+      result = update_service.call
 
       metadata_ids = result.customer.metadata.pluck(:id)
 


### PR DESCRIPTION
## Context

Currently additional customer data cannot be stored in Lago

## Description

This PR handles customer metadata for create and update API requests