### PR TITLE
feat(tax_rates): Add tax rate resource

### DIFF
--- a/app/controllers/api/v1/tax_rates_controller.rb
+++ b/app/controllers/api/v1/tax_rates_controller.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class TaxRatesController < Api::BaseController
+      def create
+        TaxRates::CreateService.call(organization: current_organization, params: input_params)
+
+        if result.success?
+          render_tax_rate(result.tax_rate)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def update
+        tax_rate = current_organization.tax_rates.find_by(code: params[:code])
+        result = TaxRates::UpdateService.call(tax_rate:, params: input_params)
+
+        if result.success?
+          render_tax_rate(result.tax_rate)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def destroy
+        tax_rate = current_organization.tax_rates.find_by(code: params[:code])
+        result = TaxRates::DestroyService.call(tax_rate:)
+
+        if result.success?
+          render_tax_rate(result.tax_rate)
+        else
+          render_error_response(result)
+        end
+      end
+
+      def show
+        tax_rate = current_organization.tax_rates.find_by(code: params[:code])
+        return not_found_error(resource: 'tax_rate') unless tax_rate
+
+        render_tax_rate(tax_rate)
+      end
+
+      def index
+        tax_rates = current_organization.tax_rates
+          .order(created_at: :desc)
+          .page(params[:page])
+          .per(params[:per_page] || PER_PAGE)
+
+        render(
+          json: ::CollectionSerializer.new(
+            tax_rates,
+            ::V1::TaxRateSerializer,
+            collection_name: 'tax_rates',
+            meta: pagination_metadata(tax_rates),
+          ),
+        )
+      end
+
+      private
+
+      def input_params
+        params.require(:tax_rate).permit(:code, :description, :name, :value)
+      end
+
+      def render_tax_rate(tax_rate)
+        render(json: ::V1::TaxRateSerializer.new(tax_rate, root_name: 'tax_rate'))
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/tax_rates_controller.rb
+++ b/app/controllers/api/v1/tax_rates_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class TaxRatesController < Api::BaseController
       def create
-        TaxRates::CreateService.call(organization: current_organization, params: input_params)
+        result = TaxRates::CreateService.call(organization: current_organization, params: input_params)
 
         if result.success?
           render_tax_rate(result.tax_rate)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -27,6 +27,7 @@ class Organization < ApplicationRecord
   has_many :wallets, through: :customers
   has_many :wallet_transactions, through: :wallets
   has_many :webhooks
+  has_many :tax_rates
 
   has_one :stripe_payment_provider, class_name: 'PaymentProviders::StripeProvider'
   has_one :gocardless_payment_provider, class_name: 'PaymentProviders::GocardlessProvider'

--- a/app/models/tax_rate.rb
+++ b/app/models/tax_rate.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class TaxRate < ApplicationRecord
+  include PaperTrailTraceable
+
+  belongs_to :organization
+
+  validates :name, :value, presence: true
+  validates :code, presence: true, uniqueness: { scope: :organization_id }
+end

--- a/app/serializers/v1/tax_rate_serializer.rb
+++ b/app/serializers/v1/tax_rate_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  class TaxRateSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        name: model.name,
+        code: model.code,
+        value: model.value,
+        description: model.description,
+        created_at: model.created_at.iso8601,
+      }
+    end
+  end
+end

--- a/app/services/tax_rates/create_service.rb
+++ b/app/services/tax_rates/create_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module TaxRates
+  class CreateService < BaseService
+    def initialize(organization:, params:)
+      @organization = organization
+      @params = params
+
+      super
+    end
+
+    def call
+      tax_rate = organization.tax_rates.create!(
+        name: params[:name],
+        code: params[:code],
+        value: params[:value],
+        description: params[:description],
+      )
+
+      result.tax_rate = tax_rate
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :organization, :params
+  end
+end

--- a/app/services/tax_rates/destroy_service.rb
+++ b/app/services/tax_rates/destroy_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module TaxRates
+  class DestroyService < BaseService
+    def initialize(tax_rate:)
+      @tax_rate = tax_rate
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'tax_rate') unless tax_rate
+
+      tax_rate.destroy!
+
+      result.tax_rate = tax_rate
+      result
+    end
+
+    private
+
+    attr_reader :tax_rate
+  end
+end

--- a/app/services/tax_rates/update_service.rb
+++ b/app/services/tax_rates/update_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module TaxRates
+  class UpdateService < BaseService
+    def initialize(tax_rate:, params:)
+      @tax_rate = tax_rate
+      @params = params
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'tax_rate') unless tax_rate
+
+      tax_rate.update!(
+        name: params[:name],
+        code: params[:code],
+        value: params[:value],
+        description: params[:description],
+      )
+
+      result.tax_rate = tax_rate
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :tax_rate, :params
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
         put :finalize, on: :member
       end
       resources :plans, param: :code
