### PR TITLE
feat(invoices): display customer and orga legal_number

### DIFF
--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -311,6 +311,8 @@ html
               = organization.legal_name
             - else
               = organization.name
+          - if organization.legal_number.present?
+            .body-2 #{organization.legal_number}
           .body-2 = organization.address_line1
           .body-2 = organization.address_line2
           .body-2
@@ -332,6 +334,8 @@ html
               | #{customer.legal_name}
             - else
               | #{customer.name}
+          - if customer.legal_number.present?
+            .body-2 #{customer.legal_number}
           .body-2 = customer.address_line1
           .body-2 = customer.address_line2
           .body-2

--- a/app/views/templates/invoices/charge.slim
+++ b/app/views/templates/invoices/charge.slim
@@ -372,6 +372,8 @@ html
               | #{organization.legal_name}
             - else
               | #{organization.name}
+          - if organization.legal_number.present?
+            .body-2 #{organization.legal_number}
           .body-2 = organization.address_line1
           .body-2 = organization.address_line2
           .body-2
@@ -393,6 +395,8 @@ html
               | #{customer.legal_name}
             - else
               | #{customer.name}
+          - if customer.legal_number.present?
+            .body-2 #{customer.legal_number}
           .body-2 = customer.address_line1
           .body-2 = customer.address_line2
           .body-2

--- a/app/views/templates/invoices/one_off.slim
+++ b/app/views/templates/invoices/one_off.slim
@@ -372,6 +372,8 @@ html
               | #{organization.legal_name}
             - else
               | #{organization.name}
+          - if organization.legal_number.present?
+            .body-2 #{organization.legal_number}
           .body-2 = organization.address_line1
           .body-2 = organization.address_line2
           .body-2
@@ -393,6 +395,8 @@ html
               | #{customer.legal_name}
             - else
               | #{customer.name}
+          - if customer.legal_number.present?
+            .body-2 #{customer.legal_number}
           .body-2 = customer.address_line1
           .body-2 = customer.address_line2
           .body-2

--- a/app/views/templates/invoices/v3.slim
+++ b/app/views/templates/invoices/v3.slim
@@ -395,6 +395,8 @@ html
               | #{organization.legal_name}
             - else
               | #{organization.name}
+          - if organization.legal_number.present?
+            .body-2 #{organization.legal_number}
           .body-2 = organization.address_line1
           .body-2 = organization.address_line2
           .body-2
@@ -416,6 +418,8 @@ html
               | #{customer.legal_name}
             - else
               | #{customer.name}
+          - if customer.legal_number.present?
+            .body-2 #{customer.legal_number}
           .body-2 = customer.address_line1
           .body-2 = customer.address_line2
           .body-2


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/display-legal-number-on-pdf-invoice

## Context

We want to display the customer and organization's legal number in PDF documents when relevant.

## Description

This PR adds the legal number displayed for both customer and organization in the:
- credit notes PDF
- charge invoice PDF
- subscription PDF
- one-off (addOn) invoice PDF