### PR TITLE
feat(coupons): Add before_vat flag to credits

### DIFF
--- a/app/serializers/v1/credit_serializer.rb
+++ b/app/serializers/v1/credit_serializer.rb
@@ -7,6 +7,7 @@ module V1
         lago_id: model.id,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,
+        before_vat: model.before_vat,
         item: {
           lago_id: model.item_id,
           type: model.item_type,

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -22,6 +22,7 @@ module Credits
         applied_coupon:,
         amount_cents: credit_amount,
         amount_currency: invoice.currency,
+        before_vat: false, # NOTE: will turn to true with invoice v3
       )
 
       applied_coupon.frequency_duration_remaining -= 1 if applied_coupon.recurring?

--- a/app/services/credits/credit_note_service.rb
+++ b/app/services/credits/credit_note_service.rb
@@ -26,6 +26,7 @@ module Credits
             credit_note:,
             amount_cents: credit_amount,
             amount_currency: invoice.currency,
+            before_vat: false,
           )
 
           # NOTE: Consume remaining credit on the credit note

--- a/db/migrate/20230421094757_add_before_vat_to_credits.rb
+++ b/db/migrate/20230421094757_add_before_vat_to_credits.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBeforeVatToCredits < ActiveRecord::Migration[7.0]
+  def change
+    add_column :credits, :before_vat, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -211,6 +211,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_24_092207) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "credit_note_id"
+    t.boolean "before_vat", default: false, null: false
     t.index ["applied_coupon_id"], name: "index_credits_on_applied_coupon_id"
     t.index ["credit_note_id"], name: "index_credits_on_credit_note_id"
     t.index ["invoice_id"], name: "index_credits_on_invoice_id"


### PR DESCRIPTION
## Context

Future changes will impact the way coupons are applied to invoices (moved before VAT computation rather than before).

## Description

This PR adds a new `before_vat` flag to the credit object. It will allow us to distinguish credit applied before vat (coupons) from the one applied after VAT (credit notes)
