### PR TITLE
feat(instant_charge): Ability to have instant charges

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
         greater_than: value_is_out_of_range
         missing_graduated_ranges: missing_graduated_ranges
         missing_volume_ranges: missing_volume_ranges
+        invalid_aggregation_type_or_charge_model: invalid_aggregation_type_or_charge_model
         invalid_amount: invalid_amount
         invalid_flat_amount: invalid_flat_amount
         invalid_per_unit_amount: invalid_per_unit_amount

--- a/db/migrate/20230227145104_add_instant_to_charges.rb
+++ b/db/migrate/20230227145104_add_instant_to_charges.rb
@@ -3,6 +3,5 @@
 class AddInstantToCharges < ActiveRecord::Migration[7.0]
   def change
     add_column :charges, :instant, :boolean, null: false, default: false
-    change_column_null :fees, :invoice_id, true
   end
 end

--- a/db/migrate/20230227145104_add_instant_to_charges.rb
+++ b/db/migrate/20230227145104_add_instant_to_charges.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddInstantToCharges < ActiveRecord::Migration[7.0]
+  def change
+    add_column :charges, :instant, :boolean, null: false, default: false
+    change_column_null :fees, :invoice_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_21_102035) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_27_145104) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -112,6 +112,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_21_102035) do
     t.integer "charge_model", default: 0, null: false
     t.jsonb "properties", default: "{}", null: false
     t.datetime "deleted_at"
+    t.boolean "instant", default: false, null: false
     t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"
     t.index ["deleted_at"], name: "index_charges_on_deleted_at"
     t.index ["plan_id"], name: "index_charges_on_plan_id"

--- a/spec/factories/billable_metrics.rb
+++ b/spec/factories/billable_metrics.rb
@@ -19,4 +19,9 @@ FactoryBot.define do
     aggregation_type { 'sum_agg' }
     field_name { 'item_id' }
   end
+
+  factory :max_billable_metric, parent: :billable_metric do
+    aggregation_type { 'max_agg' }
+    field_name { 'item_id' }
+  end
 end

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -51,5 +51,9 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :instant do
+      instant { true }
+    end
   end
 end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -343,4 +343,45 @@ RSpec.describe Charge, type: :model do
       end
     end
   end
+
+  describe '#validate_instant' do
+    it 'does not return an error' do
+      expect(build(:standard_charge)).to be_valid
+    end
+
+    context 'when billable metric is recurring_count_agg' do
+      it 'returns an error' do
+        billable_metric = create(:recurring_billable_metric)
+        charge = build(:standard_charge, :instant, billable_metric:)
+
+        aggregate_failures do
+          expect(charge).not_to be_valid
+          expect(charge.errors.messages[:instant]).to include('invalid_aggregation_type_or_charge_model')
+        end
+      end
+    end
+
+    context 'when billable metric is max_agg' do
+      it 'returns an error' do
+        billable_metric = create(:max_billable_metric)
+        charge = build(:standard_charge, :instant, billable_metric:)
+
+        aggregate_failures do
+          expect(charge).not_to be_valid
+          expect(charge.errors.messages[:instant]).to include('invalid_aggregation_type_or_charge_model')
+        end
+      end
+    end
+
+    context 'when charge model is volume' do
+      it 'returns an error' do
+        charge = build(:volume_charge, :instant)
+
+        aggregate_failures do
+          expect(charge).not_to be_valid
+          expect(charge.errors.messages[:instant]).to include('invalid_aggregation_type_or_charge_model')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

The goal of this PR is to:
- add `instant` to `Charge`
- add error when trying to create an instant charge for a `recurring_count_agg` or `max_agg` billable metric
- add error when trying to create an instant charge for a `volume` charge model