### PR TITLE
feat: Turn balance float amounts into cents

### DIFF
--- a/app/graphql/types/wallets/object.rb
+++ b/app/graphql/types/wallets/object.rb
@@ -4,26 +4,31 @@ module Types
   module Wallets
     class Object < Types::BaseObject
       graphql_name 'Wallet'
+      description 'Wallet'
 
       field :id, ID, null: false
+
       field :customer, Types::Customers::Object
 
+      field :currency, Types::CurrencyEnum, null: false
       field :name, String, null: true
       field :status, Types::Wallets::StatusEnum, null: false
-      field :rate_amount, String, null: false
-      field :currency, Types::CurrencyEnum, null: false
-      field :credits_balance, String, null: false
-      field :balance, String, null: false
-      field :consumed_amount, String, null: false
-      field :consumed_credits, String, null: false
 
-      field :expiration_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :rate_amount, GraphQL::Types::Float, null: false
 
-      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
-      field :terminated_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :balance_cents, GraphQL::Types::BigInt, null: false
+      field :consumed_amount_cents, GraphQL::Types::BigInt, null: false
+
+      field :consumed_credits, GraphQL::Types::Float, null: false
+      field :credits_balance, GraphQL::Types::Float, null: false
+
       field :last_balance_sync_at, GraphQL::Types::ISO8601DateTime, null: true
       field :last_consumed_credit_at, GraphQL::Types::ISO8601DateTime, null: true
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :expiration_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :terminated_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
     end
   end
 end

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -9,6 +9,9 @@ class Wallet < ApplicationRecord
 
   has_many :wallet_transactions
 
