### PR TITLE
feat(tax): Present applied taxes to Fee, Invoice and CreditNote

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -15,7 +15,7 @@ module Api
             json: ::V1::CreditNoteSerializer.new(
               result.credit_note,
               root_name: 'credit_note',
-              includes: %i[items taxes],
+              includes: %i[items applied_taxes],
             ),
           )
         else
@@ -31,7 +31,7 @@ module Api
           json: ::V1::CreditNoteSerializer.new(
             credit_note,
             root_name: 'credit_note',
-            includes: %i[items taxes],
+            includes: %i[items applied_taxes],
           ),
         )
       end
@@ -47,7 +47,7 @@ module Api
             json: ::V1::CreditNoteSerializer.new(
               credit_note,
               root_name: 'credit_note',
-              includes: %i[items taxes],
+              includes: %i[items applied_taxes],
             ),
           )
         else
@@ -84,7 +84,7 @@ module Api
             json: ::V1::CreditNoteSerializer.new(
               credit_note,
               root_name: 'credit_note',
-              includes: %i[items taxes],
+              includes: %i[items applied_taxes],
             ),
           )
         else
@@ -109,7 +109,7 @@ module Api
             ::V1::CreditNoteSerializer,
             collection_name: 'credit_notes',
             meta: pagination_metadata(credit_notes),
-            includes: %i[taxes],
+            includes: %i[applied_taxes],
           ),
         )
       end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -66,7 +66,7 @@ module Api
               result.fees,
               ::V1::FeeSerializer,
               collection_name: 'fees',
-              includes: %i[taxes],
+              includes: %i[applied_taxes],
             ),
           )
         else

--- a/app/controllers/api/v1/fees_controller.rb
+++ b/app/controllers/api/v1/fees_controller.rb
@@ -9,7 +9,7 @@ module Api
 
         return not_found_error(resource: 'fee') unless fee
 
-        render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee', includes: %i[taxes]))
+        render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee', includes: %i[applied_taxes]))
       end
 
       def update
@@ -18,7 +18,7 @@ module Api
         result = Fees::UpdateService.call(fee:, params: update_params)
 
         if result.success?
-          render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee', includes: %i[taxes]))
+          render(json: ::V1::FeeSerializer.new(fee, root_name: 'fee', includes: %i[applied_taxes]))
         else
           render_error_response(result)
         end
@@ -41,7 +41,7 @@ module Api
               ::V1::FeeSerializer,
               collection_name: 'fees',
               meta: pagination_metadata(result.fees),
-              includes: %i[taxes],
+              includes: %i[applied_taxes],
             ),
           )
         else

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -64,7 +64,7 @@ module Api
             ::V1::InvoiceSerializer,
             collection_name: 'invoices',
             meta: pagination_metadata(invoices),
-            includes: %i[customer metadata taxes],
+            includes: %i[customer metadata applied_taxes],
           ),
         )
       end
@@ -157,7 +157,7 @@ module Api
           json: ::V1::InvoiceSerializer.new(
             invoice,
             root_name: 'invoice',
-            includes: %i[customer subscriptions fees credits metadata taxes],
+            includes: %i[customer subscriptions fees credits metadata applied_taxes],
           ),
         )
       end

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -16,8 +16,8 @@ class CreditNote < ApplicationRecord
   has_many :fees, through: :items
   has_many :refunds
 
-  has_many :credit_notes_taxes
-  has_many :taxes, through: :credit_notes_taxes
+  has_many :applied_taxes, class_name: 'CreditNote::AppliedTax', dependent: :destroy
+  has_many :taxes, through: :applied_taxes
 
   has_one_attached :file
 

--- a/app/models/credit_note/applied_tax.rb
+++ b/app/models/credit_note/applied_tax.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreditNote
+  class AppliedTax < ApplicationRecord
+    self.table_name = 'credit_notes_taxes'
+
+    include PaperTrailTraceable
+
+    belongs_to :credit_note
+    belongs_to :tax
+  end
+end

--- a/app/models/credit_notes_tax.rb
+++ b/app/models/credit_notes_tax.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class CreditNotesTax < ApplicationRecord
-  include PaperTrailTraceable
-
-  belongs_to :credit_note
-  belongs_to :tax
-end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -20,8 +20,8 @@ class Fee < ApplicationRecord
   has_many :credit_note_items
   has_many :credit_notes, through: :credit_note_items
 
