### PR TITLE
feat(adyen refunds): Add adyen refunds

### DIFF
--- a/app/jobs/credit_notes/refunds/adyen_create_job.rb
+++ b/app/jobs/credit_notes/refunds/adyen_create_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  module Refunds
+    class AdyenCreateJob < ApplicationJob
+      queue_as 'providers'
+
+      def perform(credit_note)
+        result = CreditNotes::Refunds::AdyenService.new(credit_note).create
+        result.raise_if_error!
+      end
+    end
+  end
+end

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -184,6 +184,8 @@ module CreditNotes
         CreditNotes::Refunds::StripeCreateJob.perform_later(credit_note)
       when PaymentProviders::GocardlessProvider
         CreditNotes::Refunds::GocardlessCreateJob.perform_later(credit_note)
+      when PaymentProviders::AdyenProvider
+        CreditNotes::Refunds::AdyenCreateJob.perform_later(credit_note)
       end
     end
 

--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -66,7 +66,7 @@ module CreditNotes
         @client ||= Adyen::Client.new(
           api_key: payment.payment_provider.api_key,
           env: payment.payment_provider.environment,
-          live_url_prefix: payment.payment_provider.live_prefix
+          live_url_prefix: payment.payment_provider.live_prefix,
         )
       end
 
@@ -86,9 +86,9 @@ module CreditNotes
       end
 
       def create_adyen_refund
-        result = client.checkout.modifications_api.refund_captured_payment(
+        client.checkout.modifications_api.refund_captured_payment(
           adyen_refund_params,
-          payment.provider_payment_id
+          payment.provider_payment_id,
         )
       rescue Adyen::AdyenError => e
         deliver_error_webhook(message: e.msg, code: e.code)
@@ -103,8 +103,8 @@ module CreditNotes
           merchantAccount: payment.payment_provider.merchant_account,
           amount: {
             value: credit_note.refund_amount_cents,
-            currency: credit_note.credit_amount_currency.upcase
-          }
+            currency: credit_note.credit_amount_currency.upcase,
+          },
         }
       end
 

--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  module Refunds
+    class AdyenService < BaseService
+      def initialize(credit_note = nil)
+        @credit_note = credit_note
+
+        super
+      end
+
+      def create
+        result.credit_note = credit_note
+        return result unless should_process_refund?
+
+        adyen_result = create_adyen_refund
+
+        refund = Refund.new(
+          credit_note:,
+          payment:,
+          payment_provider: payment.payment_provider,
+          payment_provider_customer: payment.payment_provider_customer,
+          amount_cents: adyen_result.response.dig('amount', 'value'),
+          amount_currency: adyen_result.response.dig('amount', 'currency'),
+          status: 'pending',
+          provider_refund_id: adyen_result.response['pspReference'],
+        )
+        refund.save!
+
+        update_credit_note_status(refund.status)
+        track_refund_status_changed(refund.status)
+
+        result.refund = refund
+        result
+      end
+
+      def update_status(provider_refund_id:, status:, metadata: {})
+        refund = Refund.find_by(provider_refund_id:)
+        return handle_missing_refund(metadata) unless refund
+
+        result.refund = refund
+        @credit_note = result.credit_note = refund.credit_note
+        return result if refund.credit_note.succeeded?
+
+        refund.update!(status:)
+        update_credit_note_status(status)
+        track_refund_status_changed(status)
+
+        if status.to_sym == :failed
+          deliver_error_webhook(message: 'Payment refund failed', code: nil)
+          result.service_failure!(code: 'refund_failed', message: 'Refund failed to perform')
+        end
+
+        result
+      rescue ArgumentError
+        result.single_validation_failure!(field: :refund_status, error_code: 'value_is_invalid')
+      end
+
+      private
+
+      attr_accessor :credit_note
+
+      delegate :organization, :customer, :invoice, to: :credit_note
+
+      def client
+        @client ||= Adyen::Client.new(
+          api_key: payment.payment_provider.api_key,
+          env: payment.payment_provider.environment,
+          live_url_prefix: payment.payment_provider.live_prefix
+        )
+      end
+
+      def should_process_refund?
+        return false unless credit_note.refunded?
+        return false if credit_note.succeeded?
+
+        payment.present?
+      end
+
+      def payment
+        @payment ||= credit_note.invoice.payments.order(created_at: :desc).first
+      end
+
+      def adyen_api_key
+        organization.adyen_payment_provider.secret_key
+      end
+
+      def create_adyen_refund
+        result = client.checkout.modifications_api.refund_captured_payment(
+          adyen_refund_params,
+          payment.provider_payment_id
+        )
+      rescue Adyen::AdyenError => e
+        deliver_error_webhook(message: e.msg, code: e.code)
+        update_credit_note_status(:failed)
+
+        raise
+      end
+
+      def adyen_refund_params
+        {
+          paymentPspReference: payment.provider_payment_id,
+          merchantAccount: payment.payment_provider.merchant_account,
+          amount: {
+            value: credit_note.refund_amount_cents,
+            currency: credit_note.credit_amount_currency.upcase
+          }
+        }
+      end
+
+      def deliver_error_webhook(message:, code:)
+        return unless organization.webhook_url?
+
+        SendWebhookJob.perform_later(
+          'credit_note.provider_refund_failure',
+          credit_note,
+          provider_customer_id: customer.adyen_customer.provider_customer_id,
+          provider_error: {
+            message:,
+            error_code: code,
+          },
+        )
+      end
+
+      def update_credit_note_status(status)
+        credit_note.refund_status = status
+        credit_note.refunded_at = Time.current if credit_note.succeeded?
+        credit_note.save!
+      end
+
+      def track_refund_status_changed(status)
+        SegmentTrackJob.perform_later(
+          membership_id: CurrentContext.membership,
+          event: 'refund_status_changed',
+          properties: {
+            organization_id: organization.id,
+            credit_note_id: credit_note.id,
+            refund_status: status,
+          },
+        )
+      end
+
+      def handle_missing_refund(metadata)
+        # NOTE: Refund was not initiated by lago
+        return result unless metadata&.key?(:lago_invoice_id)
+
+        # NOTE: Invoice does not belongs to this lago instance
+        return result unless Invoice.find_by(id: metadata[:lago_invoice_id])
+
+        result.not_found_failure!(resource: 'adyen_refund')
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -64,6 +64,23 @@ module PaymentProviders
 
         result = service.preauthorise(organization, event)
         result.raise_if_error! || result
