### PR TITLE
feat(coupon): Add invoice v3 template

### DIFF
--- a/app/views/templates/invoices/v3.slim
+++ b/app/views/templates/invoices/v3.slim
@@ -1,0 +1,649 @@
+doctype html
+html
+  head
+    meta charset='UTF-8'
+    meta http-equiv='X-UA-Compatible' content='IE=edge'
+    meta name='viewport' content='width=device-width, initial-scale=1.0'
+    title Invoice
+  body
+    css:
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 100;
+        font-display: swap;
+        src: local("Inter-Thin");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 100;
+        font-display: swap;
+        src: local("Inter-ThinItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 200;
+        font-display: swap;
+        src: local("Inter-ExtraLight");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 200;
+        font-display: swap;
+        src: local("Inter-ExtraLightItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 300;
+        font-display: swap;
+        src: local("Inter-Light");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 300;
+        font-display: swap;
+        src: local("Inter-LightItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 400;
+        font-display: swap;
+        src: local("Inter-Regular");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 400;
+        font-display: swap;
+        src: local("Inter-Italic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 500;
+        font-display: swap;
+        src: local("Inter-Medium");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 500;
+        font-display: swap;
+        src: local("Inter-MediumItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 600;
+        font-display: swap;
+        src: local("Inter-SemiBold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 600;
+        font-display: swap;
+        src: local("Inter-SemiBoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 700;
+        font-display: swap;
+        src: local("Inter-Bold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 700;
+        font-display: swap;
+        src: local("Inter-BoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 800;
+        font-display: swap;
+        src: local("Inter-ExtraBold");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 800;
+        font-display: swap;
+        src: local("Inter-ExtraBoldItalic");
+      }
+
+      @font-face {
+        font-family: 'Inter';
+        font-style:  normal;
+        font-weight: 900;
+        font-display: swap;
+        src: local("Inter-Black");
+      }
+      @font-face {
+        font-family: 'Inter';
+        font-style:  italic;
+        font-weight: 900;
+        font-display: swap;
+        src: local("Inter-BlackItalic");
+      }
+
+
+      /* ----------------------- variable ----------------------- */
+
+      @font-face {
+        font-family: 'Inter var';
+        font-style: normal;
+        font-weight: 100 900;
+        font-display: swap;
+        src: local('Inter-roman') format('woff2');
+        font-named-instance: 'Regular';
+      }
+
+      @font-face {
+        font-family: 'Inter var';
+        font-style: italic;
+        font-weight: 100 900;
+        font-display: swap;
+        src: local('Inter-italic') format('woff2');
+        font-named-instance: 'Italic';
+      }
+      h1, h2, p { margin: 0; padding: 0; }
+      html { font-family: Inter, sans-serif; }
+      h1 { color: #19212e; font-weight: 700; font-size: 24px; line-height: 32px; }
+      h2 {
+        color: #19212e;
+        font-weight: 700;
+        font-size: 18px;
+        line-height: 24px;
+      }
+      .body-1 {
+        color: #19212e;
+        font-weight: 600;
+        font-size: 10px;
+        line-height: 16px;
+      }
+      .body-2 {
+        color: #19212e;
+        font-weight: 400;
+        font-size: 10px;
+        line-height: 16px;
+      }
+      .body-3 {
+        color: #66758f;
+        font-weight: 400;
+        font-size: 9px;
+        line-height: 16px;
+      }
+      .prepaid-amount {
+        font-size: 10px;
+        font-family: Inter;
+        color: #008559;
+        font-weight: 400;
+        line-height: 16px;
+      }
+
+      .mb-8 {
+        margin-bottom: 8px;
+      }
+      .mb-24 {
+        margin-bottom: 24px;
+      }
+
+      .overflow-auto {
+        overflow: auto;
+      }
+      tr {
+        break-inside: avoid;
+      }
+
+      .invoice-title {
+        display: inline;
+      }
+      .header-logo {
+        float: right;
+        max-height: 32px;
+      }
+
+      .invoice-information-column {
+        float: left;
+        width: 50%;
+      }
+      .invoice-information-table tr td:first-child {
+        padding: 0 16px 0 0;
+      }
+      .invoice-information-table tr td:last-child {
+        width: 55%;
+      }
+      .invoice-information-table, tr td{
+        text-wrap: normal;
+        word-wrap: break-word;
+        vertical-align: top;
+      }
+      .invoice-information-table {
+        border-collapse: collapse;
+        table-layout: fixed;
+        width: 100%;
+      }
+
+      .billing-information-column {
+        float: left;
+        width: 50%;
+      }
+
+      .invoice-resume-table tr td {
+        padding-bottom: 12px;
+      }
+      .invoice-resume-table tr td:last-child {
+        text-align: right;
+      }
+      .invoice-resume-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .invoice-resume table {
+        border-collapse: collapse;
+      }
+      .invoice-resume .total-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .invoice-resume .total-table tr:first-child td {
+        padding-top: 24px;
+      }
+      .invoice-resume .total-table tr td {
+        padding-bottom: 12px;
+        text-align: right;
+      }
+      .invoice-resume .total-table tr td:first-of-type {
+        text-align: left;
+        padding-left: 50%;
+      }
+
+      .invoice-details-title {
+        page-break-before: always;
+      }
+
+      .subscription-details-table tr td:last-child {
+        text-align: right;
+      }
+      .subscription-details-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .subscription-details table {
+        border-collapse: collapse;
+      }
+      .subscription-details .total-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .subscription-details .total-table tr:first-child td {
+        padding-top: 24px;
+      }
+      .subscription-details .total-table tr td {
+        text-align: right;
+      }
+
+      .charge-details-table tr td {
+        padding-bottom: 12px;
+      }
+      .charge-details-table tr td:last-child {
+        text-align: right;
+      }
+      .charge-details-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .charge-details table {
+        border-collapse: collapse;
+      }
+      .charge-details .total-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+      .charge-details .total-table tr:first-child td {
+        padding-top: 24px;
+      }
+      .charge-details .total-table tr td {
+        text-align: right;
+      }
+      .charge-details-resume .total-table tr td:first-of-type {
+        text-align: left;
+        padding-left: 50%;
+      }
+
+      .breakdown-details table {
+        border-collapse: collapse;
+      }
+      .breakdown-details-table tr td {
+        padding-bottom: 12px;
+      }
+      .breakdown-details-table tr td:last-child {
+        text-align: right;
+      }
+      .breakdown-details-table tr:last-child td {
+        border-bottom: 1px solid #d9dee7;
+        padding-bottom: 24px;
+      }
+
+      .powered-by {
+        width: 100%;
+        text-align: right;
+      }
+      .powered-by span {
+        color: #8c95a6;
+      }
+      .powered-by svg {
+        width: 37px;
+        height: 11px;
+        vertical-align: middle;
+        margin-top: 2px;
+      }
+      .alert {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        padding: 16px;
+        gap: 16px;
+        background: #F3F4F6;
+        border-radius: 12px;
+      }
+
+    .wrapper
+      .mb-24
+        h1.invoice-title = I18n.t('invoice.document_name')
+        - if organization.logo.present?
+          img.header-logo src="data:#{organization.logo.content_type};base64,#{organization.base64_logo}"
+
+      .mb-24.overflow-auto
+        .invoice-information-column
+          table.invoice-information-table
+            tr
+              td.body-1 = I18n.t('invoice.invoice_number')
+              td.body-2 = number
+            tr
+              td.body-1 = I18n.t('invoice.issue_date')
+              td.body-2 = I18n.l(issuing_date, format: :default)
+        .invoice-information-column
+          table.invoice-information-table
+            - if customer.metadata.displayable.any?
+              - customer.metadata.displayable.order(created_at: :asc).each do |metadata|
+                tr
+                  td.body-1 = metadata.key
+                  td.body-2 = metadata.value
+
+      .mb-24.overflow-auto
+        .billing-information-column
+          .body-1 = I18n.t('invoice.bill_from')
+          .body-2
+            - if organization.legal_name.present?
+              | #{organization.legal_name}
+            - else
+              | #{organization.name}
+          .body-2 = organization.address_line1
+          .body-2 = organization.address_line2
+          .body-2
+            span
+              = organization.zipcode
+            - if organization.zipcode.present? && organization.city.present?
+              span
+                | , &nbsp;
+            span
+              = organization.city
+          - if organization.state.present?
+            .body-2 = organization.state
+          .body-2 = ISO3166::Country.new(organization.country)&.common_name
+          .body-2 = organization.email
+        .billing-information-column
+          .body-1 = I18n.t('invoice.bill_to')
+          .body-2
+            - if customer.legal_name.present?
+              | #{customer.legal_name}
+            - else
+              | #{customer.name}
+          .body-2 = customer.address_line1
+          .body-2 = customer.address_line2
+          .body-2
+            span
+              = customer.zipcode
+            - if customer.zipcode.present? && customer.city.present?
+              span
+                | , &nbsp;
+            span
+              = customer.city
+          .body-2 = customer.state
+          .body-2 = ISO3166::Country.new(customer.country)&.common_name
+          .body-2 = customer.email
+
+      .mb-24
+        h2.title-2.mb-8 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+        .body-1 = I18n.t('invoice.due_date', date: I18n.l(issuing_date, format: :default))
+
+      .invoice-resume.mb-24.overflow-auto
+        table.invoice-resume-table width="100%"
+          tr
+            td width="70%"
+              .body-1
+                - if add_on?
+                  | #{fees.first.add_on.name}
+                - elsif credit?
+                  = I18n.t('invoice.prepaid_credits_with_value', wallet_name: fees.first.invoiceable.wallet.name)
+                  .body-3
+                    = I18n.t('invoice.total_credits_with_value', credit_amount: fees.first.invoiceable.credit_amount)
+                - elsif subscription?
+                  = I18n.t('invoice.all_subscriptions')
+            - if add_on? || credit?
+              td.body-1 style="text-align: right;" width="30%"
+                = fees.first&.amount&.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+            - elsif subscription?
+              td.body-1 style="text-align: right;" width="30%"
+                = subscription_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+          - if fees.charge_kind.any?
+            tr
+              td width="70%"
+                .body-1 = I18n.t('invoice.all_usage_based_fees')
+              td.body-1 style="text-align: right;" width="30%"
+                = charge_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+
+        table.total-table width="100%"
+          - unless credit?
+            - if coupons_amount_cents.positive?
+              - credits.coupon_kind.order(created_at: :asc).each do |credit|
+                tr
+                  td.body-2 width="70%"  #{credit.invoice_coupon_display_name}
+                  td.body-2 width="30%" style="text-align: right; color: #008559;"
+                    = credit.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+            tr
+              td.body-2 width="70%" = I18n.t('invoice.sub_total_without_tax')
+              td.body-2 width="30%" = fees_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+            tr
+              td.body-2 #{I18n.t('invoice.tax')} (#{vat_rate || 0}%)
+              td.body-2 = vat_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+            tr
+              td.body-2 = I18n.t('invoice.sub_total_with_tax')
+              td.body-2 = sub_total_vat_included_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+          - if credits.credit_note_kind.any?
+            tr
+              td.body-2 = I18n.t('invoice.credit_notes')
+              td.body-2 style="text-align: right; color: #008559;"
+                = credit_notes_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+          - if subscription? && wallet_transactions.exists?
+            tr
+              td.body-2 width="70%" = I18n.t('invoice.prepaid_credits')
+              td.prepaid-amount width="30%" = prepaid_credit_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+          tr
+            td.body-1 = I18n.t('invoice.total_due')
+            td.body-1 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+
+
+      p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
+
+      .powered-by
+        span.body-2
+          | #{I18n.t('invoice.powered_by')} &nbsp;
+        svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 37 11"
+          g fill="#8C95A6" clip-path="url(#a)"
+            path d="M32.306 8.324a2.546 2.546 0 0 1-1.075-1.066c-.258-.46-.379-.99-.379-1.587 0-.599.129-1.128.379-1.588.25-.46.613-.813 1.075-1.066a3.442 3.442 0 0 1 1.62-.375c.613 0 1.15.122 1.62.375.47.253.826.606 1.075 1.066.25.46.379.99.379 1.588 0 .605-.129 1.134-.379 1.595-.257.46-.613.812-1.075 1.058a3.442 3.442 0 0 1-1.62.375c-.613 0-1.158-.122-1.62-.375Zm2.68-1.419c.257-.314.394-.728.394-1.227 0-.506-.129-.912-.394-1.227-.265-.314-.613-.475-1.06-.475-.44 0-.787.16-1.052.475-.265.315-.394.721-.394 1.227 0 .506.129.92.394 1.227.265.314.613.476 1.052.476.447 0 .795-.162 1.06-.476ZM30.3 2.718v5.736c0 .775-.258 1.396-.758 1.856-.507.46-1.294.69-2.362.69-.825 0-1.491-.184-1.999-.552-.507-.368-.78-.89-.817-1.564h1.612c.076.283.227.498.447.651.22.154.515.23.878.23.455 0 .81-.115 1.06-.345.25-.23.379-.575.379-1.02v-.62c-.424.544-1.03.812-1.802.812a2.64 2.64 0 0 1-1.386-.368 2.548 2.548 0 0 1-.961-1.043c-.235-.444-.349-.974-.349-1.572 0-.59.114-1.112.349-1.564.227-.452.552-.798.969-1.043a2.667 2.667 0 0 1 1.393-.368c.765 0 1.37.3 1.817.897l.136-.813H30.3Zm-1.962 4.118c.258-.307.387-.705.387-1.196 0-.498-.13-.905-.387-1.22-.257-.314-.605-.467-1.037-.467-.431 0-.78.153-1.037.468-.265.306-.394.713-.394 1.211 0 .499.129.905.394 1.212.265.307.606.46 1.037.46.432-.008.78-.161 1.038-.468ZM23.69 2.718V8.63h-1.424l-.136-.828c-.462.59-1.068.882-1.817.882a2.64 2.64 0 0 1-1.386-.368 2.544 2.544 0 0 1-.961-1.058c-.235-.46-.349-.99-.349-1.603 0-.598.114-1.127.349-1.587.227-.46.552-.813.969-1.066a2.672 2.672 0 0 1 1.393-.376c.394 0 .742.077 1.045.23.303.154.552.368.75.63l.158-.783h1.409v.015Zm-1.961 4.195c.257-.307.386-.721.386-1.227 0-.514-.129-.928-.386-1.242-.258-.315-.606-.476-1.038-.476-.431 0-.78.161-1.037.476-.265.314-.394.728-.394 1.242 0 .506.13.912.394 1.227.265.314.606.467 1.037.467.432 0 .78-.16 1.038-.467ZM12.719 8.63V.58h1.703V7.15h3.157v1.48h-4.86Z"
+          g clip-path="url(#b)"
+            g fill="#8C95A6" clip-path="url(#c)"
+              path d="M9.192 5.36a4.556 4.556 0 0 1-1.296 2.547 4.545 4.545 0 0 1-2.544 1.298c0-.008-.008-.016-.008-.025v-.008c-.009-.016-.009-.025-.017-.05l-.025-.074c-.041-.116-.066-.248-.09-.38v-.009c0-.016-.009-.033-.009-.05v-.008c0-.016-.008-.033-.008-.04v-.017c0-.017-.008-.033-.008-.058-.009-.042-.009-.083-.009-.133v-.058c0-.05-.008-.099-.008-.157a2.984 2.984 0 0 1 2.973-2.977H8.358c.041 0 .091.008.132.016.017 0 .042 0 .066.009.017 0 .033.008.042.008h.008c.016 0 .033 0 .05.008h.008a3.341 3.341 0 0 1 .462.124c.017.009.025.009.041.017h.009c0 .008.008.016.016.016Z"
+              path d="M9.25 4.681h-.008c-.075-.025-.149-.041-.223-.066-.009 0-.017-.008-.033-.008a1.52 1.52 0 0 0-.207-.042h-.008c-.017 0-.041-.008-.058-.008h-.016c-.025 0-.05-.008-.067-.008-.024 0-.057-.008-.074-.008-.05-.009-.107-.009-.157-.017h-.272a3.637 3.637 0 0 0-3.634 3.64c0 .057 0 .115.008.181v.042c0 .016 0 .033.008.05.009.049.009.107.017.156 0 .025.008.05.008.075 0 .025.008.05.008.066.009.033.009.058.017.083.025.157.066.314.115.471v.008a4.545 4.545 0 0 1-2.816-.918V8.18c0-3.466 2.816-6.286 6.277-6.286h.198c.611.777.925 1.762.917 2.787Z" opacity=".6"
+              path d="M7.739 1.2c-.033 0-.075.008-.108.008-.058 0-.107.008-.165.016-.017 0-.041 0-.058.008-.016 0-.025 0-.041.009-.1.008-.198.024-.297.04-.075.01-.14.026-.215.034l-.132.025c-.05.008-.1.025-.157.033-.017.008-.042.008-.058.016-.033.009-.074.017-.107.025-.017 0-.025.009-.042.009-.041.008-.082.016-.115.033-.017.008-.042.008-.058.016-.033.008-.058.017-.091.025-.025.008-.05.017-.066.025-.041.008-.074.025-.107.033-.009 0-.017.008-.025.008-.05.017-.1.033-.149.058-.058.017-.107.041-.157.058a.305.305 0 0 0-.09.041c-.034.009-.058.025-.091.033-.05.025-.108.042-.157.067-.091.04-.182.082-.273.132a6.767 6.767 0 0 0-.339.182c-.033.025-.074.041-.107.066-.041.025-.082.05-.132.083-.041.025-.083.05-.116.074-.033.025-.074.05-.107.075l-.1.074a5.62 5.62 0 0 0-.23.174c-.033.025-.058.05-.091.074l-.157.132c-.041.034-.083.075-.124.108-.033.025-.058.058-.09.083-.1.099-.2.19-.298.297-.033.034-.058.058-.083.091-.041.042-.074.083-.107.124-.05.05-.091.108-.132.158-.025.033-.05.058-.075.09-.057.075-.115.158-.173.232l-.074.1c-.025.033-.05.074-.075.107-.025.041-.05.074-.074.116-.025.041-.058.082-.083.132-.024.033-.041.074-.066.108-.066.107-.124.223-.181.33-.05.091-.091.182-.133.273-.024.05-.05.1-.066.157-.008.025-.024.058-.033.091-.016.034-.024.067-.041.091-.025.05-.041.108-.058.158-.016.05-.033.099-.058.148 0 .009-.008.017-.008.025-.016.033-.025.075-.033.108-.008.025-.016.05-.025.066l-.024.09c-.009.017-.009.042-.017.059-.008.041-.025.083-.033.116 0 .008-.008.024-.008.041-.009.033-.017.074-.025.107 0 .017-.008.034-.017.058-.008.05-.024.1-.033.158-.008.04-.016.082-.024.132-.017.074-.025.14-.033.215-.017.1-.025.198-.042.298 0 .016 0 .024-.008.041 0 .017 0 .033-.008.058-.008.058-.008.107-.017.165 0 .033-.008.075-.008.108A4.471 4.471 0 0 1 0 4.689a4.606 4.606 0 0 1 1.272-3.25c.025-.033.058-.058.082-.083l.083-.082A4.63 4.63 0 0 1 4.625 0h.058a4.632 4.632 0 0 1 3.056 1.2Z" opacity=".3"
+          defs
+            clipPath id="a"
+              path fill="#fff" d="M0 0h24.281v10.421H0z" transform="translate(12.719 .579)"
+            clipPath id="b"
+              path fill="#fff" d="M0 0h9.25v9.263H0z"
+            clipPath id="c"
+              path fill="#fff" d="M0 0h9.25v9.263H0z"
+
+      - if subscription?
+        - subscriptions.each do |subscription|
+          - if subscription.name.present?
+            h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.name)
+          - else
+            h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.plan.name)
+          .body-1 = I18n.t('invoice.subscription')
+          .mb-24.body-3
+            | #{I18n.t('invoice.date_from')} #{I18n.l(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date, format: :default)} #{I18n.t('invoice.date_to')} #{I18n.l(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date, format: :default)}
+
+          .invoice-resume.mb-24.overflow-auto
+            table.invoice-resume-table width="100%"
+              tr
+                td width="70%"
+                  .body-1
+                    = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.name)
+                td.body-1 style="text-align: right;" width="30%"
+                  = subscription_fees(subscription.id).subscription_kind.first&.amount&.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+            table.total-table width="100%"
+              tr
+                td.body-2 width="70%" = I18n.t('invoice.sub_total')
+                td.body-1 width="30%" = invoice_subscription(subscription.id).subscription_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+
+          - if subscription? && subscription_fees(subscription.id).charge_kind.any?
+            .body-1 = I18n.t('invoice.usage_based_fees')
+            .mb-24.body-3
+              = I18n.t('invoice.list_of_charges', from: I18n.l(invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date, format: :default), to: I18n.l(invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date, format: :default))
+            .charge-details.mb-24
+              table.charge-details-table width="100%"
+                - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).group_by(&:charge_id).each do |_charge_id, fees|
+                  - fee = fees.first
+                  - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
+                    tr
+                      td width="70%"
+                        .body-1 = fee.billable_metric.name
+                        .body-3
+                          - if fee.billable_metric.recurring_count_agg?
+                            = I18n.t('invoice.see_breakdown')
+                          - elsif fee.charge.percentage?
+                            = I18n.t('invoice.total_unit_interval', events_count: fees.sum(&:events_count), units: fees.sum(&:units))
+                          - else
+                            = I18n.t('invoice.total_unit', units: fees.sum(&:units))
+                      td width="30%"
+
+                    - fees.select { |f| f.units.positive? }.each do |fee|
+                      tr
+                        td width="70%" style="padding-left: 16px;"
+                          .body-1 = fee.group.name
+                          - unless fee.billable_metric.recurring_count_agg?
+                            .body-3
+                              - if fee.charge.percentage?
+                                = I18n.t('invoice.total_unit_interval', events_count: fee.events_count, units: fee.units)
+                              - else
+                                = I18n.t('invoice.total_unit', units: fee.units)
+                        td.body-1 width="30%" = fee.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+                      - if fee.true_up_fee.present?
+                        tr
+                          td width="70%"
+                            .body-1 = I18n.t('invoice.true_up_metric', metric: fee.billable_metric.name)
+                            .body-3 = I18n.t('invoice.true_up_details', min_amount: fee.charge.min_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator')))
+                          td.body-1 width="30%" = fee.true_up_fee.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+                  - else
+                    tr
+                      td width="70%"
+                        .body-1 = fee.billable_metric.name
+                        .body-3
+                          - if fee.billable_metric.recurring_count_agg? && fees.sum(&:units) > 0
+                            = I18n.t('invoice.see_breakdown')
+                          - elsif fee.charge.percentage?
+                            = I18n.t('invoice.total_unit_interval', events_count: fees.sum(&:events_count), units: fees.sum(&:units))
+                          - else
+                            = I18n.t('invoice.total_unit', units: fees.sum(&:units))
+                      td.body-1 width="30%" = fees.sum(&:amount).format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+                    - if fee.true_up_fee.present?
+                      tr
+                        td width="70%"
+                          .body-1 = I18n.t('invoice.true_up_metric', metric: fee.billable_metric.name)
+                          .body-3 = I18n.t('invoice.true_up_details', min_amount: fee.charge.min_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator')))
+                        td.body-1 width="30%" = fee.true_up_fee.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+
+              .charge-details-resume
+                table.total-table width="100%"
+                  tr
+                    td.body-2 width="70%" = I18n.t('invoice.sub_total')
+                    td.body-1 width="30%" = invoice_subscription(subscription.id).charge_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+                table.total-table width="100%"
+                  tr
+                    td.body-2 width="70%" = I18n.t('invoice.total')
+                    td.body-1 width="30%" = invoice_subscription(subscription.id).total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+
+            - recurring_fees(subscription.id).group_by(&:charge_id).each do |_charge_id, fees|
+              - if fees.sum(&:units) > 0
+                - if subscription.name.present?
+                  h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.name)
+                - else
+                  h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.plan.name)
+
+                - if fees.all? { |f| f.group_id? }
+                  - fees.select { |f| f.units.positive? }.each do |fee|
+                    .body-3 = fees.first.billable_metric.name
+                    .body-1.mb-24 = I18n.t('invoice.breakdown_of', fee_group_name: fee.group.name)
+                    .breakdown-details.mb-24
+                      table.breakdown-details-table width="100%"
+                        - recurring_breakdown(fee).each do |breakdown|
+                          tr
+                            td.body-3 width="15%" = I18n.l(breakdown.date, format: :default)
+                            td.body-1 width="65%"
+                              - if breakdown.action.to_sym == :add
+                                | +#{breakdown.count} #{fee.item_name}
+                              - elsif breakdown.action.to_sym == :remove
+                                | -#{breakdown.count} #{fee.item_name}
+                              - else
+                                | +/-#{breakdown.count} #{fee.item_name}
+                            td.body-3 width="20%"
+                              = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
+                - else
+                  .body-3 = fees.first.billable_metric.name
+                  .body-1.mb-24 = I18n.t('invoice.breakdown')
+                  .breakdown-details.mb-24
+                    table.breakdown-details-table width="100%"
+                      - fees.each do |fee|
+                        - recurring_breakdown(fee).each do |breakdown|
+                          tr
+                            td.body-3 width="15%" = breakdown.date.strftime('%b %d, %Y')
+                            td.body-1 width="65%"
+                              - if breakdown.action.to_sym == :add
+                                | +#{breakdown.count} #{fee.item_name}
+                              - elsif breakdown.action.to_sym == :remove
+                                | -#{breakdown.count} #{fee.item_name}
+                              - else
+                                | +/-#{breakdown.count} #{fee.item_name}
+                            td.body-3 width="20%"
+                              = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
+
+                .alert.body-3 = I18n.t('invoice.notice')


### PR DESCRIPTION
## Context

Future changes will impact the way coupons are applied to invoices (moved before VAT computation rather than before).

## Description

This PR adds a new email template for future v3 invoices. The main change compared to `v2` is that coupons appears before the `sub_total_vat_included_amount_cents` item.