### PR TITLE
feat(instant_charge): Add GET /api/v1/fees route

### DIFF
--- a/app/controllers/api/v1/fees_controller.rb
+++ b/app/controllers/api/v1/fees_controller.rb
@@ -24,10 +24,53 @@ module Api
         end
       end
 
+      def index
+        result = FeesQuery.call(
+          organization: current_organization,
+          pagination: BaseQuery::Pagination.new(
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE,
+          ),
+          filters: BaseQuery::Filters.new(index_filters),
+        )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.fees,
+              ::V1::FeeSerializer,
+              collection_name: 'fees',
+              meta: pagination_metadata(result.fees),
+            ),
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
       private
 
       def update_params
         params.require(:fee).permit(:payment_status)
+      end
+
+      def index_filters
+        params.permit(
+          :fee_type,
+          :payment_status,
+          :external_subscription_id,
+          :external_customer_id,
+          :billable_metric_code,
+          :currency,
+          :created_at_from,
+          :created_at_to,
+          :failed_at_from,
+          :failed_at_to,
+          :succeeded_at_from,
+          :succeeded_at_to,
+          :refunded_at_from,
+          :refunded_at_to,
+        )
       end
     end
   end

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -1,13 +1,39 @@
 # frozen_string_literal: true
 
 class BaseQuery < BaseService
-  def initialize(organization:)
+  PER_PAGE = 100
+
+  Pagination = Struct.new(:page, :limit, keyword_init: true) do
+    def initialize(page: 0, limit: PER_PAGE)
+      super
+    end
+  end
+
+  class Filters < OpenStruct; end
+
+  def initialize(organization:, pagination: Pagination.new, filters: Filters.new)
     @organization = organization
+    @pagination = pagination
+    @filters = filters
 
     super
   end
 
   private
 
-  attr_reader :organization
+  attr_reader :organization, :pagination, :filters
+
+  def paginate(scope)
+    scope.page(pagination.page).per(pagination.limit)
+  end
+
+  def parse_datetime_filter(field_name)
+    value = filters[field_name]
+    return value if [Time, ActiveSupport::TimeWithZone, Date, DateTime].include?(value.class)
+
+    DateTime.strptime(filters[field_name])
+  rescue Date::Error
+    result.single_validation_failure!(field: field_name.to_sym, error_code: 'invalid_date')
+      .raise_if_error!
+  end
 end

