### PR TITLE
fix: Convert integer to string for subscription params

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -5,7 +5,7 @@ module Api
     class SubscriptionsController < Api::BaseController
       def create
         customer = Customer.find_or_initialize_by(
-          external_id: create_params[:external_customer_id]&.strip,
+          external_id: create_params[:external_customer_id].to_s.strip,
           organization_id: current_organization.id,
         )
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -9,10 +9,10 @@ module Subscriptions
       @plan = plan
       @params = params
 
-      @name = params[:name]&.strip
+      @name = params[:name].to_s.strip
       @subscription_at = params[:subscription_at] || Time.current
       @billing_time = params[:billing_time]
-      @external_id = params[:external_id]&.strip
+      @external_id = params[:external_id].to_s.strip
 
       @current_subscription = if api_context?
         editable_subscriptions&.find_by(external_id:)

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -42,6 +42,29 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       expect(json[:subscription][:downgrade_plan_date]).to be_nil
     end
 
+    context 'with external_customer_id, external_id and name as integer' do
+      let(:params) do
+        {
+          external_customer_id: 123,
+          plan_code:,
+          name: 456,
+          external_id: 789,
+        }
+      end
+
+      it 'returns a success' do
+        post_with_token(organization, '/api/v1/subscriptions', { subscription: params })
+
+        expect(response).to have_http_status(:ok)
+        expect(json[:subscription]).to include(
+          lago_id: String,
+          external_customer_id: '123',
+          name: '456',
+          external_id: '789',
+        )
+      end
+    end
+
     context 'with invalid plan code' do
       let(:plan_code) { "#{plan.code}-invalid" }
 


### PR DESCRIPTION
The goal of this PR is to be able to:
- Assign a plan via API with an `external_customer_id` as a number
- Assign a plan via API with an `external_id` as a number
- Assign a plan via API with a `name` as a number