### PR TITLE
misc(db): Add 'prepared_statements' for production DB config

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -22,4 +22,3 @@ production:
   url: <%= ENV['DATABASE_URL'] %>
   pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
   prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
-


### PR DESCRIPTION
## Context

When Lago was used with pgBouncer, it was throwing the 'DuplicatePstatement' error in the API. An ENV variable has been added for pgBouncer users to manage the 'prepared_statements' value.

## Description

Usage for pgBouncer users: 
`DATABASE_PREPARED_STATEMENTS=false`

Error log
```
07e55bad388d01ef091def30876b72cf] app/services/users_service.rb:5:in `login'
[07e55bad388d01ef091def30876b72cf] app/graphql/mutations/login_user.rb:14:in `resolve'
I, [2023-04-11T12:49:07.989083 #12]  INFO -- : [cbdccd60cc732f43b9ac6613f6be5709] {"method":"POST","path":"/graphql","format":"*/*","controller":"GraphqlController","action":"execute","status":500,"duration":170.16,"view":0.0,"db":28.64,"ddsource":"ruby","params":{"operationName":"customers","variables":{"limit":20},"query":"query customers($page: Int, $limit: Int, $searchTerm: String) {\n  customers(page: $page, limit: $limit, searchTerm: $searchTerm) {\n    metadata {\n      currentPage\n      totalPages\n      __typename\n    }\n    collection {\n      ...CustomerItem\n      __typename\n    }\n    __typename\n  }\n}\n\nfragment CustomerItem on Customer {\n  id\n  name\n  externalId\n  createdAt\n  activeSubscriptionCount\n  ...AddCustomerDrawer\n  __typename\n}\n\nfragment AddCustomerDrawer on Customer {\n  id\n  addressLine1\n  addressLine2\n  applicableTimezone\n  canEditAttributes\n  city\n  country\n  currency\n  email\n  externalId\n  legalName\n  legalNumber\n  name\n  paymentProvider\n  phone\n  state\n  timezone\n  zipcode\n  url\n  providerCustomer {\n    id\n    providerCustomerId\n    syncWithProvider\n    __typename\n  }\n  metadata {\n    id\n    key\n    value\n    displayInInvoice\n    __typename\n  }\n  __typename\n}"},"sql_queries":"'User Load (6.27) SELECT \"users\".* FROM \"users\" WHERE \"users\".\"id\" = $1 LIMIT $2\nOrganization Load (3.34) SELECT \"organizations\".* FROM \"organizations\" INNER JOIN \"memberships\" ON \"organizations\".\"id\" = \"memberships\".\"organization_id\" WHERE \"memberships\".\"user_id\" = $1 AND \"organizations\".\"id\" = $2 LIMIT $3\nMembership Load (2.64) SELECT \"memberships\".* FROM \"memberships\" WHERE \"memberships\".\"organization_id\" = $1 AND \"memberships\".\"user_id\" = $2 LIMIT $3\nOrganization Exists? (16.4) SELECT 1 AS one FROM \"organizations\" INNER JOIN \"memberships\" ON \"organizations\".\"id\" = \"memberships\".\"organization_id\" WHERE \"memberships\".\"user_id\" = $1 AND \"organizations\".\"id\" = $2 LIMIT $3'","sql_queries_count":4}
F, [2023-04-11T12:49:07.993679 #12] FATAL -- : [cbdccd60cc732f43b9ac6613f6be5709]   
[cbdccd60cc732f43b9ac6613f6be5709] ActiveRecord::StatementInvalid (PG::DuplicatePstatement: ERROR:  prepared statement "a11" already exists
):
[cbdccd60cc732f43b9ac6613f6be5709]   
[cbdccd60cc732f43b9ac6613f6be5709] activerecord (7.0.4) lib/active_record/connection_adapters/postgresql_adapter.rb:837:in `prepare'
[cbdccd60cc732f43b9ac6613f6be5709] activerecord (7.0.4) lib/active_record/connection_adapters/postgresql_adapter.rb:837:in `block in prepare_statement'
[cbdccd60cc732f43b9ac6613f6be5709] activesupport (7.0.4) lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
[cbdccd60cc732f43b9ac6613f6be5709] activesupport (7.0.4) lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
[cbdccd60cc732f43b9ac6613f6be5709] activesupport (7.0.4) lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
[cbdccd60cc732f43b9ac6613f6be5709] activesupport (7.0.4) lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
[cbdccd60cc732f43b9ac6613f6be5709] activerecord (7.0.4) lib/active_record/connection_adapters/postgresql_adapter.rb:832:in `prepare_statement'
[cbdccd60cc732f43b9ac6613f6be5709] activerecord (7.0.4) lib/active_record/connection_adapters/postgresql_adapter.rb:778:in `exec_cache'
[cb
```
