### PR TITLE
feat(tax_rates): Add tax rate graphql resolvers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -302,5 +302,8 @@ GraphQL/ArgumentDescription:
 GraphQL/FieldDescription:
   Enabled: false
 
+GraphQL/ObjectDescription:
+  Enabled: false
+
 GraphQL/ExtractType:
   Enabled: false

--- a/app/graphql/resolvers/tax_rate_resolver.rb
+++ b/app/graphql/resolvers/tax_rate_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class TaxRateResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description 'Query a single tax rate of an organization'
+
+    argument :id, ID, required: true, description: 'Uniq ID of the tax rate'
+
+    type Types::TaxRates::Object, null: true
+
+    def resolve(id: nil)
+      validate_organization!
+
+      current_organization.tax_rates.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: 'tax_rate')
+    end
+  end
+end

--- a/app/graphql/resolvers/tax_rates_resolver.rb
+++ b/app/graphql/resolvers/tax_rates_resolver.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class TaxRatesResolver < GraphQL::Schema::Resolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description 'Query tax rates of an organization'
+
+    argument :ids, [ID], required: false, description: 'List of tax rates IDs to fetch'
+    argument :limit, Integer, required: false
+    argument :page, Integer, required: false
+    argument :search_term, String, required: false
+
+    type Types::TaxRates::Object.collection_type, null: false
+
+    def resolve(ids: nil, page: nil, limit: nil, search_term: nil)
+      validate_organization!
+
+      query = ::TaxRatesQuery.new(organization: current_organization)
+      result = query.call(
+        search_term:,
+        page:,
+        limit:,
+        filters: {
+          ids:,
+        },
+      )
+
+      result.tax_rates
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -36,6 +36,7 @@ module Types
     field :password_reset, resolver: Resolvers::PasswordResetResolver
     field :plan, resolver: Resolvers::PlanResolver
     field :plans, resolver: Resolvers::PlansResolver
+    field :tax_rate, resolver: Resolvers::TaxRateResolver
     field :wallet_transactions, resolver: Resolvers::WalletTransactionsResolver
     field :wallets, resolver: Resolvers::WalletsResolver
     field :webhooks, resolver: Resolvers::WebhooksResolver

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -37,6 +37,7 @@ module Types
     field :plan, resolver: Resolvers::PlanResolver
     field :plans, resolver: Resolvers::PlansResolver
     field :tax_rate, resolver: Resolvers::TaxRateResolver
+    field :tax_rates, resolver: Resolvers::TaxRatesResolver
     field :wallet_transactions, resolver: Resolvers::WalletTransactionsResolver
     field :wallets, resolver: Resolvers::WalletsResolver
     field :webhooks, resolver: Resolvers::WebhooksResolver

--- a/app/graphql/types/tax_rates/object.rb
+++ b/app/graphql/types/tax_rates/object.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Types
+  module TaxRates
+    class Object < Types::BaseObject
+      graphql_name 'TaxRate'
+
+      field :id, ID, null: false
+      field :organization, Types::OrganizationType
+
+      field :code, String, null: false
+      field :description, String, null: true
+      field :name, String, null: false
+      field :value, Float, null: false
+
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :amount_currency, Types::CurrencyEnum, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      field :customers_count, Integer, null: false, description: 'Number of customers using this tax rate'
+
+      def customers_count
+        # TODO: Not yet implemented.
+        0
+      end
+    end
+  end
+end

--- a/app/graphql/types/tax_rates/object.rb
+++ b/app/graphql/types/tax_rates/object.rb
@@ -13,9 +13,6 @@ module Types
       field :name, String, null: false
       field :value, Float, null: false
 
-      field :amount_cents, GraphQL::Types::BigInt, null: false
-      field :amount_currency, Types::CurrencyEnum, null: false
-
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 