+      when 'REFUND'
+        service = CreditNotes::Refunds::AdyenService.new
+
+        provider_refund_id = event["pspReference"]
+        status = event["success"] == "true" ? :succeeded : :failed
+
+        result = service.update_status(provider_refund_id:, status:)
+        result.raise_if_error! || result
+      when 'REFUND_FAILED'
+        return result if event["success"] != "true"
+
+        service = CreditNotes::Refunds::AdyenService.new
+
+        provider_refund_id = event["pspReference"]
+
+        result = service.update_status(provider_refund_id:, status: :failed)
+        result.raise_if_error! || result
       end
     end
 

--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -67,17 +67,17 @@ module PaymentProviders
       when 'REFUND'
         service = CreditNotes::Refunds::AdyenService.new
 
-        provider_refund_id = event["pspReference"]
-        status = event["success"] == "true" ? :succeeded : :failed
+        provider_refund_id = event['pspReference']
+        status = (event['success'] == 'true') ? :succeeded : :failed
 
         result = service.update_status(provider_refund_id:, status:)
         result.raise_if_error! || result
       when 'REFUND_FAILED'
-        return result if event["success"] != "true"
+        return result if event['success'] != 'true'
 
         service = CreditNotes::Refunds::AdyenService.new
 
-        provider_refund_id = event["pspReference"]
+        provider_refund_id = event['pspReference']
 
         result = service.update_status(provider_refund_id:, status: :failed)
         result.raise_if_error! || result

--- a/spec/factories/refund_responses.rb
+++ b/spec/factories/refund_responses.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  sequence :adyen_refunds_response do
+    OpenStruct.new(
+      response: {
+        "merchantAccount" => "#{SecureRandom.uuid}",
+        "pspReference" => "#{SecureRandom.uuid}",
+        "paymentPspReference" => "#{SecureRandom.uuid}",
+        "status" => "received",
+        "amount" => {
+            "currency" => "CHF",
+            "value" => 134
+        }
+      }
+    )
+  end
+end

