### PR TITLE
feat (coupons): Add setup for billable metric limitations

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -11,6 +11,8 @@ class BillableMetric < ApplicationRecord
   has_many :groups, dependent: :delete_all
   has_many :plans, through: :charges
   has_many :persisted_events
+  has_many :coupon_targets
+  has_many :coupons, through: :coupon_targets
 
   AGGREGATION_TYPES = %i[
     count_agg

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -10,8 +10,9 @@ class Coupon < ApplicationRecord
 
   has_many :applied_coupons
   has_many :customers, through: :applied_coupons
-  has_many :coupon_plans
-  has_many :plans, through: :coupon_plans
+  has_many :coupon_targets
+  has_many :plans, through: :coupon_targets
+  has_many :billable_metrics, through: :coupon_targets
 
   STATUSES = [
     :active,

--- a/app/models/coupon_target.rb
+++ b/app/models/coupon_target.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-class CouponPlan < ApplicationRecord
+class CouponTarget < ApplicationRecord
   include PaperTrailTraceable
   include Discard::Model
   self.discard_column = :deleted_at
 
   belongs_to :coupon
-  belongs_to :plan
+  belongs_to :plan, optional: true
+  belongs_to :billable_metric, optional: true
 
   default_scope -> { kept }
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -14,8 +14,8 @@ class Plan < ApplicationRecord
   has_many :subscriptions
   has_many :customers, through: :subscriptions
   has_many :children, class_name: 'Plan', foreign_key: :parent_id
-  has_many :coupon_plans
-  has_many :coupons, through: :coupon_plans
+  has_many :coupon_targets
+  has_many :coupons, through: :coupon_targets
 
   INTERVALS = %i[
     weekly

--- a/app/services/applied_coupons/create_service.rb
+++ b/app/services/applied_coupons/create_service.rb
@@ -75,8 +75,8 @@ module AppliedCoupons
       customer
         .applied_coupons
         .active
-        .joins(coupon: :coupon_plans)
-        .where(coupon_plans: { plan_id: coupon.coupon_plans.select(:plan_id) })
+        .joins(coupon: :coupon_targets)
+        .where(coupon_targets: { plan_id: coupon.coupon_targets.select(:plan_id) })
         .exists?
     end
 

--- a/app/services/coupons/create_service.rb
+++ b/app/services/coupons/create_service.rb
@@ -33,7 +33,7 @@ module Coupons
       ActiveRecord::Base.transaction do
         coupon.save!
 
-        plans.each { |plan| CouponPlan.create!(coupon:, plan:) } if plan_identifiers.present?
+        plans.each { |plan| CouponTarget.create!(coupon:, plan:) } if plan_identifiers.present?
       end
 
       result.coupon = coupon

--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -12,7 +12,7 @@ module Coupons
 
       ActiveRecord::Base.transaction do
         coupon.discard!
-        coupon.coupon_plans.discard_all
+        coupon.coupon_targets.discard_all
 
         coupon.applied_coupons.active.each do |applied_coupon|
           AppliedCoupons::TerminateService.call(applied_coupon:)

--- a/app/services/coupons/update_service.rb
+++ b/app/services/coupons/update_service.rb
@@ -65,22 +65,22 @@ module Coupons
     end
 
     def process_plans
-      existing_coupon_plan_ids = coupon.coupon_plans.pluck(:plan_id)
+      existing_coupon_plan_ids = coupon.coupon_targets.pluck(:plan_id)
 
       plans.each do |plan|
         next if existing_coupon_plan_ids.include?(plan.id)
 
-        CouponPlan.create!(coupon:, plan:)
+        CouponTarget.create!(coupon:, plan:)
       end
 
       sanitize_coupon_plans
     end
 
     def sanitize_coupon_plans
-      not_needed_coupon_plan_ids = coupon.coupon_plans.pluck(:plan_id) - plans.pluck(:id)
+      not_needed_coupon_plan_ids = coupon.coupon_targets.pluck(:plan_id) - plans.pluck(:id)
 
       not_needed_coupon_plan_ids.each do |coupon_plan_id|
-        CouponPlan.find_by(coupon:, plan_id: coupon_plan_id).destroy!
+        CouponTarget.find_by(coupon:, plan_id: coupon_plan_id).destroy!
       end
     end
 

--- a/app/services/credits/applied_coupons_service.rb
+++ b/app/services/credits/applied_coupons_service.rb
@@ -52,7 +52,7 @@ module Credits
     end
 
     def coupon_fees(applied_coupon)
-      invoice.fees.joins(subscription: :plan).where(plan: { id: applied_coupon.coupon.coupon_plans.select(:plan_id) })
+      invoice.fees.joins(subscription: :plan).where(plan: { id: applied_coupon.coupon.coupon_targets.select(:plan_id) })
     end
 
     def coupon_base_amount_cents(coupon_related_fees:)

--- a/db/migrate/20230403094044_add_billable_metric_limitations_to_coupons.rb
+++ b/db/migrate/20230403094044_add_billable_metric_limitations_to_coupons.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddBillableMetricLimitationsToCoupons < ActiveRecord::Migration[7.0]
+  def change
+    add_column :coupons, :limited_billable_metrics, :boolean, default: false, null: false
+
+    change_column_null :coupon_plans, :plan_id, true
+
+    add_reference :coupon_plans, :billable_metric, type: :uuid, null: true, index: true, foreign_key: true
+
+    rename_table('coupon_plans', 'coupon_targets')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_28_161507) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_03_094044) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -118,15 +118,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_28_161507) do
     t.index ["plan_id"], name: "index_charges_on_plan_id"
   end
 
