### PR TITLE
feat(coupon): Take coupons before VAT into account on credit notes

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -20,16 +20,10 @@ class CreditNote < ApplicationRecord
 
   monetize :credit_amount_cents
   monetize :balance_amount_cents
-  monetize :credit_vat_amount_cents
-
   monetize :refund_amount_cents
-  monetize :refund_vat_amount_cents
-
   monetize :total_amount_cents
   monetize :vat_amount_cents
-
   monetize :sub_total_vat_excluded_amount_cents
-
   monetize :coupons_adjustment_amount_cents, with_model_currency: :total_amount_currency
 
   # NOTE: Status of the credit part

--- a/app/services/credit_notes/validate_service.rb
+++ b/app/services/credit_notes/validate_service.rb
@@ -42,9 +42,11 @@ module CreditNotes
     end
 
     def total_items_amount_cents
-      credit_note.items.sum do |item|
-        item.precise_amount_cents + (item.precise_amount_cents * item.fee.vat_rate).fdiv(100)
-      end.round
+      (
+        credit_note.items.sum(&:precise_amount_cents) -
+        credit_note.precise_coupons_adjustment_amount_cents +
+        credit_note.precise_vat_amount_cents
+      ).round
     end
 
     def valid_invoice_status?

--- a/db/migrate/20230424150952_drop_internal_credit_notes_vat_amounts.rb
+++ b/db/migrate/20230424150952_drop_internal_credit_notes_vat_amounts.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class DropInternalCreditNotesVatAmounts < ActiveRecord::Migration[7.0]
+  def up
+    change_table :credit_notes, bulk: true do |t|
+      t.remove :credit_vat_amount_cents
+      t.remove :credit_vat_amount_currency
+      t.remove :refund_vat_amount_cents
+      t.remove :refund_vat_amount_currency
+    end
+  end
+
+  def down
+    change_table :credit_notes, bulk: true do |t|
+      t.bigint :credit_vat_amount_cents, null: false, default: 0
+      t.string :credit_vat_amount_currency
+      t.bigint :refund_vat_amount_cents, null: false, default: 0
+      t.string :refund_vat_amount_currency
+    end
+
+    execute <<-SQL
+    UPDATE credit_notes
+      SET credit_vat_amount_currency = total_amount_currency,
+      refund_vat_amount_currency = total_amount_currency
+    SQL
+  end
+end

--- a/db/migrate/20230424154516_add_precise_amounts_to_credit_notes.rb
+++ b/db/migrate/20230424154516_add_precise_amounts_to_credit_notes.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddPreciseAmountsToCreditNotes < ActiveRecord::Migration[7.0]
+  def change
+    change_table :credit_notes, bulk: true do |t|
+      t.decimal :precise_coupons_adjustment_amount_cents,
+                precision: 30,
+                scale: 5,
+                null: false,
+                default: 0
+
+      t.decimal :precise_vat_amount_cents,
+                precision: 30,
+                scale: 5,
+                null: false,
+                default: 0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -190,16 +190,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_24_210224) do
     t.integer "refund_status"
     t.datetime "voided_at"
     t.text "description"
-    t.bigint "credit_vat_amount_cents", default: 0, null: false
-    t.string "credit_vat_amount_currency"
-    t.bigint "refund_vat_amount_cents", default: 0, null: false
-    t.string "refund_vat_amount_currency"
     t.bigint "vat_amount_cents", default: 0, null: false
     t.string "vat_amount_currency"
     t.datetime "refunded_at"
     t.date "issuing_date", null: false
     t.integer "status", default: 1, null: false
     t.bigint "coupons_adjustment_amount_cents", default: 0, null: false
+    t.decimal "precise_coupons_adjustment_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
+    t.decimal "precise_vat_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end

--- a/spec/factories/credit_notes.rb
+++ b/spec/factories/credit_notes.rb
@@ -15,7 +15,6 @@ FactoryBot.define do
 
     credit_status { 'available' }
     credit_amount_cents { 120 }
-    credit_vat_amount_cents { 20 }
     credit_amount_currency { 'EUR' }
     balance_amount_cents { 120 }
     balance_amount_currency { 'EUR' }

--- a/spec/services/credit_notes/validate_service_spec.rb
+++ b/spec/services/credit_notes/validate_service_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
   let(:result) { BaseService::Result.new }
   let(:amount_cents) { 10 }
   let(:credit_amount_cents) { 12 }
-  let(:item_amount_cents) { 10 }
   let(:refund_amount_cents) { 0 }
   let(:credit_note) do
     create(
@@ -17,6 +16,8 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       customer:,
       credit_amount_cents:,
       refund_amount_cents:,
+      precise_coupons_adjustment_amount_cents: 0,
+      precise_vat_amount_cents: 2,
     )
   end
   let(:item) do
@@ -161,6 +162,63 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
 
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages[:base]).to eq(['higher_than_remaining_invoice_amount'])
+        end
+      end
+    end
+
+    context 'when invoice is v3 with coupons' do
+      let(:invoice) do
+        create(
+          :invoice,
+          currency: 'EUR',
+          fees_amount_cents: 100,
+          coupons_amount_cents: 10,
+          vat_amount_cents: 18,
+          total_amount_cents: 108,
+          payment_status: :succeeded,
+          vat_rate: 20,
+          version_number: 3,
+        )
+      end
+
+      let(:amount_cents) { 20 }
+      let(:credit_amount_cents) { 22 }
+      let(:refund_amount_cents) { 0 }
+      let(:credit_note) do
+        create(
+          :credit_note,
+          invoice:,
+          customer:,
+          credit_amount_cents:,
+          refund_amount_cents:,
+          precise_coupons_adjustment_amount_cents: 2,
+          precise_vat_amount_cents: 3.6,
+        )
+      end
+      let(:item) do
+        create(
+          :credit_note_item,
+          credit_note:,
+          amount_cents:,
+          precise_amount_cents: amount_cents,
+          fee:,
+        )
+      end
+
+      it 'validates the credit_note' do
+        expect(validator).to be_valid
+      end
+
+      context 'when amount does not matches items' do
+        let(:amount_cents) { 1 }
+
+        it 'fails the validation' do
+          aggregate_failures do
+            expect(validator).not_to be_valid
+
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:base]).to eq(['does_not_match_item_amounts'])
+          end
         end
       end
     end


### PR DESCRIPTION
## Context

Future changes will impact the way coupons are applied to invoices (moved before VAT computation rather than before).

## Description

This PR adds adapt the credit note creation logic to take credit note applied before VAT into account.
