### PR TITLE
feat(tax): Return applied taxes via graphql

### DIFF
--- a/app/graphql/types/credit_notes/applied_taxes/object.rb
+++ b/app/graphql/types/credit_notes/applied_taxes/object.rb
@@ -5,22 +5,9 @@ module Types
     module AppliedTaxes
       class Object < Types::BaseObject
         graphql_name 'CreditNoteAppliedTax'
-
-        field :id, ID, null: false
+        implements Types::Taxes::AppliedTax
 
         field :credit_note, Types::CreditNotes::Object, null: false
-        field :tax, Types::Taxes::Object, null: false
-
-        field :tax_code, String, null: false
-        field :tax_description, String, null: true
-        field :tax_name, String, null: false
-        field :tax_rate, Float, null: false
-
-        field :amount_cents, GraphQL::Types::BigInt, null: false
-        field :amount_currency, Types::CurrencyEnum, null: false
-
-        field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-        field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
       end
     end
   end

--- a/app/graphql/types/credit_notes/applied_taxes/object.rb
+++ b/app/graphql/types/credit_notes/applied_taxes/object.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Types
+  module CreditNotes
+    module AppliedTaxes
+      class Object < Types::BaseObject
+        graphql_name 'CreditNoteAppliedTax'
+
+        field :id, ID, null: false
+
+        field :credit_note, Types::CreditNotes::Object, null: false
+        field :tax, Types::Taxes::Object, null: false
+
+        field :tax_code, String, null: false
+        field :tax_description, String, null: true
+        field :tax_name, String, null: false
+        field :tax_rate, Float, null: false
+
+        field :amount_cents, GraphQL::Types::BigInt, null: false
+        field :amount_currency, Types::CurrencyEnum, null: false
+
+        field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+        field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+      end
+    end
+  end
+end

--- a/app/graphql/types/credit_notes/object.rb
+++ b/app/graphql/types/credit_notes/object.rb
@@ -36,6 +36,7 @@ module Types
 
       field :file_url, String, null: true
 
+      field :applied_taxes, [Types::CreditNotes::AppliedTaxes::Object]
       field :customer, Types::Customers::Object, null: false
       field :invoice, Types::Invoices::Object
       field :items, [Types::CreditNoteItems::Object], null: false

--- a/app/graphql/types/fees/applied_taxes/object.rb
+++ b/app/graphql/types/fees/applied_taxes/object.rb
@@ -5,22 +5,9 @@ module Types
     module AppliedTaxes
       class Object < Types::BaseObject
         graphql_name 'FeeAppliedTax'
-
-        field :id, ID, null: false
+        implements Types::Taxes::AppliedTax
 
         field :fee, Types::Fees::Object, null: false
-        field :tax, Types::Taxes::Object, null: false
-
-        field :tax_code, String, null: false
-        field :tax_description, String, null: true
-        field :tax_name, String, null: false
-        field :tax_rate, Float, null: false
-
-        field :amount_cents, GraphQL::Types::BigInt, null: false
-        field :amount_currency, Types::CurrencyEnum, null: false
-
-        field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-        field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
       end
     end
   end

--- a/app/graphql/types/fees/applied_taxes/object.rb
+++ b/app/graphql/types/fees/applied_taxes/object.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Types
+  module Fees
+    module AppliedTaxes
+      class Object < Types::BaseObject
+        graphql_name 'FeeAppliedTax'
+
+        field :id, ID, null: false
+
+        field :fee, Types::Fees::Object, null: false
+        field :tax, Types::Taxes::Object, null: false
+
+        field :tax_code, String, null: false
+        field :tax_description, String, null: true
+        field :tax_name, String, null: false
+        field :tax_rate, Float, null: false
+
+        field :amount_cents, GraphQL::Types::BigInt, null: false
+        field :amount_currency, Types::CurrencyEnum, null: false
+
+        field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+        field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+      end
+    end
+  end
+end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -19,6 +19,8 @@ module Types
       field :taxes_rate, GraphQL::Types::Float, null: true
       field :units, GraphQL::Types::Float, null: false
 
+      field :applied_taxes, [Types::Fees::AppliedTaxes::Object]
+
       def item_type
         object.fee_type
       end

--- a/app/graphql/types/invoices/applied_taxes/object.rb
+++ b/app/graphql/types/invoices/applied_taxes/object.rb
@@ -5,22 +5,9 @@ module Types
     module AppliedTaxes
       class Object < Types::BaseObject
         graphql_name 'InvoiceAppliedTax'
-
-        field :id, ID, null: false
+        implements Types::Taxes::AppliedTax
 
         field :invoice, Types::Invoices::Object, null: false