+      resources :tax_rates, param: :code
       resources :wallet_transactions, only: :create
       get '/wallets/:id/wallet_transactions', to: 'wallet_transactions#index'
       resources :wallets, only: %i[create update show index]

--- a/db/migrate/20230503143229_create_tax_rates.rb
+++ b/db/migrate/20230503143229_create_tax_rates.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateTaxRates < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tax_rates, id: :uuid do |t|
+      t.references :organization, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.string :description
+      t.string :code, null: false
+      t.string :name, null: false
+      t.float :value, null: false, default: 0.0
+
+      t.timestamps
+    end
+
+    add_index :tax_rates, [:code, :organization_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_25_130239) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_03_143229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -573,6 +573,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_25_130239) do
     t.index ["plan_id"], name: "index_subscriptions_on_plan_id"
   end
 
+  create_table "tax_rates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "organization_id", null: false
+    t.string "description"
+    t.string "code", null: false
+    t.string "name", null: false
+    t.float "value", default: 0.0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code", "organization_id"], name: "index_tax_rates_on_code_and_organization_id", unique: true
+    t.index ["organization_id"], name: "index_tax_rates_on_organization_id"
+  end
+
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email"
     t.string "password_digest"
@@ -700,6 +712,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_25_130239) do
   add_foreign_key "refunds", "payments"
   add_foreign_key "subscriptions", "customers"
   add_foreign_key "subscriptions", "plans"
+  add_foreign_key "tax_rates", "organizations"
   add_foreign_key "wallet_transactions", "invoices"
   add_foreign_key "wallet_transactions", "wallets"
   add_foreign_key "wallets", "customers"

--- a/spec/factories/tax_rates.rb
+++ b/spec/factories/tax_rates.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tax_rate do
+    organization
+    code { "vat-#{SecureRandom.uuid}" }
+    description { 'French Standard VAT' }
+    name { 'VAT' }
+    value { 20.0 }
+  end
+end

--- a/spec/models/tax_rate_spec.rb
+++ b/spec/models/tax_rate_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TaxRate, type: :model do
+  subject(:tax_rate) { build(:tax_rate) }
+
+  it_behaves_like 'paper_trail traceable'
+end

