### PR TITLE
feat(min_charge): Add service to create the true-up fee

### DIFF
--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -44,13 +44,13 @@ module Fees
       else
         charge.group_properties.each do |group_properties|
           group = billable_metric.selectable_groups.find_by(id: group_properties.group_id)
-          init_fee(properties: group_properties.values, group: group)
+          init_fee(properties: group_properties.values, group:)
         end
       end
     end
 
     def init_fee(properties:, group: nil)
-      amount_result = compute_amount(properties: properties, group: group)
+      amount_result = compute_amount(properties:, group:)
       return result.fail_with_error!(amount_result.error) unless amount_result.success?
 
       # NOTE: amount_result should be a BigDecimal, we need to round it
@@ -60,10 +60,10 @@ module Fees
       amount_cents = rounded_amount * currency.subunit_to_unit
 
       new_fee = Fee.new(
-        invoice: invoice,
-        subscription: subscription,
-        charge: charge,
-        amount_cents: amount_cents,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents:,
         amount_currency: currency,
         vat_rate: customer.applicable_vat_rate,
         fee_type: :charge,
@@ -81,12 +81,12 @@ module Fees
     end
 
     def init_true_up_fee(fee:)
-      true_up_fee = Fees::CreateTrueUpService.call(fee: fee).true_up_fee
+      true_up_fee = Fees::CreateTrueUpService.call(fee:).true_up_fee
       result.fees << true_up_fee if true_up_fee
     end
 
     def compute_amount(properties:, group: nil)
-      aggregation_result = aggregator(group: group).aggregate(
+      aggregation_result = aggregator(group:).aggregate(
         from_datetime: boundaries.charges_from_datetime,
         to_datetime: boundaries.charges_to_datetime,
         options: options(properties),
@@ -129,11 +129,7 @@ module Fees
                              raise(NotImplementedError)
       end
 
-      @aggregator = aggregator_service.new(
-        billable_metric: billable_metric,
-        subscription: subscription,
-        group: group,
-      )
+      @aggregator = aggregator_service.new(billable_metric:, subscription:, group:)
     end
 
     def apply_charge_model_service(aggregation_result, properties)
@@ -152,11 +148,7 @@ module Fees
                         raise(NotImplementedError)
       end
 
-      model_service.apply(
-        charge: charge,
-        aggregation_result: aggregation_result,
-        properties: properties,
-      )
+      model_service.apply(charge:, aggregation_result:, properties:)
     end
   end
 end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -14,6 +14,7 @@ module Fees
       return result if already_billed?
 
       init_fees
+      init_true_up_fee(fee: result.fees.first)
       return result unless result.success?
 
       result.fees.each(&:save!)
@@ -46,8 +47,6 @@ module Fees
           init_fee(properties: group_properties.values, group: group)
         end
       end
-
-      init_true_up_fee(fee: result.fees.first)
     end
 
     def init_fee(properties:, group: nil)

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Fees
+  class CreateTrueUpService < BaseService
+    def initialize(fee:)
+      @fee = fee
+      super
+    end
+
+    def call
+      return result unless fee
+      return result if fee.amount_cents >= charge.min_amount_cents
+
+      true_up_fee = fee.dup.tap do |f|
+        f.amount_cents = charge.min_amount_cents - fee.amount_cents
+        f.units = 1
+        f.events_count = 0
+        f.group_id = nil
+      end
+      true_up_fee.compute_vat
+
+      result.true_up_fee = true_up_fee
+      result
+    end
+
+    private
+
+    attr_reader :fee
+
+    delegate :charge, to: :fee
+  end
+end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Fees::ChargeService do
   subject(:charge_subscription_service) do
-    described_class.new(invoice: invoice, charge: charge, subscription: subscription, boundaries: boundaries)
+    described_class.new(invoice:, charge:, subscription:, boundaries:)
   end
 
   let(:subscription) do
@@ -33,7 +33,7 @@ RSpec.describe Fees::ChargeService do
     create(
       :standard_charge,
       plan: subscription.plan,
-      billable_metric: billable_metric,
+      billable_metric:,
       properties: {
         amount: '20',
         amount_currency: 'EUR',
@@ -68,7 +68,7 @@ RSpec.describe Fees::ChargeService do
             :graduated_charge,
             plan: subscription.plan,
             charge_model: 'graduated',
-            billable_metric: billable_metric,
+            billable_metric:,
             properties: {
               graduated_ranges: [
                 {
@@ -88,7 +88,7 @@ RSpec.describe Fees::ChargeService do
             4,
             organization: subscription.organization,
             customer: subscription.customer,
-            subscription: subscription,
+            subscription:,
             code: charge.billable_metric.code,
             timestamp: DateTime.parse('2022-03-16'),
           )
@@ -114,12 +114,7 @@ RSpec.describe Fees::ChargeService do
 
       context 'when fee already exists on the period' do
         before do
-          create(
-            :fee,
-            charge: charge,
-            subscription: subscription,
-            invoice: invoice,
-          )
+          create(:fee, charge:, subscription:, invoice:)
         end
 
         it 'does not create a new fee' do
@@ -138,7 +133,7 @@ RSpec.describe Fees::ChargeService do
             :event,
             organization: invoice.organization,
             customer: subscription.customer,
-            subscription: subscription,
+            subscription:,
             code: billable_metric.code,
             timestamp: Time.zone.parse('10 Apr 2022 00:01:00'),
           )
@@ -154,7 +149,7 @@ RSpec.describe Fees::ChargeService do
         end
 
         before do
-          subscription.update!(previous_subscription: previous_subscription)
+          subscription.update!(previous_subscription:)
           event
         end
 
@@ -179,10 +174,7 @@ RSpec.describe Fees::ChargeService do
       context 'with all types of aggregation' do
         BillableMetric::AGGREGATION_TYPES.each do |aggregation_type|
           before do
-            billable_metric.update!(
-              aggregation_type: aggregation_type,
-              field_name: 'foo_bar',
-            )
+            billable_metric.update!(aggregation_type:, field_name: 'foo_bar')
           end
 
           it 'creates fees' do
@@ -212,7 +204,7 @@ RSpec.describe Fees::ChargeService do
           aggregate_failures do
             expect(result).to be_success
             expect(result.fees.count).to eq(2)
-            expect(result.fees.pluck(:amount_cents)).to match_array([0, 1000])
+            expect(result.fees.pluck(:amount_cents)).to contain_exactly(0, 1000)
           end
         end
       end
@@ -235,7 +227,7 @@ RSpec.describe Fees::ChargeService do
         create(
           :standard_charge,
           plan: subscription.plan,
-          billable_metric: billable_metric,
+          billable_metric:,
           group_properties: [
             build(
               :group_property,
@@ -270,7 +262,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'usa', foo_bar: 12 },
@@ -279,7 +271,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'europe', foo_bar: 10 },
@@ -288,7 +280,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'europe', foo_bar: 5 },
@@ -297,7 +289,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { country: 'france', foo_bar: 5 },
@@ -463,7 +455,7 @@ RSpec.describe Fees::ChargeService do
         create(
           :persisted_event,
           customer: subscription.customer,
-          billable_metric: billable_metric,
+          billable_metric:,
           external_subscription_id: subscription.external_id,
           external_id: 'ext_11',
           added_at: subscription.started_at - 1.day,
@@ -477,7 +469,7 @@ RSpec.describe Fees::ChargeService do
         create(
           :persisted_event,
           customer: subscription.customer,
-          billable_metric: billable_metric,
+          billable_metric:,
           external_subscription_id: subscription.external_id,
           external_id: 'ext_12',
           added_at: subscription.started_at - 1.day,
@@ -491,7 +483,7 @@ RSpec.describe Fees::ChargeService do
         create(
           :persisted_event,
           customer: subscription.customer,
-          billable_metric: billable_metric,
+          billable_metric:,
           external_subscription_id: subscription.external_id,
           external_id: 'ext_13',
           added_at: subscription.started_at - 1.day,
@@ -504,12 +496,7 @@ RSpec.describe Fees::ChargeService do
         )
 
         billable_metric.update!(aggregation_type: :recurring_count_agg, field_name: 'foo_bar')
-        result = described_class.new(
-          invoice: invoice,
-          charge: charge,
-          subscription: subscription,
-          boundaries: boundaries,
-        ).create
+        result = described_class.new(invoice:, charge:, subscription:, boundaries:).create
         expect(result).to be_success
         created_fees = result.fees
 
@@ -562,7 +549,7 @@ RSpec.describe Fees::ChargeService do
         create(
           :package_charge,
           plan: subscription.plan,
-          billable_metric: billable_metric,
+          billable_metric:,
           group_properties: [
             build(
               :group_property,
@@ -600,7 +587,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'usa', foo_bar: 12 },
@@ -609,7 +596,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'europe', foo_bar: 10 },
@@ -618,7 +605,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'europe', foo_bar: 5 },
@@ -627,7 +614,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { country: 'france', foo_bar: 5 },
@@ -689,7 +676,7 @@ RSpec.describe Fees::ChargeService do
         create(
           :percentage_charge,
           plan: subscription.plan,
-          billable_metric: billable_metric,
+          billable_metric:,
           group_properties: [
             build(
               :group_property,
@@ -715,7 +702,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'usa', foo_bar: 12 },
@@ -724,7 +711,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'europe', foo_bar: 10 },
@@ -733,7 +720,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'europe', foo_bar: 5 },
@@ -742,7 +729,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { country: 'france', foo_bar: 5 },
@@ -800,7 +787,7 @@ RSpec.describe Fees::ChargeService do
         create(
           :graduated_charge,
           plan: subscription.plan,
-          billable_metric: billable_metric,
+          billable_metric:,
           group_properties: [
             build(
               :group_property,
@@ -839,7 +826,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'usa', foo_bar: 12 },
@@ -848,7 +835,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'europe', foo_bar: 10 },
@@ -857,7 +844,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'europe', foo_bar: 5 },
@@ -909,7 +896,7 @@ RSpec.describe Fees::ChargeService do
         create(
           :volume_charge,
           plan: subscription.plan,
-          billable_metric: billable_metric,
+          billable_metric:,
           group_properties: [
             build(
               :group_property,
@@ -938,7 +925,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'usa', foo_bar: 12 },
@@ -947,7 +934,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'europe', foo_bar: 10 },
@@ -956,7 +943,7 @@ RSpec.describe Fees::ChargeService do
           :event,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
           properties: { region: 'europe', foo_bar: 5 },
@@ -1008,7 +995,7 @@ RSpec.describe Fees::ChargeService do
         create(
           :standard_charge,
           plan: subscription.plan,
-          billable_metric: billable_metric,
+          billable_metric:,
           min_amount_cents: 1000,
           group_properties: [
             build(
@@ -1037,7 +1024,7 @@ RSpec.describe Fees::ChargeService do
         aggregate_failures do
           expect(result).to be_success
           expect(result.fees.count).to eq(3)
-          expect(result.fees.pluck(:amount_cents)).to match_array([0, 0, 1000])
+          expect(result.fees.pluck(:amount_cents)).to contain_exactly(0, 0, 1000)
         end
       end
     end
@@ -1078,10 +1065,7 @@ RSpec.describe Fees::ChargeService do
     context 'with all types of aggregation' do
       BillableMetric::AGGREGATION_TYPES.each do |aggregation_type|
         before do
-          billable_metric.update!(
-            aggregation_type: aggregation_type,
-            field_name: 'foo_bar',
-          )
+          billable_metric.update!(aggregation_type:, field_name: 'foo_bar')
 
           charge.update!(min_amount_cents: 1000)
         end
@@ -1114,7 +1098,7 @@ RSpec.describe Fees::ChargeService do
           :graduated_charge,
           plan: subscription.plan,
           charge_model: 'graduated',
-          billable_metric: billable_metric,
+          billable_metric:,
           properties: {
             graduated_ranges: [
               {
@@ -1134,7 +1118,7 @@ RSpec.describe Fees::ChargeService do
           4,
           organization: subscription.organization,
           customer: subscription.customer,
-          subscription: subscription,
+          subscription:,
           code: charge.billable_metric.code,
           timestamp: DateTime.parse('2022-03-16'),
         )

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -1082,6 +1082,8 @@ RSpec.describe Fees::ChargeService do
             aggregation_type: aggregation_type,
             field_name: 'foo_bar',
           )
+
+          charge.update!(min_amount_cents: 1000)
         end
 
         it 'initializes fees' do
@@ -1092,6 +1094,7 @@ RSpec.describe Fees::ChargeService do
           usage_fee = result.fees.first
 
           aggregate_failures do
+            expect(result.fees.count).to eq(1)
             expect(usage_fee.id).to be_nil
             expect(usage_fee.invoice_id).to eq(invoice.id)
             expect(usage_fee.charge_id).to eq(charge.id)

--- a/spec/services/fees/create_true_up_service_spec.rb
+++ b/spec/services/fees/create_true_up_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Fees::CreateTrueUpService, type: :service do
   subject(:create_service) { described_class.new(fee:) }
 
   let(:charge) { create(:standard_charge, min_amount_cents: 1000) }
-  let(:fee) { create(:charge_fee, amount_cents: 700, charge: charge) }
+  let(:fee) { create(:charge_fee, amount_cents: 700, charge:) }
 
   describe '#call' do
     context 'when fee is nil' do

--- a/spec/services/fees/create_true_up_service_spec.rb
+++ b/spec/services/fees/create_true_up_service_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fees::CreateTrueUpService, type: :service do
+  subject(:create_service) { described_class.new(fee:) }
+
+  let(:charge) { create(:standard_charge, min_amount_cents: 1000) }
+  let(:fee) { create(:charge_fee, amount_cents: 700, charge: charge) }
+
+  describe '#call' do
+    context 'when fee is nil' do
+      let(:fee) { nil }
+
+      it 'does not instantiate a true-up fee' do
+        result = create_service.call
+        expect(result.true_up_fee).to be_nil
+      end
+    end
+
+    context 'when min_amount_cents is lower than the fee amount_cents' do
+      let(:fee) { create(:charge_fee, amount_cents: 1500) }
+
+      it 'does not instantiate a true-up fee' do
+        result = create_service.call
+        expect(result.true_up_fee).to be_nil
+      end
+    end
+
+    it 'instantiates a true-up fee' do
+      result = create_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+
+        expect(result.true_up_fee).to have_attributes(
+          subscription: fee.subscription,
+          charge: fee.charge,
+          amount_currency: fee.currency,
+          vat_rate: fee.vat_rate,
+          fee_type: 'charge',
+          invoiceable: fee.charge,
+          properties: fee.properties,
+          payment_status: 'pending',
+          units: 1,
+          events_count: 0,
+          group: nil,
+          amount_cents: 300,
+          vat_amount_cents: 0,
+          vat_amount_currency: fee.currency,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-minimum-fees

## Context

We want to allow users to set spendings minimum on usage-based charges.

## Description

The goal of this PR is to add a service for creating the true-up fee.