### PR TITLE
feat(admin): Add membership endpoint

### DIFF
--- a/app/controllers/admin/memberships_controller.rb
+++ b/app/controllers/admin/memberships_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Admin
+  class MembershipsController < BaseController
+    def create
+      result = ::Memberships::CreateService.call(user:, organization:)
+
+      return render_error_response(result) unless result.success?
+
+      render(
+        json: ::V1::MembershipSerializer.new(
+          result.membership,
+          root_name: 'membership',
+        ),
+      )
+    end
+
+    private
+
+    def user
+      @user ||= User.find_by(id: params[:user_id])
+    end
+
+    def organization
+      @organization ||= Organization.find_by(id: params[:organization_id])
+    end
+
+    def create_params
+      params.permit(:user_id, :organization_id)
+    end
+  end
+end

--- a/app/controllers/admin/memberships_controller.rb
+++ b/app/controllers/admin/memberships_controller.rb
@@ -24,9 +24,5 @@ module Admin
     def organization
       @organization ||= Organization.find_by(id: params[:organization_id])
     end
-
-    def create_params
-      params.permit(:user_id, :organization_id)
-    end
   end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -14,7 +14,7 @@ class Membership < ApplicationRecord
   enum status: STATUSES
   enum role: { admin: 0 }
 
-  validates :user_id, uniqueness: { scope: :organization_id }
+  validates :user_id, uniqueness: { conditions: -> { where(revoked_at: nil) }, scope: :organization_id }
 
   def mark_as_revoked!(timestamp = Time.current)
     self.revoked_at ||= timestamp

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -14,6 +14,8 @@ class Membership < ApplicationRecord
   enum status: STATUSES
   enum role: { admin: 0 }
 
+  validates :user_id, uniqueness: { scope: :organization_id }
+
   def mark_as_revoked!(timestamp = Time.current)
     self.revoked_at ||= timestamp
     revoked!

--- a/app/serializers/v1/membership_serializer.rb
+++ b/app/serializers/v1/membership_serializer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module V1
+  class MembershipSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        user_id: model.user_id,
+        organization_id: model.organization_id,
+        role: model.role,
+      }
+    end
+  end
+end

--- a/app/serializers/v1/membership_serializer.rb
+++ b/app/serializers/v1/membership_serializer.rb
@@ -5,8 +5,8 @@ module V1
     def serialize
       {
         lago_id: model.id,
-        user_id: model.user_id,
-        organization_id: model.organization_id,
+        lago_user_id: model.user_id,
+        lago_organization_id: model.organization_id,
         role: model.role,
       }
     end

--- a/app/services/memberships/create_service.rb
+++ b/app/services/memberships/create_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Memberships
+  class CreateService < ::BaseService
+    def initialize(user:, organization:)
+      @user = user
+      @organization = organization
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'user') unless user
+      return result.not_found_failure!(resource: 'organization') unless organization
+
+      result.membership = Membership.create(user:, organization:)
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :user, :organization
+  end
+end

--- a/app/services/memberships/create_service.rb
+++ b/app/services/memberships/create_service.rb
@@ -13,7 +13,7 @@ module Memberships
       return result.not_found_failure!(resource: 'user') unless user
       return result.not_found_failure!(resource: 'organization') unless organization
 
-      result.membership = Membership.create(user:, organization:)
+      result.membership = Membership.create!(user:, organization:)
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
+    resources :memberships, only: %i[create]
     resources :organizations, only: %i[update]
     resources :invoices do
       post :regenerate, on: :member

--- a/db/migrate/20230522091400_add_unique_index_on_memberships.rb
+++ b/db/migrate/20230522091400_add_unique_index_on_memberships.rb
@@ -2,6 +2,9 @@
 
 class AddUniqueIndexOnMemberships < ActiveRecord::Migration[7.0]
   def change
+    LagoApi::Application.load_tasks
+    Rake::Task['memberships:revoke_duplicates'].invoke
+
     add_index :memberships, [:user_id, :organization_id], unique: true, where: 'revoked_at IS NULL'
   end
 end

--- a/db/migrate/20230522091400_add_unique_index_on_memberships.rb
+++ b/db/migrate/20230522091400_add_unique_index_on_memberships.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnMemberships < ActiveRecord::Migration[7.0]
+  def change
+    add_index :memberships, [:user_id, :organization_id], unique: true
+  end
+end

--- a/db/migrate/20230522091400_add_unique_index_on_memberships.rb
+++ b/db/migrate/20230522091400_add_unique_index_on_memberships.rb
@@ -2,6 +2,6 @@
 
 class AddUniqueIndexOnMemberships < ActiveRecord::Migration[7.0]
   def change
-    add_index :memberships, [:user_id, :organization_id], unique: true
+    add_index :memberships, [:user_id, :organization_id], unique: true, where: 'revoked_at IS NULL'
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_17_093556) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_22_091400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -430,6 +430,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_17_093556) do
     t.integer "status", default: 0, null: false
     t.datetime "revoked_at"
     t.index ["organization_id"], name: "index_memberships_on_organization_id"
