### PR TITLE
feat(instant_charge): Ability to have an instant charge

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -85,11 +85,16 @@ module Api
             :id,
             :billable_metric_id,
             :charge_model,
-            { properties: {} },
-            group_properties: [
-              :group_id,
-              { values: {} },
-            ],
+            :instant,
+            {
+              properties: {},
+            },
+            {
+              group_properties: [
+                :group_id,
+                { values: {} },
+              ]
+            },
           ],
         )
       end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -93,7 +93,7 @@ module Api
               group_properties: [
                 :group_id,
                 { values: {} },
-              ]
+              ],
             },
           ],
         )

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -8,6 +8,7 @@ module V1
         lago_billable_metric_id: model.billable_metric_id,
         created_at: model.created_at.iso8601,
         charge_model: model.charge_model,
+        instant: model.instant,
         properties: model.properties,
       }.merge(group_properties)
     end

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -15,6 +15,8 @@ module V1
         amount_currency: model.amount_currency,
         vat_amount_cents: model.vat_amount_cents,
         vat_amount_currency: model.vat_amount_currency,
+        total_amount_cents: model.total_amount_cents,
+        total_amount_currency: model.amount_currency,
         units: model.units,
         events_count: model.events_count,
       }

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -7,8 +7,19 @@ module BillableMetrics
         result.aggregation = events_scope(from_datetime:, to_datetime:).count
         result.count = result.aggregation
         result.instant_aggregation = BigDecimal(1)
-        result.options = options
+        result.options = { running_total: running_total(options) }
         result