-  has_many :fees_taxes
-  has_many :taxes, through: :fees_taxes
+  has_many :applied_taxes, class_name: 'Fee::AppliedTax', dependent: :destroy
+  has_many :taxes, through: :applied_taxes
 
   monetize :amount_cents
   monetize :taxes_amount_cents, with_model_currency: :currency

--- a/app/models/fee/applied_tax.rb
+++ b/app/models/fee/applied_tax.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Fee
+  class AppliedTax < ApplicationRecord
+    self.table_name = 'fees_taxes'
+
+    include PaperTrailTraceable
+
+    belongs_to :fee
+    belongs_to :tax
+  end
+end

--- a/app/models/fees_tax.rb
+++ b/app/models/fees_tax.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class FeesTax < ApplicationRecord
-  include PaperTrailTraceable
-
-  belongs_to :fee
-  belongs_to :tax
-end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -23,8 +23,8 @@ class Invoice < ApplicationRecord
   has_many :metadata, class_name: 'Metadata::InvoiceMetadata', dependent: :destroy
   has_many :credit_notes
 
-  has_many :invoices_taxes
-  has_many :taxes, through: :invoices_taxes
+  has_many :applied_taxes, class_name: 'Invoice::AppliedTax', dependent: :destroy
+  has_many :taxes, through: :applied_taxes
 
   has_one_attached :file
 

--- a/app/models/invoice/applied_tax.rb
+++ b/app/models/invoice/applied_tax.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Invoice
+  class AppliedTax < ApplicationRecord
+    self.table_name = 'invoices_taxes'
+
+    include PaperTrailTraceable
+
+    belongs_to :invoice
+    belongs_to :tax
+  end
+end

--- a/app/models/invoices_tax.rb
+++ b/app/models/invoices_tax.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class InvoicesTax < ApplicationRecord
-  include PaperTrailTraceable
-
-  belongs_to :invoice
-  belongs_to :tax
-end

--- a/app/serializers/v1/credit_note_serializer.rb
+++ b/app/serializers/v1/credit_note_serializer.rb
@@ -30,7 +30,7 @@ module V1
 
       payload.merge!(customer) if include?(:customer)
       payload.merge!(items) if include?(:items)
-      payload.merge!(taxes) if include?(:taxes)
+      payload.merge!(applied_taxes) if include?(:applied_taxes)
 
       payload
     end
@@ -51,8 +51,12 @@ module V1
       ).serialize
     end
 
-    def taxes
-      ::CollectionSerializer.new(model.taxes, ::V1::TaxSerializer, collection_name: 'taxes').serialize
+    def applied_taxes
+      ::CollectionSerializer.new(
+        model.applied_taxes,
+        ::V1::CreditNotes::AppliedTaxSerializer,
+        collection_name: 'applied_taxes',
+      ).serialize
     end
 
     def legacy_values

--- a/app/serializers/v1/credit_notes/applied_tax_serializer.rb
+++ b/app/serializers/v1/credit_notes/applied_tax_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  module CreditNotes
+    class AppliedTaxSerializer < ModelSerializer
+      def serialize
+        {
+          lago_id: model.id,
+          lago_credit_note_id: model.credit_note_id,
+          lago_tax_id: model.tax_id,
+          tax_name: model.tax_name,
+          tax_code: model.tax_code,
+          tax_rate: model.tax_rate,
+          tax_description: model.tax_description,
+          amount_cents: model.amount_cents,
+          amount_currency: model.amount_currency,
+          created_at: model.created_at.iso8601,
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -36,7 +36,7 @@ module V1
 
       payload.merge!(date_boundaries) if model.charge? || model.subscription?
       payload.merge!(pay_in_advance_charge_attributes) if model.pay_in_advance?
-      payload.merge!(taxes) if include?(:taxes)
+      payload.merge!(applied_taxes) if include?(:applied_taxes)
 
       payload
     end
@@ -72,8 +72,12 @@ module V1
       }
     end
 
