### PR TITLE
feat(min_charge): Add min_amount_cents to Charge for graphql

### DIFF
--- a/app/graphql/types/charges/input.rb
+++ b/app/graphql/types/charges/input.rb
@@ -9,6 +9,7 @@ module Types
       argument :billable_metric_id, ID, required: true
       argument :charge_model, Types::Charges::ChargeModelEnum, required: true
       argument :instant, Boolean, required: false
+      argument :min_amount_cents, GraphQL::Types::BigInt, required: false
 
       argument :properties, Types::Charges::PropertiesInput, required: false
       argument :group_properties, [Types::Charges::GroupPropertiesInput], required: false

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -9,6 +9,7 @@ module Types
       field :billable_metric, Types::BillableMetrics::Object, null: false
       field :charge_model, Types::Charges::ChargeModelEnum, null: false
       field :instant, Boolean, null: false
+      field :min_amount_cents, GraphQL::Types::BigInt, null: false
       field :properties, Types::Charges::Properties, null: true
       field :group_properties, [Types::Charges::GroupProperties], null: true
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -139,6 +139,7 @@ type Charge {
   groupProperties: [GroupProperties!]
   id: ID!
   instant: Boolean!
+  minAmountCents: BigInt!
   properties: Properties
   updatedAt: ISO8601DateTime!
 }
@@ -149,6 +150,7 @@ input ChargeInput {
   groupProperties: [GroupPropertiesInput!]
   id: ID
   instant: Boolean
+  minAmountCents: BigInt
   properties: PropertiesInput
 }
 

--- a/schema.json
+++ b/schema.json
@@ -1288,6 +1288,24 @@
               ]
             },
             {
+              "name": "minAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "properties",
               "description": null,
               "type": {
@@ -1381,6 +1399,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minAmountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
                 "ofType": null
               },
               "defaultValue": null,


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-minimum-fees

## Context

We want to allow users to set spendings minimum on usage-based charges.

## Description

The goal of this PR is to add `min_amount_cents` into Charge for graphql.