--- a/spec/requests/api/v1/tax_rates_spec.rb
+++ b/spec/requests/api/v1/tax_rates_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::TaxRatesController, type: :request do
+  let(:organization) { create(:organization) }
+
+  describe 'POST /tax_rates' do
+    let(:create_params) do
+      {
+        name: 'tax_rate',
+        code: 'tax_rate_code',
+        value: 20.0,
+        description: 'tax_rate_description',
+      }
+    end
+
+    it 'creates a tax rate' do
+      expect { post_with_token(organization, '/api/v1/tax_rates', { tax_rate: create_params }) }
+        .to change(TaxRate, :count).by(1)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:tax_rate][:lago_id]).to be_present
+        expect(json[:tax_rate][:code]).to eq(create_params[:code])
+        expect(json[:tax_rate][:name]).to eq(create_params[:name])
+        expect(json[:tax_rate][:value]).to eq(create_params[:value])
+        expect(json[:tax_rate][:description]).to eq(create_params[:description])
+        expect(json[:tax_rate][:created_at]).to be_present
+      end
+    end
+  end
+
+  describe 'PUT /tax_rates/:code' do
+    let(:tax_rate) { create(:tax_rate, organization:) }
+    let(:code) { 'code_updated' }
+    let(:name) { 'name_updated' }
+    let(:value) { 15.0 }
+
+    let(:update_params) do
+      { code:, name:, value: }
+    end
+
+    it 'updates a tax rate' do
+      put_with_token(
+        organization,
+        "/api/v1/tax_rates/#{tax_rate.code}",
+        { tax_rate: update_params },
+      )
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:tax_rate][:lago_id]).to eq(tax_rate.id)
+        expect(json[:tax_rate][:code]).to eq(update_params[:code])
+        expect(json[:tax_rate][:name]).to eq(update_params[:name])
+        expect(json[:tax_rate][:value]).to eq(update_params[:value])
+      end
+    end
+
+    context 'when tax rate does not exist' do
+      it 'returns not_found error' do
+        put_with_token(organization, '/api/v1/tax_rates/unknown', { tax_rate: update_params })
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when tax rate code already exists in organization scope (validation error)' do
+      let(:tax_rate2) { create(:tax_rate, organization:) }
+      let(:code) { tax_rate2.code }
+
+      before { tax_rate2 }
+
+      it 'returns unprocessable_entity error' do
+        put_with_token(organization, "/api/v1/tax_rates/#{tax_rate.code}", { tax_rate: update_params })
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'GET /tax_rates/:code' do
+    let(:tax_rate) { create(:tax_rate, organization:) }
+
+    it 'returns a tax rate' do
+      get_with_token(organization, "/api/v1/tax_rates/#{tax_rate.code}")
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:tax_rate][:lago_id]).to eq(tax_rate.id)
+        expect(json[:tax_rate][:code]).to eq(tax_rate.code)
+      end
+    end
+
+    context 'when tax rate does not exist' do
+      it 'returns not found' do
+        get_with_token(organization, '/api/v1/tax_rates/unknown')
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'DELETE /tax_rates/:code' do
+    let(:tax_rate) { create(:tax_rate, organization:) }
+
+    before { tax_rate }
+
+    it 'deletes a tax rate' do
+      expect { delete_with_token(organization, "/api/v1/tax_rates/#{tax_rate.code}") }
+        .to change(TaxRate, :count).by(-1)
+    end
+
+    it 'returns deleted tax rate' do
+      delete_with_token(organization, "/api/v1/tax_rates/#{tax_rate.code}")
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:tax_rate][:lago_id]).to eq(tax_rate.id)
+        expect(json[:tax_rate][:code]).to eq(tax_rate.code)
+      end
+    end
+
+    context 'when tax rate does not exist' do
+      it 'returns not_found error' do
+        delete_with_token(organization, '/api/v1/tax_rates/unknown')
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'GET /tax_rates' do
+    let(:tax_rate) { create(:tax_rate, organization:) }
+
+    before { tax_rate }
+
+    it 'returns tax rates' do
+      get_with_token(organization, '/api/v1/tax_rates')
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:tax_rates].count).to eq(1)
+        expect(json[:tax_rates].first[:lago_id]).to eq(tax_rate.id)
+        expect(json[:tax_rates].first[:code]).to eq(tax_rate.code)
+      end
+    end
+
+    context 'with pagination' do
+      let(:tax_rate2) { create(:tax_rate, organization:) }
+
+      before { tax_rate2 }
+
+      it 'returns tax rates with correct meta data' do
+        get_with_token(organization, '/api/v1/tax_rates?page=1&per_page=1')
+
+        aggregate_failures do
+          expect(response).to have_http_status(:success)
+          expect(json[:tax_rates].count).to eq(1)
+          expect(json[:meta][:current_page]).to eq(1)
+          expect(json[:meta][:next_page]).to eq(2)
+          expect(json[:meta][:prev_page]).to eq(nil)
+          expect(json[:meta][:total_pages]).to eq(2)
+          expect(json[:meta][:total_count]).to eq(2)
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/v1/tax_rate_serializer_spec.rb
+++ b/spec/serializers/v1/tax_rate_serializer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::TaxRateSerializer do
+  subject(:serializer) { described_class.new(tax_rate, root_name: 'tax_rate') }
+
+  let(:tax_rate) { create(:tax_rate) }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['tax_rate']['lago_id']).to eq(tax_rate.id)
+      expect(result['tax_rate']['name']).to eq(tax_rate.name)
+      expect(result['tax_rate']['code']).to eq(tax_rate.code)
+      expect(result['tax_rate']['value']).to eq(tax_rate.value)
+      expect(result['tax_rate']['description']).to eq(tax_rate.description)
+      expect(result['tax_rate']['created_at']).to eq(tax_rate.created_at.iso8601)
+    end
+  end
+end

--- a/spec/serializers/v1/tax_rate_serializer_spec.rb
+++ b/spec/serializers/v1/tax_rate_serializer_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe ::V1::TaxRateSerializer do
   it 'serializes the object' do
     result = JSON.parse(serializer.to_json)
 
-    aggregate_failures do
-      expect(result['tax_rate']['lago_id']).to eq(tax_rate.id)
-      expect(result['tax_rate']['name']).to eq(tax_rate.name)
-      expect(result['tax_rate']['code']).to eq(tax_rate.code)
-      expect(result['tax_rate']['value']).to eq(tax_rate.value)
-      expect(result['tax_rate']['description']).to eq(tax_rate.description)
-      expect(result['tax_rate']['created_at']).to eq(tax_rate.created_at.iso8601)
-    end
+    expect(result['tax_rate']).to include(
+      'lago_id' => tax_rate.id,
+      'name' => tax_rate.name,
+      'code' => tax_rate.code,
+      'value' => tax_rate.value,
+      'description' => tax_rate.description,
+      'created_at' => tax_rate.created_at.iso8601,
+    )
   end
 end

