### PR TITLE
feat(tax): Apply taxes to fees

### DIFF
--- a/app/services/fees/add_on_service.rb
+++ b/app/services/fees/add_on_service.rb
@@ -19,7 +19,6 @@ module Fees
         fee_type: :add_on,
         invoiceable_type: 'AppliedAddOn',
         invoiceable: applied_add_on,
-        taxes_rate: customer.applicable_vat_rate,
         units: 1,
         payment_status: :pending,
         taxes_amount_cents: 0,

--- a/app/services/fees/add_on_service.rb
+++ b/app/services/fees/add_on_service.rb
@@ -22,12 +22,16 @@ module Fees
         taxes_rate: customer.applicable_vat_rate,
         units: 1,
         payment_status: :pending,
+        taxes_amount_cents: 0,
       )
 
-      new_fee.compute_vat
+      taxes_result = Fees::ApplyTaxesService.call(fee: new_fee)
+      taxes_result.raise_if_error!
+
       new_fee.save!
 
       result.fee = new_fee
+
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -74,9 +74,12 @@ module Fees
         events_count: amount_result.count,
         group_id: group&.id,
         payment_status: :pending,
+        taxes_amount_cents: 0,
       )
 
-      new_fee.compute_vat
+      taxes_result = Fees::ApplyTaxesService.call(fee: new_fee)
+      taxes_result.raise_if_error!
+
       result.fees << new_fee
     end
 

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -65,7 +65,6 @@ module Fees
         charge:,
         amount_cents:,
         amount_currency: currency,
-        taxes_rate: customer.applicable_vat_rate,
         fee_type: :charge,
         invoiceable_type: 'Charge',
         invoiceable: charge,

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -49,7 +49,6 @@ module Fees
         charge:,
         amount_cents: result.amount,
         amount_currency: subscription.plan.amount_currency,
-        taxes_rate: customer.applicable_vat_rate,
         fee_type: :charge,
         invoiceable: charge,
         units: result.units,

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -60,7 +60,10 @@ module Fees
         payment_status: :pending,
         pay_in_advance: true,
       )
-      fee.compute_vat
+
+      taxes_result = Fees::ApplyTaxesService.call(fee:)
+      taxes_result.raise_if_error!
+
       fee.save! unless estimate
 
       fee

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -21,7 +21,9 @@ module Fees
         f.group_id = nil
         f.true_up_parent_fee = fee
       end
-      true_up_fee.compute_vat
+
+      taxes_result = Fees::ApplyTaxesService.call(fee: true_up_fee)
+      taxes_result.raise_if_error!
 
       result.true_up_fee = true_up_fee
       result

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -28,7 +28,6 @@ module Fees
             unit_amount_cents:,
             amount_cents: (unit_amount_cents * units).round,
             amount_currency: invoice.currency,
-            taxes_rate: customer.applicable_vat_rate,
             fee_type: :add_on,
             invoiceable_type: 'AddOn',
             invoiceable: add_on,

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -36,7 +36,9 @@ module Fees
             payment_status: :pending,
           )
 
-          fee.compute_vat
+          taxes_result = Fees::ApplyTaxesService.call(fee:)
+          taxes_result.raise_if_error!
+
           fee.save!
 
           fees_result << fee

--- a/app/services/fees/paid_credit_service.rb
+++ b/app/services/fees/paid_credit_service.rb
@@ -26,11 +26,11 @@ module Fees
         units: 1,
         payment_status: :pending,
 
-        # NOTE: No VAT should be applied on as it can be considered as an advance
+        # NOTE: No taxes should be applied on as it can be considered as an advance
         taxes_rate: 0,
+        taxes_amount_cents: 0,
       )
 
-      new_fee.compute_vat
       new_fee.save!
 
       result.fee = new_fee

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -20,7 +20,6 @@ module Fees
         subscription:,
         amount_cents: new_amount_cents.round,
         amount_currency: plan.amount_currency,
-        taxes_rate: customer.applicable_vat_rate,
         fee_type: :subscription,
         invoiceable_type: 'Subscription',
         invoiceable: subscription,
@@ -29,7 +28,9 @@ module Fees
         payment_status: :pending,
       )
 
