### PR TITLE
Move boundaries from properties on invoice_subscriptions

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -32,6 +32,11 @@ module Invoices
             invoice:,
             subscription:,
             properties: boundaries,
+            timestamp: boundaries[:timestamp],
+            from_datetime: boundaries[:from_datetime],
+            to_datetime: boundaries[:to_datetime],
+            charges_from_datetime: boundaries[:charges_from_datetime],
+            charges_to_datetime: boundaries[:charges_to_datetime],
             recurring:,
           )
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -219,7 +219,7 @@ module Invoices
         to_datetime: date_service.to_datetime,
         charges_from_datetime: date_service.charges_from_datetime,
         charges_to_datetime: date_service.charges_to_datetime,
-        timestamp:,
+        timestamp: Time.zone.at(timestamp),
       }
     end
 

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -27,6 +27,7 @@ module Invoices
         InvoiceSubscription.create!(
           invoice:,
           subscription: event.subscription,
+          timestamp:,
           recurring: false,
         )
 

--- a/db/migrate/20230602090325_add_boundaries_to_invoice_subscriptions.rb
+++ b/db/migrate/20230602090325_add_boundaries_to_invoice_subscriptions.rb
@@ -20,12 +20,12 @@ class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
           THEN CASE
             WHEN properties->>'timestamp' ~ '^[0-9\.]+$' /* unix timestamp */
             THEN
-              to_timestamp((properties->>'timestamp')::integer)::timestamp(0)
+              to_timestamp((properties->>'timestamp')::integer)::timestamp
             ELSE
-              (properties->>'timestamp')::timestamp(0)
+              (properties->>'timestamp')::timestamp
             END
           ELSE
-            created_at::timestamp(0)
+            created_at::timestamp
           END);
 
           UPDATE invoice_subscriptions
@@ -35,9 +35,9 @@ class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
             THEN CASE
               WHEN properties->>'timestamp' ~ '^[0-9\.]+$' /* unix timestamp */
               THEN
-                to_timestamp((properties->>'timestamp')::integer)::timestamp(0)
+                to_timestamp((properties->>'timestamp')::integer)::timestamp
               ELSE
-                (properties->>'timestamp')::timestamp(0)
+                (properties->>'timestamp')::timestamp
               END
             ELSE /* null timestamp */
               (SELECT(properties->>'timestamp')
@@ -45,7 +45,7 @@ class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
               WHERE fees.subscription_id = invoice_subscriptions.subscription_id
               AND fees.invoice_id = invoice_subscriptions.invoice_id
               ORDER BY fees.created_at ASC
-              LIMIT 1)::timestamp(0)
+              LIMIT 1)::timestamp
             END,
           /* Set from_datetime on invoice_subscriptions */
           from_datetime = CASE
@@ -53,9 +53,9 @@ class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
             THEN CASE
               WHEN properties->>'from_datetime' ~ '^[0-9\.]+$' /* unix timestamp */
               THEN
-                to_timestamp((properties->>'from_datetime')::integer)::timestamp(0)
+                to_timestamp((properties->>'from_datetime')::integer)::timestamp
               ELSE
-                (properties->>'from_datetime')::timestamp(0)
+                (properties->>'from_datetime')::timestamp
               END
             ELSE /* null timestamp */
               (SELECT(properties->>'from_datetime')
@@ -63,7 +63,7 @@ class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
               WHERE fees.subscription_id = invoice_subscriptions.subscription_id
               AND fees.invoice_id = invoice_subscriptions.invoice_id
               ORDER BY fees.created_at ASC
-              LIMIT 1)::timestamp(0)
+              LIMIT 1)::timestamp
             END,
           /* Set to_datetime on invoice_subscriptions */
           to_datetime = CASE
@@ -71,9 +71,9 @@ class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
             THEN CASE
               WHEN properties->>'to_datetime' ~ '^[0-9\.]+$' /* unix timestamp */
               THEN