+    t.index ["user_id", "organization_id"], name: "index_memberships_on_user_id_and_organization_id", unique: true, where: "(revoked_at IS NULL)"
     t.index ["user_id"], name: "index_memberships_on_user_id"
   end
 

--- a/lib/tasks/memberships.rake
+++ b/lib/tasks/memberships.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :memberships do
+  desc 'Revoke duplicates memberships'
+  task revoke_duplicates: :environment do
+    duplicated_memberships = Membership.active
+      .group(:user_id, :organization_id)
+      .having('count(*) > 1')
+      .select(:user_id, :organization_id)
+
+    duplicated_memberships.each do |membership|
+      memberships = Membership.where(
+        user_id: membership.user_id,
+        organization_id: membership.organization_id,
+      ).order('created_at ASC')
+
+      memberships.first.mark_as_revoke!
+    end
+  end
+end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
 
     trait :revoked do
       status { :revoked }
-      revoked_at { Time.zone.now }
+      revoked_at { Time.current }
     end
   end
 end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     user
     organization
     role { 'admin' }
+
+    trait :revoked do
+      status { :revoked }
+      revoked_at { Time.zone.now }
+    end
   end
 end

--- a/spec/requests/admin/memberships_spec.rb
+++ b/spec/requests/admin/memberships_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe Admin::MembershipsController, type: [:request, :admin] do
 
       aggregate_failures do
         expect(response).to have_http_status(:success)
-        expect(json[:membership][:user_id]).to eq(user.id)
-        expect(json[:membership][:organization_id]).to eq(organization.id)
+        expect(json[:membership][:lago_user_id]).to eq(user.id)
+        expect(json[:membership][:lago_organization_id]).to eq(organization.id)
       end
     end
   end

--- a/spec/requests/admin/memberships_spec.rb
+++ b/spec/requests/admin/memberships_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::MembershipsController, type: [:request, :admin] do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user) }
+
+  describe 'POST /admin/memberships' do
+    let(:create_params) do
+      {
+        user_id: user.id,
+        organization_id: organization.id,
+      }
+    end
+
+    it 'creates a membership' do
+      admin_post(
+        '/admin/memberships',
+        create_params,
+      )
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:membership][:user_id]).to eq(user.id)
+        expect(json[:membership][:organization_id]).to eq(organization.id)
+      end
+    end
+  end
+end

--- a/spec/services/invites/accept_service_spec.rb
+++ b/spec/services/invites/accept_service_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Invites::AcceptService, type: :service do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:invite) { create(:invite, organization:, email: membership.user.email) }
+  let(:user) { create(:user) }
+  let(:invite) { create(:invite, organization:, email: user.email) }
   let(:accept_args) do
     {
       email: invite.email,
@@ -40,7 +41,7 @@ RSpec.describe Invites::AcceptService, type: :service do
     end
 
     context 'when user have already been invited then revoked' do
-      let(:revoked_membership) { create(:membership, organization:, status: :revoked) }
+      let(:revoked_membership) { create(:membership, :revoked, organization:) }
       let(:accepted_invite) do
         create(:invite, organization:, email: revoked_membership.user.email, status: :accepted)
       end

--- a/spec/services/memberships/create_service_spec.rb
+++ b/spec/services/memberships/create_service_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Memberships::CreateService, type: :service do
+  subject(:create_service) { described_class.new(user:, organization:) }
+
+  let(:user) { create(:user) }
+  let(:organization) { create(:organization) }
+
+  describe '#call' do
+    it 'creates a membership' do
+      result = create_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.membership.user_id).to eq(user.id)
+        expect(result.membership.organization_id).to eq(organization.id)
+      end
+    end
+
+    context 'when user does not exists' do
+      let(:user) { nil }
+
+      it 'returns a result with error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('user_not_found')
+        end
+      end
+    end
+
+    context 'when organization does not exists' do
+      let(:organization) { nil }
+
+      it 'returns a result with error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('organization_not_found')
+        end
+      end
+    end
+
+    context 'when user already has a membership in the organization' do
+      before do
+        Membership.create(user:, organization:)
+      end
+
+      it 'returns a result with error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/memberships/create_service_spec.rb
+++ b/spec/services/memberships/create_service_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Memberships::CreateService, type: :service do
 
     context 'when user already has a membership in the organization' do
       before do
-        Membership.create(user:, organization:)
+        create(:membership, user:, organization:)
       end
 
       it 'returns a result with error' do
@@ -55,7 +55,7 @@ RSpec.describe Memberships::CreateService, type: :service do
 
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error.error_code).to eq('')
+          expect(result.error.messages[:user_id]).to include('value_already_exist')
         end
       end
     end


### PR DESCRIPTION
## Context

We want to be able to add a membership for a defined organization and user by using our admin tool.

## Description

- Add the `POST /admin/memberships` route and logic
- Add a unique index on `memberships` table on `user_id` and `organization_id`
