### PR TITLE
feat(coupons): Apply coupons before VAT and bump invoice to v3

### DIFF
--- a/app/services/credits/applied_coupons_service.rb
+++ b/app/services/credits/applied_coupons_service.rb
@@ -9,30 +9,27 @@ module Credits
 
     def call
       return result if applied_coupons.blank?
+      return result if invoice.fees_amount_cents.zero?
 
       applied_coupons.each do |applied_coupon|
         break unless invoice.fees_amount_cents&.positive?
         next if applied_coupon.coupon.fixed_amount? && applied_coupon.amount_currency != currency
 
-        base_amount_cents = if applied_coupon.coupon.limited_billable_metrics?
-          coupon_related_fees = billable_metric_related_fees(applied_coupon)
-          next unless coupon_related_fees.exists?
-
-          coupon_base_amount_cents(coupon_related_fees:)
+        fees = if applied_coupon.coupon.limited_billable_metrics?
+          billable_metric_related_fees(applied_coupon)
         elsif applied_coupon.coupon.limited_plans?
-          coupon_related_fees = plan_related_fees(applied_coupon)
-          next unless coupon_related_fees.exists?
-
-          coupon_base_amount_cents(coupon_related_fees:)
+          plan_related_fees(applied_coupon)
         else
-          invoice.total_amount_cents
+          invoice.fees
         end
+        next unless fees.exists?
 
+        base_amount_cents = fees.sum(:amount_cents)
         credit_result = Credits::AppliedCouponService.new(invoice:, applied_coupon:, base_amount_cents:).create
         credit_result.raise_if_error!
 
         invoice.coupons_amount_cents += credit_result.credit.amount_cents
-        invoice.total_amount_cents -= credit_result.credit.amount_cents
+        invoice.sub_total_vat_excluded_amount_cents -= credit_result.credit.amount_cents
       end
 
       result.invoice = invoice
@@ -48,18 +45,16 @@ module Credits
     def applied_coupons
       return @applied_coupons if @applied_coupons
 
-      with_bm_limit = customer.applied_coupons.active.joins(:coupon).where(coupon: { limited_billable_metrics: true })
+      base_scope = customer
+        .applied_coupons.active
+        .joins(:coupon)
         .order(created_at: :asc)
-      with_plan_limit = customer.applied_coupons.active.joins(:coupon).where(coupon: { limited_plans: true })
-        .order(created_at: :asc)
+
+      with_bm_limit = base_scope.where(coupon: { limited_billable_metrics: true })
+      with_plan_limit = base_scope.where(coupon: { limited_plans: true })
       applied_to_all =
-        customer
-          .applied_coupons
-          .active
-          .joins(:coupon)
-          .where(coupon: { limited_plans: false })
+        base_scope.where(coupon: { limited_plans: false })
           .where(coupon: { limited_billable_metrics: false })
-          .order(created_at: :asc)
 
       @applied_coupons = with_bm_limit + with_plan_limit + applied_to_all
     end
@@ -73,17 +68,6 @@ module Credits
         .fees
         .joins(charge: :billable_metric)
         .where(billable_metric: { id: applied_coupon.coupon.coupon_targets.select(:billable_metric_id) })
-    end
-
-    def coupon_base_amount_cents(coupon_related_fees:)
-      fee_amounts = coupon_related_fees.select(:amount_cents, :vat_amount_cents)
-      fees_amount_cents = fee_amounts.sum(&:amount_cents)
-      fees_vat_amount_cents = fee_amounts.sum(&:vat_amount_cents)
-      total_fees_amount_cents = fees_amount_cents + fees_vat_amount_cents
-
-      # In some cases when credit note is already applied sum from above
-      # can be greater than invoice total_amount_cents
-      (total_fees_amount_cents > invoice.total_amount_cents) ? invoice.total_amount_cents : total_fees_amount_cents
     end
   end
 end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -32,9 +32,12 @@ module Invoices
           create_charges_fees(subscription, boundaries) if should_create_charge_fees?(subscription)
         end
 
