### PR TITLE
fix (payment providers): remove null constraint on refunds for payment_provider_id field

### DIFF
--- a/app/models/refund.rb
+++ b/app/models/refund.rb
@@ -5,6 +5,6 @@ class Refund < ApplicationRecord
 
   belongs_to :payment
   belongs_to :credit_note
-  belongs_to :payment_provider, class_name: 'PaymentProviders::BaseProvider'
+  belongs_to :payment_provider, optional: true, class_name: 'PaymentProviders::BaseProvider'
   belongs_to :payment_provider_customer, class_name: 'PaymentProviderCustomers::BaseCustomer'
 end

--- a/db/migrate/20230327134418_remove_payment_provider_null_constraint_on_refunds.rb
+++ b/db/migrate/20230327134418_remove_payment_provider_null_constraint_on_refunds.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemovePaymentProviderNullConstraintOnRefunds < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :refunds, :payment_provider_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_13_145506) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_27_134418) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -515,7 +515,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_13_145506) do
   create_table "refunds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "payment_id", null: false
     t.uuid "credit_note_id", null: false
-    t.uuid "payment_provider_id", null: false
+    t.uuid "payment_provider_id"
     t.uuid "payment_provider_customer_id", null: false
     t.bigint "amount_cents", default: 0, null: false
     t.string "amount_currency", null: false


### PR DESCRIPTION
## Context

Removing Stripe api Key raised 500 if there are refunds objects

## Description

When we remove PaymentProviders::BaseProvider, dependent objects also need to be nullified:
`has_many :refunds, dependent: :nullify, foreign_key: :payment_provider_id`

However, on `refunds` table, `payment_provider_id` was marked as null: false, so destroy operation raises 500 since we are not able to set null on `payment_provider_id`