--- a/app/queries/fees_query.rb
+++ b/app/queries/fees_query.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+class FeesQuery < BaseQuery
+  def call
+    fees = paginate(Fee.from_organization(organization))
+    fees = fees.order(created_at: :asc)
+
+    fees = with_external_subscription(fees) if filters.external_subscription_id
+    fees = with_external_customer(fees) if filters.external_customer_id
+
+    fees = fees.where(amount_currency: filters.currency.upcase) if filters.currency
+    fees = with_billable_metric_code(fees) if filters.billable_metric_code
+
+    fees = with_fee_type(fees) if filters.fee_type
+    fees = with_payment_status(fees) if filters.payment_status
+
+    fees = with_created_date_range(fees) if filters.created_at_from || filters.created_at_to
+    fees = with_succeeded_date_range(fees) if filters.succeeded_at_from || filters.succeeded_at_to
+    fees = with_failed_date_range(fees) if filters.failed_at_from || filters.failed_at_to
+    fees = with_refunded_date_range(fees) if filters.refunded_at_from || filters.refunded_at_to
+
+    result.fees = fees
+    result
+  rescue BaseService::FailedResult
+    result
+  end
+
+  def with_external_subscription(scope)
+    scope.joins(:subscription).where(subscription: { external_id: filters.external_subscription_id })
+  end
+
+  def with_external_customer(scope)
+    # NOTE: instant fees are not be linked to any invoice, but add_on fees does not have any subscriptions
+    #       so we need a bit of logic to find the fee in the right customer scope
+    #       - Add ons and regular fees: customers linked to the invoice
+    #       - Instant: customers linked to the subscription
+    scope
+      .joins('LEFT JOIN customers AS invoice_customers ON invoice_customers.id = invoices.customer_id')
+      .where('COALESCE(customers.external_id, invoice_customers.external_id) = ?', filters.external_customer_id)
+  end
+
+  def with_billable_metric_code(scope)
+    scope.joins(:billable_metric)
+      .where(billable_metric: { code: filters.billable_metric_code })
+  end
+
+  def with_fee_type(scope)
+    unless Fee::FEE_TYPES.include?(filters.fee_type.to_sym)
+      result.single_validation_failure!(field: :fee_type, error_code: 'value_is_invalid')
+        .raise_if_error!
+    end
+
+    scope.where(fee_type: filters.fee_type)
+  end
+
+  def with_payment_status(scope)
+    unless Fee::PAYMENT_STATUS.include?(filters.payment_status.to_sym)
+      result.single_validation_failure!(field: :payment_status, error_code: 'value_is_invalid')
+        .raise_if_error!
+    end
+
+    scope.where(payment_status: filters.payment_status)
+  end
+
+  def with_created_date_range(scope)
+    scope = scope.where(created_at: created_at_from..) if filters.created_at_from
+    scope = scope.where(created_at: ..created_at_to) if filters.created_at_to
+    scope
+  end
+
+  def created_at_from
+    @created_at_from ||= parse_datetime_filter(:created_at_from)
+  end
+
+  def created_at_to
+    @created_at_to ||= parse_datetime_filter(:created_at_to)
+  end
+
+  def with_succeeded_date_range(scope)
+    scope = scope.where(succeeded_at: succeeded_at_from..) if filters.succeeded_at_from
+    scope = scope.where(succeeded_at: ..succeeded_at_to) if filters.succeeded_at_to
+    scope
+  end
+
+  def succeeded_at_from
+    @succeeded_at_from ||= parse_datetime_filter(:succeeded_at_from)
+  end
+
+  def succeeded_at_to
+    @succeeded_at_to ||= parse_datetime_filter(:succeeded_at_to)
+  end
+
+  def with_failed_date_range(scope)
+    scope = scope.where(failed_at: failed_at_from..) if filters.failed_at_from
+    scope = scope.where(failed_at: ..failed_at_to) if filters.failed_at_to
+    scope
+  end
+
+  def failed_at_from
+    @failed_at_from ||= parse_datetime_filter(:failed_at_from)
+  end
+
+  def failed_at_to
+    @failed_at_to ||= parse_datetime_filter(:failed_at_to)
+  end
+
+  def with_refunded_date_range(scope)
+    scope = scope.where(refunded_at: refunded_at_from..) if filters.refunded_at_from
+    scope = scope.where(refunded_at: ..refunded_at_to) if filters.refunded_at_to
+    scope
+  end
+
+  def refunded_at_from
+    @refunded_at_from ||= parse_datetime_filter(:refunded_at_from)
+  end
+
+  def refunded_at_to
+    @refunded_at_to ||= parse_datetime_filter(:refunded_at_to)
+  end
+end

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -46,7 +46,7 @@ module CreditNotes
     delegate :plan, :terminated_at, :customer, to: :subscription
 
     def last_subscription_fee
-      @last_subscription_fee ||= subscription.fees.order(created_at: :desc).first
+      @last_subscription_fee ||= subscription.fees.subscription.order(created_at: :desc).first
     end
 
     def compute_amount

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
       end
       resources :applied_coupons, only: %i[create index]
       resources :applied_add_ons, only: %i[create]
-      resources :fees, only: %i[show update]
+      resources :fees, only: %i[show update index]
       resources :invoices, only: %i[update show index] do
         post :download, on: :member
         post :retry_payment, on: :member

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -16,6 +16,21 @@ FactoryBot.define do
 
     vat_amount_cents { 2 }
     vat_amount_currency { 'EUR' }
+
+    trait :succeeded do
+      payment_status { :succeeded }
+      succeeded_at { Time.current }
+    end
+
+    trait :failed do
+      payment_status { :failed }
+      failed_at { Time.current }
+    end
+
+    trait :refunded do
+      payment_status { :refunded }
+      refunded_at { Time.current }
+    end
   end
 
   factory :charge_fee, parent: :fee do

