### PR TITLE
misc(invites): remove TODO in code

### DIFF
--- a/spec/services/invites/validate_service_spec.rb
+++ b/spec/services/invites/validate_service_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-# TODO:
 RSpec.describe Invites::ValidateService, type: :service do
   subject(:validate_service) { described_class.new(result, **args) }
 


### PR DESCRIPTION
This TODO was written first before I wrote any tests here.

There is no reason to keep it.