### PR TITLE
feat(instant_charge): Add instant_event_id to fees to track instant fee source

### DIFF
--- a/db/migrate/20230307131524_add_instant_event_id_to_fees.rb
+++ b/db/migrate/20230307131524_add_instant_event_id_to_fees.rb
@@ -2,6 +2,6 @@
 
 class AddInstantEventIdToFees < ActiveRecord::Migration[7.0]
   def change
-    add_column :fees, :instant_event_id, :string
+    add_column :fees, :instant_event_id, :uuid
   end
 end

--- a/db/migrate/20230307131524_add_instant_event_id_to_fees.rb
+++ b/db/migrate/20230307131524_add_instant_event_id_to_fees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddInstantEventIdToFees < ActiveRecord::Migration[7.0]
+  def change
+    add_column :fees, :instant_event_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_27_145104) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_07_131524) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -296,6 +296,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_27_145104) do
     t.uuid "invoiceable_id"
     t.integer "events_count"
     t.uuid "group_id"
+    t.string "instant_event_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
     t.index ["group_id"], name: "index_fees_on_group_id"


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds a new `instant_event_id` column to the fees table, in order to keep track of the event leading to the creation of the fee.
The data type is intentionally using `string` over `uuid` because no foreign key will be defined on the relation and we might want to be able to delete old events or to extract event table from the main database in the future