### PR TITLE
fix(instant_charge): Fix scope for show fee route

### DIFF
--- a/app/controllers/api/v1/fees_controller.rb
+++ b/app/controllers/api/v1/fees_controller.rb
@@ -4,7 +4,13 @@ module Api
   module V1
     class FeesController < Api::BaseController
       def show
-        fee = current_organization.fees.find_by(id: params[:id])
+        # NOTE: instant fees might not be linked to any invoice, but add_on fees does not have any subscriptions
+        #       so we need a bit of logic to find the fee in the right organization scope
+        fee = Fee.left_joins(:invoice)
+          .left_joins(subscription: :customer)
+          .where('COALESCE(invoices.organization_id, customers.organization_id) = ?', current_organization.id)
+          .find_by(id: params[:id])
+
         return not_found_error(resource: 'fee') unless fee
 
         render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee'))

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -40,6 +40,7 @@ FactoryBot.define do
     invoice
     applied_add_on
     fee_type { 'add_on' }
+    subscription { nil }
 
     amount_cents { 200 }
     amount_currency { 'EUR' }

--- a/spec/requests/api/v1/fees_spec.rb
+++ b/spec/requests/api/v1/fees_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Api::V1::FeesController, type: :request do
   describe 'GET /fees/:id' do
     let(:customer) { create(:customer, organization:) }
     let(:subscription) { create(:subscription, customer:) }
-    let(:fee) { create(:fee, subscription:) }
+    let(:fee) { create(:fee, subscription:, invoice: nil) }
 
     it 'returns a fee' do
       get_with_token(organization, "/api/v1/fees/#{fee.id}")
@@ -27,6 +27,31 @@ RSpec.describe Api::V1::FeesController, type: :request do
         expect(json[:fee][:vat_amount_currency]).to eq(fee.vat_amount_currency)
         expect(json[:fee][:units]).to eq(fee.units.to_s)
         expect(json[:fee][:events_count]).to eq(fee.events_count)
+      end
+    end
+
+    context 'when fee is an add-on fee' do
+      let(:invoice) { create(:invoice, organization:) }
+      let(:fee) { create(:add_on_fee, invoice:) }
+
+      it 'returns a fee' do
+        get_with_token(organization, "/api/v1/fees/#{fee.id}")
+
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+
+          expect(json[:fee][:lago_id]).to eq(fee.id)
+          expect(json[:fee][:lago_group_id]).to eq(fee.group_id)
+          expect(json[:fee][:item][:type]).to eq(fee.fee_type)
+          expect(json[:fee][:item][:code]).to eq(fee.item_code)
+          expect(json[:fee][:item][:name]).to eq(fee.item_name)
+          expect(json[:fee][:amount_cents]).to eq(fee.amount_cents)
+          expect(json[:fee][:amount_currency]).to eq(fee.amount_currency)
+          expect(json[:fee][:vat_amount_cents]).to eq(fee.vat_amount_cents)
+          expect(json[:fee][:vat_amount_currency]).to eq(fee.vat_amount_currency)
+          expect(json[:fee][:units]).to eq(fee.units.to_s)
+          expect(json[:fee][:events_count]).to eq(fee.events_count)
+        end
       end
     end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR follows https://github.com/getlago/lago-api/pull/906 and fixes the fectch scope in the case of an add_on fee