### PR TITLE
feat (recurring-bm): Update sum aggregation

### DIFF
--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -68,15 +68,17 @@ module BillableMetrics
 
         old_max = BigDecimal(previous_event.metadata['max_aggregation'])
 
-        if current_aggregation > old_max
+        result = if current_aggregation > old_max
           update_event_metadata(current_aggregation:, max_aggregation: current_aggregation)
 
-          return BigDecimal(current_aggregation - old_max)
+          current_aggregation - old_max
         else
           update_event_metadata(current_aggregation:, max_aggregation: old_max)
 
-          return BigDecimal(0)
+          0
         end
+
+        BigDecimal(result)
       end
 
       private

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -4,7 +4,9 @@ module BillableMetrics
   module Aggregations
     class SumService < BillableMetrics::Aggregations::BaseService
       def aggregate(from_datetime:, to_datetime:, options: {})
-        events = events_scope(from_datetime:, to_datetime:)
+        charges_from_date = billable_metric.recurring? ? subscription.started_at : from_datetime
+
+        events = events_scope(from_datetime: charges_from_date, to_datetime:)
           .where("#{sanitized_field_name} IS NOT NULL")
 
         result.aggregation = events.sum("(#{sanitized_field_name})::numeric")
@@ -54,7 +56,54 @@ module BillableMetrics
         return BigDecimal(0) unless event
         return BigDecimal(0) if event.properties.blank?
 
-        BigDecimal(event.properties.fetch(billable_metric.field_name, 0).to_s)
+        unless previous_event
+          value = event.properties.fetch(billable_metric.field_name, 0).to_s
+          update_event_metadata(current_aggregation: value, max_aggregation: value)
+
+          return BigDecimal(value)
+        end
+
+        current_aggregation = BigDecimal(previous_event.metadata['current_aggregation']) +
+          BigDecimal(event.properties.fetch(billable_metric.field_name, 0).to_s)
+
+        old_max = BigDecimal(previous_event.metadata['max_aggregation'])
+
+        if current_aggregation > old_max
+          update_event_metadata(current_aggregation:, max_aggregation: current_aggregation)
+
+          return BigDecimal(current_aggregation - old_max)
+        else
+          update_event_metadata(current_aggregation:, max_aggregation: old_max)
+
+          return BigDecimal(0)
+        end
+      end
+
+      private
+
+      def date_service
+        @date_service ||= Subscriptions::DatesService.new_instance(
+          subscription,
+          Time.current,
+          current_usage: true,
+        )
+      end
+
+      def previous_event
+        @previous_event ||= begin
+          events_scope(from_datetime: date_service.charges_from_datetime, to_datetime: date_service.charges_to_datetime)
+            .where("#{sanitized_field_name} IS NOT NULL")
+            .where.not(id: event.id)
+            .order(created_at: :desc)
+            .first
+        end
+      end
+
+      def update_event_metadata(current_aggregation: nil, max_aggregation: nil)
+        event.metadata['current_aggregation'] = current_aggregation unless current_aggregation.nil?
+        event.metadata['max_aggregation'] = max_aggregation unless max_aggregation.nil?
+
+        event.save!
       end
     end
   end

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -118,7 +118,6 @@ module Events
 
     def applicable_event?
       return false if !billable_metric.count_agg? && event.properties[billable_metric.field_name].nil?
-      return false if billable_metric.sum_agg? && event.properties[billable_metric.field_name]&.to_i&.negative?
 
       true
     end

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -193,6 +193,98 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
     end
   end
 
+  describe 'with sum_agg / standard' do
+    let(:aggregation_type) { 'sum_agg' }
+    let(:field_name) { 'amount' }
+
+    it 'creates an pay_in_advance fee' do
+      ### 24 january: Create subscription.
+      jan24 = DateTime.new(2023, 1, 24)
+
+      travel_to(jan24) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+      end
+
+      charge = create(
+        :standard_charge,
+        :pay_in_advance,
+        invoiceable: true,
+        plan:,
+        billable_metric:,
+        properties: { amount: '1' },
+      )
+
+      subscription = customer.subscriptions.first
+
+      ### 15 february: Send an event.
+      feb15 = DateTime.new(2023, 2, 15)
+
+      travel_to(feb15) do
+        expect do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '10' },
+            },
+          )
+        end.to change { subscription.reload.fees.count }.from(0).to(1)
+
+        fee = subscription.fees.first
+
+        expect(fee.invoice_id).not_to be_nil
+        expect(fee.charge_id).to eq(charge.id)
+        expect(fee.pay_in_advance).to eq(true)
+        expect(fee.units).to eq(10)
+        expect(fee.events_count).to eq(1)
+        expect(fee.amount_cents).to eq(1000)
+      end
+
+      travel_to(DateTime.new(2023, 2, 17)) do
+        expect do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '-4' },
+            },
+          )
+        end.to change { subscription.reload.fees.count }.from(1).to(2)
+
+        fee = subscription.fees.order(created_at: :desc).first
+        expect(fee.units).to eq(0)
+        expect(fee.events_count).to eq(1)
+        expect(fee.amount_cents).to eq(0)
+      end
+
+      travel_to(DateTime.new(2023, 2, 18)) do
+        expect do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '8' },
+            },
+          )
+        end.to change { subscription.reload.fees.count }.from(2).to(3)
+
+        fee = subscription.fees.order(created_at: :desc).first
+        expect(fee.units).to eq(4)
+        expect(fee.events_count).to eq(1)
+        expect(fee.amount_cents).to eq(400)
+      end
+    end
+  end
+
   describe 'with sum_agg / package' do
     let(:aggregation_type) { 'sum_agg' }
     let(:field_name) { 'amount' }

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -541,7 +541,7 @@ RSpec.describe Events::CreateService, type: :service do
           }
         end
 
-        it 'does not enqueue a job' do
+        it 'enqueues a job' do
           expect do
             create_service.call(
               organization:,
@@ -549,7 +549,7 @@ RSpec.describe Events::CreateService, type: :service do
               timestamp:,
               metadata: {},
             )
-          end.not_to have_enqueued_job(Invoices::CreatePayInAdvanceChargeJob)
+          end.to have_enqueued_job(Invoices::CreatePayInAdvanceChargeJob)
         end
       end
 


### PR DESCRIPTION
## Context

Currently it is not possible to charge events period over period for `sum_gg` and `unique_count_agg`

## Description

This PR adds new logic in sum aggregation.  Base aggregation logic is updated regarding recurring field. Also, new logic is added for pay_in_advance case where we take into account maximum is current period.
