### PR TITLE
ftr (billable metrics): unique count aggregation refactoring

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,6 +11,8 @@ class Event < ApplicationRecord
   belongs_to :customer, -> { with_discarded }
   belongs_to :subscription
 
+  has_one :quantified_event
+
   validates :transaction_id, presence: true, uniqueness: { scope: :subscription_id }
   validates :code, presence: true
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -11,7 +11,7 @@ class Event < ApplicationRecord
   belongs_to :customer, -> { with_discarded }
   belongs_to :subscription
 
-  has_one :quantified_event
+  belongs_to :quantified_event, optional: true
 
   validates :transaction_id, presence: true, uniqueness: { scope: :subscription_id }
   validates :code, presence: true

--- a/app/models/quantified_event.rb
+++ b/app/models/quantified_event.rb
@@ -7,6 +7,7 @@ class QuantifiedEvent < ApplicationRecord
 
   belongs_to :customer
   belongs_to :billable_metric
+  belongs_to :event
 
   validates :external_id, presence: true
   validates :added_at, presence: true

--- a/app/models/quantified_event.rb
+++ b/app/models/quantified_event.rb
@@ -7,7 +7,8 @@ class QuantifiedEvent < ApplicationRecord
 
   belongs_to :customer
   belongs_to :billable_metric
-  belongs_to :event
+
+  has_many :events
 
   validates :external_id, presence: true
   validates :added_at, presence: true

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -4,29 +4,41 @@ module BillableMetrics
   module Aggregations
     class UniqueCountService < BillableMetrics::Aggregations::BaseService
       def aggregate(from_datetime:, to_datetime:, options: {})
-        events = events_scope(from_datetime:, to_datetime:)
-          .where("#{sanitized_field_name} IS NOT NULL")
+        @from_datetime = from_datetime
+        @to_datetime = to_datetime
 
-        result.aggregation = events.count("DISTINCT (#{sanitized_field_name})")
-        result.pay_in_advance_aggregation = BigDecimal(compute_pay_in_advance_aggregation(events))
+        result.aggregation = compute_aggregation.ceil(5)
+        result.pay_in_advance_aggregation = BigDecimal(compute_pay_in_advance_aggregation)
         result.options = { running_total: running_total(options) }
-        result.count = events.count
+        result.count = result.aggregation
         result
       end
 
-      def compute_pay_in_advance_aggregation(events)
+      def compute_pay_in_advance_aggregation
         return 0 unless event
         return 0 if event.properties.blank?
 
-        existing_property = events
-          .where("#{sanitized_field_name} = '#{event.properties[billable_metric.field_name]}'")
-          .where.not(id: event.id)
-          .any?
+        unless previous_event
+          res = operation_type == :add ? 1 : 0
+          handle_event_metadata(current_aggregation: res, max_aggregation: res)
 
-        # NOTE: bill only property that have not been received in the period yet
-        return 0 if existing_property
+          return res
+        end
 
-        1
+        old_aggregation = BigDecimal(previous_event.metadata['current_aggregation'])
+        old_max = BigDecimal(previous_event.metadata['max_aggregation'])
+
+        current_aggregation = operation_type == :add ? (old_aggregation + 1) : (old_aggregation - 1)
+
+        if current_aggregation > old_max
+         handle_event_metadata(current_aggregation:, max_aggregation: current_aggregation)
+
+         1
+        else
+         handle_event_metadata(current_aggregation:, max_aggregation: old_max)
+
+         0
+        end
       end
 
       # NOTE: Return cumulative sum of event count based on the number of free units
@@ -38,6 +50,96 @@ module BillableMetrics
         return [] if free_units_per_events.zero? && free_units_per_total_aggregation.zero?
 
         (1..result.aggregation).to_a
