### PR TITLE
fix(events): Fix debugger with deleted customers

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,7 +8,7 @@ class Event < ApplicationRecord
   include OrganizationTimezone
 
   belongs_to :organization
-  belongs_to :customer
+  belongs_to :customer, -> { with_discarded }
   belongs_to :subscription
 
   validates :transaction_id, presence: true, uniqueness: { scope: :subscription_id }

--- a/spec/graphql/resolvers/events_resolver_spec.rb
+++ b/spec/graphql/resolvers/events_resolver_spec.rb
@@ -132,4 +132,23 @@ RSpec.describe Resolvers::EventsResolver, type: :graphql do
       expect(events_response['collection'].first['matchCustomField']).to be_falsey
     end
   end
+
+  context 'with deleted customer' do
+    before { event.customer.discard! }
+
+    it 'returns the customer details' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+      )
+
+      events_response = result['data']['events']
+
+      aggregate_failures do
+        expect(events_response['collection'].first['externalCustomerId']).to eq(event.customer.external_id)
+        expect(events_response['collection'].first['customerTimezone']).to eq('TZ_UTC')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Destroying a customer (actually soft deleting it) does not destroy the customer events. It is the intended behavior but it leads to an error in the event debugger because the customer appears as missing.

## Description

To fix this issue, we need to make sure the customer remain visible from an event.