### PR TITLE
feat (coupons): add few more coupon validations

### DIFF
--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -44,8 +44,13 @@ class Coupon < ApplicationRecord
   validates :name, presence: true
   validates :code, uniqueness: { conditions: -> { where(deleted_at: nil) }, scope: :organization_id }
 
+  validates :amount_cents, presence: true, if: :fixed_amount?
   validates :amount_cents, numericality: { greater_than: 0 }, allow_nil: true
+
+  validates :amount_currency, presence: true, if: :fixed_amount?
   validates :amount_currency, inclusion: { in: currency_list }, allow_nil: true
+
+  validates :percentage_rate, presence: true, if: :percentage?
 
   default_scope -> { kept }
   scope :order_by_status_and_expiration,

--- a/spec/models/coupon_spec.rb
+++ b/spec/models/coupon_spec.rb
@@ -5,7 +5,51 @@ require 'rails_helper'
 RSpec.describe Coupon, type: :model do
   subject(:coupon) { create(:coupon) }
 
+  let(:organization) { create(:organization) }
+
   it_behaves_like 'paper_trail traceable'
+
+  describe 'validations' do
+    context 'when coupon is fixed amount' do
+      it 'validates amount_cents' do
+        expect(coupon).to be_valid
+
+        coupon.amount_cents = nil
+        expect(coupon).not_to be_valid
+      end
+
+      it 'validates amount_currency' do
+        coupon.amount_currency = nil
+        expect(coupon).not_to be_valid
+      end
+
+      it 'validates percentage_rate' do
+        coupon.percentage_rate = nil
+        expect(coupon).to be_valid
+      end
+    end
+
+    context 'when coupon is percentage' do
+      subject(:coupon) { create(:coupon, coupon_type: 'percentage', percentage_rate: 10) }
+
+      it 'validates percentage_rate' do
+        expect(coupon).to be_valid
+
+        coupon.percentage_rate = nil
+        expect(coupon).not_to be_valid
+      end
+
+      it 'validates amount_cents' do
+        coupon.amount_cents = nil
+        expect(coupon).to be_valid
+      end
+
+      it 'validates amount_currency' do
+        coupon.amount_currency = nil
+        expect(coupon).to be_valid
+      end
+    end
+  end
 
   describe '.mark_as_terminated' do
     it 'terminates the coupon' do

--- a/spec/requests/api/v1/applied_coupons_spec.rb
+++ b/spec/requests/api/v1/applied_coupons_spec.rb
@@ -88,7 +88,9 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
     end
 
     context 'with pagination' do
-      let(:coupon_latest) { create(:coupon, coupon_type: 'percentage', organization: organization) }
+      let(:coupon_latest) do
+        create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization: organization)
+      end
       let(:applied_coupon_latest) do
         create(
           :applied_coupon,
@@ -117,7 +119,9 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
     end
 
     context 'with status param' do
-      let(:coupon_latest) { create(:coupon, coupon_type: 'percentage', organization: organization) }
+      let(:coupon_latest) do
+        create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization: organization)
+      end
       let(:applied_coupon_latest) do
         create(
           :applied_coupon,
@@ -144,7 +148,9 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
 
     context 'with external_customer_id params' do
       let(:customer_new) { create(:customer, organization: organization) }
-      let(:coupon_latest) { create(:coupon, coupon_type: 'percentage', organization: organization) }
+      let(:coupon_latest) do
+        create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization: organization)
+      end
       let(:applied_coupon_latest) do
         create(
           :applied_coupon,

--- a/spec/requests/api/v1/applied_coupons_spec.rb
+++ b/spec/requests/api/v1/applied_coupons_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
 
     context 'with pagination' do
       let(:coupon_latest) do
-        create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization: organization)
+        create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization:)
       end
       let(:applied_coupon_latest) do
         create(
@@ -119,9 +119,7 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
     end
 
     context 'with status param' do
-      let(:coupon_latest) do
-        create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization: organization)
-      end
+      let(:coupon_latest) { create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization:) }
       let(:applied_coupon_latest) do
         create(
           :applied_coupon,
@@ -148,9 +146,7 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
 
     context 'with external_customer_id params' do
       let(:customer_new) { create(:customer, organization: organization) }
-      let(:coupon_latest) do
-        create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization: organization)
-      end
+      let(:coupon_latest) { create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization:) }
       let(:applied_coupon_latest) do
         create(
           :applied_coupon,

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Credits::AppliedCouponService do
     end
 
     context 'when coupon is percentage' do
-      let(:coupon) { create(:coupon, coupon_type: 'percentage') }
+      let(:coupon) { create(:coupon, coupon_type: 'percentage', percentage_rate: 10.00) }
 
       let(:applied_coupon) do
         create(:applied_coupon, coupon:, percentage_rate: 20.00)
@@ -227,7 +227,9 @@ RSpec.describe Credits::AppliedCouponService do
     end
 
     context 'when coupon is recurring and percentage' do
-      let(:coupon) { create(:coupon, frequency: 'recurring', frequency_duration: 3, coupon_type: 'percentage') }
+      let(:coupon) do
+        create(:coupon, frequency: 'recurring', frequency_duration: 3, coupon_type: 'percentage', percentage_rate: 10)
+      end
 
       let(:applied_coupon) do
         create(

--- a/spec/services/credits/applied_coupons_service_spec.rb
+++ b/spec/services/credits/applied_coupons_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Credits::AppliedCouponsService do
         amount_currency: plan.amount_currency,
       )
     end
-    let(:coupon_latest) { create(:coupon, coupon_type: 'percentage') }
+    let(:coupon_latest) { create(:coupon, coupon_type: 'percentage', percentage_rate: 10.00) }
     let(:applied_coupon_latest) do
       create(
         :applied_coupon,
@@ -98,7 +98,7 @@ RSpec.describe Credits::AppliedCouponsService do
     end
 
     context 'when both coupons are percentage' do
-      let(:coupon) { create(:coupon, coupon_type: 'percentage') }
+      let(:coupon) { create(:coupon, coupon_type: 'percentage', percentage_rate: 10.00) }
       let(:applied_coupon) do
         create(
           :applied_coupon,


### PR DESCRIPTION
## Context

`amount_cents`, `amount_currency` and `percentage_rate` are required fields but only for certain coupon type. This PR is adding missing validations