### PR TITLE
fix: Invoice organization_id migration

### DIFF
--- a/db/migrate/20230202163249_add_organization_id_to_invoices.rb
+++ b/db/migrate/20230202163249_add_organization_id_to_invoices.rb
@@ -6,8 +6,12 @@ class AddOrganizationIdToInvoices < ActiveRecord::Migration[7.0]
 
     reversible do |dir|
       dir.up do
-        LagoApi::Application.load_tasks
-        Rake::Task['invoices:fill_organization'].invoke
+        execute <<-SQL
+          UPDATE invoices
+          SET organization_id = customers.organization_id
+          FROM customers
+          WHERE customers.id = invoices.customer_id
+        SQL
       end
     end
 

--- a/lib/tasks/invoices.rake
+++ b/lib/tasks/invoices.rake
@@ -50,18 +50,4 @@ namespace :invoices do
       end
     end
   end
-
-  desc 'Fill invoice organization from customers'
-  task fill_organization: :environment do
-    # NOTE: when upgrading from before v0.24.0-beta, versions table does not exists
-    #       but PaperTrail is loaded in the model.
-    #       So we need to turn it off temporary to ensure migration passes
-    PaperTrail.request.disable_model(Invoice)
-
-    Invoice.where(organization_id: nil).find_each do |invoice|
-      invoice.update!(organization_id: invoice.customer.organization_id)
-    end
-
-    PaperTrail.request.enable_model(Invoice)
-  end
 end


### PR DESCRIPTION
Fixes https://github.com/getlago/lago/issues/238

## Context

An old migration task is failing on recent code base because it relies on models that are not aligned anymore with the migration logic.

## Description

To fix the migration, the `invoices:fill_organization` is removed and turned into a proper SQL migration
