### PR TITLE
fix(webhooks): [BUG] Change webhook type for invoice retry action

### DIFF
--- a/app/services/invoices/payments/retry_service.rb
+++ b/app/services/invoices/payments/retry_service.rb
@@ -6,7 +6,7 @@ module Invoices
       WEBHOOK_TYPE = {
         'subscription' => 'invoice.created',
         'credit' => 'invoice.paid_credit_added',
-        'add_on' => 'invoice.add_on_added'
+        'add_on' => 'invoice.add_on_added',
       }.freeze
 
       def initialize(invoice:)
@@ -23,7 +23,9 @@ module Invoices
           return result.not_allowed_failure!(code: 'payment_processor_is_currently_handling_payment')
         end
 
-        SendWebhookJob.perform_later(WEBHOOK_TYPE[invoice.invoice_type], invoice) if customer&.organization&.webhook_url?
+        if customer&.organization&.webhook_url?
+          SendWebhookJob.perform_later(WEBHOOK_TYPE[invoice.invoice_type], invoice)
+        end
         Invoices::Payments::CreateService.new(invoice).call
 
         result.invoice = invoice

--- a/app/services/invoices/payments/retry_service.rb
+++ b/app/services/invoices/payments/retry_service.rb
@@ -37,8 +37,6 @@ module Invoices
 
       delegate :customer, to: :invoice
 
-      private
-
       def deliver_webhook
         SendWebhookJob.perform_later(WEBHOOK_TYPE[invoice.invoice_type], invoice)
       end

--- a/app/services/invoices/payments/retry_service.rb
+++ b/app/services/invoices/payments/retry_service.rb
@@ -32,9 +32,14 @@ module Invoices
       delegate :customer, to: :invoice
 
       def webhook_type
-        return :invoice if invoice.invoice_type == 'subscription'
-
-        invoice.invoice_type.to_sym
+        case invoice.invoice_type
+        when 'subscription'
+          'invoice.created'
+        when 'credit'
+          'invoice.paid_credit_added'
+        when 'add_on'
+          'invoice.add_on_added'
+        end
       end
     end
   end

--- a/spec/services/invoices/payments/retry_service_spec.rb
+++ b/spec/services/invoices/payments/retry_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Invoices::Payments::RetryService, type: :service do
     it 'enqueues a SendWebhookJob' do
       expect do
         retry_service.call
-      end.to have_enqueued_job(SendWebhookJob).with(:invoice, Invoice)
+      end.to have_enqueued_job(SendWebhookJob).with('invoice.created', Invoice)
     end
 
     context 'with gocardless payment provider' do


### PR DESCRIPTION
## Description

When performing invoice retry action wrong webhook type was passed as parameter