-    def taxes
-      ::CollectionSerializer.new(model.taxes, ::V1::TaxSerializer, collection_name: 'taxes').serialize
+    def applied_taxes
+      ::CollectionSerializer.new(
+        model.applied_taxes,
+        ::V1::Fees::AppliedTaxSerializer,
+        collection_name: 'applied_taxes',
+      ).serialize
     end
 
     def legacy_values

--- a/app/serializers/v1/fees/applied_tax_serializer.rb
+++ b/app/serializers/v1/fees/applied_tax_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  module Fees
+    class AppliedTaxSerializer < ModelSerializer
+      def serialize
+        {
+          lago_id: model.id,
+          lago_fee_id: model.fee_id,
+          lago_tax_id: model.tax_id,
+          tax_name: model.tax_name,
+          tax_code: model.tax_code,
+          tax_rate: model.tax_rate,
+          tax_description: model.tax_description,
+          amount_cents: model.amount_cents,
+          amount_currency: model.amount_currency,
+          created_at: model.created_at.iso8601,
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -29,7 +29,7 @@ module V1
       payload.merge!(fees) if include?(:fees)
       payload.merge!(credits) if include?(:credits)
       payload.merge!(metadata) if include?(:metadata)
-      payload.merge!(taxes) if include?(:taxes)
+      payload.merge!(applied_taxes) if include?(:applied_taxes)
 
       payload
     end
@@ -63,8 +63,8 @@ module V1
       ).serialize
     end
 
-    def taxes
-      ::CollectionSerializer.new(model.taxes, ::V1::TaxSerializer, collection_name: 'taxes').serialize
+    def applied_taxes
+      ::CollectionSerializer.new(model.applied_taxes, ::V1::TaxSerializer, collection_name: 'applied_taxes').serialize
     end
 
     def legacy_values

--- a/app/serializers/v1/invoices/applied_tax_serializer.rb
+++ b/app/serializers/v1/invoices/applied_tax_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  module Invoices
+    class AppliedTaxSerializer < ModelSerializer
+      def serialize
+        {
+          lago_id: model.id,
+          lago_invoice_id: model.invoice_id,
+          lago_tax_id: model.tax_id,
+          tax_name: model.tax_name,
+          tax_code: model.tax_code,
+          tax_rate: model.tax_rate,
+          tax_description: model.tax_description,
+          amount_cents: model.amount_cents,
+          amount_currency: model.amount_currency,
+          created_at: model.created_at.iso8601,
+        }
+      end
+    end
+  end
+end

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -9,12 +9,12 @@ module Fees
     end
 
     def call
-      result.fees_taxes = []
-      fee_taxes_amount_cents = 0
-      fee_taxes_rate = 0
+      result.applied_taxes = []
+      applied_taxes_amount_cents = 0
+      applied_taxes_rate = 0
 
       applicable_taxes.each do |tax|