-      new_fee.compute_vat
+      taxes_result = Fees::ApplyTaxesService.call(fee: new_fee)
+      taxes_result.raise_if_error!
+
       new_fee.save!
 
       result.fee = new_fee

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
   let(:organization) { membership.organization }
   let(:currency) { 'EUR' }
   let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
   let(:add_on_first) { create(:add_on, organization:) }
   let(:add_on_second) { create(:add_on, amount_cents: 400, organization:) }
   let(:fees) do
@@ -38,6 +39,8 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
       }
     GQL
   end
+
+  before { tax }
 
   it 'creates one-off invoice' do
     result = execute_graphql(

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
+  let(:tax) { create(:tax, organization:, rate: 20) }
 
   let(:customer) { create(:customer, organization:) }
   let(:subscription) do
@@ -63,6 +64,7 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
   before do
     subscription
     charge
+    tax
 
     create_list(
       :event,

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
   describe 'GET /customers/:customer_id/current_usage' do
     let(:customer) { create(:customer, organization:) }
     let(:organization) { create(:organization) }
+    let(:tax) { create(:tax, organization:, rate: 20) }
     let(:subscription) do
       create(
         :subscription,
@@ -169,6 +170,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     before do
       subscription
       charge
+      tax
 
       create_list(
         :event,

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
+
+  before { tax }
 
   describe 'POST /invoices' do
     let(:add_on_first) { create(:add_on, organization:) }

--- a/spec/scenarios/charge_models/percentage_spec.rb
+++ b/spec/scenarios/charge_models/percentage_spec.rb
@@ -5,9 +5,12 @@ require 'rails_helper'
 describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
 
   let(:plan) { create(:plan, organization:, amount_cents: 1000) }
   let(:billable_metric) { create(:billable_metric, organization:, aggregation_type:, field_name:) }
+
+  before { tax }
 
   describe 'with sum_agg' do
     let(:aggregation_type) { 'sum_agg' }

--- a/spec/scenarios/invoices_spec.rb
+++ b/spec/scenarios/invoices_spec.rb
@@ -4,6 +4,9 @@ require 'rails_helper'
 
 describe 'Invoices Scenarios', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
+
+  before { tax }
 
   context 'when subscription is terminated with a grace period' do
     let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }

--- a/spec/scenarios/spending_minimum_spec.rb
+++ b/spec/scenarios/spending_minimum_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 describe 'Spending Minimum Scenarios', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
   let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 5000) }
   let(:metric) { create(:billable_metric, organization:) }
   let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
@@ -12,6 +13,8 @@ describe 'Spending Minimum Scenarios', :scenarios, type: :request do
   let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   before do
+    tax
+
     allow(Utils::PdfGenerator).to receive(:new)
       .and_return(pdf_generator)
     allow(pdf_generator).to receive(:call)

--- a/spec/scenarios/terminate_pay_in_advance_spec.rb
+++ b/spec/scenarios/terminate_pay_in_advance_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
   let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 5000) }
   let(:metric) { create(:billable_metric, organization:) }
   let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
@@ -12,6 +13,8 @@ describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
   let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   before do
+    tax
+
     allow(Utils::PdfGenerator).to receive(:new)
       .and_return(pdf_generator)
     allow(pdf_generator).to receive(:call)

--- a/spec/services/fees/add_on_service_spec.rb
+++ b/spec/services/fees/add_on_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Fees::AddOnService do
 
         expect(created_fee.taxes_amount_cents).to eq(40)
         expect(created_fee.taxes_rate).to eq(20.0)
-        expect(created_fee.fees_taxes.count).to eq(1)
+        expect(created_fee.applied_taxes.count).to eq(1)
       end
     end
 

--- a/spec/services/fees/add_on_service_spec.rb
+++ b/spec/services/fees/add_on_service_spec.rb
@@ -7,8 +7,14 @@ RSpec.describe Fees::AddOnService do
     described_class.new(invoice:, applied_add_on:)
   end
 
-  let(:invoice) { create(:invoice) }
-  let(:applied_add_on) { create(:applied_add_on) }
+  let(:customer) { create(:customer) }
+  let(:organization) { customer.organization }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:applied_add_on) { create(:applied_add_on, customer:) }
+
+  let(:tax) { create(:tax, rate: 20, organization:) }
+
+  before { tax }
 
   describe '.create' do
     it 'creates a fee' do
