### PR TITLE
hotfix: Fix monthly charges for yearly plan when subscription starts on last day of the month

### DIFF
--- a/app/services/subscriptions/dates/monthly_service.rb
+++ b/app/services/subscriptions/dates/monthly_service.rb
@@ -87,7 +87,14 @@ module Subscriptions
       def previous_anniversary_day(date)
         year = nil
         month = nil
-        day = subscription_at.day
+
+        # NOTE: in anniversary mode if both subscription date and current date are
+        #       the last day of month, anniversary day is on the current day
+        day = if subscription.anniversary? && last_day_of_month?(date) && last_day_of_month?(subscription_at)
+          date.day
+        else
+          subscription_at.day
+        end
 
         if date.day < day
           year = (date.month == 1) ? date.year - 1 : date.year

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -177,6 +177,10 @@ module Subscriptions
       Date.new(year, month, day)
     end
 
+    def last_day_of_month?(date)
+      date.day == date.end_of_month.day
+    end
+
     def compute_base_date
       raise(NotImplementedError)
     end

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -130,6 +130,35 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
           end
         end
       end
+
+      context 'when plan is in advance and date is on the last day of month' do
+        let(:pay_in_advance) { true }
+
+        let(:billing_at) { DateTime.parse('30 apr 2021') }
+        let(:subscription_at) { DateTime.parse('31 mar 2021') }
+
+        it 'returns the current day' do
+          expect(result).to eq('2021-04-30 00:00:00 UTC')
+        end
+
+        context 'when billing month is longer than subscription one' do
+          let(:billing_at) { DateTime.parse('29 feb 2020') }
+          let(:subscription_at) { DateTime.parse('31 jan 2020') }
+
+          it 'returns the durrent day' do
+            expect(result).to eq('2020-02-29 00:00:00 UTC')
+          end
+        end
+      end
+
+      context 'when plan is in arrear and date is on the last day of month' do
+        let(:billing_at) { DateTime.parse('30 apr 2021') }
+        let(:subscription_at) { DateTime.parse('31 mar 2021') }
+
+        it 'returns the day current billing day' do
+          expect(result).to eq('2021-03-31 00:00:00 UTC')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Context

An issue have been identified with yearly plan billed in advance with charges billed monthly when the subscription starts on the last day of a month with 31 days.

If  the next month is shorter than the subscription one, the subscription fee is re-billed on the second month...

## Description

The fix is to ensure that in this situation when subscription was started on the last day of the month, we take the last day of current month as billing day.
