### PR TITLE
feat:Payment_success_webhook for stripe

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -12,6 +12,7 @@ class SendWebhookJob < ApplicationJob
     'invoice.generated' => Webhooks::Invoices::GeneratedService,
     'invoice.drafted' => Webhooks::Invoices::DraftedService,
     'invoice.payment_status_updated' => Webhooks::Invoices::PaymentStatusUpdatedService,
+    'invoice.payment_success' => Webhooks::Invoices::InvoicePaymentSuccessService,
     'invoice.payment_failure' => Webhooks::PaymentProviders::InvoicePaymentFailureService,
     'event.error' => Webhooks::Events::ErrorService,
     'fee.instant_created' => Webhooks::Fees::InstantCreatedService,

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -92,5 +92,11 @@ module Invoices
 
       SendWebhookJob.perform_later('invoice.payment_status_updated', invoice)
     end
+
+    def deliver_payement_success_webhook
+      return unless webhook_notification
+
+      SendWebhookJob.perform_later('invoice.payment_success', invoice)
+    end
   end
 end

--- a/app/services/webhooks/invoices/invoice_payment_success_service.rb
+++ b/app/services/webhooks/invoices/invoice_payment_success_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Webhooks
+    module Invoices
+      class InvoicePaymentSuccessService < Webhooks::BaseService
+        private
+  
+        def current_organization
+          @current_organization ||= object.organization
+        end
+  
+        def object_serializer
+            ::V1::InvoiceSerializer.new(
+              object,
+              root_name: 'invoice',
+            )
+          end
+  
+        def webhook_type
+          'invoice.payment_success'
+        end
+  
+        def object_type
+            'invoice'
+        end
+      end
+    end
+  end
+  

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -360,6 +360,28 @@ RSpec.describe SendWebhookJob, type: :job do
     end
   end
 
+  context 'when webhook type is invoice.payment_success' do
+    let(:webhook_service) { instance_double(Webhooks::Invoices::InvoicePaymentSuccessService) }
+    let(:invoice) { create(:invoice, organization:) }
+
+    before do
+      allow(Webhooks::Invoices::InvoicePaymentSuccessService).to receive(:new)
+        .with(object: invoice, options: {}, webhook_id: nil)
+        .and_return(webhook_service)
+      allow(webhook_service).to receive(:call)
+    end
+
+    it 'calls the webhook service' do
+      send_webhook_job.perform_now(
+        'invoice.payment_success',
+        invoice,
+      )
+
+      expect(Webhooks::Invoices::InvoicePaymentSuccessService).to have_received(:new)
+      expect(webhook_service).to have_received(:call)
+    end
+  end
+
   context 'with not implemented webhook type' do
     it 'raises a NotImplementedError' do
       expect { send_webhook_job.perform_now(:subscription, invoice) }

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -189,6 +189,19 @@ RSpec.describe Invoices::UpdateService do
       end
     end
 
+    context 'with payment_status succeeded and notification is turned on' do
+      let(:webhook_notification) { true }
+
+      it 'deliver_payement_success_webhook' do
+        result
+
+        expect(SendWebhookJob).to have_been_enqueued.with(
+          'invoice.payment_success',
+          invoice,
+        )
+      end
+    end
+
     context 'when invoice does not exist' do
       let(:invoice) { nil }
 

--- a/spec/services/webhooks/invoices/invoice_payment_success_service_spec.rb
+++ b/spec/services/webhooks/invoices/invoice_payment_success_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Invoices::InvoicePaymentSuccessService do
+  subject(:webhook_service) { described_class.new(object: invoice) }
+
+  let(:webhook_url) { 'http://foo.bar' }
+  let(:organization) { create(:organization, webhook_url:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, organization:, customer:) }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response)
+    end
+
+    it 'builds payload with invoice.payment_success webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_url)
+      expect(lago_client).to have_received(:post_with_response) do |payload|
+        expect(payload[:webhook_type]).to eq('invoice.payment_success')
+        expect(payload[:object_type]).to eq('invoice')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Title
Payment success web hook for payments through stripe.

## Code Changes

Created a class for Invoice payment success status and added its corresponding spec.rb file.
Created function in stripe service to deliver the web hook.
Also updated about the web hook in update_service.rb and send_webhook_job.rb file.

closes https://github.com/getlago/lago/issues/145