+      end
+
+      private
+
+      attr_reader :from_datetime, :to_datetime
+
+      # This method fetches the latest event in current period. If such a event exists we know that metadata
+      # with previous aggregation and previous maximum aggregation are stored there. Fetching these metadata values
+      # would help us in pay in advance value calculation without iterating through all events in current period
+      def previous_event
+        @previous_event ||= begin
+          query = events_scope(from_datetime:, to_datetime:)
+            .joins(:quantified_event)
+            .where("#{sanitized_field_name} IS NOT NULL")
+            .where.not(id: event.id)
+            .where('quantified_events.added_at::timestamp(0) >= ?', from_datetime)
+            .where('quantified_events.added_at::timestamp(0) <= ?', to_datetime)
+            .order(created_at: :desc)
+
+          query
+            .where('quantified_events.removed_at::timestamp(0) IS NULL')
+            .or(
+              query
+                .where('quantified_events.removed_at::timestamp(0) >= ?', from_datetime)
+                .where('quantified_events.removed_at::timestamp(0) <= ?', to_datetime)
+            )
+
+          query.first
+        end
+      end
+
+      def operation_type
+        @operation_type ||= event.properties.fetch('operation_type', 'add')&.to_sym
+      end
+
+      def handle_event_metadata(current_aggregation: nil, max_aggregation: nil)
+        result.current_aggregation = current_aggregation unless current_aggregation.nil?
+        result.max_aggregation = max_aggregation unless max_aggregation.nil?
+      end
+
+      def compute_aggregation
+        ActiveRecord::Base.connection.execute(aggregation_query).first['aggregation_result']
+      end
+
+      def aggregation_query
+        queries = [
+          # NOTE: Billed on the full period. We will replace 1::numeric with proration_coefficient::numeric
+          # in the next part
+          persisted.select("SUM(1::numeric)").to_sql,
+
+          # NOTE: Added during the period, We will replace 1::numeric with proration_coefficient::numeric
+          # in the next part
+          added.select("SUM(1::numeric)").to_sql,
+        ]
+
+        "SELECT (#{queries.map { |q| "COALESCE((#{q}), 0)" }.join(' + ')}) AS aggregation_result"
+      end
+
+      def persisted
+        return QuantifiedEvent.none unless billable_metric.recurring?
+
+        base_scope
+          .where('quantified_events.added_at::timestamp(0) < ?', from_datetime)
+          .where('quantified_events.removed_at IS NULL OR quantified_events.removed_at::timestamp(0) > ?', to_datetime)
+      end
+
+      def added
+        base_scope
+          .where('quantified_events.added_at::timestamp(0) >= ?', from_datetime)
+          .where('quantified_events.added_at::timestamp(0) <= ?', to_datetime)
+          .where('quantified_events.removed_at::timestamp(0) IS NULL OR quantified_events.removed_at > ?', to_datetime)
+      end
+
+      def base_scope
+        quantified_events = QuantifiedEvent
+          .joins(customer: :organization)
+          .where(billable_metric_id: billable_metric.id)
+          .where(customer_id: subscription.customer_id)
+          .where(external_subscription_id: subscription.external_id)
+
+        return quantified_events unless group
+
+        quantified_events = quantified_events.where('properties @> ?', { group.key.to_s => group.value }.to_json)
+        return quantified_events unless group.parent
+
+        quantified_events.where('properties @> ?', { group.parent.key.to_s => group.parent.value }.to_json)
+      end
+
+      def sanitized_operation_type
+        ActiveRecord::Base.sanitize_sql_for_conditions(['events.properties->>operation_type'])
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -19,7 +19,7 @@ module BillableMetrics
         return 0 if event.properties.blank?
 
         unless previous_event
-          res = operation_type == :add ? 1 : 0
+          res = (operation_type == :add) ? 1 : 0
           handle_event_metadata(current_aggregation: res, max_aggregation: res)
 
           return res
@@ -28,16 +28,16 @@ module BillableMetrics
         old_aggregation = BigDecimal(previous_event.metadata['current_aggregation'])
         old_max = BigDecimal(previous_event.metadata['max_aggregation'])
 
-        current_aggregation = operation_type == :add ? (old_aggregation + 1) : (old_aggregation - 1)
+        current_aggregation = (operation_type == :add) ? (old_aggregation + 1) : (old_aggregation - 1)
 
         if current_aggregation > old_max
-         handle_event_metadata(current_aggregation:, max_aggregation: current_aggregation)
+          handle_event_metadata(current_aggregation:, max_aggregation: current_aggregation)
 
-         1
+          1
         else
-         handle_event_metadata(current_aggregation:, max_aggregation: old_max)
+          handle_event_metadata(current_aggregation:, max_aggregation: old_max)
 
-         0
+          0
         end
       end
 
@@ -74,7 +74,7 @@ module BillableMetrics
             .or(
               query
                 .where('quantified_events.removed_at::timestamp(0) >= ?', from_datetime)
-                .where('quantified_events.removed_at::timestamp(0) <= ?', to_datetime)
+                .where('quantified_events.removed_at::timestamp(0) <= ?', to_datetime),
             )
 
           query.first
@@ -98,11 +98,11 @@ module BillableMetrics
         queries = [
           # NOTE: Billed on the full period. We will replace 1::numeric with proration_coefficient::numeric
           # in the next part
-          persisted.select("SUM(1::numeric)").to_sql,
+          persisted.select('SUM(1::numeric)').to_sql,
 
           # NOTE: Added during the period, We will replace 1::numeric with proration_coefficient::numeric
           # in the next part
-          added.select("SUM(1::numeric)").to_sql,
+          added.select('SUM(1::numeric)').to_sql,
         ]
 
         "SELECT (#{queries.map { |q| "COALESCE((#{q}), 0)" }.join(' + ')}) AS aggregation_result"

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -98,17 +98,17 @@ module BillableMetrics
         queries = [
           # NOTE: Billed on the full period. We will replace 1::numeric with proration_coefficient::numeric
           # in the next part
-          persisted.select('SUM(1::numeric)').to_sql,
+          persisted_query.select('SUM(1::numeric)').to_sql,
 
           # NOTE: Added during the period, We will replace 1::numeric with proration_coefficient::numeric
           # in the next part
-          added.select('SUM(1::numeric)').to_sql,
+          added_query.select('SUM(1::numeric)').to_sql,
         ]
 
         "SELECT (#{queries.map { |q| "COALESCE((#{q}), 0)" }.join(' + ')}) AS aggregation_result"
       end
 
-      def persisted
+      def persisted_query
         return QuantifiedEvent.none unless billable_metric.recurring?
 
         base_scope
@@ -116,7 +116,7 @@ module BillableMetrics
           .where('quantified_events.removed_at IS NULL OR quantified_events.removed_at::timestamp(0) > ?', to_datetime)
       end
 
-      def added
+      def added_query
         base_scope
           .where('quantified_events.added_at::timestamp(0) >= ?', from_datetime)
           .where('quantified_events.added_at::timestamp(0) <= ?', to_datetime)

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -45,7 +45,7 @@ module Events
         event.save!
 
         result.event = event
-        handle_persisted_event if should_handle_persisted_event?
+        handle_quantified_event if should_handle_quantified_event?
       end
 
       if non_invoiceable_charges.any?
@@ -86,16 +86,16 @@ module Events
       end
     end
 
-    def persisted_event_service
-      @persisted_event_service ||= QuantifiedEvents::CreateOrUpdateService.new(result.event)
+    def quantified_event_service
+      @quantified_event_service ||= QuantifiedEvents::CreateOrUpdateService.new(result.event)
     end
 
-    def should_handle_persisted_event?
-      persisted_event_service.matching_billable_metric?
+    def should_handle_quantified_event?
+      quantified_event_service.matching_billable_metric?
     end
 
-    def handle_persisted_event
-      service_result = persisted_event_service.call
+    def handle_quantified_event
+      service_result = quantified_event_service.call
       service_result.raise_if_error!
     end
 

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -45,7 +45,13 @@ module Events
         event.save!
 
         result.event = event
-        handle_quantified_event if should_handle_quantified_event?
+
+        if should_handle_quantified_event?
+          # For unique count if repeated event got ingested, we want to store this event but prevent further processing
+          return result unless quantified_event_service.process_event?
+
+          handle_quantified_event
+        end
       end
 
       if non_invoiceable_charges.any?

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -97,6 +97,9 @@ module Events
     def handle_quantified_event
       service_result = quantified_event_service.call
       service_result.raise_if_error!
+
+      event.quantified_event = service_result.quantified_event
+      event.save!
     end
 
     def charges

--- a/app/services/events/validate_creation_service.rb
+++ b/app/services/events/validate_creation_service.rb
@@ -36,10 +36,10 @@ module Events
       return invalid_code_error unless valid_code?
       return invalid_properties_error unless valid_properties?
 
-      invalid_persisted_events = params[:external_subscription_ids]
+      invalid_quantified_events = params[:external_subscription_ids]
         .map { |external_id| organization.subscriptions.find_by(external_id:) }
         .each_with_object({}) do |subscription, errors|
-          validation_result = persisted_event_validation(subscription)
+          validation_result = quantified_event_validation(subscription)
           next errors if validation_result.blank?
 
           validation_result.each do |field, codes|
@@ -47,7 +47,7 @@ module Events
           end
           errors
         end
-      return invalid_persisted_event_error(invalid_persisted_events) if invalid_persisted_events.present?
+      return invalid_quantified_event_error(invalid_quantified_events) if invalid_quantified_events.present?
 
       nil
     end
@@ -59,8 +59,8 @@ module Events
       return invalid_properties_error unless valid_properties?
 
       subscription = organization.subscriptions.find_by(external_id: params[:external_subscription_id])
-      invalid_persisted_event = persisted_event_validation(subscription || customer.active_subscriptions.first)
-      return invalid_persisted_event_error(invalid_persisted_event) if invalid_persisted_event.present?
+      invalid_quantified_event = quantified_event_validation(subscription || customer.active_subscriptions.first)
+      return invalid_quantified_event_error(invalid_quantified_event) if invalid_quantified_event.present?
     end
 
     def valid_subscription?
@@ -137,7 +137,7 @@ module Events
       send_webhook_notice
     end
 
-    def invalid_persisted_event_error(errors)
+    def invalid_quantified_event_error(errors)
       result.validation_failure!(errors:)
       send_webhook_notice
     end
@@ -146,8 +146,8 @@ module Events
       @billable_metric ||= organization.billable_metrics.find_by(code: params[:code])
     end
 
-    def persisted_event_validation(subscription)
-      return {} unless billable_metric.recurring_count_agg?
+    def quantified_event_validation(subscription)
+      return {} unless billable_metric.recurring_count_agg? || billable_metric.unique_count_agg?
 
       validation_service = QuantifiedEvents::ValidateCreationService.new(
         result:,

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -113,7 +113,6 @@ module Invoices
         .where
         .not(pay_in_advance: true, billable_metric: { recurring: false })
         .each do |charge|
-
         fee_result = Fees::ChargeService.new(invoice:, charge:, subscription:, boundaries:).create
         fee_result.raise_if_error!
       end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -105,7 +105,9 @@ module Invoices
     end
 
     def create_charges_fees(subscription, boundaries)
-      subscription.plan.charges.where(pay_in_advance: false, invoiceable: true).each do |charge|
+      subscription.plan.charges.includes(:billable_metric).where(invoiceable: true).each do |charge|
+        next if charge.pay_in_advance? && !charge.billable_metric.recurring?
+
         fee_result = Fees::ChargeService.new(invoice:, charge:, subscription:, boundaries:).create
         fee_result.raise_if_error!
       end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -105,8 +105,14 @@ module Invoices
     end
 
     def create_charges_fees(subscription, boundaries)
-      subscription.plan.charges.includes(:billable_metric).where(invoiceable: true).each do |charge|
-        next if charge.pay_in_advance? && !charge.billable_metric.recurring?
+      subscription
+        .plan
+        .charges
+        .joins(:billable_metric)
+        .where(invoiceable: true)
+        .where
+        .not(pay_in_advance: true, billable_metric: { recurring: false })
+        .each do |charge|
 
         fee_result = Fees::ChargeService.new(invoice:, charge:, subscription:, boundaries:).create
         fee_result.raise_if_error!

--- a/app/services/quantified_events/create_or_update_service.rb
+++ b/app/services/quantified_events/create_or_update_service.rb
@@ -31,7 +31,7 @@ module QuantifiedEvents
 
     def event_operation_type
       operation_type = event.properties['operation_type']&.to_sym
-      operation_type.nil? && matching_billable_metric&.unique_count_agg? ? :add : operation_type
+      (operation_type.nil? && matching_billable_metric&.unique_count_agg?) ? :add : operation_type
     end
 
     def add_metric

--- a/app/services/quantified_events/create_or_update_service.rb
+++ b/app/services/quantified_events/create_or_update_service.rb
@@ -30,8 +30,8 @@ module QuantifiedEvents
     delegate :customer, :subscription, :organization, to: :event
 
     def event_operation_type
-      event_type = event.properties['operation_type']&.to_sym
-      event_type.nil? && matching_billable_metric&.unique_count_agg? ? :add : event_type
+      operation_type = event.properties['operation_type']&.to_sym
+      operation_type.nil? && matching_billable_metric&.unique_count_agg? ? :add : operation_type
     end
 
     def add_metric
@@ -49,6 +49,7 @@ module QuantifiedEvents
           external_id: event.properties[matching_billable_metric.field_name],
           properties: event.properties,
           added_at: event.timestamp,
+          event:,
         )
       end
     end

--- a/app/services/quantified_events/create_or_update_service.rb
+++ b/app/services/quantified_events/create_or_update_service.rb
@@ -41,6 +41,8 @@ module QuantifiedEvents
       #       prevent wrong units count
       if quantified_removed_on_event_day.present?
         quantified_removed_on_event_day.update!(removed_at: nil)
+
+        quantified_removed_on_event_day
       else
         QuantifiedEvent.create!(
           customer:,
@@ -49,7 +51,6 @@ module QuantifiedEvents
           external_id: event.properties[matching_billable_metric.field_name],
           properties: event.properties,
           added_at: event.timestamp,
-          event:,
         )
       end
     end

--- a/app/services/quantified_events/create_or_update_service.rb
+++ b/app/services/quantified_events/create_or_update_service.rb
@@ -20,7 +20,7 @@ module QuantifiedEvents
     end
 
     def matching_billable_metric?
-      matching_billable_metric&.recurring_count_agg?
+      matching_billable_metric&.recurring_count_agg? || matching_billable_metric&.unique_count_agg?
     end
 
     private
@@ -30,7 +30,8 @@ module QuantifiedEvents
     delegate :customer, :subscription, :organization, to: :event
 
     def event_operation_type
-      event.properties['operation_type']&.to_sym
+      event_type = event.properties['operation_type']&.to_sym
+      event_type.nil? && matching_billable_metric&.unique_count_agg? ? :add : event_type
     end
 
     def add_metric

--- a/app/services/quantified_events/create_or_update_service.rb
+++ b/app/services/quantified_events/create_or_update_service.rb
@@ -23,6 +23,18 @@ module QuantifiedEvents
       matching_billable_metric&.recurring_count_agg? || matching_billable_metric&.unique_count_agg?
     end
 
+    def process_event?
+      return true unless event_operation_type == :add
+      return true unless matching_billable_metric&.unique_count_agg?
+
+      # NOTE: Ensure no active quantified metric exists with the same external id
+      QuantifiedEvent.where(
+        customer_id: customer.id,
+        external_id: event.properties[matching_billable_metric.field_name],
+        external_subscription_id: subscription.external_id,
+      ).where(removed_at: nil).none?
+    end
+
     private
 
     attr_accessor :event

--- a/app/services/quantified_events/validate_creation_service.rb
+++ b/app/services/quantified_events/validate_creation_service.rb
@@ -26,7 +26,10 @@ module QuantifiedEvents
     delegate :customer, to: :subscription
 
     def operation_type
-      @operation_type ||= args.dig('properties', 'operation_type')&.to_sym
+      @operation_type ||= begin
+        event_type = args.dig('properties', 'operation_type')&.to_sym
+        event_type.nil? && billable_metric.unique_count_agg? ? :add : event_type
+      end
     end
 
     def external_id
@@ -49,7 +52,7 @@ module QuantifiedEvents
         external_subscription_id: subscription.external_id,
       ).where(removed_at: nil).none?
 
-      add_error(field: billable_metric.field_name, error_code: 'recurring_resource_already_added')
+      add_error(field: billable_metric.field_name, error_code: 'resource_already_added')
     end
 
     def validate_removal
@@ -61,7 +64,7 @@ module QuantifiedEvents
         external_subscription_id: subscription.external_id,
       ).where(removed_at: nil).exists?
 
-      add_error(field: billable_metric.field_name, error_code: 'recurring_resource_not_found')
+      add_error(field: billable_metric.field_name, error_code: 'resource_not_found')
     end
   end
 end

--- a/app/services/quantified_events/validate_creation_service.rb
+++ b/app/services/quantified_events/validate_creation_service.rb
@@ -27,8 +27,8 @@ module QuantifiedEvents
 
     def operation_type
       @operation_type ||= begin
-        event_type = args.dig('properties', 'operation_type')&.to_sym
-        event_type.nil? && billable_metric.unique_count_agg? ? :add : event_type
+        type = args.dig('properties', 'operation_type')&.to_sym
+        type.nil? && billable_metric.unique_count_agg? ? :add : type
       end
     end
 

--- a/app/services/quantified_events/validate_creation_service.rb
+++ b/app/services/quantified_events/validate_creation_service.rb
@@ -28,7 +28,7 @@ module QuantifiedEvents
     def operation_type
       @operation_type ||= begin
         type = args.dig('properties', 'operation_type')&.to_sym
-        type.nil? && billable_metric.unique_count_agg? ? :add : type
+        (type.nil? && billable_metric.unique_count_agg?) ? :add : type
       end
     end
 

--- a/app/services/quantified_events/validate_creation_service.rb
+++ b/app/services/quantified_events/validate_creation_service.rb
@@ -11,7 +11,6 @@ module QuantifiedEvents
 
     def valid?
       validate_operation_type
-      validate_addition
       validate_removal
 
       errors.blank?
@@ -40,19 +39,6 @@ module QuantifiedEvents
       return if %i[add remove].include?(operation_type)
 
       add_error(field: :operation_type, error_code: 'invalid_operation_type')
-    end
-
-    def validate_addition
-      return unless operation_type == :add
-
-      # NOTE: Ensure no active quantified metric exists with the same external id
-      return if QuantifiedEvent.where(
-        customer_id: customer.id,
-        external_id:,
-        external_subscription_id: subscription.external_id,
-      ).where(removed_at: nil).none?
-
-      add_error(field: billable_metric.field_name, error_code: 'resource_already_added')
     end
 
     def validate_removal

--- a/db/migrate/20230615183805_add_event_refrence_to_quantified_events.rb
+++ b/db/migrate/20230615183805_add_event_refrence_to_quantified_events.rb
@@ -2,6 +2,6 @@
 
 class AddEventRefrenceToQuantifiedEvents < ActiveRecord::Migration[7.0]
   def change
-    add_reference :quantified_events, :event, type: :uuid, index: true
+    add_reference :events, :quantified_event, type: :uuid, index: true
   end
 end

--- a/db/migrate/20230615183805_add_event_refrence_to_quantified_events.rb
+++ b/db/migrate/20230615183805_add_event_refrence_to_quantified_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEventRefrenceToQuantifiedEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :quantified_events, :event, type: :uuid, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -299,10 +299,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_15_183805) do
     t.jsonb "metadata", default: {}, null: false
     t.uuid "subscription_id"
     t.datetime "deleted_at"
+    t.uuid "quantified_event_id"
     t.index ["customer_id"], name: "index_events_on_customer_id"
     t.index ["deleted_at"], name: "index_events_on_deleted_at"
     t.index ["organization_id", "code"], name: "index_events_on_organization_id_and_code"
     t.index ["organization_id"], name: "index_events_on_organization_id"
+    t.index ["quantified_event_id"], name: "index_events_on_quantified_event_id"
     t.index ["subscription_id", "code"], name: "index_events_on_subscription_id_and_code"
     t.index ["subscription_id", "transaction_id"], name: "index_events_on_subscription_id_and_transaction_id", unique: true
     t.index ["subscription_id"], name: "index_events_on_subscription_id"
@@ -595,12 +597,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_15_183805) do
     t.uuid "billable_metric_id"
     t.jsonb "properties", default: {}, null: false
     t.datetime "deleted_at"
-    t.uuid "event_id"
     t.index ["billable_metric_id"], name: "index_quantified_events_on_billable_metric_id"
     t.index ["customer_id", "external_subscription_id", "billable_metric_id"], name: "index_search_quantified_events"
     t.index ["customer_id"], name: "index_quantified_events_on_customer_id"
     t.index ["deleted_at"], name: "index_quantified_events_on_deleted_at"
-    t.index ["event_id"], name: "index_quantified_events_on_event_id"
     t.index ["external_id"], name: "index_quantified_events_on_external_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_08_154821) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_15_183805) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -595,10 +595,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_08_154821) do
     t.uuid "billable_metric_id"
     t.jsonb "properties", default: {}, null: false
     t.datetime "deleted_at"
+    t.uuid "event_id"
     t.index ["billable_metric_id"], name: "index_quantified_events_on_billable_metric_id"
     t.index ["customer_id", "external_subscription_id", "billable_metric_id"], name: "index_search_quantified_events"
     t.index ["customer_id"], name: "index_quantified_events_on_customer_id"
     t.index ["deleted_at"], name: "index_quantified_events_on_deleted_at"
+    t.index ["event_id"], name: "index_quantified_events_on_event_id"
     t.index ["external_id"], name: "index_quantified_events_on_external_id"
   end
 

--- a/spec/factories/quantified_events.rb
+++ b/spec/factories/quantified_events.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   factory :quantified_event do
     customer
     billable_metric
-    event
 
     external_id { SecureRandom.uuid }
     added_at { Time.current - 10.days }

--- a/spec/factories/quantified_events.rb
+++ b/spec/factories/quantified_events.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :quantified_event do
     customer
     billable_metric
+    event
 
     external_id { SecureRandom.uuid }
     added_at { Time.current - 10.days }

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -145,6 +145,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
       feb17 = DateTime.new(2023, 2, 17)
 
       travel_to(feb17) do
+        # Logic has changed here. We do not persist events that are not unique. Instead, error is returned.
         expect do
           create_event(
             {
@@ -154,16 +155,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
               properties: { unique_id: 'id_1' },
             },
           )
-        end.to change { subscription.reload.fees.count }.from(1).to(2)
-
-        fee = subscription.fees.order(created_at: :desc).first
-
-        expect(fee.invoice_id).to be_nil
-        expect(fee.charge_id).to eq(charge.id)
-        expect(fee.pay_in_advance).to eq(true)
-        expect(fee.units).to eq(0)
-        expect(fee.events_count).to eq(1)
-        expect(fee.amount_cents).to eq(0)
+        end.not_to change { subscription.reload.fees.count }
       end
 
       ### 18 february: Send an other event.
@@ -179,7 +171,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
               properties: { unique_id: 'id_2' },
             },
           )
