### PR TITLE
feat(subscription): Allow plan filters on subscription index

### DIFF
--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class SubscriptionsQuery < BaseQuery
+  def call
+    subscriptions = paginate(organization.subscriptions.active)
+    subscriptions = subscriptions.order(started_at: :asc)
+
+    subscriptions = with_external_customer(subscriptions) if filters.external_customer_id
+    subscriptions = with_plan_code(subscriptions) if filters.plan_code
+
+    result.subscriptions = subscriptions
+    result
+  end
+
+  def with_external_customer(scope)
+    scope.joins(:customer).where(customers: { external_id: filters.external_customer_id })
+  end
+
+  def with_plan_code(scope)
+    scope.joins(:plan).where(plans: { code: filters.plan_code })
+  end
+end

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SubscriptionsQuery, type: :query do
+  subject(:subscriptions_query) { described_class.new(organization:, pagination:, filters:) }
+
+  let(:organization) { create(:organization) }
+  let(:pagination) { BaseQuery::Pagination.new }
+  let(:filters) { BaseQuery::Filters.new(query_filters) }
+
+  let(:query_filters) { {} }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, customer:, plan:) }
+
+  before { subscription }
+
+  describe 'call' do
+    it 'returns a list of subscriptions' do
+      result = subscriptions_query.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.subscriptions.count).to eq(1)
+        expect(result.subscriptions).to eq([subscription])
+      end
+    end
+
+    context 'with pagination' do
+      let(:pagination) { BaseQuery::Pagination.new(page: 2, limit: 10) }
+
+      it 'applies the pagination' do
+        result = subscriptions_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.subscriptions.count).to eq(0)
+          expect(result.subscriptions.current_page).to eq(2)
+        end
+      end
+    end
+
+    context 'with customer filter' do
+      let(:query_filters) { { external_customer_id: customer.external_id } }
+
+      it 'applies the filter' do
+        result = subscriptions_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.subscriptions.count).to eq(1)
+        end
+      end
+    end
+
+    context 'with plan filter' do
+      let(:query_filters) { { plan_code: plan.code } }
+
+      it 'applies the filter' do
+        result = subscriptions_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.subscriptions.count).to eq(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -223,11 +223,13 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       end
     end
 
-    context 'with invalid customer' do
-      it 'returns not_found error' do
-        get_with_token(organization, '/api/v1/subscriptions?external_customer_id=invalid')
+    context 'with plan code' do
+      it 'returns subscriptions' do
+        get_with_token(organization, "/api/v1/subscriptions?plan_code=#{plan.code}")
 
-        expect(response).to have_http_status(:not_found)
+        expect(response).to have_http_status(:success)
+        expect(json[:subscriptions].count).to eq(1)
+        expect(json[:subscriptions].first[:lago_id]).to eq(subscription1.id)
       end
     end
   end


### PR DESCRIPTION
## Context

Today it is not possible to retrieve easily all subscription attached to a specific plan using the API

## Description

This PR add a `plan_code` filter to the `GET /api/v1/subscriptions` route.
It also refactors the query logic into a new `SubscriptionsQuery` service
