### PR TITLE
feat(instant_charge): Allow fees#invoice_id to be null

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -3,7 +3,7 @@
 class Fee < ApplicationRecord
   include Currencies
 
-  belongs_to :invoice
+  belongs_to :invoice, optional: true
   belongs_to :charge, -> { with_discarded }, optional: true
   belongs_to :applied_add_on, optional: true
   belongs_to :subscription, optional: true
@@ -22,7 +22,7 @@ class Fee < ApplicationRecord
   monetize :vat_amount_cents
   monetize :total_amount_cents
 
-  FEE_TYPES = %i[charge add_on subscription credit].freeze
+  FEE_TYPES = %i[charge add_on subscription credit instant_charge].freeze
 
   enum fee_type: FEE_TYPES
 
@@ -40,7 +40,7 @@ class Fee < ApplicationRecord
   end
 
   def item_code
-    return billable_metric.code if charge?
+    return billable_metric.code if charge? || instant_charge?
     return add_on.code if add_on?
     return fee_type if credit?
 
@@ -48,7 +48,7 @@ class Fee < ApplicationRecord
   end
 
   def item_name
-    return billable_metric.name if charge?
+    return billable_metric.name if charge? || instant_charge?
     return add_on.name if add_on?
     return fee_type if credit?
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -2902,6 +2902,7 @@ enum FeeTypesEnum {
   add_on
   charge
   credit
+  instant_charge
   subscription
 }
 

--- a/schema.json
+++ b/schema.json
@@ -10742,6 +10742,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "instant_charge",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -51,6 +51,15 @@ RSpec.describe Fee, type: :model do
         expect(fee_model.new(fee_type: 'credit').item_code).to eq('credit')
       end
     end
+
+    context 'when it is an instant charge fee' do
+      let(:charge) { create(:standard_charge, :instant) }
+
+      it 'returns related billable metric code' do
+        expect(fee_model.new(charge:, fee_type: 'instant_charge').item_code)
+          .to eq(charge.billable_metric.code)
+      end
+    end
   end
 
   describe '.item_name' do
@@ -84,6 +93,15 @@ RSpec.describe Fee, type: :model do
     context 'when it is a credit fee' do
       it 'returns add on name' do
         expect(fee_model.new(fee_type: 'credit').item_name).to eq('credit')
+      end
+    end
+
+    context 'when it is an instant charge fee' do
+      let(:charge) { create(:standard_charge, :instant) }
+
+      it 'returns related billable metric name' do
+        expect(fee_model.new(charge:, fee_type: 'instant_charge').item_name)
+          .to eq(charge.billable_metric.name)
       end
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR allows a fee to be created withou an invoice