### PR TITLE
chore: Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Roadmap Task
 
-👉  https://github.com/getlago/lago/issues/{{NUMBER}}
+👉  https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}
 
 ## Context
 


### PR DESCRIPTION
We now use Canny to maintain our public roadmap.

https://getlago.canny.io/feature-requests