### PR TITLE
imp(fees): Add dates boundaries into serializer

### DIFF
--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -44,12 +44,12 @@ module V1
       }
     end
 
-    def date_from
-      model.properties['from_datetime'].to_datetime.iso8601
+    def from_date
+      model.properties['from_datetime']&.to_datetime&.iso8601
     end
 
-    def date_to
-      model.properties['to_datetime'].to_datetime.iso8601
+    def to_date
+      model.properties['to_datetime']&.to_datetime&.iso8601
     end
   end
 end

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -3,7 +3,7 @@
 module V1
   class FeeSerializer < ModelSerializer
     def serialize
-      {
+      payload = {
         lago_id: model.id,
         lago_group_id: model.group_id,
         item: {
@@ -29,6 +29,33 @@ module V1
         failed_at: model.failed_at&.iso8601,
         refunded_at: model.refunded_at&.iso8601,
       }
+
+      payload = payload.merge(date_boundaries) if model.charge? || model.subscription?
+
+      payload
+    end
+
+    private
+
+    def date_boundaries
+      {
+        date_from:,
+        date_to:,
+      }
+    end
+
+    def date_from
+      invoice = model.invoice
+      subscription = model.subscription
+
+      invoice.invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date
+    end
+
+    def date_to
+      invoice = model.invoice
+      subscription = model.subscription
+
+      invoice.invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date
     end
   end
 end

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -39,23 +39,17 @@ module V1
 
     def date_boundaries
       {
-        date_from:,
-        date_to:,
+        from_date:,
+        to_date:,
       }
     end
 
     def date_from
-      invoice = model.invoice
-      subscription = model.subscription
-
-      invoice.invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date
+      model.properties['from_datetime'].to_datetime.iso8601
     end
 
     def date_to
-      invoice = model.invoice
-      subscription = model.subscription
-
-      invoice.invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date
+      model.properties['to_datetime'].to_datetime.iso8601
     end
   end
 end

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -5,23 +5,17 @@ require 'rails_helper'
 RSpec.describe ::V1::FeeSerializer do
   subject(:serializer) { described_class.new(fee, root_name: 'fee') }
 
-  let(:subscription) { create(:subscription) }
-  let(:invoice) { create(:invoice) }
-  let(:fee) { create(:fee, invoice:, subscription:) }
-
-  let(:result) { JSON.parse(serializer.to_json) }
-
-  before do
+  let(:fee) do
     create(
-      :invoice_subscription,
-      invoice:,
-      subscription:,
+      :fee,
       properties: {
         from_datetime: Time.current,
         to_datetime: Time.current,
       },
     )
   end
+
+  let(:result) { JSON.parse(serializer.to_json) }
 
   it 'serializes the fee' do
     aggregate_failures do
@@ -50,28 +44,38 @@ RSpec.describe ::V1::FeeSerializer do
         'item_type' => fee.item_type,
       )
 
-      expect(result['fee']['date_from']).not_to be_nil
-      expect(result['fee']['date_to']).not_to be_nil
+      expect(result['fee']['from_date']).not_to be_nil
+      expect(result['fee']['to_date']).not_to be_nil
     end
   end
 
   context 'when fee is charge' do
     let(:charge) { create(:standard_charge) }
-    let(:fee) { create(:fee, fee_type: 'charge', invoice:, subscription:, charge:) }
+    let(:fee) do
+      create(
+        :fee,
+        fee_type: 'charge',
+        charge:,
+        properties: {
+          from_datetime: Time.current,
+          to_datetime: Time.current,
+        },
+      )
+    end
 
     it 'serializes the fees with dates boundaries' do
-      expect(result['fee']['date_from']).not_to be_nil
-      expect(result['fee']['date_to']).not_to be_nil
+      expect(result['fee']['from_date']).not_to be_nil
+      expect(result['fee']['to_date']).not_to be_nil
     end
   end
 
   context 'when fee is add_on' do
     let(:add_on) { create(:add_on) }
-    let(:fee) { create(:fee, fee_type: 'add_on', invoice:, add_on:) }
+    let(:fee) { create(:fee, fee_type: 'add_on', add_on:) }
 
     it 'does not serializes the fees with date boundaries' do
-      expect(result['fee']['date_from']).to be_nil
-      expect(result['fee']['date_to']).to be_nil
+      expect(result['fee']['from_date']).to be_nil
+      expect(result['fee']['to_date']).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Context

We miss the fees boundaries on the invoice payload.

## Description

- Add `date_from` and `date_to` to fees when it applies
