### PR TITLE
fix(invoice): Duplication validation should only be checked for recurring billing

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -87,7 +87,8 @@ module Invoices
     end
 
     def duplicated_invoices?
-      # TODO(duplicated_invoices): Migrate conditions to datetime columns
+      return false unless recurring
+
       subscriptions_boundaries.any? do |subscription_id, boundaries|
         InvoiceSubscription
           .where(subscription_id:)

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -582,7 +582,9 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       end
     end
 
-    context 'when invoice subscription already exists' do
+    context 'when invoice subscription already exists for recurring billing' do
+      let(:recurring) { true }
+
       let(:date_service) do
         Subscriptions::DatesService.new_instance(
           subscription,


### PR DESCRIPTION
## Context

A pre-condition was recently added to prevent the creation of duplicated invoices.

See https://github.com/getlago/lago-api/pull/1086

The fix introduced a regression because it was applied to every subscription billing cases (recurring, termination...) and not only to the recurring subscription billing

## Description

This PR fixes the precondition to ensure we are in a recurring case.