-        end.to change { subscription.reload.fees.count }.from(2).to(3)
+        end.to change { subscription.reload.fees.count }.from(1).to(2)
 
         fee = subscription.fees.order(created_at: :desc).first
 

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -186,9 +186,9 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
         expect(fee.invoice_id).to be_nil
         expect(fee.charge_id).to eq(charge.id)
         expect(fee.pay_in_advance).to eq(true)
-        expect(fee.units).to eq(1)
+        expect(fee.units).to eq(0)
         expect(fee.events_count).to eq(1)
-        expect(fee.amount_cents).to eq(1200)
+        expect(fee.amount_cents).to eq(0)
       end
 
       ### 18 february: Send an other event.

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -114,7 +114,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
         properties: { amount: '12' },
       )
 
-      subscription = customer.subscriptions.first
+      subscription = customer.subscriptions.order(created_at: :desc).first
 
       ### 15 february: Send an event.
       feb15 = DateTime.new(2023, 2, 15)
@@ -131,7 +131,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
           )
         end.to change { subscription.reload.fees.count }.from(0).to(1)
 
-        fee = subscription.fees.first
+        fee = subscription.fees.order(created_at: :desc).first
 
         expect(fee.invoice_id).to be_nil
         expect(fee.charge_id).to eq(charge.id)
