### PR TITLE
fix(invoice template): fix invoice template header overflow

### DIFF
--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -218,9 +218,17 @@ html
       }
       .credit-note-information-table tr td:first-child {
         padding: 0 16px 0 0;
+        width: 35%;
+      }
+      .credit-note-information-table, tr td{
+        text-wrap: normal;
+        word-wrap: break-word;
+        vertical-align: top;
       }
       .credit-note-information-table {
         border-collapse: collapse;
+        table-layout: fixed;
+        width: 100%;
       }
 
       .billing-information-column {

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -225,9 +225,17 @@ html
       }
       .invoice-information-table tr td:first-child {
         padding: 0 16px 0 0;
+        width: 35%;
+      }
+      .invoice-information-table, tr td{
+        text-wrap: normal;
+        word-wrap: break-word;
+        vertical-align: top;
       }
       .invoice-information-table {
         border-collapse: collapse;
+        table-layout: fixed;
+        width: 100%;
       }
 
       .billing-information-column {


### PR DESCRIPTION
## Context

If metadata key and value are too long, table content gets cut and not displayed properly