### PR TITLE
feat(tax): Apply taxes to invoices

### DIFF
--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -64,7 +64,11 @@ module V1
     end
 
     def applied_taxes
-      ::CollectionSerializer.new(model.applied_taxes, ::V1::Invoices::AppliedTaxSerializer, collection_name: 'applied_taxes').serialize
+      ::CollectionSerializer.new(
+        model.applied_taxes,
+        ::V1::Invoices::AppliedTaxSerializer,
+        collection_name: 'applied_taxes',
+      ).serialize
     end
 
     def legacy_values

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -64,7 +64,7 @@ module V1
     end
 
     def applied_taxes
-      ::CollectionSerializer.new(model.applied_taxes, ::V1::TaxSerializer, collection_name: 'applied_taxes').serialize
+      ::CollectionSerializer.new(model.applied_taxes, ::V1::Invoices::AppliedTaxSerializer, collection_name: 'applied_taxes').serialize
     end
 
     def legacy_values

--- a/app/services/invoices/apply_taxes_service.rb
+++ b/app/services/invoices/apply_taxes_service.rb
@@ -24,8 +24,7 @@ module Invoices
         )
         invoice.applied_taxes << applied_tax
 
-        fees_amount_cents = indexed_fees[tax.id].sum(&:amount_cents)
-        tax_amount_cents = (fees_amount_cents * tax.rate).fdiv(100)
+        tax_amount_cents = compute_tax_amount_cents(tax)
         applied_tax.amount_cents = tax_amount_cents.round
 
         # NOTE: when applied on user current usage, the invoice is
@@ -66,6 +65,18 @@ module Invoices
           applied_taxes[applied_tax.tax_id] << fee
         end
       end
+    end
+
+    # NOTE: Because coupons are applied before VAT,
+    #       we have to distribute the coupons amount at prorata on each fees
+    #       compared to the invoice total fees amount
+    def compute_tax_amount_cents(tax)
+      indexed_fees[tax.id].sum do |fee|
+        # NOTE: ratio of the fee on the fees total amount
+        fee_rate = invoice.fees_amount_cents.zero? ? 0 : fee.amount_cents.fdiv(invoice.fees_amount_cents)
+        prorated_coupon_amount = fee_rate * invoice.coupons_amount_cents
+        (fee.amount_cents - prorated_coupon_amount) * tax.rate
+      end.fdiv(100)
     end
 
     # NOTE: Tax might not be applied to all taxes of the invoice.

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -96,7 +96,10 @@ module Invoices
 
     def compute_amounts
       invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
-      invoice.taxes_amount_cents = invoice.fees.sum { |f| f.amount_cents * f.taxes_rate }.fdiv(100).round
+
+      taxes_result = Invoices::ApplyTaxesService.call(invoice:)
+      taxes_result.raise_if_error!
+
       invoice.total_amount_cents = invoice.fees_amount_cents + invoice.taxes_amount_cents
     end
 

--- a/app/services/invoices/one_off_service.rb
+++ b/app/services/invoices/one_off_service.rb
@@ -28,7 +28,6 @@ module Invoices
           issuing_date:,
           invoice_type: :one_off,
           currency:,
-          taxes_rate: customer.applicable_vat_rate,
           timezone: customer.applicable_timezone,
           status: :finalized,
         )

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -26,15 +26,14 @@ module Invoices
         )
 
         create_credit_fee(invoice)
-
         compute_amounts(invoice)
 
         invoice.save!
 
-        track_invoice_created(invoice)
         result.invoice = invoice
       end
 
+      track_invoice_created(result.invoice)
       SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice) if should_deliver_webhook?
       InvoiceMailer.with(invoice: result.invoice).finalized.deliver_later if should_deliver_email?
 

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe Invoices::AddOnService, type: :service do
           total_amount_cents: 240,
         )
 
+        expect(result.invoice.applied_taxes.count).to eq(1)
+
         expect(result.invoice).to be_finalized
       end
     end

--- a/spec/services/invoices/apply_taxes_service_spec.rb
+++ b/spec/services/invoices/apply_taxes_service_spec.rb
@@ -8,8 +8,9 @@ RSpec.describe Invoices::ApplyTaxesService, type: :service do
   let(:customer) { create(:customer) }
   let(:organization) { customer.organization }
 
-  let(:invoice) { create(:invoice, organization:, customer:, fees_amount_cents:) }
+  let(:invoice) { create(:invoice, organization:, customer:, fees_amount_cents:, coupons_amount_cents:) }
   let(:fees_amount_cents) { 3000 }
+  let(:coupons_amount_cents) { 0 }
 
   let(:tax1) { create(:tax, organization:, rate: 10) }
   let(:tax2) { create(:tax, organization:, rate: 12) }