-        fees_tax = FeesTax.new(
+        applied_tax = Fee::AppliedTax.new(
           fee:,
           tax:,
           tax_description: tax.description,
@@ -23,20 +23,20 @@ module Fees
           tax_rate: tax.rate,
           amount_currency: fee.amount_currency,
         )
-        fee.fees_taxes << fees_tax
+        fee.applied_taxes << applied_tax
 
         tax_amount_cents = (fee.amount_cents * tax.rate).fdiv(100)
-        fees_tax.amount_cents = tax_amount_cents.round
-        fees_tax.save! if fee.persisted?
+        applied_tax.amount_cents = tax_amount_cents.round
+        applied_tax.save! if fee.persisted?
 
-        fee_taxes_amount_cents += tax_amount_cents
-        fee_taxes_rate += tax.rate
+        applied_taxes_amount_cents += tax_amount_cents
+        applied_taxes_rate += tax.rate
 
-        result.fees_taxes << fees_tax
+        result.applied_taxes << applied_tax
       end
 
-      fee.taxes_amount_cents = fee_taxes_amount_cents.round
-      fee.taxes_rate = fee_taxes_rate
+      fee.taxes_amount_cents = applied_taxes_amount_cents.round
+      fee.taxes_rate = applied_taxes_rate
 
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/webhooks/credit_notes/created_service.rb
+++ b/app/services/webhooks/credit_notes/created_service.rb
@@ -11,7 +11,7 @@ module Webhooks
         ::V1::CreditNoteSerializer.new(
           object,
           root_name: 'credit_note',
-          includes: %i[customer items taxes],
+          includes: %i[customer items applied_taxes],
         )
       end
 

--- a/app/services/webhooks/invoices/created_service.rb
+++ b/app/services/webhooks/invoices/created_service.rb
@@ -13,7 +13,7 @@ module Webhooks
         ::V1::InvoiceSerializer.new(
           object,
           root_name: 'invoice',
-          includes: %i[customer subscriptions fees credits taxes],
+          includes: %i[customer subscriptions fees credits applied_taxes],
         )
       end
 

--- a/app/services/webhooks/invoices/drafted_service.rb
+++ b/app/services/webhooks/invoices/drafted_service.rb
@@ -11,7 +11,7 @@ module Webhooks
         ::V1::InvoiceSerializer.new(
           object,
           root_name: 'invoice',
-          includes: %i[customer subscriptions fees credits taxes],
+          includes: %i[customer subscriptions fees credits applied_taxes],
         )
       end
 

--- a/app/services/webhooks/invoices/one_off_created_service.rb
+++ b/app/services/webhooks/invoices/one_off_created_service.rb
@@ -13,7 +13,7 @@ module Webhooks
         ::V1::InvoiceSerializer.new(
           object,
           root_name: 'invoice',
-          includes: %i[customer fees taxes],
+          includes: %i[customer fees applied_taxes],
         )
       end
 

--- a/app/services/webhooks/invoices/paid_credit_added_service.rb
+++ b/app/services/webhooks/invoices/paid_credit_added_service.rb
@@ -13,7 +13,7 @@ module Webhooks
         ::V1::InvoiceSerializer.new(
           object,
           root_name: 'invoice',
-          includes: %i[customer fees taxes],
+          includes: %i[customer fees applied_taxes],
         )
       end
 

--- a/spec/factories/credit_note_applied_taxes.rb
+++ b/spec/factories/credit_note_applied_taxes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :credit_notes_tax do
+  factory :credit_note_applied_tax, class: 'CreditNote::AppliedTax' do
     credit_note
     tax
     tax_code { "vat-#{SecureRandom.uuid}" }

--- a/spec/factories/fee_applied_taxes.rb
+++ b/spec/factories/fee_applied_taxes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :fees_tax do
+  factory :fee_applied_tax, class: 'Fee::AppliedTax' do
     fee
     tax
     tax_code { "vat-#{SecureRandom.uuid}" }

--- a/spec/factories/invoice_applied_taxes.rb
+++ b/spec/factories/invoice_applied_taxes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :invoices_tax do
+  factory :invoice_applied_tax, class: 'Invoice::AppliedTax' do
     invoice
     tax
     tax_code { "vat-#{SecureRandom.uuid}" }

--- a/spec/models/credit_note/applied_tax_spec.rb
+++ b/spec/models/credit_note/applied_tax_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNote::AppliedTax, type: :model do
+  subject(:applied_tax) { create(:credit_note_applied_tax) }
+
+  it_behaves_like 'paper_trail traceable'
+end

--- a/spec/models/credit_notes_tax_spec.rb
+++ b/spec/models/credit_notes_tax_spec.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe CreditNotesTax, type: :model do
-  subject(:credit_notes_tax) { create(:credit_notes_tax) }
-
-  it_behaves_like 'paper_trail traceable'
-end

--- a/spec/models/fee/applied_tax_spec.rb
+++ b/spec/models/fee/applied_tax_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-RSpec.describe FeesTax, type: :model do
-  subject(:fees_tax) { create(:fees_tax) }
+RSpec.describe Fee::AppliedTax, type: :model do
+  subject(:applied_tax) { create(:fee_applied_tax) }
 
   it_behaves_like 'paper_trail traceable'
 end

--- a/spec/models/invoice/applied_tax_spec.rb
+++ b/spec/models/invoice/applied_tax_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoice::AppliedTax, type: :model do
+  subject(:applied_tax) { create(:invoice_applied_tax) }
+
+  it_behaves_like 'paper_trail traceable'
+end

--- a/spec/models/invoices_tax_spec.rb
+++ b/spec/models/invoices_tax_spec.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe InvoicesTax, type: :model do
-  subject(:invoices_tax) { create(:invoices_tax) }
-
-  it_behaves_like 'paper_trail traceable'
-end

--- a/spec/requests/api/v1/credit_notes_spec.rb
+++ b/spec/requests/api/v1/credit_notes_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
           balance_amount_currency: credit_note.balance_amount_currency,
           created_at: credit_note.created_at.iso8601,
           updated_at: credit_note.updated_at.iso8601,
-          taxes: [],
+          applied_taxes: [],
         )
 
         expect(json[:credit_note][:items].count).to eq(2)
