### PR TITLE
fix(coupons): Fix deleted coupon display on invoice

### DIFF
--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -44,7 +44,6 @@ class Credit < ApplicationRecord
   def invoice_coupon_display_name
     return nil if applied_coupon.blank?
 
-    coupon = applied_coupon.coupon
     suffix = if coupon.percentage?
       "#{format('%.2f', applied_coupon.percentage_rate)}%"
     else

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -24,6 +24,29 @@ RSpec.describe Credit, type: :model do
           expect(credit.item_name).to eq('Coupon name')
         end
       end
+
+      context 'when coupon is deleted' do
+        let(:coupon) do
+          create(
+            :coupon,
+            :deleted,
+            code: 'coupon_code',
+            name: 'Coupon name',
+            amount_cents: 200,
+            amount_currency: 'EUR',
+          )
+        end
+
+        it 'returns coupon details' do
+          aggregate_failures do
+            expect(credit.item_id).to eq(coupon.id)
+            expect(credit.item_type).to eq('coupon')
+            expect(credit.item_code).to eq('coupon_code')
+            expect(credit.item_name).to eq('Coupon name')
+            expect(credit.invoice_coupon_display_name).to eq('Coupon name (€2.00)')
+          end
+        end
+      end
     end
 
     context 'when credit is a credit note' do


### PR DESCRIPTION
## Context

When a coupon is deleted it could remain visible on invoice if it has generated a credit line.

## Description

Current implementation fails when trying to retrieve the coupon display name for the PDF document.

To fix the issue, we need to rely on the `coupon` relation at credit level rather than on `applied_coupon.coupon` because relation uses `with_discared` scope to include automatically deleted coupons.
