### PR TITLE
fix(invoice): Prevent double billing with timezone

### DIFF
--- a/spec/services/billing_service_spec.rb
+++ b/spec/services/billing_service_spec.rb
@@ -384,6 +384,16 @@ RSpec.describe BillingService, type: :service do
           end
         end
       end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'Pacific/Noumea' }
+
+        it 'does not enqueue a job' do
+          travel_to(subscription_at + 10.hours) do
+            expect { billing_service.call }.not_to have_enqueued_job
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

Protection against double billing was not effective for `UTC+X` timezone as it was not checking the timestamp in the customer timezone.

This was leading to double invoice generation...

## Description

The fix is to ensure that customer applicable timezone is taken into account when checking if a subscription has already been billed on its billing day.