@@ -283,7 +283,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
           balance_amount_currency: 'EUR',
           refund_amount_cents: 5,
           refund_amount_currency: 'EUR',
-          taxes: [],
+          applied_taxes: [],
         )
 
         expect(json[:credit_note][:items][0][:lago_id]).to be_present

--- a/spec/requests/api/v1/fees_spec.rb
+++ b/spec/requests/api/v1/fees_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Api::V1::FeesController, type: :request do
           taxes_amount_cents: fee.taxes_amount_cents,
           units: fee.units.to_s,
           events_count: fee.events_count,
-          taxes: [],
+          applied_taxes: [],
         )
         expect(json[:fee][:item]).to include(
           type: fee.fee_type,
@@ -52,7 +52,7 @@ RSpec.describe Api::V1::FeesController, type: :request do
             taxes_amount_cents: fee.taxes_amount_cents,
             units: fee.units.to_s,
             events_count: fee.events_count,
-            taxes: [],
+            applied_taxes: [],
           )
           expect(json[:fee][:item]).to include(
             type: fee.fee_type,
@@ -109,7 +109,7 @@ RSpec.describe Api::V1::FeesController, type: :request do
           succeeded_at: fee.succeeded_at&.iso8601,
           failed_at: fee.failed_at&.iso8601,
           refunded_at: fee.refunded_at&.iso8601,
-          taxes: [],
+          applied_taxes: [],
         )
         expect(json[:fee][:item]).to include(
           type: fee.fee_type,

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
           customer: Hash,
           subscriptions: [],
           credits: [],
-          taxes: [],
+          applied_taxes: [],
         )
         expect(json[:invoice][:fees].first).to include(lago_group_id: group.id)
       end
@@ -206,7 +206,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
             customer: Hash,
             subscriptions: [],
             credits: [],
-            taxes: [],
+            applied_taxes: [],
           )
 
           json_fee = json[:invoice][:fees].first

--- a/spec/serializers/v1/credit_notes/applied_tax_serializer_spec.rb
+++ b/spec/serializers/v1/credit_notes/applied_tax_serializer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::CreditNotes::AppliedTaxSerializer do
+  subject(:serializer) { described_class.new(applied_tax, root_name: 'applied_tax') }
+
+  let(:applied_tax) { create(:credit_note_applied_tax) }
+
+  before { applied_tax }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['applied_tax']['lago_id']).to eq(applied_tax.id)
+      expect(result['applied_tax']['lago_credit_note_id']).to eq(applied_tax.credit_note_id)
+      expect(result['applied_tax']['lago_tax_id']).to eq(applied_tax.tax_id)
+      expect(result['applied_tax']['tax_name']).to eq(applied_tax.tax_name)
+      expect(result['applied_tax']['tax_code']).to eq(applied_tax.tax_code)
+      expect(result['applied_tax']['tax_rate']).to eq(applied_tax.tax_rate)
+      expect(result['applied_tax']['tax_description']).to eq(applied_tax.tax_description)
+      expect(result['applied_tax']['amount_cents']).to eq(applied_tax.amount_cents)
+      expect(result['applied_tax']['amount_currency']).to eq(applied_tax.amount_currency)
+      expect(result['applied_tax']['created_at']).to eq(applied_tax.created_at.iso8601)
+    end
+  end
+end

