### PR TITLE
feat(instant_charge): Deliver webhooks for created fees

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -14,6 +14,7 @@ class SendWebhookJob < ApplicationJob
     'invoice.payment_status_updated' => Webhooks::Invoices::PaymentStatusUpdatedService,
     'invoice.payment_failure' => Webhooks::PaymentProviders::InvoicePaymentFailureService,
     'event.error' => Webhooks::Events::ErrorService,
+    'fee.instant_created' => Webhooks::Fees::InstantCreatedService,
     'customer.payment_provider_created' => Webhooks::PaymentProviders::CustomerCreatedService,
     'customer.payment_provider_error' => Webhooks::PaymentProviders::CustomerErrorService,
     'customer.checkout_url_generated' => Webhooks::PaymentProviders::CustomerCheckoutService,

--- a/app/services/webhooks/fees/instant_created_service.rb
+++ b/app/services/webhooks/fees/instant_created_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Fees
+    class InstantCreatedService < Webhooks::BaseService
+      private
+
+      def current_organization
+        @current_organization ||= object.customer.organization
+      end
+
+      def object_serializer
+        ::V1::FeeSerializer.new(
+          object,
+          root_name: 'fee',
+        )
+      end
+
+      def webhook_type
+        'fee.instant_created'
+      end
+
+      def object_type
+        'fee'
+      end
+    end
+  end
+end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -91,6 +91,25 @@ RSpec.describe SendWebhookJob, type: :job do
     end
   end
 
+  context 'when webhook_type is fee.instant_created' do
+    let(:webhook_service) { instance_double(Webhooks::Fees::InstantCreatedService) }
+    let(:fee) { create(:fee) }
+
+    before do
+      allow(Webhooks::Fees::InstantCreatedService).to receive(:new)
+        .with(object: fee, options: {}, webhook_id: nil)
+        .and_return(webhook_service)
+      allow(webhook_service).to receive(:call)
+    end
+
+    it 'calls the webhook fee service' do
+      send_webhook_job.perform_now('fee.instant_created', fee)
+
+      expect(Webhooks::Fees::InstantCreatedService).to have_received(:new)
+      expect(webhook_service).to have_received(:call)
+    end
+  end
+
   context 'when webhook_type is event.error' do
     let(:webhook_service) { instance_double(Webhooks::PaymentProviders::InvoicePaymentFailureService) }
 

--- a/spec/services/fees/create_instant_service_spec.rb
+++ b/spec/services/fees/create_instant_service_spec.rb
@@ -69,6 +69,13 @@ RSpec.describe Fees::CreateInstantService, type: :service do
       end
     end
 
+    it 'delivers a webhook' do
+      fee_service.call
+
+      expect(SendWebhookJob).to have_been_enqueued
+        .with('fee.instant_created', Fee)
+    end
+
     context 'when aggregation fails' do
       let(:aggregation_result) do
         BaseService::Result.new.service_failure!(code: 'failure', message: 'Failure')

--- a/spec/services/webhooks/fees/instant_created_service_spec.rb
+++ b/spec/services/webhooks/fees/instant_created_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Fees::InstantCreatedService do
+  subject(:webhook_service) { described_class.new(object: fee) }
+
+  let(:organization) { create(:organization, webhook_url:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, organization:) }
+  let(:fee) { create(:fee, customer:, subscription:) }
+  let(:webhook_url) { 'http://foo.bar' }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response)
+    end
+
+    it 'builds payload with fee.instant_created webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post_with_response) do |payload|
+        expect(payload[:webhook_type]).to eq('fee.instant_created')
+        expect(payload[:object_type]).to eq('fee')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR delivers a new webhook `fee.instant_charge_created` when a fee is created for an instant charge