### PR TITLE
fix(instant_charge): event properties might be nil

### DIFF
--- a/app/services/events/validate_creation_service.rb
+++ b/app/services/events/validate_creation_service.rb
@@ -86,7 +86,7 @@ module Events
     def valid_properties?
       return true unless billable_metric.max_agg? || billable_metric.sum_agg?
 
-      valid_number?(params[:properties][billable_metric.field_name.to_sym])
+      valid_number?((params[:properties] || {})[billable_metric.field_name.to_sym])
     end
 
     def valid_number?(value)

--- a/spec/services/events/validate_creation_service_spec.rb
+++ b/spec/services/events/validate_creation_service_spec.rb
@@ -223,6 +223,21 @@ RSpec.describe Events::ValidateCreationService, type: :service do
             expect(result).to be_success
           end
         end
+
+        context 'when properties are missing' do
+          let(:params) do
+            {
+              code: billable_metric.code,
+              external_customer_id: customer.external_id,
+            }
+          end
+
+          it 'does not raise error' do
+            validate_event
+
+            expect(result).to be_success
+          end
+        end
       end
 
       context 'when event belongs to a recurring persisted event' do


### PR DESCRIPTION
## Context

The event validation is failing if the property field is missing while the billable metric is expecting a property. 

## Description

This PR fixes this by handling the missing property field. The event will be ignored by the aggregation process, but will be flagged in the debugger as it will be if the aggregation property is not a valid numeric value. 
