### PR TITLE
fix: Refresh draft credit note

### DIFF
--- a/app/services/credit_notes/refresh_draft_service.rb
+++ b/app/services/credit_notes/refresh_draft_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class RefreshDraftService < BaseService
+    def initialize(credit_note:, fee:)
+      @credit_note = credit_note
+      @fee = fee
+
+      super
+    end
+
+    def call
+      result.credit_note = credit_note
+      return result unless credit_note.draft?
+
+      credit_note.items.update_all(fee_id: fee.id) # rubocop:disable Rails/SkipsModelValidations
+
+      amount_cents = credit_note.items.sum(:amount_cents)
+      credit_amount_cents = (amount_cents + (amount_cents * fee.vat_rate).fdiv(100)).round
+      return result if credit_amount_cents == credit_note.credit_amount_cents
+
+      credit_note.update!(
+        vat_amount_cents: credit_note.items.sum { |i| i.amount_cents * i.fee.vat_rate }.fdiv(100).round,
+        credit_amount_cents:,
+        balance_amount_cents: credit_amount_cents,
+        total_amount_cents: credit_amount_cents + credit_note.refund_amount_cents,
+      )
+      result
+    end
+
+    private
+
+    attr_accessor :credit_note, :fee
+  end
+end

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -39,7 +39,7 @@ module Invoices
         invoice.credit_notes.each do |credit_note|
           subscription_id = cn_subscription_ids.find { |h| h[:credit_note_id] == credit_note.id }[:subscription_id]
           fee = invoice.fees.subscription.find_by(subscription_id:)
-          credit_note.items.update_all(fee_id: fee.id) # rubocop:disable Rails/SkipsModelValidations
+          CreditNotes::RefreshDraftService.call(credit_note:, fee:)
         end
 
         return calculate_result unless calculate_result.success?

--- a/spec/services/credit_notes/refresh_draft_service_spec.rb
+++ b/spec/services/credit_notes/refresh_draft_service_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::RefreshDraftService, type: :service do
+  subject(:refresh_service) { described_class.new(credit_note:, fee:) }
+
+  describe '#call' do
+    let(:status) { :draft }
+    let(:credit_note) { create(:credit_note, status:) }
+    let(:fee) { create(:fee, vat_rate: 0) }
+
+    before do
+      create(:credit_note_item, credit_note:, fee: create(:fee, vat_rate: 20))
+    end
+
+    context 'when credit_note is finalized' do
+      let(:status) { :finalized }
+
+      it 'does not refresh it' do
+        expect { refresh_service.call }.not_to change(credit_note, :updated_at)
+      end
+    end
+
+    it 'assigns credit note to the fee' do
+      expect { refresh_service.call }.to change { credit_note.reload.items.pluck(:fee_id) }.to([fee.id])
+    end
+
+    it 'updates vat amounts of the credit note' do
+      expect { refresh_service.call }
+        .to change { credit_note.reload.vat_amount_cents }.from(20).to(0)
+        .and change(credit_note, :credit_amount_cents).from(120).to(100)
+        .and change(credit_note, :balance_amount_cents).from(120).to(100)
+        .and change(credit_note, :total_amount_cents).from(120).to(100)
+    end
+  end
+end


### PR DESCRIPTION
When finalizing a draft invoice including a credit note, the related credit note needs to be refreshed as well.
For instance, when the vat rate of the customer has changed, we need to recalculate the vat amounts of the credit note.