### PR TITLE
feat(tax): Add credit_notes_taxes resource

### DIFF
--- a/app/models/credit_notes_tax.rb
+++ b/app/models/credit_notes_tax.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CreditNotesTax < ApplicationRecord
+  include PaperTrailTraceable
+
+  belongs_to :credit_note
+  belongs_to :tax
+end

--- a/db/migrate/20230525154612_create_credit_notes_taxes.rb
+++ b/db/migrate/20230525154612_create_credit_notes_taxes.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class CreateCreditNotesTaxes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :credit_notes_taxes, id: :uuid do |t|
+      t.references :credit_note, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :tax, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.string :tax_description
+      t.string :tax_code, null: false
+      t.string :tax_name, null: false
+      t.float :tax_rate, null: false, default: 0.0
+
+      t.bigint :amount_cents, null: false, default: 0
+      t.string :amount_currency, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_25_122232) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_25_154612) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -209,6 +209,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_25_122232) do
     t.float "taxes_rate", default: 0.0, null: false
     t.index ["customer_id"], name: "index_credit_notes_on_customer_id"
     t.index ["invoice_id"], name: "index_credit_notes_on_invoice_id"
+  end
+
+  create_table "credit_notes_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "credit_note_id", null: false
+    t.uuid "tax_id", null: false
+    t.string "tax_description"
+    t.string "tax_code", null: false
+    t.string "tax_name", null: false
+    t.float "tax_rate", default: 0.0, null: false
+    t.bigint "amount_cents", default: 0, null: false
+    t.string "amount_currency", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["credit_note_id"], name: "index_credit_notes_taxes_on_credit_note_id"
+    t.index ["tax_id"], name: "index_credit_notes_taxes_on_tax_id"
   end
 
   create_table "credits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -712,6 +727,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_25_122232) do
   add_foreign_key "credit_note_items", "fees"
   add_foreign_key "credit_notes", "customers"
   add_foreign_key "credit_notes", "invoices"
+  add_foreign_key "credit_notes_taxes", "credit_notes"
+  add_foreign_key "credit_notes_taxes", "taxes"
   add_foreign_key "credits", "applied_coupons"
   add_foreign_key "credits", "credit_notes"
   add_foreign_key "credits", "invoices"

--- a/spec/factories/credit_notes_taxes.rb
+++ b/spec/factories/credit_notes_taxes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :credit_notes_tax do
+    credit_note
+    tax
+    tax_code { "vat-#{SecureRandom.uuid}" }
+    tax_description { 'French Standard VAT' }
+    tax_name { 'VAT' }
+    tax_rate { 20.0 }
+    amount_cents { 200 }
+    amount_currency { 'EUR' }
+  end
+end

--- a/spec/models/credit_notes_tax_spec.rb
+++ b/spec/models/credit_notes_tax_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotesTax, type: :model do
+  subject(:credit_notes_tax) { create(:credit_notes_tax) }
+
+  it_behaves_like 'paper_trail traceable'
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to add the `credit_notes_taxes` table.

Column | Type | Attributes
-- | -- | --
id | uuid | not null
credit_note_id | uuid | not null
tax_id | uuid | not null
tax_code | string | not null
tax_name | string | not null
tax_description | string | null
tax_rate | float | not null
amount_cents | bigint | not null
amount_currency | string | not null
created_at | datetime | not null
updated_at | datetime | not null
