### PR TITLE
misc: Fix fee boundaries migration by turning it into SQL

### DIFF
--- a/db/migrate/20221128132620_change_fees_boundaries.rb
+++ b/db/migrate/20221128132620_change_fees_boundaries.rb
@@ -2,7 +2,25 @@
 
 class ChangeFeesBoundaries < ActiveRecord::Migration[7.0]
   def change
-    # NOTE: Wait to ensure workers are loaded with the added tasks
-    MigrationTaskJob.set(wait: 40.seconds).perform_later('fees:migrate_boundaries')
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE fees
+          SET properties = CONCAT (
+            '{',
+            '"from_datetime": "', (properties->>'from_date')::timestamp, '",',
+            '"to_datetime": "', date_trunc('day', (properties->>'to_date')::date) + interval '1 day' - interval '1 millisecond', '",',
+            '"charges_from_datetime":', CASE WHEN properties ? 'charges_from_date'
+                                        THEN CONCAT('"', (properties->>'charges_from_date')::timestamp, '"')
+                                        ELSE 'null' END, ',',
+            '"charges_to_datetime":', CASE WHEN properties ? 'charges_to_date'
+                                      THEN CONCAT('"', date_trunc('day', (properties->>'charges_to_date')::date) + interval '1 day' - interval '1 millisecond', '"')
+                                      ELSE 'null' END,
+            '}'
+          )::jsonb
+          WHERE (properties ? 'from_date');
+        SQL
+      end
+    end
   end
 end

--- a/lib/tasks/fees.rake
+++ b/lib/tasks/fees.rake
@@ -10,20 +10,4 @@ namespace :fees do
       fee.subscription!
     end
   end
-
-  desc 'Migrate boundaries'
-  task migrate_boundaries: :environment do
-    Fee.find_each do |fee|
-      next if fee.properties['from_datetime'].present?
-      next if fee.properties['from_date'].blank?
-
-      fee.properties = {
-        'from_datetime' => fee.properties['from_date'].to_date.beginning_of_day,
-        'to_datetime' => fee.properties['to_date'].to_date.end_of_day,
-        'charges_from_datetime' => fee.properties['charges_from_date']&.to_date&.beginning_of_day,
-        'charges_to_datetime' => fee.properties['charges_to_date']&.to_date&.end_of_day,
-      }
-      fee.save!
-    end
-  end
 end


### PR DESCRIPTION
## Context

An old migration task is failing on recent code base because it relies on models that are not aligned anymore with the migration logic.
Since the data migration itself was performed in a Job we have no way to ensure the state of the database schema and the models.

## Description

To fix the migration, the `fees:migrate_boundaries` is removed and turned into a proper SQL migration
