### PR TITLE
feat(admin): Add invoice regenerate endpoint

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Admin
+  class InvoicesController < BaseController
+    def regenerate
+      result = ::Invoices::GeneratePdfService.call(invoice:, context: 'admin')
+
+      return render_error_response(result) unless result.success?
+
+      head(:ok)
+    end
+
+    private
+
+    def invoice
+      @invoice ||= Invoice.find(params[:id])
+    end
+  end
+end

--- a/app/services/invoices/generate_pdf_service.rb
+++ b/app/services/invoices/generate_pdf_service.rb
@@ -13,7 +13,7 @@ module Invoices
       return result.not_found_failure!(resource: 'invoice') if invoice.blank?
       return result.not_allowed_failure!(code: 'is_draft') if invoice.draft?
 
-      generate_pdf if invoice.file.blank?
+      generate_pdf if should_generate_pdf?
 
       SendWebhookJob.perform_later('invoice.generated', invoice) if should_send_webhook?
 
@@ -50,6 +50,10 @@ module Invoices
 
     def should_send_webhook?
       context == 'api'
+    end
+
+    def should_generate_pdf?
+      context == 'admin' || invoice.file.blank?
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,9 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :organizations, only: %i[update]
+    resources :invoices do
+      post :regenerate, on: :member
+    end
   end
 
   match '*unmatched' => 'application#not_found',

--- a/spec/requests/admin/invoices_spec.rb
+++ b/spec/requests/admin/invoices_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::InvoicesController, type: [:request, :admin] do
+  let(:invoice) { create(:invoice) }
+
+  describe 'POST /admin/invoices/:id/regenerate' do
+    it 'regenerates the invoice PDF' do
+      admin_post("/admin/invoices/#{invoice.id}/regenerate")
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/requests/admin/invoices_spec.rb
+++ b/spec/requests/admin/invoices_spec.rb
@@ -4,11 +4,25 @@ require 'rails_helper'
 
 RSpec.describe Admin::InvoicesController, type: [:request, :admin] do
   let(:invoice) { create(:invoice) }
+  let(:result) { BaseService::Result.new }
+
+  let(:generate_service) do
+    instance_double(Invoices::GeneratePdfService)
+  end
+
+  before do
+    allow(Invoices::GeneratePdfService).to receive(:new)
+      .with(invoice:, context: 'admin')
+      .and_return(generate_service)
+    allow(generate_service).to receive(:call)
+      .and_return(result)
+  end
 
   describe 'POST /admin/invoices/:id/regenerate' do
     it 'regenerates the invoice PDF' do
       admin_post("/admin/invoices/#{invoice.id}/regenerate")
 
+      expect(Invoices::GeneratePdfService).to have_received(:new)
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/services/invoices/generate_pdf_service_spec.rb
+++ b/spec/services/invoices/generate_pdf_service_spec.rb
@@ -112,5 +112,23 @@ RSpec.describe Invoices::GeneratePdfService, type: :service do
         expect { invoice_generate_service.call }.to have_enqueued_job(SendWebhookJob)
       end
     end
+
+    context 'when in Admin context' do
+      let(:context) { 'admin' }
+
+      before do
+        invoice.file.attach(
+          io: StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))),
+          filename: 'invoice.pdf',
+          content_type: 'application/pdf',
+        )
+      end
+
+      it 'generates the invoice synchronously' do
+        result = invoice_generate_service.call
+
+        expect(result.invoice.file.filename.to_s).not_to eq('invoice.pdf')
+      end
+    end
   end
 end

--- a/spec/support/admin_helper.rb
+++ b/spec/support/admin_helper.rb
@@ -14,6 +14,11 @@ module AdminHelper
     put(path, params: params.to_json, headers:)
   end
 
+  def admin_post(path, params = {}, headers = {})
+    apply_headers(headers)
+    post(path, params: params.to_json, headers:)
+  end
+
   def json
     return response.body unless response.media_type.include?('json')
 


### PR DESCRIPTION
## Context

We want to be able to regenerate an invoice PDF with the admin endpoints

## Description

- Add the `POST /admin/invoices/:id/regenerate` endpoint and logic