+        invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
+        invoice.sub_total_vat_excluded_amount_cents = invoice.fees.sum(:amount_cents)
+        Credits::AppliedCouponsService.call(invoice:) if should_create_coupon_credit?
+
         Invoices::ComputeAmountsFromFees.call(invoice:)
         create_credit_note_credit if should_create_credit_note_credit?
-        Credits::AppliedCouponsService.call(invoice:) if should_create_coupon_credit?
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
 
         invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded

--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -9,15 +9,26 @@ module Invoices
 
     def call
       invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
-      invoice.sub_total_vat_excluded_amount_cents = invoice.fees_amount_cents
-      invoice.vat_amount_cents = invoice.fees.sum { |f| f.amount_cents * f.vat_rate }.fdiv(100).round
+      invoice.coupons_amount_cents = invoice.credits.coupon_kind.sum(:amount_cents)
+      invoice.sub_total_vat_excluded_amount_cents = (
+        invoice.fees_amount_cents - invoice.coupons_amount_cents
+      )
+
+      invoice.vat_amount_cents = invoice.fees.sum do |fee|
+        # NOTE: Because coupons are applied before VAT,
+        #       we have to distribute the coupons amount at prorata of each fees
+        #       compared to the invoice total fees amount
+        fee_rate = invoice.fees_amount_cents.zero? ? 0 : fee.amount_cents.fdiv(invoice.fees_amount_cents)
+        prorated_coupon_amount = fee_rate * invoice.coupons_amount_cents
+        (fee.amount_cents - prorated_coupon_amount) * fee.vat_rate
+      end.fdiv(100).round
+
       invoice.sub_total_vat_included_amount_cents = (
         invoice.sub_total_vat_excluded_amount_cents + invoice.vat_amount_cents
       )
-      invoice.total_amount_cents = invoice.sub_total_vat_included_amount_cents -
-                                   invoice.credit_notes_amount_cents -
-                                   invoice.coupons_amount_cents -
-                                   invoice.prepaid_credit_amount_cents
+      invoice.total_amount_cents = (
+        invoice.sub_total_vat_included_amount_cents - invoice.credit_notes_amount_cents
+      )
 
       result.invoice = invoice
       result

--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -388,8 +388,8 @@ html
           - if coupons_adjustment_amount_cents.positive?
             tr
               td.body-2 width="70%" = I18n.t('credit_note.coupon_adjustment')
-              td.body-1 width="30%" - #{}
-                | -#{coupons_adjustment_amount_cents.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))}
+              td.body-1 width="30%"
+                | -#{coupons_adjustment_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))}
           tr
             td.body-2 width="70%" = I18n.t('credit_note.sub_total_without_tax')
             td.body-1 width="30%" = sub_total_vat_excluded_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))

--- a/config/locales/de/credit_note.yml
+++ b/config/locales/de/credit_note.yml
@@ -10,6 +10,7 @@ de:
     credited_notice: Gutschrift auf Kundenguthaben am %{issuing_date}
     credited_refunded_notice: Auf Kundenguthaben gutgeschrieben und zurückerstattet am %{issuing_date}
     subscription: Abonnement
+    coupon_adjustment: Coupons
     sub_total_without_tax: Zwischensumme (ohne Steuern)
     tax: Steuern
     credited_on_customer_balance: Auf Kundenguthaben gutgeschrieben

--- a/config/locales/en/credit_note.yml
+++ b/config/locales/en/credit_note.yml
@@ -10,7 +10,7 @@ en:
     credited_notice: Credited on customer balance on %{issuing_date}
     credited_refunded_notice: Credited on customer balance and refunded on %{issuing_date}
     subscription: Subscription
-    coupon_adjustment: Coupon adjustment
+    coupon_adjustment: Coupons
     sub_total_without_tax: Sub total (excl. tax)
     tax: Tax
     credited_on_customer_balance: Credited on customer balance

--- a/config/locales/fr/credit_note.yml
+++ b/config/locales/fr/credit_note.yml
@@ -10,6 +10,7 @@ fr:
     credited_notice: Crédité sur le solde du client le %{issuing_date}
     credited_refunded_notice: Crédité sur le solde du client et remboursée le %{issuing_date}
     subscription: Souscription
