### PR TITLE
fix(plan): Validate pay_in_advance

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -32,6 +32,7 @@ class Plan < ApplicationRecord
   validates :code,
             presence: true,
             uniqueness: { conditions: -> { where(deleted_at: nil) }, scope: :organization_id }
+  validates :pay_in_advance, inclusion: { in: [true, false] }
 
   default_scope -> { kept }
 

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe Plan, type: :model do
 
   it_behaves_like 'paper_trail traceable'
 
+  describe 'Validations' do
+    it 'requires the pay_in_advance' do
+      plan.pay_in_advance = nil
+      expect(plan).not_to be_valid
+
+      plan.pay_in_advance = true
+      expect(plan).to be_valid
+    end
+  end
+
   describe '.has_trial?' do
     it 'returns true when trial_period' do
       expect(plan).to have_trial


### PR DESCRIPTION
## Context

If we try to create an plan via the API without sending the `pay_in_advance` value, the request fails with an HTTP 500 error, because the value is not validated while the not null is enforced at database level.

## Description

This PR adds a validation rule on the plan model, to ensure that `pay_in_advance` is always set to `true` or `false`. The service will now returns a validation failure instead of a database error.