### PR TITLE
feat(tax_rates): Refresh draft invoices when tax rate is updated

### DIFF
--- a/app/serializers/v1/tax_rate_serializer.rb
+++ b/app/serializers/v1/tax_rate_serializer.rb
@@ -9,8 +9,16 @@ module V1
         code: model.code,
         value: model.value,
         description: model.description,
+        customers_count:,
         created_at: model.created_at.iso8601,
       }
+    end
+
+    private
+
+    def customers_count
+      # TODO: Not yet implemented.
+      0
     end
   end
 end

--- a/app/services/tax_rates/destroy_service.rb
+++ b/app/services/tax_rates/destroy_service.rb
@@ -13,6 +13,10 @@ module TaxRates
 
       tax_rate.destroy!
 
+      # TODO: Refresh only invoices related to the corresponding customers.
+      draft_invoices = tax_rate.organization.invoices.draft
+      Invoices::RefreshBatchJob.perform_later(draft_invoices.pluck(:id))
+
       result.tax_rate = tax_rate
       result
     end

--- a/app/services/tax_rates/update_service.rb
+++ b/app/services/tax_rates/update_service.rb
@@ -19,6 +19,10 @@ module TaxRates
         description: params[:description],
       )
 
+      # TODO: Refresh only invoices related to the corresponding customers.
+      draft_invoices = tax_rate.organization.invoices.draft
+      Invoices::RefreshBatchJob.perform_later(draft_invoices.pluck(:id))
+
       result.tax_rate = tax_rate
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/spec/serializers/v1/tax_rate_serializer_spec.rb
+++ b/spec/serializers/v1/tax_rate_serializer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ::V1::TaxRateSerializer do
       'code' => tax_rate.code,
       'value' => tax_rate.value,
       'description' => tax_rate.description,
+      'customers_count' => 0,
       'created_at' => tax_rate.created_at.iso8601,
     )
   end

--- a/spec/services/tax_rates/destroy_service_spec.rb
+++ b/spec/services/tax_rates/destroy_service_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe TaxRates::DestroyService, type: :service do
       end
     end
 
+    it 'refreshes draft invoices' do
+      draft_invoice = create(:invoice, :draft, organization:)
+
+      expect do
+        destroy_service.call
+      end.to have_enqueued_job(Invoices::RefreshBatchJob).with([draft_invoice.id])
+    end
+
     context 'when tax rate is not found' do
       let(:tax_rate) { nil }
 

--- a/spec/services/tax_rates/update_service_spec.rb
+++ b/spec/services/tax_rates/update_service_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe TaxRates::UpdateService, type: :service do
       expect(result.tax_rate).to be_a(TaxRate)
     end
 
+    it 'refreshes draft invoices' do
+      draft_invoice = create(:invoice, :draft, organization:)
+
+      expect do
+        update_service.call
+      end.to have_enqueued_job(Invoices::RefreshBatchJob).with([draft_invoice.id])
+    end
+
     context 'when tax rate is not found' do
       let(:tax_rate) { nil }
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to be able to:
- add customers_count on tax rate serializer
- refresh draft invoices when tax rate is updated or deleted