### PR TITLE
feat(coupon): Add coupons adjustment amount to credit notes

### DIFF
--- a/app/graphql/types/credit_notes/object.rb
+++ b/app/graphql/types/credit_notes/object.rb
@@ -3,40 +3,34 @@
 module Types
   module CreditNotes
     class Object < Types::BaseObject
+      description 'CreditNote'
       graphql_name 'CreditNote'
 
       field :id, ID, null: false
-      field :issuing_date, GraphQL::Types::ISO8601Date, null: false
       field :number, String, null: false
       field :sequential_id, ID, null: false
 
-      field :credit_status, Types::CreditNotes::CreditStatusTypeEnum, null: true
+      field :issuing_date, GraphQL::Types::ISO8601Date, null: false
+
       field :description, String, null: true
       field :reason, Types::CreditNotes::ReasonTypeEnum, null: false
+
+      field :credit_status, Types::CreditNotes::CreditStatusTypeEnum, null: true
       field :refund_status, Types::CreditNotes::RefundStatusTypeEnum, null: true
 
-      field :sub_total_vat_excluded_amount_cents, GraphQL::Types::BigInt, null: false
-      field :sub_total_vat_excluded_amount_currency, Types::CurrencyEnum, null: false
-
-      field :total_amount_cents, GraphQL::Types::BigInt, null: false
-      field :total_amount_currency, Types::CurrencyEnum, null: false
-
-      field :credit_amount_cents, GraphQL::Types::BigInt, null: false
-      field :credit_amount_currency, Types::CurrencyEnum, null: false
+      field :currency, Types::CurrencyEnum, null: false
 
       field :balance_amount_cents, GraphQL::Types::BigInt, null: false
-      field :balance_amount_currency, Types::CurrencyEnum, null: false
-
+      field :coupons_adjustment_amount_cents, GraphQL::Types::BigInt, null: false
+      field :credit_amount_cents, GraphQL::Types::BigInt, null: false
       field :refund_amount_cents, GraphQL::Types::BigInt, null: false
-      field :refund_amount_currency, Types::CurrencyEnum, null: false
-
+      field :sub_total_vat_excluded_amount_cents, GraphQL::Types::BigInt, null: false
+      field :total_amount_cents, GraphQL::Types::BigInt, null: false
       field :vat_amount_cents, GraphQL::Types::BigInt, null: false
-      field :vat_amount_currency, Types::CurrencyEnum, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
-
       field :refunded_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
       field :voided_at, GraphQL::Types::ISO8601DateTime, null: true
 
       field :file_url, String, null: true
@@ -48,6 +42,14 @@ module Types
       field :can_be_voided, Boolean, null: false, method: :voidable? do
         description 'Check if credit note can be voided'
       end
+
+      # NOTE(legacy): Remove with coupon before VAT refactor
+      field :balance_amount_currency, Types::CurrencyEnum, null: false
+      field :credit_amount_currency, Types::CurrencyEnum, null: false
+      field :refund_amount_currency, Types::CurrencyEnum, null: false
+      field :sub_total_vat_excluded_amount_currency, Types::CurrencyEnum, null: false
+      field :total_amount_currency, Types::CurrencyEnum, null: false
+      field :vat_amount_currency, Types::CurrencyEnum, null: false
     end
   end
 end

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -30,6 +30,8 @@ class CreditNote < ApplicationRecord
 
   monetize :sub_total_vat_excluded_amount_cents
 
+  monetize :coupons_adjustment_amount_cents, with_model_currency: :total_amount_currency
+
   # NOTE: Status of the credit part
   # - available: a credit amount remain available
   # - consumed: the credit amount was totaly consumed

--- a/app/serializers/v1/credit_note_serializer.rb
+++ b/app/serializers/v1/credit_note_serializer.rb
@@ -14,22 +14,18 @@ module V1
         refund_status: model.refund_status,
         reason: model.reason,
         description: model.description,
+        currency: model.currency,
         total_amount_cents: model.total_amount_cents,
-        total_amount_currency: model.total_amount_currency,
         vat_amount_cents: model.vat_amount_cents,