+  monetize :balance_cents
+  monetize :consumed_amount_cents
+
   STATUSES = [
     :active,
     :terminated,
@@ -22,4 +25,13 @@ class Wallet < ApplicationRecord
   end
 
   scope :expired, -> { where('wallets.expiration_at::timestamp(0) <= ?', Time.current) }
+
+  def currency=(currency)
+    self.balance_currency = currency
+    self.consumed_amount_currenty = currency
+  end
+
+  def currency
+    balance_currency
+  end
 end

--- a/app/serializers/v1/legacy/wallet_serializer.rb
+++ b/app/serializers/v1/legacy/wallet_serializer.rb
@@ -6,6 +6,7 @@ module V1
       def serialize
         {
           expiration_date: model.expiration_at&.to_date&.iso8601,
+          balance: model.balance.to_s,
         }
       end
     end

--- a/app/serializers/v1/wallet_serializer.rb
+++ b/app/serializers/v1/wallet_serializer.rb
@@ -12,7 +12,7 @@ module V1
         name: model.name,
         rate_amount: model.rate_amount,
         credits_balance: model.credits_balance,
-        balance: model.balance,
+        balance_cents: model.balance_cents,
         consumed_credits: model.consumed_credits,
         created_at: model.created_at&.iso8601,
         expiration_at: model.expiration_at&.iso8601,

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -51,7 +51,7 @@ module WalletTransactions
 
       ActiveRecord::Base.transaction do
         wallet_transaction = WalletTransaction.create!(
-          wallet: wallet,
+          wallet:,
           transaction_type: :inbound,
           amount: wallet.rate_amount * granted_credits_amount,
           credit_amount: granted_credits_amount,
@@ -59,7 +59,7 @@ module WalletTransactions
           settled_at: Time.current,
         )
 
-        Wallets::Balance::IncreaseService.new(wallet: wallet, credits_amount: granted_credits_amount).call
+        Wallets::Balance::IncreaseService.new(wallet:, credits_amount: granted_credits_amount).call
 
         wallet_transaction
       end

--- a/app/services/wallets/apply_paid_credits_service.rb
+++ b/app/services/wallets/apply_paid_credits_service.rb
@@ -8,7 +8,7 @@ module Wallets
       return unless wallet_transaction
       return if wallet_transaction.status == 'settled'
 
-      WalletTransactions::SettleService.new(wallet_transaction: wallet_transaction).call
+      WalletTransactions::SettleService.new(wallet_transaction:).call
       Wallets::Balance::IncreaseService
         .new(wallet: wallet_transaction.wallet, credits_amount: wallet_transaction.credit_amount).call
     end

--- a/app/services/wallets/balance/decrease_service.rb
+++ b/app/services/wallets/balance/decrease_service.rb
@@ -11,15 +11,16 @@ module Wallets
       end
 
       def call
-        amount = wallet.rate_amount * credits_amount
+        currency = wallet.balance.currency
+        amount_cents = wallet.rate_amount * credits_amount * currency.subunit_to_unit
 
         wallet.update!(
-          balance: wallet.balance - amount,
+          balance_cents: wallet.balance_cents - amount_cents,
           credits_balance: wallet.credits_balance - credits_amount,
           last_balance_sync_at: Time.zone.now,
           consumed_credits: wallet.consumed_credits + credits_amount,
-          consumed_amount: wallet.consumed_amount + amount,
-          last_consumed_credit_at: Time.current
+          consumed_amount_cents: wallet.consumed_amount_cents + amount_cents,
+          last_consumed_credit_at: Time.current,
         )
 
         result.wallet = wallet

--- a/app/services/wallets/balance/increase_service.rb
+++ b/app/services/wallets/balance/increase_service.rb
@@ -11,10 +11,11 @@ module Wallets
       end
 
       def call
-        amount = wallet.rate_amount * credits_amount
+        currency = wallet.balance.currency
+        amount_cents = wallet.rate_amount * credits_amount * currency.subunit_to_unit
 
         wallet.update!(
-          balance: wallet.balance + amount,
+          balance_cents: wallet.balance_cents + amount_cents,
           credits_balance: wallet.credits_balance + credits_amount,
           last_balance_sync_at: Time.current,
         )

--- a/db/migrate/20230403093407_add_balance_cents_to_wallets.rb
+++ b/db/migrate/20230403093407_add_balance_cents_to_wallets.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class AddBalanceCentsToWallets < ActiveRecord::Migration[7.0]
+  def change
+    change_table :wallets, bulk: true do |t|
+      t.bigint :balance_cents
+      t.string :balance_currency
+
+      t.bigint :consumed_amount_cents
+      t.string :consumed_amount_currenty
+    end
+
+    Wallet.find_each do |wallet|
+      currency = Money::Currency.new(wallet.attributes['currency'])
+
+      wallet.update!(
+        balance_cents: (wallet.attributes['balance'] * currency.subunit_to_unit).to_i,
+        balance_currency: currency.iso_code,
+        consumed_amount_cents: (wallet.attributes['consumed_amount'] * currency.subunit_to_unit).to_i,
+        consumed_amount_currenty: currency.iso_code,
+      )
+    end
+
+    change_column_default :wallets, :balance_cents, from: nil, to: 0
+    change_column_null :wallets, :balance_cents, false
+    change_column_null :wallets, :balance_currency, false
+
+    change_column_default :wallets, :consumed_amount_cents, from: nil, to: 0
+    change_column_null :wallets, :consumed_amount_cents, false
+    change_column_null :wallets, :consumed_amount_currenty, false
+
+    reversible do |dir|
+      dir.up do
+        remove_column :wallets, :balance
+        remove_column :wallets, :consumed_amount
+        remove_column :wallets, :currency
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_28_161507) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_03_093407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -597,11 +597,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_28_161507) do
   create_table "wallets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "customer_id", null: false
     t.integer "status", null: false
-    t.string "currency", null: false
     t.string "name"
     t.decimal "rate_amount", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "credits_balance", precision: 30, scale: 5, default: "0.0", null: false
-    t.decimal "balance", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "consumed_credits", precision: 30, scale: 5, default: "0.0", null: false
     t.datetime "expiration_at", precision: nil
     t.datetime "last_balance_sync_at", precision: nil
@@ -609,7 +607,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_28_161507) do
     t.datetime "terminated_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.decimal "consumed_amount", precision: 30, scale: 5, default: "0.0"
+    t.bigint "balance_cents", default: 0, null: false
+    t.string "balance_currency", null: false
+    t.bigint "consumed_amount_cents", default: 0, null: false
+    t.string "consumed_amount_currenty", null: false
     t.index ["customer_id"], name: "index_wallets_on_customer_id"
   end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -5161,12 +5161,15 @@ input VolumeRangeInput {
   toValue: BigInt
 }
 