@@ -141,11 +141,35 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
         expect(fee.amount_cents).to eq(1200)
       end
 
+      ### 16 february: Send an event.
+      feb16 = DateTime.new(2023, 2, 16)
+
+      travel_to(feb16) do
+        expect do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { unique_id: 'id_1', operation_type: 'remove' },
+            },
+          )
+        end.to change { subscription.reload.fees.count }.from(1).to(2)
+
+        fee = subscription.fees.order(created_at: :desc).first
+
+        expect(fee.invoice_id).to be_nil
+        expect(fee.charge_id).to eq(charge.id)
+        expect(fee.pay_in_advance).to eq(true)
+        expect(fee.units).to eq(0)
+        expect(fee.events_count).to eq(1)
+        expect(fee.amount_cents).to eq(0)
+      end
+
       ### 17 february: Send an other event.
       feb17 = DateTime.new(2023, 2, 17)
 
       travel_to(feb17) do
-        # Logic has changed here. We do not persist events that are not unique. Instead, error is returned.
         expect do
           create_event(
             {
@@ -155,7 +179,16 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
               properties: { unique_id: 'id_1' },
             },
           )
-        end.not_to change { subscription.reload.fees.count }
+        end.to change { subscription.reload.fees.count }.from(2).to(3)
+
+        fee = subscription.fees.order(created_at: :desc).first
+
+        expect(fee.invoice_id).to be_nil
+        expect(fee.charge_id).to eq(charge.id)
+        expect(fee.pay_in_advance).to eq(true)
+        expect(fee.units).to eq(1)
+        expect(fee.events_count).to eq(1)
+        expect(fee.amount_cents).to eq(1200)
       end
 
       ### 18 february: Send an other event.