@@ -24,11 +30,13 @@ RSpec.describe Fees::AddOnService do
         expect(created_fee.applied_add_on_id).to eq(applied_add_on.id)
         expect(created_fee.amount_cents).to eq(200)
         expect(created_fee.amount_currency).to eq('EUR')
-        expect(created_fee.taxes_amount_cents).to eq(40)
-        expect(created_fee.taxes_rate).to eq(20.0)
         expect(created_fee.units).to eq(1)
         expect(created_fee.events_count).to be_nil
         expect(created_fee.payment_status).to eq('pending')
+
+        expect(created_fee.taxes_amount_cents).to eq(40)
+        expect(created_fee.taxes_rate).to eq(20.0)
+        expect(created_fee.fees_taxes.count).to eq(1)
       end
     end
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -7,11 +7,17 @@ RSpec.describe Fees::ChargeService do
     described_class.new(invoice:, charge:, subscription:, boundaries:)
   end
 
+  let(:customer) { create(:customer) }
+  let(:organization) { customer.organization }
+
+  let(:tax) { create(:tax, rate: 20, organization:) }
+
   let(:subscription) do
     create(
       :subscription,
       status: :active,
       started_at: DateTime.parse('2022-03-15'),
+      customer:,
     )
   end
 
@@ -25,10 +31,10 @@ RSpec.describe Fees::ChargeService do
   end
 
   let(:invoice) do
-    create(:invoice)
+    create(:invoice, customer:, organization:)
   end
 
-  let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
+  let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: 'count_agg') }
   let(:charge) do
     create(
       :standard_charge,
@@ -40,6 +46,8 @@ RSpec.describe Fees::ChargeService do
       },
     )
   end
+
+  before { tax }
 
   describe '.create' do
     context 'without group properties' do
@@ -54,11 +62,13 @@ RSpec.describe Fees::ChargeService do
           expect(created_fee.charge_id).to eq(charge.id)
           expect(created_fee.amount_cents).to eq(0)
           expect(created_fee.amount_currency).to eq('EUR')
-          expect(created_fee.taxes_amount_cents).to eq(0)
-          expect(created_fee.taxes_rate).to eq(20.0)
           expect(created_fee.units).to eq(0)
           expect(created_fee.events_count).to eq(0)
           expect(created_fee.payment_status).to eq('pending')
+
+          expect(created_fee.taxes_amount_cents).to eq(0)
+          expect(created_fee.taxes_rate).to eq(20.0)
+          expect(created_fee.fees_taxes.count).to eq(1)
         end
       end
 
@@ -105,9 +115,11 @@ RSpec.describe Fees::ChargeService do
             expect(created_fee.charge_id).to eq(charge.id)
             expect(created_fee.amount_cents).to eq(5)
             expect(created_fee.amount_currency).to eq('EUR')
+            expect(created_fee.units.to_s).to eq('4.0')
+
             expect(created_fee.taxes_amount_cents).to eq(1)
             expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.units.to_s).to eq('4.0')
+            expect(created_fee.fees_taxes.count).to eq(1)
           end
         end
       end
@@ -164,9 +176,11 @@ RSpec.describe Fees::ChargeService do
             expect(created_fee.charge_id).to eq(charge.id)
             expect(created_fee.amount_cents).to eq(2000)
             expect(created_fee.amount_currency).to eq('EUR')
+            expect(created_fee.units).to eq(1)
+
             expect(created_fee.taxes_amount_cents).to eq(400)
             expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.units).to eq(1)
+            expect(created_fee.fees_taxes.count).to eq(1)
           end
         end
       end
@@ -188,9 +202,11 @@ RSpec.describe Fees::ChargeService do
               expect(created_fee.charge_id).to eq(charge.id)
               expect(created_fee.amount_cents).to eq(0)
               expect(created_fee.amount_currency).to eq('EUR')
+              expect(created_fee.units).to eq(0)
+
               expect(created_fee.taxes_amount_cents).to eq(0)
               expect(created_fee.taxes_rate).to eq(20.0)