+      end
+
+      # NOTE: Return cumulative sum of event count based on the number of free units
+      #       (per_events or per_total_aggregation).
+      def running_total(options)
+        free_units_per_events = options[:free_units_per_events].to_i
+        free_units_per_total_aggregation = BigDecimal(options[:free_units_per_total_aggregation] || 0)
+
+        return [] if free_units_per_events.zero? && free_units_per_total_aggregation.zero?
+
+        (1..result.aggregation).to_a
       end
     end
   end

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -46,6 +46,7 @@ module Plans
         charge_model: args[:charge_model]&.to_sym,
         properties: args[:properties] || {},
         group_properties: (args[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
+        instant: args[:instant] || false,
       )
     end
 

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -41,13 +41,15 @@ module Plans
     private
 
     def create_charge(plan, args)
-      plan.charges.create!(
+      charge = plan.charges.new(
         billable_metric_id: args[:billable_metric_id],
         charge_model: args[:charge_model]&.to_sym,
         properties: args[:properties] || {},
         group_properties: (args[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
-        instant: args[:instant] || false,
       )
+      charge.instant = args[:instant] || false if License.premium? && args.key?(:instant)
+      charge.save!
+      charge
     end
 
     def track_plan_created(plan)

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -82,7 +82,7 @@ module Plans
           # NOTE: charges cannot be edited if plan is attached to a subscription
           unless plan.attached_to_subscriptions?
             payload_charge[:group_properties]&.map! { |gp| GroupProperty.new(gp) }
-            charge.update(payload_charge)
+            charge.update!(payload_charge)
             charge
           end
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -58,13 +58,17 @@ module Plans
     end
 
     def create_charge(plan, params)
-      plan.charges.create!(
+      charge = plan.charges.new(
         billable_metric_id: params[:billable_metric_id],
         amount_currency: params[:amount_currency],
         charge_model: params[:charge_model]&.to_sym,
+        instant: params[:instant] || false,
         properties: params[:properties] || {},
         group_properties: (params[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )
+      charge.instant = params[:instant] || false if License.premium?
+      charge.save!
+      charge
     end
 
     def process_charges(plan, params_charges)

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -62,7 +62,6 @@ module Plans
         billable_metric_id: params[:billable_metric_id],
         amount_currency: params[:amount_currency],
         charge_model: params[:charge_model]&.to_sym,
-        instant: params[:instant] || false,
         properties: params[:properties] || {},
         group_properties: (params[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )
@@ -82,6 +81,8 @@ module Plans
           # NOTE: charges cannot be edited if plan is attached to a subscription
           unless plan.attached_to_subscriptions?
             payload_charge[:group_properties]&.map! { |gp| GroupProperty.new(gp) }
+            instant = payload_charge.delete(:instant)
+            charge.instant = instant || false if License.premium?
             charge.update!(payload_charge)
             charge
           end

--- a/spec/serializers/v1/charge_serializer_spec.rb
+++ b/spec/serializers/v1/charge_serializer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe ::V1::ChargeSerializer do
       expect(result['charge']['lago_billable_metric_id']).to eq(charge.billable_metric_id)
       expect(result['charge']['created_at']).to eq(charge.created_at.iso8601)
       expect(result['charge']['charge_model']).to eq(charge.charge_model)
+      expect(result['charge']['instant']).to eq(charge.instant)
       expect(result['charge']['properties']).to eq(charge.properties)
     end
   end

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::FeeSerializer do
+  subject(:serializer) { described_class.new(fee, root_name: 'fee') }
+
+  let(:fee) { create(:fee) }
+
+  let(:result) { JSON.parse(serializer.to_json) }
+
+  it 'serializes the fee' do
+    aggregate_failures do
+      expect(result['fee']['lago_id']).to eq(fee.id)
+      expect(result['fee']['lago_group_id']).to eq(fee.group_id)
+      expect(result['fee']['amount_cents']).to eq(fee.amount_cents)
+      expect(result['fee']['amount_currency']).to eq(fee.amount_currency)
+      expect(result['fee']['vat_amount_cents']).to eq(fee.vat_amount_cents)
+      expect(result['fee']['vat_amount_currency']).to eq(fee.vat_amount_currency)
+      expect(result['fee']['total_amount_cents']).to eq(fee.total_amount_cents)
+      expect(result['fee']['total_amount_currency']).to eq(fee.amount_currency)
+      expect(result['fee']['units']).to eq(fee.units.to_s)
+      expect(result['fee']['events_count']).to eq(fee.events_count)
+
+      expect(result['fee']['item']['type']).to eq(fee.fee_type)
+      expect(result['fee']['item']['code']).to eq(fee.item_code)
+      expect(result['fee']['item']['name']).to eq(fee.item_name)
+    end
+  end
+end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -57,6 +57,8 @@ RSpec.describe Plans::CreateService, type: :service do
       }
     end
 
+    around { |test| lago_premium!(&test) }
+
     before do
       allow(SegmentTrackJob).to receive(:perform_later)
     end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe Plans::UpdateService, type: :service do
   end
 
   describe 'call' do
+    around { |test| lago_premium!(&test) }
+
     it 'updates a plan' do
       result = plans_service.call
 
@@ -162,6 +164,7 @@ RSpec.describe Plans::UpdateService, type: :service do
               id: existing_charge.id,
               billable_metric_id: billable_metrics.first.id,
               charge_model: 'standard',
+              instant: true,
               group_properties: [
                 {
                   group_id: group.id,
@@ -193,6 +196,7 @@ RSpec.describe Plans::UpdateService, type: :service do
           group_id: group.id,
           values: { 'amount' => '100' },
         )
+        expect(existing_charge).to be_instant
       end
     end
 

--- a/spec/services/webhooks/base_service_spec.rb
+++ b/spec/services/webhooks/base_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Webhooks::BaseService, type: :service do
     it 'creates a succeeded webhook' do
       webhook_service.call
 
-      webhook = Webhook.first
+      webhook = Webhook.order(created_at: :desc).first
 
       aggregate_failures do
         expect(webhook).to be_succeeded
@@ -107,7 +107,7 @@ RSpec.describe Webhooks::BaseService, type: :service do
       it 'creates a failed webhook' do
         webhook_service.call
 
-        webhook = Webhook.first
+        webhook = Webhook.order(created_at: :desc).first
 
         aggregate_failures do
           expect(webhook).to be_failed


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR allows to have an instant charge.