### PR TITLE
feat (charges): rename from instant to pay in advance

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -55,7 +55,7 @@ module Api
       end
 
       def estimate_fees
-        result = Fees::EstimateInstantService.call(
+        result = Fees::EstimatePayInAdvanceService.call(
           organization: current_organization,
           params: create_params,
         )

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -85,7 +85,7 @@ module Api
             :id,
             :billable_metric_id,
             :charge_model,
-            :instant,
+            :pay_in_advance,
             :min_amount_cents,
             {
               properties: {},

--- a/app/graphql/types/charges/input.rb
+++ b/app/graphql/types/charges/input.rb
@@ -8,7 +8,7 @@ module Types
       argument :billable_metric_id, ID, required: true
       argument :charge_model, Types::Charges::ChargeModelEnum, required: true
       argument :id, ID, required: false
-      argument :instant, Boolean, required: false
+      argument :pay_in_advance, Boolean, required: false
       argument :min_amount_cents, GraphQL::Types::BigInt, required: false
 
       argument :group_properties, [Types::Charges::GroupPropertiesInput], required: false

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -9,7 +9,7 @@ module Types
       field :charge_model, Types::Charges::ChargeModelEnum, null: false
       field :group_properties, [Types::Charges::GroupProperties], null: true
       field :id, ID, null: false
-      field :instant, Boolean, null: false
+      field :pay_in_advance, Boolean, null: false
       field :min_amount_cents, GraphQL::Types::BigInt, null: false
       field :properties, Types::Charges::Properties, null: true
 

--- a/app/jobs/fees/create_pay_in_advance_job.rb
+++ b/app/jobs/fees/create_pay_in_advance_job.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 module Fees
-  class CreateInstantJob < ApplicationJob
+  class CreatePayInAdvanceJob < ApplicationJob
     queue_as :default
 
     def perform(charge:, event:)
-      result = Fees::CreateInstantService.call(charge:, event:)
+      result = Fees::CreatePayInAdvanceService.call(charge:, event:)
 
       result.raise_if_error!
     end

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -15,7 +15,7 @@ class SendWebhookJob < ApplicationJob
     'invoice.payment_status_updated' => Webhooks::Invoices::PaymentStatusUpdatedService,
     'invoice.payment_failure' => Webhooks::PaymentProviders::InvoicePaymentFailureService,
     'event.error' => Webhooks::Events::ErrorService,
-    'fee.instant_created' => Webhooks::Fees::InstantCreatedService,
+    'fee.pay_in_advance_created' => Webhooks::Fees::PayInAdvanceCreatedService,
     'customer.payment_provider_created' => Webhooks::PaymentProviders::CustomerCreatedService,
     'customer.payment_provider_error' => Webhooks::PaymentProviders::CustomerErrorService,
     'customer.checkout_url_generated' => Webhooks::PaymentProviders::CustomerCheckoutService,

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -26,7 +26,7 @@ class Fee < ApplicationRecord
   monetize :unit_amount_cents, disable_validation: true, allow_nil: true
 
   # TODO: Deprecate add_on type in the near future
-  FEE_TYPES = %i[charge add_on subscription credit instant_charge].freeze
+  FEE_TYPES = %i[charge add_on subscription credit].freeze
   PAYMENT_STATUS = %i[pending succeeded failed refunded].freeze
 
   enum fee_type: FEE_TYPES
@@ -41,7 +41,7 @@ class Fee < ApplicationRecord
   scope :subscription_kind, -> { where(fee_type: :subscription) }
   scope :charge_kind, -> { where(fee_type: :charge) }
 
-  # NOTE: instant fees are not be linked to any invoice, but add_on fees does not have any subscriptions
+  # NOTE: pay_in_advance fees are not be linked to any invoice, but add_on fees does not have any subscriptions
   #       so we need a bit of logic to find the fee in the right organization scope
   scope :from_organization,
         lambda { |organization|
@@ -56,7 +56,7 @@ class Fee < ApplicationRecord
   end
 
   def item_id
-    return billable_metric.id if charge? || instant_charge?
+    return billable_metric.id if charge?
     return add_on.id if add_on?
     return invoiceable_id if credit?
 
@@ -64,7 +64,7 @@ class Fee < ApplicationRecord
   end
 
   def item_type
-    return BillableMetric.name if charge? || instant_charge?
+    return BillableMetric.name if charge?
     return AddOn.name if add_on?
     return WalletTransaction.name if credit?
 
@@ -72,7 +72,7 @@ class Fee < ApplicationRecord
   end
 
   def item_code
-    return billable_metric.code if charge? || instant_charge?
+    return billable_metric.code if charge?
     return add_on.code if add_on?
     return fee_type if credit?
 
@@ -80,7 +80,7 @@ class Fee < ApplicationRecord
   end
 
   def item_name
-    return billable_metric.name if charge? || instant_charge?
+    return billable_metric.name if charge?
     return add_on.name if add_on?
     return fee_type if credit?
 

--- a/app/queries/fees_query.rb
+++ b/app/queries/fees_query.rb
@@ -30,7 +30,7 @@ class FeesQuery < BaseQuery
   end
 
   def with_external_customer(scope)
-    # NOTE: instant fees are not be linked to any invoice, but add_on fees does not have any subscriptions
+    # NOTE: pay_in_advance fees are not be linked to any invoice, but add_on fees does not have any subscriptions
     #       so we need a bit of logic to find the fee in the right customer scope
     #       - Add ons and regular fees: customers linked to the invoice
     #       - Instant: customers linked to the subscription

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -9,7 +9,7 @@ module V1
         billable_metric_code: model.billable_metric.code,
         created_at: model.created_at.iso8601,
         charge_model: model.charge_model,
-        instant: model.instant,
+        pay_in_advance: model.pay_in_advance,
         min_amount_cents: model.min_amount_cents,
         properties: model.properties,
       }.merge(group_properties)

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -16,6 +16,7 @@ module V1
           lago_item_id: model.item_id,
           item_type: model.item_type,
         },
+        pay_in_advance: model.pay_in_advance,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,
         vat_amount_cents: model.vat_amount_cents,
@@ -34,7 +35,7 @@ module V1
       }
 
       payload = payload.merge(date_boundaries) if model.charge? || model.subscription?
-      payload.merge!(instant_charge_attributes) if model.instant_charge?
+      payload.merge!(pay_in_advance_charge_attributes) if model.pay_in_advance?
 
       payload
     end
@@ -56,10 +57,10 @@ module V1
       model.properties['to_datetime']&.to_datetime&.iso8601
     end
 
-    def instant_charge_attributes
-      return {} unless model.instant_charge?
+    def pay_in_advance_charge_attributes
+      return {} unless model.pay_in_advance?
 
