### PR TITLE
feat(billable_metric): allow to filter by aggregation_type

### DIFF
--- a/app/graphql/resolvers/billable_metrics_resolver.rb
+++ b/app/graphql/resolvers/billable_metrics_resolver.rb
@@ -12,9 +12,11 @@ module Resolvers
     argument :limit, Integer, required: false
     argument :search_term, String, required: false
 
+    argument :aggregation_types, [Types::BillableMetrics::AggregationTypeEnum], required: false
+
     type Types::BillableMetrics::Object.collection_type, null: false
 
-    def resolve(ids: nil, page: nil, limit: nil, search_term: nil)
+    def resolve(ids: nil, page: nil, limit: nil, search_term: nil, aggregation_types: nil)
       validate_organization!
 
       query = ::BillableMetricsQuery.new(organization: current_organization)
@@ -24,6 +26,7 @@ module Resolvers
         limit:,
         filters: {
           ids:,
+          aggregation_types:,
         },
       )
 

--- a/app/queries/billable_metrics_query.rb
+++ b/app/queries/billable_metrics_query.rb
@@ -6,6 +6,7 @@ class BillableMetricsQuery < BaseQuery
 
     metrics = base_scope.result
     metrics = metrics.where(id: filters[:ids]) if filters[:ids].present?
+    metrics = metrics.where(aggregation_type: filters[:aggregation_types]) if filters[:aggregation_types].present?
     metrics = metrics.order(created_at: :desc).page(page).per(limit)
 
     result.billable_metrics = metrics

--- a/schema.graphql
+++ b/schema.graphql
@@ -3788,6 +3788,8 @@ type Query {
   Query billable metrics of an organization
   """
   billableMetrics(
+    aggregationTypes: [AggregationTypeEnum!]
+
     """
     List of plan ID to fetch
     """

--- a/schema.json
+++ b/schema.json
@@ -15134,6 +15134,26 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "aggregationTypes",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "AggregationTypeEnum",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },

--- a/spec/queries/billable_metrics_query_spec.rb
+++ b/spec/queries/billable_metrics_query_spec.rb
@@ -12,11 +12,13 @@ RSpec.describe BillableMetricsQuery, type: :query do
   let(:billable_metric_first) { create(:billable_metric, organization:, name: 'defgh', code: '11') }
   let(:billable_metric_second) { create(:billable_metric, organization:, name: 'abcde', code: '22') }
   let(:billable_metric_third) { create(:billable_metric, organization:, name: 'presuv', code: '33') }
+  let(:billable_metric_fourth) { create(:recurring_billable_metric, organization:, name: 'qwerty', code: '44') }
 
   before do
     billable_metric_first
     billable_metric_second
     billable_metric_third
+    billable_metric_fourth
   end
 
   it 'returns all billable metrics' do
@@ -29,10 +31,80 @@ RSpec.describe BillableMetricsQuery, type: :query do
     returned_ids = result.billable_metrics.pluck(:id)
 
     aggregate_failures do
-      expect(result.billable_metrics.count).to eq(3)
+      expect(result.billable_metrics.count).to eq(4)
       expect(returned_ids).to include(billable_metric_first.id)
       expect(returned_ids).to include(billable_metric_second.id)
       expect(returned_ids).to include(billable_metric_third.id)
+      expect(returned_ids).to include(billable_metric_fourth.id)
+    end
+  end
+
+  context 'when searching for count_agg aggregation type' do
+    it 'returns 3 billable metrics' do
+      result = billable_metric_query.call(
+        search_term: nil,
+        page: 1,
+        limit: 10,
+        filters: {
+          aggregation_types: ['count_agg'],
+        },
+      )
+
+      returned_ids = result.billable_metrics.pluck(:id)
+
+      aggregate_failures do
+        expect(result.billable_metrics.count).to eq(3)
+        expect(returned_ids).to include(billable_metric_first.id)
+        expect(returned_ids).to include(billable_metric_second.id)
+        expect(returned_ids).to include(billable_metric_third.id)
+        expect(returned_ids).not_to include(billable_metric_fourth.id)
+      end
+    end
+  end
+
+  context 'when searching for recurring_count_agg aggregation type' do
+    it 'returns 1 billable metrics' do
+      result = billable_metric_query.call(
+        search_term: nil,
+        page: 1,
+        limit: 10,
+        filters: {
+          aggregation_types: ['recurring_count_agg'],
+        },
+      )
+
+      returned_ids = result.billable_metrics.pluck(:id)
+
+      aggregate_failures do
+        expect(result.billable_metrics.count).to eq(1)
+        expect(returned_ids).not_to include(billable_metric_first.id)
+        expect(returned_ids).not_to include(billable_metric_second.id)
+        expect(returned_ids).not_to include(billable_metric_third.id)
+        expect(returned_ids).to include(billable_metric_fourth.id)
+      end
+    end
+  end
+
+  context 'when searching for max_agg aggregation type' do
+    it 'returns 0 billable metrics' do
+      result = billable_metric_query.call(
+        search_term: nil,
+        page: 1,
+        limit: 10,
+        filters: {
+          aggregation_types: ['max_agg'],
+        },
+      )
+
+      returned_ids = result.billable_metrics.pluck(:id)
+
+      aggregate_failures do
+        expect(result.billable_metrics.count).to eq(0)
+        expect(returned_ids).not_to include(billable_metric_first.id)
+        expect(returned_ids).not_to include(billable_metric_second.id)
+        expect(returned_ids).not_to include(billable_metric_third.id)
+        expect(returned_ids).not_to include(billable_metric_fourth.id)
+      end
     end
   end
 


### PR DESCRIPTION
## Context

We're refactoring the plan view on FE side.

It does required to have 2 inputs to search for billable metric. One in the "normal" charge section and one in the Instant charges section.

The instant charge section should only retrieve BM according to their `aggregation_type` value.

## Description

This PR updates the BM query to allow to filter by an array of `aggregation_type`