-              expect(created_fee.units).to eq(0)
+              expect(created_fee.fees_taxes.count).to eq(1)
             end
           end
         end
@@ -320,18 +336,23 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 800,
             units: 2,
           )
+          expect(created_fees.first.fees_taxes.count).to eq(1)
+
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 5000,
             taxes_amount_cents: 1000,
             units: 1,
           )
+          expect(created_fees.second.fees_taxes.count).to eq(1)
+
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 4000,
             taxes_amount_cents: 800,
             units: 1,
           )
+          expect(created_fees.third.fees_taxes.count).to eq(1)
         end
       end
 
@@ -357,18 +378,23 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 6000,
             units: 15,
           )
+          expect(created_fees.first.fees_taxes.count).to eq(1)
+
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 60_000,
             taxes_amount_cents: 12_000,
             units: 12,
           )
+          expect(created_fees.second.fees_taxes.count).to eq(1)
+
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 20_000,
             taxes_amount_cents: 4000,
             units: 5,
           )
+          expect(created_fees.third.fees_taxes.count).to eq(1)
         end
       end
 
@@ -394,18 +420,23 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 4000,
             units: 10,
           )
+          expect(created_fees.first.fees_taxes.count).to eq(1)
+
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 60_000,
             taxes_amount_cents: 12_000,
             units: 12,
           )
+          expect(created_fees.second.fees_taxes.count).to eq(1)
+
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 20_000,
             taxes_amount_cents: 4000,
             units: 5,
           )
+          expect(created_fees.third.fees_taxes.count).to eq(1)
         end
       end
 
@@ -431,18 +462,23 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 800,
             units: 2,
           )
+          expect(created_fees.first.fees_taxes.count).to eq(1)
+
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 5000,
             taxes_amount_cents: 1000,
             units: 1,
           )
+          expect(created_fees.second.fees_taxes.count).to eq(1)
+
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 4000,
             taxes_amount_cents: 800,
             units: 1,
           )
+          expect(created_fees.third.fees_taxes.count).to eq(1)
         end
       end
 
@@ -518,18 +554,23 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 400,
             units: 1,
           )
+          expect(created_fees.first.fees_taxes.count).to eq(1)
+
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 5000,
             taxes_amount_cents: 1000,
             units: 1,
           )
+          expect(created_fees.second.fees_taxes.count).to eq(1)
+
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 4000,
             taxes_amount_cents: 800,
             units: 1,
           )
+          expect(created_fees.third.fees_taxes.count).to eq(1)
         end
       end
     end
@@ -645,18 +686,23 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 2000,
             units: 2,
           )
+          expect(created_fees.first.fees_taxes.count).to eq(1)
+
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 5000,
             taxes_amount_cents: 1000,
             units: 1,
           )
+          expect(created_fees.second.fees_taxes.count).to eq(1)
+
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 0,
             taxes_amount_cents: 0,
             units: 1,
           )
+          expect(created_fees.third.fees_taxes.count).to eq(1)
         end
       end
     end
@@ -760,18 +806,23 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 41,
             units: 2,
           )
+          expect(created_fees.first.fees_taxes.count).to eq(1)
+
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 1 * 1,
             taxes_amount_cents: 0,
             units: 1,
           )
+          expect(created_fees.second.fees_taxes.count).to eq(1)
+
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 100 + 5 * 1,
             taxes_amount_cents: 21,
             units: 1,
           )
+          expect(created_fees.third.fees_taxes.count).to eq(1)
         end
       end
     end
@@ -875,12 +926,15 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 1,
             units: 2,
           )
+          expect(created_fees.first.fees_taxes.count).to eq(1)
+
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 4,
             taxes_amount_cents: 1,
             units: 1,
           )
+          expect(created_fees.second.fees_taxes.count).to eq(1)
         end
       end
     end
@@ -974,12 +1028,15 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 280,
             units: 2,
           )
+          expect(created_fees.first.fees_taxes.count).to eq(1)
+
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 1100,
             taxes_amount_cents: 220,
             units: 1,
           )
+          expect(created_fees.second.fees_taxes.count).to eq(1)
         end
       end
     end
