### PR TITLE
feat(instant_charge): Enqueue job to process an instant charge for a new event

### DIFF
--- a/app/jobs/fees/create_instant_job.rb
+++ b/app/jobs/fees/create_instant_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Fees
+  class CreateInstantJob < ApplicationJob
+    queue_as :default
+
+    def perform(charge:, event:)
+      result = Fees::CreateInstantService.call(charge:, event:)
+
+      result.raise_if_error!
+    end
+  end
+end

--- a/app/services/fees/create_instant_service.rb
+++ b/app/services/fees/create_instant_service.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Fees
+  class CreateInstantService < BaseService
+    def initialize(charge:, event:)
+      @charge = charge
+      @event = event
+
+      super
+    end
+
+    def call
+      result
+    end
+
+    private
+
+    attr_reader :charge, :event
+  end
+end

--- a/spec/jobs/fees/create_instant_job_spec.rb
+++ b/spec/jobs/fees/create_instant_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fees::CreateInstantJob, type: :job do
+  let(:charge) { create(:standard_charge, :instant) }
+  let(:event) { create(:event) }
+
+  let(:result) { BaseService::Result.new }
+
+  let(:instant_service) do
+    instance_double(Fees::CreateInstantService)
+  end
+
+  it 'delegates to the instant aggregation service' do
+    allow(Fees::CreateInstantService).to receive(:new)
+      .with(charge:, event:)
+      .and_return(instant_service)
+    allow(instant_service).to receive(:call)
+      .and_return(result)
+
+    described_class.perform_now(charge:, event:)
+
+    expect(Fees::CreateInstantService).to have_received(:new)
+    expect(instant_service).to have_received(:call)
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds a the logic to perform an instant fee creation when an created event matches an instant charge