-                to_timestamp((properties->>'to_datetime')::integer)::timestamp(0)
+                to_timestamp((properties->>'to_datetime')::integer)::timestamp
               ELSE
-                (properties->>'to_datetime')::timestamp(0)
+                (properties->>'to_datetime')::timestamp
               END
             ELSE /* null timestamp */
               (SELECT(properties->>'to_datetime')
@@ -81,7 +81,7 @@ class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
               WHERE fees.subscription_id = invoice_subscriptions.subscription_id
               AND fees.invoice_id = invoice_subscriptions.invoice_id
               ORDER BY fees.created_at ASC
-              LIMIT 1)::timestamp(0)
+              LIMIT 1)::timestamp
             END,
           /* Set charges_from_datetime on invoice_subscriptions */
           charges_from_datetime = CASE
@@ -89,9 +89,9 @@ class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
             THEN CASE
               WHEN properties->>'charges_from_datetime' ~ '^[0-9\.]+$' /* unix timestamp */
               THEN
-                to_timestamp((properties->>'charges_from_datetime')::integer)::timestamp(0)
+                to_timestamp((properties->>'charges_from_datetime')::integer)::timestamp
               ELSE
-                (properties->>'charges_from_datetime')::timestamp(0)
+                (properties->>'charges_from_datetime')::timestamp
               END
             ELSE /* null timestamp */
               (SELECT(properties->>'charges_from_datetime')
@@ -99,7 +99,7 @@ class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
               WHERE fees.subscription_id = invoice_subscriptions.subscription_id
               AND fees.invoice_id = invoice_subscriptions.invoice_id
               ORDER BY fees.created_at ASC
-              LIMIT 1)::timestamp(0)
+              LIMIT 1)::timestamp
             END,
           /* Set charges_to_datetime on invoice_subscriptions */
           charges_to_datetime = CASE
@@ -107,9 +107,9 @@ class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
             THEN CASE
               WHEN properties->>'charges_to_datetime' ~ '^[0-9\.]+$' /* unix timestamp */
               THEN
-                to_timestamp((properties->>'charges_to_datetime')::integer)::timestamp(0)
+                to_timestamp((properties->>'charges_to_datetime')::integer)::timestamp
               ELSE
-                (properties->>'charges_to_datetime')::timestamp(0)
+                (properties->>'charges_to_datetime')::timestamp
               END
             ELSE /* null timestamp */
               (SELECT(properties->>'charges_to_datetime')
@@ -117,7 +117,7 @@ class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
               WHERE fees.subscription_id = invoice_subscriptions.subscription_id
               AND fees.invoice_id = invoice_subscriptions.invoice_id
               ORDER BY fees.created_at ASC
-              LIMIT 1)::timestamp(0)
+              LIMIT 1)::timestamp
             END
         SQL
       end

--- a/db/migrate/20230602090325_add_boundaries_to_invoice_subscriptions.rb
+++ b/db/migrate/20230602090325_add_boundaries_to_invoice_subscriptions.rb
@@ -1,6 +1,3 @@
-# TODO:
-# [] Use datetime instead of timestamp when setting fees
-
 # frozen_string_literal: true
 
 class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]

