### PR TITLE
feat(tax): Present taxes on fees, invoices and credit notes serializers

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -15,7 +15,7 @@ module Api
             json: ::V1::CreditNoteSerializer.new(
               result.credit_note,
               root_name: 'credit_note',
-              includes: %i[items],
+              includes: %i[items taxes],
             ),
           )
         else
@@ -31,7 +31,7 @@ module Api
           json: ::V1::CreditNoteSerializer.new(
             credit_note,
             root_name: 'credit_note',
-            includes: %i[items],
+            includes: %i[items taxes],
           ),
         )
       end
@@ -47,7 +47,7 @@ module Api
             json: ::V1::CreditNoteSerializer.new(
               credit_note,
               root_name: 'credit_note',
-              includes: %i[items],
+              includes: %i[items taxes],
             ),
           )
         else
@@ -84,7 +84,7 @@ module Api
             json: ::V1::CreditNoteSerializer.new(
               credit_note,
               root_name: 'credit_note',
-              includes: %i[items],
+              includes: %i[items taxes],
             ),
           )
         else
@@ -109,6 +109,7 @@ module Api
             ::V1::CreditNoteSerializer,
             collection_name: 'credit_notes',
             meta: pagination_metadata(credit_notes),
+            includes: %i[taxes],
           ),
         )
       end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -66,6 +66,7 @@ module Api
               result.fees,
               ::V1::FeeSerializer,
               collection_name: 'fees',
+              includes: %i[taxes],
             ),
           )
         else

--- a/app/controllers/api/v1/fees_controller.rb
+++ b/app/controllers/api/v1/fees_controller.rb
@@ -9,7 +9,7 @@ module Api
 
         return not_found_error(resource: 'fee') unless fee
 
-        render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee'))
+        render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee', includes: %i[taxes]))
       end
 
       def update
@@ -18,7 +18,7 @@ module Api
         result = Fees::UpdateService.call(fee:, params: update_params)
 
         if result.success?
-          render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee'))
+          render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee', includes: %i[taxes]))
         else
           render_error_response(result)
         end
@@ -41,6 +41,7 @@ module Api
               ::V1::FeeSerializer,
               collection_name: 'fees',
               meta: pagination_metadata(result.fees),
+              includes: %i[taxes],
             ),
           )
         else

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -64,7 +64,7 @@ module Api
             ::V1::InvoiceSerializer,
             collection_name: 'invoices',
             meta: pagination_metadata(invoices),
-            includes: %i[customer metadata],
+            includes: %i[customer metadata taxes],
           ),
         )
       end
@@ -157,7 +157,7 @@ module Api
           json: ::V1::InvoiceSerializer.new(
             invoice,
             root_name: 'invoice',
-            includes: %i[customer subscriptions fees credits metadata],
+            includes: %i[customer subscriptions fees credits metadata taxes],
           ),
         )
       end

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -16,6 +16,9 @@ class CreditNote < ApplicationRecord
   has_many :fees, through: :items
   has_many :refunds
 
+  has_many :credit_notes_taxes
+  has_many :taxes, through: :credit_notes_taxes
+
   has_one_attached :file
 
   monetize :credit_amount_cents

--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -10,6 +10,8 @@ class Tax < ApplicationRecord
   has_many :fees, through: :fees_taxes
   has_many :invoices_taxes
   has_many :invoices, through: :invoices_taxes
+  has_many :credit_notes_taxes
+  has_many :credit_notes, through: :credit_notes_taxes
 
   belongs_to :organization
 

--- a/app/serializers/v1/credit_note_serializer.rb
+++ b/app/serializers/v1/credit_note_serializer.rb
@@ -28,8 +28,9 @@ module V1
         file_url: model.file_url,
       }.merge(legacy_values)
 
-      payload = payload.merge(customer) if include?(:customer)
-      payload = payload.merge(items) if include?(:items)
+      payload.merge!(customer) if include?(:customer)
+      payload.merge!(items) if include?(:items)
+      payload.merge!(taxes) if include?(:taxes)
 
       payload
     end
@@ -48,6 +49,10 @@ module V1
         ::V1::CreditNoteItemSerializer,
         collection_name: 'items',
       ).serialize
