### PR TITLE
feat(instant_charge): Add instant fee creation service

### DIFF
--- a/app/services/fees/create_instant_service.rb
+++ b/app/services/fees/create_instant_service.rb
@@ -10,11 +10,110 @@ module Fees
     end
 
     def call
+      fees = []
+
+      ActiveRecord::Base.transaction do
+        if charge.group_properties.blank?
+          fees << create_fee(properties: charge.properties)
+        else
+          fees += create_group_properties_fees
+        end
+      end
+
+      result.fees = fees.compact
+      # TODO(instant_charges): deliver webhooks for fees
+
       result
+    rescue BaseService::FailedResult => e
+      result.fail_with_error!(e)
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
     end
 
     private
 
     attr_reader :charge, :event
+
+    delegate :billable_metric, to: :charge
+    delegate :subscription, :customer, to: :event
+
+    def create_fee(properties:, group: nil)
+      aggregation_result = aggregate(properties:, group:)
+      result = apply_charge_model(aggregation_result:, properties:)
+
+      fee = Fee.new(
+        subscription: event.subscription,
+        charge:,
+        amount_cents: result.amount,
+        amount_currency: subscription.plan.amount_currency,
+        vat_rate: customer.applicable_vat_rate,
+        fee_type: :instant_charge,
+        invoiceable: charge,
+        units: result.units,
+        properties: boundaries, # TODO: should we add event id in the property / add a relation ??
+        events_count: result.count,
+        group_id: group&.id,
+        instant_event_id: event.id,
+      )
+      fee.compute_vat
+      fee.save!
+
+      fee
+    end
+
+    def create_group_properties_fees
+      charge.group_properties.each_with_object([]) do |group_properties, fees|
+        group = billable_metric.selectable_groups.find_by(id: group_properties.group_id)
+        next unless event_linked_to?(group:)
+
+        fees << create_fee(properties: group_properties.values, group:)
+      end
+    end
+
+    def date_service
+      @date_service ||= Subscriptions::DatesService.new_instance(
+        subscription,
+        Time.current,
+        current_usage: true,
+      )
+    end
+
+    def boundaries
+      @boundaries ||= {
+        from_datetime: date_service.from_datetime,
+        to_datetime: date_service.to_datetime,
+        charges_from_datetime: date_service.charges_from_datetime,
+        charges_to_datetime: date_service.charges_to_datetime,
+        timestamp: Time.current,
+      }
+    end
+
+    def aggregate(properties:, group:)
+      aggregation_result = BillableMetrics::InstantAggregationService.call(
+        billable_metric:, boundaries:, group:, properties:, event:,
+      )
+      aggregation_result.raise_if_error!
+      aggregation_result
+    end
+
+    def apply_charge_model(aggregation_result:, properties:)
+      charge_model_result = Charges::ApplyInstantChargeModelService.call(
+        charge:, aggregation_result:, properties:,
+      )
+      charge_model_result.raise_if_error!
+      charge_model_result
+    end
+
+    def event_linked_to?(group:)
+      return match_group?(group) && match_group?(group.parent) if group.parent
+
+      match_group?(group)
+    end
+
+    def match_group?(group)
+      return false unless event.properties.key?(group.key.to_s)
+
+      event.properties[group.key.to_s] == group.value
+    end
   end
 end

