### PR TITLE
fix(invoices): Fix invoices template when no fees

### DIFF
--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -553,9 +553,9 @@ html
                       td width="70%"
                         .body-1 = fee.billable_metric.name
                         .body-3
-                          - if fee.billable_metric.recurring_count_agg?
+                          - if fee&.billable_metric&.recurring_count_agg?
                             = I18n.t('invoice.see_breakdown')
-                          - elsif fee.charge.percentage?
+                          - elsif fee&.charge&.percentage?
                             = I18n.t('invoice.total_unit_interval', events_count: fees.sum(&:events_count), units: fees.sum(&:units))
                           - else
                             = I18n.t('invoice.total_unit', units: fees.sum(&:units))


### PR DESCRIPTION
- Add `nil` escape for billable metrics on invoice template
