### PR TITLE
feat(coupon): Replace legacy with version_number on invoices

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -5,6 +5,8 @@ class Invoice < ApplicationRecord
   include Sequenced
   include RansackUuidSearch
 
+  CURRENT_VERSION = 2
+
   before_save :ensure_number
 
   belongs_to :customer, -> { with_discarded }
@@ -169,6 +171,11 @@ class Invoice < ApplicationRecord
     amount = creditable_amount_cents - credits.sum(:amount_cents) - wallet_transaction_amount_cents
     amount.negative? ? 0 : amount
   end
+
+  def legacy
+    version_number < CURRENT_VERSION
+  end
+  alias legacy? legacy
 
   private
 

--- a/db/migrate/20230414074225_add_version_to_invoices.rb
+++ b/db/migrate/20230414074225_add_version_to_invoices.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AddVersionToInvoices < ActiveRecord::Migration[7.0]
+  def up
+    add_column :invoices, :version_number, :integer, null: false, default: 2
+
+    execute <<-SQL
+      UPDATE invoices
+      SET version_number = 1
+      WHERE legacy = 't'
+    SQL
+
+    remove_column :invoices, :legacy
+  end
+
+  def down
+    add_column :invoices, :legacy, :boolean, null: false, default: false
+
+    execute <<-SQL
+      UPDATE invoices
+      SET legacy = 't'
+      WHERE version_number = 1
+    SQL
+
+    remove_column :invoices, :version_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_11_085545) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_14_074225) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -391,7 +391,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_11_085545) do
     t.integer "sequential_id"
     t.string "file"
     t.uuid "customer_id"
-    t.boolean "legacy", default: false, null: false
     t.float "vat_rate", default: 0.0, null: false
     t.bigint "credit_amount_cents", default: 0, null: false
     t.string "credit_amount_currency"
@@ -400,6 +399,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_11_085545) do
     t.integer "payment_attempts", default: 0, null: false
     t.boolean "ready_for_payment_processing", default: true, null: false
     t.uuid "organization_id", null: false
+    t.integer "version_number", default: 2, null: false
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
   end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Invoice, type: :model do
   describe '#creditable_amount_cents' do
     context 'when legacy' do
       it 'returns 0' do
-        invoice = build(:invoice, legacy: true)
+        invoice = build(:invoice, version_number: 1)
         expect(invoice.creditable_amount_cents).to eq(0)
       end
     end

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -320,7 +320,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
               total_amount_cents: 24,
               payment_status: :succeeded,
               vat_rate: 20,
-              legacy: true,
+              version_number: 1,
             )
           end
 


### PR DESCRIPTION
## Context

Future changes will impact the way coupons are applied to invoices (moved before VAT computation rather than before).
Since already invoices created with the current implementation will still have to be generated or impacted by credit notes, we need a way to quickly identify which logic was applied when creating the invoice.

## Description

This PR turn the current `legacy` field of invoice into a `version_number`. It will default to 2 for now, and will be changed to 3 with the coming changes on coupons.

A next PR will remove the `legacy` and `legacy?` methods to use the versioning logic when applying credit notes and when generating PDFs