-  create_table "coupon_plans", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+  create_table "coupon_targets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "coupon_id", null: false
-    t.uuid "plan_id", null: false
+    t.uuid "plan_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
-    t.index ["coupon_id"], name: "index_coupon_plans_on_coupon_id"
-    t.index ["deleted_at"], name: "index_coupon_plans_on_deleted_at"
-    t.index ["plan_id"], name: "index_coupon_plans_on_plan_id"
+    t.uuid "billable_metric_id"
+    t.index ["billable_metric_id"], name: "index_coupon_targets_on_billable_metric_id"
+    t.index ["coupon_id"], name: "index_coupon_targets_on_coupon_id"
+    t.index ["deleted_at"], name: "index_coupon_targets_on_deleted_at"
+    t.index ["plan_id"], name: "index_coupon_targets_on_plan_id"
   end
 
   create_table "coupons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -148,6 +150,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_28_161507) do
     t.boolean "reusable", default: true, null: false
     t.boolean "limited_plans", default: false, null: false
     t.datetime "deleted_at"
+    t.boolean "limited_billable_metrics", default: false, null: false
     t.index ["deleted_at"], name: "index_coupons_on_deleted_at"
     t.index ["organization_id", "code"], name: "index_coupons_on_organization_id_and_code", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_coupons_on_organization_id"
@@ -638,8 +641,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_28_161507) do
   add_foreign_key "billable_metrics", "organizations"
   add_foreign_key "charges", "billable_metrics"
   add_foreign_key "charges", "plans"
-  add_foreign_key "coupon_plans", "coupons"
-  add_foreign_key "coupon_plans", "plans"
+  add_foreign_key "coupon_targets", "billable_metrics"
+  add_foreign_key "coupon_targets", "coupons"
+  add_foreign_key "coupon_targets", "plans"
   add_foreign_key "credit_note_items", "credit_notes"
   add_foreign_key "credit_note_items", "fees"
   add_foreign_key "credit_notes", "customers"

--- a/spec/factories/coupon_plans.rb
+++ b/spec/factories/coupon_plans.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-FactoryBot.define do
-  factory :coupon_plan do
-    coupon
-    plan
-  end
-end

--- a/spec/factories/coupon_targets.rb
+++ b/spec/factories/coupon_targets.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :coupon_plan, class: 'CouponTarget' do
+    coupon
+    plan
+  end
+
+  factory :coupon_billable_metric, class: 'CouponTarget' do
+    coupon
+    billable_metric
+  end
+end

--- a/spec/services/coupons/create_service_spec.rb
+++ b/spec/services/coupons/create_service_spec.rb
@@ -138,9 +138,9 @@ RSpec.describe Coupons::CreateService, type: :service do
           .to change(Coupon, :count).by(1)
       end
 
-      it 'creates a coupon plan' do
+      it 'creates a coupon target' do
         expect { create_service.create(**create_args) }
-          .to change(CouponPlan, :count).by(1)
+          .to change(CouponTarget, :count).by(1)
       end
     end
 
@@ -171,9 +171,9 @@ RSpec.describe Coupons::CreateService, type: :service do
           .to change(Coupon, :count).by(1)
       end
 
-      it 'creates a coupon plan' do
+      it 'creates a coupon target' do
         expect { create_service.create(**create_args) }
-          .to change(CouponPlan, :count).by(1)
+          .to change(CouponTarget, :count).by(1)
       end
     end
   end

--- a/spec/services/coupons/update_service_spec.rb
+++ b/spec/services/coupons/update_service_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe Coupons::UpdateService, type: :service do
         coupon_plan
       end
 
-      it 'creates new coupon plans' do
-        expect { update_service.call }.to change(CouponPlan, :count).by(1)
+      it 'creates new coupon target' do
+        expect { update_service.call }.to change(CouponTarget, :count).by(1)
       end
 
       context 'with API context' do
@@ -80,8 +80,8 @@ RSpec.describe Coupons::UpdateService, type: :service do
 
         let(:applies_to) { { plan_codes: [plan.code, plan_second.code] } }
 
-        it 'creates new coupon plans using plan code' do
-          expect { update_service.call }.to change(CouponPlan, :count).by(1)
+        it 'creates new coupon target using plan code' do
+          expect { update_service.call }.to change(CouponTarget, :count).by(1)
         end
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe Coupons::UpdateService, type: :service do
       end
 
       it 'deletes a coupon plan' do
-        expect { update_service.call }.to change(CouponPlan, :count).by(-1)
+        expect { update_service.call }.to change(CouponTarget, :count).by(-1)
       end
     end
 


### PR DESCRIPTION
## Context

In some cases coupons needs to be applied only on certain charges. In order to support it, billable metric limitations will be added.

## Description

Main points of this PR:

- Renaming of the join table `coupon_plans` => `coupon_targets`
- Adding billable metric relation to `coupon_targets`
- Fixing `coupon_plans` occurrences across the project
