### PR TITLE
feat(instant_charge): Add API route to estimate instant fees amount

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -51,6 +51,25 @@ module Api
         )
       end
 
+      def estimate_fees
+        result = Fees::EstimateInstantService.call(
+          organization: current_organization,
+          params: create_params,
+        )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.fees,
+              ::V1::FeeSerializer,
+              collection_name: 'fees',
+            ),
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
       private
 
       def create_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,9 @@ Rails.application.routes.draw do
         post :download, on: :member
         put :void, on: :member
       end
-      resources :events, only: %i[create show]
+      resources :events, only: %i[create show] do
+        post :estimate_fees, on: :collection
+      end
       resources :applied_coupons, only: %i[create index]
       resources :applied_add_ons, only: %i[create]
       resources :fees, only: %i[show]


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/instantly-charge-the-customer-when-an-event-is-processed

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR introduces a new `POST api/v1/events/estimate_fees` route to retrieve a list of expected instant fees that would be created after reception of a specific event
