### PR TITLE
fix(invoice): prevent invoice template from raising error when billable metric is deleted

### DIFF
--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -592,7 +592,7 @@ html
                       td width="70%"
                         .body-1 = fee.billable_metric.name
                         .body-3
-                          - if fee.charge.billable_metric.recurring_count_agg? && fees.sum(&:units) > 0
+                          - if fee.billable_metric.recurring_count_agg? && fees.sum(&:units) > 0
                             = I18n.t('invoice.see_breakdown')
                           - elsif fee.charge.percentage?
                             = I18n.t('invoice.total_unit_interval', events_count: fees.sum(&:events_count), units: fees.sum(&:units))


### PR DESCRIPTION
## Context

Prevent invoice template from raising error when billable metric is deleted

## Description

In invoice template we want to also use discarded billable metrics in order to present data. Currently in one place we query over billable metrics that are NOT deleted
