### PR TITLE
feat(tax): Add base amount to credit note applied taxes

### DIFF
--- a/app/models/credit_note/applied_tax.rb
+++ b/app/models/credit_note/applied_tax.rb
@@ -8,5 +8,8 @@ class CreditNote
 
     belongs_to :credit_note
     belongs_to :tax
+
+    monetize :amount_cents
+    monetize :base_amount_cents, with_model_currency: :amount_currency
   end
 end

--- a/db/migrate/20230619101701_add_base_amount_cents_to_credit_notes_applied_taxes.rb
+++ b/db/migrate/20230619101701_add_base_amount_cents_to_credit_notes_applied_taxes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddBaseAmountCentsToCreditNotesAppliedTaxes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :credit_notes_taxes, :base_amount_cents, :bigint, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_08_154821) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_19_101701) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -214,6 +214,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_08_154821) do
     t.string "amount_currency", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "base_amount_cents", default: 0, null: false
     t.index ["credit_note_id"], name: "index_credit_notes_taxes_on_credit_note_id"
     t.index ["tax_id"], name: "index_credit_notes_taxes_on_tax_id"
   end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to add a new `base_amount_cents` to the `CreditNote::AppliedTax` model. The role of this field is to store the amount used as the basic to compute the tax_amount for a specific tax.

The field will be used later on the credit note PDF template reducing the need for recomputing it on each PDF rendering / api call