### PR TITLE
fix(invoices): Prevent double billing when refreshing draft invoices

### DIFF
--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -24,6 +24,8 @@ class InvoiceSubscription < ApplicationRecord
           order(Arel.sql(ActiveRecord::Base.sanitize_sql_for_conditions(condition)))
         }
 
+  # NOTE: Billed automatically by the recurring billing process
+  #       It is used to prevent double billing on billing day
   scope :recurring, -> { where(recurring: true) }
 
   def fees

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -6,7 +6,11 @@ module Invoices
       @invoice = invoice
       @subscriptions = subscriptions
       @timestamp = timestamp
+
+      # NOTE: Billed automatically by the recurring billing process
+      #       It is used to prevent double billing on billing day
       @recurring = recurring
+
       @context = context
 
       super

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -6,6 +6,11 @@ module Invoices
       @invoice = invoice
       @subscription_ids = invoice.subscriptions.pluck(:id)
       @context = context
+
+      # NOTE: Recurring status (meaning billed automatically from the recurring billing process)
+      #       should be kept to prevent double billing on billing day
+      @recurring = invoice.invoice_subscriptions.first&.recurring || false
+
       super
     end
 
@@ -27,6 +32,7 @@ module Invoices
           invoice: invoice.reload,
           subscriptions: Subscription.find(subscription_ids),
           timestamp: invoice.created_at.to_i + 1.second, # NOTE: Adding 1 second because of to_i rounding.
+          recurring:,
           context:,
         )
 
@@ -47,6 +53,6 @@ module Invoices
 
     private
 
-    attr_accessor :invoice, :subscription_ids, :context
+    attr_accessor :invoice, :subscription_ids, :recurring, :context
   end
 end

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -5,7 +5,11 @@ module Invoices
     def initialize(subscriptions:, timestamp:, recurring:)
       @subscriptions = subscriptions
       @timestamp = timestamp
+
+      # NOTE: Billed automatically by the recurring billing process
+      #       It is used to prevent double billing on billing day
       @recurring = recurring
+
       @customer = subscriptions&.first&.customer
       @currency = subscriptions&.first&.plan&.amount_currency
 


### PR DESCRIPTION
## Context

An issue of "double invoice generation" has been raised. After investigation, it is related to the  `recurring` status of an invoice subscription that is lost during the refresh of a draft invoice.

This status is used by the BillingService to identify the subscription that have already been billed on their billing day to prevent them to be re-billed during the same day.
By loosing the `recurring` status, the billing job was unable to identify these subscription and so was re-enqueuing a `BillingJob`

## Description

To fix the issue, we need to keep the pre-existing `recurring` flag when refresing a draft invoice.