### PR TITLE
fix(stripe): Improve Stripe error handling on payment creation

### DIFF
--- a/app/jobs/invoices/payments/stripe_create_job.rb
+++ b/app/jobs/invoices/payments/stripe_create_job.rb
@@ -7,6 +7,8 @@ module Invoices
 
       unique :until_executed
 
+      retry_on Stripe::RateLimitError, wait: :exponentially_longer, attempts: 6
+
       def perform(invoice)
         result = Invoices::Payments::StripeService.new(invoice).create
         result.raise_if_error!

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -187,8 +187,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       end
 
       it 'delivers an error webhook' do
-        expect { stripe_service.create }
-          .to raise_error(Stripe::CardError)
+        stripe_service.create
 
         expect(SendWebhookJob).to have_been_enqueued
           .with(


### PR DESCRIPTION
## Context

Some payment creation attempt are failing on stripe due to misconfiguration or processing error (expired card, insufficient funds...).

Those errors are already sent to lago users via a specific `'invoice.payment_failure` webhook and the payment is marked as failed but in parallel, has we are still raising the error, they appear in the dead queue of sidekiq.

## Description

This PRs improve the Stripe error handling when trying to create a payment:
- `Stripe::CardError`, `Stripe::InvalidRequestError` and `Stripe::PermissionError` are sent back to the user via webhook but does not lead to a failed job.
- `Stripe::RateLimitError` are re-enqueued for new attempt