+    end
+
+    def taxes
+      ::CollectionSerializer.new(model.taxes, ::V1::TaxSerializer, collection_name: 'taxes').serialize
     end
 
     def legacy_values

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -34,8 +34,9 @@ module V1
         refunded_at: model.refunded_at&.iso8601,
       }.merge(legacy_values)
 
-      payload = payload.merge(date_boundaries) if model.charge? || model.subscription?
+      payload.merge!(date_boundaries) if model.charge? || model.subscription?
       payload.merge!(pay_in_advance_charge_attributes) if model.pay_in_advance?
+      payload.merge!(taxes) if include?(:taxes)
 
       payload
     end
@@ -69,6 +70,10 @@ module V1
         external_customer_id: model.customer.external_id,
         event_transaction_id: event&.transaction_id,
       }
+    end
+
+    def taxes
+      ::CollectionSerializer.new(model.taxes, ::V1::TaxSerializer, collection_name: 'taxes').serialize
     end
 
     def legacy_values

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -24,11 +24,12 @@ module V1
         version_number: model.version_number,
       }.merge(legacy_values)
 
-      payload = payload.merge(customer) if include?(:customer)
-      payload = payload.merge(subscriptions) if include?(:subscriptions)
-      payload = payload.merge(fees) if include?(:fees)
-      payload = payload.merge(credits) if include?(:credits)
-      payload = payload.merge(metadata) if include?(:metadata)
+      payload.merge!(customer) if include?(:customer)
+      payload.merge!(subscriptions) if include?(:subscriptions)
+      payload.merge!(fees) if include?(:fees)
+      payload.merge!(credits) if include?(:credits)
+      payload.merge!(metadata) if include?(:metadata)
+      payload.merge!(taxes) if include?(:taxes)
 
       payload
     end
@@ -60,6 +61,10 @@ module V1
         ::V1::Invoices::MetadataSerializer,
         collection_name: 'metadata',
       ).serialize
+    end
+
+    def taxes
+      ::CollectionSerializer.new(model.taxes, ::V1::TaxSerializer, collection_name: 'taxes').serialize
     end
 
     def legacy_values

--- a/app/services/webhooks/credit_notes/created_service.rb
+++ b/app/services/webhooks/credit_notes/created_service.rb
@@ -11,7 +11,7 @@ module Webhooks
         ::V1::CreditNoteSerializer.new(
           object,
           root_name: 'credit_note',
-          includes: %i[customer items],
+          includes: %i[customer items taxes],
         )
       end
 

--- a/app/services/webhooks/invoices/created_service.rb
+++ b/app/services/webhooks/invoices/created_service.rb
@@ -13,7 +13,7 @@ module Webhooks
         ::V1::InvoiceSerializer.new(
           object,
           root_name: 'invoice',
-          includes: %i[customer subscriptions fees credits],
+          includes: %i[customer subscriptions fees credits taxes],
         )
       end
 

--- a/app/services/webhooks/invoices/drafted_service.rb
+++ b/app/services/webhooks/invoices/drafted_service.rb
@@ -11,7 +11,7 @@ module Webhooks
         ::V1::InvoiceSerializer.new(
           object,
           root_name: 'invoice',
-          includes: %i[customer subscriptions fees credits],
+          includes: %i[customer subscriptions fees credits taxes],
         )
       end
 

--- a/app/services/webhooks/invoices/one_off_created_service.rb
+++ b/app/services/webhooks/invoices/one_off_created_service.rb
@@ -13,7 +13,7 @@ module Webhooks
         ::V1::InvoiceSerializer.new(
           object,
           root_name: 'invoice',
-          includes: %i[customer fees],
+          includes: %i[customer fees taxes],
         )
       end
 

--- a/app/services/webhooks/invoices/paid_credit_added_service.rb
+++ b/app/services/webhooks/invoices/paid_credit_added_service.rb
@@ -13,7 +13,7 @@ module Webhooks
         ::V1::InvoiceSerializer.new(
           object,
           root_name: 'invoice',
-          includes: %i[customer fees],
+          includes: %i[customer fees taxes],
         )
       end
 

--- a/spec/requests/api/v1/credit_notes_spec.rb
+++ b/spec/requests/api/v1/credit_notes_spec.rb
@@ -29,35 +29,40 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
 
       aggregate_failures do
         expect(response).to have_http_status(:success)