--- a/spec/factories/refund_responses.rb
+++ b/spec/factories/refund_responses.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   sequence :adyen_refunds_response do
     OpenStruct.new(
       response: {
-        "merchantAccount" => "#{SecureRandom.uuid}",
-        "pspReference" => "#{SecureRandom.uuid}",
-        "paymentPspReference" => "#{SecureRandom.uuid}",
-        "status" => "received",
-        "amount" => {
-            "currency" => "CHF",
-            "value" => 134
-        }
+        'merchantAccount' => SecureRandom.uuid,
+        'pspReference' => SecureRandom.uuid,
+        'paymentPspReference' => SecureRandom.uuid,
+        'status' => 'received',
+        'amount' => {
+          'currency' => 'CHF',
+          'value' => 134,
+        },
       }
     )
   end

--- a/spec/factories/refund_responses.rb
+++ b/spec/factories/refund_responses.rb
@@ -12,7 +12,7 @@ FactoryBot.define do
           'currency' => 'CHF',
           'value' => 134,
         },
-      }
+      },
     )
   end
 end

--- a/spec/fixtures/adyen/webhook_refund_response.json
+++ b/spec/fixtures/adyen/webhook_refund_response.json
@@ -1,0 +1,25 @@
+{
+  "live": "false",
+  "notificationItems": [
+    {
+      "NotificationRequestItem": {
+        "additionalData": {
+          "bookingDate": "2023-05-13T18:03:05Z"
+        },
+        "amount": {
+          "currency": "USD",
+          "value": 1000
+        },
+        "eventCode": "REFUND",
+        "eventDate": "2023-05-13T18:02:30+02:00",
+        "merchantAccountCode": "Lago",
+        "merchantReference": "2280c3e7-569c-4346-893d-12a23798322e",
+        "originalReference": "ABCDEFGH",
+        "paymentMethod": "amex",
+        "pspReference": "ABCDEFGH",
+        "reason": "",
+        "success": "true"
+      }
+    }
+  ]
+}

--- a/spec/jobs/credit_notes/refunds/adyen_create_job_spec.rb
+++ b/spec/jobs/credit_notes/refunds/adyen_create_job_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::Refunds::AdyenCreateJob, type: :job do
+  let(:credit_note) { create(:credit_note) }
+
+  let(:refund_service) do
+    instance_double(CreditNotes::Refunds::AdyenService)
+  end
+
+  it 'delegates to the adyen refund service' do
+    allow(CreditNotes::Refunds::AdyenService).to receive(:new)
+      .with(credit_note)
+      .and_return(refund_service)
+    allow(refund_service).to receive(:create)
+      .and_return(BaseService::Result.new)
+
+    described_class.perform_now(credit_note)
+
+    expect(CreditNotes::Refunds::AdyenService).to have_received(:new)
+    expect(refund_service).to have_received(:create)
+  end
+end

--- a/spec/services/credit_notes/refunds/adyen_service_spec.rb
+++ b/spec/services/credit_notes/refunds/adyen_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
       invoice:,
       refund_amount_cents: 134,
       refund_amount_currency: 'CHF',
-      refund_status: :pending
+      refund_status: :pending,
     )
   end
 

