### PR TITLE
fix(plan): Prevent error when creating a plan without interval

### DIFF
--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -9,7 +9,7 @@ module Plans
         code: args[:code],
         description: args[:description],
         parent_id: args[:parent_id],
-        interval: args[:interval].to_sym,
+        interval: args[:interval]&.to_sym,
         pay_in_advance: args[:pay_in_advance],
         amount_cents: args[:amount_cents],
         amount_currency: args[:amount_currency],


### PR DESCRIPTION
## Context

Plan creation via API is failing with an `HTTP 500` when no interval is provided in the input parameters when it should respond with an `HTTP 422`.

## Description

This PR uses the safe navigation operator to prevent error when trying to convert the provided value into a `symbol`. The service will automatically fail with a validation_error if no value is provided
