### PR TITLE
fix(recurring-bm): fix period duration calculation

### DIFF
--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -84,8 +84,11 @@ module BillableMetrics
       # NOTE: Full period duration to take upgrade, terminate
       #       or start on non-anniversary day into account
       def period_duration
-        @period_duration ||= Subscriptions::DatesService.new_instance(subscription, to_datetime + 1.day)
-          .charges_duration_in_days
+        @period_duration ||= Subscriptions::DatesService.new_instance(
+          subscription,
+          to_datetime + 1.day,
+          current_usage: subscription.terminated? && subscription.upgraded?,
+        ).charges_duration_in_days
       end
 
       # NOTE: when subscription is terminated or upgraded,

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -257,6 +257,34 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
             expect(item.total_duration).to eq(31)
           end
         end
+
+        context 'with calendar subscription and pay in advance' do
+          let(:subscription) do
+            create(
+              :subscription,
+              started_at:,
+              subscription_at:,
+              billing_time: :calendar,
+              terminated_at: to_datetime,
+              status: :terminated,
+            )
+          end
+
+          before { subscription.plan.update!(pay_in_advance: true) }
+
+          it 'returns the detail the persisted metrics' do
+            aggregate_failures do
+              expect(result.count).to eq(1)
+
+              item = result.first
+              expect(item.date.to_s).to eq(from_datetime.to_date.to_s)
+              expect(item.action).to eq('add')
+              expect(item.count).to eq(1)
+              expect(item.duration).to eq(16)
+              expect(item.total_duration).to eq(31)
+            end
+          end
+        end
       end
 
       context 'when subscription was started in the period' do


### PR DESCRIPTION
There is special case when period duration calculation hasn't been working for recurring BM: `calendar` subscription that is `pay_in_advance` and upgraded