### PR TITLE
feat(invoice): Add new prepaid_credit_amount_cents to invoice

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -40,7 +40,7 @@ module Types
       field :credit_notes, [Types::CreditNotes::Object], null: true
 
       field :coupons_amount_cents, GraphQL::Types::BigInt, null: false
-      field :wallet_transaction_amount_cents, GraphQL::Types::BigInt, null: false
+      field :prepaid_credit_amount_cents, GraphQL::Types::BigInt, null: false
       field :subtotal_before_prepaid_credits, String, null: false
 
       field :credit_notes_amount_cents, GraphQL::Types::BigInt, null: false
@@ -54,6 +54,7 @@ module Types
       field :coupon_total_amount_cents, GraphQL::Types::BigInt, null: false, method: :coupons_amount_cents
       field :credit_note_total_amount_cents, GraphQL::Types::BigInt, null: false, method: :credit_notes_amount_cents
       field :sub_total_vat_excluded_amount_cents, GraphQL::Types::BigInt, null: false, method: :fees_amount_cents
+      field :wallet_transaction_amount_cents, GraphQL::Types::BigInt, null: false, method: :prepaid_credit_amount_cents
     end
   end
 end

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -22,6 +22,7 @@ module V1
         credit_amount_currency: model.credit_amount_currency,
         total_amount_cents: model.total_amount_cents,
         total_amount_currency: model.total_amount_currency,
+        prepaid_credit_amount_cents: model.prepaid_credit_amount_cents,
         file_url: model.file_url,
         legacy: model.legacy,
       }

--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -9,7 +9,7 @@ module Credits
       super(nil)
     end
 
-    def create
+    def call
       return result if already_applied?
 
       amount_cents = compute_amount
@@ -31,6 +31,7 @@ module Credits
         Wallets::Balance::DecreaseService.new(wallet:, credits_amount: credit_amount).call
 
         result.prepaid_credit_amount_cents = amount_cents
+        invoice.prepaid_credit_amount_cents += amount_cents
       end
 
       result

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -166,7 +166,7 @@ module Invoices
     end
 
     def create_applied_prepaid_credit
-      prepaid_credit_result = Credits::AppliedPrepaidCreditService.new(invoice:, wallet:).create
+      prepaid_credit_result = Credits::AppliedPrepaidCreditService.call(invoice:, wallet:)
       prepaid_credit_result.raise_if_error!
 
       refresh_amounts(credit_amount_cents: prepaid_credit_result.prepaid_credit_amount_cents)

--- a/app/views/templates/invoice.slim
+++ b/app/views/templates/invoice.slim
@@ -475,7 +475,7 @@ html
             - if subscription? && wallet_transactions.exists?
               tr
                 td.body-2 width="70%" = I18n.t('invoice.prepaid_credits')
-                td.prepaid-amount width="30%" = wallet_transaction_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+                td.prepaid-amount width="30%" = prepaid_credit_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
             tr
               td.body-2 = I18n.t('invoice.tax')
               td.body-2 = vat_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
@@ -507,7 +507,7 @@ html
             - if subscription? && wallet_transactions.exists?
               tr
                 td.body-2 width="70%" = I18n.t('invoice.prepaid_credits')
-                td.prepaid-amount width="30%" = wallet_transaction_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+                td.prepaid-amount width="30%" = prepaid_credit_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
             tr
               td.body-1 = I18n.t('invoice.total_due')
               td.body-1 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))

--- a/db/migrate/20230417140356_add_prepaid_credit_amount_cents_to_invoices.rb
+++ b/db/migrate/20230417140356_add_prepaid_credit_amount_cents_to_invoices.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class AddPrepaidCreditAmountCentsToInvoices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invoices, :prepaid_credit_amount_cents, :bigint, null: false, default: 0
+
+    reversible do |dir|
+      dir.up do
+        currency_list = WalletTransaction.joins(:wallet).pluck('DISTINCT(wallets.balance_currency)')
+        next if currency_list.blank?
+
+        currency_sql = currency_list.each_with_object([]) do |code, currencies|
+          currency = Money::Currency.new(code)
+          currencies << "('#{code}', #{currency.exponent}, #{currency.subunit_to_unit})"
+        end
+
+        execute <<-SQL
+          WITH transaction_total AS (
+            SELECT
+              wallet_transactions.invoice_id,
+              (ROUND(SUM(wallet_transactions.amount), currencies.exponent) * currencies.subunit_to_unit) AS amount_cents
+            FROM wallet_transactions
+              INNER JOIN wallets ON wallet_transactions.wallet_id = wallets.id
+              INNER JOIN (
+                SELECT *
+                FROM (VALUES #{currency_sql.join(', ')}) AS t(currency, exponent, subunit_to_unit)
+              ) currencies ON currencies.currency = wallets.balance_currency
+            GROUP BY wallet_transactions.invoice_id, currencies.currency, currencies.exponent, currencies.subunit_to_unit
+          )
+          UPDATE invoices
+          SET prepaid_credit_amount_cents = transaction_total.amount_cents
+          FROM transaction_total
+          WHERE invoices.id = transaction_total.invoice_id
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_17_131515) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_17_140356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -403,6 +403,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_17_131515) do
     t.bigint "fees_amount_cents", default: 0, null: false
     t.bigint "credit_notes_amount_cents", default: 0, null: false
     t.bigint "coupons_amount_cents", default: 0, null: false
+    t.bigint "prepaid_credit_amount_cents", default: 0, null: false
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
   end

--- a/lib/tasks/invoices.rake
+++ b/lib/tasks/invoices.rake
@@ -54,8 +54,13 @@ namespace :invoices do
   desc 'Fill invoice credit amount'
   task fill_credit_amount: :environment do
     Invoice.where(credit_amount_cents: 0).find_each do |invoice|
