### PR TITLE
feat(tax_rate): Assign a tax rate to an organization via API

### DIFF
--- a/app/controllers/api/v1/tax_rates_controller.rb
+++ b/app/controllers/api/v1/tax_rates_controller.rb
@@ -61,7 +61,7 @@ module Api
       private
 
       def input_params
-        params.require(:tax_rate).permit(:code, :description, :name, :value)
+        params.require(:tax_rate).permit(:code, :description, :name, :value, :applied_by_default)
       end
 
       def render_tax_rate(tax_rate)

--- a/app/serializers/v1/tax_rate_serializer.rb
+++ b/app/serializers/v1/tax_rate_serializer.rb
@@ -9,6 +9,7 @@ module V1
         code: model.code,
         value: model.value,
         description: model.description,
+        applied_by_default: model.applied_by_default,
         customers_count:,
         created_at: model.created_at.iso8601,
       }

--- a/app/services/tax_rates/create_service.rb
+++ b/app/services/tax_rates/create_service.rb
@@ -10,12 +10,15 @@ module TaxRates
     end
 
     def call
-      tax_rate = organization.tax_rates.create!(
+      tax_rate = organization.tax_rates.new(
         name: params[:name],
         code: params[:code],
         value: params[:value],
         description: params[:description],
       )
+
+      tax_rate.applied_by_default = params[:applied_by_default] if params.key?(:applied_by_default)
+      tax_rate.save!
 
       result.tax_rate = tax_rate
       result

--- a/app/services/tax_rates/update_service.rb
+++ b/app/services/tax_rates/update_service.rb
@@ -16,6 +16,7 @@ module TaxRates
       tax_rate.code = params[:code] if params.key?(:code)
       tax_rate.value = params[:value] if params.key?(:value)
       tax_rate.description = params[:description] if params.key?(:description)
+      tax_rate.applied_by_default = params[:applied_by_default] if params.key?(:applied_by_default)
 
       tax_rate.save!
 

--- a/spec/requests/api/v1/tax_rates_spec.rb
+++ b/spec/requests/api/v1/tax_rates_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Api::V1::TaxRatesController, type: :request do
         code: 'tax_rate_code',
         value: 20.0,
         description: 'tax_rate_description',
+        applied_by_default: false,
       }
     end
 
@@ -27,6 +28,7 @@ RSpec.describe Api::V1::TaxRatesController, type: :request do
         expect(json[:tax_rate][:value]).to eq(create_params[:value])
         expect(json[:tax_rate][:description]).to eq(create_params[:description])
         expect(json[:tax_rate][:created_at]).to be_present
+        expect(json[:tax_rate][:applied_by_default]).to eq(create_params[:applied_by_default])
       end
     end
   end
@@ -36,9 +38,10 @@ RSpec.describe Api::V1::TaxRatesController, type: :request do
     let(:code) { 'code_updated' }
     let(:name) { 'name_updated' }
     let(:value) { 15.0 }
+    let(:applied_by_default) { false }
 
     let(:update_params) do
-      { code:, name:, value: }
+      { code:, name:, value:, applied_by_default: }
     end
 
     it 'updates a tax rate' do
@@ -54,6 +57,7 @@ RSpec.describe Api::V1::TaxRatesController, type: :request do
         expect(json[:tax_rate][:code]).to eq(update_params[:code])
         expect(json[:tax_rate][:name]).to eq(update_params[:name])
         expect(json[:tax_rate][:value]).to eq(update_params[:value])
+        expect(json[:tax_rate][:applied_by_default]).to eq(update_params[:applied_by_default])
       end
     end
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to expose the `TaxRate#applied_by_default` attribute in API in order to turn it on/off for the organization