### PR TITLE
fix(subscription): Take coupons into account for credit note creation at subscription termination

### DIFF
--- a/app/services/credit_notes/compute_amount_service.rb
+++ b/app/services/credit_notes/compute_amount_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class ComputeAmountService < BaseService
+    def initialize(invoice:, items:)
+      @invoice = invoice
+      @items = items
+
+      super
+    end
+
+    def call
+      result.coupons_adjustment_amount_cents = coupons_adjustment_amount_cents
+      result.vat_amount_cents = vat_amount_cents
+      result.creditable_amount_cents = creditable_amount_cents
+      result
+    end
+
+    private
+
+    attr_reader :invoice, :items
+
+    def items_amount_cents
+      @items_amount_cents ||= items.map(&:precise_amount_cents).sum
+    end
+
+    def coupons_adjustment_amount_cents
+      return 0 if invoice.version_number < Invoice::COUPON_BEFORE_VAT_VERSION
+
+      invoice.coupons_amount_cents.fdiv(invoice.fees_amount_cents) * items_amount_cents
+    end
+
+    def vat_amount_cents
+      items.map do |item|
+        # NOTE: Because coupons are applied before VAT,
+        #       we have to discribute the coupon adjustement at prorata of each items
+        #       to compute the VAT
+        item_rate = item.precise_amount_cents.fdiv(items_amount_cents)
+        prorated_coupon_amount = coupons_adjustment_amount_cents * item_rate
+        (item.precise_amount_cents - prorated_coupon_amount) * (item.fee.vat_rate || 0)
+      end.sum.fdiv(100)
+    end
+
+    def creditable_amount_cents
+      (items_amount_cents - coupons_adjustment_amount_cents + vat_amount_cents).round
+    end
+  end
+end

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -22,11 +22,19 @@ module CreditNotes
       amount -= last_subscription_fee.credit_note_items.sum(:amount_cents)
       return result unless amount.positive?
 
-      vat_amount = (amount * last_subscription_fee.vat_rate).fdiv(100)
+      adjustment_result = CreditNotes::ComputeAmountService.call(
+        invoice: last_subscription_fee.invoice,
+        items: [
+          CreditNoteItem.new(
+            fee_id: last_subscription_fee.id,
+            precise_amount_cents: amount.truncate(DB_PRECISION_SCALE),
+          ),
+        ],
+      )
 
       CreditNotes::CreateService.new(
         invoice: last_subscription_fee.invoice,
-        credit_amount_cents: (amount + vat_amount).round,
+        credit_amount_cents: adjustment_result.creditable_amount_cents,
         refund_amount_cents: 0,
         items: [
           {

--- a/spec/services/credit_notes/compute_amount_service_spec.rb
+++ b/spec/services/credit_notes/compute_amount_service_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::ComputeAmountService, type: :service do
+  subject(:amount_service) { described_class.new(invoice:, items:) }
+
+  let(:invoice) do
+    create(
+      :invoice,
+      currency: 'EUR',
+      fees_amount_cents: 20,
+      coupons_amount_cents: 10,
+      vat_amount_cents: 2,
+      total_amount_cents: 12,
+      payment_status: :succeeded,
+      vat_rate: 20,
+      version_number: 3,
+    )
+  end
+
+  let(:items) do
+    [
+      CreditNoteItem.new(
+        fee_id: fee1.id,
+        precise_amount_cents: 10,
+      ),
+      CreditNoteItem.new(
+        fee_id: fee2.id,
+        precise_amount_cents: 5,
+      ),
+    ]
+  end
+
+  let(:fee1) { create(:fee, invoice:, amount_cents: 10, vat_amount_cents: 1, vat_rate: 20) }
+  let(:fee2) { create(:fee, invoice:, amount_cents: 10, vat_amount_cents: 1, vat_rate: 20) }
+
+  describe '.call' do
+    it 'computes the credit note amounts' do
+      result = amount_service.call
+
+      expect(result).to have_attributes(
+        coupons_adjustment_amount_cents: 7.5,
+        vat_amount_cents: 1.5,
+        creditable_amount_cents: 9,
+      )
+    end
+  end
+end

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -364,5 +364,35 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
         end
       end
     end
+
+    context 'with a coupon applied to the invoice' do
+      let(:invoice) do
+        create(
+          :invoice,
+          customer:,
+          currency: 'EUR',
+          fees_amount_cents: 100,
+          total_amount_cents: 108,
+          coupons_amount_cents: 10,
+          vat_amount_cents: 18,
+          vat_rate: 20,
+        )
+      end
+
+      it 'takes the coupon into account' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          credit_note = result.credit_note
+          expect(credit_note).to have_attributes(
+            total_amount_cents: 17,
+            credit_amount_cents: 17,
+            balance_amount_cents: 17,
+          )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

With recent changes regarding coupons, that are now applied before VAT rather than after, credit note creation was impacted at vat level and with the introduction of coupon_adjustment_amount_cents.

When terminating a payed in advance subscription, a credit note is created on the subscription fee, at pro-rata of the remaining days before the expected duration of subscription, but we forgot to take the coupon into account.

## Description

This PR introduce a new `CreditNotes::CompouteAmountService` to compute, the coupon adjustment, vat and creditable amount base on the amount to credit at fee level and the applied coupons
