### PR TITLE
feat(invoice): Add new credit_notes_amount_cents to invoice

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -42,15 +42,16 @@ module Types
       field :wallet_transaction_amount_cents, GraphQL::Types::BigInt, null: false
       field :subtotal_before_prepaid_credits, String, null: false
 
+      field :coupon_total_amount_cents, GraphQL::Types::BigInt, null: false
+      field :credit_notes_amount_cents, GraphQL::Types::BigInt, null: false
       field :fees_amount_cents, GraphQL::Types::BigInt, null: false
       field :sub_total_vat_included_amount_cents, GraphQL::Types::BigInt, null: false
-      field :coupon_total_amount_cents, GraphQL::Types::BigInt, null: false
-      field :credit_note_total_amount_cents, GraphQL::Types::BigInt, null: false
 
       field :refundable_amount_cents, GraphQL::Types::BigInt, null: false
       field :creditable_amount_cents, GraphQL::Types::BigInt, null: false
 
       # NOTE(legacy): Remove with coupon before VAT refactor
+      field :credit_note_total_amount_cents, GraphQL::Types::BigInt, null: false, method: :credit_notes_amount_cents
       field :sub_total_vat_excluded_amount_cents, GraphQL::Types::BigInt, null: false, method: :fees_amount_cents
     end
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -28,12 +28,12 @@ class Invoice < ApplicationRecord
   monetize :fees_amount_cents, with_model_currency: :amount_currency
   monetize :vat_amount_cents
   monetize :credit_amount_cents
+  monetize :credit_notes_amount_cents, with_model_currency: :amount_currency
   monetize :total_amount_cents
 
   # NOTE: Readonly fields
   monetize :sub_total_vat_included_amount_cents, disable_validation: true, allow_nil: true
   monetize :coupon_total_amount_cents, disable_validation: true, allow_nil: true
-  monetize :credit_note_total_amount_cents, disable_validation: true, allow_nil: true
   monetize :charge_amount_cents, disable_validation: true, allow_nil: true
   monetize :subscription_amount_cents, disable_validation: true, allow_nil: true
   monetize :wallet_transaction_amount_cents, disable_validation: true, allow_nil: true
@@ -94,11 +94,6 @@ class Invoice < ApplicationRecord
     credits.coupon_kind.sum(:amount_cents)
   end
   alias coupon_total_amount_currency currency
-
-  def credit_note_total_amount_cents
-    credits.credit_note_kind.sum(:amount_cents)
-  end
-  alias credit_note_total_amount_currency currency
 
   def charge_amount_cents
     fees.charge_kind.sum(:amount_cents)

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -16,6 +16,7 @@ module V1
         amount_currency: model.amount_currency,
         vat_amount_cents: model.vat_amount_cents,
         vat_amount_currency: model.vat_amount_currency,
+        credit_notes_amount_cents: model.credit_notes_amount_cents,
         credit_amount_cents: model.credit_amount_cents,
         credit_amount_currency: model.credit_amount_currency,
         total_amount_cents: model.total_amount_cents,

--- a/app/services/credits/credit_note_service.rb
+++ b/app/services/credits/credit_note_service.rb
@@ -33,6 +33,7 @@ module Credits
           remaining_invoice_amount -= credit_amount
 
           result.credits << credit
+          invoice.credit_notes_amount_cents += credit.amount_cents
 
           # NOTE: Invoice amount is fully covered by the credit notes
           break if remaining_invoice_amount.zero?

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -497,7 +497,7 @@ html
               tr
                 td.body-2 = I18n.t('invoice.credit_notes')
                 td.body-2 style="text-align: right; color: #008559;"
-                  = credit_note_total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+                  = credit_notes_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
             - if credits.coupon_kind.any?
               - credits.coupon_kind.order(created_at: :asc).each do |credit|
                 tr

