### PR TITLE
fix(aggregation): Fix sum aggregation when event property is a float

### DIFF
--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -8,7 +8,7 @@ module BillableMetrics
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.sum("(#{sanitized_field_name})::numeric")
-        result.pay_in_advance_aggregation = BigDecimal(compute_pay_in_advance_aggregation)
+        result.pay_in_advance_aggregation = compute_pay_in_advance_aggregation
         result.count = events.count
         result.options = { running_total: running_total(events, options) }
         result
@@ -51,10 +51,10 @@ module BillableMetrics
       end
 
       def compute_pay_in_advance_aggregation
-        return 0 unless event
-        return 0 if event.properties.blank?
+        return BigDecimal(0) unless event
+        return BigDecimal(0) if event.properties.blank?
 
-        event.properties[billable_metric.field_name] || 0
+        BigDecimal(event.properties.fetch(billable_metric.field_name, 0).to_s)
       end
     end
   end

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -238,10 +238,20 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
 
     let(:properties) { { total_count: 12 } }
 
-    it 'assigns an pay_in_advance aggregation' do
+    it 'assigns a pay_in_advance aggregation' do
       result = sum_service.aggregate(from_datetime:, to_datetime:)
 
       expect(result.pay_in_advance_aggregation).to eq(12)
+    end
+
+    context 'when properties is a float' do
+      let(:properties) { { total_count: 12.4 } }
+
+      it 'assigns a pay_in_advance aggregation' do
+        result = sum_service.aggregate(from_datetime:, to_datetime:)
+
+        expect(result.pay_in_advance_aggregation).to eq(12.4)
+      end
     end
 
     context 'when event propertie does not match metric field name' do


### PR DESCRIPTION
## Context

Pay in advance aggregation is failing with sum aggregation when the  event property is a floating point value.

The source of the issue is that we are relying on `BigDecimal` to handle the event property, but BigDecimal accepts only strings or integers as input values...

## Description

The fix is to convert the event value into a string before initializing the BigDecimal.