### PR TITLE
fix(charge_models): Change Integer types to BigInt

### DIFF
--- a/app/graphql/types/charges/graduated_range.rb
+++ b/app/graphql/types/charges/graduated_range.rb
@@ -3,10 +3,8 @@
 module Types
   module Charges
     class GraduatedRange < Types::BaseObject
-      graphql_name 'GraduatedRange'
-
-      field :from_value, Integer, null: false
-      field :to_value, Integer, null: true
+      field :from_value, GraphQL::Types::BigInt, null: false
+      field :to_value, GraphQL::Types::BigInt, null: true
 
       field :per_unit_amount, String, null: false
       field :flat_amount, String, null: false

--- a/app/graphql/types/charges/graduated_range_input.rb
+++ b/app/graphql/types/charges/graduated_range_input.rb
@@ -3,10 +3,8 @@
 module Types
   module Charges
     class GraduatedRangeInput < Types::BaseInputObject
-      graphql_name 'GraduatedRangeInput'
-
-      argument :from_value, Integer, required: true
-      argument :to_value, Integer, required: false
+      argument :from_value, GraphQL::Types::BigInt, required: true
+      argument :to_value, GraphQL::Types::BigInt, required: false
 
       argument :per_unit_amount, String, required: true
       argument :flat_amount, String, required: true

--- a/app/graphql/types/charges/group_properties.rb
+++ b/app/graphql/types/charges/group_properties.rb
@@ -3,8 +3,6 @@
 module Types
   module Charges
     class GroupProperties < Types::BaseObject
-      graphql_name 'GroupProperties'
-
       field :group_id, ID, null: false
       field :values, Types::Charges::Properties, null: false
 

--- a/app/graphql/types/charges/group_properties_input.rb
+++ b/app/graphql/types/charges/group_properties_input.rb
@@ -3,8 +3,6 @@
 module Types
   module Charges
     class GroupPropertiesInput < Types::BaseInputObject
-      graphql_name 'GroupPropertiesInput'
-
       argument :group_id, ID, required: true
       argument :values, Types::Charges::PropertiesInput, required: true
     end

--- a/app/graphql/types/charges/properties.rb
+++ b/app/graphql/types/charges/properties.rb
@@ -3,62 +3,24 @@
 module Types
   module Charges
     class Properties < Types::BaseObject
-      graphql_name 'Properties'
-
       # NOTE: Standard and Package charge model
-      field :amount, String, null: true
+      field :amount, String, null: true, hash_key: :amount
 
       # NOTE: Graduated charge model
-      field :graduated_ranges, [Types::Charges::GraduatedRange], null: true
+      field :graduated_ranges, [Types::Charges::GraduatedRange], null: true, hash_key: :graduated_ranges
 
       # NOTE: Package charge model
-      field :free_units, Integer, null: true
-      field :package_size, Integer, null: true
+      field :free_units, GraphQL::Types::BigInt, null: true, hash_key: :free_units
+      field :package_size, GraphQL::Types::BigInt, null: true, hash_key: :package_size
 
       # NOTE: Percentage charge model
-      field :rate, String, null: true
-      field :fixed_amount, String, null: true
-      field :free_units_per_events, Integer, null: true
-      field :free_units_per_total_aggregation, String, null: true
+      field :fixed_amount, String, null: true, hash_key: :fixed_amount
+      field :free_units_per_events, GraphQL::Types::BigInt, null: true, hash_key: :free_units_per_events
+      field :free_units_per_total_aggregation, String, null: true, hash_key: :free_units_per_total_aggregation
+      field :rate, String, null: true, hash_key: :rate
 
       # NOTE: Volume charge model
