### PR TITLE
fix(credit_note): takes coupons into account when refreshing a credit…

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -5,6 +5,8 @@ class CreditNote < ApplicationRecord
   include Sequenced
   include RansackUuidSearch
 
+  DB_PRECISION_SCALE = 5
+
   before_save :ensure_number
 
   belongs_to :customer, -> { with_discarded }

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -2,8 +2,6 @@
 
 module CreditNotes
   class CreateFromTermination < BaseService
-    DB_PRECISION_SCALE = 5
-
     def initialize(subscription:, reason: 'order_change')
       @subscription = subscription
       @reason = reason
@@ -27,7 +25,7 @@ module CreditNotes
         items: [
           CreditNoteItem.new(
             fee_id: last_subscription_fee.id,
-            precise_amount_cents: amount.truncate(DB_PRECISION_SCALE),
+            precise_amount_cents: amount.truncate(CreditNote::DB_PRECISION_SCALE),
           ),
         ],
       )
@@ -39,7 +37,7 @@ module CreditNotes
         items: [
           {
             fee_id: last_subscription_fee.id,
-            amount_cents: amount.truncate(DB_PRECISION_SCALE),
+            amount_cents: amount.truncate(CreditNote::DB_PRECISION_SCALE),
           },
         ],
         reason: reason.to_sym,

--- a/app/services/credit_notes/refresh_draft_service.rb
+++ b/app/services/credit_notes/refresh_draft_service.rb
@@ -15,16 +15,27 @@ module CreditNotes
 
       credit_note.items.update_all(fee_id: fee.id) # rubocop:disable Rails/SkipsModelValidations
 
-      amount_cents = credit_note.items.sum(:amount_cents)
-      credit_amount_cents = (amount_cents + (amount_cents * fee.taxes_rate).fdiv(100)).round
-      return result if credit_amount_cents == credit_note.credit_amount_cents
-
-      credit_note.update!(
-        taxes_amount_cents: credit_note.items.sum { |i| i.amount_cents * i.fee.taxes_rate }.fdiv(100).round,
-        credit_amount_cents:,
-        balance_amount_cents: credit_amount_cents,
-        total_amount_cents: credit_amount_cents + credit_note.refund_amount_cents,
+      amount_result = CreditNotes::ComputeAmountService.call(
+        invoice: fee.invoice,
+        items: credit_note.items,
       )
+
+      credit_note.precise_coupons_adjustment_amount_cents = amount_result.coupons_adjustment_amount_cents
+      credit_note.coupons_adjustment_amount_cents = amount_result.coupons_adjustment_amount_cents.round
+      credit_note.precise_taxes_amount_cents = amount_result.taxes_amount_cents
+      credit_note.taxes_amount_cents = amount_result.taxes_amount_cents.round
+
+      credit_note.credit_amount_cents = (
+        credit_note.items.sum(:precise_amount_cents).truncate(CreditNote::DB_PRECISION_SCALE) -
+        amount_result.coupons_adjustment_amount_cents +
+        amount_result.taxes_amount_cents
+      ).round
+
+      credit_note.balance_amount_cents = credit_note.credit_amount_cents
+      credit_note.total_amount_cents = credit_note.credit_amount_cents + credit_note.refund_amount_cents
+
+      credit_note.save!
+
       result
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -328,9 +328,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_19_101701) do
     t.uuid "group_id"
     t.uuid "pay_in_advance_event_id"
     t.integer "payment_status", default: 0, null: false
-    t.datetime "succeeded_at", precision: nil
-    t.datetime "failed_at", precision: nil
-    t.datetime "refunded_at", precision: nil
+    t.datetime "succeeded_at"
+    t.datetime "failed_at"
+    t.datetime "refunded_at"
     t.uuid "true_up_parent_fee_id"
     t.uuid "add_on_id"
     t.string "description"
@@ -418,11 +418,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_19_101701) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "recurring"
-    t.datetime "timestamp", precision: nil
-    t.datetime "from_datetime", precision: nil
-    t.datetime "to_datetime", precision: nil
-    t.datetime "charges_from_datetime", precision: nil
-    t.datetime "charges_to_datetime", precision: nil
+    t.datetime "timestamp"
+    t.datetime "from_datetime"
+    t.datetime "to_datetime"
+    t.datetime "charges_from_datetime"
+    t.datetime "charges_to_datetime"
     t.index ["invoice_id"], name: "index_invoice_subscriptions_on_invoice_id"
     t.index ["subscription_id", "charges_from_datetime", "charges_to_datetime"], name: "index_invoice_subscriptions_on_charges_from_and_to_datetime", unique: true, where: "((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE))"
     t.index ["subscription_id", "from_datetime", "to_datetime"], name: "index_invoice_subscriptions_on_from_and_to_datetime", unique: true, where: "((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE))"

--- a/spec/services/credit_notes/refresh_draft_service_spec.rb
+++ b/spec/services/credit_notes/refresh_draft_service_spec.rb
@@ -5,10 +5,25 @@ require 'rails_helper'
 RSpec.describe CreditNotes::RefreshDraftService, type: :service do
   subject(:refresh_service) { described_class.new(credit_note:, fee:) }
 
+  let(:customer) { create(:customer) }
+  let(:organization) { customer.organization }
+
+  let(:invoice) do
+    create(
+      :invoice,
+      organization:,
+      customer:,
+      currency: 'EUR',
+      fees_amount_cents: 100,
+      total_amount_cents: 120,
+      coupons_amount_cents: 20,
+    )
+  end
+
   describe '#call' do
     let(:status) { :draft }
-    let(:credit_note) { create(:credit_note, status:) }
-    let(:fee) { create(:fee, taxes_rate: 0) }
+    let(:credit_note) { create(:credit_note, status:, invoice:) }
+    let(:fee) { create(:fee, invoice:, taxes_rate: 0) }
 
     before do
       create(:credit_note_item, credit_note:, fee: create(:fee, taxes_rate: 20))
@@ -29,9 +44,10 @@ RSpec.describe CreditNotes::RefreshDraftService, type: :service do
     it 'updates vat amounts of the credit note' do
       expect { refresh_service.call }
         .to change { credit_note.reload.taxes_amount_cents }.from(20).to(0)
-        .and change(credit_note, :credit_amount_cents).from(120).to(100)
-        .and change(credit_note, :balance_amount_cents).from(120).to(100)
-        .and change(credit_note, :total_amount_cents).from(120).to(100)
+        .and change(credit_note, :coupons_adjustment_amount_cents).from(0).to(20)
+        .and change(credit_note, :credit_amount_cents).from(120).to(80)
+        .and change(credit_note, :balance_amount_cents).from(120).to(80)
+        .and change(credit_note, :total_amount_cents).from(120).to(80)
     end
   end
 end


### PR DESCRIPTION
## Context

Refresh of credit note (called when refreshing an invoice) was not taking coupons before VAT into account.

## Description

This PR re-use the `CreditNotes::ComputeAmountService` to ensure coupons amount is taken into account.
