### PR TITLE
feat(tax_rates): Assign and unassign tax rate to a customer

### DIFF
--- a/app/controllers/api/v1/customers/applied_tax_rates_controller.rb
+++ b/app/controllers/api/v1/customers/applied_tax_rates_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Customers
+      class AppliedTaxRatesController < Api::BaseController
+        def create
+          return not_found_error(resource: 'customer') unless customer
+
+          tax_rate = current_organization.tax_rates.find_by(code: input_params[:tax_rate_code])
+          return not_found_error(resource: 'tax_rate') unless tax_rate
+
+          result = ::AppliedTaxRates::CreateService.call(customer:, tax_rate:)
+          if result.success?
+            render(json: ::V1::AppliedTaxRateSerializer.new(result.applied_tax_rate, root_name: 'applied_tax_rate'))
+          else
+            render_error_response(result)
+          end
+        end
+
+        def destroy
+          return not_found_error(resource: 'customer') unless customer
+
+          tax_rate = current_organization.tax_rates.find_by(code: params[:tax_rate_code])
+          return not_found_error(resource: 'tax_rate') unless tax_rate
+
+          applied_tax_rate = customer.applied_tax_rates.find_by(customer:, tax_rate:)
+          return not_found_error(resource: 'applied_tax_rate') unless applied_tax_rate
+
+          result = ::AppliedTaxRates::DestroyService.call(applied_tax_rate:)
+          if result.success?
+            render(json: ::V1::AppliedTaxRateSerializer.new(result.applied_tax_rate, root_name: 'applied_tax_rate'))
+          else
+            render_error_response(result)
+          end
+        end
+
+        private
+
+        def customer
+          @customer ||= current_organization.customers.find_by(external_id: params[:customer_external_id])
+        end
+
+        def input_params
+          params.require(:applied_tax_rate).permit(:tax_rate_code)
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/v1/applied_tax_rate_serializer.rb
+++ b/app/serializers/v1/applied_tax_rate_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  class AppliedTaxRateSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        lago_customer_id: model.customer.id,
+        lago_tax_rate_id: model.tax_rate.id,
+        tax_rate_code: model.tax_rate.code,
+        external_customer_id: model.customer.external_id,
+        created_at: model.created_at.iso8601,
+      }
+    end
+  end
+end

--- a/app/services/applied_tax_rates/create_service.rb
+++ b/app/services/applied_tax_rates/create_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module AppliedTaxRates
+  class CreateService < BaseService
+    def initialize(customer:, tax_rate:)
+      @customer = customer
+      @tax_rate = tax_rate
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'customer') unless customer
+      return result.not_found_failure!(resource: 'tax_rate') unless tax_rate
+
+      applied_tax_rate = customer.applied_tax_rates.create!(tax_rate:)
+
+      result.applied_tax_rate = applied_tax_rate
+      result
+    end
+
+    private
+
+    attr_reader :customer, :tax_rate
+  end
+end

--- a/app/services/applied_tax_rates/destroy_service.rb
+++ b/app/services/applied_tax_rates/destroy_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module AppliedTaxRates
+  class DestroyService < BaseService
+    def initialize(applied_tax_rate:)
+      @applied_tax_rate = applied_tax_rate
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'applied_tax_rate') unless applied_tax_rate
+
+      applied_tax_rate.destroy!
+
+      result.applied_tax_rate = applied_tax_rate
+      result
+    end
+
+    private
+
+    attr_reader :applied_tax_rate
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
 
         scope module: :customers do
           resources :applied_coupons, only: %i[destroy]
+          resources :applied_tax_rates, only: %i[create destroy], param: :tax_rate_code
         end
       end
 

