### PR TITLE
misc(fern): Fix java client repository name

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -9,7 +9,7 @@ groups:
           username: ${MAVEN_USERNAME}
           password: ${MAVEN_PASSWORD}
         github:
-          repository: fern-lago/lago-java-client
+          repository: getlago/lago-java-client
       - name: fernapi/fern-postman
         version: 0.0.40
         output:

--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -21,4 +21,4 @@ groups:
       - name: fernapi/fern-openapi
         version: 0.0.21
         github:
-          repository: getlago/docs
+          repository: getlago/lago-doc-v2


### PR DESCRIPTION
## Context

Updating the java client with fern failed because it was pointing to a non-existent repo.