--- a/spec/serializers/v1/fees/applied_tax_serializer_spec.rb
+++ b/spec/serializers/v1/fees/applied_tax_serializer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::Fees::AppliedTaxSerializer do
+  subject(:serializer) { described_class.new(applied_tax, root_name: 'applied_tax') }
+
+  let(:applied_tax) { create(:fee_applied_tax) }
+
+  before { applied_tax }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['applied_tax']['lago_id']).to eq(applied_tax.id)
+      expect(result['applied_tax']['lago_fee_id']).to eq(applied_tax.fee_id)
+      expect(result['applied_tax']['lago_tax_id']).to eq(applied_tax.tax_id)
+      expect(result['applied_tax']['tax_name']).to eq(applied_tax.tax_name)
+      expect(result['applied_tax']['tax_code']).to eq(applied_tax.tax_code)
+      expect(result['applied_tax']['tax_rate']).to eq(applied_tax.tax_rate)
+      expect(result['applied_tax']['tax_description']).to eq(applied_tax.tax_description)
+      expect(result['applied_tax']['amount_cents']).to eq(applied_tax.amount_cents)
+      expect(result['applied_tax']['amount_currency']).to eq(applied_tax.amount_currency)
+      expect(result['applied_tax']['created_at']).to eq(applied_tax.created_at.iso8601)
+    end
+  end
+end

--- a/spec/serializers/v1/invoices/applied_tax_serializer_spec.rb
+++ b/spec/serializers/v1/invoices/applied_tax_serializer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::Invoices::AppliedTaxSerializer do
+  subject(:serializer) { described_class.new(applied_tax, root_name: 'applied_tax') }
+
+  let(:applied_tax) { create(:invoice_applied_tax) }
+
+  before { applied_tax }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['applied_tax']['lago_id']).to eq(applied_tax.id)
+      expect(result['applied_tax']['lago_invoice_id']).to eq(applied_tax.invoice_id)
+      expect(result['applied_tax']['lago_tax_id']).to eq(applied_tax.tax_id)
+      expect(result['applied_tax']['tax_name']).to eq(applied_tax.tax_name)
+      expect(result['applied_tax']['tax_code']).to eq(applied_tax.tax_code)
+      expect(result['applied_tax']['tax_rate']).to eq(applied_tax.tax_rate)
+      expect(result['applied_tax']['tax_description']).to eq(applied_tax.tax_description)
+      expect(result['applied_tax']['amount_cents']).to eq(applied_tax.amount_cents)
+      expect(result['applied_tax']['amount_currency']).to eq(applied_tax.amount_currency)
+      expect(result['applied_tax']['created_at']).to eq(applied_tax.created_at.iso8601)
+    end
+  end
+end

--- a/spec/services/fees/apply_taxes_service_spec.rb
+++ b/spec/services/fees/apply_taxes_service_spec.rb
@@ -26,16 +26,16 @@ RSpec.describe Fees::ApplyTaxesService, type: :service do
   end
 
   describe 'call' do
-    it 'creates fees_taxes' do
+    it 'creates applied_taxes' do
       result = apply_service.call
 
       aggregate_failures do
         expect(result).to be_success
 
-        fees_taxes = result.fees_taxes
-        expect(fees_taxes.count).to eq(2)
+        applied_taxes = result.applied_taxes
+        expect(applied_taxes.count).to eq(2)
 
-        expect(fees_taxes[0]).to have_attributes(
+        expect(applied_taxes[0]).to have_attributes(
           fee:,
           tax: tax1,
           tax_description: tax1.description,
@@ -46,7 +46,7 @@ RSpec.describe Fees::ApplyTaxesService, type: :service do
           amount_cents: 100,
         )
 
-        expect(fees_taxes[1]).to have_attributes(
+        expect(applied_taxes[1]).to have_attributes(
           fee:,
           tax: tax2,
           tax_description: tax2.description,
@@ -68,16 +68,16 @@ RSpec.describe Fees::ApplyTaxesService, type: :service do
       let(:applied_tax1) { nil }
       let(:applied_tax2) { nil }
 
-      it 'creates fees_taxes based on the organization taxes' do
+      it 'creates applied_taxes based on the organization taxes' do
         result = apply_service.call
 
         aggregate_failures do
           expect(result).to be_success
 
-          fees_taxes = result.fees_taxes
-          expect(fees_taxes.count).to eq(1)
+          applied_taxes = result.applied_taxes
+          expect(applied_taxes.count).to eq(1)
 
-          expect(fees_taxes[0]).to have_attributes(
+          expect(applied_taxes[0]).to have_attributes(
             fee:,
             tax: tax3,
             tax_description: tax3.description,


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to:
- Present applied taxes on Invoice serializer
- Present applied taxes on Fee serializer
- Present applied taxes on CreditNote serializer