--- a/spec/services/fees/create_instant_service_spec.rb
+++ b/spec/services/fees/create_instant_service_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fees::CreateInstantService, type: :service do
+  subject(:fee_service) { described_class.new(charge:, event:) }
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:active_subscription, organization:, customer:, plan:) }
+
+  let(:group) { nil }
+
+  let(:charge) { create(:standard_charge, :instant, billable_metric:, plan:) }
+  let(:event) { create(:event, subscription:, customer:) }
+
+  describe '#call' do
+    let(:aggregation_result) do
+      BaseService::Result.new.tap do |result|
+        result.aggregation = 9
+        result.count = 4
+        result.options = {}
+      end
+    end
+
+    let(:charge_result) do
+      BaseService::Result.new.tap do |result|
+        result.amount = 10
+        result.count = 1
+        result.units = 9
+      end
+    end
+
+    before do
+      allow(BillableMetrics::InstantAggregationService).to receive(:call)
+        .with(billable_metric:, boundaries: Hash, group:, properties: Hash, event:)
+        .and_return(aggregation_result)
+
+      allow(Charges::ApplyInstantChargeModelService).to receive(:call)
+        .with(charge:, aggregation_result:, properties: Hash)
+        .and_return(charge_result)
+    end
+
+    it 'creates a fee' do
+      result = fee_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+
+        expect(result.fees.count).to eq(1)
+        expect(result.fees.first).to have_attributes(
+          subscription:,
+          charge:,
+          amount_cents: 10,
+          amount_currency: 'EUR',
+          vat_rate: 20.0,
+          vat_amount_cents: 2,
+          vat_amount_currency: 'EUR',
+          fee_type: 'instant_charge',
+          invoiceable: charge,
+          units: 9,
+          properties: Hash,
+          events_count: 1,
+          group: nil,
+          instant_event_id: event.id,
+        )
+      end
+    end
+
+    context 'when aggregation fails' do
+      let(:aggregation_result) do
+        BaseService::Result.new.service_failure!(code: 'failure', message: 'Failure')
+      end
+
+      it 'returns a failure' do
+        result = fee_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq('failure')
+          expect(result.error.error_message).to eq('Failure')
+        end
+      end
+    end
+
+    context 'when charge model fails' do
+      let(:charge_result) do
+        BaseService::Result.new.service_failure!(code: 'failure', message: 'Failure')
+      end
+
+      it 'returns a failure' do
+        result = fee_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq('failure')
+          expect(result.error.error_message).to eq('Failure')
+        end
+      end
+    end
+
+    context 'when charge has groups' do
+      let(:parent_group_id) { nil }
+      let(:group) do
+        create(:group, billable_metric:, key: 'region', value: 'europe', parent_group_id:)
+      end
+
+      let(:charge) do
+        create(
+          :standard_charge,
+          :instant,
+          plan: subscription.plan,
+          billable_metric:,
+          group_properties: [
+            build(
+              :group_property,
+              group:,
+              values: {
+                amount: '20',
+                amount_currency: 'EUR',
+              },
+            ),
+          ],
+        )
+      end
+
+      let(:event) do
+        create(
+          :event,
+          subscription:,
+          customer:,
+          properties: {
+            region: 'europe',
+          },
+        )
+      end
+
+      it 'creates a fee' do
+        result = fee_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.fees.count).to eq(1)
+          expect(result.fees.first).to have_attributes(
+            subscription:,
+            charge:,
+            amount_cents: 10,
+            amount_currency: 'EUR',
+            vat_rate: 20.0,
+            vat_amount_cents: 2,
+            vat_amount_currency: 'EUR',
+            fee_type: 'instant_charge',
+            invoiceable: charge,
+            units: 9,
+            properties: Hash,
+            events_count: 1,
+            group:,
+            instant_event_id: event.id,
+          )
+        end
+      end
+
+      context 'when group has a parent' do
+        let(:parent_group_id) do
+          create(:group, billable_metric:, key: 'cloud', value: 'AWS').id
+        end
+
+        let(:event) do
+          create(
+            :event,
+            subscription:,
+            customer:,
+            properties: {
+              cloud: 'AWS',
+              region: 'europe',
+            },
+          )
+        end
+
+        it 'creates a fee' do
+          result = fee_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(result.fees.count).to eq(1)
+            expect(result.fees.first).to have_attributes(
+              subscription:,
+              charge:,
+              amount_cents: 10,
+              amount_currency: 'EUR',
+              vat_rate: 20.0,
+              vat_amount_cents: 2,
+              vat_amount_currency: 'EUR',
+              fee_type: 'instant_charge',
+              invoiceable: charge,
+              units: 9,
+              properties: Hash,
+              events_count: 1,
+              group:,
+              instant_event_id: event.id,
+            )
+          end
+        end
+      end
+
+      context 'when event does not match a group' do
+        let(:event) do
+          create(
+            :event,
+            subscription:,
+            customer:,
+            properties: {
+              region: 'usa',
+            },
+          )
+        end
+
+        it 'does not create fees' do
+          result = fee_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.fees.count).to be_zero
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds the instant fee creation logic using previously introduced `BillableMetrics::InstantAggregationService` and `Charges::ApplyInstantChargeModelService`