-        expect(json[:credit_note][:lago_id]).to eq(credit_note.id)
-        expect(json[:credit_note][:sequential_id]).to eq(credit_note.sequential_id)
-        expect(json[:credit_note][:number]).to eq(credit_note.number)
-        expect(json[:credit_note][:lago_invoice_id]).to eq(invoice.id)
-        expect(json[:credit_note][:invoice_number]).to eq(invoice.number)
-        expect(json[:credit_note][:credit_status]).to eq(credit_note.credit_status)
-        expect(json[:credit_note][:reason]).to eq(credit_note.reason)
-        expect(json[:credit_note][:total_amount_cents]).to eq(credit_note.total_amount_cents)
-        expect(json[:credit_note][:total_amount_currency]).to eq(credit_note.total_amount_currency)
-        expect(json[:credit_note][:credit_amount_cents]).to eq(credit_note.credit_amount_cents)
-        expect(json[:credit_note][:credit_amount_currency]).to eq(credit_note.credit_amount_currency)
-        expect(json[:credit_note][:balance_amount_cents]).to eq(credit_note.balance_amount_cents)
-        expect(json[:credit_note][:balance_amount_currency]).to eq(credit_note.balance_amount_currency)
-        expect(json[:credit_note][:created_at]).to eq(credit_note.created_at.iso8601)
-        expect(json[:credit_note][:updated_at]).to eq(credit_note.updated_at.iso8601)
+
+        expect(json[:credit_note]).to include(
+          lago_id: credit_note.id,
+          sequential_id: credit_note.sequential_id,
+          number: credit_note.number,
+          lago_invoice_id: invoice.id,
+          invoice_number: invoice.number,
+          credit_status: credit_note.credit_status,
+          reason: credit_note.reason,
+          total_amount_cents: credit_note.total_amount_cents,
+          total_amount_currency: credit_note.total_amount_currency,
+          credit_amount_cents: credit_note.credit_amount_cents,
+          credit_amount_currency: credit_note.credit_amount_currency,
+          balance_amount_cents: credit_note.balance_amount_cents,
+          balance_amount_currency: credit_note.balance_amount_currency,
+          created_at: credit_note.created_at.iso8601,
+          updated_at: credit_note.updated_at.iso8601,
+          taxes: [],
+        )
 
         expect(json[:credit_note][:items].count).to eq(2)
 
-        json_item = json[:credit_note][:items].first
         item = credit_note_items.first
-        expect(json_item[:lago_id]).to eq(item.id)
-        expect(json_item[:amount_cents]).to eq(item.amount_cents)
-        expect(json_item[:amount_currency]).to eq(item.amount_currency)
-        expect(json_item[:fee][:lago_id]).to eq(item.fee.id)
-        expect(json_item[:fee][:amount_cents]).to eq(item.fee.amount_cents)
-        expect(json_item[:fee][:amount_currency]).to eq(item.fee.amount_currency)
-        expect(json_item[:fee][:item][:type]).to eq(item.fee.fee_type)
-        expect(json_item[:fee][:item][:code]).to eq(item.fee.item_code)
-        expect(json_item[:fee][:item][:name]).to eq(item.fee.item_name)
+        expect(json[:credit_note][:items][0]).to include(
+          lago_id: item.id,
+          amount_cents: item.amount_cents,
+          amount_currency: item.amount_currency,
+        )
+
+        expect(json[:credit_note][:items][0][:fee][:item]).to include(
+          type: item.fee.fee_type,
+          code: item.fee.item_code,
+          name: item.fee.item_name,
+        )
       end
     end
 
@@ -206,11 +211,13 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
           expect(response).to have_http_status(:success)
           expect(json[:credit_notes].count).to eq(1)
 
-          expect(json[:meta][:current_page]).to eq(1)
-          expect(json[:meta][:next_page]).to eq(2)
-          expect(json[:meta][:prev_page]).to eq(nil)
-          expect(json[:meta][:total_pages]).to eq(2)
-          expect(json[:meta][:total_count]).to eq(2)
+          expect(json[:meta]).to include(
+            current_page: 1,
+            next_page: 2,
+            prev_page: nil,
+            total_pages: 2,
+            total_count: 2,
+          )
         end
       end
     end