-        vat_amount_currency: model.vat_amount_currency,
         sub_total_vat_excluded_amount_cents: model.sub_total_vat_excluded_amount_cents,
-        sub_total_vat_excluded_amount_currency: model.sub_total_vat_excluded_amount_currency,
         balance_amount_cents: model.balance_amount_cents,
-        balance_amount_currency: model.balance_amount_currency,
         credit_amount_cents: model.credit_amount_cents,
-        credit_amount_currency: model.credit_amount_currency,
         refund_amount_cents: model.refund_amount_cents,
-        refund_amount_currency: model.refund_amount_currency,
+        coupons_adjustment_amount_cents: model.coupons_adjustment_amount_cents,
         created_at: model.created_at.iso8601,
         updated_at: model.updated_at.iso8601,
         file_url: model.file_url,
-      }
+      }.merge(legacy_values)
 
       payload = payload.merge(customer) if include?(:customer)
       payload = payload.merge(items) if include?(:items)
@@ -51,6 +47,10 @@ module V1
         ::V1::CreditNoteItemSerializer,
         collection_name: 'items',
       ).serialize
+    end
+
+    def legacy_values
+      ::V1::Legacy::CreditNoteSerializer.new(model).serialize
     end
   end
 end

--- a/app/serializers/v1/legacy/credit_note_serializer.rb
+++ b/app/serializers/v1/legacy/credit_note_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Legacy
+    class CreditNoteSerializer < ModelSerializer
+      def serialize
+        {
+          total_amount_currency: model.total_amount_currency,
+          vat_amount_currency: model.vat_amount_currency,
+          sub_total_vat_excluded_amount_currency: model.sub_total_vat_excluded_amount_currency,
+          balance_amount_currency: model.balance_amount_currency,
+          credit_amount_currency: model.credit_amount_currency,
+          refund_amount_currency: model.refund_amount_currency,
+        }
+      end
+    end
+  end
+end

--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -379,11 +379,16 @@ html
                     = item.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
 
         table.total-table width="100%"
+          - if coupons_adjustment_amount_cents.positive?
+            tr
+              td.body-2 width="70%" = I18n.t('credit_note.coupon_adjustment')
+              td.body-1 width="30%" - #{}
+                | -#{coupons_adjustment_amount_cents.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))}
           tr
             td.body-2 width="70%" = I18n.t('credit_note.sub_total_without_tax')
             td.body-1 width="30%" = sub_total_vat_excluded_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
           tr
-            td.body-2 = I18n.t('credit_note.tax')
+            td.body-2 #{I18n.t('credit_note.tax')} (#{invoice.vat_rate || 0}%)
             td.body-1 = vat_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
           - if credited?
             tr

--- a/config/locales/en/credit_note.yml
+++ b/config/locales/en/credit_note.yml
@@ -10,6 +10,7 @@ en:
     credited_notice: Credited on customer balance on %{issuing_date}
     credited_refunded_notice: Credited on customer balance and refunded on %{issuing_date}
     subscription: Subscription
+    coupon_adjustment: Coupon adjustment
     sub_total_without_tax: Sub total (excl. tax)
     tax: Tax
     credited_on_customer_balance: Credited on customer balance

--- a/db/migrate/20230424091446_add_coupons_adjustment_amount_to_credit_notes.rb
+++ b/db/migrate/20230424091446_add_coupons_adjustment_amount_to_credit_notes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCouponsAdjustmentAmountToCreditNotes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :credit_notes, :coupons_adjustment_amount_cents, :bigint, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -199,6 +199,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_24_092207) do
     t.datetime "refunded_at"
     t.date "issuing_date", null: false
     t.integer "status", default: 1, null: false
+    t.bigint "coupons_adjustment_amount_cents", default: 0, null: false
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1721,6 +1721,9 @@ input CreateSubscriptionInput {
   subscriptionId: ID
 }
 