--- a/app/queries/tax_rates_query.rb
+++ b/app/queries/tax_rates_query.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class TaxRatesQuery < BaseQuery
+  def call(search_term:, page:, limit:, filters: {})
+    @search_term = search_term
+
+    tax_rates = base_scope.result
+    tax_rates = tax_rates.where(id: filters[:ids]) if filters[:ids].present?
+    tax_rates = tax_rates.order(:name).page(page).per(limit)
+
+    result.tax_rates = tax_rates
+    result
+  end
+
+  private
+
+  attr_reader :search_term
+
+  def base_scope
+    TaxRate.where(organization:).ransack(search_params)
+  end
+
+  def search_params
+    return nil if search_term.blank?
+
+    {
+      m: 'or',
+      name_cont: search_term,
+      code_cont: search_term,
+    }
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4020,6 +4020,29 @@ type Query {
   ): PlanCollection!
 
   """
+  Query a single tax rate of an organization
+  """
+  taxRate(
+    """
+    Uniq ID of the tax rate
+    """
+    id: ID!
+  ): TaxRate
+
+  """
+  Query tax rates of an organization
+  """
+  taxRates(
+    """
+    List of tax rates IDs to fetch
+    """
+    ids: [ID!]
+    limit: Int
+    page: Int
+    searchTerm: String
+  ): TaxRateCollection!
+
+  """
   Query wallet transactions
   """
   walletTransactions(
@@ -4201,6 +4224,27 @@ type Subscription {
   subscriptionAt: ISO8601DateTime
   terminatedAt: ISO8601DateTime
   updatedAt: ISO8601DateTime!
+}
+
+type TaxRate {
+  code: String!
+  createdAt: ISO8601DateTime!
+
+  """
+  Number of customers using this tax rate
+  """
+  customersCount: Int!
+  description: String
+  id: ID!
+  name: String!
+  organization: Organization
+  updatedAt: ISO8601DateTime!
+  value: Float!
+}
+
+type TaxRateCollection {
+  collection: [TaxRate!]!
+  metadata: CollectionMetadata!
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -16287,6 +16287,108 @@
               ]
             },
             {
+              "name": "taxRate",
+              "description": "Query a single tax rate of an organization",
+              "type": {
+                "kind": "OBJECT",
+                "name": "TaxRate",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the tax rate",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "taxRates",
+              "description": "Query tax rates of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TaxRateCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "ids",
+                  "description": "List of tax rates IDs to fetch",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "ID",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "searchTerm",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "walletTransactions",
               "description": "Query wallet transactions",
               "type": {
@@ -17455,6 +17557,230 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TaxRate",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customersCount",
+              "description": "Number of customers using this tax rate",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "description",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organization",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Organization",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "value",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TaxRateCollection",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "TaxRate",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
                   "ofType": null
                 }
               },

--- a/spec/graphql/resolvers/tax_rate_resolver_spec.rb
+++ b/spec/graphql/resolvers/tax_rate_resolver_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::TaxRateResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($taxRateId: ID!) {
+        taxRate(id: $taxRateId) {
+          id code description name value customersCount
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:tax_rate) { create(:tax_rate, organization:) }
+
+  before do
+    tax_rate
+  end
+
+  it 'returns a single tax rate' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+      variables: { taxRateId: tax_rate.id },
+    )
+
+    expect(result['data']['taxRate']).to include(
+      'id' => tax_rate.id,
+      'code' => tax_rate.code,
+      'description' => tax_rate.description,
+      'name' => tax_rate.name,
+      'value' => tax_rate.value,
+      'customersCount' => 0,
+    )
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query:,
+        variables: { taxRateId: tax_rate.id },
+      )
+
+      expect_graphql_error(result:, message: 'Missing organization id')
+    end
+  end
+
+  context 'when tax rate is not found' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: { taxRateId: 'unknown' },
+      )
+
+      expect_graphql_error(result:, message: 'Resource not found')
+    end
+  end
+end

--- a/spec/graphql/resolvers/tax_rates_resolver_spec.rb
+++ b/spec/graphql/resolvers/tax_rates_resolver_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::TaxRatesResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query {
+        taxRates(limit: 5) {
+          collection { id name }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:tax_rate) { create(:tax_rate, organization:) }
+
+  before { tax_rate }
+
+  it 'returns a list of tax rates' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+    )
+
+    tax_rates_response = result['data']['taxRates']
+
+    aggregate_failures do
+      expect(tax_rates_response['collection'].first).to include(
+        'id' => tax_rate.id,
+        'name' => tax_rate.name,
+      )
+
+      expect(tax_rates_response['metadata']).to include(
+        'currentPage' => 1,
+        'totalCount' => 1,
+      )
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(current_user: membership.user, query:)
+
+      expect_graphql_error(result:, message: 'Missing organization id')
+    end
+  end
+
+  context 'when not member of the organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: create(:organization),
+        query:,
+      )
+
+      expect_graphql_error(result:, message: 'Not in organization')
+    end
+  end
+end

--- a/spec/queries/tax_rates_query_spec.rb
+++ b/spec/queries/tax_rates_query_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TaxRatesQuery, type: :query do
+  subject(:tax_rates_query) do
+    described_class.new(organization:)
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:tax_rate_first) { create(:tax_rate, organization:, name: 'defgh', code: '11') }
+  let(:tax_rate_second) { create(:tax_rate, organization:, name: 'abcde', code: '22') }
+  let(:tax_rate_third) { create(:tax_rate, organization:, name: 'presuv', code: '33') }
+
+  before do
+    tax_rate_first
+    tax_rate_second
+    tax_rate_third
+  end
+
+  it 'returns all tax_rates ordered by name asc' do
+    result = tax_rates_query.call(search_term: nil, page: 1, limit: 10)
+
+    expect(result.tax_rates).to eq([tax_rate_second, tax_rate_first, tax_rate_third])
+  end
+
+  context 'when searching for /de/ term' do
+    it 'returns only two tax_rates' do
+      result = tax_rates_query.call(search_term: 'de', page: 1, limit: 10)
+
+      expect(result.tax_rates).to eq([tax_rate_second, tax_rate_first])
+    end
+  end
+
+  context 'when searching for /de/ term and filtering by id' do
+    it 'returns only one tax_rate' do
+      result = tax_rates_query.call(
+        search_term: 'de',
+        page: 1,
+        limit: 10,
+        filters: { ids: [tax_rate_second.id] },
+      )
+
+      expect(result.tax_rates).to eq([tax_rate_second])
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to be able to:
- add the tax rate graphql resolver
- add the tax rates graphql resolver