### PR TITLE
feat(min_charge): add `true_up_fee_id` on `Fee`

### DIFF
--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -8,17 +8,16 @@ module Types
 
       field :charge, Types::Charges::Object, null: true
       field :subscription, Types::Subscriptions::Object, null: true
+      field :true_up_fee, Types::Fees::Object, null: true
 
       field :vat_amount_cents, GraphQL::Types::BigInt, null: false
       field :vat_amount_currency, Types::CurrencyEnum, null: false
 
-      field :vat_rate, GraphQL::Types::Float, null: true
-      field :units, GraphQL::Types::Float, null: false
-      field :events_count, GraphQL::Types::BigInt, null: true
-
-      field :fee_type, Types::Fees::TypesEnum, null: false
-
       field :creditable_amount_cents, GraphQL::Types::BigInt, null: false
+      field :events_count, GraphQL::Types::BigInt, null: true
+      field :fee_type, Types::Fees::TypesEnum, null: false
+      field :units, GraphQL::Types::Float, null: false
+      field :vat_rate, GraphQL::Types::Float, null: true
 
       def item_type
         object.fee_type

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -14,6 +14,7 @@ class Fee < ApplicationRecord
   has_one :organization, through: :invoice
   has_one :billable_metric, -> { with_discarded }, through: :charge
   has_one :add_on, -> { with_discarded }, through: :applied_add_on
+  has_one :true_up_fee
 
   has_many :credit_note_items
   has_many :credit_notes, through: :credit_note_items
@@ -32,6 +33,7 @@ class Fee < ApplicationRecord
   validates :vat_amount_currency, inclusion: { in: currency_list }
   validates :units, numericality: { greated_than_or_equal_to: 0 }
   validates :events_count, numericality: { greated_than_or_equal_to: 0 }, allow_nil: true
+  validates :true_up_fee_id, presence: false, unless: :charge?
 
   scope :subscription_kind, -> { where(fee_type: :subscription) }
   scope :charge_kind, -> { where(fee_type: :charge) }

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -14,7 +14,7 @@ class Fee < ApplicationRecord
   has_one :organization, through: :invoice
   has_one :billable_metric, -> { with_discarded }, through: :charge
   has_one :add_on, -> { with_discarded }, through: :applied_add_on
-  has_one :true_up_fee
+  has_one :true_up_fee, class_name: 'Fee', foreign_key: :true_up_fee_id
 
   has_many :credit_note_items
   has_many :credit_notes, through: :credit_note_items

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -6,6 +6,8 @@ module V1
       payload = {
         lago_id: model.id,
         lago_group_id: model.group_id,
+        lago_invoice_id: model.invoice_id,
+        lago_true_up_fee_id: model.true_up_fee_id,
         item: {
           type: model.fee_type,
           code: model.item_code,
@@ -21,7 +23,6 @@ module V1
         total_amount_currency: model.amount_currency,
         units: model.units,
         events_count: model.events_count,
-        lago_invoice_id: model.invoice_id,
         external_subscription_id: model.subscription&.external_id,
         payment_status: model.payment_status,
         created_at: model.created_at&.iso8601,

--- a/db/migrate/20230419123538_add_true_up_fee_id_to_fees.rb
+++ b/db/migrate/20230419123538_add_true_up_fee_id_to_fees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTrueUpFeeIdToFees < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :fees, :true_up_fee, type: :uuid, null: true, index: true, foreign_key: { to_table: :fees }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_17_140356) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_19_123538) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -305,12 +305,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_17_140356) do
     t.datetime "succeeded_at", precision: nil
     t.datetime "failed_at", precision: nil
     t.datetime "refunded_at", precision: nil
+    t.uuid "true_up_fee_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
     t.index ["group_id"], name: "index_fees_on_group_id"
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"
     t.index ["invoiceable_type", "invoiceable_id"], name: "index_fees_on_invoiceable"
     t.index ["subscription_id"], name: "index_fees_on_subscription_id"
+    t.index ["true_up_fee_id"], name: "index_fees_on_true_up_fee_id"
   end
 
   create_table "group_properties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -664,6 +666,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_17_140356) do
   add_foreign_key "events", "subscriptions"
   add_foreign_key "fees", "applied_add_ons"
   add_foreign_key "fees", "charges"
+  add_foreign_key "fees", "fees", column: "true_up_fee_id"
   add_foreign_key "fees", "groups"
   add_foreign_key "fees", "invoices"
   add_foreign_key "fees", "subscriptions"

--- a/schema.graphql
+++ b/schema.graphql
@@ -2822,6 +2822,7 @@ type Fee implements InvoiceItem {
   itemName: String!
   itemType: String!
   subscription: Subscription
+  trueUpFee: Fee
   units: Float!
   vatAmountCents: BigInt!
   vatAmountCurrency: CurrencyEnum!

--- a/schema.json
+++ b/schema.json
@@ -9453,6 +9453,20 @@
               ]
             },
             {
+              "name": "trueUpFee",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Fee",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "units",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
               itemName
               group { id key value }
               charge { id billableMetric { code } }
+              trueUpFee { id }
             }
           }
           subscriptions {
@@ -71,7 +72,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
-      query: query,
+      query:,
       variables: {
         id: invoice.id,
       },
@@ -99,7 +100,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
-      query: query,
+      query:,
       variables: { id: invoice.id },
     )
 
@@ -115,16 +116,13 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: invoice.organization,
-        query: query,
+        query:,
         variables: {
           id: 'foo',
         },
       )
 
-      expect_graphql_error(
-        result: result,
-        message: 'Resource not found',
-      )
+      expect_graphql_error(result:, message: 'Resource not found')
     end
   end
 

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe ::V1::FeeSerializer do
       expect(result['fee']).to include(
         'lago_id' => fee.id,
         'lago_group_id' => fee.group_id,
+        'lago_invoice_id' => fee.invoice_id,
+        'lago_true_up_fee_id' => fee.true_up_fee_id,
         'amount_cents' => fee.amount_cents,
         'amount_currency' => fee.amount_currency,
         'vat_amount_cents' => fee.vat_amount_cents,


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-minimum-fees

## Context

We want to allow users to set spendings minimum on usage-based charges.

## Description

The goal of this PR is to add `true_up_fee_id` on `Fee`.