### PR TITLE
fix(credits): turn primary key column into uuid

### DIFF
--- a/db/migrate/20230505093030_change_credits_id_type.rb
+++ b/db/migrate/20230505093030_change_credits_id_type.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ChangeCreditsIdType < ActiveRecord::Migration[7.0]
+  def up
+    add_column :credits, :uuid, :uuid, null: false, default: -> { 'gen_random_uuid()' }
+
+    change_table :credits do |t|
+      t.remove :id
+      t.rename :uuid, :id
+    end
+
+    execute 'ALTER TABLE credits ADD PRIMARY KEY (id);'
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_03_143229) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_05_093030) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -202,7 +202,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_03_143229) do
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
   end
 
-  create_table "credits", force: :cascade do |t|
+  create_table "credits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "invoice_id"
     t.uuid "applied_coupon_id"
     t.bigint "amount_cents", null: false


### PR DESCRIPTION
## Context

`Credits#id` type is currently integer, this is inconsistent considering all id columns have an `uuid` type 

## Description

This PR turns the id column into an uuid.
Since no other resource belongs to credits, it relatively safe to update
