### PR TITLE
feat(tax_rate): Update tax rate only if params given

### DIFF
--- a/app/services/tax_rates/update_service.rb
+++ b/app/services/tax_rates/update_service.rb
@@ -12,12 +12,12 @@ module TaxRates
     def call
       return result.not_found_failure!(resource: 'tax_rate') unless tax_rate
 
-      tax_rate.update!(
-        name: params[:name],
-        code: params[:code],
-        value: params[:value],
-        description: params[:description],
-      )
+      tax_rate.name = params[:name] if params.key?(:name)
+      tax_rate.code = params[:code] if params.key?(:code)
+      tax_rate.value = params[:value] if params.key?(:value)
+      tax_rate.description = params[:description] if params.key?(:description)
+
+      tax_rate.save!
 
       # TODO: Refresh only invoices related to the corresponding customers.
       draft_invoices = tax_rate.organization.invoices.draft

--- a/spec/services/tax_rates/update_service_spec.rb
+++ b/spec/services/tax_rates/update_service_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe TaxRates::UpdateService, type: :service do
 
     let(:params) do
       {
-        name: 'updated name',
         code: 'updated code',
         value: 15.0,
         description: 'updated desc',
@@ -26,7 +25,8 @@ RSpec.describe TaxRates::UpdateService, type: :service do
 
       expect(result).to be_success
       expect(result.tax_rate).to have_attributes(
-        name: params[:name],
+        name: tax_rate.name,
+        code: params[:code],
         value: params[:value],
         description: params[:description],
       )


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to fix the update of a tax rate.