-        field :tax, Types::Taxes::Object, null: false
-
-        field :tax_code, String, null: false
-        field :tax_description, String, null: true
-        field :tax_name, String, null: false
-        field :tax_rate, Float, null: false
-
-        field :amount_cents, GraphQL::Types::BigInt, null: false
-        field :amount_currency, Types::CurrencyEnum, null: false
-
-        field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-        field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
       end
     end
   end

--- a/app/graphql/types/invoices/applied_taxes/object.rb
+++ b/app/graphql/types/invoices/applied_taxes/object.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Types
+  module Invoices
+    module AppliedTaxes
+      class Object < Types::BaseObject
+        graphql_name 'InvoiceAppliedTax'
+
+        field :id, ID, null: false
+
+        field :invoice, Types::Invoices::Object, null: false
+        field :tax, Types::Taxes::Object, null: false
+
+        field :tax_code, String, null: false
+        field :tax_description, String, null: true
+        field :tax_name, String, null: false
+        field :tax_rate, Float, null: false
+
+        field :amount_cents, GraphQL::Types::BigInt, null: false
+        field :amount_currency, Types::CurrencyEnum, null: false
+
+        field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+        field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+      end
+    end
+  end
+end

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -42,6 +42,7 @@ module Types
       field :file_url, String, null: true
       field :metadata, [Types::Invoices::Metadata::Object], null: true
 
+      field :applied_taxes, [Types::Invoices::AppliedTaxes::Object]
       field :credit_notes, [Types::CreditNotes::Object], null: true
       field :fees, [Types::Fees::Object], null: true
       field :invoice_subscriptions, [Types::InvoiceSubscription::Object]