--- a/spec/requests/api/v1/customers/applied_tax_rates_spec.rb
+++ b/spec/requests/api/v1/customers/applied_tax_rates_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::Customers::AppliedTaxRatesController, type: :request do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:tax_rate) { create(:tax_rate, organization:) }
+
+  describe 'POST /applied_tax_rates' do
+    it 'creates an applied tax rate' do
+      expect do
+        post_with_token(
+          organization,
+          "/api/v1/customers/#{customer.external_id}/applied_tax_rates",
+          { applied_tax_rate: { tax_rate_code: tax_rate.code } },
+        )
+      end.to change(AppliedTaxRate, :count).by(1)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:applied_tax_rate][:lago_id]).to be_present
+        expect(json[:applied_tax_rate][:lago_customer_id]).to eq(customer.id)
+        expect(json[:applied_tax_rate][:lago_tax_rate_id]).to eq(tax_rate.id)
+      end
+    end
+
+    context 'when customer does not exist' do
+      it 'returns not_found error' do
+        post_with_token(organization, '/api/v1/customers/unknown/applied_tax_rates', {})
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when tax rate does not exist' do
+      it 'returns not_found error' do
+        post_with_token(
+          organization,
+          "/api/v1/customers/#{customer.external_id}/applied_tax_rates",
+          { applied_tax_rate: { tax_rate_code: 'unknown' } },
+        )
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'DELETE /applied_tax_rates/:tax_rate_code' do
+    let(:applied_tax_rate) { create(:applied_tax_rate, customer:, tax_rate:) }
+
+    before { applied_tax_rate }
+
+    it 'deletes an applied tax rate' do
+      expect do
+        delete_with_token(
+          organization,
+          "/api/v1/customers/#{customer.external_id}/applied_tax_rates/#{tax_rate.code}",
+        )
+      end.to change(AppliedTaxRate, :count).by(-1)
+    end
+
+    it 'returns the deleted applied tax rate' do
+      delete_with_token(
+        organization,
+        "/api/v1/customers/#{customer.external_id}/applied_tax_rates/#{tax_rate.code}",
+      )
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:applied_tax_rate][:lago_customer_id]).to eq(customer.id)
+        expect(json[:applied_tax_rate][:external_customer_id]).to eq(customer.external_id)
+        expect(json[:applied_tax_rate][:lago_tax_rate_id]).to eq(tax_rate.id)
+        expect(json[:applied_tax_rate][:tax_rate_code]).to eq(tax_rate.code)
+      end
+    end
+
+    context 'when customer does not exist' do
+      it 'returns not_found error' do
+        delete_with_token(organization, "/api/v1/customers/unknown/applied_tax_rates/#{tax_rate.code}")
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when tax rate does not exist' do
+      it 'returns not_found error' do
+        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_tax_rates/unknown")
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when applied tax rate does not exist' do
+      let(:applied_tax_rate) { nil }
+
+      it 'returns not_found error' do
+        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_tax_rates/#{tax_rate.code}")
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/serializers/v1/applied_tax_rate_serializer_spec.rb
+++ b/spec/serializers/v1/applied_tax_rate_serializer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::AppliedTaxRateSerializer do
+  subject(:serializer) { described_class.new(applied_tax_rate, root_name: 'applied_tax_rate') }
+
+  let(:applied_tax_rate) { create(:applied_tax_rate) }
+
+  before { applied_tax_rate }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['applied_tax_rate']['lago_id']).to eq(applied_tax_rate.id)
+      expect(result['applied_tax_rate']['lago_customer_id']).to eq(applied_tax_rate.customer.id)
+      expect(result['applied_tax_rate']['lago_tax_rate_id']).to eq(applied_tax_rate.tax_rate.id)
+      expect(result['applied_tax_rate']['tax_rate_code']).to eq(applied_tax_rate.tax_rate.code)
+      expect(result['applied_tax_rate']['external_customer_id']).to eq(applied_tax_rate.customer.external_id)
+    end
+  end
+end

--- a/spec/services/applied_tax_rates/create_service_spec.rb
+++ b/spec/services/applied_tax_rates/create_service_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AppliedTaxRates::CreateService, type: :service do
+  subject(:create_service) { described_class.new(customer:, tax_rate:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:tax_rate) { create(:tax_rate, organization:) }
+
+  describe '#call' do
+    it 'creates an applied tax rate' do
+      expect { create_service.call }.to change(AppliedTaxRate, :count).by(1)
+    end
+
+    context 'when customer is not found' do
+      let(:customer) { nil }
+
+      it 'returns an error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('customer_not_found')
+        end
+      end
+    end
+
+    context 'when tax rate is not found' do
+      let(:tax_rate) { nil }
+
+      it 'returns an error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('tax_rate_not_found')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/applied_tax_rates/destroy_service_spec.rb
+++ b/spec/services/applied_tax_rates/destroy_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AppliedTaxRates::DestroyService, type: :service do
+  subject(:destroy_service) { described_class.new(applied_tax_rate:) }
+
+  let(:applied_tax_rate) { create(:applied_tax_rate) }
+
+  describe '#call' do
+    before { applied_tax_rate }
+
+    it 'destroys the applied tax rate' do
+      expect { destroy_service.call }.to change(AppliedTaxRate, :count).by(-1)
+    end
+
+    context 'when applied tax rate is not found' do
+      let(:applied_tax_rate) { nil }
+
+      it 'returns an error' do
+        result = destroy_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('applied_tax_rate_not_found')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to be able to:
- assign a tax rate to a customer via API
- unassign a tax rate to a customer via API