### PR TITLE
feat(min_charge): Add min_amount_cents to charges

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -28,8 +28,11 @@ class Charge < ApplicationRecord
   validate :validate_percentage, if: -> { percentage? && group_properties.empty? }
   validate :validate_volume, if: -> { volume? && group_properties.empty? }
 
+  validates :min_amount_cents, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+
   validate :validate_group_properties
   validate :validate_instant
+  validate :validate_min_amount_cents
 
   default_scope -> { kept }
 
@@ -86,5 +89,11 @@ class Charge < ApplicationRecord
     return unless billable_metric.recurring_count_agg? || billable_metric.max_agg? || volume?
 
     errors.add(:instant, :invalid_aggregation_type_or_charge_model)
+  end
+
+  def validate_min_amount_cents
+    return unless instant? && min_amount_cents.positive?
+
+    errors.add(:min_amount_cents, :not_compatible_with_instant)
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,7 @@ en:
         invalid_free_units_per_total_aggregation: invalid_free_units_per_total_aggregation
         invalid_content_type: invalid_content_type
         invalid_size: invalid_size
+        not_compatible_with_instant: not_compatible_with_instant
         value_already_exists: value_already_exists
         too_long: value_is_too_long
         values_not_all_present: values_not_all_present

--- a/db/migrate/20230411083336_add_min_amount_cents_to_charges.rb
+++ b/db/migrate/20230411083336_add_min_amount_cents_to_charges.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddMinAmountCentsToCharges < ActiveRecord::Migration[7.0]
   def change
     add_column :charges, :min_amount_cents, :bigint, null: false, default: 0

--- a/db/migrate/20230411083336_add_min_amount_cents_to_charges.rb
+++ b/db/migrate/20230411083336_add_min_amount_cents_to_charges.rb
@@ -1,0 +1,5 @@
+class AddMinAmountCentsToCharges < ActiveRecord::Migration[7.0]
+  def change
+    add_column :charges, :min_amount_cents, :bigint, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -113,6 +113,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_11_085545) do
     t.jsonb "properties", default: "{}", null: false
     t.datetime "deleted_at"
     t.boolean "instant", default: false, null: false
+    t.bigint "min_amount_cents", default: 0, null: false
     t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"
     t.index ["deleted_at"], name: "index_charges_on_deleted_at"
     t.index ["plan_id"], name: "index_charges_on_plan_id"

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -384,4 +384,21 @@ RSpec.describe Charge, type: :model do
       end
     end
   end
+
+  describe '#validate_min_amount_cents' do
+    it 'does not return an error' do
+      expect(build(:standard_charge)).to be_valid
+    end
+
+    context 'when charge is instant' do
+      it 'returns an error' do
+        charge = build(:standard_charge, :instant, min_amount_cents: 1200)
+
+        aggregate_failures do
+          expect(charge).not_to be_valid
+          expect(charge.errors.messages[:min_amount_cents]).to include('not_compatible_with_instant')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-minimum-fees

## Context

We want to allow users to set spendings minimum on usage-based charges.

## Description

The goal of this PR is to add `min_amount_cents` to `Charge`.
