### PR TITLE
fix(event): fix event webhook error

### DIFF
--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -64,7 +64,7 @@ module Events
 
       if organization.webhook_url?
         SendWebhookJob.perform_later(
-          :event,
+          'event.error',
           { input_params: params, error: result.error.message, organization_id: organization.id },
         )
       end


### PR DESCRIPTION
This PR will fix a `NotImplementedError` that is raised by the `SendWebhookJob`