### PR TITLE
feat (charges): apply invoiceble field on existing logic

### DIFF
--- a/app/serializers/v1/charge_usage_serializer.rb
+++ b/app/serializers/v1/charge_usage_serializer.rb
@@ -10,6 +10,8 @@ module V1
         charge: {
           lago_id: model.charge.id,
           charge_model: model.charge.charge_model,
+          invoiceable: model.charge.invoiceable,
+          pay_in_advance: model.charge.pay_in_advance,
         },
         billable_metric: {
           lago_id: model.billable_metric.id,

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -17,6 +17,7 @@ module V1
           item_type: model.item_type,
         },
         pay_in_advance: model.pay_in_advance,
+        invoiceable: model.charge&.invoiceable || false,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,
         vat_amount_cents: model.vat_amount_cents,

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -97,6 +97,7 @@ module Events
         .charges
         .pay_in_advance
         .joins(:billable_metric)
+        .where(invoiceable: false)
         .where(billable_metric: { code: event.code })
     end
 

--- a/app/services/fees/update_service.rb
+++ b/app/services/fees/update_service.rb
@@ -13,7 +13,7 @@ module Fees
       return result.not_found_failure!(resource: 'fee') if fee.nil?
 
       if params.key?(:payment_status)
-        return result.not_allowed_failure!(code: 'not_an_pay_in_advance_fee') unless fee.pay_in_advance?
+        return result.not_allowed_failure!(code: 'invoiceable_fee') if fee.charge? && fee.charge&.invoiceable?
 
         unless valid_payment_status?(params[:payment_status])
           return result.single_validation_failure!(

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -75,7 +75,7 @@ module Invoices
     end
 
     def create_charges_fees(subscription, boundaries)
-      subscription.plan.charges.where(pay_in_advance: false).each do |charge|
+      subscription.plan.charges.where(pay_in_advance: false, invoiceable: true).each do |charge|
         fee_result = Fees::ChargeService.new(invoice:, charge:, subscription:, boundaries:).create
         fee_result.raise_if_error!
       end

--- a/spec/requests/api/v1/fees_spec.rb
+++ b/spec/requests/api/v1/fees_spec.rb
@@ -77,9 +77,12 @@ RSpec.describe Api::V1::FeesController, type: :request do
   describe 'PUT /fees/:id' do
     let(:customer) { create(:customer, organization:) }
     let(:subscription) { create(:subscription, customer:) }
-    let(:fee) { create(:charge_fee, fee_type: 'charge', pay_in_advance: true, subscription:, invoice: nil) }
-
     let(:update_params) { { payment_status: 'succeeded' } }
+    let(:fee) do
+      create(:charge_fee, fee_type: 'charge', pay_in_advance: true, subscription:, invoice: nil)
+    end
+
+    before { fee.charge.update!(invoiceable: false) }
 
     it 'updates the fee' do
       put_with_token(organization, "/api/v1/fees/#{fee.id}", fee: update_params)

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -29,6 +29,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
       charge = create(
         :standard_charge,
         :pay_in_advance,
+        invoiceable: false,
         plan:,
         billable_metric:,
         properties: { amount: '10' },
@@ -107,6 +108,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
       charge = create(
         :standard_charge,
         :pay_in_advance,
+        invoiceable: false,
         plan:,
         billable_metric:,
         properties: { amount: '12' },
@@ -212,6 +214,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
       charge = create(
         :package_charge,
         :pay_in_advance,
+        invoiceable: false,
         plan:,
         billable_metric:,
         properties: { amount: '100', free_units: 3, package_size: 2 },
@@ -303,6 +306,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
       charge = create(
         :graduated_charge,
         :pay_in_advance,
+        invoiceable: false,
         plan:,
         billable_metric:,
         properties: {
@@ -410,6 +414,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
         charge = create(
           :percentage_charge,
           :pay_in_advance,
+          invoiceable: false,
           plan:,
           billable_metric:,
           properties: {
@@ -502,6 +507,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
         charge = create(
           :percentage_charge,
           :pay_in_advance,
+          invoiceable: false,
           plan:,
           billable_metric:,
           properties: {
@@ -571,6 +577,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
       charge = create(
         :percentage_charge,
         :pay_in_advance,
+        invoiceable: false,
         plan:,
         billable_metric:,
         properties: {
@@ -649,6 +656,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
         charge = create(
           :percentage_charge,
           :pay_in_advance,
+          invoiceable: false,
           plan:,
           billable_metric:,
           properties: {

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -113,6 +113,8 @@ RSpec.describe ::V1::FeeSerializer do
           'lago_customer_id' => customer.id,
           'external_customer_id' => customer.external_id,
           'event_transaction_id' => event.transaction_id,
+          'pay_in_advance' => true,
+          'invoiceable' => true,
         )
       end
     end

--- a/spec/services/fees/update_service_spec.rb
+++ b/spec/services/fees/update_service_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 RSpec.describe Fees::UpdateService, type: :service do
   subject(:update_service) { described_class.new(fee:, params:) }
 
-  let(:fee) { create(:charge_fee, fee_type: 'charge', pay_in_advance: true, invoice: nil) }
+  let(:charge) { create(:standard_charge, invoiceable: false) }
+  let(:fee) { create(:charge_fee, fee_type: 'charge', pay_in_advance: true, invoice: nil, charge:) }
 
   let(:params) { { payment_status: } }
   let(:payment_status) { 'succeeded' }
@@ -36,8 +37,9 @@ RSpec.describe Fees::UpdateService, type: :service do
       end
     end
 
-    context 'when fee is not pay_in_advance' do
-      let(:fee) { create(:fee, fee_type: 'charge', pay_in_advance: false, invoice: nil) }
+    context 'when fee charge is invoiceable' do
+      let(:charge) { create(:standard_charge, invoiceable: true) }
+      let(:fee) { create(:charge_fee, fee_type: 'charge', pay_in_advance: true, invoice: nil, charge:) }
 
       it 'returns a not allowed failure' do
         result = update_service.call
@@ -45,7 +47,7 @@ RSpec.describe Fees::UpdateService, type: :service do
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-          expect(result.error.code).to eq('not_an_pay_in_advance_fee')
+          expect(result.error.code).to eq('invoiceable_fee')
         end
       end
     end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -83,8 +83,37 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         end
       end
 
-      context 'when charge is pay_in_advance' do
-        let(:charge) { create(:standard_charge, :pay_in_advance, plan: subscription.plan, charge_model: 'standard') }
+      context 'when charge is pay_in_advance and invoiceable' do
+        let(:charge) do
+          create(
+            :standard_charge,
+            :pay_in_advance,
+            plan: subscription.plan,
+            charge_model: 'standard',
+            invoiceable: true,
+          )
+        end
+
+        it 'does not create a charge fee' do
+          result = invoice_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(invoice.fees.charge_kind.count).to eq(0)
+          end
+        end
+      end
+
+      context 'when charge is pay_in_arrear and not invoiceable' do
+        let(:charge) do
+          create(
+            :standard_charge,
+            plan: subscription.plan,
+            charge_model: 'standard',
+            invoiceable: false,
+          )
+        end
 
         it 'does not create a charge fee' do
           result = invoice_service.call


### PR DESCRIPTION
## Context

This feature adds possibility to bill charges in advance

## Description

In this PR several small changes are added, in order to apply charge's invoiceable field on existing logic:

- fee update service can be applied only for `invoiceable = false`
- charge usage and fee serailizer are extended with `invoiceable`
- current 'instant charge' logic is applied only for `pay_in_advance = true` and `invoiceable = false`
- charge fees that are applied on subscription invoice are only caluclated for `pay_in_advance = false` and `invoiceable = true` -> `pay_in_advance = true` and `invoiceable = true` case will be handled later (as well as recurring case)
