### PR TITLE
feat(instant_charge): add API end-point to update fee payment_status

### DIFF
--- a/app/controllers/api/v1/fees_controller.rb
+++ b/app/controllers/api/v1/fees_controller.rb
@@ -4,16 +4,30 @@ module Api
   module V1
     class FeesController < Api::BaseController
       def show
-        # NOTE: instant fees might not be linked to any invoice, but add_on fees does not have any subscriptions
-        #       so we need a bit of logic to find the fee in the right organization scope
-        fee = Fee.left_joins(:invoice)
-          .left_joins(subscription: :customer)
-          .where('COALESCE(invoices.organization_id, customers.organization_id) = ?', current_organization.id)
+        fee = Fee.from_organization(current_organization)
           .find_by(id: params[:id])
 
         return not_found_error(resource: 'fee') unless fee
 
         render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee'))
+      end
+
+      def update
+        fee = Fee.from_organization(current_organization)
+          .find_by(id: params[:id])
+        result = Fees::UpdateService.call(fee:, params: update_params)
+
+        if result.success?
+          render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee'))
+        else
+          render_error_response(result)
+        end
+      end
+
+      private
+
+      def update_params
+        params.require(:fee).permit(:payment_status)
       end
     end
   end

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -23,6 +23,11 @@ module V1
         events_count: model.events_count,
         lago_invoice_id: model.invoice_id,
         external_subscription_id: model.subscription&.external_id,
+        payment_status: model.payment_status,
+        created_at: model.created_at&.iso8601,
+        succeeded_at: model.succeeded_at&.iso8601,
+        failed_at: model.failed_at&.iso8601,
+        refunded_at: model.refunded_at&.iso8601,
       }
     end
   end

--- a/app/services/customers/terminate_relations_service.rb
+++ b/app/services/customers/terminate_relations_service.rb
@@ -8,7 +8,7 @@ module Customers
     end
 
     def call
-      return result.not_allowed_failure!(resource: 'customer') unless customer
+      return result.not_found_failure!(resource: 'customer') unless customer
 
       # NOTE: Terminate active subscriptions.
       customer.subscriptions.active.each do |subscription|

--- a/app/services/fees/update_service.rb
+++ b/app/services/fees/update_service.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Fees
+  class UpdateService < BaseService
+    def initialize(fee:, params:)
+      @fee = fee
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'fee') if fee.nil?
+
+      if params.key?(:payment_status)
+        return result.not_allowed_failure!(code: 'not_an_instant_fee') unless fee.instant_charge?
+
+        unless valid_payment_status?(params[:payment_status])
+          return result.single_validation_failure!(
+            field: :payment_status,
+            error_code: 'value_is_invalid',
+          )
+        end
+
+        update_payment_status(params[:payment_status])
+      end
+
+      fee.save!
+
+      result.fee = fee
+      result
+    end
+
+    private
+
+    attr_reader :fee, :params
+
+    def valid_payment_status?(payment_status)
+      Fee::PAYMENT_STATUS.include?(payment_status&.to_sym)
+    end
+
+    def update_payment_status(payment_status)
+      fee.payment_status = payment_status
+
+      case payment_status.to_sym
+      when :succeeded
+        fee.succeeded_at = Time.current
+      when :failed
+        fee.failed_at = Time.current
+      when :refunded
+        fee.refunded_at = Time.current
+      end
+    end
+  end
+end

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -28,10 +28,7 @@ module Invoices
         )
       end
 
-      if params.key?(:payment_status)
-        invoice.payment_status = params[:payment_status]
-        invoice.fees.update_all(payment_status: params[:payment_status]) # rubocop:disable Rails/SkipsModelValidations
-      end
+      invoice.payment_status = params[:payment_status] if params.key?(:payment_status)
 
       if params.key?(:ready_for_payment_processing)
         invoice.ready_for_payment_processing = params[:ready_for_payment_processing]

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -28,7 +28,10 @@ module Invoices
         )
       end
 
-      invoice.payment_status = params[:payment_status] if params.key?(:payment_status)
+      if params.key?(:payment_status)
+        invoice.payment_status = params[:payment_status]
+        invoice.fees.update_all(payment_status: params[:payment_status]) # rubocop:disable Rails/SkipsModelValidations
+      end
 
       if params.key?(:ready_for_payment_processing)
         invoice.ready_for_payment_processing = params[:ready_for_payment_processing]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
       end
       resources :applied_coupons, only: %i[create index]
       resources :applied_add_ons, only: %i[create]
-      resources :fees, only: %i[show]
+      resources :fees, only: %i[show update]
       resources :invoices, only: %i[update show index] do
         post :download, on: :member
         post :retry_payment, on: :member

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe ::V1::FeeSerializer do
         'total_amount_currency' => fee.amount_currency,
         'units' => fee.units.to_s,
         'events_count' => fee.events_count,
+        'payment_status' => fee.payment_status,
+        'created_at' => fee.created_at&.iso8601,
+        'succeeded_at' => fee.succeeded_at&.iso8601,
+        'failed_at' => fee.failed_at&.iso8601,
+        'refunded_at' => fee.refunded_at&.iso8601,
       )
       expect(result['fee']['item']).to include(
         'type' => fee.fee_type,

--- a/spec/services/fees/update_service_spec.rb
+++ b/spec/services/fees/update_service_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fees::UpdateService, type: :service do
+  subject(:update_service) { described_class.new(fee:, params:) }
+
+  let(:fee) { create(:charge_fee, fee_type: 'instant_charge', invoice: nil) }
+
+  let(:params) { { payment_status: } }
+  let(:payment_status) { 'succeeded' }
+
+  describe 'call' do
+    it 'updates the fee' do
+      result = update_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+
+        expect(result.fee.payment_status).to eq('succeeded')
+        expect(result.fee.succeeded_at).to be_present
+      end
+    end
+
+    context 'when fee is nil' do
+      let(:fee) { nil }
+
+      it 'returns a not found failure' do
+        result = update_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('fee_not_found')
+        end
+      end
+    end
+
+    context 'when fee is not instant' do
+      let(:fee) { create(:fee, fee_type: 'charge', invoice: nil) }
+
+      it 'returns a not allowed failure' do
+        result = update_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(result.error.code).to eq('not_an_instant_fee')
+        end
+      end
+    end
+
+    context 'when payment_status is invalid' do
+      let(:payment_status) { 'foo' }
+
+      it 'returns a validation failure' do
+        result = update_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:payment_status]).to eq(['value_is_invalid'])
+        end
+      end
+    end
+
+    context 'when payment_status is failed' do
+      let(:payment_status) { 'failed' }
+
+      it 'updates the fee' do
+        result = update_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.fee.payment_status).to eq('failed')
+          expect(result.fee.failed_at).to be_present
+        end
+      end
+    end
+
+    context 'when payment_status is refunded' do
+      let(:payment_status) { 'refunded' }
+
+      it 'updates the fee' do
+        result = update_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.fee.payment_status).to eq('refunded')
+          expect(result.fee.refunded_at).to be_present
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/instantly-charge-the-customer-when-an-event-is-processed

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds a new `PUT /api/v1/fees/:id` route to update the payment status of a fee. It delegates the logic to a `Fees::UpdateService` 