@@ -1088,9 +1145,11 @@ RSpec.describe Fees::ChargeService do
             expect(usage_fee.charge_id).to eq(charge.id)
             expect(usage_fee.amount_cents).to eq(0)
             expect(usage_fee.amount_currency).to eq('EUR')
+            expect(usage_fee.units).to eq(0)
+
             expect(usage_fee.taxes_amount_cents).to eq(0)
             expect(usage_fee.taxes_rate).to eq(20.0)
-            expect(usage_fee.units).to eq(0)
+            expect(usage_fee.fees_taxes.size).to eq(1)
           end
         end
       end
@@ -1141,9 +1200,11 @@ RSpec.describe Fees::ChargeService do
           expect(usage_fee.charge_id).to eq(charge.id)
           expect(usage_fee.amount_cents).to eq(5)
           expect(usage_fee.amount_currency).to eq('EUR')
+          expect(usage_fee.units.to_s).to eq('4.0')
+
           expect(usage_fee.taxes_amount_cents).to eq(1)
           expect(usage_fee.taxes_rate).to eq(20.0)
-          expect(usage_fee.units.to_s).to eq('4.0')
+          expect(usage_fee.fees_taxes.size).to eq(1)
         end
       end
     end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Fees::ChargeService do
 
           expect(created_fee.taxes_amount_cents).to eq(0)
           expect(created_fee.taxes_rate).to eq(20.0)
-          expect(created_fee.fees_taxes.count).to eq(1)
+          expect(created_fee.applied_taxes.count).to eq(1)
         end
       end
 
@@ -119,7 +119,7 @@ RSpec.describe Fees::ChargeService do
 
             expect(created_fee.taxes_amount_cents).to eq(1)
             expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.fees_taxes.count).to eq(1)
+            expect(created_fee.applied_taxes.count).to eq(1)
           end
         end
       end
@@ -180,7 +180,7 @@ RSpec.describe Fees::ChargeService do
 
             expect(created_fee.taxes_amount_cents).to eq(400)
             expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.fees_taxes.count).to eq(1)
+            expect(created_fee.applied_taxes.count).to eq(1)
           end
         end
       end
@@ -206,7 +206,7 @@ RSpec.describe Fees::ChargeService do
 
               expect(created_fee.taxes_amount_cents).to eq(0)
               expect(created_fee.taxes_rate).to eq(20.0)
-              expect(created_fee.fees_taxes.count).to eq(1)
+              expect(created_fee.applied_taxes.count).to eq(1)
             end
           end
         end
@@ -336,7 +336,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 800,
             units: 2,
           )
-          expect(created_fees.first.fees_taxes.count).to eq(1)
+          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
@@ -344,7 +344,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 1000,
             units: 1,
           )
-          expect(created_fees.second.fees_taxes.count).to eq(1)
+          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
@@ -352,7 +352,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 800,
             units: 1,
           )
-          expect(created_fees.third.fees_taxes.count).to eq(1)
+          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
 
@@ -378,7 +378,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 6000,
             units: 15,
           )
-          expect(created_fees.first.fees_taxes.count).to eq(1)
+          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
@@ -386,7 +386,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 12_000,
             units: 12,
           )
-          expect(created_fees.second.fees_taxes.count).to eq(1)
+          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
@@ -394,7 +394,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 4000,
             units: 5,
           )
-          expect(created_fees.third.fees_taxes.count).to eq(1)
+          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
 
@@ -420,7 +420,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 4000,
             units: 10,
           )
-          expect(created_fees.first.fees_taxes.count).to eq(1)
+          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
@@ -428,7 +428,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 12_000,
             units: 12,
           )
-          expect(created_fees.second.fees_taxes.count).to eq(1)
+          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
@@ -436,7 +436,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 4000,
             units: 5,
           )
-          expect(created_fees.third.fees_taxes.count).to eq(1)
+          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
 
@@ -462,7 +462,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 800,
             units: 2,
           )
-          expect(created_fees.first.fees_taxes.count).to eq(1)
+          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
@@ -470,7 +470,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 1000,
             units: 1,
           )
-          expect(created_fees.second.fees_taxes.count).to eq(1)
+          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
@@ -478,7 +478,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 800,
             units: 1,
           )
