### PR TITLE
feat(instant_charge): Fetch fee from subscriptions instead of invoices

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,7 +12,7 @@ class Organization < ApplicationRecord
   has_many :subscriptions, through: :customers
   has_many :invoices
   has_many :credit_notes, through: :invoices
-  has_many :fees, through: :invoices
+  has_many :fees, through: :subscriptions
   has_many :events
   has_many :coupons
   has_many :applied_coupons, through: :coupons

--- a/spec/requests/api/v1/fees_spec.rb
+++ b/spec/requests/api/v1/fees_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Api::V1::FeesController, type: :request do
   let(:organization) { create(:organization) }
 
   describe 'GET /fees/:id' do
-    let(:invoice) { create(:invoice, organization:) }
-    let(:fee) { create(:fee, invoice:) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, customer:) }
+    let(:fee) { create(:fee, subscription:) }
 
     it 'returns a fee' do
       get_with_token(organization, "/api/v1/fees/#{fee.id}")


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR allows fetching an instant charge via `GET api/v1/fees/:id` endpoint.