--- a/app/graphql/types/taxes/applied_tax.rb
+++ b/app/graphql/types/taxes/applied_tax.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Types
+  module Taxes
+    module AppliedTax
+      include Types::BaseInterface
+
+      field :id, ID, null: false
+
+      field :tax, Types::Taxes::Object, null: false
+      field :tax_code, String, null: false
+      field :tax_description, String, null: true
+      field :tax_name, String, null: false
+      field :tax_rate, Float, null: false
+
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :amount_currency, Types::CurrencyEnum, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1750,6 +1750,7 @@ input CreateSubscriptionInput {
 CreditNote
 """
 type CreditNote {
+  appliedTaxes: [CreditNoteAppliedTax!]
   balanceAmountCents: BigInt!
 
   """
@@ -1780,6 +1781,20 @@ type CreditNote {
   totalAmountCents: BigInt!
   updatedAt: ISO8601DateTime!
   voidedAt: ISO8601DateTime
+}
+
+type CreditNoteAppliedTax {
+  amountCents: BigInt!
+  amountCurrency: CurrencyEnum!
+  createdAt: ISO8601DateTime!
+  creditNote: CreditNote!
+  id: ID!
+  tax: Tax!
+  taxCode: String!
+  taxDescription: String
+  taxName: String!
+  taxRate: Float!
+  updatedAt: ISO8601DateTime!
 }
 
 type CreditNoteCollection {

--- a/schema.graphql
+++ b/schema.graphql
@@ -3027,6 +3027,7 @@ enum InviteStatusTypeEnum {
 Invoice
 """
 type Invoice {
+  appliedTaxes: [InvoiceAppliedTax!]
   chargeAmountCents: BigInt!
   couponsAmountCents: BigInt!
   createdAt: ISO8601DateTime!
@@ -3057,6 +3058,20 @@ type Invoice {
   totalAmountCents: BigInt!
   updatedAt: ISO8601DateTime!
   versionNumber: Int!
+}
+
+type InvoiceAppliedTax {
+  amountCents: BigInt!
+  amountCurrency: CurrencyEnum!
+  createdAt: ISO8601DateTime!
+  id: ID!
+  invoice: Invoice!
+  tax: Tax!
+  taxCode: String!
+  taxDescription: String
+  taxName: String!
+  taxRate: Float!
+  updatedAt: ISO8601DateTime!
 }
 
 type InvoiceCollection {

--- a/schema.graphql
+++ b/schema.graphql
@@ -93,6 +93,19 @@ type AppliedCoupon {
   terminatedAt: ISO8601DateTime!
 }
 
+interface AppliedTax {
+  amountCents: BigInt!
+  amountCurrency: CurrencyEnum!
+  createdAt: ISO8601DateTime!
+  id: ID!
+  tax: Tax!
+  taxCode: String!
+  taxDescription: String
+  taxName: String!
+  taxRate: Float!
+  updatedAt: ISO8601DateTime!
+}
+
 """
 Represents non-fractional signed whole numeric values. Since the value may
 exceed the size of a 32-bit integer, it's encoded as a string.
@@ -1783,7 +1796,7 @@ type CreditNote {
   voidedAt: ISO8601DateTime
 }
 
-type CreditNoteAppliedTax {
+type CreditNoteAppliedTax implements AppliedTax {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   createdAt: ISO8601DateTime!
@@ -2910,7 +2923,7 @@ type Fee implements InvoiceItem {
   units: Float!
 }
 
-type FeeAppliedTax {
+type FeeAppliedTax implements AppliedTax {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   createdAt: ISO8601DateTime!
@@ -3090,7 +3103,7 @@ type Invoice {
   versionNumber: Int!
 }
 
-type InvoiceAppliedTax {
+type InvoiceAppliedTax implements AppliedTax {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   createdAt: ISO8601DateTime!

--- a/schema.graphql
+++ b/schema.graphql
@@ -2876,6 +2876,7 @@ type EventCollection {
 type Fee implements InvoiceItem {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
+  appliedTaxes: [FeeAppliedTax!]
   charge: Charge
   creditableAmountCents: BigInt!
   currency: CurrencyEnum!
@@ -2892,6 +2893,20 @@ type Fee implements InvoiceItem {
   trueUpFee: Fee
   trueUpParentFee: Fee
   units: Float!
+}
+
+type FeeAppliedTax {
+  amountCents: BigInt!
+  amountCurrency: CurrencyEnum!
+  createdAt: ISO8601DateTime!
+  fee: Fee!
+  id: ID!
+  tax: Tax!
+  taxCode: String!
+  taxDescription: String
+  taxName: String!
+  taxRate: Float!
+  updatedAt: ISO8601DateTime!
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -9555,6 +9555,28 @@
               ]
             },
             {
+              "name": "appliedTaxes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "FeeAppliedTax",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "charge",
               "description": null,
               "type": {
@@ -9805,6 +9827,213 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FeeAppliedTax",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fee",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Fee",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "tax",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Tax",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxDescription",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxRate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
                   "ofType": null
                 }
               },

--- a/schema.json
+++ b/schema.json
@@ -10851,6 +10851,28 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "appliedTaxes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "InvoiceAppliedTax",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "chargeAmountCents",
               "description": null,
               "type": {
@@ -11393,6 +11415,213 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InvoiceAppliedTax",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoice",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Invoice",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "tax",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Tax",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxDescription",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxRate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
                   "ofType": null
                 }
               },

--- a/schema.json
+++ b/schema.json
@@ -5524,6 +5524,28 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "appliedTaxes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "CreditNoteAppliedTax",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "balanceAmountCents",
               "description": null,
               "type": {
@@ -5964,6 +5986,213 @@
                 "kind": "SCALAR",
                 "name": "ISO8601DateTime",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CreditNoteAppliedTax",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditNote",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CreditNote",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "tax",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Tax",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxDescription",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxRate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/schema.json
+++ b/schema.json
@@ -768,6 +768,211 @@
           "enumValues": null
         },
         {
+          "kind": "INTERFACE",
+          "name": "AppliedTax",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "CreditNoteAppliedTax",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "FeeAppliedTax",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "InvoiceAppliedTax",
+              "ofType": null
+            }
+          ],
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "tax",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Tax",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxDescription",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxRate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
           "kind": "SCALAR",
           "name": "BigInt",
           "description": "Represents non-fractional signed whole numeric values. Since the value may exceed the size of a 32-bit integer, it's encoded as a string.",
@@ -6002,7 +6207,11 @@
           "name": "CreditNoteAppliedTax",
           "description": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "AppliedTax",
+              "ofType": null
+            }
           ],
           "possibleTypes": null,
           "fields": [
@@ -10074,7 +10283,11 @@
           "name": "FeeAppliedTax",
           "description": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "AppliedTax",
+              "ofType": null
+            }
           ],
           "possibleTypes": null,
           "fields": [
@@ -11891,7 +12104,11 @@
           "name": "InvoiceAppliedTax",
           "description": null,
           "interfaces": [
-
+            {
+              "kind": "INTERFACE",
+              "name": "AppliedTax",
+              "ofType": null
+            }
           ],
           "possibleTypes": null,
           "fields": [

--- a/spec/graphql/resolvers/credit_note_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_note_resolver_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe Resolvers::CreditNoteResolver, type: :graphql do
             createdAt
             fee { id amountCents itemType itemCode itemName }
           }
+          appliedTaxes {
+            taxCode
+            taxName
+            taxRate
+            taxDescription
+            amountCents
+            amountCurrency
+          }
         }
       }
     GQL

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
             name
             deletedAt
           }
+          appliedTaxes {
+            taxCode
+            taxName
+            taxRate
+            taxDescription
+            amountCents
+            amountCurrency
+          }
           invoiceSubscriptions {
             fromDatetime
             toDatetime

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
               taxesAmountCents
               trueUpFee { id }
               trueUpParentFee { id }
+              appliedTaxes {
+                taxCode
+                taxName
+                taxRate
+                taxDescription
+                amountCents
+                amountCurrency
+              }
             }
           }
           subscriptions {


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to return applied taxes for fees, invoices and credit notes on graphql.