### PR TITLE
feat(tax): Add a service to apply taxes to an invoice

### DIFF
--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -38,6 +38,12 @@ module Fees
       fee.taxes_amount_cents = applied_taxes_amount_cents.round
       fee.taxes_rate = applied_taxes_rate
 
+      if fee.taxes_amount_cents.zero?
+        # TODO(taxes): Remove the fallback on applicable vat to switch to new tax system
+        fee.taxes_rate = customer.applicable_vat_rate
+        fee.compute_vat
+      end
+
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/invoices/apply_taxes_service.rb
+++ b/app/services/invoices/apply_taxes_service.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Invoices
+  class ApplyTaxesService < BaseService
+    def initialize(invoice:)
+      @invoice = invoice
+
+      super
+    end
+
+    def call
+      result.applied_taxes = []
+      applied_taxes_amount_cents = 0
+      taxes_rate = 0
+
+      applicable_taxes.each do |tax|
+        applied_tax = invoice.applied_taxes.new(
+          tax:,
+          tax_description: tax.description,
+          tax_code: tax.code,
+          tax_name: tax.name,
+          tax_rate: tax.rate,
+          amount_currency: invoice.currency,
+        )
+        invoice.applied_taxes << applied_tax
+
+        fees_amount_cents = indexed_fees[tax.id].sum(&:amount_cents)
+        tax_amount_cents = (fees_amount_cents * tax.rate).fdiv(100)
+        applied_tax.amount_cents = tax_amount_cents.round
+
+        # NOTE: when applied on user current usage, the invoice is
+        #       not created in DB
+        applied_tax.save! if invoice.persisted?
+
+        applied_taxes_amount_cents += tax_amount_cents
+        taxes_rate += pro_rated_taxes_rate(tax)
+
+        result.applied_taxes << applied_tax
+      end
+
+      invoice.taxes_amount_cents = applied_taxes_amount_cents.round
+      invoice.taxes_rate = taxes_rate.round(5)
+      result.invoice = invoice
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :invoice
+
+    delegate :organization, to: :invoice
+
+    def applicable_taxes
+      organization.taxes.where(id: indexed_fees.keys)
+    end
+
+    # NOTE: indexes the invoice fees by taxes.
+    #       Example output will be: { tax1 => [fee1, fee2], tax2 => [fee2] }
+    def indexed_fees
+      @indexed_fees ||= invoice.fees.each_with_object({}) do |fee, applied_taxes|
+        fee.applied_taxes.each do |applied_tax|
+          applied_taxes[applied_tax.tax_id] ||= []
+          applied_taxes[applied_tax.tax_id] << fee
+        end
+      end
+    end
+
+    # NOTE: Tax might not be applied to all taxes of the invoice.
+    #       In order to compute the invoice#taxes_rate, we have to apply
+    #       a pro-rata of the fees attached to the tax on the invoices#fees_amount_cents
+    def pro_rated_taxes_rate(tax)
+      fees_amount_cents = indexed_fees[tax.id].sum(&:amount_cents)
+
+      fees_rate = if invoice.fees_amount_cents.positive?
+        fees_amount_cents.fdiv(invoice.fees_amount_cents)
+      else
+        # NOTE: when invoice have a 0 amount. The prorata is on the number of fees
+        indexed_fees[tax.id].count.fdiv(invoice.fees.count)
+      end
+
+      fees_rate * tax.rate
+    end
+  end
+end

--- a/spec/services/invoices/apply_taxes_service_spec.rb
+++ b/spec/services/invoices/apply_taxes_service_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::ApplyTaxesService, type: :service do
+  subject(:apply_service) { described_class.new(invoice:) }
+
+  let(:customer) { create(:customer) }
+  let(:organization) { customer.organization }
+
+  let(:invoice) { create(:invoice, organization:, customer:, fees_amount_cents:) }
+  let(:fees_amount_cents) { 3000 }
+
+  let(:tax1) { create(:tax, organization:, rate: 10) }
+  let(:tax2) { create(:tax, organization:, rate: 12) }
+
+  describe 'call' do
+    context 'with non zero fees amount' do
+      before do
+        fee1 = create(:fee, invoice:, amount_cents: 1000)
+        create(:fee_applied_tax, tax: tax1, fee: fee1, amount_cents: 100)
+
+        fee2 = create(:fee, invoice:, amount_cents: 2000)
+        create(:fee_applied_tax, tax: tax1, fee: fee2, amount_cents: 200)
+        create(:fee_applied_tax, tax: tax2, fee: fee2, amount_cents: 240)
+      end
+
+      it 'creates applied taxes' do
+        result = apply_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          applied_taxes = result.applied_taxes
+          expect(applied_taxes.count).to eq(2)
+
+          expect(applied_taxes[0]).to have_attributes(
+            invoice:,
+            tax: tax1,
+            tax_description: tax1.description,
+            tax_code: tax1.code,
+            tax_name: tax1.name,
+            tax_rate: 10,
+            amount_currency: invoice.currency,
+            amount_cents: 300,
+          )
+
+          expect(applied_taxes[1]).to have_attributes(
+            invoice:,
+            tax: tax2,
+            tax_description: tax2.description,
+            tax_code: tax2.code,
+            tax_name: tax2.name,
+            tax_rate: 12,
+            amount_currency: invoice.currency,
+            amount_cents: 240,
+          )
+
+          expect(invoice).to have_attributes(
+            taxes_amount_cents: 540,
+            taxes_rate: 18,
+          )
+        end
+      end
+    end
+
+    context 'when invoices fees_amount_cents is zero' do
+      let(:fees_amount_cents) { 0 }
+
+      before do
+        fee1 = create(:fee, invoice:, amount_cents: 0)
+        create(:fee_applied_tax, tax: tax1, fee: fee1, amount_cents: 0)
+
+        fee2 = create(:fee, invoice:, amount_cents: 0)
+        create(:fee_applied_tax, tax: tax1, fee: fee2, amount_cents: 0)
+        create(:fee_applied_tax, tax: tax2, fee: fee2, amount_cents: 0)
+      end
+
+      it 'creates applied_taxes' do
+        result = apply_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          applied_taxes = result.applied_taxes
+          expect(applied_taxes.count).to eq(2)
+
+          expect(applied_taxes[0]).to have_attributes(
+            invoice:,
+            tax: tax1,
+            tax_description: tax1.description,
+            tax_code: tax1.code,
+            tax_name: tax1.name,
+            tax_rate: 10,
+            amount_currency: invoice.currency,
+            amount_cents: 0,
+          )
+
+          expect(applied_taxes[1]).to have_attributes(
+            invoice:,
+            tax: tax2,
+            tax_description: tax2.description,
+            tax_code: tax2.code,
+            tax_name: tax2.name,
+            tax_rate: 12,
+            amount_currency: invoice.currency,
+            amount_cents: 0,
+          )
+
+          expect(invoice).to have_attributes(
+            taxes_amount_cents: 0,
+            taxes_rate: 16,
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/getlago/lago-api/pull/1068

## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to add a new service `Invoices::ApplyTaxesService` to create `applied_taxes` for invoices based on previously created `fees#applied_taxes`