--- a/db/migrate/20230602090325_add_boundaries_to_invoice_subscriptions.rb
+++ b/db/migrate/20230602090325_add_boundaries_to_invoice_subscriptions.rb
@@ -1,0 +1,129 @@
+# TODO:
+# [] Use datetime instead of timestamp when setting fees
+
+# frozen_string_literal: true
+
+class AddBoundariesToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    change_table(:invoice_subscriptions, bulk: true) do |t|
+      t.column :timestamp, :datetime
+      t.column :from_datetime, :datetime
+      t.column :to_datetime, :datetime
+      t.column :charges_from_datetime, :datetime
+      t.column :charges_to_datetime, :datetime
+    end
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          /* Unify fees->timestamp to be a required timestamp */
+          UPDATE fees
+          SET properties['timestamp'] = to_jsonb(CASE
+          WHEN properties?'timestamp'
+          THEN CASE
+            WHEN properties->>'timestamp' ~ '^[0-9\.]+$' /* unix timestamp */
+            THEN
+              to_timestamp((properties->>'timestamp')::integer)::timestamp(0)
+            ELSE
+              (properties->>'timestamp')::timestamp(0)
+            END
+          ELSE
+            created_at::timestamp(0)
+          END);
+
+          UPDATE invoice_subscriptions
+          /* Set timestamp on invoice_subscriptions */
+          SET timestamp = CASE
+            WHEN properties?'timestamp'
+            THEN CASE
+              WHEN properties->>'timestamp' ~ '^[0-9\.]+$' /* unix timestamp */
+              THEN
+                to_timestamp((properties->>'timestamp')::integer)::timestamp(0)
+              ELSE
+                (properties->>'timestamp')::timestamp(0)
+              END
+            ELSE /* null timestamp */
+              (SELECT(properties->>'timestamp')
+              FROM fees
+              WHERE fees.subscription_id = invoice_subscriptions.subscription_id
+              AND fees.invoice_id = invoice_subscriptions.invoice_id
+              ORDER BY fees.created_at ASC
+              LIMIT 1)::timestamp(0)
+            END,
+          /* Set from_datetime on invoice_subscriptions */
+          from_datetime = CASE
+            WHEN properties?'from_datetime'
+            THEN CASE
+              WHEN properties->>'from_datetime' ~ '^[0-9\.]+$' /* unix timestamp */
+              THEN
+                to_timestamp((properties->>'from_datetime')::integer)::timestamp(0)
+              ELSE
+                (properties->>'from_datetime')::timestamp(0)
+              END
+            ELSE /* null timestamp */
+              (SELECT(properties->>'from_datetime')
+              FROM fees
+              WHERE fees.subscription_id = invoice_subscriptions.subscription_id
+              AND fees.invoice_id = invoice_subscriptions.invoice_id
+              ORDER BY fees.created_at ASC
+              LIMIT 1)::timestamp(0)
+            END,
+          /* Set to_datetime on invoice_subscriptions */
+          to_datetime = CASE
+            WHEN properties?'to_datetime'
+            THEN CASE
+              WHEN properties->>'to_datetime' ~ '^[0-9\.]+$' /* unix timestamp */
+              THEN
+                to_timestamp((properties->>'to_datetime')::integer)::timestamp(0)
+              ELSE
+                (properties->>'to_datetime')::timestamp(0)
+              END
+            ELSE /* null timestamp */
+              (SELECT(properties->>'to_datetime')
+              FROM fees
+              WHERE fees.subscription_id = invoice_subscriptions.subscription_id
+              AND fees.invoice_id = invoice_subscriptions.invoice_id
+              ORDER BY fees.created_at ASC
+              LIMIT 1)::timestamp(0)
+            END,
+          /* Set charges_from_datetime on invoice_subscriptions */
+          charges_from_datetime = CASE
+            WHEN properties?'charges_from_datetime'
+            THEN CASE
+              WHEN properties->>'charges_from_datetime' ~ '^[0-9\.]+$' /* unix timestamp */
+              THEN
+                to_timestamp((properties->>'charges_from_datetime')::integer)::timestamp(0)
+              ELSE
+                (properties->>'charges_from_datetime')::timestamp(0)
+              END
+            ELSE /* null timestamp */
+              (SELECT(properties->>'charges_from_datetime')
+              FROM fees
+              WHERE fees.subscription_id = invoice_subscriptions.subscription_id
+              AND fees.invoice_id = invoice_subscriptions.invoice_id
+              ORDER BY fees.created_at ASC
+              LIMIT 1)::timestamp(0)
+            END,
+          /* Set charges_to_datetime on invoice_subscriptions */
+          charges_to_datetime = CASE
+            WHEN properties?'charges_to_datetime'
+            THEN CASE
+              WHEN properties->>'charges_to_datetime' ~ '^[0-9\.]+$' /* unix timestamp */
+              THEN
+                to_timestamp((properties->>'charges_to_datetime')::integer)::timestamp(0)
+              ELSE
+                (properties->>'charges_to_datetime')::timestamp(0)
+              END
+            ELSE /* null timestamp */
+              (SELECT(properties->>'charges_to_datetime')
+              FROM fees
+              WHERE fees.subscription_id = invoice_subscriptions.subscription_id
+              AND fees.invoice_id = invoice_subscriptions.invoice_id
+              ORDER BY fees.created_at ASC
+              LIMIT 1)::timestamp(0)
+            END
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_29_093955) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_02_090325) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -417,6 +417,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_29_093955) do
     t.datetime "updated_at", null: false
     t.jsonb "properties", default: "{}", null: false
     t.boolean "recurring"