@@ -171,7 +204,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
               properties: { unique_id: 'id_2' },
             },
           )
-        end.to change { subscription.reload.fees.count }.from(1).to(2)
+        end.to change { subscription.reload.fees.count }.from(3).to(4)
 
         fee = subscription.fees.order(created_at: :desc).first
 
@@ -181,6 +214,72 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
         expect(fee.units).to eq(1)
         expect(fee.events_count).to eq(1)
         expect(fee.amount_cents).to eq(1200)
+      end
+
+      ### 19 february: Send an other event. Event uses the same value so it is ignored.
+      feb18 = DateTime.new(2023, 2, 19)
+
+      travel_to(feb18) do
+        expect do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { unique_id: 'id_2' },
+            },
+          )
+        end.not_to change { subscription.reload.fees.count }
+      end
+
+      ### 20 february: Send an other event.
+      feb20 = DateTime.new(2023, 2, 20)
+
+      travel_to(feb20) do
+        expect do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { unique_id: 'id_3' },
+            },
+          )
+        end.to change { subscription.reload.fees.count }.from(4).to(5)
+
+        fee = subscription.fees.order(created_at: :desc).first
+
+        expect(fee.invoice_id).to be_nil
+        expect(fee.charge_id).to eq(charge.id)
+        expect(fee.pay_in_advance).to eq(true)
+        expect(fee.units).to eq(1)
+        expect(fee.events_count).to eq(1)
+        expect(fee.amount_cents).to eq(1200)
+      end
+
+      ### 21 february: Send an event.
+      feb21 = DateTime.new(2023, 2, 21)
+
+      travel_to(feb21) do
+        expect do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { unique_id: 'id_3', operation_type: 'remove' },
+            },
+          )
+        end.to change { subscription.reload.fees.count }.from(5).to(6)
+
+        fee = subscription.fees.order(created_at: :desc).first
+
+        expect(fee.invoice_id).to be_nil
+        expect(fee.charge_id).to eq(charge.id)
+        expect(fee.pay_in_advance).to eq(true)
+        expect(fee.units).to eq(0)
+        expect(fee.events_count).to eq(1)
+        expect(fee.amount_cents).to eq(0)
       end
     end
   end

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
 
       before { new_quantified_event }
 
-      it 'returns the only the number of events ingested in current period' do
+      it 'returns only the number of events ingested in the current period' do
         expect(result.aggregation).to eq(1)
       end
     end

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -228,6 +228,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
     end
 
     context 'when event is given' do
+      let(:properties) { { unique_id: '111' } }
       let(:pay_in_advance_event) do
         create(
           :event,
@@ -251,8 +252,6 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       end
 
       before { new_quantified_event }
-
-      let(:properties) { { unique_id: '111' } }
 
       it 'assigns an pay_in_advance aggregation' do
         result = count_service.aggregate(from_datetime:, to_datetime:)

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -12,7 +12,18 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
     )
   end
 
-  let(:subscription) { create(:subscription) }
+  let(:subscription) do
+    create(
+      :subscription,
+      started_at:,
+      subscription_at:,
+      billing_time: :anniversary,
+    )
+  end
+
+  let(:pay_in_advance_event) { nil }
+  let(:subscription_at) { DateTime.parse('2022-06-09') }
+  let(:started_at) { subscription_at }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:group) { nil }
@@ -22,157 +33,319 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       :billable_metric,
       organization:,
       aggregation_type: 'unique_count_agg',
-      field_name: 'anonymous_id',
+      field_name: 'unique_id',
+      recurring: true,
     )
   end
 
-  let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
-  let(:to_datetime) { Time.current.end_of_day }
+  let(:from_datetime) { DateTime.parse('2022-07-09 00:00:00 UTC') }
+  let(:to_datetime) { DateTime.parse('2022-08-08 23:59:59 UTC') }
 