--- a/spec/services/tax_rates/create_service_spec.rb
+++ b/spec/services/tax_rates/create_service_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TaxRates::CreateService, type: :service do
+  subject(:create_service) { described_class.new(organization:, params:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:code) { 'tax_rate_code' }
+  let(:params) do
+    {
+      name: 'Tax Rate',
+      code:,
+      value: 15.0,
+      description: 'Tax Rate Description',
+    }
+  end
+
+  describe '#call' do
+    it 'creates a tax rate' do
+      expect { create_service.call }.to change(TaxRate, :count).by(1)
+    end
+
+    it 'returns tax rate in the result' do
+      result = create_service.call
+      expect(result.tax_rate).to be_a(TaxRate)
+    end
+
+    context 'with validation error' do
+      before { create(:tax_rate, organization:, code:) }
+
+      it 'returns an error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:code]).to eq(['value_already_exist'])
+        end
+      end
+    end
+  end
+end

--- a/spec/services/tax_rates/destroy_service_spec.rb
+++ b/spec/services/tax_rates/destroy_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TaxRates::DestroyService, type: :service do
+  subject(:destroy_service) { described_class.new(tax_rate:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:tax_rate) { create(:tax_rate, organization:) }
+
+  describe '#call' do
+    before { tax_rate }
+
+    it 'destroys the tax rate' do
+      aggregate_failures do
+        expect { destroy_service.call }.to change(TaxRate, :count).by(-1)
+      end
+    end
+
+    context 'when tax rate is not found' do
+      let(:tax_rate) { nil }
+
+      it 'returns an error' do
+        result = destroy_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('tax_rate_not_found')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/tax_rates/update_service_spec.rb
+++ b/spec/services/tax_rates/update_service_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TaxRates::UpdateService, type: :service do
+  subject(:update_service) { described_class.new(tax_rate:, params:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:tax_rate) { create(:tax_rate, organization:) }
+
+  describe '#call' do
+    before { tax_rate }
+
+    let(:params) do
+      {
+        name: 'updated name',
+        code: 'updated code',
+        value: 15.0,
+        description: 'updated desc',
+      }
+    end
+
+    it 'updates the tax rate' do
+      result = update_service.call
+      expect(result).to be_success
+
+      aggregate_failures do
+        expect(result.tax_rate.name).to eq(params[:name])
+        expect(result.tax_rate.code).to eq(params[:code])
+        expect(result.tax_rate.value).to eq(params[:value])
+        expect(result.tax_rate.description).to eq(params[:description])
+      end
+    end
+
+    it 'returns tax rate in the result' do
+      result = update_service.call
+      expect(result.tax_rate).to be_a(TaxRate)
+    end
+
+    context 'when tax rate is not found' do
+      let(:tax_rate) { nil }
+
+      it 'returns an error' do
+        result = update_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('tax_rate_not_found')
+        end
+      end
+    end
+
+    context 'with validation error' do
+      let(:params) do
+        {
+          id: tax_rate.id,
+          name: nil,
+          code: 'code',
+          amount_cents: 100,
+          amount_currency: 'EUR',
+        }
+      end
+
+      it 'returns an error' do
+        result = update_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:name]).to eq(['value_is_mandatory'])
+        end
+      end
+    end
+  end
+end

--- a/spec/services/tax_rates/update_service_spec.rb
+++ b/spec/services/tax_rates/update_service_spec.rb
@@ -23,14 +23,13 @@ RSpec.describe TaxRates::UpdateService, type: :service do
 
     it 'updates the tax rate' do
       result = update_service.call
-      expect(result).to be_success
 
-      aggregate_failures do
-        expect(result.tax_rate.name).to eq(params[:name])
-        expect(result.tax_rate.code).to eq(params[:code])
-        expect(result.tax_rate.value).to eq(params[:value])
-        expect(result.tax_rate.description).to eq(params[:description])
-      end
+      expect(result).to be_success
+      expect(result.tax_rate).to have_attributes(
+        name: params[:name],
+        value: params[:value],
+        description: params[:description],
+      )
     end
 
     it 'returns tax rate in the result' do


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to be able to:
- fetch a tax rate
- list tax rates
- create a tax rate
- update a tax rate
- delete a tax rate
