### PR TITLE
feat(applied_coupon): expose coupon name in serializer

### DIFF
--- a/app/serializers/v1/applied_coupon_serializer.rb
+++ b/app/serializers/v1/applied_coupon_serializer.rb
@@ -7,6 +7,7 @@ module V1
         lago_id: model.id,
         lago_coupon_id: model.coupon.id,
         coupon_code: model.coupon.code,
+        coupon_name: model.coupon.name,
         lago_customer_id: model.customer.id,
         external_customer_id: model.customer.external_id,
         status: model.status,

--- a/spec/serializers/v1/applied_coupon_serializer_spec.rb
+++ b/spec/serializers/v1/applied_coupon_serializer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ::V1::AppliedCouponSerializer do
       expect(result['applied_coupon']['lago_id']).to eq(applied_coupon.id)
       expect(result['applied_coupon']['lago_coupon_id']).to eq(applied_coupon.coupon.id)
       expect(result['applied_coupon']['coupon_code']).to eq(applied_coupon.coupon.code)
+      expect(result['applied_coupon']['coupon_name']).to eq(applied_coupon.coupon.name)
       expect(result['applied_coupon']['lago_customer_id']).to eq(applied_coupon.customer.id)
       expect(result['applied_coupon']['external_customer_id']).to eq(applied_coupon.customer.external_id)
       expect(result['applied_coupon']['status']).to eq(applied_coupon.status)


### PR DESCRIPTION
## Context

The `applied_coupon` object does not include `coupon_name`, so we need to use `coupon_code` and perform `GET /api/v1/coupons/:code` to retrieve the name of the applied coupon, which is not convenient.

## Description

This PR adds the `coupon_name` directly to the `applied_coupon_serializer`