### PR TITLE
feat(tax): Add service to appliy taxes on credit notes

### DIFF
--- a/app/services/credit_notes/apply_taxes_service.rb
+++ b/app/services/credit_notes/apply_taxes_service.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class ApplyTaxesService < BaseService
+    def initialize(invoice:, items:)
+      @invoice = invoice
+      @items = items
+
+      super
+    end
+
+    def call
+      result.applied_taxes = []
+      result.coupons_adjustment_amount_cents = coupons_adjustment_amount_cents
+
+      applied_taxes_amount_cents = 0
+      taxes_rate = 0
+
+      applicable_taxes.each do |tax|
+        invoice_applied_tax = find_invoice_applied_tax(tax)
+
+        applied_tax = CreditNote::AppliedTax.new(
+          tax:,
+          tax_description: invoice_applied_tax&.tax_description || tax.description,
+          tax_code: invoice_applied_tax&.tax_code || tax.code,
+          tax_name: invoice_applied_tax&.tax_name || tax.name,
+          tax_rate: invoice_applied_tax&.tax_rate || tax.rate,
+          amount_currency: invoice.currency,
+        )
+        result.applied_taxes << applied_tax
+
+        tax_amount_cents = compute_tax_amount_cents(tax)
+        applied_tax.amount_cents = tax_amount_cents.round
+
+        applied_taxes_amount_cents += tax_amount_cents
+        taxes_rate += pro_rated_taxes_rate(tax)
+      end
+
+      result.taxes_amount_cents = applied_taxes_amount_cents
+      result.taxes_rate = taxes_rate.round(5)
+
+      result
+    end
+
+    private
+
+    attr_reader :invoice, :items
+
+    delegate :organization, to: :invoice
+
+    def applicable_taxes
+      organization.taxes.where(id: indexed_items.keys)
+    end
+
+    # NOTE: indexes the credit note fees by taxes.
+    #       Example output will be: { tax1 => [fee1, fee2], tax2 => [fee2] }
+    def indexed_items
+      @indexed_items ||= items.each_with_object({}) do |item, applied_taxes|
+        item.fee.applied_taxes.each do |applied_tax|
+          applied_taxes[applied_tax.tax_id] ||= []
+          applied_taxes[applied_tax.tax_id] << item
+        end
+      end
+    end
+
+    def items_amount_cents
+      @items_amount_cents ||= items.sum(&:precise_amount_cents)
+    end
+
+    def coupons_adjustment_amount_cents
+      return 0 if invoice.version_number < Invoice::COUPON_BEFORE_VAT_VERSION
+
+      invoice.coupons_amount_cents.fdiv(invoice.fees_amount_cents) * items_amount_cents
+    end
+
+    def compute_tax_amount_cents(tax)
+      indexed_items[tax.id].map do |item|
+        # NOTE: Part of the item from to the total items amount
+        item_rate = item.precise_amount_cents.fdiv(items_amount_cents)
+
+        # NOTE: Part of the coupons applied to the item
+        prorated_coupon_amount = result.coupons_adjustment_amount_cents * item_rate
+
+        (item.precise_amount_cents - prorated_coupon_amount) * tax.rate
+      end.sum.fdiv(100)
+    end
+
+    # NOTE: Tax might not be applied to all items of the credit note.
+    #       In order to compute the credit_note#taxes_rate, we have to apply
+    #       a pro-rata of the items attached to the tax on the total items amount
+    def pro_rated_taxes_rate(tax)
+      # TODO: should this also takes proportion of the fee into account??
+      tax_items_amount_cents = indexed_items[tax.id].sum(&:precise_amount_cents)
+
+      items_rate = tax_items_amount_cents.fdiv(items_amount_cents)
+
+      items_rate * tax.rate
+    end
+
+    def find_invoice_applied_tax(tax)
+      invoice.applied_taxes.find_by(tax_id: tax.id)
+    end
+  end
+end