+"""
+Wallet
+"""
 type Wallet {
-  balance: String!
-  consumedAmount: String!
-  consumedCredits: String!
+  balanceCents: BigInt!
+  consumedAmountCents: BigInt!
+  consumedCredits: Float!
   createdAt: ISO8601DateTime!
-  creditsBalance: String!
+  creditsBalance: Float!
   currency: CurrencyEnum!
   customer: Customer
   expirationAt: ISO8601DateTime
@@ -5174,7 +5177,7 @@ type Wallet {
   lastBalanceSyncAt: ISO8601DateTime
   lastConsumedCreditAt: ISO8601DateTime
   name: String
-  rateAmount: String!
+  rateAmount: Float!
   status: WalletStatusEnum!
   terminatedAt: ISO8601DateTime
   updatedAt: ISO8601DateTime!

--- a/schema.json
+++ b/schema.json
@@ -20188,21 +20188,21 @@
         {
           "kind": "OBJECT",
           "name": "Wallet",
-          "description": null,
+          "description": "Wallet",
           "interfaces": [
 
           ],
           "possibleTypes": null,
           "fields": [
             {
-              "name": "balance",
+              "name": "balanceCents",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "BigInt",
                   "ofType": null
                 }
               },
@@ -20213,14 +20213,14 @@
               ]
             },
             {
-              "name": "consumedAmount",
+              "name": "consumedAmountCents",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "BigInt",
                   "ofType": null
                 }
               },
@@ -20238,7 +20238,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Float",
                   "ofType": null
                 }
               },
@@ -20274,7 +20274,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Float",
                   "ofType": null
                 }
               },
@@ -20398,7 +20398,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "String",
+                  "name": "Float",
                   "ofType": null
                 }
               },

--- a/spec/factories/wallets.rb
+++ b/spec/factories/wallets.rb
@@ -7,8 +7,8 @@ FactoryBot.define do
     status { 'active' }
     rate_amount { '1.00' }
     currency { 'EUR' }
-    credits_balance { '0.00' }
-    balance { '0.00' }
-    consumed_credits { '0.00' }
+    credits_balance { 0 }
+    balance_cents { 0 }
+    consumed_credits { 0 }
   end
 end

--- a/spec/jobs/invoices/prepaid_credit_job_spec.rb
+++ b/spec/jobs/invoices/prepaid_credit_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Invoices::PrepaidCreditJob, type: :job do
   let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
   let(:customer) { create(:customer) }
   let(:subscription) { create(:subscription, customer:) }
-  let(:wallet) { create(:wallet, customer:, balance: 10.0, credits_balance: 10.0) }
+  let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0) }
   let(:wallet_transaction) do
     create(:wallet_transaction, wallet:, amount: 15.0, credit_amount: 15.0, status: 'pending')
   end
@@ -30,7 +30,7 @@ RSpec.describe Invoices::PrepaidCreditJob, type: :job do
   it 'updates wallet balance' do
     described_class.perform_now(invoice)
 
-    expect(wallet.reload.balance).to eq 25.0
+    expect(wallet.reload.balance_cents).to eq(2500)
   end
 
   it 'settles the wallet transaction' do

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Wallet, type: :model do
+  subject(:wallet) { build(:wallet) }
+
+  describe 'currency=' do
+    it 'assigns the currency to all amounts' do
+      wallet.currency = 'CAD'
+
+      expect(wallet).to have_attributes(
+        balance_currency: 'CAD',
+        consumed_amount_currenty: 'CAD',
+      )
+    end
+  end
+
+  describe 'currency' do
+    it 'returns the wallet currency' do
+      expect(wallet.currency).to eq(wallet.balance_currency)
+    end
+  end
+end

--- a/spec/serializers/v1/wallet_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_serializer_spec.rb
@@ -11,21 +11,28 @@ RSpec.describe ::V1::WalletSerializer do
     result = JSON.parse(serializer.to_json)
 
     aggregate_failures do
