### PR TITLE
fix(stripe): checkout URL should return empty result when no webhook URL

### DIFF
--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -76,7 +76,7 @@ module PaymentProviderCustomers
     end
 
     def generate_checkout_url
-      return unless customer.organization.webhook_url?
+      return result unless customer.organization.webhook_url?
 
       res = Stripe::Checkout::Session.create(
         checkout_link_params,


### PR DESCRIPTION
Related to https://github.com/getlago/lago-api/pull/1107