### PR TITLE
feat(tax): Add a service to apply taxes to a fee

### DIFF
--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -16,6 +16,8 @@ class Tax < ApplicationRecord
   validates :name, :rate, presence: true
   validates :code, presence: true, uniqueness: { scope: :organization_id }
 
+  scope :applied_to_organization, -> { where(applied_to_organization: true) }
+
   def customers_count
     applicable_customers.count
   end

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Fees
+  class ApplyTaxesService < BaseService
+    def initialize(fee:)
+      @fee = fee
+
+      super
+    end
+
+    def call
+      result.fees_taxes = []
+      fee_taxes_amount_cents = 0
+      fee_tax_rate = 0
+
+      applicable_taxes.each do |tax|
+        fees_tax = FeesTax.new(
+          fee:,
+          tax:,
+          tax_description: tax.description,
+          tax_code: tax.code,
+          tax_name: tax.name,
+          tax_rate: tax.rate,
+          amount_currency: fee.amount_currency,
+        )
+
+        tax_amount = (fee.amount_cents * tax.rate).fdiv(100)
+        fees_tax.amount_cents = tax_amount.round
+        fees_tax.save!
+
+        fee_taxes_amount_cents += tax_amount
+        fee_tax_rate += tax.rate
+
+        result.fees_taxes << fees_tax
+      end
+
+      fee.taxes_amount_cents = fee_taxes_amount_cents.round
+      fee.taxes_rate = fee_tax_rate
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :fee
+
+    def customer
+      @customer ||= fee.invoice.customer
+    end
+
+    def applicable_taxes
+      customer_taxes = customer.taxes
+      return customer_taxes if customer_taxes.any?
+
+      customer.organization.taxes.applied_to_organization
+    end
+  end
+end

--- a/spec/services/fees/apply_taxes_service_spec.rb
+++ b/spec/services/fees/apply_taxes_service_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fees::ApplyTaxesService, type: :service do
+  subject(:apply_service) { described_class.new(fee:) }
+
+  let(:customer) { create(:customer) }
+  let(:organization) { customer.organization }
+
+  let(:invoice) { create(:invoice, organization:, customer:) }
+
+  let(:fee) { create(:fee, invoice:, amount_cents: 1000) }
+
+  let(:tax1) { create(:tax, organization:, rate: 10) }
+  let(:tax2) { create(:tax, organization:, rate: 12) }
+  let(:tax3) { create(:tax, organization:, rate: 5, applied_to_organization: true) }
+
+  let(:applied_tax1) { create(:applied_tax, customer:, tax: tax1) }
+  let(:applied_tax2) { create(:applied_tax, customer:, tax: tax2) }
+
+  before do
+    applied_tax1
+    applied_tax2
+    tax3
+  end
+
+  describe 'call' do
+    it 'creates fees_taxes' do
+      result = apply_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+
+        fees_taxes = result.fees_taxes
+        expect(fees_taxes.count).to eq(2)
+
+        expect(fees_taxes[0]).to have_attributes(
+          fee:,
+          tax: tax1,
+          tax_description: tax1.description,
+          tax_code: tax1.code,
+          tax_name: tax1.name,
+          tax_rate: 10,
+          amount_currency: fee.currency,
+          amount_cents: 100,
+        )
+
+        expect(fees_taxes[1]).to have_attributes(
+          fee:,
+          tax: tax2,
+          tax_description: tax2.description,
+          tax_code: tax2.code,
+          tax_name: tax2.name,
+          tax_rate: 12,
+          amount_currency: fee.currency,
+          amount_cents: 120,
+        )
+
+        expect(fee).to have_attributes(
+          taxes_amount_cents: 220,
+          taxes_rate: 22,
+        )
+      end
+    end
+
+    context 'when customer does not have applied_taxes' do
+      let(:applied_tax1) { nil }
+      let(:applied_tax2) { nil }
+
+      it 'creates fees_taxes based on the organization taxes' do
+        result = apply_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          fees_taxes = result.fees_taxes
+          expect(fees_taxes.count).to eq(1)
+
+          expect(fees_taxes[0]).to have_attributes(
+            fee:,
+            tax: tax3,
+            tax_description: tax3.description,
+            tax_code: tax3.code,
+            tax_name: tax3.name,
+            tax_rate: 5,
+            amount_currency: fee.currency,
+            amount_cents: 50,
+          )
+
+          expect(fee).to have_attributes(
+            taxes_amount_cents: 50,
+            taxes_rate: 5,
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to add a new `Fees::ApplyTaxesService` to apply customer or organizations taxes to a fee and creates the related `FeesTaxes` records