### PR TITLE
feat (billable metrics): extend billable metric query service

### DIFF
--- a/app/graphql/resolvers/billable_metrics_resolver.rb
+++ b/app/graphql/resolvers/billable_metrics_resolver.rb
@@ -10,13 +10,21 @@ module Resolvers
     argument :ids, [String], required: false, description: 'List of plan ID to fetch'
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
+    argument :recurring, Boolean, required: false
     argument :search_term, String, required: false
 
     argument :aggregation_types, [Types::BillableMetrics::AggregationTypeEnum], required: false
 
     type Types::BillableMetrics::Object.collection_type, null: false
 
-    def resolve(ids: nil, page: nil, limit: nil, search_term: nil, aggregation_types: nil)
+    def resolve( # rubocop:disable Metrics/ParameterLists
+      ids: nil,
+      page: nil,
+      limit: nil,
+      search_term: nil,
+      aggregation_types: nil,
+      recurring: nil
+    )
       validate_organization!
 
       query = ::BillableMetricsQuery.new(organization: current_organization)
@@ -26,6 +34,7 @@ module Resolvers
         limit:,
         filters: {
           ids:,
+          recurring:,
           aggregation_types:,
         },
       )

--- a/app/graphql/resolvers/billable_metrics_resolver.rb
+++ b/app/graphql/resolvers/billable_metrics_resolver.rb
@@ -17,26 +17,14 @@ module Resolvers
 
     type Types::BillableMetrics::Object.collection_type, null: false
 
-    def resolve( # rubocop:disable Metrics/ParameterLists
-      ids: nil,
-      page: nil,
-      limit: nil,
-      search_term: nil,
-      aggregation_types: nil,
-      recurring: nil
-    )
+    def resolve(**args)
       validate_organization!
 
-      query = ::BillableMetricsQuery.new(organization: current_organization)
-      result = query.call(
-        search_term:,
-        page:,
-        limit:,
-        filters: {
-          ids:,
-          recurring:,
-          aggregation_types:,
-        },
+      result = ::BillableMetricsQuery.new(organization: current_organization).call(
+        search_term: args[:search_term],
+        page: args[:page],
+        limit: args[:limit],
+        filters: args.slice(args[:ids], args[:recurring], args[:aggregation_types]),
       )
 
       result.billable_metrics

--- a/app/queries/billable_metrics_query.rb
+++ b/app/queries/billable_metrics_query.rb
@@ -6,6 +6,7 @@ class BillableMetricsQuery < BaseQuery
 
     metrics = base_scope.result
     metrics = metrics.where(id: filters[:ids]) if filters[:ids].present?
+    metrics = metrics.where(recurring: filters[:recurring]) unless filters[:recurring].nil?
     metrics = metrics.where(aggregation_type: filters[:aggregation_types]) if filters[:aggregation_types].present?
     metrics = metrics.order(created_at: :desc).page(page).per(limit)
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -4051,6 +4051,7 @@ type Query {
     ids: [String!]
     limit: Int
     page: Int
+    recurring: Boolean
     searchTerm: String
   ): BillableMetricCollection!
 

--- a/schema.json
+++ b/schema.json
@@ -16979,6 +16979,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "recurring",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "searchTerm",
                   "description": null,
                   "type": {

--- a/spec/queries/billable_metrics_query_spec.rb
+++ b/spec/queries/billable_metrics_query_spec.rb
@@ -39,6 +39,44 @@ RSpec.describe BillableMetricsQuery, type: :query do
     end
   end
 
+  context 'when searching for recurring billable metrics' do
+    let(:billable_metric_recurring) do
+      create(
+        :billable_metric,
+        organization:,
+        aggregation_type: 'unique_count_agg',
+        name: 'defghz',
+        code: '55',
+        field_name: 'test',
+        recurring: true,
+      )
+    end
+
+    before { billable_metric_recurring }
+
+    it 'returns 1 billable metric' do
+      result = billable_metric_query.call(
+        search_term: nil,
+        page: 1,
+        limit: 10,
+        filters: {
+          recurring: true,
+        },
+      )
+
+      returned_ids = result.billable_metrics.pluck(:id)
+
+      aggregate_failures do
+        expect(result.billable_metrics.count).to eq(1)
+        expect(returned_ids).not_to include(billable_metric_first.id)
+        expect(returned_ids).not_to include(billable_metric_second.id)
+        expect(returned_ids).not_to include(billable_metric_third.id)
+        expect(returned_ids).not_to include(billable_metric_fourth.id)
+        expect(returned_ids).to include(billable_metric_recurring.id)
+      end
+    end
+  end
+
   context 'when searching for count_agg aggregation type' do
     it 'returns 3 billable metrics' do
       result = billable_metric_query.call(


### PR DESCRIPTION
In order to support UI experience for recurring billable metric, it has to be enabled to filter billable metrics by `recurring` field