### PR TITLE
feat(tax): Apply taxes and coupons before vat when refreshing a credi…

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -5,6 +5,8 @@ class CreditNote < ApplicationRecord
   include Sequenced
   include RansackUuidSearch
 
+  DB_PRECISION_SCALE = 5
+
   before_save :ensure_number
 
   belongs_to :customer, -> { with_discarded }

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -2,8 +2,6 @@
 
 module CreditNotes
   class CreateFromTermination < BaseService
-    DB_PRECISION_SCALE = 5
-
     def initialize(subscription:, reason: 'order_change')
       @subscription = subscription
       @reason = reason
@@ -29,7 +27,7 @@ module CreditNotes
         items: [
           {
             fee_id: last_subscription_fee.id,
-            amount_cents: amount.truncate(DB_PRECISION_SCALE),
+            amount_cents: amount.truncate(CreditNote::DB_PRECISION_SCALE),
           },
         ],
         reason: reason.to_sym,
@@ -90,13 +88,13 @@ module CreditNotes
         items: [
           CreditNoteItem.new(
             fee_id: last_subscription_fee.id,
-            precise_amount_cents: item_amount.truncate(DB_PRECISION_SCALE),
+            precise_amount_cents: item_amount.truncate(CreditNote::DB_PRECISION_SCALE),
           ),
         ],
       )
 
       (
-        item_amount.truncate(DB_PRECISION_SCALE) -
+        item_amount.truncate(CreditNote::DB_PRECISION_SCALE) -
         taxes_result.coupons_adjustment_amount_cents +
         taxes_result.taxes_amount_cents
       ).round

--- a/spec/services/credit_notes/refresh_draft_service_spec.rb
+++ b/spec/services/credit_notes/refresh_draft_service_spec.rb
@@ -5,13 +5,31 @@ require 'rails_helper'
 RSpec.describe CreditNotes::RefreshDraftService, type: :service do
   subject(:refresh_service) { described_class.new(credit_note:, fee:) }
 
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:invoice) { create(:invoice, organization:, customer:, fees_amount_cents: 100) }
+
   describe '#call' do
     let(:status) { :draft }
-    let(:credit_note) { create(:credit_note, status:) }
-    let(:fee) { create(:fee, taxes_rate: 0) }
+    let(:credit_note) do
+      create(
+        :credit_note,
+        invoice:,
+        status:,
+        taxes_rate: 0,
+        taxes_amount_cents: 0,
+        credit_amount_cents: 100,
+        balance_amount_cents: 100,
+        total_amount_cents: 100,
+      )
+    end
+    let(:fee) { create(:fee, invoice:, taxes_rate: 20) }
+    let(:applied_tax) { create(:fee_applied_tax, tax:, fee:, amount_cents: 0) }
 
     before do
-      create(:credit_note_item, credit_note:, fee: create(:fee, taxes_rate: 20))
+      applied_tax
+      create(:credit_note_item, credit_note:, fee: create(:fee, invoice:, taxes_rate: 0))
     end
 
     context 'when credit_note is finalized' do
@@ -28,10 +46,10 @@ RSpec.describe CreditNotes::RefreshDraftService, type: :service do
 
     it 'updates vat amounts of the credit note' do
       expect { refresh_service.call }
-        .to change { credit_note.reload.taxes_amount_cents }.from(20).to(0)
-        .and change(credit_note, :credit_amount_cents).from(120).to(100)
-        .and change(credit_note, :balance_amount_cents).from(120).to(100)
-        .and change(credit_note, :total_amount_cents).from(120).to(100)
+        .to change { credit_note.reload.taxes_amount_cents }.from(0).to(20)
+        .and change(credit_note, :credit_amount_cents).from(100).to(120)
+        .and change(credit_note, :balance_amount_cents).from(100).to(120)
+        .and change(credit_note, :total_amount_cents).from(100).to(120)
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

This PR updates the `CreditNotes::RefreshDraftService` to :
- Refresh the `credit_note#applied_taxes`
- Takes the coupon before taxes into account