### PR TITLE
feat(stripe) send webhook when user is created

### DIFF
--- a/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PaymentProviderCustomers
+  class StripeCheckoutUrlJob < ApplicationJob
+    queue_as :providers
+
+    retry_on Stripe::APIConnectionError, wait: :exponentially_longer, attempts: 6
+    retry_on Stripe::APIError, wait: :exponentially_longer, attempts: 6
+    retry_on Stripe::RateLimitError, wait: :exponentially_longer, attempts: 6
+
+    def perform(stripe_customer)
+      result = PaymentProviderCustomers::StripeService.new(stripe_customer).generate_checkout_url
+      result.raise_if_error!
+    end
+  end
+end

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -2,6 +2,8 @@
 
 module PaymentProviderCustomers
   class StripeService < BaseService
+    CHECKOUT_SUCCESS_URL = 'https://www.getlago.com'
+
     def initialize(stripe_customer = nil)
       @stripe_customer = stripe_customer
 
@@ -20,6 +22,7 @@ module PaymentProviderCustomers
       )
 
       deliver_success_webhook
+      PaymentProviderCustomers::StripeCheckoutUrlJob.perform_later(stripe_customer)
 
       result.stripe_customer = stripe_customer
       result
@@ -72,6 +75,30 @@ module PaymentProviderCustomers
       result.single_validation_failure!(field: :payment_method_id, error_code: 'value_is_invalid')
     end
 
+    def generate_checkout_url
+      return unless customer.organization.webhook_url?
+
+      res = Stripe::Checkout::Session.create(
+        checkout_link_params,
+        {
+          api_key:,
+        },
+      )
+
+      result.checkout_url = res['url']
+
+      SendWebhookJob.perform_later(
+        'customer.checkout_url_generated',
+        customer,
+        checkout_url: result.checkout_url,
+      )
+
+      result
+    rescue Stripe::InvalidRequestError, Stripe::PermissionError => e
+      deliver_error_webhook(e)
+      result
+    end
+
     private
 
     attr_accessor :stripe_customer
@@ -84,6 +111,15 @@ module PaymentProviderCustomers
 
     def api_key
       organization.stripe_payment_provider.secret_key
+    end
+
+    def checkout_link_params
+      {
+        success_url: CHECKOUT_SUCCESS_URL,
+        mode: 'setup',
+        payment_method_types: ['card'],
+        customer: stripe_customer.provider_customer_id,
+      }
     end
 
     def create_stripe_customer

--- a/spec/jobs/payment_provider_customers/stripe_checkout_url_job_spec.rb
+++ b/spec/jobs/payment_provider_customers/stripe_checkout_url_job_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentProviderCustomers::StripeCheckoutUrlJob, type: :job do
+  subject(:stripe_checkout_job) { described_class }
+
+  let(:stripe_customer) { create(:stripe_customer) }
+
+  let(:stripe_service) { instance_double(PaymentProviderCustomers::StripeService) }
+
+  it 'calls generate_checkout_url method' do
+    allow(PaymentProviderCustomers::StripeService).to receive(:new)
+      .with(stripe_customer)
+      .and_return(stripe_service)
+    allow(stripe_service).to receive(:generate_checkout_url)
+      .and_return(BaseService::Result.new)
+
+    stripe_checkout_job.perform_now(stripe_customer)
+
+    expect(PaymentProviderCustomers::StripeService).to have_received(:new)
+    expect(stripe_service).to have_received(:generate_checkout_url)
+  end
+end


### PR DESCRIPTION
This PR adds a new feature.

Once a new customer with Stripe as a payment provider is added to the app, via UI or API, we send a webhook with a checkout session url.

This checkout session will be used to store customer payment information on Stripe in order to ease future payments.

This URL is sent on the `customer.checkout_url_generated` webhook event.