### PR TITLE
feat(invoice): Add new coupons_amount_cents to invoice

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -39,10 +39,10 @@ module Types
       field :fees, [Types::Fees::Object], null: true
       field :credit_notes, [Types::CreditNotes::Object], null: true
 
+      field :coupons_amount_cents, GraphQL::Types::BigInt, null: false
       field :wallet_transaction_amount_cents, GraphQL::Types::BigInt, null: false
       field :subtotal_before_prepaid_credits, String, null: false
 
-      field :coupon_total_amount_cents, GraphQL::Types::BigInt, null: false
       field :credit_notes_amount_cents, GraphQL::Types::BigInt, null: false
       field :fees_amount_cents, GraphQL::Types::BigInt, null: false
       field :sub_total_vat_included_amount_cents, GraphQL::Types::BigInt, null: false
@@ -51,6 +51,7 @@ module Types
       field :creditable_amount_cents, GraphQL::Types::BigInt, null: false
 
       # NOTE(legacy): Remove with coupon before VAT refactor
+      field :coupon_total_amount_cents, GraphQL::Types::BigInt, null: false, method: :coupons_amount_cents
       field :credit_note_total_amount_cents, GraphQL::Types::BigInt, null: false, method: :credit_notes_amount_cents
       field :sub_total_vat_excluded_amount_cents, GraphQL::Types::BigInt, null: false, method: :fees_amount_cents
     end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -26,6 +26,7 @@ class Invoice < ApplicationRecord
 
   monetize :amount_cents
   monetize :fees_amount_cents, with_model_currency: :amount_currency
+  monetize :coupons_amount_cents, with_model_currency: :amount_currency
   monetize :vat_amount_cents
   monetize :credit_amount_cents
   monetize :credit_notes_amount_cents, with_model_currency: :amount_currency
@@ -33,7 +34,6 @@ class Invoice < ApplicationRecord
 
   # NOTE: Readonly fields
   monetize :sub_total_vat_included_amount_cents, disable_validation: true, allow_nil: true
-  monetize :coupon_total_amount_cents, disable_validation: true, allow_nil: true
   monetize :charge_amount_cents, disable_validation: true, allow_nil: true
   monetize :subscription_amount_cents, disable_validation: true, allow_nil: true
   monetize :wallet_transaction_amount_cents, disable_validation: true, allow_nil: true
@@ -89,11 +89,6 @@ class Invoice < ApplicationRecord
     fees_amount_cents + vat_amount_cents
   end
   alias sub_total_vat_included_amount_currency currency
-
-  def coupon_total_amount_cents
-    credits.coupon_kind.sum(:amount_cents)
-  end
-  alias coupon_total_amount_currency currency
 
   def charge_amount_cents
     fees.charge_kind.sum(:amount_cents)

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -16,6 +16,7 @@ module V1
         amount_currency: model.amount_currency,
         vat_amount_cents: model.vat_amount_cents,
         vat_amount_currency: model.vat_amount_currency,
+        coupons_amount_cents: model.coupons_amount_cents,
         credit_notes_amount_cents: model.credit_notes_amount_cents,
         credit_amount_cents: model.credit_amount_cents,
         credit_amount_currency: model.credit_amount_currency,

--- a/app/services/credits/applied_coupons_service.rb
+++ b/app/services/credits/applied_coupons_service.rb
@@ -7,7 +7,7 @@ module Credits
       super
     end
 
-    def create
+    def call
       return result if applied_coupons.blank?
 
       applied_coupons.each do |applied_coupon|
@@ -31,6 +31,7 @@ module Credits
         credit_result = Credits::AppliedCouponService.new(invoice:, applied_coupon:, base_amount_cents:).create
         credit_result.raise_if_error!
 
+        invoice.coupons_amount_cents += credit_result.credit.amount_cents
         invoice.credit_amount_cents += credit_result.credit.amount_cents
         invoice.total_amount_cents -= credit_result.credit.amount_cents
       end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -34,7 +34,7 @@ module Invoices
 
         Invoices::ComputeAmountsFromFees.call(invoice:)
         create_credit_note_credit if should_create_credit_note_credit?
-        Credits::AppliedCouponsService.new(invoice:).create if should_create_coupon_credit?
+        Credits::AppliedCouponsService.call(invoice:) if should_create_coupon_credit?
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
 
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
@@ -161,13 +161,6 @@ module Invoices
     def create_credit_note_credit
       credit_result = Credits::CreditNoteService.new(invoice:, credit_notes:).call
       credit_result.raise_if_error!
-
-      refresh_amounts(credit_amount_cents: credit_result.credits.sum(&:amount_cents)) if credit_result.credits
-    end
-
-    def create_applied_coupons_credit
-      credits_result = Credits::AppliedCouponsService.new(invoice:).create
-      credits_result.raise_if_error!
 
       refresh_amounts(credit_amount_cents: credit_result.credits.sum(&:amount_cents)) if credit_result.credits
     end

--- a/db/migrate/20230417122020_add_coupons_amount_cents_to_invoices.rb
+++ b/db/migrate/20230417122020_add_coupons_amount_cents_to_invoices.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddCouponsAmountCentsToInvoices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invoices, :coupons_amount_cents, :bigint, null: false, default: 0
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          WITH coupons_total AS (
+            SELECT credits.invoice_id, sum(credits.amount_cents) AS coupons_amount_cents
+            FROM credits
+            WHERE applied_coupon_id IS NOT NULL
+            GROUP BY credits.invoice_id
+          )
+          UPDATE invoices
+          SET coupons_amount_cents = coupons_total.coupons_amount_cents
+          FROM coupons_total
+          WHERE invoices.id = coupons_total.invoice_id
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -402,6 +402,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_17_131515) do
     t.integer "version_number", default: 2, null: false
     t.bigint "fees_amount_cents", default: 0, null: false
     t.bigint "credit_notes_amount_cents", default: 0, null: false
