### PR TITLE
publish java client to `io.github.lago-api:lago`

### DIFF
--- a/fern/api/generators.yml
+++ b/fern/api/generators.yml
@@ -5,7 +5,7 @@ groups:
         version: 0.0.132
         output:
           location: maven
-          coordinate: io.github.fern-api:lago
+          coordinate: io.github.lago-api:lago
           username: ${MAVEN_USERNAME}
           password: ${MAVEN_PASSWORD}
         github:


### PR DESCRIPTION
## Context

The java client should be published under Lago's GitHub org.