-          expect(created_fees.third.fees_taxes.count).to eq(1)
+          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
 
@@ -554,7 +554,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 400,
             units: 1,
           )
-          expect(created_fees.first.fees_taxes.count).to eq(1)
+          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
@@ -562,7 +562,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 1000,
             units: 1,
           )
-          expect(created_fees.second.fees_taxes.count).to eq(1)
+          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
@@ -570,7 +570,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 800,
             units: 1,
           )
-          expect(created_fees.third.fees_taxes.count).to eq(1)
+          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -686,7 +686,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 2000,
             units: 2,
           )
-          expect(created_fees.first.fees_taxes.count).to eq(1)
+          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
@@ -694,7 +694,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 1000,
             units: 1,
           )
-          expect(created_fees.second.fees_taxes.count).to eq(1)
+          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
@@ -702,7 +702,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 0,
             units: 1,
           )
-          expect(created_fees.third.fees_taxes.count).to eq(1)
+          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -806,7 +806,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 41,
             units: 2,
           )
-          expect(created_fees.first.fees_taxes.count).to eq(1)
+          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
@@ -814,7 +814,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 0,
             units: 1,
           )
-          expect(created_fees.second.fees_taxes.count).to eq(1)
+          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
@@ -822,7 +822,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 21,
             units: 1,
           )
-          expect(created_fees.third.fees_taxes.count).to eq(1)
+          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -926,7 +926,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 1,
             units: 2,
           )
-          expect(created_fees.first.fees_taxes.count).to eq(1)
+          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
@@ -934,7 +934,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 1,
             units: 1,
           )
-          expect(created_fees.second.fees_taxes.count).to eq(1)
+          expect(created_fees.second.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -1028,7 +1028,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 280,
             units: 2,
           )
-          expect(created_fees.first.fees_taxes.count).to eq(1)
+          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
@@ -1036,7 +1036,7 @@ RSpec.describe Fees::ChargeService do
             taxes_amount_cents: 220,
             units: 1,
           )
-          expect(created_fees.second.fees_taxes.count).to eq(1)
+          expect(created_fees.second.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -1149,7 +1149,7 @@ RSpec.describe Fees::ChargeService do
 
             expect(usage_fee.taxes_amount_cents).to eq(0)
             expect(usage_fee.taxes_rate).to eq(20.0)
-            expect(usage_fee.fees_taxes.size).to eq(1)
+            expect(usage_fee.applied_taxes.size).to eq(1)
           end
         end
       end
@@ -1204,7 +1204,7 @@ RSpec.describe Fees::ChargeService do
 
           expect(usage_fee.taxes_amount_cents).to eq(1)
           expect(usage_fee.taxes_rate).to eq(20.0)
-          expect(usage_fee.fees_taxes.size).to eq(1)
+          expect(usage_fee.applied_taxes.size).to eq(1)
         end
       end
     end

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -59,8 +59,6 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
           charge:,
           amount_cents: 10,
           amount_currency: 'EUR',
-          taxes_rate: 20.0,
-          taxes_amount_cents: 2,
           fee_type: 'charge',
           pay_in_advance: true,
           invoiceable: charge,
@@ -70,7 +68,11 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
           group: nil,
           pay_in_advance_event_id: event.id,
           payment_status: 'pending',
+
+          taxes_rate: 20.0,
+          taxes_amount_cents: 2,
         )
+        expect(result.fees.first.applied_taxes.count).to eq(1)
       end
     end
 
@@ -163,8 +165,6 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
             charge:,
             amount_cents: 10,
             amount_currency: 'EUR',
-            taxes_rate: 20.0,
-            taxes_amount_cents: 2,
             fee_type: 'charge',
             pay_in_advance: true,
             invoiceable: charge,
@@ -173,7 +173,11 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
             events_count: 1,
             group:,
             pay_in_advance_event_id: event.id,
+
+            taxes_rate: 20.0,
+            taxes_amount_cents: 2,
           )
+          expect(result.fees.first.applied_taxes.count).to eq(1)
         end
       end
 
@@ -206,8 +210,6 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
               charge:,
               amount_cents: 10,
               amount_currency: 'EUR',
