### PR TITLE
feat(instant_charge): Expose more details in fee.instant_created webhook

### DIFF
--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -24,7 +24,6 @@ module V1
         total_amount_currency: model.amount_currency,
         units: model.units,
         events_count: model.events_count,
-        external_subscription_id: model.subscription&.external_id,
         payment_status: model.payment_status,
         created_at: model.created_at&.iso8601,
         succeeded_at: model.succeeded_at&.iso8601,
@@ -33,6 +32,7 @@ module V1
       }
 
       payload = payload.merge(date_boundaries) if model.charge? || model.subscription?
+      payload.merge!(instant_charge_attributes) if model.instant_charge?
 
       payload
     end
@@ -52,6 +52,20 @@ module V1
 
     def to_date
       model.properties['to_datetime']&.to_datetime&.iso8601
+    end
+
+    def instant_charge_attributes
+      return {} unless model.instant_charge?
+
+      event = model.subscription.organization.events.find_by(id: model.instant_event_id)
+
+      {
+        lago_subscription_id: model.subscription_id,
+        external_subscription_id: model.subscription&.external_id,
+        lago_customer_id: model.customer.id,
+        external_customer_id: model.customer.external_id,
+        event_transaction_id: event&.transaction_id,
+      }
     end
   end
 end

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ::V1::FeeSerializer do
-  subject(:serializer) { described_class.new(fee, root_name: 'fee') }
+  subject(:serializer) { described_class.new(fee, root_name: 'fee', includes: inclusion) }
 
   let(:fee) do
     create(
@@ -15,6 +15,7 @@ RSpec.describe ::V1::FeeSerializer do
     )
   end
 
+  let(:inclusion) { [] }
   let(:result) { JSON.parse(serializer.to_json) }
 
   it 'serializes the fee' do
@@ -79,6 +80,31 @@ RSpec.describe ::V1::FeeSerializer do
     it 'does not serializes the fees with date boundaries' do
       expect(result['fee']['from_date']).to be_nil
       expect(result['fee']['to_date']).to be_nil
+    end
+  end
+
+  context 'when instant_charge attributes are included' do
+    let(:inclusion) { %i[instant_charge] }
+
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+    let(:plan) { create(:plan, organization:) }
+    let(:subscription) { create(:subscription, customer:, organization:, plan:) }
+    let(:charge) { create(:standard_charge, :instant, plan:) }
+    let(:event) { create(:event, subscription:, organization:, customer:) }
+
+    let(:fee) { create(:fee, fee_type: 'instant_charge', subscription:, charge:, instant_event_id: event.id) }
+
+    it 'serializes the instant charge attributes' do
+      aggregate_failures do
+        expect(result['fee']).to include(
+          'lago_subscription_id' => subscription.id,
+          'external_subscription_id' => subscription.external_id,
+          'lago_customer_id' => customer.id,
+          'external_customer_id' => customer.external_id,
+          'event_transaction_id' => event.transaction_id,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

`fee.instant_created` webhook is missing some details about customer, subscription and event attributes

## Description

This PR is adding  `lago_subscription_id`, `external_subscription_id`, `lago_customer_id`, `external_customer_id` and `event_transaction_id` to the fee serializer when `instant_charge` inclusion is passed
