### PR TITLE
bug(password-reset): fix displayed links in email

### DIFF
--- a/app/mailers/password_reset_mailer.rb
+++ b/app/mailers/password_reset_mailer.rb
@@ -9,6 +9,7 @@ class PasswordResetMailer < ApplicationMailer
     return if @email.blank?
 
     @reset_url = "#{ENV['LAGO_FRONT_URL']}/reset-password/#{@password_reset.token}"
+    @forgot_url = "#{ENV['LAGO_FRONT_URL']}/forgot-password"
 
     I18n.with_locale(:en) do
       mail(

--- a/app/views/password_reset_mailer/requested.slim
+++ b/app/views/password_reset_mailer/requested.slim
@@ -31,8 +31,8 @@ table style='margin-bottom: 32px' width="100%" cellspacing="0" cellpadding="0"
               = I18n.t('password_reset.main_cta_label')
 div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
   = I18n.t('password_reset.fallback_text')
-  a href="#{@reset_url}" target="_blank" style="color: #006CFA;text-decoration: none;"
-    = @reset_url
+  a href="#{@forgot_url}" target="_blank" style="color: #006CFA;text-decoration: none;"
+    = @forgot_url
 div style='font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;'
   = I18n.t('password_reset.thanks')
 div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'


### PR DESCRIPTION
## Context

There were a misunderstanding in specs regarding the email template

We need to have 2 links
- One for the button, leading to the reset password flow
- One that redirect to forgot password flow, in order to renew your token  

## Description

This PR updated the wrong link usage and replace with the expected one