### PR TITLE
feat(invoice_metadata): Handle invoice metadata through the api

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -8,7 +8,7 @@ module Api
 
         result = Invoices::UpdateService.new(
           invoice: invoice,
-          params: update_params,
+          params: update_params.to_h.deep_symbolize_keys,
         ).call
 
         if result.success?
@@ -49,7 +49,7 @@ module Api
             ::V1::InvoiceSerializer,
             collection_name: 'invoices',
             meta: pagination_metadata(invoices),
-            includes: %i[customer],
+            includes: %i[customer metadata],
           ),
         )
       end
@@ -110,7 +110,14 @@ module Api
       private
 
       def update_params
-        params.require(:invoice).permit(:payment_status)
+        params.require(:invoice).permit(
+          :payment_status,
+          metadata: [
+            :id,
+            :key,
+            :value,
+          ],
+        )
       end
 
       def render_invoice(invoice)
@@ -118,7 +125,7 @@ module Api
           json: ::V1::InvoiceSerializer.new(
             invoice,
             root_name: 'invoice',
-            includes: %i[customer subscriptions fees credits],
+            includes: %i[customer subscriptions fees credits metadata],
           ),
         )
       end

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -27,6 +27,7 @@ module V1
       payload = payload.merge(subscriptions) if include?(:subscriptions)
       payload = payload.merge(fees) if include?(:fees)
       payload = payload.merge(credits) if include?(:credits)
+      payload = payload.merge(metadata) if include?(:metadata)
 
       payload
     end
@@ -50,6 +51,14 @@ module V1
 
     def credits
       ::CollectionSerializer.new(model.credits, ::V1::CreditSerializer, collection_name: 'credits').serialize
+    end
+
+    def metadata
+      ::CollectionSerializer.new(
+        model.metadata,
+        ::V1::Invoices::MetadataSerializer,
+        collection_name: 'metadata',
+      ).serialize
     end
   end
 end

--- a/app/serializers/v1/invoices/metadata_serializer.rb
+++ b/app/serializers/v1/invoices/metadata_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Invoices
+    class MetadataSerializer < ModelSerializer
+      def serialize
+        {
+          lago_id: model.id,
+          key: model.key,
+          value: model.value,
+          created_at: model.created_at.iso8601,
+        }
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -27,6 +27,34 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'with metadata' do
+      let(:update_params) do
+        {
+          metadata: [
+            {
+              key: 'Hello',
+              value: 'Hi',
+            },
+          ],
+        }
+      end
+
+      it 'returns a success' do
+        put_with_token(organization, "/api/v1/invoices/#{invoice.id}", { invoice: update_params })
+
+        metadata = json[:invoice][:metadata]
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+
+          expect(json[:invoice][:lago_id]).to eq(invoice.id)
+
+          expect(metadata).to be_present
+          expect(metadata.first[:key]).to eq('Hello')
+          expect(metadata.first[:value]).to eq('Hi')
+        end
+      end
+    end
   end
 
   describe 'GET /invoices/:id' do

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::InvoiceSerializer do
+  subject(:serializer) { described_class.new(invoice, root_name: 'invoice', includes: %i[metadata]) }
+
+  let(:invoice) { create(:invoice) }
+  let(:metadata) { create(:invoice_metadata, invoice:) }
+
+  before { metadata }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['invoice']['lago_id']).to eq(invoice.id)
+      expect(result['invoice']['sequential_id']).to eq(invoice.sequential_id)
+      expect(result['invoice']['number']).to eq(invoice.number)
+      expect(result['invoice']['issuing_date']).to eq(invoice.issuing_date.iso8601)
+      expect(result['invoice']['invoice_type']).to eq(invoice.invoice_type)
+      expect(result['invoice']['status']).to eq(invoice.status)
+      expect(result['invoice']['payment_status']).to eq(invoice.payment_status)
+      expect(result['invoice']['amount_cents']).to eq(invoice.amount_cents)
+      expect(result['invoice']['amount_currency']).to eq(invoice.amount_currency)
+      expect(result['invoice']['vat_amount_cents']).to eq(invoice.vat_amount_cents)
+      expect(result['invoice']['vat_amount_currency']).to eq(invoice.vat_amount_currency)
+      expect(result['invoice']['credit_amount_cents']).to eq(invoice.credit_amount_cents)
+      expect(result['invoice']['credit_amount_currency']).to eq(invoice.credit_amount_currency)
+      expect(result['invoice']['total_amount_cents']).to eq(invoice.total_amount_cents)
+      expect(result['invoice']['total_amount_currency']).to eq(invoice.total_amount_currency)
+      expect(result['invoice']['file_url']).to eq(invoice.file_url)
+      expect(result['invoice']['legacy']).to eq(invoice.legacy)
+      expect(result['invoice']['metadata'].first['lago_id']).to eq(metadata.id)
+      expect(result['invoice']['metadata'].first['key']).to eq(metadata.key)
+      expect(result['invoice']['metadata'].first['value']).to eq(metadata.value)
+    end
+  end
+end

--- a/spec/serializers/v1/invoices/metadata_serializer_spec.rb
+++ b/spec/serializers/v1/invoices/metadata_serializer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::Invoices::MetadataSerializer do
+  subject(:serializer) { described_class.new(metadata, root_name: 'metadata') }
+
+  let(:metadata) { create(:invoice_metadata) }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['metadata']['lago_id']).to eq(metadata.id)
+      expect(result['metadata']['key']).to eq(metadata.key)
+      expect(result['metadata']['value']).to eq(metadata.value)
+      expect(result['metadata']['created_at']).to eq(metadata.created_at.iso8601)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently it is not possible to store additional invoice informations in the Lago

## Description

This PR adds support for handling invoice metadata through the API.