--- a/spec/queries/fees_query_spec.rb
+++ b/spec/queries/fees_query_spec.rb
@@ -1,0 +1,381 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FeesQuery, type: :query do
+  subject(:fees_query) { described_class.new(organization:, pagination:, filters:) }
+
+  let(:organization) { create(:organization) }
+  let(:pagination) { BaseQuery::Pagination.new }
+  let(:filters) { BaseQuery::Filters.new(query_filters) }
+
+  let(:query_filters) { {} }
+
+  describe 'call' do
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, customer:) }
+    let(:fee) { create(:fee, subscription:, invoice: nil) }
+
+    before { fee }
+
+    it 'returns a list of fees' do
+      result = fees_query.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.fees.count).to eq(1)
+        expect(result.fees).to eq([fee])
+      end
+    end
+
+    context 'with pagination' do
+      let(:pagination) { BaseQuery::Pagination.new(page: 2, limit: 10) }
+
+      it 'applies the pagination' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(0)
+          expect(result.fees.current_page).to eq(2)
+        end
+      end
+    end
+
+    context 'with subscription filter' do
+      let(:query_filters) { { external_subscription_id: subscription.external_id } }
+
+      it 'applies the filter' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+        end
+      end
+    end
+
+    context 'with customer filter' do
+      let(:query_filters) { { external_customer_id: customer.external_id } }
+
+      it 'applies the filter' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+        end
+      end
+
+      context 'when fee is for an add_on' do
+        let(:add_on) { create(:add_on, organization:) }
+        let(:applied_add_on) { create(:applied_add_on, customer:, add_on:) }
+        let(:invoice) { create(:invoice, organization:, customer:) }
+        let(:fee) { create(:add_on_fee, applied_add_on:, invoice:) }
+
+        let(:query_filters) { { external_customer_id: customer.external_id } }
+
+        it 'applies the filter' do
+          result = fees_query.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.fees.count).to eq(1)
+          end
+        end
+      end
+    end
+
+    context 'with currency filter' do
+      let(:query_filters) { { currency: fee.amount_currency } }
+
+      it 'applies the filter' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+        end
+      end
+    end
+
+    context 'with billable metric code filter' do
+      let(:billable_metric) { create(:billable_metric, organization:) }
+      let(:plan) { create(:plan, organization:) }
+      let(:charge) { create(:standard_charge, billable_metric:, plan:) }
+
+      let(:fee) { create(:charge_fee, charge:, subscription:, invoice: nil) }
+
+      let(:query_filters) { { billable_metric_code: billable_metric.code } }
+
+      it 'applies the filter' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+        end
+      end
+    end
+
+    context 'with fee_type filter' do
+      let(:query_filters) { { fee_type: fee.fee_type } }
+
+      it 'applies the filter' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+        end
+      end
+
+      context 'when fee_type is invalid' do
+        let(:query_filters) { { fee_type: 'foo_bar' } }
+
+        it 'returns a failed result' do
+          result = fees_query.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:fee_type]).to include('value_is_invalid')
+          end
+        end
+      end
+    end
+
+    context 'with payment_status filter' do
+      let(:query_filters) { { payment_status: fee.payment_status } }
+
+      it 'applies the filter' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+        end
+      end
+
+      context 'when payment_status is invalid' do
+        let(:query_filters) { { payment_status: 'foo_bar' } }
+
+        it 'returns a failed result' do
+          result = fees_query.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:payment_status]).to include('value_is_invalid')
+          end
+        end
+      end
+    end
+
+    context 'with created_at filters' do
+      let(:query_filters) do
+        {
+          created_at_from: (fee.created_at - 1.minute).iso8601,
+          created_at_to: (fee.created_at + 1.minute).iso8601,
+        }
+      end
+
+      it 'applies the filter' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+        end
+      end
+
+      context 'when fee is not covered by range' do
+        let(:query_filters) do
+          {
+            created_at_from: (fee.created_at - 2.minutes).iso8601,
+            created_at_to: (fee.created_at - 2.minutes).iso8601,
+          }
+        end
+
+        it 'applies the filter' do
+          result = fees_query.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.fees.count).to eq(0)
+          end
+        end
+      end
+
+      context 'with invalid date' do
+        let(:query_filters) { { created_at_from: 'invalid_date_value' } }
+
+        it 'returns a failed result' do
+          result = fees_query.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:created_at_from]).to include('invalid_date')
+          end
+        end
+      end
+    end
+
+    context 'with succeeded_at filters' do
+      let(:query_filters) do
+        {
+          succeeded_at_from: (fee.succeeded_at - 1.minute).iso8601,
+          succeeded_at_to: (fee.succeeded_at + 1.minute).iso8601,
+        }
+      end
+
+      let(:fee) { create(:fee, :succeeded, subscription:, invoice: nil) }
+
+      it 'applies the filter' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+        end
+      end
+
+      context 'when fee is not covered by range' do
+        let(:query_filters) do
+          {
+            succeeded_at_from: (fee.succeeded_at - 2.minutes).iso8601,
+            succeeded_at_to: (fee.succeeded_at - 2.minutes).iso8601,
+          }
+        end
+
+        it 'applies the filter' do
+          result = fees_query.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.fees.count).to eq(0)
+          end
+        end
+      end
+
+      context 'with invalid date' do
+        let(:query_filters) { { succeeded_at_from: 'invalid_date_value' } }
+
+        it 'returns a failed result' do
+          result = fees_query.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:succeeded_at_from]).to include('invalid_date')
+          end
+        end
+      end
+    end
+
+    context 'with failed_at filters' do
+      let(:query_filters) do
+        {
+          failed_at_from: (fee.failed_at - 1.minute).iso8601,
+          failed_at_to: (fee.failed_at + 1.minute).iso8601,
+        }
+      end
+
+      let(:fee) { create(:fee, :failed, subscription:, invoice: nil) }
+
+      it 'applies the filter' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+        end
+      end
+
+      context 'when fee is not covered by range' do
+        let(:query_filters) do
+          {
+            failed_at_from: (fee.failed_at - 2.minutes).iso8601,
+            failed_at_to: (fee.failed_at - 2.minutes).iso8601,
+          }
+        end
+
+        it 'applies the filter' do
+          result = fees_query.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.fees.count).to eq(0)
+          end
+        end
+      end
+
+      context 'with invalid date' do
+        let(:query_filters) { { failed_at_from: 'invalid_date_value' } }
+
+        it 'returns a failed result' do
+          result = fees_query.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:failed_at_from]).to include('invalid_date')
+          end
+        end
+      end
+    end
+
+    context 'with refunded_at filters' do
+      let(:query_filters) do
+        {
+          refunded_at_from: (fee.refunded_at - 1.minute).iso8601,
+          refunded_at_to: (fee.refunded_at + 1.minute).iso8601,
+        }
+      end
+
+      let(:fee) { create(:fee, :refunded, subscription:, invoice: nil) }
+
+      it 'applies the filter' do
+        result = fees_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.fees.count).to eq(1)
+        end
+      end
+
+      context 'when fee is not covered by range' do
+        let(:query_filters) do
+          {
+            refunded_at_from: (fee.refunded_at - 2.minutes).iso8601,
+            refunded_at_to: (fee.refunded_at - 2.minutes).iso8601,
+          }
+        end
+
+        it 'applies the filter' do
+          result = fees_query.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.fees.count).to eq(0)
+          end
+        end
+      end
+
+      context 'with invalid date' do
+        let(:query_filters) { { refunded_at_from: 'invalid_date_value' } }
+
+        it 'returns a failed result' do
+          result = fees_query.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:refunded_at_from]).to include('invalid_date')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/instantly-charge-the-customer-when-an-event-is-processed

## Context

Fintech companies want to deduct fees as transactions occur. They need to charge their customers instantly and report those fees in the invoice issued at the end of the billing period.

Example: 0.5% charge on FX transfers. When the customer makes a transfer of $100, they are immediately charged $0.5 (automatically deducted from their wallet). The corresponding fee is included in the invoice sent to the customer at the end of the billing period.

## Description

This PR adds a new `GET /api/v1/fees` to retrieve fees. It accepts a lot of filter attributes