+    t.bigint "coupons_amount_cents", default: 0, null: false
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2952,6 +2952,7 @@ type Invoice {
   amountCurrency: CurrencyEnum!
   chargeAmountCents: BigInt!
   couponTotalAmountCents: BigInt!
+  couponsAmountCents: BigInt!
   createdAt: ISO8601DateTime!
   creditAmountCents: BigInt!
   creditAmountCurrency: CurrencyEnum!

--- a/schema.json
+++ b/schema.json
@@ -10560,6 +10560,24 @@
               ]
             },
             {
+              "name": "couponsAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "createdAt",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
           id
           number
           feesAmountCents
+          couponsAmountCents
           creditNotesAmountCents
           refundableAmountCents
           creditableAmountCents

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -97,20 +97,6 @@ RSpec.describe Invoice, type: :model do
     end
   end
 
-  describe '#coupon_total_amount' do
-    let(:organization) { create(:organization, name: 'LAGO') }
-    let(:customer) { create(:customer, organization:) }
-    let(:subscription) { create(:subscription, organization:, customer:) }
-    let(:invoice) { create(:invoice, customer:, organization:) }
-    let(:credit) { create(:credit, invoice:) }
-
-    before { credit }
-
-    it 'returns the coupon amount' do
-      expect(invoice.coupon_total_amount.to_s).to eq('2.00')
-    end
-  end
-
   describe '#charge_amount' do
     let(:organization) { create(:organization, name: 'LAGO') }
     let(:customer) { create(:customer, organization:) }

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe ::V1::InvoiceSerializer do
       expect(result['invoice']['amount_currency']).to eq(invoice.amount_currency)
       expect(result['invoice']['vat_amount_cents']).to eq(invoice.vat_amount_cents)
       expect(result['invoice']['vat_amount_currency']).to eq(invoice.vat_amount_currency)
+      expect(result['invoice']['coupons_amount_cents']).to eq(invoice.coupons_amount_cents)
       expect(result['invoice']['credit_notes_amount_cents']).to eq(invoice.credit_notes_amount_cents)
       expect(result['invoice']['credit_amount_cents']).to eq(invoice.credit_amount_cents)
       expect(result['invoice']['credit_amount_currency']).to eq(invoice.credit_amount_currency)

--- a/spec/services/credits/applied_coupons_service_spec.rb
+++ b/spec/services/credits/applied_coupons_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Credits::AppliedCouponsService do
   let(:started_at) { Time.zone.now - 2.years }
   let(:created_at) { started_at }
 
-  describe '#create' do
+  describe '#call' do
     let(:timestamp) { Time.zone.now.beginning_of_month }
     let(:fee) { create(:fee, invoice:, subscription:) }
     let(:applied_coupon) do
@@ -62,10 +62,11 @@ RSpec.describe Credits::AppliedCouponsService do
     end
 
     it 'updates the invoice accordingly' do
-      result = credit_service.create
+      result = credit_service.call
 
       aggregate_failures do
         expect(result).to be_success
+        expect(result.invoice.coupons_amount_cents).to eq(32)
         expect(result.invoice.credit_amount_cents).to eq(32)
         expect(result.invoice.total_amount_cents).to eq(88)
         expect(result.invoice.credits.count).to eq(2)
@@ -86,7 +87,7 @@ RSpec.describe Credits::AppliedCouponsService do
       end
 
       it 'updates the invoice accordingly' do
-        result = credit_service.create
+        result = credit_service.call
 
         aggregate_failures do
           expect(result).to be_success
@@ -110,7 +111,7 @@ RSpec.describe Credits::AppliedCouponsService do
       end
 
       it 'updates the invoice accordingly' do
-        result = credit_service.create
+        result = credit_service.call
 
         aggregate_failures do
           expect(result).to be_success
@@ -135,7 +136,7 @@ RSpec.describe Credits::AppliedCouponsService do
       before { applied_coupon_latest.update!(status: :terminated) }
 
       it 'ignores the coupon' do
-        result = credit_service.create
+        result = credit_service.call
 
         expect(result).to be_success
         expect(result.invoice.credits.count).to be_zero
@@ -173,7 +174,7 @@ RSpec.describe Credits::AppliedCouponsService do
       end
 
       it 'ignores coupons' do
-        result = credit_service.create
+        result = credit_service.call
 
         aggregate_failures do
           expect(result).to be_success
@@ -216,7 +217,7 @@ RSpec.describe Credits::AppliedCouponsService do
       end
 
       it 'ignores only one coupon and applies the other one' do
-        result = credit_service.create
+        result = credit_service.call
 
         aggregate_failures do
           expect(result).to be_success
@@ -257,7 +258,7 @@ RSpec.describe Credits::AppliedCouponsService do
       end
 
       it 'applies two coupons' do
-        result = credit_service.create
+        result = credit_service.call
 
         aggregate_failures do
           expect(result).to be_success
@@ -340,7 +341,7 @@ RSpec.describe Credits::AppliedCouponsService do
       end
 
       it 'applies two coupons' do
-        result = credit_service.create
+        result = credit_service.call
 
         aggregate_failures do
           expect(result).to be_success


### PR DESCRIPTION
## Context

Future changes will impact the way coupons are applied to invoices (moved before VAT computation rather than before).
In order to make this change easier, we need to improve the way we store amounts and currency on invoice.

## Description

This PR adds a new `coupons_amount_cents` column to the `invoices` table. It will store the sum of coupon credit amount.