--- a/spec/services/credit_notes/refunds/adyen_service_spec.rb
+++ b/spec/services/credit_notes/refunds/adyen_service_spec.rb
@@ -1,0 +1,293 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
+  subject(:adyen_service) { described_class.new(credit_note) }
+
+  let(:customer) { create(:customer) }
+  let(:organization) { customer.organization }
+  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:adyen_payment_provider) { create(:adyen_provider, organization:) }
+  let(:adyen_customer) { create(:adyen_customer, customer:) }
+  let(:adyen_client) { instance_double(Adyen::Client) }
+  let(:modifications_api) { Adyen::ModificationsApi.new(adyen_client, 70) }
+  let(:checkout) { Adyen::Checkout.new(adyen_client, 70) }
+  let(:refunds_response) { generate(:adyen_refunds_response) }
+
+  let(:payment) do
+    create(
+      :payment,
+      payment_provider: adyen_payment_provider,
+      payment_provider_customer: adyen_customer,
+      amount_cents: 200,
+      amount_currency: 'CHF',
+      invoice: credit_note.invoice,
+    )
+  end
+
+  let(:credit_note) do
+    create(
+      :credit_note,
+      customer:,
+      invoice:,
+      refund_amount_cents: 134,
+      refund_amount_currency: 'CHF',
+      refund_status: :pending
+    )
+  end
+
+  describe '#create' do
+    before do
+      payment
+
+      allow(Adyen::Client).to receive(:new)
+        .and_return(adyen_client)
+      allow(adyen_client).to receive(:checkout)
+        .and_return(checkout)
+      allow(checkout).to receive(:modifications_api)
+        .and_return(modifications_api)
+      allow(modifications_api).to receive(:refund_captured_payment)
+        .and_return(refunds_response)
+      allow(SegmentTrackJob).to receive(:perform_later)
+    end
+
+    it 'creates a adyen refund and a refund' do
+      result = adyen_service.create
+
+      aggregate_failures do
+        expect(result).to be_success
+
+        expect(result.refund.id).to be_present
+
+        expect(result.refund.credit_note).to eq(credit_note)
+        expect(result.refund.payment).to eq(payment)
+        expect(result.refund.payment_provider).to eq(adyen_payment_provider)
+        expect(result.refund.payment_provider_customer).to eq(adyen_customer)
+        expect(result.refund.amount_cents).to eq(134)
+        expect(result.refund.amount_currency).to eq('CHF')
+        expect(result.refund.status).to eq('pending')
+        expect(result.refund.provider_refund_id).to eq(refunds_response.response['pspReference'])
+
+        expect(result.credit_note).not_to be_succeeded
+        expect(result.credit_note.refunded_at).not_to be_present
+      end
+    end
+
+    it 'call SegmentTrackJob' do
+      adyen_service.create
+
+      expect(SegmentTrackJob).to have_received(:perform_later).with(
+        membership_id: CurrentContext.membership,
+        event: 'refund_status_changed',
+        properties: {
+          organization_id: credit_note.organization.id,
+          credit_note_id: credit_note.id,
+          refund_status: 'pending',
+        },
+      )
+    end
+
+    context 'with an error on adyen' do
+      before do
+        allow(modifications_api).to receive(:refund_captured_payment)
+          .and_raise(Adyen::AdyenError.new(nil, nil, 'error'))
+      end
+
+      it 'delivers an error webhook' do
+        expect { adyen_service.create }
+          .to raise_error(Adyen::AdyenError)
+
+        expect(SendWebhookJob).to have_been_enqueued
+          .with(
+            'credit_note.provider_refund_failure',
+            credit_note,
+            provider_customer_id: adyen_customer.provider_customer_id,
+            provider_error: {
+              message: 'error',
+              error_code: nil,
+            },
+          )
+      end
+    end
+
+    context 'when credit note does not have a refund amount' do
+      let(:credit_note) do
+        create(
+          :credit_note,
+          customer:,
+          refund_amount_cents: 0,
+          refund_amount_currency: 'CHF',
+        )
+      end
+
+      it 'does not create a refund' do
+        result = adyen_service.create
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.credit_note).to eq(credit_note)
+          expect(result.refund).to be_nil
+
+          expect(modifications_api).not_to have_received(:refund_captured_payment)
+        end
+      end
+    end
+
+    context 'when invoice does not have a payment' do
+      let(:payment) { nil }
+
+      it 'does not create a refund' do
+        result = adyen_service.create
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.credit_note).to eq(credit_note)
+          expect(result.refund).to be_nil
+
+          expect(modifications_api).not_to have_received(:refund_captured_payment)
+        end
+      end
+    end
+  end
+
+  describe '#update_status' do
+    let(:refund) do
+      create(:refund, credit_note:)
+    end
+
+    before { credit_note.pending! }
+
+    it 'updates the refund status' do
+      result = adyen_service.update_status(
+        provider_refund_id: refund.provider_refund_id,
+        status: 'succeeded',
+      )
+
+      aggregate_failures do
+        expect(result).to be_success
+
+        expect(result.refund).to eq(refund)
+        expect(result.refund.status).to eq('succeeded')
+
+        expect(result.credit_note).to be_succeeded
+      end
+    end
+
+    it 'calls SegmentTrackJob' do
+      allow(SegmentTrackJob).to receive(:perform_later)
+
+      adyen_service.update_status(
+        provider_refund_id: refund.provider_refund_id,
+        status: 'succeeded',
+      )
+
+      expect(SegmentTrackJob).to have_received(:perform_later).with(
+        membership_id: CurrentContext.membership,
+        event: 'refund_status_changed',
+        properties: {
+          organization_id: credit_note.organization.id,
+          credit_note_id: credit_note.id,
+          refund_status: 'succeeded',
+        },
+      )
+    end
+
+    context 'when refund is not found' do
+      let(:refund) { nil }
+
+      it 'returns an empty result' do
+        result = adyen_service.update_status(
+          provider_refund_id: 'foo',
+          status: 'succeeded',
+        )
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.refund).to be_nil
+        end
+      end
+
+      context 'with invoice id in metadata' do
+        it 'returns an empty result' do
+          result = adyen_service.update_status(
+            provider_refund_id: 'foo',
+            status: 'succeeded',
+            metadata: { lago_invoice_id: SecureRandom.uuid },
+          )
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.refund).to be_nil
+          end
+        end
+
+        context 'when invoice belongs to lago' do
+          let(:invoice) { create(:invoice) }
+
+          it 'returns a not found failure' do
+            result = adyen_service.update_status(
+              provider_refund_id: 're_123456',
+              status: 'succeeded',
+              metadata: { lago_invoice_id: invoice.id },
+            )
+
+            aggregate_failures do
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::NotFoundFailure)
+              expect(result.error.message).to eq('adyen_refund_not_found')
+            end
+          end
+        end
+      end
+    end
+
+    context 'when status is not valid' do
+      it 'fails' do
+        result = adyen_service.update_status(
+          provider_refund_id: refund.provider_refund_id,
+          status: 'invalid',
+        )
+
+        aggregate_failures do
+          expect(result).not_to be_success
+
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:refund_status]).to include('value_is_invalid')
+        end
+      end
+    end
+
+    context 'when status is failed' do
+      before { adyen_customer }
+
+      it 'delivers an error webhook' do
+        result = adyen_service.update_status(
+          provider_refund_id: refund.provider_refund_id,
+          status: 'failed',
+        )
+
+        aggregate_failures do
+          expect(result).not_to be_success
+
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq('refund_failed')
+          expect(result.error.error_message).to eq('Refund failed to perform')
+
+          expect(SendWebhookJob).to have_been_enqueued
+            .with(
+              'credit_note.provider_refund_failure',
+              credit_note,
+              provider_customer_id: adyen_customer.provider_customer_id,
+              provider_error: {
+                message: 'Payment refund failed',
+                error_code: nil,
+              },
+            )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/payment_providers/adyen_service_spec.rb
+++ b/spec/services/payment_providers/adyen_service_spec.rb
@@ -145,8 +145,8 @@ RSpec.describe PaymentProviders::AdyenService, type: :service do
       let(:refund_service) { instance_double(CreditNotes::Refunds::AdyenService) }
 
       let(:event_json) do