+    coupon_adjustment: Coupons
     sub_total_without_tax: Sous total (HT)
     tax: Taxe
     credited_on_customer_balance: Crédit sur le solde du client

--- a/config/locales/nb/credit_note.yml
+++ b/config/locales/nb/credit_note.yml
@@ -10,6 +10,7 @@ nb:
     credited_notice: Kreditert til kontobalanse %{issuing_date}
     credited_refunded_notice: Kreditert til kontobalanse og refundert %{issuing_date}
     subscription: Abonnement
+    coupon_adjustment: Kuponger
     sub_total_without_tax: Sub total (ekskl. MVA)
     tax: Merverdiavgift
     credited_on_customer_balance: Kreditert til kontobalanse

--- a/db/migrate/20230425130239_change_default_invoice_version.rb
+++ b/db/migrate/20230425130239_change_default_invoice_version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeDefaultInvoiceVersion < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :invoices, :version_number, from: 2, to: 3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_24_210224) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_25_130239) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -399,7 +399,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_24_210224) do
     t.integer "payment_attempts", default: 0, null: false
     t.boolean "ready_for_payment_processing", default: true, null: false
     t.uuid "organization_id", null: false
-    t.integer "version_number", default: 2, null: false
+    t.integer "version_number", default: 3, null: false
     t.string "currency"
     t.bigint "fees_amount_cents", default: 0, null: false
     t.bigint "coupons_amount_cents", default: 0, null: false

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
       organization:,
       payment_status: 'succeeded',
       currency: 'EUR',
-      sub_total_vat_excluded_amount_cents: 100,
+      fees_amount_cents: 100,
       vat_amount_cents: 120,
       total_amount_cents: 120,
     )

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
   let(:invoice_subscription) { create(:invoice_subscription, invoice:) }
-  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:invoice) { create(:invoice, customer:, organization:, fees_amount_cents: 10) }
   let(:subscription) { invoice_subscription.subscription }
   let(:fee) { create(:fee, subscription:, invoice:, amount_cents: 10) }
 
@@ -171,7 +171,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
   end
 
   context 'with an add on invoice' do
-    let(:invoice) { create(:invoice, customer:, organization:) }
+    let(:invoice) { create(:invoice, customer:, organization:, fees_amount_cents: 10) }
     let(:add_on) { create(:add_on, organization:) }
     let(:applied_add_on) { create(:applied_add_on, add_on:, customer:) }
     let(:fee) { create(:add_on_fee, invoice:, applied_add_on:) }

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -125,8 +125,10 @@ RSpec.describe CreditNote, type: :model do
     end
 
     it 'returns the list of subscription ids' do
-      expect(credit_note.subscription_ids)
-        .to contain_exactly(subscription_fee.subscription_id, charge_fee.subscription_id)
+      expect(credit_note.subscription_ids).to contain_exactly(
+        subscription_fee.subscription_id,
+        charge_fee.subscription_id,
+      )
     end
 
     context 'with add_on fee' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -213,8 +213,8 @@ RSpec.describe Invoice, type: :model do
     end
 
     it 'returns the expected creditable amount in cents' do
-      invoice_subscription = create(:invoice_subscription)
-      invoice = invoice_subscription.invoice
+      invoice = create(:invoice, version_number: 2)
+      invoice_subscription = create(:invoice_subscription, invoice:)
       subscription = invoice_subscription.subscription
       billable_metric = create(:recurring_billable_metric, organization: subscription.organization)
       charge = create(:standard_charge, plan: subscription.plan, billable_metric:)

--- a/spec/requests/api/v1/credit_notes_spec.rb
+++ b/spec/requests/api/v1/credit_notes_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       customer:,
       payment_status: 'succeeded',
       currency: 'EUR',
-      sub_total_vat_excluded_amount_cents: 100,
+      fees_amount_cents: 100,
       vat_amount_cents: 120,
       total_amount_cents: 120,
     )

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ::V1::InvoiceSerializer do
         'sub_total_vat_included_amount_cents' => invoice.sub_total_vat_included_amount_cents,
         'total_amount_cents' => invoice.total_amount_cents,
         'file_url' => invoice.file_url,
