### PR TITLE
feat(tax): Display taxes on credit note PDF template

### DIFF
--- a/app/graphql/types/credit_notes/applied_taxes/object.rb
+++ b/app/graphql/types/credit_notes/applied_taxes/object.rb
@@ -7,6 +7,7 @@ module Types
         graphql_name 'CreditNoteAppliedTax'
         implements Types::Taxes::AppliedTax
 
+        field :base_amount_cents, GraphQL::Types::BigInt, null: false
         field :credit_note, Types::CreditNotes::Object, null: false
       end
     end

--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -7,4 +7,8 @@ class CreditNoteItem < ApplicationRecord
   monetize :amount_cents
 
   validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
+
+  def applied_taxes
+    credit_note.applied_taxes.where(tax_id: fee.applied_taxes.select('fees_taxes.tax_id'))
+  end
 end

--- a/app/serializers/v1/credit_notes/applied_tax_serializer.rb
+++ b/app/serializers/v1/credit_notes/applied_tax_serializer.rb
@@ -12,6 +12,7 @@ module V1
           tax_code: model.tax_code,
           tax_rate: model.tax_rate,
           tax_description: model.tax_description,
+          base_amount_cents: model.base_amount_cents,
           amount_cents: model.amount_cents,
           amount_currency: model.amount_currency,
           created_at: model.created_at.iso8601,

--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -239,28 +239,44 @@ html
       }
 
       .credit-note-resume-table tr td {
-        padding-bottom: 12px;
+        padding-top: 8px;
+        padding-bottom: 8px;
       }
       .credit-note-resume-table tr td:last-child {
         text-align: right;
       }