-        JSON.parse(event_response_json)['notificationItems'].
-          first&.dig('NotificationRequestItem').to_json
+        JSON.parse(event_response_json)['notificationItems']
+          .first&.dig('NotificationRequestItem').to_json
       end
 
       let(:event_response_json) do

--- a/spec/services/payment_providers/adyen_service_spec.rb
+++ b/spec/services/payment_providers/adyen_service_spec.rb
@@ -140,5 +140,33 @@ RSpec.describe PaymentProviders::AdyenService, type: :service do
         expect(payment_provider_service).to have_received(:preauthorise)
       end
     end
+
+    context 'when succeeded refund event' do
+      let(:refund_service) { instance_double(CreditNotes::Refunds::AdyenService) }
+
+      let(:event_json) do
+        JSON.parse(event_response_json)['notificationItems'].
+          first&.dig('NotificationRequestItem').to_json
+      end
+
+      let(:event_response_json) do
+        path = Rails.root.join('spec/fixtures/adyen/webhook_refund_response.json')
+        File.read(path)
+      end
+
+      before do
+        allow(CreditNotes::Refunds::AdyenService).to receive(:new)
+          .and_return(refund_service)
+        allow(refund_service).to receive(:update_status)
+          .and_return(service_result)
+      end
+
+      it 'routes the event to an other service' do
+        adyen_service.handle_event(organization:, event_json:)
+
+        expect(CreditNotes::Refunds::AdyenService).to have_received(:new)
+        expect(refund_service).to have_received(:update_status)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/support-integration-with-adyen

## Context

Adyen provides payment apis for card and other payments.

## Description

Add Adyen as a payment provider supported natively