-              taxes_rate: 20.0,
-              taxes_amount_cents: 2,
               fee_type: 'charge',
               pay_in_advance: true,
               invoiceable: charge,
@@ -216,7 +218,11 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
               events_count: 1,
               group:,
               pay_in_advance_event_id: event.id,
+
+              taxes_rate: 20.0,
+              taxes_amount_cents: 2,
             )
+            expect(result.fees.first.applied_taxes.count).to eq(1)
           end
         end
       end
@@ -260,8 +266,6 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
             charge:,
             amount_cents: 10,
             amount_currency: 'EUR',
-            taxes_rate: 20.0,
-            taxes_amount_cents: 2,
             fee_type: 'charge',
             pay_in_advance: true,
             invoiceable: charge,
@@ -270,7 +274,11 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
             events_count: 1,
             group: nil,
             pay_in_advance_event_id: event.id,
+
+            taxes_rate: 20.0,
+            taxes_amount_cents: 2,
           )
+          expect(result.fees.first.applied_taxes.size).to eq(1)
         end
       end
 

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -10,12 +10,15 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:active_subscription, organization:, customer:, plan:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
 
   let(:group) { nil }
 
   let(:charge) { create(:standard_charge, :pay_in_advance, billable_metric:, plan:) }
   let(:event) { create(:event, subscription:, customer:) }
   let(:estimate) { false }
+
+  before { tax }
 
   describe '#call' do
     let(:aggregation_result) do

--- a/spec/services/fees/create_true_up_service_spec.rb
+++ b/spec/services/fees/create_true_up_service_spec.rb
@@ -5,9 +5,16 @@ require 'rails_helper'
 RSpec.describe Fees::CreateTrueUpService, type: :service do
   subject(:create_service) { described_class.new(fee:, amount_cents:) }
 
-  let(:charge) { create(:standard_charge, min_amount_cents: 1000) }
-  let(:fee) { create(:charge_fee, amount_cents:, charge:) }
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:plan) { create(:plan, organization:) }
+
+  let(:charge) { create(:standard_charge, plan:, min_amount_cents: 1000) }
+  let(:fee) { create(:charge_fee, amount_cents:, customer:, charge:) }
   let(:amount_cents) { 700 }
+
+  before { tax }
 
   describe '#call' do
     context 'when fee is nil' do
@@ -39,7 +46,6 @@ RSpec.describe Fees::CreateTrueUpService, type: :service do
             subscription: fee.subscription,
             charge: fee.charge,
             amount_currency: fee.currency,
-            taxes_rate: fee.taxes_rate,
             fee_type: 'charge',
             invoiceable: fee.charge,
             properties: fee.properties,
@@ -48,8 +54,10 @@ RSpec.describe Fees::CreateTrueUpService, type: :service do
             events_count: 0,
             group: nil,
             amount_cents: 300,
-            taxes_amount_cents: 0,
             true_up_parent_fee_id: fee.id,
+
+            taxes_rate: tax.rate,
+            taxes_amount_cents: 60,
           )
         end
       end

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -49,10 +49,12 @@ RSpec.describe Fees::OneOffService do
         expect(first_fee.units).to eq(2)
         expect(first_fee.amount_cents).to eq(2400)
         expect(first_fee.amount_currency).to eq('EUR')
-        expect(first_fee.taxes_amount_cents).to eq(480)
-        expect(first_fee.taxes_rate).to eq(20.0)
         expect(first_fee.fee_type).to eq('add_on')
         expect(first_fee.payment_status).to eq('pending')
+
+        expect(first_fee.taxes_amount_cents).to eq(480)
+        expect(first_fee.taxes_rate).to eq(20.0)
+        expect(first_fee.applied_taxes.count).to eq(1)
 
         expect(second_fee.id).not_to be_nil
         expect(second_fee.invoice_id).to eq(invoice.id)
@@ -62,10 +64,12 @@ RSpec.describe Fees::OneOffService do
         expect(second_fee.units).to eq(1)
         expect(second_fee.amount_cents).to eq(400)
         expect(second_fee.amount_currency).to eq('EUR')