+    t.datetime "timestamp", precision: nil
+    t.datetime "from_datetime", precision: nil
+    t.datetime "to_datetime", precision: nil
+    t.datetime "charges_from_datetime", precision: nil
+    t.datetime "charges_to_datetime", precision: nil
     t.index ["invoice_id"], name: "index_invoice_subscriptions_on_invoice_id"
     t.index ["subscription_id"], name: "index_invoice_subscriptions_on_subscription_id"
   end

--- a/lib/tasks/invoices.rake
+++ b/lib/tasks/invoices.rake
@@ -19,7 +19,7 @@ namespace :invoices do
 
       next if invoice_subscription
 
-      InvoiceSubscription.create!(invoice_id: invoice.id, subscription_id:)
+      InvoiceSubscription.create!(invoice_id: invoice.id, subscription_id:, timestamp: Time.current)
     end
   end
 

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -80,6 +80,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           invoice_subscription = invoice.invoice_subscriptions.first
           expect(invoice_subscription.properties['to_datetime']).to match_datetime('2022-03-05 23:59:59')
           expect(invoice_subscription.properties['from_datetime']).to match_datetime('2022-02-06 00:00:00')
+
+          expect(invoice_subscription).to have_attributes(
+            to_datetime: DateTime.parse('2022-03-05 23:59:59'),
+            from_datetime: DateTime.parse('2022-02-06 00:00:00'),
+          )
         end
       end
 
@@ -146,6 +151,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             .to match_datetime((timestamp - 1.day).end_of_day)
           expect(invoice_subscription.properties['from_datetime'])
             .to match_datetime(subscription.subscription_at.beginning_of_day)
+
+          expect(invoice_subscription).to have_attributes(
+            to_datetime: (timestamp - 1.day).end_of_day.to_datetime,
+            from_datetime: subscription.subscription_at.beginning_of_day,
+          )
         end
       end
     end
@@ -178,6 +188,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             .to match_datetime((timestamp - 1.day).end_of_day)
           expect(invoice_subscription.properties['from_datetime'])
             .to match_datetime((timestamp - 1.month).beginning_of_day)
+
+          expect(invoice_subscription).to have_attributes(
+            to_datetime: (timestamp - 1.day).end_of_day.to_datetime,
+            from_datetime: (timestamp - 1.month).beginning_of_day,
+          )
         end
       end
     end
@@ -200,6 +215,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             .to match_datetime(terminated_at)
           expect(invoice_subscription.properties['from_datetime'])
             .to match_datetime(terminated_at.beginning_of_month)
+
+          expect(invoice_subscription).to have_attributes(
+            to_datetime: match_datetime(terminated_at),
+            from_datetime: match_datetime(terminated_at.beginning_of_month),
+          )
         end
       end
 
@@ -221,6 +241,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               .to match_datetime(terminated_at)
             expect(invoice_subscription.properties['from_datetime'])
               .to match_datetime('2022-03-06 00:00:00')
+
+            expect(invoice_subscription).to have_attributes(
+              to_datetime: match_datetime(terminated_at),
+              from_datetime: DateTime.parse('2022-03-06 00:00:00'),
+            )
           end
         end
       end