-      expect(result['wallet']['lago_id']).to eq(wallet.id)
-      expect(result['wallet']['lago_customer_id']).to eq(wallet.customer_id)
-      expect(result['wallet']['external_customer_id']).to eq(wallet.customer.external_id)
-      expect(result['wallet']['status']).to eq(wallet.status)
-      expect(result['wallet']['currency']).to eq(wallet.currency)
-      expect(result['wallet']['name']).to eq(wallet.name)
-      expect(result['wallet']['rate_amount']).to eq(wallet.rate_amount.to_s)
-      expect(result['wallet']['credits_balance']).to eq(wallet.credits_balance.to_s)
-      expect(result['wallet']['balance']).to eq(wallet.balance.to_s)
-      expect(result['wallet']['consumed_credits']).to eq(wallet.consumed_credits.to_s)
-      expect(result['wallet']['created_at']).to eq(wallet.created_at.iso8601)
-      expect(result['wallet']['expiration_at']).to eq(wallet.expiration_at&.iso8601)
-      expect(result['wallet']['last_balance_sync_at']).to eq(wallet.last_balance_sync_at&.iso8601)
-      expect(result['wallet']['last_consumed_credit_at']).to eq(wallet.last_consumed_credit_at&.iso8601)
-      expect(result['wallet']['terminated_at']).to eq(wallet.terminated_at)
+      expect(result['wallet']).to include(
+        'lago_id' => wallet.id,
+        'lago_customer_id' => wallet.customer_id,
+        'external_customer_id' => wallet.customer.external_id,
+        'status' => wallet.status,
+        'currency' => wallet.currency,
+        'name' => wallet.name,
+        'rate_amount' => wallet.rate_amount.to_s,
+        'created_at' => wallet.created_at.iso8601,
+        'expiration_at' => wallet.expiration_at&.iso8601,
+        'last_balance_sync_at' => wallet.last_balance_sync_at&.iso8601,
+        'last_consumed_credit_at' => wallet.last_consumed_credit_at&.iso8601,
+        'terminated_at' => wallet.terminated_at,
+        'credits_balance' => wallet.credits_balance.to_s,
+        'balance_cents' => wallet.balance_cents,
+        'consumed_credits' => wallet.consumed_credits.to_s,
+      )
+
+      # NOTE: legacy values
+      expect(result['wallet']).to include(
+        'balance' => wallet.balance.to_s,
+      )
     end
   end
 end

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -3,22 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe Credits::AppliedPrepaidCreditService do
-  subject(:credit_service) { described_class.new(invoice: invoice, wallet: wallet) }
+  subject(:credit_service) { described_class.new(invoice:, wallet:) }
 
   let(:invoice) do
     create(
       :invoice,
-      customer: customer,
-      amount_cents: amount_cents,
+      customer:,
+      amount_cents:,
       amount_currency: 'EUR',
       total_amount_cents: amount_cents,
       total_amount_currency: 'EUR',
     )
   end
   let(:amount_cents) { 100 }
-  let(:wallet) { create(:wallet, customer: customer, balance: 10.00, credits_balance: 10.00) }
+  let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0) }
   let(:customer) { create(:customer) }
-  let(:subscription) { create(:subscription, customer: customer) }
+  let(:subscription) { create(:subscription, customer:) }
 
   before { subscription }
 
@@ -42,7 +42,7 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
       result = credit_service.create
       wallet = result.wallet_transaction.wallet
 
-      expect(wallet.balance).to eq(9.0)
+      expect(wallet.balance_cents).to eq(900)
       expect(wallet.credits_balance).to eq(9.0)
     end
 

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization: organization) }
-  let(:subscription) { create(:subscription, customer: customer) }
-  let(:wallet) { create(:wallet, customer: customer, balance: 10.0, credits_balance: 10.0) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:) }
+  let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0) }
 
   before do
     subscription
@@ -22,8 +22,8 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
       {
         wallet_id: wallet.id,
         organization_id: organization.id,
-        paid_credits: paid_credits,
-        granted_credits: granted_credits,
+        paid_credits:,
+        granted_credits:,
       }
     end
 
@@ -40,7 +40,7 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
     it 'updates wallet balance only with granted credits' do
       create_service.create(**create_args)
 
-      expect(wallet.reload.balance).to eq(25.0)
+      expect(wallet.reload.balance_cents).to eq(2500)
       expect(wallet.reload.credits_balance).to eq(25.0)
     end
 

--- a/spec/services/wallets/apply_paid_credits_service_spec.rb
+++ b/spec/services/wallets/apply_paid_credits_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Wallets::ApplyPaidCreditsService, type: :service do
     let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
     let(:customer) { create(:customer) }
     let(:subscription) { create(:subscription, customer:) }
