### PR TITLE
feat(instant_charge): Add and update fees#payment_status

### DIFF
--- a/app/jobs/invoices/update_fees_payment_status_job.rb
+++ b/app/jobs/invoices/update_fees_payment_status_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Invoices
+  class UpdateFeesPaymentStatusJob < ApplicationJob
+    queue_as 'invoices'
+
+    def perform(invoice)
+      invoice.fees.update!(payment_status: invoice.payment_status)
+    end
+  end
+end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -23,8 +23,10 @@ class Fee < ApplicationRecord
   monetize :total_amount_cents
 
   FEE_TYPES = %i[charge add_on subscription credit instant_charge].freeze
+  PAYMENT_STATUS = %i[pending succeeded failed refunded].freeze
 
   enum fee_type: FEE_TYPES
+  enum payment_status: PAYMENT_STATUS
 
   validates :amount_currency, inclusion: { in: currency_list }
   validates :vat_amount_currency, inclusion: { in: currency_list }

--- a/app/services/fees/add_on_service.rb
+++ b/app/services/fees/add_on_service.rb
@@ -21,6 +21,7 @@ module Fees
         invoiceable: applied_add_on,
         vat_rate: customer.applicable_vat_rate,
         units: 1,
+        payment_status: :pending,
       )
 
       new_fee.compute_vat

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -69,6 +69,7 @@ module Fees
         properties: boundaries.to_h,
         events_count: amount_result.count,
         group_id: group&.id,
+        payment_status: :pending,
       )
 
       new_fee.compute_vat

--- a/app/services/fees/create_instant_service.rb
+++ b/app/services/fees/create_instant_service.rb
@@ -55,6 +55,7 @@ module Fees
         events_count: result.count,
         group_id: group&.id,
         instant_event_id: event.id,
+        payment_status: :pending,
       )
       fee.compute_vat
       fee.save! unless estimate

--- a/app/services/fees/paid_credit_service.rb
+++ b/app/services/fees/paid_credit_service.rb
@@ -24,6 +24,7 @@ module Fees
         amount_cents: amount_cents,
         amount_currency: wallet_transaction.wallet.currency,
         units: 1,
+        payment_status: :pending,
 
         # NOTE: No VAT should be applied on as it can be considered as an advance
         vat_rate: 0,

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -26,6 +26,7 @@ module Fees
         invoiceable: subscription,
         units: 1,
         properties: boundaries.to_h,
+        payment_status: :pending,
       )
 
       new_fee.compute_vat

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -44,6 +44,7 @@ module Invoices
         handle_prepaid_credits(params[:payment_status])
         track_payment_status_changed
         deliver_webhook
+        Invoices::UpdateFeesPaymentStatusJob.perform_later(invoice)
       end
 
       result.invoice = invoice

--- a/db/migrate/20230323112252_add_payment_status_to_fees.rb
+++ b/db/migrate/20230323112252_add_payment_status_to_fees.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class AddPaymentStatusToFees < ActiveRecord::Migration[7.0]
+  def change
+    change_table :fees, bulk: true do |t|
+      # NOTE: will be changed after migration
+      t.integer :payment_status, null: true
+
+      t.datetime :succeeded_at
+      t.datetime :failed_at
+      t.datetime :refunded_at
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE fees
+          SET payment_status = invoices.payment_status
+          FROM invoices
+          WHERE invoices.id = fees.invoice_id
+        SQL
+      end
+
+      change_column_null :fees, :payment_status, false
+      change_column_default :fees, :payment_status, 0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -297,6 +297,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_27_134418) do
     t.integer "events_count"
     t.uuid "group_id"
     t.uuid "instant_event_id"
+    t.integer "payment_status", default: 0, null: false
+    t.datetime "succeeded_at", precision: nil
+    t.datetime "failed_at", precision: nil
+    t.datetime "refunded_at", precision: nil
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
     t.index ["group_id"], name: "index_fees_on_group_id"

--- a/spec/jobs/invoices/update_fees_payment_status_job_spec.rb
+++ b/spec/jobs/invoices/update_fees_payment_status_job_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::UpdateFeesPaymentStatusJob, type: :job do
+  let(:invoice) { create(:invoice, payment_status: 'succeeded') }
+  let(:fee) { create(:fee, invoice:) }
+
+  before { fee }
+
+  it 'updates the payment_status of the fee' do
+    described_class.perform_now(invoice)
+
+    expect(fee.reload.payment_status).to eq('succeeded')
+  end
+end

--- a/spec/services/fees/add_on_service_spec.rb
+++ b/spec/services/fees/add_on_service_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Fees::AddOnService do
         expect(created_fee.vat_rate).to eq(20.0)
         expect(created_fee.units).to eq(1)
         expect(created_fee.events_count).to be_nil
+        expect(created_fee.payment_status).to eq('pending')
       end
     end
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe Fees::ChargeService do
           expect(created_fee.vat_rate).to eq(20.0)
           expect(created_fee.units).to eq(0)
           expect(created_fee.events_count).to eq(0)
+          expect(created_fee.payment_status).to eq('pending')
         end
       end
 

--- a/spec/services/fees/create_instant_service_spec.rb
+++ b/spec/services/fees/create_instant_service_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe Fees::CreateInstantService, type: :service do
           events_count: 1,
           group: nil,
           instant_event_id: event.id,
+          payment_status: 'pending',
         )
       end
     end

--- a/spec/services/fees/paid_credit_service_spec.rb
+++ b/spec/services/fees/paid_credit_service_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Fees::PaidCreditService do
         expect(created_fee.vat_amount_cents).to eq(0)
         expect(created_fee.vat_rate).to eq(0)
         expect(created_fee.units).to eq(1)
+        expect(created_fee.payment_status).to eq('pending')
       end
     end
 

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Fees::SubscriptionService do
         expect(created_fee.vat_rate).to eq(20.0)
         expect(created_fee.units).to eq(1)
         expect(created_fee.events_count).to be_nil
+        expect(created_fee.payment_status).to eq('pending')
       end
     end
 

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe Invoices::UpdateService do
       )
     end
 
+    context 'with attached fees' do
+      it 'euqueus a job to update the payment_status of the fees' do
+        result
+
+        expect(Invoices::UpdateFeesPaymentStatusJob)
+          .to have_been_enqueued
+          .with(invoice)
+      end
+    end
+
     context 'with metadata' do
       let(:invoice_metadata) { create(:invoice_metadata, invoice:) }
       let(:another_invoice_metadata) { create(:invoice_metadata, invoice:, key: 'test', value: '1') }


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/instantly-charge-the-customer-when-an-event-is-processed

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds new `payment_status` field to `fees` table and ensures this field is always set
