### PR TITLE
feat(instant_charge): Add API route to show a fee

### DIFF
--- a/app/controllers/api/v1/fees_controller.rb
+++ b/app/controllers/api/v1/fees_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class FeesController < Api::BaseController
+      def show
+        fee = current_organization.fees.find_by(id: params[:id])
+        return not_found_error(resource: 'fee') unless fee
+
+        render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee'))
+      end
+    end
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,6 +12,7 @@ class Organization < ApplicationRecord
   has_many :subscriptions, through: :customers
   has_many :invoices
   has_many :credit_notes, through: :invoices
+  has_many :fees, through: :invoices
   has_many :events
   has_many :coupons
   has_many :applied_coupons, through: :coupons

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
       resources :events, only: %i[create show]
       resources :applied_coupons, only: %i[create index]
       resources :applied_add_ons, only: %i[create]
+      resources :fees, only: %i[show]
       resources :invoices, only: %i[update show index] do
         post :download, on: :member
         post :retry_payment, on: :member

--- a/spec/requests/api/v1/fees_spec.rb
+++ b/spec/requests/api/v1/fees_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::FeesController, type: :request do
+  let(:organization) { create(:organization) }
+
+  describe 'GET /fees/:id' do
+    let(:invoice) { create(:invoice, organization:) }
+    let(:fee) { create(:fee, invoice:) }
+
+    it 'returns a fee' do
+      get_with_token(organization, "/api/v1/fees/#{fee.id}")
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+
+        expect(json[:fee][:lago_id]).to eq(fee.id)
+        expect(json[:fee][:lago_group_id]).to eq(fee.group_id)
+        expect(json[:fee][:item][:type]).to eq(fee.fee_type)
+        expect(json[:fee][:item][:code]).to eq(fee.item_code)
+        expect(json[:fee][:item][:name]).to eq(fee.item_name)
+        expect(json[:fee][:amount_cents]).to eq(fee.amount_cents)
+        expect(json[:fee][:amount_currency]).to eq(fee.amount_currency)
+        expect(json[:fee][:vat_amount_cents]).to eq(fee.vat_amount_cents)
+        expect(json[:fee][:vat_amount_currency]).to eq(fee.vat_amount_currency)
+        expect(json[:fee][:units]).to eq(fee.units.to_s)
+        expect(json[:fee][:events_count]).to eq(fee.events_count)
+      end
+    end
+
+    context 'when fee does not exsits' do
+      it 'returns not found' do
+        get_with_token(organization, '/api/v1/fees/foo')
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when fee belongs to an other organization' do
+      let(:fee) { create(:fee) }
+
+      it 'returns not found' do
+        get_with_token(organization, "/api/v1/fee/#{fee.id}")
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds a new route to retrieve a single fee via the API (`GET /api/v1/fees/:id`)