### PR TITLE
fix(redis): activejob-uniqueness should take care of redis password

### DIFF
--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -2,4 +2,12 @@
 
 ActiveJob::Uniqueness.configure do |config|
   config.lock_ttl = 1.hour
+
+  if ENV['REDIS_PASSWORD'].present? && !ENV['REDIS_PASSWORD'].empty?
+    uri = URI(ENV['REDIS_URL'])
+    host = [uri.host, uri.path].join('')
+    host = [host, uri.query].join('?')
+
+    config.redlock_servers = ["redis://:#{ENV['REDIS_PASSWORD']}@#{host}:#{uri.port}"]
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -401,8 +401,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_17_140356) do
     t.uuid "organization_id", null: false
     t.integer "version_number", default: 2, null: false
     t.bigint "fees_amount_cents", default: 0, null: false
-    t.bigint "credit_notes_amount_cents", default: 0, null: false
     t.bigint "coupons_amount_cents", default: 0, null: false
+    t.bigint "credit_notes_amount_cents", default: 0, null: false
     t.bigint "prepaid_credit_amount_cents", default: 0, null: false
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"


### PR DESCRIPTION
## Context

An issue was raised in the community about a problem with Stripe payment job processing:

The job enqueuing was failing with a Redis Error:
```
Failed enqueuing Invoices::Payments::StripeCreateJob to Sidekiq(providers): Redis::CommandError (NOAUTH Authentication required.)
```

The `REDIS_PASSWORD` variable was correctly set and other jobs were enqueuing just fine.

After some investigation, it appears the issue is related to the `activejob-uniqueness` used in `Invoices::Payments::StripeCreateJob` and Invoices::Payments::GoCardlessCreateJob to prevent double processing of these jobs.

## Description

The fix is to ensure that the `REDIS_PASSWORD` is passed in the redis connection string when present.