-      event = model.subscription.organization.events.find_by(id: model.instant_event_id)
+      event = model.subscription.organization.events.find_by(id: model.pay_in_advance_event_id)
 
       {
         lago_subscription_id: model.subscription_id,

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -6,7 +6,7 @@ module BillableMetrics
       def aggregate(from_datetime:, to_datetime:, options: {})
         result.aggregation = events_scope(from_datetime:, to_datetime:).count
         result.count = result.aggregation
-        result.instant_aggregation = BigDecimal(1)
+        result.pay_in_advance_aggregation = BigDecimal(1)
         result.options = { running_total: running_total(options) }
         result
       end

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -8,7 +8,7 @@ module BillableMetrics
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.sum("(#{sanitized_field_name})::numeric")
-        result.instant_aggregation = BigDecimal(compute_instant_aggregation)
+        result.pay_in_advance_aggregation = BigDecimal(compute_pay_in_advance_aggregation)
         result.count = events.count
         result.options = { running_total: running_total(events, options) }
         result
@@ -50,7 +50,7 @@ module BillableMetrics
           end
       end
 
-      def compute_instant_aggregation
+      def compute_pay_in_advance_aggregation
         return 0 unless event
         return 0 if event.properties.blank?
 

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -8,13 +8,13 @@ module BillableMetrics
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.count("DISTINCT (#{sanitized_field_name})")
-        result.instant_aggregation = BigDecimal(compute_instant_aggregation(events))
+        result.pay_in_advance_aggregation = BigDecimal(compute_pay_in_advance_aggregation(events))
         result.options = { running_total: running_total(options) }
         result.count = events.count
         result
       end
 
-      def compute_instant_aggregation(events)
+      def compute_pay_in_advance_aggregation(events)
         return 0 unless event
         return 0 if event.properties.blank?
 

--- a/app/services/billable_metrics/pay_in_advance_aggregation_service.rb
+++ b/app/services/billable_metrics/pay_in_advance_aggregation_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BillableMetrics
-  class InstantAggregationService < BaseService
+  class PayInAdvanceAggregationService < BaseService
     def initialize(billable_metric:, boundaries:, properties:, event:, group: nil)
       @billable_metric = billable_metric
       @boundaries = boundaries

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Charges
-  class ApplyInstantChargeModelService < BaseService
+  class ApplyPayInAdvanceChargeModelService < BaseService
     def initialize(charge:, aggregation_result:, properties:)
       @charge = charge
       @aggregation_result = aggregation_result
@@ -11,8 +11,8 @@ module Charges
     end
 
     def call
-      unless charge.instant?
-        return result.service_failure!(code: 'apply_charge_model_error', message: 'Charge is not instant')
+      unless charge.pay_in_advance?
+        return result.service_failure!(code: 'apply_charge_model_error', message: 'Charge is not pay_in_advance')
       end
 
       amount = amount_including_event - amount_excluding_event
@@ -22,7 +22,7 @@ module Charges
       rounded_amount = amount.round(currency.exponent)
       amount_cents = rounded_amount * currency.subunit_to_unit
 
-      result.units = aggregation_result.instant_aggregation
+      result.units = aggregation_result.pay_in_advance_aggregation
       result.count = 1
       result.amount = amount_cents
       result
@@ -53,7 +53,7 @@ module Charges
 
     def amount_excluding_event
       previous_result = BaseService::Result.new
-      previous_result.aggregation = aggregation_result.aggregation - aggregation_result.instant_aggregation
+      previous_result.aggregation = aggregation_result.aggregation - aggregation_result.pay_in_advance_aggregation
       previous_result.count = aggregation_result.count - 1
       previous_result.options = aggregation_result.options
 

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -48,7 +48,7 @@ module Events
         handle_persisted_event if should_handle_persisted_event?
       end
 
-      charges.each { |c| Fees::CreateInstantJob.perform_later(charge: c, event:) } if instant_charges?
+      charges.each { |c| Fees::CreatePayInAdvanceJob.perform_later(charge: c, event:) } if pay_in_advance_charges?
 
       result
     rescue ActiveRecord::RecordInvalid => e
@@ -95,12 +95,12 @@ module Events
       @charges ||= event.subscription
         .plan
         .charges
-        .instant
+        .pay_in_advance
         .joins(:billable_metric)
         .where(billable_metric: { code: event.code })
     end
 
-    def instant_charges?
+    def pay_in_advance_charges?
       charges.any?
     end
   end

--- a/app/services/fees/estimate_pay_in_advance_service.rb
+++ b/app/services/fees/estimate_pay_in_advance_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Fees
-  class EstimateInstantService < BaseService
+  class EstimatePayInAdvanceService < BaseService
     def initialize(organization:, params:)
       @organization = organization
       @params = params
@@ -27,7 +27,7 @@ module Fees
         raise ActiveRecord::Rollback
       end
 
-      fees.each { |f| f.instant_event_id = nil }
+      fees.each { |f| f.pay_in_advance_event_id = nil }
 
       result.fees = fees
       result
@@ -76,13 +76,13 @@ module Fees
       @charges ||= event.subscription
         .plan
         .charges
-        .instant
+        .pay_in_advance
         .joins(:billable_metric)
         .where(billable_metric: { code: event.code })
     end
 
     def estimated_charge_fees(charge)
-      service_result = Fees::CreateInstantService.call(charge:, event:, estimate: true)
+      service_result = Fees::CreatePayInAdvanceService.call(charge:, event:, estimate: true)
       service_result.raise_if_error!
 
       service_result.fees

--- a/app/services/fees/update_service.rb
+++ b/app/services/fees/update_service.rb
@@ -13,7 +13,7 @@ module Fees
       return result.not_found_failure!(resource: 'fee') if fee.nil?
 
       if params.key?(:payment_status)
-        return result.not_allowed_failure!(code: 'not_an_instant_fee') unless fee.instant_charge?
+        return result.not_allowed_failure!(code: 'not_an_pay_in_advance_fee') unless fee.pay_in_advance?
 
         unless valid_payment_status?(params[:payment_status])
           return result.single_validation_failure!(

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -75,7 +75,7 @@ module Invoices
     end
 
     def create_charges_fees(subscription, boundaries)
-      subscription.plan.charges.where(instant: false).each do |charge|
+      subscription.plan.charges.where(pay_in_advance: false).each do |charge|
         fee_result = Fees::ChargeService.new(invoice:, charge:, subscription:, boundaries:).create
         fee_result.raise_if_error!
       end

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -49,7 +49,7 @@ module Plans
       )
 
       if License.premium?
-        charge.instant = args[:instant] || false
+        charge.pay_in_advance = args[:pay_in_advance] || false
         charge.min_amount_cents = args[:min_amount_cents] || 0
       end
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -67,7 +67,7 @@ module Plans
       )
 
       if License.premium?
-        charge.instant = params[:instant] || false
+        charge.pay_in_advance = params[:pay_in_advance] || false
         charge.min_amount_cents = params[:min_amount_cents] || 0
       end
 
@@ -87,10 +87,10 @@ module Plans
           unless plan.attached_to_subscriptions?
             payload_charge[:group_properties]&.map! { |gp| GroupProperty.new(gp) }
 
-            instant = payload_charge.delete(:instant)
+            pay_in_advance = payload_charge.delete(:pay_in_advance)
             min_amount_cents = payload_charge.delete(:min_amount_cents)
             if License.premium?
-              charge.instant = instant || false
+              charge.pay_in_advance = pay_in_advance || false
               charge.min_amount_cents = min_amount_cents || 0
             end
 

--- a/app/services/webhooks/fees/pay_in_advance_created_service.rb
+++ b/app/services/webhooks/fees/pay_in_advance_created_service.rb
@@ -2,7 +2,7 @@
 
 module Webhooks
   module Fees
-    class InstantCreatedService < Webhooks::BaseService
+    class PayInAdvanceCreatedService < Webhooks::BaseService
       private
 
       def current_organization
@@ -17,7 +17,7 @@ module Webhooks
       end
 
       def webhook_type