-    let(:wallet) { create(:wallet, customer:, balance: 10.0, credits_balance: 10.0) }
+    let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0) }
     let(:wallet_transaction) do
       create(:wallet_transaction, wallet:, amount: 15.0, credit_amount: 15.0, status: 'pending')
     end
@@ -33,7 +33,7 @@ RSpec.describe Wallets::ApplyPaidCreditsService, type: :service do
     it 'updates wallet balance' do
       service.call(invoice)
 
-      expect(wallet.reload.balance).to eq 25.0
+      expect(wallet.reload.balance_cents).to eq 2500
     end
 
     it 'settles the wallet transaction' do

--- a/spec/services/wallets/balance/decrease_service_spec.rb
+++ b/spec/services/wallets/balance/decrease_service_spec.rb
@@ -3,26 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe Wallets::Balance::DecreaseService, type: :service do
-  subject(:create_service) { described_class.new(wallet: wallet, credits_amount: credits_amount) }
+  subject(:create_service) { described_class.new(wallet:, credits_amount:) }
 
-  let(:wallet) { create(:wallet, balance: 10.0, credits_balance: 10.0) }
+  let(:wallet) { create(:wallet, balance_cents: 1000, credits_balance: 10.0) }
   let(:credits_amount) { BigDecimal('4.5') }
 
   before { wallet }
 
   describe '.call' do
     it 'updates wallet balance' do
-      expect {
-        create_service.call
-      }.to change { wallet.reload.balance }.from(10.0).to(5.5)
-      .and change { wallet.credits_balance }.from(10.0).to(5.5)
+      expect { create_service.call }
+        .to change(wallet.reload, :balance_cents).from(1000).to(550)
+        .and change(wallet, :credits_balance).from(10.0).to(5.5)
     end
 
     it 'updates wallet consumed status' do
-      expect {
-        create_service.call
-      }.to change { wallet.reload.consumed_credits }.from(0.0).to(4.5)
-      .and change { wallet.consumed_amount }.from(0.0).to(4.5)
+      expect { create_service.call }
+        .to change(wallet.reload, :consumed_credits).from(0).to(4.5)
+        .and change(wallet, :consumed_amount_cents).from(0).to(450)
     end
   end
 end

--- a/spec/services/wallets/balance/increase_service_spec.rb
+++ b/spec/services/wallets/balance/increase_service_spec.rb
@@ -3,19 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe Wallets::Balance::IncreaseService, type: :service do
-  subject(:create_service) { described_class.new(wallet: wallet, credits_amount: credits_amount) }
+  subject(:create_service) { described_class.new(wallet:, credits_amount:) }
 
-  let(:wallet) { create(:wallet, balance: 10.0, credits_balance: 10.0) }
+  let(:wallet) { create(:wallet, balance_cents: 1000, credits_balance: 10.0) }
   let(:credits_amount) { BigDecimal('4.5') }
 
   before { wallet }
 
   describe '.call' do
     it 'updates wallet balance' do
-      expect {
-        create_service.call
-      }.to change { wallet.reload.balance }.from(10.0).to(14.5)
-     .and change { wallet.credits_balance }.from(10.0).to(14.5)
+      expect { create_service.call }
+        .to change(wallet.reload, :balance_cents).from(1000).to(1450)
+        .and change(wallet, :credits_balance).from(10.0).to(14.5)
     end
   end
 end


### PR DESCRIPTION
## Context

In our data model, amounts are usually integers in cents (e.g. `amount_cents` or `vat_amount_cents`).

However, in wallet, amount attributes are defined in float and exposed as string in the two API

This difference makes it difficult for users to use this information for calculation purposes (e.g. cannot easily deduct `amount_cents` from `balance` without converting the attribute into an integer).

## Description

This PR changes turned wallet fields into bigint and adds currency columns to match the amount and currency handling from other models.
- `balance_cents` / `balance_currency`
- `consumed_amount_cents` / `consumed_amount_currenty`

For compatibility purpose, all float fields are still exposed in public API but are deprecated.
This changes also requires an update of the front-end to adapt to the new amount fields

NOTE: the same changes will be applied to wallet_transaction that suffers from the same limitations.