-  let(:pay_in_advance_event) { nil }
-
-  before do
-    create_list(
-      :event,
-      4,
-      code: billable_metric.code,
+  let(:added_at) { from_datetime - 1.month }
+  let(:removed_at) { nil }
+  let(:quantified_event) do
+    create(
+      :quantified_event,
       customer:,
-      subscription:,
-      timestamp: Time.zone.now - 1.day,
-      properties: {
-        anonymous_id: 'foo_bar',
-      },
+      added_at:,
+      removed_at:,
+      external_subscription_id: subscription.external_id,
+      billable_metric:,
     )
   end
 
-  it 'aggregates the events' do
-    result = count_service.aggregate(from_datetime:, to_datetime:)
+  before { quantified_event }
 
-    expect(result.aggregation).to eq(1)
-    expect(result.count).to eq(4)
-  end
+  describe '#aggregate' do
+    let(:result) { count_service.aggregate(from_datetime:, to_datetime:) }
 
-  context 'when events are out of bounds' do
-    let(:to_datetime) { Time.zone.now - 2.days }
+    context 'when there is persisted event and event added in period' do
+      let(:new_quantified_event) do
+        create(
+          :quantified_event,
+          customer:,
+          added_at: from_datetime + 10.days,
+          removed_at:,
+          external_subscription_id: subscription.external_id,
+          billable_metric:,
+        )
+      end
 
-    it 'does not take events into account' do
-      result = count_service.aggregate(from_datetime:, to_datetime:)
+      before { new_quantified_event }
 
-      expect(result.aggregation).to eq(0)
-      expect(result.count).to eq(0)
-    end
-  end
-
-  context 'when properties is not found on events' do
-    before do
-      billable_metric.update!(field_name: 'foo_bar')
-    end
-
-    it 'counts as zero' do
-      result = count_service.aggregate(from_datetime:, to_datetime:)
-
-      expect(result.aggregation).to eq(0)
-      expect(result.count).to eq(0)
-    end
-  end
-
-  context 'when group_id is given' do
-    let(:group) do
-      create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+      it 'returns the correct number' do
+        expect(result.aggregation).to eq(2)
+      end
     end
 
-    before do
-      create(
-        :event,
-        code: billable_metric.code,
-        customer:,
-        subscription:,
-        timestamp: Time.zone.now,
-        properties: {
-          anonymous_id: 'foo_bar',
-          region: 'europe',
-        },
-      )
+    context 'when there is persisted event and event added in period but billable metric is not recurring' do
+      let(:billable_metric) do
+        create(
+          :billable_metric,
+          organization:,
+          aggregation_type: 'unique_count_agg',
+          field_name: 'unique_id',
+          recurring: false,
+        )
+      end
+      let(:new_quantified_event) do
+        create(
+          :quantified_event,
+          customer:,
+          added_at: from_datetime + 10.days,
+          removed_at:,
+          external_subscription_id: subscription.external_id,
+          billable_metric:,
+        )
+      end
 
-      create(
-        :event,
-        code: billable_metric.code,
-        customer:,
-        subscription:,
-        timestamp: Time.zone.now,
-        properties: {
-          anonymous_id: 'foo_bar',
-          region: 'europe',
-        },
-      )
+      before { new_quantified_event }
 
-      create(
-        :event,
-        code: billable_metric.code,
-        customer:,
-        subscription:,
-        timestamp: Time.zone.now,
-        properties: {
-          anonymous_id: 'foo_bar',
-          region: 'africa',
-        },
-      )
+      it 'returns the only the number of events ingested in current period' do
+        expect(result.aggregation).to eq(1)
+      end
     end
 
-    it 'aggregates the events' do
-      result = count_service.aggregate(from_datetime:, to_datetime:)
+    context 'with persisted metric on full period' do
+      it 'returns the number of persisted metric' do
+        expect(result.aggregation).to eq(1)
+      end
 
-      expect(result.aggregation).to eq(1)
-      expect(result.count).to eq(2)
+      context 'when subscription was terminated in the period' do
+        let(:subscription) do
+          create(
+            :subscription,
+            started_at:,
+            subscription_at:,
+            billing_time: :anniversary,
+            terminated_at: to_datetime,
+            status: :terminated,
+          )
+        end
+        let(:to_datetime) { DateTime.parse('2022-07-24 23:59:59') }
+
+        it 'returns the correct number' do
+          expect(result.aggregation).to eq(1)
+        end
+      end
+
+      context 'when subscription was upgraded in the period' do
+        let(:subscription) do
+          create(
+            :subscription,
+            started_at:,
+            subscription_at:,
+            billing_time: :anniversary,
+            terminated_at: to_datetime,
+            status: :terminated,
+          )
+        end
+        let(:to_datetime) { DateTime.parse('2022-07-24 23:59:59') }
+
+        before do
+          create(
+            :subscription,
+            previous_subscription: subscription,
+            organization:,
+            customer:,
+            started_at: to_datetime,
+          )
+        end
+
+        it 'returns the correct number' do
+          expect(result.aggregation).to eq(1)
+        end
+      end
+
+      context 'when subscription was started in the period' do
+        let(:started_at) { DateTime.parse('2022-08-01') }
+        let(:from_datetime) { started_at }
+
+        it 'returns the correct number' do
+          expect(result.aggregation).to eq(1)
+        end
+      end
+
+      context 'when plan is pay in advance' do
+        before do
+          subscription.plan.update!(pay_in_advance: true)
+        end
+
+        it 'returns the correct number' do
+          expect(result.aggregation).to eq(1)
+        end
+      end
     end
-  end
 
-  context 'when event is given' do
-    let(:pay_in_advance_event) do
-      create(
-        :event,
-        code: billable_metric.code,
-        customer:,
-        subscription:,
-        timestamp: Time.zone.now - 1.day,
-        properties:,
-      )
+    context 'with persisted metrics added in the period' do
+      let(:added_at) { from_datetime + 15.days }
+
+      it 'returns the correct number' do
+        expect(result.aggregation).to eq(1)
+      end
+
+      context 'when added on the first day of the period' do
+        let(:added_at) { from_datetime }
+
+        it 'returns the correct number' do
+          expect(result.aggregation).to eq(1)
+        end
+      end
     end
 
-    let(:properties) { { anonymous_id: 'unknown' } }
+    context 'with persisted metrics terminated in the period' do
+      let(:removed_at) { to_datetime - 15.days }
 
-    it 'assigns an pay_in_advance aggregation' do
-      result = count_service.aggregate(from_datetime:, to_datetime:)
+      it 'returns the correct number' do
+        expect(result.aggregation).to eq(0)
+      end
 
-      expect(result.pay_in_advance_aggregation).to eq(1)
+      context 'when removed on the last day of the period' do
+        let(:removed_at) { to_datetime }
+
+        it 'returns the correct number' do
+          expect(result.aggregation).to eq(0)
+        end
+      end
     end
 
-    context 'when event property is already known' do
-      before do
+    context 'with persisted metrics added and terminated in the period' do
+      let(:added_at) { from_datetime + 1.day }
+      let(:removed_at) { to_datetime - 1.day }
+
+      it 'returns the correct number' do
+        expect(result.aggregation).to eq(0)
+      end
+
+      context 'when added and removed the same day' do
+        let(:added_at) { from_datetime + 1.day }
+        let(:removed_at) { added_at.end_of_day }
+
+        it 'returns a correct number' do
+          expect(result.aggregation).to eq(0)
+        end
+      end
+    end
+
+    context 'when event is given' do
+      let(:pay_in_advance_event) do
         create(
           :event,
           code: billable_metric.code,
           customer:,
           subscription:,
-          timestamp: Time.zone.now - 1.day,
+          timestamp: from_datetime + 10.days,
           properties:,
         )
       end
-
-      it 'assigns zero as pay_in_advance aggregation' do
-        result = count_service.aggregate(from_datetime:, to_datetime:)
-
-        expect(result.pay_in_advance_aggregation).to be_zero
+      let(:new_quantified_event) do
+        create(
+          :quantified_event,
+          customer:,
+          added_at: from_datetime + 10.days,
+          removed_at:,
+          event: pay_in_advance_event,
+          external_subscription_id: subscription.external_id,
+          billable_metric:,
+        )
       end
-    end
 
-    context 'when event is missing properties' do
-      let(:properties) { {} }
+      before { new_quantified_event }
 
-      it 'assigns 0 as pay_in_advance aggregation' do
+      let(:properties) { { unique_id: '111' } }
+
+      it 'assigns an pay_in_advance aggregation' do
         result = count_service.aggregate(from_datetime:, to_datetime:)
 
-        expect(result.pay_in_advance_aggregation).to be_zero
+        expect(result.pay_in_advance_aggregation).to eq(1)
+      end
+
+      context 'when event is missing properties' do
+        let(:properties) { {} }
+
+        it 'assigns 0 as pay_in_advance aggregation' do
+          result = count_service.aggregate(from_datetime:, to_datetime:)
+
+          expect(result.pay_in_advance_aggregation).to be_zero
+        end
+      end
+
+      context 'when current period aggregation is greater than period maximum' do
+        let(:previous_event) do
+          create(
+            :event,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: from_datetime + 5.days,
+            properties: {
+              unique_id: '000',
+            },
+            metadata: {
+              current_aggregation: '7',
+              max_aggregation: '7',
+            },
+          )
+        end
+        let(:previous_quantified_event) do
+          create(
+            :quantified_event,
+            customer:,
+            added_at: from_datetime + 5.days,
+            removed_at:,
+            external_id: '000',
+            event: previous_event,
+            external_subscription_id: subscription.external_id,
+            billable_metric:,
+          )
+        end
+
+        before { previous_quantified_event }
+
+        it 'assigns a pay_in_advance aggregation' do
+          result = count_service.aggregate(from_datetime:, to_datetime:)
+
+          expect(result.pay_in_advance_aggregation).to eq(1)
+        end
+      end
+
+      context 'when current period aggregation is less than period maximum' do
+        let(:previous_event) do
+          create(
+            :event,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: from_datetime + 5.days,
+            properties: {
+              unique_id: '000',
+            },
+            metadata: {
+              current_aggregation: '4',
+              max_aggregation: '7',
+            },
+          )
+        end
+        let(:previous_quantified_event) do
+          create(
+            :quantified_event,
+            customer:,
+            added_at: from_datetime + 5.days,
+            removed_at:,
+            external_id: '000',
+            event: previous_event,
+            external_subscription_id: subscription.external_id,
+            billable_metric:,
+          )
+        end
+
+        before { previous_quantified_event }
+
+        it 'assigns a pay_in_advance aggregation' do
+          result = count_service.aggregate(from_datetime:, to_datetime:)
+
+          expect(result.pay_in_advance_aggregation).to eq(0)
+        end
       end
     end
   end

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -237,6 +237,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
           subscription:,
           timestamp: from_datetime + 10.days,
           properties:,
+          quantified_event: new_quantified_event,
         )
       end
       let(:new_quantified_event) do