+      transaction_amount = invoice.wallet_transactions.sum(:amount)
+      currency = invoice.amount.currency
+      rounded_amount = transaction_amount.round(currency.exponent)
+      prepaid_credit_amount = rounded_amount * currency.subunit_to_unit
+
       invoice.update!(
-        credit_amount_cents: invoice.credit_amount_cents + invoice.wallet_transaction_amount_cents,
+        credit_amount_cents: invoice.credit_amount_cents + prepaid_credit_amount,
         credit_amount_currency: invoice.currency,
       )
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2972,6 +2972,7 @@ type Invoice {
   metadata: [InvoiceMetadata!]
   number: String!
   paymentStatus: InvoicePaymentStatusTypeEnum!
+  prepaidCreditAmountCents: BigInt!
   refundableAmountCents: BigInt!
   sequentialId: ID!
   status: InvoiceStatusTypeEnum!

--- a/schema.json
+++ b/schema.json
@@ -10932,6 +10932,24 @@
               ]
             },
             {
+              "name": "prepaidCreditAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "refundableAmountCents",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
           feesAmountCents
           couponsAmountCents
           creditNotesAmountCents
+          prepaidCreditAmountCents
           refundableAmountCents
           creditableAmountCents
           paymentStatus

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -121,41 +121,20 @@ RSpec.describe Invoice, type: :model do
     end
   end
 
-  describe '#wallet_transaction_amount' do
-    let(:customer) { create(:customer) }
-    let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
-    let(:wallet) { create(:wallet, customer:, balance: 10.0, credits_balance: 10.0) }
-    let(:wallet_transaction) do
-      create(:wallet_transaction, invoice:, wallet:, amount: 1, credit_amount: 1)
-    end
-
-    before { wallet_transaction }
-
-    it 'returns the wallet transaction amount' do
-      expect(invoice.wallet_transaction_amount.to_s).to eq('1.00')
-    end
-  end
-
   describe '#subtotal_before_prepaid_credits' do
     let(:customer) { create(:customer) }
-    let(:invoice) { create(:invoice, customer:, amount_cents: 555, organization: customer.organization) }
-    let(:wallet) { create(:wallet, customer:, balance: 10.0, credits_balance: 10.0) }
-    let(:wallet_transaction) do
-      create(:wallet_transaction, invoice:, wallet:, amount: 1, credit_amount: 1)
+    let(:invoice) do
+      create(
+        :invoice,
+        customer:,
+        amount_cents: 555,
+        organization: customer.organization,
+        prepaid_credit_amount_cents: 100,
+      )
     end
-
-    before { wallet_transaction }
 
     it 'returns the subtotal before prepaid credits' do
       expect(invoice.subtotal_before_prepaid_credits.to_s).to eq('6.55')
-    end
-
-    context 'when there is no prepaid credits' do
-      let(:wallet_transaction) { create(:wallet_transaction, wallet: wallet, amount: 1, credit_amount: 1) }
-
-      it 'returns the invoice amount' do
-        expect(invoice.subtotal_before_prepaid_credits.to_s).to eq('5.55')
-      end
     end
   end
 

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe ::V1::InvoiceSerializer do
       expect(result['invoice']['coupons_amount_cents']).to eq(invoice.coupons_amount_cents)
       expect(result['invoice']['credit_notes_amount_cents']).to eq(invoice.credit_notes_amount_cents)
       expect(result['invoice']['credit_amount_cents']).to eq(invoice.credit_amount_cents)
+      expect(result['invoice']['prepaid_credit_amount_cents']).to eq(invoice.prepaid_credit_amount_cents)
       expect(result['invoice']['credit_amount_currency']).to eq(invoice.credit_amount_currency)
       expect(result['invoice']['total_amount_cents']).to eq(invoice.total_amount_cents)
       expect(result['invoice']['total_amount_currency']).to eq(invoice.total_amount_currency)

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -22,16 +22,17 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
 
   before { subscription }
 
-  describe 'create' do
+  describe 'call' do
     it 'calculates prepaid credit' do
-      result = credit_service.create
+      result = credit_service.call
 
       expect(result).to be_success
       expect(result.prepaid_credit_amount_cents).to eq(100)
+      expect(invoice.prepaid_credit_amount_cents).to eq(100)
     end
 
     it 'creates wallet transaction' do
-      result = credit_service.create
+      result = credit_service.call
 
       expect(result).to be_success
       expect(result.wallet_transaction).to be_present
@@ -39,7 +40,7 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
     end
 
     it 'updates wallet balance' do
-      result = credit_service.create
+      result = credit_service.call
       wallet = result.wallet_transaction.wallet
 
       expect(wallet.balance_cents).to eq(900)
@@ -50,14 +51,14 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
       let(:amount_cents) { 1500 }
 
       it 'calculates prepaid credit' do
-        result = credit_service.create
+        result = credit_service.call
 
         expect(result).to be_success
         expect(result.prepaid_credit_amount_cents).to eq(1000)
       end
 
       it 'creates wallet transaction' do
-        result = credit_service.create
+        result = credit_service.call
 
         expect(result).to be_success
         expect(result.wallet_transaction).to be_present
@@ -65,7 +66,7 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
       end
 
       it 'updates wallet balance' do
-        result = credit_service.create
+        result = credit_service.call
         wallet = result.wallet_transaction.wallet
 
         expect(wallet.balance).to eq(0.0)


### PR DESCRIPTION
## Context

Future changes will impact the way coupons are applied to invoices (moved before VAT computation rather than before).
In order to make this change easier, we need to improve the way we store amounts and currency on invoice.

## Description

This PR adds a new `prepaid_credit_amount_cents` column to the `invoices` table. It will store the sum of wallet transaction amount.