+"""
+CreditNote
+"""
 type CreditNote {
   balanceAmountCents: BigInt!
   balanceAmountCurrency: CurrencyEnum!
@@ -1729,10 +1732,12 @@ type CreditNote {
   Check if credit note can be voided
   """
   canBeVoided: Boolean!
+  couponsAdjustmentAmountCents: BigInt!
   createdAt: ISO8601DateTime!
   creditAmountCents: BigInt!
   creditAmountCurrency: CurrencyEnum!
   creditStatus: CreditNoteCreditStatusEnum
+  currency: CurrencyEnum!
   customer: Customer!
   description: String
   fileUrl: String

--- a/schema.json
+++ b/schema.json
@@ -5387,7 +5387,7 @@
         {
           "kind": "OBJECT",
           "name": "CreditNote",
-          "description": null,
+          "description": "CreditNote",
           "interfaces": [
 
           ],
@@ -5438,6 +5438,24 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "couponsAdjustmentAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
                   "ofType": null
                 }
               },
@@ -5508,6 +5526,24 @@
                 "kind": "ENUM",
                 "name": "CreditNoteCreditStatusEnum",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "currency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/resolvers/credit_note_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_note_resolver_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Resolvers::CreditNoteResolver, type: :graphql do
           number
           creditStatus
           reason
+          currency
           totalAmountCents
           totalAmountCurrency
           creditAmountCents
@@ -23,6 +24,7 @@ RSpec.describe Resolvers::CreditNoteResolver, type: :graphql do
           vatAmountCurrency
           subTotalVatExcludedAmountCents
           subTotalVatExcludedAmountCurrency
+          couponsAdjustmentAmountCents
           createdAt
           updatedAt
           voidedAt

--- a/spec/serializers/v1/credit_note_serializer_spec.rb
+++ b/spec/serializers/v1/credit_note_serializer_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V1::CreditNoteSerializer, type: :serializer do
+  subject(:serializer) do
+    described_class.new(credit_note, root_name: 'credit_note', includes: %i[customer items])
+  end
+
+  let(:credit_note) { create(:credit_note) }
+  let(:customer) { credit_note.customer }
+  let(:item) { create(:credit_note_item, credit_note:) }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    expect(result['credit_note']).to include(
+      'lago_id' => credit_note.id,
+      'sequential_id' => credit_note.sequential_id,
+      'number' => credit_note.number,
+      'lago_invoice_id' => credit_note.invoice_id,
+      'invoice_number' => credit_note.invoice.number,
+      'issuing_date' => credit_note.issuing_date.iso8601,
+      'credit_status' => credit_note.credit_status,
+      'refund_status' => credit_note.refund_status,
+      'reason' => credit_note.reason,
+      'description' => credit_note.description,
+      'currency' => credit_note.currency,
+      'total_amount_cents' => credit_note.total_amount_cents,
+      'vat_amount_cents' => credit_note.vat_amount_cents,
+      'sub_total_vat_excluded_amount_cents' => credit_note.sub_total_vat_excluded_amount_cents,
+      'balance_amount_cents' => credit_note.balance_amount_cents,
+      'credit_amount_cents' => credit_note.credit_amount_cents,
+      'refund_amount_cents' => credit_note.refund_amount_cents,
+      'coupons_adjustment_amount_cents' => credit_note.coupons_adjustment_amount_cents,
+      'created_at' => credit_note.created_at.iso8601,
+      'updated_at' => credit_note.updated_at.iso8601,
+      'file_url' => credit_note.file_url,
+
+      # NOTE: deprecated fields
+      'total_amount_currency' => credit_note.total_amount_currency,
+      'vat_amount_currency' => credit_note.vat_amount_currency,
+      'sub_total_vat_excluded_amount_currency' => credit_note.sub_total_vat_excluded_amount_currency,
+      'balance_amount_currency' => credit_note.balance_amount_currency,
+      'credit_amount_currency' => credit_note.credit_amount_currency,
+      'refund_amount_currency' => credit_note.refund_amount_currency,
+    )
+
+    expect(result['credit_note'].keys).to include('customer', 'items')
+  end
+end


### PR DESCRIPTION
## Context

Future changes will impact the way coupons are applied to invoices (moved before VAT computation rather than before).

## Description

This PR adds a new `coupons_adjustment_amount_cents` fields to the credit notes object. 
It will allow us to store the adjustment made on credited and refunded amount based on the applied coupons before VAT