-        'version_number' => 2,
+        'version_number' => 3,
 
         # NOTE: deprecated fields
         'legacy' => false,

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
       :invoice,
       customer:,
       currency: 'EUR',
+      fees_amount_cents: 100,
       total_amount_cents: 120,
     )
   end
@@ -319,7 +320,8 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
           :invoice,
           customer:,
           currency: 'EUR',
-          total_amount_cents: 999,
+          fees_amount_cents: 999,
+          total_amount_cents: 0,
         )
       end
 

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -254,6 +254,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
               :invoice,
               :draft,
               currency: 'EUR',
+              fees_amount_cents: 20,
               total_amount_cents: 24,
               payment_status: :succeeded,
               vat_rate: 20,

--- a/spec/services/credits/applied_coupons_service_spec.rb
+++ b/spec/services/credits/applied_coupons_service_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe Credits::AppliedCouponsService do
       :invoice,
       fees_amount_cents: 100,
       sub_total_vat_excluded_amount_cents: 100,
-      vat_amount_cents: 20,
-      total_amount_cents: 120,
       currency: 'EUR',
       customer: subscription.customer,
     )
@@ -33,7 +31,7 @@ RSpec.describe Credits::AppliedCouponsService do
 
   describe '#call' do
     let(:timestamp) { Time.zone.now.beginning_of_month }
