### PR TITLE
feat(tax_rate): Rename customers_tax_rates to applied_tax_rates

### DIFF
--- a/app/models/applied_tax_rate.rb
+++ b/app/models/applied_tax_rate.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CustomersTaxRate < ApplicationRecord
+class AppliedTaxRate < ApplicationRecord
   include PaperTrailTraceable
 
   belongs_to :customer

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -29,8 +29,8 @@ class Customer < ApplicationRecord
            dependent: :destroy
   has_many :persisted_events
 
-  has_many :customers_tax_rates
-  has_many :tax_rates, through: :customers_tax_rates
+  has_many :applied_tax_rates
+  has_many :tax_rates, through: :applied_tax_rates
 
   has_one :stripe_customer, class_name: 'PaymentProviderCustomers::StripeCustomer'
   has_one :gocardless_customer, class_name: 'PaymentProviderCustomers::GocardlessCustomer'

--- a/app/models/tax_rate.rb
+++ b/app/models/tax_rate.rb
@@ -3,8 +3,8 @@
 class TaxRate < ApplicationRecord
   include PaperTrailTraceable
 
-  has_many :customers_tax_rates
-  has_many :customers, through: :customers_tax_rates
+  has_many :applied_tax_rates
+  has_many :customers, through: :applied_tax_rates
 
   belongs_to :organization
 

--- a/db/migrate/20230511124419_rename_customers_tax_rates_to_applied_tax_rates.rb
+++ b/db/migrate/20230511124419_rename_customers_tax_rates_to_applied_tax_rates.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameCustomersTaxRatesToAppliedTaxRates < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :customers_tax_rates, :applied_tax_rates
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_10_113501) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_11_124419) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -85,6 +85,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_10_113501) do
     t.integer "frequency_duration_remaining"
     t.index ["coupon_id"], name: "index_applied_coupons_on_coupon_id"
     t.index ["customer_id"], name: "index_applied_coupons_on_customer_id"
+  end
+
+  create_table "applied_tax_rates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "customer_id", null: false
+    t.uuid "tax_rate_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_applied_tax_rates_on_customer_id"
+    t.index ["tax_rate_id"], name: "index_applied_tax_rates_on_tax_rate_id"
   end
 
   create_table "billable_metrics", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -258,15 +267,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_10_113501) do
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_customers_on_organization_id"
     t.check_constraint "invoice_grace_period >= 0", name: "check_customers_on_invoice_grace_period"
-  end
-
-  create_table "customers_tax_rates", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "customer_id", null: false
-    t.uuid "tax_rate_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["customer_id"], name: "index_customers_tax_rates_on_customer_id"
-    t.index ["tax_rate_id"], name: "index_customers_tax_rates_on_tax_rate_id"
   end
 
   create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -669,6 +669,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_10_113501) do
   add_foreign_key "add_ons", "organizations"
   add_foreign_key "applied_add_ons", "add_ons"
   add_foreign_key "applied_add_ons", "customers"
+  add_foreign_key "applied_tax_rates", "customers"
+  add_foreign_key "applied_tax_rates", "tax_rates"
   add_foreign_key "billable_metrics", "organizations"
   add_foreign_key "charges", "billable_metrics"
   add_foreign_key "charges", "plans"
@@ -684,8 +686,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_10_113501) do
   add_foreign_key "credits", "invoices"
   add_foreign_key "customer_metadata", "customers"
   add_foreign_key "customers", "organizations"
-  add_foreign_key "customers_tax_rates", "customers"
-  add_foreign_key "customers_tax_rates", "tax_rates"
   add_foreign_key "events", "customers"
   add_foreign_key "events", "organizations"
   add_foreign_key "events", "subscriptions"

--- a/lib/tasks/tax_rates.rake
+++ b/lib/tasks/tax_rates.rake
@@ -20,7 +20,7 @@ namespace :tax_rates do
         code: "tax_#{customer.vat_rate}",
       )
 
-      customer.customers_tax_rates.create!(tax_rate:)
+      customer.applied_tax_rates.create!(tax_rate:)
     end
   end
 end

--- a/spec/factories/applied_tax_rates.rb
+++ b/spec/factories/applied_tax_rates.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :customers_tax_rate do
+  factory :applied_tax_rate do
     customer
     tax_rate
   end

--- a/spec/models/applied_tax_rate_spec.rb
+++ b/spec/models/applied_tax_rate_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AppliedTaxRate, type: :model do
+  subject(:applied_tax_rate) { create(:applied_tax_rate) }
+
+  it_behaves_like 'paper_trail traceable'
+end

--- a/spec/models/customers_tax_rate_spec.rb
+++ b/spec/models/customers_tax_rate_spec.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe CustomersTaxRate, type: :model do
-  subject(:customers_tax_rate) { create(:customers_tax_rate) }
-
-  it_behaves_like 'paper_trail traceable'
-end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to rename `customers_tax_rates` to `applied_tax_rates`.