@@ -263,19 +270,21 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       aggregate_failures do
         expect(response).to have_http_status(:success)
 
-        expect(json[:credit_note][:lago_id]).to be_present
-        expect(json[:credit_note][:credit_status]).to eq('available')
-        expect(json[:credit_note][:refund_status]).to eq('pending')
-        expect(json[:credit_note][:reason]).to eq('duplicated_charge')
-        expect(json[:credit_note][:description]).to eq('Duplicated charge')
-        expect(json[:credit_note][:total_amount_cents]).to eq(15)
-        expect(json[:credit_note][:total_amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:credit_amount_cents]).to eq(10)
-        expect(json[:credit_note][:credit_amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:balance_amount_cents]).to eq(10)
-        expect(json[:credit_note][:balance_amount_currency]).to eq('EUR')
-        expect(json[:credit_note][:refund_amount_cents]).to eq(5)
-        expect(json[:credit_note][:refund_amount_currency]).to eq('EUR')
+        expect(json[:credit_note]).to include(
+          credit_status: 'available',
+          refund_status: 'pending',
+          reason: 'duplicated_charge',
+          description: 'Duplicated charge',
+          total_amount_cents: 15,
+          total_amount_currency: 'EUR',
+          credit_amount_cents: 10,
+          credit_amount_currency: 'EUR',
+          balance_amount_cents: 10,
+          balance_amount_currency: 'EUR',
+          refund_amount_cents: 5,
+          refund_amount_currency: 'EUR',
+          taxes: [],
+        )
 
         expect(json[:credit_note][:items][0][:lago_id]).to be_present
         expect(json[:credit_note][:items][0][:amount_cents]).to eq(10)

--- a/spec/requests/api/v1/fees_spec.rb
+++ b/spec/requests/api/v1/fees_spec.rb
@@ -16,17 +16,21 @@ RSpec.describe Api::V1::FeesController, type: :request do
       aggregate_failures do
         expect(response).to have_http_status(:success)
 
-        expect(json[:fee][:lago_id]).to eq(fee.id)
-        expect(json[:fee][:lago_group_id]).to eq(fee.group_id)
-        expect(json[:fee][:item][:type]).to eq(fee.fee_type)
-        expect(json[:fee][:item][:code]).to eq(fee.item_code)
-        expect(json[:fee][:item][:name]).to eq(fee.item_name)
-        expect(json[:fee][:amount_cents]).to eq(fee.amount_cents)
-        expect(json[:fee][:amount_currency]).to eq(fee.amount_currency)
-        expect(json[:fee][:taxes_amount_cents]).to eq(fee.taxes_amount_cents)
-        expect(json[:fee][:vat_amount_cents]).to eq(fee.taxes_amount_cents)
-        expect(json[:fee][:units]).to eq(fee.units.to_s)
-        expect(json[:fee][:events_count]).to eq(fee.events_count)
+        expect(json[:fee]).to include(
+          lago_id: fee.id,
+          lago_group_id: fee.group_id,
+          amount_cents: fee.amount_cents,
+          amount_currency: fee.amount_currency,
+          taxes_amount_cents: fee.taxes_amount_cents,
+          units: fee.units.to_s,
+          events_count: fee.events_count,
+          taxes: [],
+        )
+        expect(json[:fee][:item]).to include(
+          type: fee.fee_type,
+          code: fee.item_code,
+          name: fee.item_name,
+        )
       end
     end
 
@@ -48,6 +52,7 @@ RSpec.describe Api::V1::FeesController, type: :request do
             taxes_amount_cents: fee.taxes_amount_cents,
             units: fee.units.to_s,
             events_count: fee.events_count,
+            taxes: [],
           )
           expect(json[:fee][:item]).to include(
             type: fee.fee_type,
@@ -104,6 +109,7 @@ RSpec.describe Api::V1::FeesController, type: :request do
           succeeded_at: fee.succeeded_at&.iso8601,
           failed_at: fee.failed_at&.iso8601,
           refunded_at: fee.refunded_at&.iso8601,
+          taxes: [],
         )
         expect(json[:fee][:item]).to include(
           type: fee.fee_type,


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to:
- Present taxes on Invoice serializer
- Present taxes on Fee serializer
- Present taxes on CreditNote serializer