-      field :volume_ranges, [Types::Charges::VolumeRange], null: true
-
-      def amount
-        object['amount']
-      end
-
-      def graduated_ranges
-        object['graduated_ranges']
-      end
-
-      def free_units
-        object['free_units']
-      end
-
-      def package_size
-        object['package_size']
-      end
-
-      def rate
-        object['rate']
-      end
-
-      def fixed_amount
-        object['fixed_amount']
-      end
-
-      def free_units_per_events
-        object['free_units_per_events']
-      end
-
-      def free_units_per_total_aggregation
-        object['free_units_per_total_aggregation']
-      end
-
-      def volume_ranges
-        object['volume_ranges']
-      end
+      field :volume_ranges, [Types::Charges::VolumeRange], null: true, hash_key: :volume_ranges
     end
   end
 end

--- a/app/graphql/types/charges/properties_input.rb
+++ b/app/graphql/types/charges/properties_input.rb
@@ -3,8 +3,6 @@
 module Types
   module Charges
     class PropertiesInput < Types::BaseInputObject
-      graphql_name 'PropertiesInput'
-
       # NOTE: Standard and Package charge model
       argument :amount, String, required: false
 
@@ -12,13 +10,13 @@ module Types
       argument :graduated_ranges, [Types::Charges::GraduatedRangeInput], required: false
 
       # NOTE: Package charge model
-      argument :free_units, Integer, required: false
-      argument :package_size, Integer, required: false
+      argument :free_units, GraphQL::Types::BigInt, required: false
+      argument :package_size, GraphQL::Types::BigInt, required: false
 
       # NOTE: Percentage charge model
       argument :rate, String, required: false
       argument :fixed_amount, String, required: false
-      argument :free_units_per_events, Integer, required: false
+      argument :free_units_per_events, GraphQL::Types::BigInt, required: false
       argument :free_units_per_total_aggregation, String, required: false
 
       # NOTE: Volume charge model

--- a/app/graphql/types/charges/volume_range.rb
+++ b/app/graphql/types/charges/volume_range.rb
@@ -3,10 +3,8 @@
 module Types
   module Charges
     class VolumeRange < Types::BaseObject
-      graphql_name 'VolumeRange'
-
-      field :from_value, Integer, null: false
-      field :to_value, Integer, null: true
+      field :from_value, GraphQL::Types::BigInt, null: false
+      field :to_value, GraphQL::Types::BigInt, null: true
 
       field :per_unit_amount, String, null: false
       field :flat_amount, String, null: false

--- a/app/graphql/types/charges/volume_range_input.rb
+++ b/app/graphql/types/charges/volume_range_input.rb
@@ -3,10 +3,8 @@
 module Types
   module Charges
     class VolumeRangeInput < Types::BaseInputObject
-      graphql_name 'VolumeRangeInput'
-
-      argument :from_value, Integer, required: true
-      argument :to_value, Integer, required: false
+      argument :from_value, GraphQL::Types::BigInt, required: true
+      argument :to_value, GraphQL::Types::BigInt, required: false
 
       argument :per_unit_amount, String, required: true
       argument :flat_amount, String, required: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -2839,16 +2839,16 @@ type GocardlessProvider {
 
 type GraduatedRange {
   flatAmount: String!
-  fromValue: Int!
+  fromValue: BigInt!
   perUnitAmount: String!
-  toValue: Int
+  toValue: BigInt
 }
 
 input GraduatedRangeInput {
   flatAmount: String!
-  fromValue: Int!
+  fromValue: BigInt!
   perUnitAmount: String!
-  toValue: Int
+  toValue: BigInt
 }
 
 type Group {
@@ -3649,11 +3649,11 @@ enum PlanInterval {
 type Properties {
   amount: String
   fixedAmount: String
-  freeUnits: Int
-  freeUnitsPerEvents: Int
+  freeUnits: BigInt
+  freeUnitsPerEvents: BigInt
   freeUnitsPerTotalAggregation: String
   graduatedRanges: [GraduatedRange!]
-  packageSize: Int
+  packageSize: BigInt
   rate: String
   volumeRanges: [VolumeRange!]
 }
@@ -3661,11 +3661,11 @@ type Properties {
 input PropertiesInput {
   amount: String
   fixedAmount: String
-  freeUnits: Int
-  freeUnitsPerEvents: Int
+  freeUnits: BigInt
+  freeUnitsPerEvents: BigInt
   freeUnitsPerTotalAggregation: String
   graduatedRanges: [GraduatedRangeInput!]
-  packageSize: Int
+  packageSize: BigInt
   rate: String
   volumeRanges: [VolumeRangeInput!]
 }
@@ -5038,16 +5038,16 @@ input VoidCreditNoteInput {
 
 type VolumeRange {
   flatAmount: String!
-  fromValue: Int!
+  fromValue: BigInt!
   perUnitAmount: String!
-  toValue: Int
+  toValue: BigInt
 }
 
 input VolumeRangeInput {
   flatAmount: String!
-  fromValue: Int!
+  fromValue: BigInt!
   perUnitAmount: String!
-  toValue: Int
+  toValue: BigInt
 }
 
 type Wallet {

--- a/schema.json
+++ b/schema.json
@@ -9591,7 +9591,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Int",
+                  "name": "BigInt",
                   "ofType": null
                 }
               },
@@ -9624,7 +9624,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -9653,7 +9653,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Int",
+                  "name": "BigInt",
                   "ofType": null
                 }
               },
@@ -9666,7 +9666,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               },
               "defaultValue": null,
@@ -14337,7 +14337,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -14351,7 +14351,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -14401,7 +14401,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -14495,7 +14495,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               },
               "defaultValue": null,
