### PR TITLE
feat(min_charge): Assign true up fee to the usage fee

### DIFF
--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -19,6 +19,7 @@ module Fees
       end
       true_up_fee.compute_vat
 
+      fee.true_up_fee = true_up_fee
       result.true_up_fee = true_up_fee
       result
     end

--- a/spec/services/fees/create_true_up_service_spec.rb
+++ b/spec/services/fees/create_true_up_service_spec.rb
@@ -51,5 +51,9 @@ RSpec.describe Fees::CreateTrueUpService, type: :service do
         )
       end
     end
+
+    it 'sets true_up_fee_id to the fee' do
+      expect { create_service.call }.to change(fee, :true_up_fee).from(nil)
+    end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-minimum-fees

## Context

We want to allow users to set spendings minimum on usage-based charges.

## Description

The goal of this PR is to assign `true_up_fee_id` on `Fee`.