### PR TITLE
generate OpenAPI for `getlago/lago-openapi-v2`

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -19,6 +19,10 @@ groups:
         github:
           repository: getlago/lago-postman
       - name: fernapi/fern-openapi
-        version: 0.0.21
+        version: 0.0.22
         github:
           repository: getlago/lago-doc-v2
+      - name: fernapi/fern-openapi
+        version: 0.0.22
+        github:
+          repository: getlago/lago-openapi-v2


### PR DESCRIPTION
## Context

Adds a new generator to publish the fern generated OpenAPI spec to `getlago/lago-openapi-v2`