@@ -14507,7 +14507,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               },
               "defaultValue": null,
@@ -14543,7 +14543,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               },
               "defaultValue": null,
@@ -19580,7 +19580,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Int",
+                  "name": "BigInt",
                   "ofType": null
                 }
               },
@@ -19613,7 +19613,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -19642,7 +19642,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Int",
+                  "name": "BigInt",
                   "ofType": null
                 }
               },
@@ -19655,7 +19655,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "BigInt",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -171,15 +171,15 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
       expect(package_charge['chargeModel']).to eq('package')
       group_properties = package_charge['groupProperties'][0]['values']
       expect(group_properties['amount']).to eq('300.00')
-      expect(group_properties['freeUnits']).to eq(10)
-      expect(group_properties['packageSize']).to eq(10)
+      expect(group_properties['freeUnits']).to eq('10')
+      expect(group_properties['packageSize']).to eq('10')
 
       percentage_charge = result_data['charges'][2]
       expect(percentage_charge['chargeModel']).to eq('percentage')
       group_properties = percentage_charge['groupProperties'][0]['values']
       expect(group_properties['rate']).to eq('0.25')
       expect(group_properties['fixedAmount']).to eq('2')
-      expect(group_properties['freeUnitsPerEvents']).to eq(5)
+      expect(group_properties['freeUnitsPerEvents']).to eq('5')
       expect(group_properties['freeUnitsPerTotalAggregation']).to eq('50')
 
       graduated_charge = result_data['charges'][3]

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -172,15 +172,15 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
       expect(package_charge['chargeModel']).to eq('package')
       group_properties = package_charge['groupProperties'][0]['values']
       expect(group_properties['amount']).to eq('300.00')
-      expect(group_properties['freeUnits']).to eq(10)
-      expect(group_properties['packageSize']).to eq(10)
+      expect(group_properties['freeUnits']).to eq('10')
+      expect(group_properties['packageSize']).to eq('10')
 
       percentage_charge = result_data['charges'][2]
       expect(percentage_charge['chargeModel']).to eq('percentage')
       group_properties = percentage_charge['groupProperties'][0]['values']
       expect(group_properties['rate']).to eq('0.25')
       expect(group_properties['fixedAmount']).to eq('2')
-      expect(group_properties['freeUnitsPerEvents']).to eq(5)
+      expect(group_properties['freeUnitsPerEvents']).to eq('5')
       expect(group_properties['freeUnitsPerTotalAggregation']).to eq('50')
 
       graduated_charge = result_data['charges'][3]


### PR DESCRIPTION
## Context

A bug was discovered wile trying to create charges with large numbers (`9,999,999,999` for example).
This issue is that GraphQL type definition are using `Integer` type which is limiter to 32 bits.

## Description

The fix is to switch the type to `BigInt`