@@ -245,13 +246,12 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
           customer:,
           added_at: from_datetime + 10.days,
           removed_at:,
-          event: pay_in_advance_event,
           external_subscription_id: subscription.external_id,
           billable_metric:,
         )
       end
 
-      before { new_quantified_event }
+      before { pay_in_advance_event }
 
       it 'assigns an pay_in_advance aggregation' do
         result = count_service.aggregate(from_datetime:, to_datetime:)
@@ -277,6 +277,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
             customer:,
             subscription:,
             timestamp: from_datetime + 5.days,
+            quantified_event: previous_quantified_event,
             properties: {
               unique_id: '000',
             },
@@ -293,13 +294,12 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
             added_at: from_datetime + 5.days,
             removed_at:,
             external_id: '000',
-            event: previous_event,
             external_subscription_id: subscription.external_id,
             billable_metric:,
           )
         end
 
-        before { previous_quantified_event }
+        before { previous_event }
 
         it 'assigns a pay_in_advance aggregation' do
           result = count_service.aggregate(from_datetime:, to_datetime:)
@@ -316,6 +316,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
             customer:,
             subscription:,
             timestamp: from_datetime + 5.days,
+            quantified_event: previous_quantified_event,
             properties: {
               unique_id: '000',
             },
@@ -332,13 +333,12 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
             added_at: from_datetime + 5.days,
             removed_at:,
             external_id: '000',
-            event: previous_event,
             external_subscription_id: subscription.external_id,
             billable_metric:,
           )
         end
 
-        before { previous_quantified_event }
+        before { previous_event }
 
         it 'assigns a pay_in_advance aggregation' do
           result = count_service.aggregate(from_datetime:, to_datetime:)

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -367,6 +367,18 @@ RSpec.describe Events::CreateService, type: :service do
         end.to change(QuantifiedEvent, :count).by(1)
       end
 