-      .credit-note-resume-table tr:last-child td {
-        border-bottom: 1px solid #d9dee7;
-        padding-bottom: 24px;
+      .credit-note-resume-table tr td {
+        box-shadow: inset 0px -1px 0px #D9DEE7;
       }
       .credit-note-resume table {
         border-collapse: collapse;
       }
-      .credit-note-resume .total-table tr:last-child td {
-        border-bottom: 1px solid #d9dee7;
-        padding-bottom: 24px;
-      }
-      .credit-note-resume .total-table tr:first-child td {
-        padding-top: 24px;
-      }
+
       .credit-note-resume .total-table tr td {
-        padding-bottom: 12px;
+        padding-top: 8px;
+        padding-bottom: 8px;
         text-align: right;
+      }
+      .credit-note-resume  .total-table td:first-child {
+        width: 50%;
+      }
+      .credit-note-resume .total-table tr:not(:last-child) td:nth-child(2) {
+        box-shadow: inset 0px -1px 0px #D9DEE7;
+        text-align: left;
+        width: 35%;
+      }
+      .credit-note-resume .total-table tr:not(:last-child) td:nth-child(3) {
+        box-shadow: inset 0px -1px 0px #D9DEE7;
+        text-align: right;
+        width: 15%;
+      }
+      .credit-note-resume .total-table tr:last-child td:nth-child(2) {
+        text-align: left;
+        width: 35%;
+      }
+      .credit-note-resume .total-table tr:last-child td:nth-child(3) {
+        text-align: right;
+        width: 15%;
       }
 
       .powered-by {
@@ -355,7 +371,7 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
 
       .mb-24
-        h2.title-2.mb-8 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+        h2.title-2.mb-8 = MoneyHelper.format(total_amount)
         .body-1
           - if credited? && refunded?
             = I18n.t('credit_note.credited_refunded_notice', issuing_date: I18n.l(issuing_date, format: :default))
@@ -366,21 +382,33 @@ html
 
       .credit-note-resume.mb-24.overflow-auto
         table.credit-note-resume-table width="100%"
+          tr
+            td.body-3 style="text-align: left;"  = I18n.t('credit_note.item')
+            td.body-3 style="text-align: left;" = I18n.t('credit_note.tax_rate')
+            td.body-3 style="text-align: right;" = I18n.t('credit_note.amount')
+
           - subscription_ids.each do |subscription_id|
             - if subscription_id.present?
               tr
-                td.body-1 width="70%"
+                td.body-1 width="60%"
                   | #{I18n.t('credit_note.subscription')} - #{Subscription.find_by(id: subscription_id)&.display_name}
-                td.body-1 width="30%" style="text-align: right;"
-                  = subscription_item(subscription_id).amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+                td.body-2 width="20%"
+                  - subscription_item(subscription_id).applied_taxes.each do |applied_tax|
+                    div = "#{applied_tax.tax_rate}%"
+                td.body-2 width="20%" style="text-align: right;"
+                  = MoneyHelper.format(subscription_item(subscription_id).amount)
               - subscription_charge_items(subscription_id).each do |item|
                 tr
                   - if item.fee.true_up_parent_fee_id?
                     td.body-1 = I18n.t('invoice.true_up_metric', metric: item.fee.item_name)
                   - else
                     td.body-1 = item.fee.item_name
-                  td.body-1 width="30%" style="text-align: right;"
-                    = item.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+
+                  td.body-2 width="20%"
+                    - item.applied_taxes.each do |applied_tax|
+                      div = "#{applied_tax.tax_rate}%"
+                  td.body-2 width="20%" style="text-align: right;"
+                    = MoneyHelper.format(item.amount)
             - else
               - add_on_items.each do |item|
                 tr
@@ -389,32 +417,44 @@ html
                       | #{I18n.t('invoice.true_up_metric', metric: item.fee.item_name)}
                     - else
                       | #{item.fee.item_name}
-                  td.body-1 width="30%" style="text-align: right;"
-                    = item.amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+
+                  td.body-2 width="20%"
+                    - item.applied_taxes.each do |applied_tax|
+                      div = "#{applied_tax.tax_rate}%"
+                  td.body-2 width="20%" style="text-align: right;"
+                    = MoneyHelper.format(item.amount)
 
         table.total-table width="100%"
           - if coupons_adjustment_amount_cents.positive?
             tr
+              td.body-2
               td.body-2 width="70%" = I18n.t('credit_note.coupon_adjustment')
-              td.body-1 width="30%"
-                | -#{coupons_adjustment_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))}
+              td.body-2 width="30%"
+                | -#{MoneyHelper.format(coupons_adjustment_amount)}
           tr
+            td.body-2
             td.body-2 width="70%" = I18n.t('credit_note.sub_total_without_tax')
-            td.body-1 width="30%" = sub_total_excluding_taxes_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
-          tr
-            td.body-2 #{I18n.t('credit_note.tax')} (#{invoice.taxes_rate || 0}%)
-            td.body-1 = taxes_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+            td.body-2 width="30%" = MoneyHelper.format(sub_total_excluding_taxes_amount)
+          - applied_taxes.order(tax_rate: :desc).each do |applied_tax|
+            tr
+              td.body-2
+              td.body-2
+                = I18n.t('credit_note.tax', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.base_amount))
+              td.body-2 = MoneyHelper.format(applied_tax.amount)
           - if credited?
             tr
+              td.body-2
               td.body-2 = I18n.t('credit_note.credited_on_customer_balance')
-              td.body-1 = credit_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+              td.body-2 = MoneyHelper.format(credit_amount)
           - if refunded?
             tr
+              td.body-2
               td.body-2 = I18n.t('credit_note.refunded')
-              td.body-1 = refund_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+              td.body-2 = MoneyHelper.format(refund_amount)
           tr
-            td.body-1 = I18n.t('credit_note.total_due')
-            td.body-1 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+            td.body-2
+            td.body-1 = I18n.t('credit_note.total')
+            td.body-1 = MoneyHelper.format(total_amount)
 
       p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
 

--- a/config/locales/de/credit_note.yml
+++ b/config/locales/de/credit_note.yml
@@ -5,6 +5,9 @@ de:
     invoice_number: Rechnungsnummer
     issue_date: Ausgabedatum
     credit_from: Von
+    item: Artikel
+    tax_rate: Tax rate
+    amount: Betrag (ohne Steuern)
     credit_to: Gutschrift für
     refunded_notice: Erstattung am %{issuing_date}
     credited_notice: Gutschrift auf Kundenguthaben am %{issuing_date}
@@ -12,8 +15,8 @@ de:
     subscription: Abonnement
     coupon_adjustment: Coupons
     sub_total_without_tax: Zwischensumme (ohne Steuern)
-    tax: Steuern
+    tax: "%{name} (%{rate}% on %{amount})"
     credited_on_customer_balance: Auf Kundenguthaben gutgeschrieben
     refunded: Erstattet
-    total_due: Insgesamt fällig
+    total: Insgesamt
     powered_by: Bereitgestellt von

--- a/config/locales/en/credit_note.yml
+++ b/config/locales/en/credit_note.yml
@@ -6,14 +6,17 @@ en:
     issue_date: Issue date
     credit_from: From
     credit_to: Credit to
+    item: Item
+    tax_rate: Tax rate
+    amount: Amount (excl. tax)
     refunded_notice: Refunded on %{issuing_date}
     credited_notice: Credited on customer balance on %{issuing_date}
     credited_refunded_notice: Credited on customer balance and refunded on %{issuing_date}
     subscription: Subscription
     coupon_adjustment: Coupons
     sub_total_without_tax: Sub total (excl. tax)
-    tax: Tax
+    tax: "%{name} (%{rate}% on %{amount})"
     credited_on_customer_balance: Credited on customer balance
     refunded: Refunded
-    total_due: Total due
+    total: Total
     powered_by: Powered by

--- a/config/locales/fr/credit_note.yml
+++ b/config/locales/fr/credit_note.yml
@@ -6,14 +6,17 @@ fr:
     issue_date: Date d'émission
     credit_from: De
     credit_to: Crédité à
+    item: Article
+    tax_rate: Taux de taxe
+    amount: Montant (HT)
     refunded_notice: Remboursé le %{issuing_date}
     credited_notice: Crédité sur le solde du client le %{issuing_date}
     credited_refunded_notice: Crédité sur le solde du client et remboursée le %{issuing_date}
     subscription: Souscription
     coupon_adjustment: Coupons
     sub_total_without_tax: Sous total (HT)
-    tax: Taxe
+    tax: "%{name} (%{rate}% sur %{amount})"
     credited_on_customer_balance: Crédit sur le solde du client
     refunded: Remboursement
-    total_due: Total dû
+    total: Total
     powered_by: Généré par

--- a/config/locales/nb/credit_note.yml
+++ b/config/locales/nb/credit_note.yml
@@ -6,14 +6,17 @@ nb:
     issue_date: Dato
     credit_from: Fra
     credit_to: Til
+    item: Vare
+    tax_rate: Tax rate
+    amount: Beløp (ekskl. MVA)
     refunded_notice: Refundert %{issuing_date}
     credited_notice: Kreditert til kontobalanse %{issuing_date}
     credited_refunded_notice: Kreditert til kontobalanse og refundert %{issuing_date}
     subscription: Abonnement
     coupon_adjustment: Kuponger
     sub_total_without_tax: Sub total (ekskl. MVA)
-    tax: Merverdiavgift
+    tax: "%{name} (%{rate}% on %{amount})"
     credited_on_customer_balance: Kreditert til kontobalanse
     refunded: Refundert
-    total_due: Beløp
+    total: Beløp
     powered_by: Fakturering drevet av

--- a/schema.graphql
+++ b/schema.graphql
@@ -1824,6 +1824,7 @@ type CreditNote {
 type CreditNoteAppliedTax implements AppliedTax {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
+  baseAmountCents: BigInt!
   createdAt: ISO8601DateTime!
   creditNote: CreditNote!
   id: ID!

--- a/schema.json
+++ b/schema.json
@@ -6456,6 +6456,24 @@
               ]
             },
             {
+              "name": "baseAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "createdAt",
               "description": null,
               "type": {


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to update the credit note PDF template to render the taxes