@@ -110,6 +111,57 @@ RSpec.describe Invoices::ApplyTaxesService, type: :service do
           expect(invoice).to have_attributes(
             taxes_amount_cents: 0,
             taxes_rate: 16,
+          )
+        end
+      end
+    end
+
+    context 'with coupon applied to invoice' do
+      let(:coupons_amount_cents) { 1000 }
+
+      before do
+        fee1 = create(:fee, invoice:, amount_cents: 1000)
+        create(:fee_applied_tax, tax: tax1, fee: fee1, amount_cents: 100)
+
+        fee2 = create(:fee, invoice:, amount_cents: 2000)
+        create(:fee_applied_tax, tax: tax1, fee: fee2, amount_cents: 200)
+        create(:fee_applied_tax, tax: tax2, fee: fee2, amount_cents: 240)
+      end
+
+      it 'taxes the coupon at pro-rata of each fees' do
+        result = apply_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          applied_taxes = result.applied_taxes
+          expect(applied_taxes.count).to eq(2)
+
+          expect(applied_taxes[0]).to have_attributes(
+            invoice:,
+            tax: tax1,
+            tax_description: tax1.description,
+            tax_code: tax1.code,
+            tax_name: tax1.name,
+            tax_rate: 10,
+            amount_currency: invoice.currency,
+            amount_cents: 200,
+          )
+
+          expect(applied_taxes[1]).to have_attributes(
+            invoice:,
+            tax: tax2,
+            tax_description: tax2.description,
+            tax_code: tax2.code,
+            tax_name: tax2.name,
+            tax_rate: 12,
+            amount_currency: invoice.currency,
+            amount_cents: 160,
+          )
+
+          expect(invoice).to have_attributes(
+            taxes_amount_cents: 360,
+            taxes_rate: 18,
           )
         end
       end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
     let(:invoice) do
       create(
         :invoice,
+        organization:,
         currency: 'EUR',
         issuing_date: Time.zone.at(timestamp).to_date,
         customer: subscription.customer,

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -5,11 +5,19 @@ require 'rails_helper'
 RSpec.describe Invoices::ComputeAmountsFromFees, type: :service do
   subject(:compute_amounts) { described_class.new(invoice:) }
 
-  let(:invoice) { create(:invoice) }
+  let(:organization) { create(:organization) }
+  let(:invoice) { create(:invoice, organization:) }
+
+  let(:tax1) { create(:tax, organization:, rate: 10) }
+  let(:tax2) { create(:tax, organization:, rate: 20) }
 
   before do
-    create(:fee, invoice:, amount_cents: 151, taxes_rate: 10)
-    create(:fee, invoice:, amount_cents: 379, taxes_rate: 20)
+    fee1 = create(:fee, invoice:, amount_cents: 151, taxes_rate: 10)
+    create(:fee_applied_tax, fee: fee1, tax: tax1, amount_cents: 151, tax_rate: 10)
+
+    fee2 = create(:fee, invoice:, amount_cents: 379, taxes_rate: 20)
+    create(:fee_applied_tax, fee: fee2, tax: tax2, amount_cents: 379, tax_rate: 20)
+
     create(:credit, invoice:, amount_cents: 100)
   end
 

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -81,8 +81,11 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
 
         expect(result.invoice.currency).to eq(customer.currency)
         expect(result.invoice.fees_amount_cents).to eq(10)
+
         expect(result.invoice.taxes_amount_cents).to eq(2)
         expect(result.invoice.taxes_rate).to eq(20)
+        expect(result.invoice.applied_taxes.count).to eq(1)
+
         expect(result.invoice.total_amount_cents).to eq(12)
 
         expect(result.invoice).to be_finalized

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
   let(:event) { create(:event, subscription:, customer:, organization:) }
   let(:group) { nil }
 
+  before { create(:tax, organization:, applied_to_organization: true) }
+
   describe 'call' do
     let(:aggregation_result) do
       BaseService::Result.new.tap do |result|

--- a/spec/services/invoices/one_off_service_spec.rb
+++ b/spec/services/invoices/one_off_service_spec.rb
@@ -50,10 +50,12 @@ RSpec.describe Invoices::OneOffService, type: :service do
 
         expect(result.invoice.currency).to eq('EUR')
         expect(result.invoice.fees_amount_cents).to eq(2800)
+
         expect(result.invoice.taxes_amount_cents).to eq(560)
         expect(result.invoice.taxes_rate).to eq(20)
-        expect(result.invoice.total_amount_cents).to eq(3360)
         expect(result.invoice.applied_taxes.count).to eq(1)
+
+        expect(result.invoice.total_amount_cents).to eq(3360)
 
         expect(result.invoice).to be_finalized
       end

--- a/spec/services/invoices/one_off_service_spec.rb
+++ b/spec/services/invoices/one_off_service_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Invoices::OneOffService, type: :service do
         expect(result.invoice.taxes_amount_cents).to eq(560)
         expect(result.invoice.taxes_rate).to eq(20)
         expect(result.invoice.total_amount_cents).to eq(3360)
+        expect(result.invoice.applied_taxes.count).to eq(1)
 
         expect(result.invoice).to be_finalized
       end

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
           total_amount_cents: 1500,
         )
 
+        expect(result.invoice.applied_taxes.count).to eq(0)
+
         expect(result.invoice).to be_finalized
       end
     end

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
   describe '#call' do
     let(:status) { :draft }
     let(:invoice) do
-      create(:invoice, status:, organization:, customer:,)
+      create(:invoice, status:, organization:, customer:)
     end
 
     let(:started_at) { 1.month.ago }

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -91,8 +91,11 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
 
         expect(result.invoice.currency).to eq('EUR')
         expect(result.invoice.fees_amount_cents).to eq(100)
+
         expect(result.invoice.taxes_amount_cents).to eq(20)
         expect(result.invoice.taxes_rate).to eq(20)
+        expect(result.invoice.applied_taxes.count).to eq(1)
+
         expect(result.invoice.total_amount_cents).to eq(120)
         expect(result.invoice.version_number).to eq(3)
         expect(result.invoice).to be_finalized


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to creates the `invoices#applied_taxes` when creating new invoice using the applied customer taxes or the organization default one. It relies on the previously created `Invoices::ApplyTaxesService`.