+      it 'creates association with quantified event' do
+        result = create_service.call(
+          organization:,
+          params: create_args,
+          timestamp:,
+          metadata: {},
+        )
+
+        expect(result).to be_success
+        expect(result.event.reload.quantified_event).to be_present
+      end
+
       context 'when a validation error occurs' do
         let(:create_args) do
           {

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -409,40 +409,75 @@ RSpec.describe Fees::ChargeService do
         end
       end
 
-      it 'creates expected fees for unique_count_agg aggregation type' do
-        billable_metric.update!(aggregation_type: :unique_count_agg, field_name: 'foo_bar')
-        result = charge_subscription_service.create
-        expect(result).to be_success
-        created_fees = result.fees
+      context 'when unique_count_agg' do
+        before do
+          create(
+            :quantified_event,
+            customer: subscription.customer,
+            added_at: DateTime.parse('2022-03-16'),
+            removed_at: nil,
+            external_id: '12',
+            external_subscription_id: subscription.external_id,
+            billable_metric: charge.billable_metric,
+            properties: { region: 'usa', foo_bar: 12 },
+          )
+          create(
+            :quantified_event,
+            customer: subscription.customer,
+            added_at: DateTime.parse('2022-03-16'),
+            removed_at: nil,
+            external_id: '10',
+            external_subscription_id: subscription.external_id,
+            billable_metric: charge.billable_metric,
+            properties: { region: 'europe', foo_bar: 10 },
+          )
+          create(
+            :quantified_event,
+            customer: subscription.customer,
+            added_at: DateTime.parse('2022-03-16'),
+            removed_at: nil,
+            external_id: '5',
+            external_subscription_id: subscription.external_id,
+            billable_metric: charge.billable_metric,
+            properties: { country: 'france', foo_bar: 5 },
+          )
+        end
 
-        aggregate_failures do
-          expect(created_fees.count).to eq(3)
-          expect(created_fees).to all(
-            have_attributes(
-              invoice_id: invoice.id,
-              charge_id: charge.id,
-              amount_currency: 'EUR',
-              taxes_rate: 20.0,
-            ),
-          )
-          expect(created_fees.first).to have_attributes(
-            group: europe,
-            amount_cents: 4000,
-            taxes_amount_cents: 800,
-            units: 2,
-          )
-          expect(created_fees.second).to have_attributes(
-            group: usa,
-            amount_cents: 5000,
-            taxes_amount_cents: 1000,
-            units: 1,
-          )
-          expect(created_fees.third).to have_attributes(
-            group: france,
-            amount_cents: 4000,
-            taxes_amount_cents: 800,
-            units: 1,
-          )
+        it 'creates expected fees for unique_count_agg aggregation type' do
+          billable_metric.update!(aggregation_type: :unique_count_agg, field_name: 'foo_bar')
+          result = charge_subscription_service.create
+          expect(result).to be_success
+          created_fees = result.fees
+
+          aggregate_failures do
+            expect(created_fees.count).to eq(3)
+            expect(created_fees).to all(
+              have_attributes(
+                invoice_id: invoice.id,
+                charge_id: charge.id,
+                amount_currency: 'EUR',
+                taxes_rate: 20.0,
+              ),
+            )
+            expect(created_fees.first).to have_attributes(
+              group: europe,
+              amount_cents: 2000,
+              taxes_amount_cents: 400,
+              units: 1,
+            )
+            expect(created_fees.second).to have_attributes(
+              group: usa,
+              amount_cents: 5000,
+              taxes_amount_cents: 1000,
+              units: 1,
+            )
+            expect(created_fees.third).to have_attributes(
+              group: france,
+              amount_cents: 4000,
+              taxes_amount_cents: 800,
+              units: 1,
+            )
+          end
         end
       end
 

--- a/spec/services/quantified_events/create_or_update_service_spec.rb
+++ b/spec/services/quantified_events/create_or_update_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
   let(:billable_metric) do
     create(
       :billable_metric,
-      aggregation_type: 'recurring_count_agg',
+      aggregation_type: 'unique_count_agg',
       field_name: 'item_id',
     )
   end
@@ -173,6 +173,26 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
       end
 
       it { expect(create_service).not_to be_matching_billable_metric }
+    end
+  end
+
+  describe '#process_event?' do
+    it { expect(create_service).to be_process_event }
+
+    context 'with an active quantified metric' do
+      before do
+        create(
+          :quantified_event,
+          customer: event.customer,
+          billable_metric:,
+          external_subscription_id: event.subscription.external_id,
+          external_id: 'ext_12345',
+        )
+      end
+
+      it 'does not add quantified event for the same external id' do
+        expect(create_service).not_to be_process_event
+      end
     end
   end
 end

--- a/spec/services/quantified_events/create_or_update_service_spec.rb
+++ b/spec/services/quantified_events/create_or_update_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
       end
     end
 
-    context 'context without operation type for unique_count_agg' do
+    context 'without operation type for unique_count_agg' do
       let(:operation_type) { nil }
       let(:billable_metric) do
         create(

--- a/spec/services/quantified_events/create_or_update_service_spec.rb
+++ b/spec/services/quantified_events/create_or_update_service_spec.rb
@@ -80,6 +80,32 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
       end
     end
 
+    context 'context without operation type for unique_count_agg' do
+      let(:operation_type) { nil }
+      let(:billable_metric) do
+        create(
+          :billable_metric,
+          aggregation_type: 'unique_count_agg',
+          field_name: 'item_id',
+        )
+      end
+
+      it 'creates a quantified metric' do
+        aggregate_failures do
+          expect { service_result }.to change(QuantifiedEvent, :count).by(1)
+
+          expect(service_result).to be_success
+
+          quantified_event = service_result.quantified_event
+          expect(quantified_event.customer).to eq(event.customer)
+          expect(quantified_event.external_subscription_id).to eq(event.subscription.external_id)
+          expect(quantified_event.external_id).to eq('ext_12345')
+          expect(quantified_event.properties).to eq(event.properties)
+          expect(quantified_event.added_at.to_s).to eq(event.timestamp.to_s)
+        end
+      end
+    end
+
     context 'with remove operation type' do
       let(:quantified_event) do
         create(
@@ -137,7 +163,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
   describe '#matching_billable_metric?' do
     it { expect(create_service).to be_matching_billable_metric }
 
-    context 'when billable metric is not a recurring count aggregation' do
+    context 'when billable metric is not a recurring_count or unique_count aggregation' do
       let(:billable_metric) do
         create(
           :billable_metric,

--- a/spec/services/quantified_events/validate_creation_service_spec.rb
+++ b/spec/services/quantified_events/validate_creation_service_spec.rb
@@ -76,44 +76,6 @@ RSpec.describe QuantifiedEvents::ValidateCreationService, type: :service do
     end
   end
 
-  context 'when operation type is add' do
-    it { expect(validation_service).to be_valid }
-
-    context 'with an active quantified metric' do
-      before do
-        create(
-          :quantified_event,
-          customer:,
-          external_id:,
-          external_subscription_id: subscription.external_id,
-        )
-      end
-
-      it 'fails' do
-        aggregate_failures do
-          expect(validation_service).not_to be_valid
-          expect(validation_service.errors.keys).to include(billable_metric.field_name.to_sym)
-          expect(validation_service.errors[billable_metric.field_name.to_sym])
-            .to eq(['resource_already_added'])
-        end
-      end
-    end
-
-    context 'with removed quantified metric' do
-      before do
-        create(
-          :quantified_event,
-          customer:,
-          external_id:,
-          external_subscription_id: subscription.external_id,
-          removed_at: Time.current - 3.days,
-        )
-      end
-
-      it { expect(validation_service).to be_valid }
-    end
-  end
-
   context 'when operation type is remove' do
     let(:operation_type) { 'remove' }
 

--- a/spec/services/quantified_events/validate_creation_service_spec.rb
+++ b/spec/services/quantified_events/validate_creation_service_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe QuantifiedEvents::ValidateCreationService, type: :service do
   let(:external_id) { 'ext_12345' }
   let(:operation_type) { 'add' }
 
-  context 'without operation type' do
+  context 'without operation type for recurring_count_agg metric' do
     let(:operation_type) { nil }
 
     it 'fails' do
@@ -48,6 +48,20 @@ RSpec.describe QuantifiedEvents::ValidateCreationService, type: :service do
         expect(validation_service.errors[:operation_type]).to eq(['invalid_operation_type'])
       end
     end
+  end
+
+  context 'without operation type for unique_count_agg metric' do
+    let(:operation_type) { nil }
+    let(:billable_metric) do
+      create(
+        :billable_metric,
+        aggregation_type: 'unique_count_agg',
+        organization: customer.organization,
+        field_name: 'item_id',
+      )
+    end
+
+    it { expect(validation_service).to be_valid }
   end
 
   context 'with invalid operation type' do
@@ -80,7 +94,7 @@ RSpec.describe QuantifiedEvents::ValidateCreationService, type: :service do
           expect(validation_service).not_to be_valid
           expect(validation_service.errors.keys).to include(billable_metric.field_name.to_sym)
           expect(validation_service.errors[billable_metric.field_name.to_sym])
-            .to eq(['recurring_resource_already_added'])
+            .to eq(['resource_already_added'])
         end
       end
     end
@@ -108,7 +122,7 @@ RSpec.describe QuantifiedEvents::ValidateCreationService, type: :service do
         aggregate_failures do
           expect(validation_service).not_to be_valid
           expect(validation_service.errors.keys).to include(billable_metric.field_name.to_sym)
-          expect(validation_service.errors[billable_metric.field_name.to_sym]).to eq(['recurring_resource_not_found'])
+          expect(validation_service.errors[billable_metric.field_name.to_sym]).to eq(['resource_not_found'])
         end
       end
     end
@@ -141,7 +155,7 @@ RSpec.describe QuantifiedEvents::ValidateCreationService, type: :service do
         aggregate_failures do
           expect(validation_service).not_to be_valid
           expect(validation_service.errors.keys).to include(billable_metric.field_name.to_sym)
-          expect(validation_service.errors[billable_metric.field_name.to_sym]).to eq(['recurring_resource_not_found'])
+          expect(validation_service.errors[billable_metric.field_name.to_sym]).to eq(['resource_not_found'])
         end
       end
     end


### PR DESCRIPTION
## Context

As part of new charge pay in advance feature, unique count aggregation is refactored and computation of pay in advance event is changed

## Description

This PR covers few parts:

- aggregation for unique count BM has changed since currently we support operation types
- computation of pay in advance event has changed since we need to take into account maximum in current period in order to calculate fair price for the user
