### PR TITLE
fix(credit-notes): Truncate item amount on termination

### DIFF
--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -2,6 +2,8 @@
 
 module CreditNotes
   class CreateFromTermination < BaseService
+    DB_PRECISION_SCALE = 5
+
     def initialize(subscription:, reason: 'order_change')
       @subscription = subscription
       @reason = reason
@@ -29,7 +31,7 @@ module CreditNotes
         items: [
           {
             fee_id: last_subscription_fee.id,
-            amount_cents: amount,
+            amount_cents: amount.truncate(DB_PRECISION_SCALE),
           },
         ],
         reason: reason.to_sym,


### PR DESCRIPTION
## Context

A new rounding error just poped-up with the credit note termination amount.

The issue is related to the automatic rounding done by rails when setting the "precise_amount" on the credit note item. Since the max precision of the field is 5 digit, rails apply a rounding to the value. In some cases this rounding led to a validation error when comparing the item amount and the credit note amount.

Example:

Computed amount in the terminate service: 499.49999999999994
Rounded for the `credit_amount_cents`: 499
Stored at item level: 499.5 (`= amount.round(5)`)
Rounded for comparison with credit note total_amount: 500 :boom: 

## Description

To prevent the issue, we should manually apply a `truncate` with the maximum precision instead of letting rails rounding the value