--- a/app/services/invoices/apply_taxes_service.rb
+++ b/app/services/invoices/apply_taxes_service.rb
@@ -68,7 +68,7 @@ module Invoices
       end
     end
 
-    # NOTE: Tax might not be applied to all taxes of the invoice.
+    # NOTE: Tax might not be applied to all fees of the invoice.
     #       In order to compute the invoice#taxes_rate, we have to apply
     #       a pro-rata of the fees attached to the tax on the invoices#fees_amount_cents
     def pro_rated_taxes_rate(tax)

--- a/spec/services/credit_notes/apply_taxes_service_spec.rb
+++ b/spec/services/credit_notes/apply_taxes_service_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
+  subject(:apply_service) { described_class.new(invoice:, items:) }
+
+  let(:customer) { create(:customer) }
+  let(:organization) { customer.organization }
+
+  let(:invoice) do
+    create(
+      :invoice,
+      customer:,
+      organization:,
+      currency: 'EUR',
+      fees_amount_cents: 120,
+      coupons_amount_cents: 20,
+      taxes_amount_cents: 20,
+      total_amount_cents: 120,
+      payment_status: :succeeded,
+      taxes_rate: 20,
+      version_number: 3,
+    )
+  end
+  let(:fee1) { create(:fee, invoice:, amount_cents: 100, taxes_amount_cents: 12, taxes_rate: 12) }
+  let(:fee2) { create(:fee, invoice:, amount_cents: 20, taxes_amount_cents: 4, taxes_rate: 20) }
+
+  let(:tax1) { create(:tax, organization:, rate: 12) }
+  let(:tax2) { create(:tax, organization:, rate: 8) }
+
+  let(:applied_tax1) { create(:fee_applied_tax, tax: tax1, fee: fee1, amount_cents: 12) }
+
+  let(:applied_tax21) { create(:fee_applied_tax, tax: tax1, fee: fee2, amount_cents: 2) }
+  let(:applied_tax22) { create(:fee_applied_tax, tax: tax2, fee: fee2, amount_cents: 2) }
+
+  let(:items) do
+    [
+      build(
+        :credit_note_item,
+        credit_note: nil,
+        fee: fee1,
+        amount_cents: 20,
+        precise_amount_cents: 20,
+        amount_currency: invoice.currency,
+      ),
+      build(
+        :credit_note_item,
+        credit_note: nil,
+        fee: fee2,
+        amount_cents: 50,
+        precise_amount_cents: 50,
+        amount_currency: invoice.currency,
+      ),
+    ]
+  end
+
+  before do
+    applied_tax1
+    applied_tax21
+    applied_tax22
+  end
+
+  describe 'call' do
+    it 'creates applied taxes' do
+      result = apply_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+
+        aggregate_failures do
+          applied_taxes = result.applied_taxes
+          expect(applied_taxes.count).to eq(2)
+
+          expect(applied_taxes[0]).to have_attributes(
+            credit_note: nil,
+            tax: tax1,
+            tax_description: tax1.description,
+            tax_code: tax1.code,
+            tax_name: tax1.name,
+            tax_rate: 12,
+            amount_currency: invoice.currency,
+            amount_cents: 7,
+          )
+
+          expect(applied_taxes[1]).to have_attributes(
+            credit_note: nil,
+            tax: tax2,
+            tax_description: tax2.description,
+            tax_code: tax2.code,
+            tax_name: tax2.name,
+            tax_rate: 8,
+            amount_currency: invoice.currency,
+            amount_cents: 3,
+          )
+
+          expect(result.taxes_amount_cents.round).to eq(10)
+          expect(result.taxes_rate).to eq(17.71429)
+          expect(result.coupons_adjustment_amount_cents.round).to eq(12)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to add a new service `CreditNotes::ApplyTaxesService` to create `applied_taxes` for credit notes based on previously created `fees#applied_taxes` and `invoices#applied_taxes`