### PR TITLE
feat(tax_rates): Add TaxRate model

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -27,6 +27,7 @@ class Organization < ApplicationRecord
   has_many :wallets, through: :customers
   has_many :wallet_transactions, through: :wallets
   has_many :webhooks
+  has_many :tax_rates
 
   has_one :stripe_payment_provider, class_name: 'PaymentProviders::StripeProvider'
   has_one :gocardless_payment_provider, class_name: 'PaymentProviders::GocardlessProvider'

--- a/app/models/tax_rate.rb
+++ b/app/models/tax_rate.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class TaxRate < ApplicationRecord
+  include PaperTrailTraceable
+
+  belongs_to :organization
+
+  validates :name, :value, presence: true
+  validates :code, presence: true, uniqueness: { scope: :organization_id }
+end

--- a/db/migrate/20230503143229_create_tax_rates.rb
+++ b/db/migrate/20230503143229_create_tax_rates.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateTaxRates < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tax_rates, id: :uuid do |t|
+      t.references :organization, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.string :description
+      t.string :code, null: false
+      t.string :name, null: false
+      t.float :value, null: false, default: 0.0
+
+      t.timestamps
+    end
+
+    add_index :tax_rates, [:code, :organization_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_25_130239) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_03_143229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -573,6 +573,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_25_130239) do
     t.index ["plan_id"], name: "index_subscriptions_on_plan_id"
   end
 
+  create_table "tax_rates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "organization_id", null: false
+    t.string "description"
+    t.string "code", null: false
+    t.string "name", null: false
+    t.float "value", default: 0.0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code", "organization_id"], name: "index_tax_rates_on_code_and_organization_id", unique: true
+    t.index ["organization_id"], name: "index_tax_rates_on_organization_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email"
     t.string "password_digest"
@@ -700,6 +712,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_25_130239) do
   add_foreign_key "refunds", "payments"
   add_foreign_key "subscriptions", "customers"
   add_foreign_key "subscriptions", "plans"
+  add_foreign_key "tax_rates", "organizations"
   add_foreign_key "wallet_transactions", "invoices"
   add_foreign_key "wallet_transactions", "wallets"
   add_foreign_key "wallets", "customers"

--- a/spec/factories/tax_rates.rb
+++ b/spec/factories/tax_rates.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tax_rate do
+    organization
+    code { "vat-#{SecureRandom.uuid}" }
+    description { 'French Standard VAT' }
+    name { 'VAT' }
+    value { 20.0 }
+  end
+end

--- a/spec/models/tax_rate_spec.rb
+++ b/spec/models/tax_rate_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TaxRate, type: :model do
+  subject(:tax_rate) { build(:tax_rate) }
+
+  it_behaves_like 'paper_trail traceable'
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to add the `TaxRate` model.
