### PR TITLE
feat(invoice): Add new fees_amount_cents to invoice

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -42,13 +42,16 @@ module Types
       field :wallet_transaction_amount_cents, GraphQL::Types::BigInt, null: false
       field :subtotal_before_prepaid_credits, String, null: false
 
-      field :sub_total_vat_excluded_amount_cents, GraphQL::Types::BigInt, null: false
+      field :fees_amount_cents, GraphQL::Types::BigInt, null: false
       field :sub_total_vat_included_amount_cents, GraphQL::Types::BigInt, null: false
       field :coupon_total_amount_cents, GraphQL::Types::BigInt, null: false
       field :credit_note_total_amount_cents, GraphQL::Types::BigInt, null: false
 
       field :refundable_amount_cents, GraphQL::Types::BigInt, null: false
       field :creditable_amount_cents, GraphQL::Types::BigInt, null: false
+
+      # NOTE(legacy): Remove with coupon before VAT refactor
+      field :sub_total_vat_excluded_amount_cents, GraphQL::Types::BigInt, null: false, method: :fees_amount_cents
     end
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -25,12 +25,12 @@ class Invoice < ApplicationRecord
   has_one_attached :file
 
   monetize :amount_cents
+  monetize :fees_amount_cents, with_model_currency: :amount_currency
   monetize :vat_amount_cents
   monetize :credit_amount_cents
   monetize :total_amount_cents
 
   # NOTE: Readonly fields
-  monetize :sub_total_vat_excluded_amount_cents, disable_validation: true, allow_nil: true
   monetize :sub_total_vat_included_amount_cents, disable_validation: true, allow_nil: true
   monetize :coupon_total_amount_cents, disable_validation: true, allow_nil: true
   monetize :credit_note_total_amount_cents, disable_validation: true, allow_nil: true
@@ -85,13 +85,8 @@ class Invoice < ApplicationRecord
     amount_currency
   end
 
-  def sub_total_vat_excluded_amount_cents
-    fees.sum(:amount_cents)
-  end
-  alias sub_total_vat_excluded_amount_currency currency
-
   def sub_total_vat_included_amount_cents
-    sub_total_vat_excluded_amount_cents + vat_amount_cents
+    fees_amount_cents + vat_amount_cents
   end
   alias sub_total_vat_included_amount_currency currency
 

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -11,6 +11,7 @@ module V1
         invoice_type: model.invoice_type,
         status: model.status,
         payment_status: model.payment_status,
+        fees_amount_cents: model.fees_amount_cents,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,
         vat_amount_cents: model.vat_amount_cents,

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -57,9 +57,8 @@ module Invoices
       fee_amounts = invoice.fees.select(:amount_cents, :vat_amount_cents)
 
       invoice.amount_cents = fee_amounts.sum(&:amount_cents)
-      invoice.amount_currency = applied_add_on.amount_currency
+      invoice.fees_amount_cents = invoice.amount_cents
       invoice.vat_amount_cents = fee_amounts.sum(&:vat_amount_cents)
-      invoice.vat_amount_currency = applied_add_on.amount_currency
     end
 
     def create_add_on_fee(invoice)

--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -9,6 +9,7 @@ module Invoices
 
     def call
       invoice.amount_cents = invoice.fees.sum(:amount_cents)
+      invoice.fees_amount_cents = invoice.amount_cents
       invoice.vat_amount_cents = invoice.fees.sum { |f| f.amount_cents * f.vat_rate }.fdiv(100).round
       invoice.credit_amount_cents = 0 if invoice.credits.empty?
       invoice.total_amount_cents = invoice.amount_cents + invoice.vat_amount_cents - invoice.credit_amount_cents

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -61,9 +61,8 @@ module Invoices
       fee_amounts = invoice.fees.select(:amount_cents, :vat_amount_cents)
 
       invoice.amount_cents = fee_amounts.sum(:amount_cents)
-      invoice.amount_currency = currency
+      invoice.fees_amount_cents = invoice.amount_cents
       invoice.vat_amount_cents = fee_amounts.sum(:vat_amount_cents)
-      invoice.vat_amount_currency = currency
     end
 
     def create_credit_fee(invoice)

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -486,7 +486,7 @@ html
             - unless credit?
               tr
                 td.body-2 width="70%" = I18n.t('invoice.sub_total_without_tax')
-                td.body-2 width="30%" = sub_total_vat_excluded_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+                td.body-2 width="30%" = fees_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
               tr
                 td.body-2 #{I18n.t('invoice.tax')} (#{vat_rate || 0}%)
                 td.body-2 = vat_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))