-        'fee.instant_created'
+        'fee.created'
       end
 
       def object_type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
         invalid_free_units_per_total_aggregation: invalid_free_units_per_total_aggregation
         invalid_content_type: invalid_content_type
         invalid_size: invalid_size
-        not_compatible_with_instant: not_compatible_with_instant
+        not_compatible_with_pay_in_advance: not_compatible_with_pay_in_advance
         value_already_exists: value_already_exists
         too_long: value_is_too_long
         values_not_all_present: values_not_all_present

--- a/db/migrate/20230517093556_rename_instant_to_pay_in_advance.rb
+++ b/db/migrate/20230517093556_rename_instant_to_pay_in_advance.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class RenameInstantToPayInAdvance < ActiveRecord::Migration[7.0]
+  def change
+    add_column :fees, :pay_in_advance, :boolean, null: false, default: false
+    rename_column :charges, :instant, :pay_in_advance
+    rename_column :fees, :instant_event_id, :pay_in_advance_event_id
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE fees
+          SET pay_in_advance = charges.pay_in_advance,
+              fee_type = CASE WHEN charges.pay_in_advance = true THEN 0 ELSE fee_type END
+          FROM charges
+          WHERE fees.charge_id = charges.id;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_11_124419) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_17_093556) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -121,7 +121,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_124419) do
     t.integer "charge_model", default: 0, null: false
     t.jsonb "properties", default: "{}", null: false
     t.datetime "deleted_at"
-    t.boolean "instant", default: false, null: false
+    t.boolean "pay_in_advance", default: false, null: false
     t.bigint "min_amount_cents", default: 0, null: false
     t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"
     t.index ["deleted_at"], name: "index_charges_on_deleted_at"
@@ -309,7 +309,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_124419) do
     t.uuid "invoiceable_id"
     t.integer "events_count"
     t.uuid "group_id"
-    t.uuid "instant_event_id"
+    t.uuid "pay_in_advance_event_id"
     t.integer "payment_status", default: 0, null: false
     t.datetime "succeeded_at", precision: nil
     t.datetime "failed_at", precision: nil
@@ -318,6 +318,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_11_124419) do
     t.uuid "add_on_id"
     t.string "description"
     t.bigint "unit_amount_cents", default: 0, null: false
+    t.boolean "pay_in_advance", default: false, null: false
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -145,8 +145,8 @@ type Charge {
   deletedAt: ISO8601DateTime
   groupProperties: [GroupProperties!]
   id: ID!
-  instant: Boolean!
   minAmountCents: BigInt!
+  payInAdvance: Boolean!
   properties: Properties
   updatedAt: ISO8601DateTime!
 }
@@ -156,8 +156,8 @@ input ChargeInput {
   chargeModel: ChargeModelEnum!
   groupProperties: [GroupPropertiesInput!]
   id: ID
-  instant: Boolean
   minAmountCents: BigInt
+  payInAdvance: Boolean
   properties: PropertiesInput
 }
 
@@ -2916,7 +2916,6 @@ enum FeeTypesEnum {
   add_on
   charge
   credit
-  instant_charge
   subscription
 }
 

--- a/schema.json
+++ b/schema.json
@@ -1355,14 +1355,14 @@
               ]
             },
             {
-              "name": "instant",
+              "name": "minAmountCents",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Boolean",
+                  "name": "BigInt",
                   "ofType": null
                 }
               },
@@ -1373,14 +1373,14 @@
               ]
             },
             {
-              "name": "minAmountCents",
+              "name": "payInAdvance",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "BigInt",
+                  "name": "Boolean",
                   "ofType": null
                 }
               },