@@ -248,6 +273,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             invoice_subscription = invoice.invoice_subscriptions.first
             expect(invoice_subscription.properties['to_datetime']).to match_datetime('2022-04-05 23:59:59')
             expect(invoice_subscription.properties['from_datetime']).to match_datetime('2022-03-06 00:00:00')
+
+            expect(invoice_subscription).to have_attributes(
+              to_datetime: DateTime.parse('2022-04-05 23:59:59'),
+              from_datetime: DateTime.parse('2022-03-06 00:00:00'),
+            )
           end
         end
       end
@@ -339,6 +369,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               .to match_datetime(subscription.started_at.end_of_month)
             expect(invoice_subscription.properties['from_datetime'])
               .to match_datetime(subscription.started_at)
+
+            expect(invoice_subscription).to have_attributes(
+              to_datetime: subscription.started_at.end_of_month.to_datetime,
+              from_datetime: subscription.started_at,
+            )
           end
         end
       end
@@ -389,6 +424,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             invoice_subscription = invoice.invoice_subscriptions.first
             expect(invoice_subscription.properties['charges_from_datetime']).to match_datetime('2022-10-01 00:00:00')
             expect(invoice_subscription.properties['charges_to_datetime']).to match_datetime(terminated_at)
+
+            expect(invoice_subscription).to have_attributes(
+              charges_from_datetime: DateTime.parse('2022-10-01 00:00:00'),
+              charges_to_datetime: terminated_at,
+            )
           end
         end
       end
@@ -413,6 +453,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             .to match_datetime((timestamp - 1.day).end_of_day)
           expect(invoice_subscription.properties['from_datetime'])
             .to match_datetime((timestamp - 1.year).beginning_of_day)
+
+          expect(invoice_subscription).to have_attributes(
+            to_datetime: (timestamp - 1.day).end_of_day.to_datetime,
+            from_datetime: (timestamp - 1.year).beginning_of_day,
+          )
         end
       end
 
@@ -435,6 +480,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             invoice_subscription = invoice.invoice_subscriptions.first
             expect(invoice_subscription.properties['to_datetime']).to match_datetime('2022-06-05 23:59:59')
             expect(invoice_subscription.properties['from_datetime']).to match_datetime('2021-06-06 00:00:00')
+
+            expect(invoice_subscription).to have_attributes(
+              to_datetime: DateTime.parse('2022-06-05 23:59:59'),
+              from_datetime: DateTime.parse('2021-06-06 00:00:00'),
+            )
           end
         end
 
@@ -454,6 +504,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription.properties['to_datetime']).to match_datetime('2023-06-05 23:59:59')
               expect(invoice_subscription.properties['from_datetime']).to match_datetime('2022-06-06 00:00:00')
+
+              expect(invoice_subscription).to have_attributes(
+                to_datetime: DateTime.parse('2023-06-05 23:59:59'),
+                from_datetime: DateTime.parse('2022-06-06 00:00:00'),
+              )
             end
           end
         end
@@ -477,6 +532,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             expect(invoice_subscription.properties['to_datetime']).to match_datetime((timestamp - 1.day).end_of_day)
             expect(invoice_subscription.properties['from_datetime'])
               .to match_datetime(subscription.subscription_at.beginning_of_day)
+
+            expect(invoice_subscription).to have_attributes(
+              to_datetime: (timestamp - 1.day).end_of_day.to_datetime,
+              from_datetime: subscription.subscription_at.beginning_of_day,
+            )
           end
         end
       end


### PR DESCRIPTION
The goal of this PR is to:
- Unify `fees->timestamp` to be a required `timestamp`
- Create and set `timestamp` on `invoice_subscriptions`
- Create and set `from_datetime` on `invoice_subscriptions`
- Create and set `to_datetime` on `invoice_subscriptions`
- Create and set `charges_from_datetime` on `invoice_subscriptions`
- Create and set `charges_to_datetime` on `invoice_subscriptions`