-    let(:fee) { create(:fee, invoice:, subscription:) }
+    let(:fee) { create(:fee, amount_cents: 100, invoice:, subscription:) }
     let(:applied_coupon) do
       create(
         :applied_coupon,
@@ -67,8 +65,8 @@ RSpec.describe Credits::AppliedCouponsService do
 
       aggregate_failures do
         expect(result).to be_success
-        expect(result.invoice.coupons_amount_cents).to eq(32)
-        expect(result.invoice.total_amount_cents).to eq(88)
+        expect(result.invoice.coupons_amount_cents).to eq(30)
+        expect(result.invoice.sub_total_vat_excluded_amount_cents).to eq(70)
         expect(result.invoice.credits.count).to eq(2)
       end
     end
@@ -91,9 +89,8 @@ RSpec.describe Credits::AppliedCouponsService do
 
         aggregate_failures do
           expect(result).to be_success
-          expect(result.invoice.sub_total_vat_excluded_amount_cents).to eq(100)
-          expect(result.invoice.vat_amount_cents).to eq(20)
-          expect(result.invoice.total_amount_cents).to eq(90)
+          expect(result.invoice.coupons_amount_cents).to eq(30)
+          expect(result.invoice.sub_total_vat_excluded_amount_cents).to eq(70)
           expect(result.invoice.credits.count).to eq(2)
         end
       end
@@ -115,9 +112,8 @@ RSpec.describe Credits::AppliedCouponsService do
 
         aggregate_failures do
           expect(result).to be_success
-          expect(result.invoice.sub_total_vat_excluded_amount_cents).to eq(100)
-          expect(result.invoice.vat_amount_cents).to eq(20)
-          expect(result.invoice.total_amount_cents).to eq(82)
+          expect(result.invoice.coupons_amount_cents).to eq(35)
+          expect(result.invoice.sub_total_vat_excluded_amount_cents).to eq(65)
           expect(result.invoice.credits.count).to eq(2)
         end
       end
@@ -178,9 +174,8 @@ RSpec.describe Credits::AppliedCouponsService do
 
         aggregate_failures do
           expect(result).to be_success
+          expect(result.invoice.coupons_amount_cents).to eq(0)
           expect(result.invoice.sub_total_vat_excluded_amount_cents).to eq(100)
-          expect(result.invoice.vat_amount_cents).to eq(20)
-          expect(result.invoice.total_amount_cents).to eq(120)
           expect(result.invoice.credits.count).to be_zero
         end
       end
@@ -221,7 +216,8 @@ RSpec.describe Credits::AppliedCouponsService do
 
         aggregate_failures do
           expect(result).to be_success
-          expect(result.invoice.total_amount_cents).to eq(100)
+          expect(result.invoice.coupons_amount_cents).to eq(20)
+          expect(result.invoice.sub_total_vat_excluded_amount_cents).to eq(80)
           expect(result.invoice.credits.count).to eq(1)
         end
       end
@@ -262,7 +258,8 @@ RSpec.describe Credits::AppliedCouponsService do
 
         aggregate_failures do
           expect(result).to be_success
-          expect(result.invoice.total_amount_cents).to eq(90)
+          expect(result.invoice.coupons_amount_cents).to eq(30)
+          expect(result.invoice.sub_total_vat_excluded_amount_cents).to eq(70)
           expect(result.invoice.credits.count).to eq(2)
         end
       end
@@ -345,7 +342,8 @@ RSpec.describe Credits::AppliedCouponsService do
 
         aggregate_failures do
           expect(result).to be_success
-          expect(result.invoice.total_amount_cents).to eq(35)
+          expect(result.invoice.coupons_amount_cents).to eq(80)
+          expect(result.invoice.sub_total_vat_excluded_amount_cents).to eq(20)
           expect(result.invoice.credits.count).to eq(2)
         end
       end

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -10,25 +10,30 @@ RSpec.describe Invoices::ComputeAmountsFromFees, type: :service do
   before do
     create(:fee, invoice:, amount_cents: 151, vat_rate: 10)
     create(:fee, invoice:, amount_cents: 379, vat_rate: 20)
+    create(:credit, invoice:, amount_cents: 100)
   end
 
   it 'sets fees_amount_cents from the list of fees' do
     expect { compute_amounts.call }.to change(invoice, :fees_amount_cents).from(0).to(530)
   end
 
+  it 'sets coupons_amount_cents from the list of fees' do
+    expect { compute_amounts.call }.to change(invoice, :coupons_amount_cents).from(0).to(100)
+  end
+
   it 'sets sub_total_vat_excluded_amount_cents from the list of fees' do
-    expect { compute_amounts.call }.to change(invoice, :sub_total_vat_excluded_amount_cents).from(0).to(530)
+    expect { compute_amounts.call }.to change(invoice, :sub_total_vat_excluded_amount_cents).from(0).to(430)
   end
 
   it 'sets vat_amount_cents from the list of fees' do
-    expect { compute_amounts.call }.to change(invoice, :vat_amount_cents).from(0).to(91)
+    expect { compute_amounts.call }.to change(invoice, :vat_amount_cents).from(0).to(74)
   end
 
   it 'sets sub_total_vat_included_amount_cents' do
-    expect { compute_amounts.call }.to change(invoice, :sub_total_vat_included_amount_cents).from(0).to(621)
+    expect { compute_amounts.call }.to change(invoice, :sub_total_vat_included_amount_cents).from(0).to(504)
   end
 
   it 'sets total_amount_cents' do
-    expect { compute_amounts.call }.to change(invoice, :total_amount_cents).from(0).to(621)
+    expect { compute_amounts.call }.to change(invoice, :total_amount_cents).from(0).to(504)
   end
 end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
         expect(result.invoice.vat_amount_cents).to eq(20)
         expect(result.invoice.vat_rate).to eq(20)
         expect(result.invoice.total_amount_cents).to eq(120)
-        expect(result.invoice.version_number).to eq(2)
+        expect(result.invoice.version_number).to eq(3)
         expect(result.invoice).to be_finalized
       end
     end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -381,6 +381,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
                 customer:,
                 currency: 'EUR',
                 sub_total_vat_excluded_amount_cents: 100,
+                fees_amount_cents: 100,
                 vat_amount_cents: 20,
                 total_amount_cents: 120,
               )

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Subscriptions::TerminateService do
           customer: subscription.customer,
           currency: 'EUR',
           sub_total_vat_excluded_amount_cents: 100,
+          fees_amount_cents: 100,
           vat_amount_cents: 20,
           total_amount_cents: 120,
         )


### PR DESCRIPTION
## Context

Future changes will impact the way coupons are applied to invoices (moved before VAT computation rather than before).

## Description

This PR updates the coupon application logic on invoice to include the amount before VAT computation and to make sure the `before_vat` flag is set on the resulting `credit` record.

Invoice is also bumped to version 3