@@ -1479,7 +1479,7 @@
               "deprecationReason": null
             },
             {
-              "name": "instant",
+              "name": "payInAdvance",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -10048,12 +10048,6 @@
             },
             {
               "name": "credit",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "instant_charge",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -52,8 +52,8 @@ FactoryBot.define do
       end
     end
 
-    trait :instant do
-      instant { true }
+    trait :pay_in_advance do
+      pay_in_advance { true }
     end
   end
 end

--- a/spec/jobs/fees/create_pay_in_advance_job_spec.rb
+++ b/spec/jobs/fees/create_pay_in_advance_job_spec.rb
@@ -2,18 +2,18 @@
 
 require 'rails_helper'
 
-RSpec.describe Fees::CreateInstantJob, type: :job do
-  let(:charge) { create(:standard_charge, :instant) }
+RSpec.describe Fees::CreatePayInAdvanceJob, type: :job do
+  let(:charge) { create(:standard_charge, :pay_in_advance) }
   let(:event) { create(:event) }
 
   let(:result) { BaseService::Result.new }
 
   let(:instant_service) do
-    instance_double(Fees::CreateInstantService)
+    instance_double(Fees::CreatePayInAdvanceService)
   end
 
-  it 'delegates to the instant aggregation service' do
-    allow(Fees::CreateInstantService).to receive(:new)
+  it 'delegates to the pay_in_advance aggregation service' do
+    allow(Fees::CreatePayInAdvanceService).to receive(:new)
       .with(charge:, event:)
       .and_return(instant_service)
     allow(instant_service).to receive(:call)
@@ -21,7 +21,7 @@ RSpec.describe Fees::CreateInstantJob, type: :job do
 
     described_class.perform_now(charge:, event:)
 
-    expect(Fees::CreateInstantService).to have_received(:new)
+    expect(Fees::CreatePayInAdvanceService).to have_received(:new)
     expect(instant_service).to have_received(:call)
   end
 end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -91,21 +91,21 @@ RSpec.describe SendWebhookJob, type: :job do
     end
   end
 
-  context 'when webhook_type is fee.instant_created' do
-    let(:webhook_service) { instance_double(Webhooks::Fees::InstantCreatedService) }
+  context 'when webhook_type is fee.created' do
+    let(:webhook_service) { instance_double(Webhooks::Fees::PayInAdvanceCreatedService) }
     let(:fee) { create(:fee) }
 
     before do
-      allow(Webhooks::Fees::InstantCreatedService).to receive(:new)
+      allow(Webhooks::Fees::PayInAdvanceCreatedService).to receive(:new)
         .with(object: fee, options: {}, webhook_id: nil)
         .and_return(webhook_service)
       allow(webhook_service).to receive(:call)
     end
 
     it 'calls the webhook fee service' do
-      send_webhook_job.perform_now('fee.instant_created', fee)
+      send_webhook_job.perform_now('fee.pay_in_advance_created', fee)
 
-      expect(Webhooks::Fees::InstantCreatedService).to have_received(:new)
+      expect(Webhooks::Fees::PayInAdvanceCreatedService).to have_received(:new)
       expect(webhook_service).to have_received(:call)
     end
   end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -352,11 +352,11 @@ RSpec.describe Charge, type: :model do
     context 'when billable metric is recurring_count_agg' do
       it 'returns an error' do
         billable_metric = create(:recurring_billable_metric)
-        charge = build(:standard_charge, :instant, billable_metric:)
+        charge = build(:standard_charge, :pay_in_advance, billable_metric:)
 
         aggregate_failures do
           expect(charge).not_to be_valid
-          expect(charge.errors.messages[:instant]).to include('invalid_aggregation_type_or_charge_model')
+          expect(charge.errors.messages[:pay_in_advance]).to include('invalid_aggregation_type_or_charge_model')
         end
       end
     end
@@ -364,22 +364,22 @@ RSpec.describe Charge, type: :model do
     context 'when billable metric is max_agg' do
       it 'returns an error' do
         billable_metric = create(:max_billable_metric)
-        charge = build(:standard_charge, :instant, billable_metric:)
+        charge = build(:standard_charge, :pay_in_advance, billable_metric:)
 
         aggregate_failures do
           expect(charge).not_to be_valid
-          expect(charge.errors.messages[:instant]).to include('invalid_aggregation_type_or_charge_model')
+          expect(charge.errors.messages[:pay_in_advance]).to include('invalid_aggregation_type_or_charge_model')
         end
       end
     end
 
     context 'when charge model is volume' do
       it 'returns an error' do
-        charge = build(:volume_charge, :instant)
+        charge = build(:volume_charge, :pay_in_advance)
 
         aggregate_failures do
           expect(charge).not_to be_valid
-          expect(charge.errors.messages[:instant]).to include('invalid_aggregation_type_or_charge_model')
+          expect(charge.errors.messages[:pay_in_advance]).to include('invalid_aggregation_type_or_charge_model')
         end
       end
     end
@@ -390,13 +390,13 @@ RSpec.describe Charge, type: :model do
       expect(build(:standard_charge)).to be_valid
     end
 
-    context 'when charge is instant' do
+    context 'when charge is pay_in_advance' do
       it 'returns an error' do
-        charge = build(:standard_charge, :instant, min_amount_cents: 1200)
+        charge = build(:standard_charge, :pay_in_advance, min_amount_cents: 1200)
 
         aggregate_failures do
           expect(charge).not_to be_valid
-          expect(charge.errors.messages[:min_amount_cents]).to include('not_compatible_with_instant')
+          expect(charge.errors.messages[:min_amount_cents]).to include('not_compatible_with_pay_in_advance')
         end
       end
     end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -52,11 +52,11 @@ RSpec.describe Fee, type: :model do
       end
     end
 
-    context 'when it is an instant charge fee' do
-      let(:charge) { create(:standard_charge, :instant) }
+    context 'when it is an pay_in_advance charge fee' do
+      let(:charge) { create(:standard_charge, :pay_in_advance) }
 
       it 'returns related billable metric code' do
-        expect(fee_model.new(charge:, fee_type: 'instant_charge').item_code)
+        expect(fee_model.new(charge:, fee_type: 'charge').item_code)
           .to eq(charge.billable_metric.code)
       end
     end
@@ -96,11 +96,11 @@ RSpec.describe Fee, type: :model do
       end
     end
 
-    context 'when it is an instant charge fee' do
-      let(:charge) { create(:standard_charge, :instant) }
+    context 'when it is an pay_in_advance charge fee' do
+      let(:charge) { create(:standard_charge, :pay_in_advance) }
 
       it 'returns related billable metric name' do
-        expect(fee_model.new(charge:, fee_type: 'instant_charge').item_name)
+        expect(fee_model.new(charge:, fee_type: 'charge').item_name)
           .to eq(charge.billable_metric.name)
       end
     end
@@ -140,11 +140,11 @@ RSpec.describe Fee, type: :model do
       end
     end
 
-    context 'when it is an instant charge fee' do
-      let(:charge) { create(:standard_charge, :instant) }
+    context 'when it is an pay_in_advance charge fee' do
+      let(:charge) { create(:standard_charge, :pay_in_advance) }
 
       it 'returns billable metric' do
-        expect(fee_model.new(charge:, fee_type: 'instant_charge').item_type)
+        expect(fee_model.new(charge:, fee_type: 'charge').item_type)
           .to eq('BillableMetric')
       end
     end
@@ -187,11 +187,11 @@ RSpec.describe Fee, type: :model do
       end
     end
 
-    context 'when it is an instant charge fee' do
-      let(:charge) { create(:standard_charge, :instant) }
+    context 'when it is an pay_in_advance charge fee' do
+      let(:charge) { create(:standard_charge, :pay_in_advance) }
 
       it 'returns the billable metric id' do
-        expect(fee_model.new(charge:, fee_type: 'instant_charge').item_id)
+        expect(fee_model.new(charge:, fee_type: 'charge').item_id)
           .to eq(charge.billable_metric.id)
       end
     end

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
   end
 
   describe 'POST /events/estimate_fees' do
-    let(:charge) { create(:standard_charge, :instant, plan:, billable_metric: metric) }
+    let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric: metric) }
 
     before { charge }
 
@@ -174,9 +174,10 @@ RSpec.describe Api::V1::EventsController, type: :request do
         fee = json[:fees].first
         expect(fee[:lago_id]).to be_nil
         expect(fee[:lago_group_id]).to be_nil
-        expect(fee[:item][:type]).to eq('instant_charge')
+        expect(fee[:item][:type]).to eq('charge')
         expect(fee[:item][:code]).to eq(metric.code)
         expect(fee[:item][:name]).to eq(metric.name)
+        expect(fee[:pay_in_advance]).to eq(true)
         expect(fee[:amount_cents]).to be_an(Integer)
         expect(fee[:amount_currency]).to eq('EUR')
         expect(fee[:vat_amount_cents]).to be_an(Integer)
@@ -206,7 +207,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
       end
     end
 
-    context 'when metric code does not match an instant charge' do
+    context 'when metric code does not match an pay_in_advance charge' do
       let(:charge) { create(:standard_charge, plan:, billable_metric: metric) }
 
       it 'returns a validation error' do

--- a/spec/requests/api/v1/fees_spec.rb
+++ b/spec/requests/api/v1/fees_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Api::V1::FeesController, type: :request do
   describe 'PUT /fees/:id' do
     let(:customer) { create(:customer, organization:) }
     let(:subscription) { create(:subscription, customer:) }
-    let(:fee) { create(:charge_fee, fee_type: 'instant_charge', subscription:, invoice: nil) }
+    let(:fee) { create(:charge_fee, fee_type: 'charge', pay_in_advance: true, subscription:, invoice: nil) }
 
     let(:update_params) { { payment_status: 'succeeded' } }
 

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Instant charges Scenarios', :scenarios, type: :request do
+describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 
@@ -12,7 +12,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
   let(:billable_metric) { create(:billable_metric, organization:, aggregation_type:, field_name:) }
 
   describe 'with count_agg / standard' do
-    it 'creates an instant fee' do
+    it 'creates an pay_in_advance fee' do
       ### 24 january: Create subscription.
       jan24 = DateTime.new(2023, 1, 24)
 
