### PR TITLE
fix: Ensure migrations with tasks from prior v0.24.0-beta passes

### DIFF
--- a/lib/tasks/invoices.rake
+++ b/lib/tasks/invoices.rake
@@ -63,8 +63,15 @@ namespace :invoices do
 
   desc 'Fill invoice organization from customers'
   task fill_organization: :environment do
+    # NOTE: when upgrading from before v0.24.0-beta, versions table does not exists
+    #       but PaperTrail is loaded in the model.
+    #       So we need to turn it off temporary to ensure migration passes
+    PaperTrail.request.disable_model(Invoice)
+
     Invoice.where(organization_id: nil).find_each do |invoice|
       invoice.update!(organization_id: invoice.customer.organization_id)
     end
+
+    PaperTrail.request.enable_model(Invoice)
   end
 end


### PR DESCRIPTION
## Context

It seens it's not possible to migrate from a version prior to v0.22.0-beta to version higher than v0.24.0-beta.

It's related to the introduction of paper trail, preventing to run a migration task in `AddOrganizationIdToInvoices` migration because the `versions` table used by papertrail does not exist yet.

## Description

The solution is to temporary turn off the versioning while running the migration task