### PR TITLE
feat(min_charge): Update invoice template to include true up fees

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -34,6 +34,8 @@ class Charge < ApplicationRecord
   validate :validate_instant
   validate :validate_min_amount_cents
 
+  monetize :min_amount_cents, with_currency: ->(charge) { charge.plan.amount_currency }
+
   default_scope -> { kept }
 
   scope :instant, -> { where(instant: true) }

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -9,6 +9,7 @@ class Fee < ApplicationRecord
   belongs_to :subscription, optional: true
   belongs_to :group, -> { with_discarded }, optional: true
   belongs_to :invoiceable, polymorphic: true, optional: true
+  belongs_to :true_up_parent_fee, class_name: 'Fee', foreign_key: :true_up_fee_id, optional: true
 
   has_one :customer, through: :subscription
   has_one :organization, through: :invoice

--- a/app/views/templates/invoices/v2.slim
+++ b/app/views/templates/invoices/v2.slim
@@ -541,7 +541,7 @@ html
               = I18n.t('invoice.list_of_charges', from: I18n.l(invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date, format: :default), to: I18n.l(invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date, format: :default))
             .charge-details.mb-24
               table.charge-details-table width="100%"
-                - subscription_fees(subscription.id).charge_kind.group_by(&:charge_id).each do |_charge_id, fees|
+                - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).group_by(&:charge_id).each do |_charge_id, fees|
                   - fee = fees.first
                   - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
                     tr
@@ -567,6 +567,12 @@ html
                               - else
                                 = I18n.t('invoice.total_unit', units: fee.units)
                         td.body-1 width="30%" = fee.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+                      - if fee.true_up_fee.present?
+                      tr
+                        td width="70%"
+                          .body-1 = I18n.t('invoice.true_up_metric', metric: fee.billable_metric.name)
+                          .body-3 = I18n.t('invoice.true_up_details', min_amount: fee.charge.min_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator')))
+                        td.body-1 width="30%" = fee.true_up_fee.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
                   - else
                     tr
                       td width="70%"
@@ -579,6 +585,12 @@ html
                           - else
                             = I18n.t('invoice.total_unit', units: fees.sum(&:units))
                       td.body-1 width="30%" = fees.sum(&:amount).format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+                    - if fee.true_up_fee.present?
+                      tr
+                        td width="70%"
+                          .body-1 = I18n.t('invoice.true_up_metric', metric: fee.billable_metric.name)
+                          .body-3 = I18n.t('invoice.true_up_details', min_amount: fee.charge.min_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator')))
+                        td.body-1 width="30%" = fee.true_up_fee.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
 
               .charge-details-resume
                 table.total-table width="100%"

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -39,5 +39,7 @@ de:
     breakdown_for_days: "%{breakdown_duration} für %{breakdown_total_duration} Tage"
     breakdown_of: "%{breakdown} für %{fee_group_name}"
     notice: Wenn beispielsweise eine Einheit mit 15 verbleibenden Tagen in Ihrem Monatsplan hinzugefügt wird, multiplizieren wir den Preis mit 15/31 (verbleibende Tage dividiert durch die Gesamtzahl der Tage in Ihrem Plan), um den anteiligen Preis zu berechnen. Dieselbe Logik greift beim Entfernen einer Einheit, die 10 Tage lang verwendet wurde, wir multiplizieren den Preis mit 10/31.
+    true_up_metric: "%{metric} - Kosten für die Anpassung"
+    true_up_details: "Mindestausgabe von %{min_amount} anteilig an den Nutzungstagen"
 
     total_credits: Gesamtguthaben

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -39,5 +39,7 @@ en:
     breakdown_for_days: "%{breakdown_duration} of %{breakdown_total_duration} days"
     breakdown_of: "Breakdown of %{fee_group_name}"
     notice: For example, if a unit is added with 15 days left in your monthly plan, we multiply the price by 15/31 (days remaining divided by the total number of days in your plan) to calculate the prorated price. Same logic when removing a unit used during 10 days, we multiply the price by 10/31.
+    true_up_metric: "%{metric} - True-up"
+    true_up_details: "Minimum spend of %{min_amount} prorated on days of usage"
 
     total_credits: Total credits

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -39,5 +39,7 @@ fr:
     breakdown_for_days: "%{breakdown_duration} sur %{breakdown_total_duration} jours"
     breakdown_of: "Détails de consommation de %{fee_group_name}"
     notice: Par exemple, si une unité est ajoutée alors qu'il reste 15 jours à votre abonnement mensuel et que le mois concerné compte 31 jours, nous multiplions le prix mensuel par 15/31 (nombre de jours restants dans le mois divisé par le nombre total de jours du mois), pour un abonnement mensuel. Le principe est similaire lorsque vous retirez une unité qui n'aura été utilisée que 10 jours dans le mois, nous multiplions le prix par 10/31.
+    true_up_metric: "%{metric} - Frais d'ajustement"
+    true_up_details: "Dépense minimale de %{min_amount} au prorata des jours d'utilisation"
 
     total_credits: Total crédits

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -39,5 +39,7 @@ nb:
     breakdown_for_days: "%{breakdown_duration} av %{breakdown_total_duration} dager"
     breakdown_of: "Fordeling av %{fee_group_name}"
     notice: For eksempel, hvis en enhet legges til med 15 dager igjen på månedsabonnementet ganger vi prisen med 15/31 (antall dager gjenstående delt på antall dager å abonnementet ditt) for å beregne den rette prisen. Samme logikk benyttes når en enhet fjernes etter f.eks 10 dager, da ganger vi prisen med 10/31.
+    true_up_metric: "%{metric} - Tilpasningskostnader"
+    true_up_details: "Minimumsutgift på %{min_amount} beregnet etter antall brukte dager"
 
     total_credits: Antall kreditter


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-minimum-fees

## Context

We want to allow users to set spendings minimum on usage-based charges.

## Description

The goal of this PR is to update the invoice template to include true up fees.