### PR TITLE
fix (gocardless): update invoice payment status for GCL

### DIFF
--- a/app/services/invoices/payments/gocardless_service.rb
+++ b/app/services/invoices/payments/gocardless_service.rb
@@ -138,15 +138,15 @@ module Invoices
       end
 
       def update_invoice_payment_status(payment_status:, deliver_webhook: true)
-        result = Invoices::UpdateService.call(
-          invoice:,
+        update_invoice_result = Invoices::UpdateService.call(
+          invoice: result.invoice,
           params: {
             payment_status:,
             ready_for_payment_processing: payment_status.to_sym != :succeeded,
           },
           webhook_notification: deliver_webhook,
         )
-        result.raise_if_error!
+        update_invoice_result.raise_if_error!
       end
 
       def increment_payment_attempts


### PR DESCRIPTION
## Context

Update payment status didn't work properly if invoice has not been passed to constructor.