--- a/db/migrate/20230417131515_add_credit_notes_amount_cents_to_invoices.rb
+++ b/db/migrate/20230417131515_add_credit_notes_amount_cents_to_invoices.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AddCreditNotesAmountCentsToInvoices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invoices, :credit_notes_amount_cents, :bigint, null: false, default: 0
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          WITH credit_notes_total AS (
+            SELECT credits.invoice_id, sum(credits.amount_cents) AS credit_notes_amount_cents
+            FROM credits
+            WHERE credit_note_id IS NOT NULL
+            GROUP BY credits.invoice_id
+          )
+          UPDATE invoices
+          SET credit_notes_amount_cents = credit_notes_total.credit_notes_amount_cents
+          FROM credit_notes_total
+          WHERE invoices.id = credit_notes_total.invoice_id
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_17_094339) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_17_131515) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -401,6 +401,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_17_094339) do
     t.uuid "organization_id", null: false
     t.integer "version_number", default: 2, null: false
     t.bigint "fees_amount_cents", default: 0, null: false
+    t.bigint "credit_notes_amount_cents", default: 0, null: false
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2957,6 +2957,7 @@ type Invoice {
   creditAmountCurrency: CurrencyEnum!
   creditNoteTotalAmountCents: BigInt!
   creditNotes: [CreditNote!]
+  creditNotesAmountCents: BigInt!
   creditableAmountCents: BigInt!
   customer: Customer!
   fees: [Fee!]

--- a/schema.json
+++ b/schema.json
@@ -10654,6 +10654,24 @@
               ]
             },
             {
+              "name": "creditNotesAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "creditableAmountCents",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
           id
           number
           feesAmountCents
+          creditNotesAmountCents
           refundableAmountCents
           creditableAmountCents
           paymentStatus

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -111,20 +111,6 @@ RSpec.describe Invoice, type: :model do
     end
   end
 
-  describe '#credit_note_total_amount' do
-    let(:organization) { create(:organization, name: 'LAGO') }
-    let(:customer) { create(:customer, organization:) }
-    let(:subscription) { create(:subscription, organization:, customer:) }
-    let(:invoice) { create(:invoice, customer:, organization:) }
-    let(:credit) { create(:credit_note_credit, invoice:) }
-
-    before { credit }
-
-    it 'returns the credit note amount' do
-      expect(invoice.credit_note_total_amount.to_s).to eq('2.00')
-    end
-  end
-
   describe '#charge_amount' do
     let(:organization) { create(:organization, name: 'LAGO') }
     let(:customer) { create(:customer, organization:) }

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe ::V1::InvoiceSerializer do
       expect(result['invoice']['amount_currency']).to eq(invoice.amount_currency)
       expect(result['invoice']['vat_amount_cents']).to eq(invoice.vat_amount_cents)
       expect(result['invoice']['vat_amount_currency']).to eq(invoice.vat_amount_currency)
+      expect(result['invoice']['credit_notes_amount_cents']).to eq(invoice.credit_notes_amount_cents)
       expect(result['invoice']['credit_amount_cents']).to eq(invoice.credit_amount_cents)
       expect(result['invoice']['credit_amount_currency']).to eq(invoice.credit_amount_currency)
       expect(result['invoice']['total_amount_cents']).to eq(invoice.total_amount_cents)

--- a/spec/services/credits/credit_note_service_spec.rb
+++ b/spec/services/credits/credit_note_service_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe Credits::CreditNoteService do
         expect(credit2.amount_currency).to eq('EUR')
         expect(credit_note2.reload.balance_amount_cents).to be_zero
         expect(credit_note1).to be_consumed
+
+        expect(invoice.credit_notes_amount_cents).to eq(70)
       end
     end
 


### PR DESCRIPTION
## Context

Future changes will impact the way coupons are applied to invoices (moved before VAT computation rather than before).
In order to make this change easier, we need to improve the way we store amounts and currency on invoice.

## Description

This PR adds a new `credit_notes_amount_cents` column to the `invoices` table. It will store the sum of credit notes credit amount.
