### PR TITLE
feat(instant_charge): exclude instant charges from monthly billing

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -33,6 +33,8 @@ class Charge < ApplicationRecord
 
   default_scope -> { kept }
 
+  scope :instant, -> { where(instant: true) }
+
   def properties(group_id: nil)
     group_properties.find_by(group_id:)&.values || read_attribute(:properties)
   end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -72,7 +72,7 @@ module Invoices
     end
 
     def create_charges_fees(subscription, boundaries)
-      subscription.plan.charges.each do |charge|
+      subscription.plan.charges.where(instant: false).each do |charge|
         fee_result = Fees::ChargeService.new(invoice:, charge:, subscription:, boundaries:).create
         fee_result.raise_if_error!
       end

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -432,6 +432,21 @@ RSpec.describe Events::CreateService, type: :service do
           )
         end.to have_enqueued_job(Fees::CreateInstantJob)
       end
+
+      context 'when multiple charges have the billable metric' do
+        before { create(:standard_charge, :instant, plan:, billable_metric:) }
+
+        it 'enqueues a job for each charge' do
+          expect do
+            create_service.call(
+              organization:,
+              params: create_args,
+              timestamp:,
+              metadata: {},
+            )
+          end.to have_enqueued_job(Fees::CreateInstantJob).twice
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://github.com/getlago/lago/issues/149

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR:
- prevents instant charges from being taken into account in the periodic billing
- Ensure that if a billable metrics is related to multiple instant charges a job is enqueued to process a fee per charge