### PR TITLE
feat(instant_charge): Add instant to Charge via GraphQL

### DIFF
--- a/app/graphql/types/charges/input.rb
+++ b/app/graphql/types/charges/input.rb
@@ -8,6 +8,7 @@ module Types
       argument :id, ID, required: false
       argument :billable_metric_id, ID, required: true
       argument :charge_model, Types::Charges::ChargeModelEnum, required: true
+      argument :instant, Boolean, required: false
 
       argument :properties, Types::Charges::PropertiesInput, required: false
       argument :group_properties, [Types::Charges::GroupPropertiesInput], required: false

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -8,6 +8,7 @@ module Types
       field :id, ID, null: false
       field :billable_metric, Types::BillableMetrics::Object, null: false
       field :charge_model, Types::Charges::ChargeModelEnum, null: false
+      field :instant, Boolean, null: false
       field :properties, Types::Charges::Properties, null: true
       field :group_properties, [Types::Charges::GroupProperties], null: true
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -171,6 +171,7 @@ type Charge {
   deletedAt: ISO8601DateTime
   groupProperties: [GroupProperties!]
   id: ID!
+  instant: Boolean!
   properties: Properties
   updatedAt: ISO8601DateTime!
 }
@@ -180,6 +181,7 @@ input ChargeInput {
   chargeModel: ChargeModelEnum!
   groupProperties: [GroupPropertiesInput!]
   id: ID
+  instant: Boolean
   properties: PropertiesInput
 }
 

--- a/schema.json
+++ b/schema.json
@@ -1736,6 +1736,24 @@
               ]
             },
             {
+              "name": "instant",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "properties",
               "description": null,
               "type": {
@@ -1818,6 +1836,18 @@
                   "name": "ChargeModelEnum",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "instant",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

The goal of this PR is to return `instant` to `Charge` via graphql.