### PR TITLE
fix: Invoice credit amount migration

### DIFF
--- a/db/migrate/20221020093745_add_credit_amount_to_invoices.rb
+++ b/db/migrate/20221020093745_add_credit_amount_to_invoices.rb
@@ -7,7 +7,48 @@ class AddCreditAmountToInvoices < ActiveRecord::Migration[7.0]
       t.string :credit_amount_currency
     end
 
-    MigrationTaskJob.set(wait: 40.seconds).perform_later('invoices:fill_credit_amount')
+    currency_list = WalletTransaction.joins(:wallet).pluck('DISTINCT(wallets.currency)')
+    currency_list << 'EUR' if currency_list.blank?
+    currency_sql = currency_list.each_with_object([]) do |code, currencies|
+      currency = Money::Currency.new(code)
+      currencies << "('#{code}', #{currency.exponent}, #{currency.subunit_to_unit})"
+    end
+
+    execute <<-SQL
+      WITH invoice_credit_amounts AS (
+        SELECT
+          invoices.id AS invoice_id,
+          COALESCE(credit_amounts.credit_sum, 0) AS credit_amount_cents,
+          COALESCE(prepaid_amounts.prepaid_sum, 0) AS prepaid_credit_amount_cents
+        FROM invoices
+          LEFT JOIN (
+            SELECT
+              credits.invoice_id,
+              SUM(credits.amount_cents) AS credit_sum
+            FROM credits
+            GROUP BY credits.invoice_id
+          ) credit_amounts ON credit_amounts.invoice_id = invoices.id
+          LEFT JOIN (
+            SELECT
+              wallet_transactions.invoice_id,
+              (ROUND(SUM(wallet_transactions.amount), currencies.exponent) * currencies.subunit_to_unit) AS prepaid_sum
+            FROM wallet_transactions
+              INNER JOIN wallets ON wallet_transactions.wallet_id = wallets.id
+              INNER JOIN (
+                SELECT *
+                FROM (VALUES #{currency_sql.join(', ')}) AS t(currency, exponent, subunit_to_unit)
+              ) currencies ON currencies.currency = wallets.currency
+            GROUP BY wallet_transactions.invoice_id, currencies.currency, currencies.exponent, currencies.subunit_to_unit
+          ) AS prepaid_amounts ON prepaid_amounts.invoice_id = invoices.id
+      )
+
+      UPDATE invoices
+      SET
+        credit_amount_currency = invoices.amount_currency,
+        credit_amount_cents = invoice_credit_amounts.credit_amount_cents + invoice_credit_amounts.prepaid_credit_amount_cents
+      FROM invoice_credit_amounts
+      WHERE invoice_credit_amounts.invoice_id = invoices.id
+    SQL
   end
 
   def down

--- a/lib/tasks/invoices.rake
+++ b/lib/tasks/invoices.rake
@@ -51,21 +51,6 @@ namespace :invoices do
     end
   end
 
-  desc 'Fill invoice credit amount'
-  task fill_credit_amount: :environment do
-    Invoice.where(credit_amount_cents: 0).find_each do |invoice|
-      transaction_amount = invoice.wallet_transactions.sum(:amount)
-      currency = invoice.amount.currency
-      rounded_amount = transaction_amount.round(currency.exponent)
-      prepaid_credit_amount = rounded_amount * currency.subunit_to_unit
-
-      invoice.update!(
-        credit_amount_cents: invoice.credits.sum(&:amount_cents) + prepaid_credit_amount,
-        credit_amount_currency: invoice.currency,
-      )
-    end
-  end
-
   desc 'Fill invoice organization from customers'
   task fill_organization: :environment do
     # NOTE: when upgrading from before v0.24.0-beta, versions table does not exists


### PR DESCRIPTION
Fixes https://github.com/getlago/lago/issues/238

## Context

An old migration task is failing on recent code base because it relies on models that are not aligned anymore with the migration logic.
Since the data migration itself was performed in a Job we have no way to ensure the state of the database schema and the models.

## Description

To fix the migration, the `invoices:fill_credit_amount` is removed and turned into a proper SQL migration
