### PR TITLE
Add admin organization update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'sidekiq'
 # Security
 gem 'bcrypt'
 gem 'jwt'
+gem 'googleauth', require: false
 gem 'oauth2'
 gem 'rack-cors'
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem 'sidekiq'
 
 # Security
 gem 'bcrypt'
-gem 'jwt'
 gem 'googleauth', require: false
+gem 'jwt'
 gem 'oauth2'
 gem 'rack-cors'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,8 +80,8 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
     analytics-ruby (2.4.0)
     aws-eventstream (1.2.0)
     aws-partitions (1.605.0)
@@ -145,7 +145,7 @@ GEM
       railties (>= 5.0.0)
     faker (2.23.0)
       i18n (>= 1.8.11, < 2)
-    faraday (1.10.2)
+    faraday (1.10.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -173,7 +173,7 @@ GEM
       activesupport (>= 5.0)
     gocardless_pro (2.34.0)
       faraday (>= 0.9.2, < 2)
-    google-apis-core (0.9.1)
+    google-apis-core (0.11.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -182,8 +182,8 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-apis-iamcredentials_v1 (0.15.0)
-      google-apis-core (>= 0.9.0, < 2.a)
+    google-apis-iamcredentials_v1 (0.17.0)
+      google-apis-core (>= 0.11.0, < 2.a)
     google-apis-storage_v1 (0.19.0)
       google-apis-core (>= 0.9.0, < 2.a)
     google-cloud-core (1.6.0)
@@ -191,8 +191,8 @@ GEM
       google-cloud-errors (~> 1.0)
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
-    google-cloud-errors (1.3.0)
-    google-cloud-storage (1.43.0)
+    google-cloud-errors (1.3.1)
+    google-cloud-storage (1.44.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
@@ -200,7 +200,7 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
-    googleauth (1.2.0)
+    googleauth (1.5.2)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -219,7 +219,7 @@ GEM
     irb (1.4.1)
       reline (>= 0.3.0)
     jmespath (1.6.1)
-    jwt (2.4.1)
+    jwt (2.7.0)
     kaminari-activerecord (1.2.2)
       activerecord
       kaminari-core (= 1.2.2)
@@ -258,7 +258,7 @@ GEM
     msgpack (1.5.3)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    multipart-post (2.2.3)
+    multipart-post (2.3.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -290,7 +290,7 @@ GEM
       activerecord (>= 6.0)
       request_store (~> 1.4)
     pg (1.4.1)
-    public_suffix (4.0.7)
+    public_suffix (5.0.1)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.2)
@@ -436,7 +436,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
+    webrick (1.8.1)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -469,6 +469,7 @@ DEPENDENCIES
   faker
   gocardless_pro (~> 2.34)
   google-cloud-storage
+  googleauth
   graphiql-rails!
   graphql
   graphql-pagination

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'googleauth'
+
+module Admin
+  class BaseController < ApplicationController
+    before_action :authenticate
+
+    private
+
+    def authenticate
+      auth_header = request.headers['Authorization']
+
+      return unauthorized_error unless auth_header
+
+      token = auth_header.split(' ').second
+      pp token
+      payload = Google::Auth::IDTokens::verify_oidc token, aud: ENV['GOOGLE_AUTH_CLIENT_ID']
+
+      CurrentContext.email = payload['email']
+
+      true
+    rescue Google::Auth::IDTokens::SignatureError
+      return unauthorized_error
+    end
+
+    def unauthorized_error
+      render(
+        json: {
+          status: 401,
+          error: 'Unauthorized',
+        },
+        status: :unauthorized,
+      )
+    end
+  end
+end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -14,7 +14,6 @@ module Admin
       return unauthorized_error unless auth_header
 
       token = auth_header.split(' ').second
-      pp token
       payload = Google::Auth::IDTokens::verify_oidc token, aud: ENV['GOOGLE_AUTH_CLIENT_ID']
 
       CurrentContext.email = payload['email']

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -4,7 +4,10 @@ require 'googleauth'
 
 module Admin
   class BaseController < ApplicationController
+    include ApiErrors
+
     before_action :authenticate
+    before_action :set_context_source
 
     private
 
@@ -14,23 +17,20 @@ module Admin
       return unauthorized_error unless auth_header
 
       token = auth_header.split(' ').second
-      payload = Google::Auth::IDTokens::verify_oidc token, aud: ENV['GOOGLE_AUTH_CLIENT_ID']
+      payload = Google::Auth::IDTokens.verify_oidc(
+        token,
+        aud: ENV['GOOGLE_AUTH_CLIENT_ID'],
+      )
 
       CurrentContext.email = payload['email']
 
       true
     rescue Google::Auth::IDTokens::SignatureError
-      return unauthorized_error
+      unauthorized_error
     end
 
-    def unauthorized_error
-      render(
-        json: {
-          status: 401,
-          error: 'Unauthorized',
-        },
-        status: :unauthorized,
-      )
+    def set_context_source
+      CurrentContext.source = 'admin'
     end
   end
 end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -4,7 +4,7 @@ module Admin
   class OrganizationsController < BaseController
     def update
       result = Admin::Organizations::UpdateService.call(
-        organization: current_organization,
+        organization:,
         params: update_params,
       )
 
@@ -20,8 +20,8 @@ module Admin
 
     private
 
-    def current_organization
-      @current_organization ||= Organization.find_by(id: params[:id])
+    def organization
+      @organization ||= Organization.find_by(id: params[:id])
     end
 
     def update_params

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -3,22 +3,28 @@
 module Admin
   class OrganizationsController < BaseController
     def update
+      result = Admin::Organizations::UpdateService.call(
+        organization: current_organization,
+        params: update_params,
+      )
+
+      return render_error_response(result) unless result.success?
+
       render(
-            json: ::V1::OrganizationSerializer.new(
-              current_organization,
-              root_name: 'organization',
-            ),
-          )
+        json: ::V1::OrganizationSerializer.new(
+          result.organization,
+          root_name: 'organization',
+        ),
+      )
     end
 
     private
 
     def current_organization
-      pp params[:id]
       @current_organization ||= Organization.find_by(id: params[:id])
     end
 
-    def input_params
+    def update_params
       params.permit(:name)
     end
   end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Admin
+  class OrganizationsController < BaseController
+    def update
+      result = Organizations::UpdateService.call(organization: current_organization, params: input_params)
+
+      
+    end
+
+    private
+
+    def current_organization
+      @current_organization ||= Organization.find_by(params[:id])
+    end
+
+    def input_params
+      params.require(:organization).permit(:name)
+    end
+  end
+end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -3,19 +3,23 @@
 module Admin
   class OrganizationsController < BaseController
     def update
-      result = Organizations::UpdateService.call(organization: current_organization, params: input_params)
-
-      
+      render(
+            json: ::V1::OrganizationSerializer.new(
+              current_organization,
+              root_name: 'organization',
+            ),
+          )
     end
 
     private
 
     def current_organization
-      @current_organization ||= Organization.find_by(params[:id])
+      pp params[:id]
+      @current_organization ||= Organization.find_by(id: params[:id])
     end
 
     def input_params
-      params.require(:organization).permit(:name)
+      params.permit(:name)
     end
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -4,6 +4,7 @@ module Api
   class BaseController < ApplicationController
     include Pagination
     include Common
+    include ApiErrors
 
     before_action :authenticate
     before_action :set_context_source
@@ -22,65 +23,6 @@ module Api
       return unauthorized_error unless current_organization(api_key)
 
       true
-    end
-
-    def unauthorized_error
-      render(
-        json: {
-          status: 401,
-          error: 'Unauthorized',
-        },
-        status: :unauthorized,
-      )
-    end
-
-    def validation_errors(errors:)
-      render(
-        json: {
-          status: 422,
-          error: 'Unprocessable Entity',
-          code: 'validation_errors',
-          error_details: errors,
-        },
-        status: :unprocessable_entity,
-      )
-    end
-
-    def forbidden_error(code:)
-      render(
-        json: {
-          status: 403,
-          error: 'Forbidden',
-          code:,
-        },
-        status: :forbidden,
-      )
-    end
-
-    def method_not_allowed_error(code:)
-      render(
-        json: {
-          status: 405,
-          error: 'Method Not Allowed',
-          code:,
-        },
-        status: :method_not_allowed,
-      )
-    end
-
-    def render_error_response(error_result)
-      case error_result.error
-      when BaseService::NotFoundFailure
-        not_found_error(resource: error_result.error.resource)
-      when BaseService::MethodNotAllowedFailure
-        method_not_allowed_error(code: error_result.error.code)
-      when BaseService::ValidationFailure
-        validation_errors(errors: error_result.error.messages)
-      when BaseService::ForbiddenFailure
-        forbidden_error(code: error_result.error.code)
-      else
-        raise(error_result.error)
-      end
     end
 
     def current_organization(api_key = nil)

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module ApiErrors
+  extend ActiveSupport::Concern
+
+  def unauthorized_error
+    render(
+      json: {
+        status: 401,
+        error: 'Unauthorized',
+      },
+      status: :unauthorized,
+    )
+  end
+
+  def validation_errors(errors:)
+    render(
+      json: {
+        status: 422,
+        error: 'Unprocessable Entity',
+        code: 'validation_errors',
+        error_details: errors,
+      },
+      status: :unprocessable_entity,
+    )
+  end
+
+  def forbidden_error(code:)
+    render(
+      json: {
+        status: 403,
+        error: 'Forbidden',
+        code:,
+      },
+      status: :forbidden,
+    )
+  end
+
+  def method_not_allowed_error(code:)
+    render(
+      json: {
+        status: 405,
+        error: 'Method Not Allowed',
+        code:,
+      },
+      status: :method_not_allowed,
+    )
+  end
+
+  def render_error_response(error_result)
+    case error_result.error
+    when BaseService::NotFoundFailure
+      not_found_error(resource: error_result.error.resource)
+    when BaseService::MethodNotAllowedFailure
+      method_not_allowed_error(code: error_result.error.code)
+    when BaseService::ValidationFailure
+      validation_errors(errors: error_result.error.messages)
+    when BaseService::ForbiddenFailure
+      forbidden_error(code: error_result.error.code)
+    else
+      raise(error_result.error)
+    end
+  end
+end

--- a/app/services/admin/organizations/update_service.rb
+++ b/app/services/admin/organizations/update_service.rb
@@ -3,6 +3,27 @@
 module Admin
   module Organizations
     class UpdateService < ::BaseService
+      def initialize(organization:, params:)
+        @organization = organization
+        @params = params
+  
+        super(nil)
+      end
+
+      def call
+        organization.name = params[:name] if params.key?(:name)
+
+        organization.save!
+
+        result.organization = organization
+        result
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
+      end
+
+      private
+
+      attr_reader :organization, :params
     end
   end
 end

--- a/app/services/admin/organizations/update_service.rb
+++ b/app/services/admin/organizations/update_service.rb
@@ -6,11 +6,13 @@ module Admin
       def initialize(organization:, params:)
         @organization = organization
         @params = params
-  
-        super(nil)
+
+        super
       end
 
       def call
+        return result.not_found_failure!(resource: 'organization') unless organization
+
         organization.name = params[:name] if params.key?(:name)
 
         organization.save!

--- a/app/services/admin/organizations/update_service.rb
+++ b/app/services/admin/organizations/update_service.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Admin
+  module Organizations
+    class UpdateService < ::BaseService
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
 
   config.hosts << 'api.lago.dev'
   config.hosts << 'api'
-  config.hosts << "lago.ngrok.dev"
+  config.hosts << 'lago.ngrok.dev'
 
   config.license_url = 'http://license:3000'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,6 +47,7 @@ Rails.application.configure do
 
   config.hosts << 'api.lago.dev'
   config.hosts << 'api'
+  config.hosts << "lago.ngrok.dev"
 
   config.license_url = 'http://license:3000'
 

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -15,7 +15,7 @@ Rails.application.config.middleware.insert_before(0, Rack::Cors) do
 
       origins frontend_origin
     elsif Rails.env.development?
-      origins 'app.lago.dev', 'api'
+      origins 'app.lago.dev', 'api', 'lago.ngrok.dev'
     end
 
     resource '*',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,10 @@ Rails.application.routes.draw do
     post 'gocardless/:organization_id', to: 'webhooks#gocardless', on: :collection, as: :gocardless
   end
 
+  namespace :admin do
+    resources :organizations, only: %i[update]
+  end
+
   match '*unmatched' => 'application#not_found',
         via: %i[get post put delete patch],
         constraints: lambda { |req|

--- a/lib/current_context.rb
+++ b/lib/current_context.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CurrentContext
-  thread_mattr_accessor :membership, :source
+  thread_mattr_accessor :membership, :source, :email
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,6 +42,7 @@ end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include GraphQLHelper, type: :graphql
+  config.include AdminHelper, type: :request
   config.include ApiHelper, type: :request
   config.include ScenariosHelper
   config.include LicenseHelper

--- a/spec/requests/admin/base_spec.rb
+++ b/spec/requests/admin/base_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::BaseController, type: [:controller, :admin] do
+  controller do
+    def index
+      render nothing: true
+    end
+  end
+
+  describe 'authenticate' do
+    it 'validates the organization api key' do
+      request.headers['Authorization'] = 'Bearer 123456'
+
+      get :index
+
+      expect(response).to have_http_status(:success)
+    end
+
+    context 'without authentication header' do
+      it 'returns an authentication error' do
+        get :index
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/base_spec.rb
+++ b/spec/requests/admin/base_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Admin::BaseController, type: [:controller, :admin] do
+RSpec.describe Admin::BaseController, type: [:request, :admin] do
   controller do
     def index
       render nothing: true

--- a/spec/requests/admin/base_spec.rb
+++ b/spec/requests/admin/base_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Admin::BaseController, type: [:request, :admin] do
+RSpec.describe Admin::BaseController, type: [:controller, :admin] do
   controller do
     def index
       render nothing: true

--- a/spec/requests/admin/organizations_spec.rb
+++ b/spec/requests/admin/organizations_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Admin::OrganizationsController, type: [:request, :admin] do
 
       aggregate_failures do
         expect(json[:organization][:name]).to eq('FooBar')
+        expect(organization.reload.name).to eq('FooBar')
       end
     end
   end

--- a/spec/requests/admin/organizations_spec.rb
+++ b/spec/requests/admin/organizations_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::OrganizationsController, type: [:request, :admin] do
+  let(:organization) { create(:organization) }
+
+  describe 'update' do
+    let(:update_params) do
+      {
+        name: 'FooBar',
+      }
+    end
+
+    it 'updates an organization' do
+      admin_put(
+        "/admin/organizations/#{organization.id}",
+        update_params,
+      )
+
+      expect(response).to have_http_status(:success)
+
+      aggregate_failures do
+        expect(json[:organization][:name]).to eq('FooBar')
+      end
+    end
+  end
+end

--- a/spec/requests/admin/organizations_spec.rb
+++ b/spec/requests/admin/organizations_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Admin::OrganizationsController, type: [:request, :admin] do
   let(:organization) { create(:organization) }
 
-  describe 'update' do
+  describe 'PUT /admin/organizations/:id' do
     let(:update_params) do
       {
         name: 'FooBar',

--- a/spec/services/admin/organizations/update_service_spec.rb
+++ b/spec/services/admin/organizations/update_service_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::Organizations::UpdateService do
+  subject(:update_service) { described_class.new(organization:, params:) }
+
+  let(:organization) { create(:organization) }
+
+  let(:params) do
+    {
+      name: 'FooBar',
+    }
+  end
+
+  describe '#call' do
+    it 'updates the organization' do
+      result = update_service.call
+
+      expect(result.organization.name).to eq('FooBar')
+    end
+  end
+end

--- a/spec/services/admin/organizations/update_service_spec.rb
+++ b/spec/services/admin/organizations/update_service_spec.rb
@@ -17,7 +17,23 @@ RSpec.describe Admin::Organizations::UpdateService do
     it 'updates the organization' do
       result = update_service.call
 
-      expect(result.organization.name).to eq('FooBar')
+      aggregate_failures do
+        expect(result.organization.name).to eq('FooBar')
+        expect(organization.reload.name).to eq('FooBar')
+      end
+    end
+
+    context 'when organization is nil' do
+      let(:organization) { nil }
+
+      it 'returns a not found error' do
+        result = update_service.call
+
+        aggregate_failures do
+          expect(result.success).to be_falsey
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+        end
+      end
     end
   end
 end

--- a/spec/support/admin_helper.rb
+++ b/spec/support/admin_helper.rb
@@ -7,3 +7,24 @@ RSpec.configure do |config|
       .and_return({ email: 'test@getlago.com' })
   end
 end
+
+module AdminHelper
+  def admin_put(path, params = {}, headers = {})
+    apply_headers(headers)
+    put(path, params: params.to_json, headers:)
+  end
+
+  def json
+    return response.body unless response.media_type.include?('json')
+
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  private
+
+  def apply_headers(headers)
+    headers['Content-Type'] = 'application/json'
+    headers['Accept'] = 'application/json'
+    headers['Authorization'] = 'Bearer 123456'
+  end
+end

--- a/spec/support/admin_helper.rb
+++ b/spec/support/admin_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before(:each, type: :admin) do
+    allow(Google::Auth::IDTokens)
+      .to receive(:verify_oidc)
+      .and_return({ email: 'test@getlago.com' })
+  end
+end


### PR DESCRIPTION
## Context

- We want to use an admin tool to be able to do basic operations
- The first one to be covered is to be able to rename an organization

## Description

- Add the `/admin` api logic
- It uses the `googleauth` gem and it's based on a Google Oauth2
- Add the `PUT /admin/organizations/:id` endpoint and logic