### PR TITLE
feat(tax_rates): Migration from vat_rate to tax rates

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -29,6 +29,9 @@ class Customer < ApplicationRecord
            dependent: :destroy
   has_many :persisted_events
 
+  has_many :customers_tax_rates
+  has_many :tax_rates, through: :customers_tax_rates
+
   has_one :stripe_customer, class_name: 'PaymentProviderCustomers::StripeCustomer'
   has_one :gocardless_customer, class_name: 'PaymentProviderCustomers::GocardlessCustomer'
 

--- a/app/models/customers_tax_rate.rb
+++ b/app/models/customers_tax_rate.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CustomersTaxRate < ApplicationRecord
+  include PaperTrailTraceable
+
+  belongs_to :customer
+  belongs_to :tax_rate
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -24,10 +24,10 @@ class Organization < ApplicationRecord
   has_many :add_ons
   has_many :invites
   has_many :payment_providers
+  has_many :tax_rates
   has_many :wallets, through: :customers
   has_many :wallet_transactions, through: :wallets
   has_many :webhooks
-  has_many :tax_rates
 
   has_one :stripe_payment_provider, class_name: 'PaymentProviders::StripeProvider'
   has_one :gocardless_payment_provider, class_name: 'PaymentProviders::GocardlessProvider'

--- a/app/models/tax_rate.rb
+++ b/app/models/tax_rate.rb
@@ -3,6 +3,9 @@
 class TaxRate < ApplicationRecord
   include PaperTrailTraceable
 
+  has_many :customers_tax_rates
+  has_many :customers, through: :customers_tax_rates
+
   belongs_to :organization
 
   validates :name, :value, presence: true

--- a/db/migrate/20230510113501_create_customers_tax_rates.rb
+++ b/db/migrate/20230510113501_create_customers_tax_rates.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateCustomersTaxRates < ActiveRecord::Migration[7.0]
+  def change
+    add_column :tax_rates, :applied_by_default, :boolean, null: false, default: false
+
+    create_table :customers_tax_rates, id: :uuid do |t|
+      t.references :customer, type: :uuid, foreign_key: true, null: false, index: true
+      t.references :tax_rate, type: :uuid, foreign_key: true, null: false, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_05_093030) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_10_113501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -258,6 +258,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_05_093030) do
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_customers_on_organization_id"
     t.check_constraint "invoice_grace_period >= 0", name: "check_customers_on_invoice_grace_period"
+  end
+
+  create_table "customers_tax_rates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "customer_id", null: false
+    t.uuid "tax_rate_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_customers_tax_rates_on_customer_id"
+    t.index ["tax_rate_id"], name: "index_customers_tax_rates_on_tax_rate_id"
   end
 
   create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -581,6 +590,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_05_093030) do
     t.float "value", default: 0.0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "applied_by_default", default: false, null: false
     t.index ["code", "organization_id"], name: "index_tax_rates_on_code_and_organization_id", unique: true
     t.index ["organization_id"], name: "index_tax_rates_on_organization_id"
   end
@@ -674,6 +684,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_05_093030) do
   add_foreign_key "credits", "invoices"
   add_foreign_key "customer_metadata", "customers"
   add_foreign_key "customers", "organizations"
+  add_foreign_key "customers_tax_rates", "customers"
+  add_foreign_key "customers_tax_rates", "tax_rates"
   add_foreign_key "events", "customers"
   add_foreign_key "events", "organizations"
   add_foreign_key "events", "subscriptions"

--- a/lib/tasks/tax_rates.rake
+++ b/lib/tasks/tax_rates.rake
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+namespace :tax_rates do
+  desc 'Migrate vat_rate to tax rates for organizations and customers'
+  task migrate_from_vate_rate: :environment do
+    ::Organization.where('vat_rate > 0').find_each do |organization|
+      organization.tax_rates.create_with(
+        value: organization.vat_rate,
+        name: "Tax (#{organization.vat_rate}%)",
+        applied_by_default: true,
+      ).find_or_create_by!(code: "tax_#{organization.vat_rate}")
+    end
+
+    ::Customer.where.not(vat_rate: nil).find_each do |customer|
+      tax_rate = ::TaxRate.create_with(
+        name: "Tax (#{customer.vat_rate}%)",
+        value: customer.vat_rate,
+      ).find_or_create_by!(
+        organization_id: customer.organization_id,
+        code: "tax_#{customer.vat_rate}",
+      )
+
+      customer.customers_tax_rates.create!(tax_rate:)
+    end
+  end
+end

--- a/spec/factories/customers_tax_rates.rb
+++ b/spec/factories/customers_tax_rates.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :customers_tax_rate do
+    customer
+    tax_rate
+  end
+end

--- a/spec/factories/tax_rates.rb
+++ b/spec/factories/tax_rates.rb
@@ -7,5 +7,6 @@ FactoryBot.define do
     description { 'French Standard VAT' }
     name { 'VAT' }
     value { 20.0 }
+    applied_by_default { true }
   end
 end

--- a/spec/models/customers_tax_rate_spec.rb
+++ b/spec/models/customers_tax_rate_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CustomersTaxRate, type: :model do
+  subject(:customers_tax_rate) { create(:customers_tax_rate) }
+
+  it_behaves_like 'paper_trail traceable'
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to:
- add `applied_by_default` boolean to `tax_rates` table
- create `customers_tax_rates` join table
- add task to migrate from `vat_rate` to `tax_rates`