--- a/db/migrate/20230417094339_add_fees_amount_cents_to_invoices.rb
+++ b/db/migrate/20230417094339_add_fees_amount_cents_to_invoices.rb
@@ -1,0 +1,23 @@
+# frozen_String_literal: true
+
+class AddFeesAmountCentsToInvoices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invoices, :fees_amount_cents, :bigint, null: false, default: 0
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          WITH fees_total AS (
+            SELECT fees.invoice_id, sum(fees.amount_cents) AS fees_amount_cents
+            FROM fees
+            GROUP BY fees.invoice_id
+          )
+          UPDATE invoices
+          SET fees_amount_cents = fees_total.fees_amount_cents
+          FROM fees_total
+          WHERE invoices.id = fees_total.invoice_id
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_14_074225) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_17_094339) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -400,6 +400,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_14_074225) do
     t.boolean "ready_for_payment_processing", default: true, null: false
     t.uuid "organization_id", null: false
     t.integer "version_number", default: 2, null: false
+    t.bigint "fees_amount_cents", default: 0, null: false
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2960,6 +2960,7 @@ type Invoice {
   creditableAmountCents: BigInt!
   customer: Customer!
   fees: [Fee!]
+  feesAmountCents: BigInt!
   fileUrl: String
   id: ID!
   invoiceSubscriptions: [InvoiceSubscription!]

--- a/schema.json
+++ b/schema.json
@@ -10712,6 +10712,24 @@
               ]
             },
             {
+              "name": "feesAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "fileUrl",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
         invoice(id: $id) {
           id
           number
+          feesAmountCents
           refundableAmountCents
           creditableAmountCents
           paymentStatus

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -84,28 +84,13 @@ RSpec.describe Invoice, type: :model do
     it { expect(invoice.currency).to eq('JPY') }
   end
 
-  describe '#sub_total_vat_excluded_amount' do
-    let(:organization) { create(:organization, name: 'LAGO') }
-    let(:customer) { create(:customer, organization:) }
-    let(:subscription) { create(:subscription, organization:, customer:) }
-    let(:invoice) { create(:invoice, customer:, amount_currency: 'EUR', organization:) }
-    let(:fees) { create_list(:fee, 3, invoice:, amount_cents: 300) }
-
-    before { fees }
-
-    it 'returns the sub total amount without VAT' do
-      expect(invoice.sub_total_vat_excluded_amount.to_s).to eq('9.00')
-    end
-  end
-
   describe '#sub_total_vat_included_amount' do
     let(:organization) { create(:organization, name: 'LAGO') }
     let(:customer) { create(:customer, organization:, vat_rate: 20) }
     let(:subscription) { create(:subscription, organization:, customer:) }
-    let(:invoice) { create(:invoice, customer:, amount_currency: 'EUR', vat_amount_cents: 180, organization:) }
-    let(:fees) { create_list(:fee, 3, invoice:, amount_cents: 300) }
-
-    before { fees }
+    let(:invoice) do
+      create(:invoice, customer:, amount_currency: 'EUR', fees_amount_cents: 900, vat_amount_cents: 180, organization:)
+    end
 
     it 'returns the sub total amount with VAT' do
       expect(invoice.sub_total_vat_included_amount.to_s).to eq('10.80')

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ::V1::InvoiceSerializer do
       expect(result['invoice']['invoice_type']).to eq(invoice.invoice_type)
       expect(result['invoice']['status']).to eq(invoice.status)
       expect(result['invoice']['payment_status']).to eq(invoice.payment_status)
+      expect(result['invoice']['fees_amount_cents']).to eq(invoice.fees_amount_cents)
       expect(result['invoice']['amount_cents']).to eq(invoice.amount_cents)
       expect(result['invoice']['amount_currency']).to eq(invoice.amount_currency)
       expect(result['invoice']['vat_amount_cents']).to eq(invoice.vat_amount_cents)

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Invoices::AddOnService, type: :service do
         expect(result.invoice.invoice_type).to eq('add_on')
         expect(result.invoice.payment_status).to eq('pending')
 
+        expect(result.invoice.fees_amount_cents).to eq(200)
         expect(result.invoice.amount_cents).to eq(200)
         expect(result.invoice.amount_currency).to eq('EUR')
         expect(result.invoice.vat_amount_cents).to eq(40)

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Invoices::ComputeAmountsFromFees, type: :service do
     expect { compute_amounts.call }.to change(invoice, :amount_cents).from(0).to(530)
   end
 
+  it 'sets fees_amount_cents from the list of fees' do
+    expect { compute_amounts.call }.to change(invoice, :fees_amount_cents).from(0).to(530)
+  end
+
   it 'sets vat_amount_cents from the list of fees' do
     expect { compute_amounts.call }.to change(invoice, :vat_amount_cents).from(0).to(91)
   end

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
         expect(result.invoice.invoice_type).to eq('credit')
         expect(result.invoice.payment_status).to eq('pending')
 
+        expect(result.invoice.fees_amount_cents).to eq(1500)
         expect(result.invoice.amount_cents).to eq(1500)
         expect(result.invoice.amount_currency).to eq('EUR')
         expect(result.invoice.vat_amount_cents).to eq(0)


### PR DESCRIPTION
## Context

Future changes will impact the way coupons are applied to invoices (moved before VAT computation rather than before).
In order to make this change easier, we need to improve the way we store amounts and currency on invoice.

## Description

This PR adds a new `fees_amount_cents` column to the `invoices` table. It will store the sum of fees amount without VAT.

It will later replace the `amount_cents` column
