### PR TITLE
feat(instant_charge): Compute instant aggregation

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -3,11 +3,12 @@
 module BillableMetrics
   module Aggregations
     class BaseService < ::BaseService
-      def initialize(billable_metric:, subscription:, group: nil)
+      def initialize(billable_metric:, subscription:, group: nil, event: nil)
         super(nil)
         @billable_metric = billable_metric
         @subscription = subscription
         @group = group
+        @event = event
       end
 
       def aggregate(from_date:, to_date:, options: {})
@@ -16,7 +17,7 @@ module BillableMetrics
 
       protected
 
-      attr_accessor :billable_metric, :subscription, :group
+      attr_accessor :billable_metric, :subscription, :group, :event
 
       delegate :customer, to: :subscription
 

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -4,8 +4,9 @@ module BillableMetrics
   module Aggregations
     class CountService < BillableMetrics::Aggregations::BaseService
       def aggregate(from_datetime:, to_datetime:, options: {})
-        result.aggregation = events_scope(from_datetime: from_datetime, to_datetime: to_datetime).count
+        result.aggregation = events_scope(from_datetime:, to_datetime:).count
         result.count = result.aggregation
+        result.instant_aggregation = BigDecimal(1)
         result.options = options
         result
       end

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -4,13 +4,29 @@ module BillableMetrics
   module Aggregations
     class UniqueCountService < BillableMetrics::Aggregations::BaseService
       def aggregate(from_datetime:, to_datetime:, options: {})
-        events = events_scope(from_datetime: from_datetime, to_datetime: to_datetime)
+        events = events_scope(from_datetime:, to_datetime:)
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.count("DISTINCT (#{sanitized_field_name})")
+        result.instant_aggregation = BigDecimal(compute_instant_aggregation(events))
         result.count = events.count
         result.options = options
         result
+      end
+
+      def compute_instant_aggregation(events)
+        return 0 unless event
+        return 0 if event.properties.blank?
+
+        existing_property = events
+          .where("#{sanitized_field_name} = '#{event.properties[billable_metric.field_name]}'")
+          .where.not(id: event.id)
+          .any?
+
+        # NOTE: bill only property that have not been received in the period yet
+        return 0 if existing_property
+
+        1
       end
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds the logic to compute the instant aggregation for each aggregation types impacted by the feature