-        expect(second_fee.taxes_amount_cents).to eq(80)
-        expect(second_fee.taxes_rate).to eq(20.0)
         expect(second_fee.fee_type).to eq('add_on')
         expect(second_fee.payment_status).to eq('pending')
+
+        expect(second_fee.taxes_amount_cents).to eq(80)
+        expect(second_fee.taxes_rate).to eq(20.0)
+        expect(second_fee.applied_taxes.count).to eq(1)
       end
     end
 

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe Fees::OneOffService do
     described_class.new(invoice:, fees:)
   end
 
-  let(:invoice) { create(:invoice, organization:) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
   let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
   let(:add_on_first) { create(:add_on, organization:) }
   let(:add_on_second) { create(:add_on, amount_cents: 400, organization:) }
   let(:fees) do
@@ -24,6 +26,8 @@ RSpec.describe Fees::OneOffService do
       },
     ]
   end
+
+  before { tax }
 
   describe 'create' do
     before { CurrentContext.source = 'api' }

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -8,7 +8,14 @@ RSpec.describe Invoices::AddOnService, type: :service do
   end
 
   let(:datetime) { Time.zone.now }
-  let(:applied_add_on) { create(:applied_add_on) }
+
+  let(:customer) { create(:customer) }
+  let(:organization) { customer.organization }
+  let(:applied_add_on) { create(:applied_add_on, customer:) }
+
+  let(:tax) { create(:tax, rate: 20, organization:) }
+
+  before { tax }
 
   describe 'create' do
     before do

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
     )
   end
 
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
   let(:recurring) { false }
 
   describe '#call' do
@@ -28,6 +31,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       create(
         :subscription,
         plan:,
+        customer:,
         billing_time:,
         subscription_at: started_at,
         started_at:,
@@ -45,7 +49,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
     let(:terminated_at) { nil }
     let(:status) { :active }
 
-    let(:plan) { create(:plan, interval:, pay_in_advance:) }
+    let(:plan) { create(:plan, organization:, interval:, pay_in_advance:) }
     let(:pay_in_advance) { false }
     let(:billing_time) { :calendar }
     let(:interval) { 'monthly' }
@@ -53,6 +57,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
     let(:charge) { create(:standard_charge, plan: subscription.plan, charge_model: 'standard') }
 
     before do
+      tax
       charge
 
       allow(SegmentTrackJob).to receive(:perform_later)

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer) { create(:customer, organization:, vat_rate: 20) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:customer) { create(:customer, organization:) }
   let(:customer_id) { customer&.id }
   let(:subscription_id) { subscription&.id }
   let(:plan) { create(:plan, interval: 'monthly') }
@@ -54,6 +55,8 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
       )
       allow(Rails).to receive(:cache).and_return(memory_store)
       Rails.cache.clear
+
+      tax
     end
 
     it 'uses the Rails cache' do

--- a/spec/services/invoices/one_off_service_spec.rb
+++ b/spec/services/invoices/one_off_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Invoices::OneOffService, type: :service do
   let(:timestamp) { Time.zone.now.beginning_of_month }
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
   let(:currency) { 'EUR' }
   let(:add_on_first) { create(:add_on, organization:) }
   let(:add_on_second) { create(:add_on, amount_cents: 400, organization:) }
@@ -29,6 +30,8 @@ RSpec.describe Invoices::OneOffService, type: :service do
 
   describe 'create' do
     before do
+      tax
+
       allow(SegmentTrackJob).to receive(:perform_later)
       CurrentContext.source = 'api'
     end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -11,11 +11,16 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
     )
   end
 
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
+
   describe 'create' do
     let(:subscription) do
       create(
         :subscription,
         plan:,
+        customer:,
         subscription_at: started_at.to_date,
         started_at:,
         created_at: started_at,
@@ -31,6 +36,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
     let(:pay_in_advance) { false }
 
     before do
+      tax
       create(:standard_charge, plan: subscription.plan, charge_model: 'standard')
 
       allow(SegmentTrackJob).to receive(:perform_later)


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to creates the `fees_taxes` when creating new fees using the applied customer taxes or the organization default one. It relies on the previously created `Fees::ApplyTaxesService`.

`NOTE:` the service is also temporary using the `applicable_vat_rate` as a fallback, until we switch to the new tax logic