### PR TITLE
feat(tax): Add fees_taxes resource

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -20,6 +20,9 @@ class Fee < ApplicationRecord
   has_many :credit_note_items
   has_many :credit_notes, through: :credit_note_items
 
+  has_many :fees_taxes
+  has_many :taxes, through: :fees_taxes
+
   monetize :amount_cents
   monetize :taxes_amount_cents
   monetize :total_amount_cents

--- a/app/models/fees_tax.rb
+++ b/app/models/fees_tax.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class FeesTax < ApplicationRecord
+  include PaperTrailTraceable
+
+  belongs_to :fee
+  belongs_to :tax
+end

--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -6,6 +6,9 @@ class Tax < ApplicationRecord
   has_many :applied_taxes
   has_many :customers, through: :applied_taxes
 
+  has_many :fees_taxes
+  has_many :fees, through: :fees_taxes
+
   belongs_to :organization
 
   validates :name, :rate, presence: true

--- a/db/migrate/20230525120005_create_fees_taxes.rb
+++ b/db/migrate/20230525120005_create_fees_taxes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateFeesTaxes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :fees_taxes, id: :uuid do |t|
+      t.references :fee, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :tax, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.string :tax_description
+      t.string :tax_code, null: false
+      t.string :tax_name, null: false
+      t.float :tax_rate, null: false, default: 0.0
+
+      t.bigint :amount_cents, null: false, default: 0
+      t.string :amount_currency, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_24_130637) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_25_120005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -326,6 +326,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_24_130637) do
     t.index ["invoiceable_type", "invoiceable_id"], name: "index_fees_on_invoiceable"
     t.index ["subscription_id"], name: "index_fees_on_subscription_id"
     t.index ["true_up_parent_fee_id"], name: "index_fees_on_true_up_parent_fee_id"
+  end
+
+  create_table "fees_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "fee_id", null: false
+    t.uuid "tax_id", null: false
+    t.string "tax_description"
+    t.string "tax_code", null: false
+    t.string "tax_name", null: false
+    t.float "tax_rate", default: 0.0, null: false
+    t.bigint "amount_cents", default: 0, null: false
+    t.string "amount_currency", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fee_id"], name: "index_fees_taxes_on_fee_id"
+    t.index ["tax_id"], name: "index_fees_taxes_on_tax_id"
   end
 
   create_table "group_properties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -697,6 +712,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_24_130637) do
   add_foreign_key "fees", "groups"
   add_foreign_key "fees", "invoices"
   add_foreign_key "fees", "subscriptions"
+  add_foreign_key "fees_taxes", "fees"
+  add_foreign_key "fees_taxes", "taxes"
   add_foreign_key "group_properties", "charges", on_delete: :cascade
   add_foreign_key "group_properties", "groups", on_delete: :cascade
   add_foreign_key "groups", "billable_metrics", on_delete: :cascade

--- a/spec/factories/fees_taxes.rb
+++ b/spec/factories/fees_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :fees_tax do
+    fee
+    tax
+    tax_code { "vat-#{SecureRandom.uuid}" }
+    tax_description { 'French Standard VAT' }
+    tax_name { 'VAT' }
+    tax_rate { 20.0 }
+    amount_cents { 200 }
+    amount_currency { 'EUR' }
+  end
+end

--- a/spec/models/fees_tax_spec.rb
+++ b/spec/models/fees_tax_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FeesTax, type: :model do
+  subject(:fees_tax) { create(:fees_tax) }
+
+  it_behaves_like 'paper_trail traceable'
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to add the `fees_taxes` table.

Column | Type | Attributes
-- | -- | --
id | uuid | not null
fee_id | uuid | not null
tax_id | uuid | not null
tax_code | string | not null
tax_name | string | not null
tax_description | string | null
tax_rate | float | not null
amount_cents | bigint | not null
amount_currency | string | not null
created_at | datetime | not null
updated_at | datetime | not null


