### PR TITLE
feat(tax_rate): Handle legacy vat_rate at organization level

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -38,8 +38,10 @@ module Api
           billing_configuration: [
             :invoice_footer,
             :invoice_grace_period,
-            :vat_rate,
             :document_locale,
+
+            # NOTE(legacy): vat has been moved to tax rate model
+            :vat_rate,
           ],
         )
       end

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -11,6 +11,7 @@ module Api
             json: ::V1::OrganizationSerializer.new(
               result.organization,
               root_name: 'organization',
+              includes: %i[taxes],
             ),
           )
         else
@@ -40,7 +41,7 @@ module Api
             :invoice_grace_period,
             :document_locale,
 
-            # NOTE(legacy): vat has been moved to tax rate model
+            # NOTE(legacy): vat has been moved to tax model
             :vat_rate,
           ],
         )

--- a/app/serializers/v1/legacy/organization_serializer.rb
+++ b/app/serializers/v1/legacy/organization_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module V1
+  module Legacy
+    class OrganizationSerializer < ModelSerializer
+      def serialize
+        {
+          billing_configuration: { vat_rate: model.vat_rate },
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/v1/organization_serializer.rb
+++ b/app/serializers/v1/organization_serializer.rb
@@ -3,7 +3,7 @@
 module V1
   class OrganizationSerializer < ModelSerializer
     def serialize
-      {
+      payload = {
         lago_id: model.id,
         name: model.name,
         created_at: model.created_at.iso8601,
@@ -20,13 +20,34 @@ module V1
         timezone: model.timezone,
         email_settings: model.email_settings,
         tax_identification_number: model.tax_identification_number,
-        billing_configuration: {
-          invoice_footer: model.invoice_footer,
-          invoice_grace_period: model.invoice_grace_period,
-          vat_rate: model.vat_rate,
-          document_locale: model.document_locale,
-        },
-      }
+        billing_configuration:,
+      }.merge(legacy_values.except(:billing_configuration))
+
+      payload = payload.merge(taxes) if include?(:taxes)
+
+      payload
+    end
+
+    private
+
+    def billing_configuration
+      {
+        invoice_footer: model.invoice_footer,
+        invoice_grace_period: model.invoice_grace_period,
+        document_locale: model.document_locale,
+      }.merge(legacy_values[:billing_configuration])
+    end
+
+    def legacy_values
+      @legacy_values ||= ::V1::Legacy::OrganizationSerializer.new(model).serialize
+    end
+
+    def taxes
+      ::CollectionSerializer.new(
+        model.taxes.applied_to_organization,
+        ::V1::TaxSerializer,
+        collection_name: 'taxes',
+      ).serialize
     end
   end
 end

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -80,24 +80,24 @@ module Organizations
     end
 
     def handle_legacy_vat_rate(vat_rate)
-      if organization.tax_rates.applied_by_default.count > 1
-        result.single_validation_failure!(field: :vat_rate, error_code: 'multiple_tax_rates')
+      if organization.taxes.applied_to_organization.count > 1
+        result.single_validation_failure!(field: :vat_rate, error_code: 'multiple_taxes')
           .raise_if_error!
       end
 
-      # NOTE(legacy): Keep updating vat_rate untill we remove the field
+      # NOTE(legacy): Keep updating vat_rate until we remove the field
       organization.vat_rate = vat_rate
 
-      current_tax_rate = organization.tax_rates.applied_by_default.first
-      return if current_tax_rate&.value == vat_rate
+      current_tax = organization.taxes.applied_to_organization.first
+      return if current_tax&.rate == vat_rate
 
-      current_tax_rate&.update!(applied_by_default: false)
+      current_tax&.update!(applied_to_organization: false)
       return if vat_rate.zero?
 
-      organization.tax_rates.create_with(
-        value: vat_rate,
+      organization.taxes.create_with(
+        rate: vat_rate,
         name: "Tax (#{vat_rate}%)",
-        applied_by_default: true,
+        applied_to_organization: true,
       ).find_or_create_by!(code: "tax_#{vat_rate}")
     end
   end

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
         expect(billing[:invoice_footer]).to eq('footer')
         expect(billing[:document_locale]).to eq('fr')
         expect(billing[:vat_rate]).to eq(20)
+
+        expect(json[:organization][:taxes]).not_to be_nil
       end
     end
 

--- a/spec/serializers/v1/organization_serializer_spec.rb
+++ b/spec/serializers/v1/organization_serializer_spec.rb
@@ -3,9 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe ::V1::OrganizationSerializer do
-  subject(:serializer) { described_class.new(org, root_name: 'organization') }
+  subject(:serializer) do
+    described_class.new(org, root_name: 'organization', includes: %i[taxes])
+  end
 
   let(:org) { create(:organization) }
+  let(:tax) { create(:tax, organization: org, applied_to_organization: true) }
+
+  before { tax }
 
   it 'serializes the object' do
     result = JSON.parse(serializer.to_json)
@@ -29,6 +34,8 @@ RSpec.describe ::V1::OrganizationSerializer do
       expect(result['organization']['billing_configuration']['document_locale']).to eq(org.document_locale)
       expect(result['organization']['tax_identification_number']).to eq(org.tax_identification_number)
       expect(result['organization']['timezone']).to eq(org.timezone)
+
+      expect(result['organization']['taxes'].count).to eq(1)
     end
   end
 end

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -167,15 +167,15 @@ RSpec.describe Organizations::UpdateService do
         aggregate_failures do
           expect(result.organization.vat_rate).to eq(12.5)
 
-          expect(result.organization.tax_rates.count).to eq(1)
+          expect(result.organization.taxes.count).to eq(1)
 
-          tax_rate = result.organization.tax_rates.first
-          expect(tax_rate.value).to eq(12.5)
+          tax_rate = result.organization.taxes.first
+          expect(tax_rate.rate).to eq(12.5)
         end
       end
 
       context 'when organization already have a tax rate' do
-        before { create(:tax_rate, organization:, value: 14) }
+        before { create(:tax, organization:, rate: 14) }
 
         it 'create a new tax_rate' do
           result = update_service.call
@@ -183,25 +183,25 @@ RSpec.describe Organizations::UpdateService do
           aggregate_failures do
             expect(result.organization.vat_rate).to eq(12.5)
 
-            expect(result.organization.tax_rates.count).to eq(2)
-            expect(result.organization.tax_rates.applied_by_default.count).to eq(1)
+            expect(result.organization.taxes.count).to eq(2)
+            expect(result.organization.taxes.applied_to_organization.count).to eq(1)
 
-            tax_rate = result.organization.tax_rates.applied_by_default.first
-            expect(tax_rate.value).to eq(12.5)
+            tax_rate = result.organization.taxes.applied_to_organization.first
+            expect(tax_rate.rate).to eq(12.5)
           end
         end
 
         context 'with vat_rate equals to 0' do
           let(:vat_rate) { 0 }
 
-          it 'toggle the applied_by_default flag' do
+          it 'toggle the applied_to_organization flag' do
             result = update_service.call
 
             aggregate_failures do
               expect(result.organization.vat_rate).to eq(0)
 
-              expect(result.organization.tax_rates.count).to eq(1)
-              expect(result.organization.tax_rates.applied_by_default.count).to eq(0)
+              expect(result.organization.taxes.count).to eq(1)
+              expect(result.organization.taxes.applied_to_organization.count).to eq(0)
             end
           end
         end
@@ -209,8 +209,8 @@ RSpec.describe Organizations::UpdateService do
 
       context 'when organization have multiple tax rates' do
         before do
-          create(:tax_rate, organization:, value: 14)
-          create(:tax_rate, organization:, value: 15)
+          create(:tax, organization:, rate: 14)
+          create(:tax, organization:, rate: 15)
         end
 
         it 'raises a validation error' do
@@ -219,7 +219,7 @@ RSpec.describe Organizations::UpdateService do
           aggregate_failures do
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages[:vat_rate]).to eq(['multiple_tax_rates'])
+            expect(result.error.messages[:vat_rate]).to eq(['multiple_taxes'])
           end
         end
       end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to ensure the PUT `/api/v1/organizations` route keeps handle legacy `vat_rate` attributes.