### PR TITLE
misc(mailer): prevent orga info display when data is not present

### DIFF
--- a/app/views/layouts/mailer.slim
+++ b/app/views/layouts/mailer.slim
@@ -42,29 +42,31 @@ html
       tr
         td
           table.main-table cellpadding="0" cellspacing="0" style="padding: 64px 0"
-            tr
-              td
-                table cellpadding="0" cellspacing="0" style="margin: auto; padding-bottom: 32px"
-                  tr
-                    - if @organization.logo.present?
-                      td valign="middle" style="vertical-align: middle; padding-right: 12px"
-                        a style="text-decoration: none" href=""
-                          img src=@organization.logo_url valign="middle" style="vertical-align: middle; height: 32px; width: 32px; border-radius: 8px;"
-                    td style="height: 32px; font-size: 20px; font-weight: 700; line-height: 28px; letter-spacing: 0em;"
-                      = @organization.name
+            - if @organization.present?
+              tr
+                td
+                  table cellpadding="0" cellspacing="0" style="margin: auto; padding-bottom: 32px"
+                    tr
+                      - if @organization.logo.present?
+                        td valign="middle" style="vertical-align: middle; padding-right: 12px"
+                          a style="text-decoration: none" href=""
+                            img src=@organization.logo_url valign="middle" style="vertical-align: middle; height: 32px; width: 32px; border-radius: 8px;"
+                      td style="height: 32px; font-size: 20px; font-weight: 700; line-height: 28px; letter-spacing: 0em;"
+                        = @organization.name
             tr
               td
                 table cellpadding="0" cellspacing="0" style="width: 100%; background-color: #fff; border: 1px solid #d9dee7; border-radius: 12px; padding: 32px;"
                   tr
                     td
                       = yield
-                      table cellpadding="0" cellspacing="0" style="margin: auto; padding-top: 24px"
-                        tr
-                          td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: center; color: #66758f;"
-                            = I18n.t('email.questions')
-                            | &nbsp;
-                            a style="text-decoration: none; color: #006cfa" href="mailto:#{@organization.email}"
-                              = @organization.email
+                      - if @organization.present?
+                        table cellpadding="0" cellspacing="0" style="margin: auto; padding-top: 24px"
+                          tr
+                            td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: center; color: #66758f;"
+                              = I18n.t('email.questions')
+                              | &nbsp;
+                              a style="text-decoration: none; color: #006cfa" href="mailto:#{@organization.email}"
+                                = @organization.email
                 table cellpadding="0" cellspacing="0" style="margin: auto; padding-top: 32px"
                   tr
                     td style="font-size: 12px; font-weight: 400; line-height: 16px; letter-spacing: 0em; text-align: center; color: #8c95a6; padding-right: 4px;"


### PR DESCRIPTION
## Context

We'll have a new mail templates that won't have certain data we expect to be provided.

This template will use this mailer template.

It was initially done [in the feature PR](https://github.com/getlago/lago-api/pull/942/commits) but can easily be extracted

## Description

This PR makes the template hide those sections if the data is not provided