### PR TITLE
fix: Do not bill subscription if not active

### DIFF
--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -94,7 +94,7 @@ module Subscriptions
         new_subscription.mark_as_active!
       end
 
-      if plan.pay_in_advance? && new_subscription.subscription_at.today?
+      if new_subscription.active? && new_subscription.subscription_at.today? && plan.pay_in_advance?
         # NOTE: Since job is laucnhed from inside a db transaction
         #       we must wait for it to be commited before processing the job
         BillSubscriptionJob


### PR DESCRIPTION
The goal of this PR is to not bill the subscription if pending.

Here is the following issue we want to fix in that PR:
- when a user is creating a subscription via API
- and plan is pay in advance
- with a subscription date in the future but today
- we don't want to enqueue a `BillSubscriptionJob`
