### PR TITLE
feat(taxes): Refresh draft invoices on taxes update

### DIFF
--- a/app/services/customers/applied_taxes/create_service.rb
+++ b/app/services/customers/applied_taxes/create_service.rb
@@ -15,6 +15,8 @@ module Customers
 
         applied_tax = customer.applied_taxes.find_or_create_by!(tax:)
 
+        Invoices::RefreshBatchJob.perform_later(customer.invoices.draft.pluck(:id))
+
         result.applied_tax = applied_tax
         result
       end

--- a/app/services/customers/applied_taxes/destroy_service.rb
+++ b/app/services/customers/applied_taxes/destroy_service.rb
@@ -13,6 +13,8 @@ module Customers
 
         applied_tax.destroy!
 
+        Invoices::RefreshBatchJob.perform_later(applied_tax.customer.invoices.draft.pluck(:id))
+
         result.applied_tax = applied_tax
         result
       end

--- a/spec/services/customers/applied_taxes/create_service_spec.rb
+++ b/spec/services/customers/applied_taxes/create_service_spec.rb
@@ -14,6 +14,14 @@ RSpec.describe Customers::AppliedTaxes::CreateService, type: :service do
       expect { create_service.call }.to change(Customer::AppliedTax, :count).by(1)
     end
 
+    it 'refreshes draft invoices' do
+      draft_invoice = create(:invoice, :draft, organization:, customer:)
+
+      expect do
+        create_service.call
+      end.to have_enqueued_job(Invoices::RefreshBatchJob).with([draft_invoice.id])
+    end
+
     context 'when already applied to the customer' do
       it 'does not apply the tax once again' do
         create(:customer_applied_tax, tax:, customer:)

--- a/spec/services/customers/applied_taxes/destroy_service_spec.rb
+++ b/spec/services/customers/applied_taxes/destroy_service_spec.rb
@@ -6,12 +6,21 @@ RSpec.describe Customers::AppliedTaxes::DestroyService, type: :service do
   subject(:destroy_service) { described_class.new(applied_tax:) }
 
   let(:applied_tax) { create(:customer_applied_tax) }
+  let(:customer) { applied_tax.customer }
 
   describe '#call' do
     before { applied_tax }
 
     it 'destroys the applied tax' do
       expect { destroy_service.call }.to change(Customer::AppliedTax, :count).by(-1)
+    end
+
+    it 'refreshes draft invoices' do
+      draft_invoice = create(:invoice, :draft, organization: customer.organization, customer:)
+
+      expect do
+        destroy_service.call
+      end.to have_enqueued_job(Invoices::RefreshBatchJob).with([draft_invoice.id])
     end
 
     context 'when applied tax is not found' do

--- a/spec/services/taxes/update_service_spec.rb
+++ b/spec/services/taxes/update_service_spec.rb
@@ -39,6 +39,35 @@ RSpec.describe Taxes::UpdateService, type: :service do
       expect(result.tax).to be_a(Tax)
     end
 
+    context 'when applied_to_organization is updated to false' do
+      let(:params) do
+        { applied_to_organization: false }
+      end
+
+      it 'refreshes draft invoices' do
+        draft_invoice = create(:invoice, :draft, organization:, customer:)
+
+        expect do
+          update_service.call
+        end.to have_enqueued_job(Invoices::RefreshBatchJob).with([draft_invoice.id])
+      end
+    end
+
+    context 'when applied_to_organization is updated to true' do
+      let(:tax) { create(:tax, organization:, applied_to_organization: false) }
+      let(:params) do
+        { applied_to_organization: true }
+      end
+
+      it 'refreshes draft invoices' do
+        draft_invoice = create(:invoice, :draft, organization:, customer:)
+
+        expect do
+          update_service.call
+        end.to have_enqueued_job(Invoices::RefreshBatchJob).with([draft_invoice.id])
+      end
+    end
+
     it 'refreshes draft invoices' do
       draft_invoice = create(:invoice, :draft, organization:, customer:)
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

Currently, tax can be set individually either on the customer or the organization level. However, it’s not possible to define a global tax tag that can be reusable everywhere.

## Description

The goal of this PR is to correctly refresh draft invoices when a tax is updated or assigned to a customer.