### PR TITLE
feat(tax): Add invoices_taxes resource

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -23,6 +23,9 @@ class Invoice < ApplicationRecord
   has_many :metadata, class_name: 'Metadata::InvoiceMetadata', dependent: :destroy
   has_many :credit_notes
 
+  has_many :invoices_taxes
+  has_many :taxes, through: :invoices_taxes
+
   has_one_attached :file
 
   monetize :coupons_amount_cents,

--- a/app/models/invoices_tax.rb
+++ b/app/models/invoices_tax.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class InvoicesTax < ApplicationRecord
+  include PaperTrailTraceable
+
+  belongs_to :invoice
+  belongs_to :tax
+end

--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -8,6 +8,8 @@ class Tax < ApplicationRecord
 
   has_many :fees_taxes
   has_many :fees, through: :fees_taxes
+  has_many :invoices_taxes
+  has_many :invoices, through: :invoices_taxes
 
   belongs_to :organization
 

--- a/db/migrate/20230525122232_create_invoices_taxes.rb
+++ b/db/migrate/20230525122232_create_invoices_taxes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateInvoicesTaxes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :invoices_taxes, id: :uuid do |t|
+      t.references :invoice, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :tax, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.string :tax_description
+      t.string :tax_code, null: false
+      t.string :tax_name, null: false
+      t.float :tax_rate, null: false, default: 0.0
+
+      t.bigint :amount_cents, null: false, default: 0
+      t.string :amount_currency, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_25_120005) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_25_122232) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -435,6 +435,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_25_120005) do
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
   end
 
+  create_table "invoices_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "invoice_id", null: false
+    t.uuid "tax_id", null: false
+    t.string "tax_description"
+    t.string "tax_code", null: false
+    t.string "tax_name", null: false
+    t.float "tax_rate", default: 0.0, null: false
+    t.bigint "amount_cents", default: 0, null: false
+    t.string "amount_currency", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["invoice_id"], name: "index_invoices_taxes_on_invoice_id"
+    t.index ["tax_id"], name: "index_invoices_taxes_on_tax_id"
+  end
+
   create_table "memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "organization_id", null: false
     t.uuid "user_id", null: false
@@ -725,6 +740,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_25_120005) do
   add_foreign_key "invoice_subscriptions", "subscriptions"
   add_foreign_key "invoices", "customers"
   add_foreign_key "invoices", "organizations"
+  add_foreign_key "invoices_taxes", "invoices"
+  add_foreign_key "invoices_taxes", "taxes"
   add_foreign_key "memberships", "organizations"
   add_foreign_key "memberships", "users"
   add_foreign_key "password_resets", "users"

--- a/spec/factories/invoices_taxes.rb
+++ b/spec/factories/invoices_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :invoices_tax do
+    invoice
+    tax
+    tax_code { "vat-#{SecureRandom.uuid}" }
+    tax_description { 'French Standard VAT' }
+    tax_name { 'VAT' }
+    tax_rate { 20.0 }
+    amount_cents { 200 }
+    amount_currency { 'EUR' }
+  end
+end

--- a/spec/models/invoices_tax_spec.rb
+++ b/spec/models/invoices_tax_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe InvoicesTax, type: :model do
+  subject(:invoices_tax) { create(:invoices_tax) }
+
+  it_behaves_like 'paper_trail traceable'
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to add the `invoices_taxes` table.

Column | Type | Attributes
-- | -- | --
id | uuid | not null
invoice_id | uuid | not null
tax_id | uuid | not null
tax_code | string | not null
tax_name | string | not null
tax_description | string | null
tax_rate | float | not null
amount_cents | bigint | not null
amount_currency | string | not null
created_at | datetime | not null
updated_at | datetime | not null