@@ -28,7 +28,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
       charge = create(
         :standard_charge,
-        :instant,
+        :pay_in_advance,
         plan:,
         billable_metric:,
         properties: { amount: '10' },
@@ -54,7 +54,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
         expect(fee.invoice_id).to be_nil
         expect(fee.charge_id).to eq(charge.id)
-        expect(fee).to be_instant_charge
+        expect(fee.pay_in_advance).to eq(true)
         expect(fee.units).to eq(1)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(1000)
@@ -78,7 +78,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
         expect(fee.invoice_id).to be_nil
         expect(fee.charge_id).to eq(charge.id)
-        expect(fee).to be_instant_charge
+        expect(fee.pay_in_advance).to eq(true)
         expect(fee.units).to eq(1)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(1000)
@@ -90,7 +90,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
     let(:aggregation_type) { 'unique_count_agg' }
     let(:field_name) { 'unique_id' }
 
-    it 'creates an instant fee' do
+    it 'creates an pay_in_advance fee' do
       ### 24 january: Create subscription.
       jan24 = DateTime.new(2023, 1, 24)
 
@@ -106,7 +106,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
       charge = create(
         :standard_charge,
-        :instant,
+        :pay_in_advance,
         plan:,
         billable_metric:,
         properties: { amount: '12' },
@@ -133,7 +133,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
         expect(fee.invoice_id).to be_nil
         expect(fee.charge_id).to eq(charge.id)
-        expect(fee).to be_instant_charge
+        expect(fee.pay_in_advance).to eq(true)
         expect(fee.units).to eq(1)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(1200)
@@ -158,7 +158,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
         expect(fee.invoice_id).to be_nil
         expect(fee.charge_id).to eq(charge.id)
-        expect(fee).to be_instant_charge
+        expect(fee.pay_in_advance).to eq(true)
         expect(fee.units).to eq(0)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(0)
@@ -183,7 +183,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
         expect(fee.invoice_id).to be_nil
         expect(fee.charge_id).to eq(charge.id)
-        expect(fee).to be_instant_charge
+        expect(fee.pay_in_advance).to eq(true)
         expect(fee.units).to eq(1)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(1200)
@@ -195,7 +195,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
     let(:aggregation_type) { 'sum_agg' }
     let(:field_name) { 'amount' }
 
-    it 'creates an instant fee' do
+    it 'creates an pay_in_advance fee' do
       ### 24 january: Create subscription.
       jan24 = DateTime.new(2023, 1, 24)
 
@@ -211,7 +211,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
       charge = create(
         :package_charge,
-        :instant,
+        :pay_in_advance,
         plan:,
         billable_metric:,
         properties: { amount: '100', free_units: 3, package_size: 2 },
@@ -238,7 +238,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
         expect(fee.invoice_id).to be_nil
         expect(fee.charge_id).to eq(charge.id)
-        expect(fee).to be_instant_charge
+        expect(fee.pay_in_advance).to eq(true)
         expect(fee.units).to eq(3)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(0) # free units
@@ -286,7 +286,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
     let(:aggregation_type) { 'sum_agg' }
     let(:field_name) { 'amount' }
 
-    it 'creates an instant fee' do
+    it 'creates an pay_in_advance fee' do
       ### 24 january: Create subscription.
       jan24 = DateTime.new(2023, 1, 24)
 
@@ -302,7 +302,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
       charge = create(
         :graduated_charge,
-        :instant,
+        :pay_in_advance,
         plan:,
         billable_metric:,
         properties: {
@@ -344,7 +344,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
         expect(fee.invoice_id).to be_nil
         expect(fee.charge_id).to eq(charge.id)
-        expect(fee).to be_instant_charge
+        expect(fee.pay_in_advance).to eq(true)
         expect(fee.units).to eq(3)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(2 * 3 + 1)
@@ -393,7 +393,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
     let(:field_name) { 'amount' }
 
     describe 'with free_units_per_events' do
-      it 'creates an instant fee ' do
+      it 'creates an pay_in_advance fee ' do
         ### 24 january: Create subscription.
         jan24 = DateTime.new(2023, 1, 24)
 
@@ -409,7 +409,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
         charge = create(
           :percentage_charge,
-          :instant,
+          :pay_in_advance,
           plan:,
           billable_metric:,
           properties: {
@@ -452,7 +452,8 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
           expect(fee).to have_attributes(
             invoice_id: nil,
             charge_id: charge.id,
-            fee_type: 'instant_charge',
+            fee_type: 'charge',
+            pay_in_advance: true,
             units: 5,
             events_count: 1,
             amount_cents: 0,
@@ -473,7 +474,8 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
           expect(fee).to have_attributes(
             invoice_id: nil,
             charge_id: charge.id,
-            fee_type: 'instant_charge',
+            fee_type: 'charge',
+            pay_in_advance: true,
             units: 3,
             events_count: 1,
             amount_cents: 100 + 15,
@@ -483,7 +485,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
     end
 
     describe 'with free_units_per_total_aggregation' do
-      it 'creates an instant fee ' do
+      it 'creates an pay_in_advance fee ' do
         ### 24 january: Create subscription.
         jan24 = DateTime.new(2023, 1, 24)
 
@@ -499,7 +501,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
         charge = create(
           :percentage_charge,
-          :instant,
+          :pay_in_advance,
           plan:,
           billable_metric:,
           properties: {
@@ -542,7 +544,8 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
           expect(fee).to have_attributes(
             invoice_id: nil,
             charge_id: charge.id,
-            fee_type: 'instant_charge',
+            fee_type: 'charge',
+            pay_in_advance: true,
             units: 1,
             events_count: 1,
             amount_cents: 100 + 5,
@@ -551,7 +554,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
       end
     end
 
-    it 'creates an instant fee' do
+    it 'creates an pay_in_advance fee' do
       ### 24 january: Create subscription.
       jan24 = DateTime.new(2023, 1, 24)
 
@@ -567,7 +570,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
       charge = create(
         :percentage_charge,
-        :instant,
+        :pay_in_advance,
         plan:,
         billable_metric:,
         properties: {
@@ -598,7 +601,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
         expect(fee.invoice_id).to be_nil
         expect(fee.charge_id).to eq(charge.id)
-        expect(fee).to be_instant_charge
+        expect(fee.pay_in_advance).to eq(true)
         expect(fee.units).to eq(5)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(100 + 2 * 5) # 2 units not free
@@ -629,7 +632,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
     let(:field_name) { 'amount' }
 
     describe 'with free_units_per_events' do
-      it 'creates an instant fee ' do
+      it 'creates an pay_in_advance fee ' do
         ### 24 january: Create subscription.
         jan24 = DateTime.new(2023, 1, 24)
 
@@ -645,7 +648,7 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
 
         charge = create(
           :percentage_charge,
-          :instant,
+          :pay_in_advance,
           plan:,
           billable_metric:,
           properties: {
@@ -676,7 +679,8 @@ describe 'Instant charges Scenarios', :scenarios, type: :request do
           expect(fee).to have_attributes(
             invoice_id: nil,
             charge_id: charge.id,
-            fee_type: 'instant_charge',
+            fee_type: 'charge',
+            pay_in_advance: true,
             units: 1,
             events_count: 1,
             amount_cents: 0,

--- a/spec/serializers/v1/charge_serializer_spec.rb
+++ b/spec/serializers/v1/charge_serializer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ::V1::ChargeSerializer do
       expect(result['charge']['billable_metric_code']).to eq(charge.billable_metric.code)
       expect(result['charge']['created_at']).to eq(charge.created_at.iso8601)
       expect(result['charge']['charge_model']).to eq(charge.charge_model)
-      expect(result['charge']['instant']).to eq(charge.instant)
+      expect(result['charge']['pay_in_advance']).to eq(charge.pay_in_advance)
       expect(result['charge']['properties']).to eq(charge.properties)
     end
   end

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -91,19 +91,21 @@ RSpec.describe ::V1::FeeSerializer do
     end
   end
 
-  context 'when instant_charge attributes are included' do
-    let(:inclusion) { %i[instant_charge] }
+  context 'when pay_in_advance attributes are included' do
+    let(:inclusion) { %i[pay_in_advance] }
 
     let(:organization) { create(:organization) }
     let(:customer) { create(:customer, organization:) }
     let(:plan) { create(:plan, organization:) }
     let(:subscription) { create(:subscription, customer:, organization:, plan:) }
-    let(:charge) { create(:standard_charge, :instant, plan:) }
+    let(:charge) { create(:standard_charge, :pay_in_advance, plan:) }
     let(:event) { create(:event, subscription:, organization:, customer:) }
 
-    let(:fee) { create(:fee, fee_type: 'instant_charge', subscription:, charge:, instant_event_id: event.id) }
+    let(:fee) do
+      create(:fee, fee_type: 'charge', pay_in_advance: true, subscription:, charge:, pay_in_advance_event_id: event.id)
+    end
 
-    it 'serializes the instant charge attributes' do
+    it 'serializes the pay_in_advance charge attributes' do
       aggregate_failures do
         expect(result['fee']).to include(
           'lago_subscription_id' => subscription.id,

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       billable_metric:,
       subscription:,
       group:,
-      event: instant_event,
+      event: pay_in_advance_event,
     )
   end
 
@@ -28,7 +28,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
   let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
   let(:to_datetime) { Time.current.end_of_day }
 
-  let(:instant_event) { nil }
+  let(:pay_in_advance_event) { nil }
 
   before do
     create_list(
@@ -120,13 +120,13 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
     end
   end
 
-  context 'when instant aggregation' do
-    let(:instant_event) { create(:event, subscription:, customer:) }
+  context 'when pay_in_advance aggregation' do
+    let(:pay_in_advance_event) { create(:event, subscription:, customer:) }
 
-    it 'assigns an instant aggregation' do
+    it 'assigns an pay_in_advance aggregation' do
       result = count_service.aggregate(from_datetime:, to_datetime:)
 
-      expect(result.instant_aggregation).to eq(1)
+      expect(result.pay_in_advance_aggregation).to eq(1)
     end
   end
 end

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       billable_metric:,
       subscription:,
       group:,
-      event: instant_event,
+      event: pay_in_advance_event,
     )
   end
 
@@ -32,7 +32,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     { free_units_per_events: 2, free_units_per_total_aggregation: 30 }
   end
 
-  let(:instant_event) { nil }
+  let(:pay_in_advance_event) { nil }
 
   before do
     create_list(
@@ -52,7 +52,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
 
     expect(result.aggregation).to eq(48)
-    expect(result.instant_aggregation).to be_zero
+    expect(result.pay_in_advance_aggregation).to be_zero
     expect(result.count).to eq(4)
     expect(result.options).to eq({ running_total: [12, 24] })
   end
@@ -225,7 +225,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
   end
 
   context 'when event is given' do
-    let(:instant_event) do
+    let(:pay_in_advance_event) do
       create(
         :event,
         code: billable_metric.code,
@@ -238,29 +238,29 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
 
     let(:properties) { { total_count: 12 } }
 
-    it 'assigns an instant aggregation' do
+    it 'assigns an pay_in_advance aggregation' do
       result = sum_service.aggregate(from_datetime:, to_datetime:)
 
-      expect(result.instant_aggregation).to eq(12)
+      expect(result.pay_in_advance_aggregation).to eq(12)
     end
 
     context 'when event propertie does not match metric field name' do
       let(:properties) { { final_count: 10 } }
 
-      it 'assigns 0 as instant aggregation' do
+      it 'assigns 0 as pay_in_advance aggregation' do
         result = sum_service.aggregate(from_datetime:, to_datetime:)
 
-        expect(result.instant_aggregation).to be_zero
+        expect(result.pay_in_advance_aggregation).to be_zero
       end
     end
 
     context 'when event is missing properties' do
       let(:properties) { {} }
 
-      it 'assigns 0 as instant aggregation' do
+      it 'assigns 0 as pay_in_advance aggregation' do
         result = sum_service.aggregate(from_datetime:, to_datetime:)
 
-        expect(result.instant_aggregation).to be_zero
+        expect(result.pay_in_advance_aggregation).to be_zero
       end
     end
   end

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       billable_metric:,
       subscription:,
       group:,
-      event: instant_event,
+      event: pay_in_advance_event,
     )
   end
 
@@ -29,7 +29,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
   let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
   let(:to_datetime) { Time.current.end_of_day }
 
-  let(:instant_event) { nil }
+  let(:pay_in_advance_event) { nil }
 
   before do
     create_list(
@@ -128,7 +128,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
   end
 
   context 'when event is given' do
-    let(:instant_event) do
+    let(:pay_in_advance_event) do
       create(
         :event,
         code: billable_metric.code,
@@ -141,13 +141,13 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
 
     let(:properties) { { anonymous_id: 'unknown' } }
 
-    it 'assigns an instant aggregation' do
+    it 'assigns an pay_in_advance aggregation' do
       result = count_service.aggregate(from_datetime:, to_datetime:)
 
-      expect(result.instant_aggregation).to eq(1)
+      expect(result.pay_in_advance_aggregation).to eq(1)
     end
 
-    context 'when event propety is already known' do
+    context 'when event property is already known' do
       before do
         create(
           :event,
@@ -159,20 +159,20 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         )
       end
 
-      it 'assigns zero as instant aggregation' do
+      it 'assigns zero as pay_in_advance aggregation' do
         result = count_service.aggregate(from_datetime:, to_datetime:)
 
-        expect(result.instant_aggregation).to be_zero
+        expect(result.pay_in_advance_aggregation).to be_zero
       end
     end
 
     context 'when event is missing properties' do
       let(:properties) { {} }
 
-      it 'assigns 0 as instant aggregation' do
+      it 'assigns 0 as pay_in_advance aggregation' do
         result = count_service.aggregate(from_datetime:, to_datetime:)
 
-        expect(result.instant_aggregation).to be_zero
+        expect(result.pay_in_advance_aggregation).to be_zero
       end
     end
   end

--- a/spec/services/billable_metrics/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/billable_metrics/pay_in_advance_aggregation_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BillableMetrics::InstantAggregationService, type: :service do
+RSpec.describe BillableMetrics::PayInAdvanceAggregationService, type: :service do
   subject(:agg_service) do
     described_class.new(billable_metric:, boundaries:, group:, properties:, event:)
   end

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -2,14 +2,14 @@
 
 require 'rails_helper'
 
-RSpec.describe Charges::ApplyInstantChargeModelService, type: :service do
+RSpec.describe Charges::ApplyPayInAdvanceChargeModelService, type: :service do
   let(:charge_service) { described_class.new(charge:, aggregation_result:, properties:) }
 
-  let(:charge) { create(:standard_charge, :instant) }
+  let(:charge) { create(:standard_charge, :pay_in_advance) }
   let(:aggregation_result) do
     BaseService::Result.new.tap do |result|
       result.aggregation = 10
-      result.instant_aggregation = 1
+      result.pay_in_advance_aggregation = 1
       result.count = 5
       result.options = {}
     end
@@ -17,7 +17,7 @@ RSpec.describe Charges::ApplyInstantChargeModelService, type: :service do
   let(:properties) { {} }
 
   describe '#call' do
-    context 'when charge is not instant' do
+    context 'when charge is not pay_in_advance' do
       let(:charge) { create(:standard_charge) }
 
       it 'returns an error' do
@@ -27,7 +27,7 @@ RSpec.describe Charges::ApplyInstantChargeModelService, type: :service do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ServiceFailure)
           expect(result.error.code).to eq('apply_charge_model_error')
-          expect(result.error.error_message).to eq('Charge is not instant')
+          expect(result.error.error_message).to eq('Charge is not pay_in_advance')
         end
       end
     end
@@ -66,7 +66,7 @@ RSpec.describe Charges::ApplyInstantChargeModelService, type: :service do
       let(:charge) do
         create(
           :graduated_charge,
-          :instant,
+          :pay_in_advance,
           properties: {
             graduated_ranges: [
               {
@@ -85,14 +85,14 @@ RSpec.describe Charges::ApplyInstantChargeModelService, type: :service do
     end
 
     describe 'when package charge model' do
-      let(:charge) { create(:package_charge, :instant) }
+      let(:charge) { create(:package_charge, :pay_in_advance) }
       let(:charge_model_class) { Charges::ChargeModels::PackageService }
 
       it_behaves_like 'a charge model'
     end
 
     describe 'when percentage charge model' do
-      let(:charge) { create(:percentage_charge, :instant) }
+      let(:charge) { create(:percentage_charge, :pay_in_advance) }
       let(:charge_model_class) { Charges::ChargeModels::PercentageService }
 
       it_behaves_like 'a charge model'

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -398,8 +398,8 @@ RSpec.describe Events::CreateService, type: :service do
       end
     end
 
-    context 'when event matches an instant charge' do
-      let(:charge) { create(:standard_charge, :instant, plan:, billable_metric:) }
+    context 'when event matches an pay_in_advance charge' do
+      let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric:) }
       let(:billable_metric) do
         create(
           :billable_metric,
@@ -422,7 +422,7 @@ RSpec.describe Events::CreateService, type: :service do
 
       before { charge }
 
-      it 'enqueues a job to perform the instant aggregation' do
+      it 'enqueues a job to perform the pay_in_advance aggregation' do
         expect do
           create_service.call(
             organization:,
@@ -430,11 +430,11 @@ RSpec.describe Events::CreateService, type: :service do
             timestamp:,
             metadata: {},
           )
-        end.to have_enqueued_job(Fees::CreateInstantJob)
+        end.to have_enqueued_job(Fees::CreatePayInAdvanceJob)
       end
 
       context 'when multiple charges have the billable metric' do
-        before { create(:standard_charge, :instant, plan:, billable_metric:) }
+        before { create(:standard_charge, :pay_in_advance, plan:, billable_metric:) }
 
         it 'enqueues a job for each charge' do
           expect do
@@ -444,7 +444,7 @@ RSpec.describe Events::CreateService, type: :service do
               timestamp:,
               metadata: {},
             )
-          end.to have_enqueued_job(Fees::CreateInstantJob).twice
+          end.to have_enqueued_job(Fees::CreatePayInAdvanceJob).twice
         end
       end
     end

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Fees::CreateInstantService, type: :service do
+RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
   subject(:fee_service) { described_class.new(charge:, event:, estimate:) }
 
   let(:organization) { create(:organization) }
@@ -13,7 +13,7 @@ RSpec.describe Fees::CreateInstantService, type: :service do
 
   let(:group) { nil }
 
-  let(:charge) { create(:standard_charge, :instant, billable_metric:, plan:) }
+  let(:charge) { create(:standard_charge, :pay_in_advance, billable_metric:, plan:) }
   let(:event) { create(:event, subscription:, customer:) }
   let(:estimate) { false }
 
@@ -35,11 +35,11 @@ RSpec.describe Fees::CreateInstantService, type: :service do
     end
 
     before do
-      allow(BillableMetrics::InstantAggregationService).to receive(:call)
+      allow(BillableMetrics::PayInAdvanceAggregationService).to receive(:call)
         .with(billable_metric:, boundaries: Hash, group:, properties: Hash, event:)
         .and_return(aggregation_result)
 
-      allow(Charges::ApplyInstantChargeModelService).to receive(:call)
+      allow(Charges::ApplyPayInAdvanceChargeModelService).to receive(:call)
         .with(charge:, aggregation_result:, properties: Hash)
         .and_return(charge_result)
     end
@@ -59,13 +59,14 @@ RSpec.describe Fees::CreateInstantService, type: :service do
           vat_rate: 20.0,
           vat_amount_cents: 2,
           vat_amount_currency: 'EUR',
-          fee_type: 'instant_charge',
+          fee_type: 'charge',
+          pay_in_advance: true,
           invoiceable: charge,
           units: 9,
           properties: Hash,
           events_count: 1,
           group: nil,
-          instant_event_id: event.id,
+          pay_in_advance_event_id: event.id,
           payment_status: 'pending',
         )
       end
@@ -75,7 +76,7 @@ RSpec.describe Fees::CreateInstantService, type: :service do
       fee_service.call
 
       expect(SendWebhookJob).to have_been_enqueued
-        .with('fee.instant_created', Fee)
+        .with('fee.pay_in_advance_created', Fee)
     end
 
     context 'when aggregation fails' do
@@ -121,7 +122,7 @@ RSpec.describe Fees::CreateInstantService, type: :service do
       let(:charge) do
         create(
           :standard_charge,
-          :instant,
+          :pay_in_advance,
           plan: subscription.plan,
           billable_metric:,
           group_properties: [
@@ -163,13 +164,14 @@ RSpec.describe Fees::CreateInstantService, type: :service do
             vat_rate: 20.0,
             vat_amount_cents: 2,
             vat_amount_currency: 'EUR',
-            fee_type: 'instant_charge',
+            fee_type: 'charge',
+            pay_in_advance: true,
             invoiceable: charge,
             units: 9,
             properties: Hash,
             events_count: 1,
             group:,
-            instant_event_id: event.id,
+            pay_in_advance_event_id: event.id,
           )
         end
       end
@@ -206,13 +208,14 @@ RSpec.describe Fees::CreateInstantService, type: :service do
               vat_rate: 20.0,
               vat_amount_cents: 2,
               vat_amount_currency: 'EUR',
-              fee_type: 'instant_charge',
+              fee_type: 'charge',
+              pay_in_advance: true,
               invoiceable: charge,
               units: 9,
               properties: Hash,
               events_count: 1,
               group:,
-              instant_event_id: event.id,
+              pay_in_advance_event_id: event.id,
             )
           end
         end
@@ -260,13 +263,14 @@ RSpec.describe Fees::CreateInstantService, type: :service do
             vat_rate: 20.0,
             vat_amount_cents: 2,
             vat_amount_currency: 'EUR',
-            fee_type: 'instant_charge',
+            fee_type: 'charge',
+            pay_in_advance: true,
             invoiceable: charge,
             units: 9,
             properties: Hash,
             events_count: 1,
             group: nil,
-            instant_event_id: event.id,
+            pay_in_advance_event_id: event.id,
           )
         end
       end
@@ -275,7 +279,7 @@ RSpec.describe Fees::CreateInstantService, type: :service do
         fee_service.call
 
         expect(SendWebhookJob).not_to have_been_enqueued
-          .with('fee.instant_created', Fee)
+          .with('fee.pay_in_advance_created', Fee)
       end
     end
   end

--- a/spec/services/fees/estimate_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/estimate_pay_in_advance_service_spec.rb
@@ -2,13 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe Fees::EstimateInstantService do
+RSpec.describe Fees::EstimatePayInAdvanceService do
   subject(:estimate_service) { described_class.new(organization:, params:) }
 
   let(:organization) { create(:organization) }
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:plan) { create(:plan, organization:) }
-  let(:charge) { create(:standard_charge, :instant, plan:, billable_metric:) }
+  let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric:) }
 
   let(:customer) { create(:customer, organization:) }
 
@@ -48,15 +48,16 @@ RSpec.describe Fees::EstimateInstantService do
         expect(fee).to have_attributes(
           subscription:,
           charge:,
-          fee_type: 'instant_charge',
+          fee_type: 'charge',
+          pay_in_advance: true,
           invoiceable: charge,
           events_count: 1,
-          instant_event_id: nil,
+          pay_in_advance_event_id: nil,
         )
       end
     end
 
-    context 'when event code does not match an instant charge' do
+    context 'when event code does not match an pay_in_advance charge' do
       let(:charge) { create(:standard_charge, plan:, billable_metric:) }
 
       it 'fails with a validation error' do
@@ -71,7 +72,7 @@ RSpec.describe Fees::EstimateInstantService do
     end
 
     context 'when event matches multiple charges' do
-      let(:charge2) { create(:standard_charge, :instant, plan:, billable_metric:) }
+      let(:charge2) { create(:standard_charge, :pay_in_advance, plan:, billable_metric:) }
 
       before { charge2 }
 
@@ -137,10 +138,11 @@ RSpec.describe Fees::EstimateInstantService do
             expect(fee).to have_attributes(
               subscription:,
               charge:,
-              fee_type: 'instant_charge',
+              fee_type: 'charge',
+              pay_in_advance: true,
               invoiceable: charge,
               events_count: 1,
-              instant_event_id: nil,
+              pay_in_advance_event_id: nil,
             )
           end
         end

--- a/spec/services/fees/update_service_spec.rb
+++ b/spec/services/fees/update_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Fees::UpdateService, type: :service do
   subject(:update_service) { described_class.new(fee:, params:) }
 
-  let(:fee) { create(:charge_fee, fee_type: 'instant_charge', invoice: nil) }
+  let(:fee) { create(:charge_fee, fee_type: 'charge', pay_in_advance: true, invoice: nil) }
 
   let(:params) { { payment_status: } }
   let(:payment_status) { 'succeeded' }
@@ -36,8 +36,8 @@ RSpec.describe Fees::UpdateService, type: :service do
       end
     end
 
-    context 'when fee is not instant' do
-      let(:fee) { create(:fee, fee_type: 'charge', invoice: nil) }
+    context 'when fee is not pay_in_advance' do
+      let(:fee) { create(:fee, fee_type: 'charge', pay_in_advance: false, invoice: nil) }
 
       it 'returns a not allowed failure' do
         result = update_service.call
@@ -45,7 +45,7 @@ RSpec.describe Fees::UpdateService, type: :service do
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-          expect(result.error.code).to eq('not_an_instant_fee')
+          expect(result.error.code).to eq('not_an_pay_in_advance_fee')
         end
       end
     end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         end
       end
 
-      context 'when charge is instant' do
-        let(:charge) { create(:standard_charge, :instant, plan: subscription.plan, charge_model: 'standard') }
+      context 'when charge is pay_in_advance' do
+        let(:charge) { create(:standard_charge, :pay_in_advance, plan: subscription.plan, charge_model: 'standard') }
 
         it 'does not create a charge fee' do
           result = invoice_service.call

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Plans::CreateService, type: :service do
           {
             billable_metric_id: billable_metrics.last.id,
             charge_model: 'graduated',
-            instant: true,
+            pay_in_advance: true,
             properties: {
               graduated_ranges: [
                 {
@@ -76,7 +76,7 @@ RSpec.describe Plans::CreateService, type: :service do
       standard_charge = plan.charges.standard.first
       graduated_charge = plan.charges.graduated.first
 
-      expect(standard_charge).to have_attributes(instant: false, min_amount_cents: 0)
+      expect(standard_charge).to have_attributes(pay_in_advance: false, min_amount_cents: 0)
       expect(standard_charge.group_properties.first).to have_attributes(
         {
           group_id: group.id,
@@ -84,7 +84,7 @@ RSpec.describe Plans::CreateService, type: :service do
         },
       )
 
-      expect(graduated_charge).not_to be_instant
+      expect(graduated_charge).not_to be_pay_in_advance
     end
 
     it 'calls SegmentTrackJob' do
@@ -117,8 +117,8 @@ RSpec.describe Plans::CreateService, type: :service do
       it 'saves premium attributes' do
         plan = plans_service.create(**create_args).plan
 
-        expect(plan.charges.standard.first).to have_attributes(instant: false, min_amount_cents: 100)
-        expect(plan.charges.graduated.first).to be_instant
+        expect(plan.charges.standard.first).to have_attributes(pay_in_advance: false, min_amount_cents: 100)
+        expect(plan.charges.graduated.first).to be_pay_in_advance
       end
     end
 

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe Plans::UpdateService, type: :service do
               id: existing_charge.id,
               billable_metric_id: billable_metrics.first.id,
               charge_model: 'standard',
-              instant: true,
+              pay_in_advance: true,
               group_properties: [
                 {
                   group_id: group.id,
@@ -201,8 +201,8 @@ RSpec.describe Plans::UpdateService, type: :service do
       it 'does not update premium attributes' do
         plan = plans_service.call.plan
 
-        expect(existing_charge.reload).not_to be_instant
-        expect(plan.charges.where(instant: false).first.min_amount_cents).to eq(0)
+        expect(existing_charge.reload).not_to be_pay_in_advance
+        expect(plan.charges.where(pay_in_advance: false).first.min_amount_cents).to eq(0)
       end
 
       context 'when premium' do
@@ -211,8 +211,8 @@ RSpec.describe Plans::UpdateService, type: :service do
         it 'saves premium attributes' do
           plans_service.call
 
-          expect(existing_charge.reload).to be_instant
-          expect(plan.charges.where(instant: false).first.min_amount_cents).to eq(100)
+          expect(existing_charge.reload).to be_pay_in_advance
+          expect(plan.charges.where(pay_in_advance: false).first.min_amount_cents).to eq(100)
         end
       end
     end

--- a/spec/services/webhooks/fees/pay_in_advance_created_service_spec.rb
+++ b/spec/services/webhooks/fees/pay_in_advance_created_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Webhooks::Fees::InstantCreatedService do
+RSpec.describe Webhooks::Fees::PayInAdvanceCreatedService do
   subject(:webhook_service) { described_class.new(object: fee) }
 
   let(:organization) { create(:organization, webhook_url:) }
@@ -21,13 +21,13 @@ RSpec.describe Webhooks::Fees::InstantCreatedService do
       allow(lago_client).to receive(:post_with_response)
     end
 
-    it 'builds payload with fee.instant_created webhook type' do
+    it 'builds payload with fee.created webhook type' do
       webhook_service.call
 
       expect(LagoHttpClient::Client).to have_received(:new)
         .with(organization.webhook_url)
       expect(lago_client).to have_received(:post_with_response) do |payload|
-        expect(payload[:webhook_type]).to eq('fee.instant_created')
+        expect(payload[:webhook_type]).to eq('fee.created')
         expect(payload[:object_type]).to eq('fee')
       end
     end


### PR DESCRIPTION
## Context

This feature is first step in handling invoiceable charges that are paid in advance

## Description

In this PR all `instant` occurrences are changed to `pay_in_advance`.
Also, there is a migration that besides renaming instant to `pay_in_advance` on `charges`, adds `pay_in_advance` column on `fees` and sets on `fees` `fee_type` to 0 ('charge') instead of having `instant_charge` type.