### PR TITLE
feat(instant_charge): Add instant aggregation service on charges

### DIFF
--- a/app/services/charges/apply_instant_charge_model_service.rb
+++ b/app/services/charges/apply_instant_charge_model_service.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Charges
+  class ApplyInstantChargeModelService < BaseService
+    def initialize(charge:, aggregation_result:, properties:)
+      @charge = charge
+      @aggregation_result = aggregation_result
+      @properties = properties
+
+      super
+    end
+
+    def call
+      unless charge.instant?
+        return result.service_failure!(code: 'apply_charge_model_error', message: 'Charge is not instant')
+      end
+
+      amount = amount_including_event - amount_excluding_event
+
+      # NOTE: amount_result should be a BigDecimal, we need to round it
+      # to the currency decimals and transform it into currency cents
+      rounded_amount = amount.round(currency.exponent)
+      amount_cents = rounded_amount * currency.subunit_to_unit
+
+      result.units = aggregation_result.instant_aggregation
+      result.count = 1
+      result.amount = amount_cents
+      result
+    end
+
+    private
+
+    attr_reader :charge, :aggregation_result, :properties
+
+    def charge_model
+      @charge_model ||= case charge.charge_model.to_sym
+                        when :standard
+                          Charges::ChargeModels::StandardService
+                        when :graduated
+                          Charges::ChargeModels::GraduatedService
+                        when :package
+                          Charges::ChargeModels::PackageService
+                        when :percentage
+                          Charges::ChargeModels::PercentageService
+                        else
+                          raise(NotImplementedError)
+      end
+    end
+
+    def amount_including_event
+      charge_model.apply(charge:, aggregation_result:, properties:).amount
+    end
+
+    def amount_excluding_event
+      previous_result = BaseService::Result.new
+      previous_result.aggregation = aggregation_result.aggregation - aggregation_result.instant_aggregation
+      previous_result.count = aggregation_result.count - 1
+
+      # TODO: Make it works with percentage model
+      previous_result.options = aggregation_result.options
+
+      charge_model.apply(charge:, aggregation_result: previous_result, properties:).amount
+    end
+
+    def currency
+      @currency ||= charge.plan.amount.currency
+    end
+  end
+end

--- a/spec/services/charges/apply_instant_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_instant_charge_model_service_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::ApplyInstantChargeModelService, type: :service do
+  let(:charge_service) { described_class.new(charge:, aggregation_result:, properties:) }
+
+  let(:charge) { create(:standard_charge, :instant) }
+  let(:aggregation_result) do
+    BaseService::Result.new.tap do |result|
+      result.aggregation = 10
+      result.instant_aggregation = 1
+      result.count = 5
+      result.options = {}
+    end
+  end
+  let(:properties) { {} }
+
+  describe '#call' do
+    context 'when charge is not instant' do
+      let(:charge) { create(:standard_charge) }
+
+      it 'returns an error' do
+        result = charge_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq('apply_charge_model_error')
+          expect(result.error.error_message).to eq('Charge is not instant')
+        end
+      end
+    end
+
+    shared_examples 'a charge model' do
+      it 'delegates to the standard charge model service' do
+        previous_agg_result = BaseService::Result.new.tap do |result|
+          result.aggregation = 9
+          result.count = 4
+          result.options = {}
+        end
+
+        allow(charge_model_class).to receive(:apply)
+          .with(charge:, aggregation_result:, properties:)
+          .and_return(BaseService::Result.new.tap { |r| r.amount = 10 })
+
+        allow(charge_model_class).to receive(:apply)
+          .with(charge:, aggregation_result: previous_agg_result, properties:)
+          .and_return(BaseService::Result.new.tap { |r| r.amount = 8 })
+
+        result = charge_service.call
+
+        expect(result.units).to eq(1)
+        expect(result.count).to eq(1)
+        expect(result.amount).to eq(200)
+      end
+    end
+
+    describe 'when standard charge model' do
+      let(:charge_model_class) { Charges::ChargeModels::StandardService }
+
+      it_behaves_like 'a charge model'
+    end
+
+    describe 'when graduated charge model' do
+      let(:charge) do
+        create(
+          :graduated_charge,
+          :instant,
+          properties: {
+            graduated_ranges: [
+              {
+                from_value: 0,
+                to_value: nil,
+                per_unit_amount: '0.01',
+                flat_amount: '0.01',
+              },
+            ],
+          },
+        )
+      end
+      let(:charge_model_class) { Charges::ChargeModels::GraduatedService }
+
+      it_behaves_like 'a charge model'
+    end
+
+    describe 'when package charge model' do
+      let(:charge) { create(:package_charge, :instant) }
+      let(:charge_model_class) { Charges::ChargeModels::PackageService }
+
+      it_behaves_like 'a charge model'
+    end
+
+    describe 'when percentage charge model' do
+      let(:charge) { create(:percentage_charge, :instant) }
+      let(:charge_model_class) { Charges::ChargeModels::PercentageService }
+
+      it_behaves_like 'a charge model'
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds the instant aggregation service on charges.