### PR TITLE
fix(coupons): Ignore applied coupons for deleted customers

### DIFF
--- a/app/queries/applied_coupons_query.rb
+++ b/app/queries/applied_coupons_query.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AppliedCouponsQuery < BaseQuery
+  def call
+    applied_coupons = paginate(base_scope)
+    applied_coupons = applied_coupons.order(created_at: :desc)
+
+    applied_coupons = with_external_customer(applied_coupons) if filters.external_customer_id
+    applied_coupons = with_status(applied_coupons) if valid_status?
+
+    result.applied_coupons = applied_coupons
+    result
+  end
+
+  def base_scope
+    organization.applied_coupons
+      .joins(:customer).where(customers: { deleted_at: nil })
+  end
+
+  def with_external_customer(scope)
+    scope.where(customers: { external_id: filters.external_customer_id })
+  end
+
+  def with_status(scope)
+    scope.where(status: filters.status)
+  end
+
+  def valid_status?
+    AppliedCoupon.statuses.key?(filters.status)
+  end
+end

--- a/spec/queries/applied_coupons_query_spec.rb
+++ b/spec/queries/applied_coupons_query_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AppliedCouponsQuery, type: :query do
+  subject(:applied_coupons_query) { described_class.new(organization:, pagination:, filters:) }
+
+  let(:organization) { create(:organization) }
+  let(:pagination) { BaseQuery::Pagination.new }
+  let(:filters) { BaseQuery::Filters.new(query_filters) }
+
+  let(:query_filters) { {} }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:coupon) { create(:coupon, organization:) }
+
+  let(:applied_coupon) { create(:applied_coupon, coupon:, customer:) }
+
+  before { applied_coupon }
+
+  describe 'call' do
+    it 'returns a list of applied_coupons' do
+      result = applied_coupons_query.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.applied_coupons.count).to eq(1)
+        expect(result.applied_coupons).to eq([applied_coupon])
+      end
+    end
+
+    context 'when customer is deleted' do
+      let(:customer) { create(:customer, :deleted, organization:) }
+
+      it 'filters the applied_coupons' do
+        result = applied_coupons_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.applied_coupons.count).to eq(0)
+        end
+      end
+    end
+
+    context 'with pagination' do
+      let(:pagination) { BaseQuery::Pagination.new(page: 2, limit: 10) }
+
+      it 'applies the pagination' do
+        result = applied_coupons_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.applied_coupons.count).to eq(0)
+          expect(result.applied_coupons.current_page).to eq(2)
+        end
+      end
+    end
+
+    context 'with customer filter' do
+      let(:query_filters) { { external_customer_id: customer.external_id } }
+
+      it 'applies the filter' do
+        result = applied_coupons_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.applied_coupons.count).to eq(1)
+        end
+      end
+    end
+
+    context 'with status filter' do
+      let(:query_filters) { { status: 'terminated' } }
+
+      it 'applies the filter' do
+        result = applied_coupons_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.applied_coupons.count).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/applied_coupons_spec.rb
+++ b/spec/requests/api/v1/applied_coupons_spec.rb
@@ -84,90 +84,12 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
         expect(json[:applied_coupons].first[:lago_id]).to eq(applied_coupon.id)
         expect(json[:applied_coupons].first[:amount_cents]).to eq(applied_coupon.amount_cents)
         expect(json[:applied_coupons].first[:amount_cents_remaining]).to eq(8)
-      end
-    end
 
-    context 'with pagination' do
-      let(:coupon_latest) do
-        create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization:)
-      end
-      let(:applied_coupon_latest) do
-        create(
-          :applied_coupon,
-          coupon: coupon_latest,
-          customer:,
-          percentage_rate: 20.00,
-          created_at: applied_coupon.created_at + 1.day,
-        )
-      end
-
-      before { applied_coupon_latest }
-
-      it 'returns applied coupons with correct meta data' do
-        get_with_token(organization, '/api/v1/applied_coupons?page=1&per_page=1')
-
-        aggregate_failures do
-          expect(response).to have_http_status(:success)
-          expect(json[:applied_coupons].count).to eq(1)
-          expect(json[:meta][:current_page]).to eq(1)
-          expect(json[:meta][:next_page]).to eq(2)
-          expect(json[:meta][:prev_page]).to eq(nil)
-          expect(json[:meta][:total_pages]).to eq(2)
-          expect(json[:meta][:total_count]).to eq(2)
-        end
-      end
-    end
-
-    context 'with status param' do
-      let(:coupon_latest) { create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization:) }
-      let(:applied_coupon_latest) do
-        create(
-          :applied_coupon,
-          coupon: coupon_latest,
-          customer:,
-          status: :terminated,
-          percentage_rate: 20.00,
-          created_at: applied_coupon.created_at + 1.day,
-        )
-      end
-
-      before { applied_coupon_latest }
-
-      it 'returns applied coupons with correct status' do
-        get_with_token(organization, '/api/v1/applied_coupons?status=terminated')
-
-        aggregate_failures do
-          expect(response).to have_http_status(:success)
-          expect(json[:applied_coupons].count).to eq(1)
-          expect(json[:applied_coupons].first[:lago_id]).to eq(applied_coupon_latest.id)
-        end
-      end
-    end
-
-    context 'with external_customer_id params' do
-      let(:customer_new) { create(:customer, organization:) }
-      let(:coupon_latest) { create(:coupon, coupon_type: 'percentage', percentage_rate: 10, organization:) }
-      let(:applied_coupon_latest) do
-        create(
-          :applied_coupon,
-          coupon: coupon_latest,
-          customer: customer_new,
-          status: :active,
-          percentage_rate: 20.00,
-          created_at: applied_coupon.created_at + 1.day,
-        )
-      end
-
-      before { applied_coupon_latest }
-
-      it 'returns applied coupons of the selected customer' do
-        get_with_token(organization, "/api/v1/applied_coupons?external_customer_id=#{customer_new.external_id}")
-
-        aggregate_failures do
-          expect(response).to have_http_status(:success)
-          expect(json[:applied_coupons].count).to eq(1)
-          expect(json[:applied_coupons].first[:lago_id]).to eq(applied_coupon_latest.id)
-        end
+        expect(json[:meta][:current_page]).to eq(1)
+        expect(json[:meta][:next_page]).to eq(nil)
+        expect(json[:meta][:prev_page]).to eq(nil)
+        expect(json[:meta][:total_pages]).to eq(1)
+        expect(json[:meta][:total_count]).to eq(1)
       end
     end
   end


### PR DESCRIPTION
## Context

Fetching applied coupons via the API end-points is failing when the attached customer is deleted.

Applied coupons should not be returned when the customer is deleted.

## Description

This PR moved the coupon filtering into a query service and ensure that applied coupons are filtered when the attached customer is deleted.