### PR TITLE
fix: Unify invoice taxes_rate to not be a NaN

### DIFF
--- a/db/migrate/20230626123648_unify_invoices_taxes_rate.rb
+++ b/db/migrate/20230626123648_unify_invoices_taxes_rate.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class UnifyInvoicesTaxesRate < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          /* Unify invoices->taxes_rate to be a number */
+          UPDATE invoices
+          SET taxes_rate = 0.0
+          WHERE taxes_rate = 'NaN'::NUMERIC;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_19_101701) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_26_123648) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
Due to a previous migration, some invoices were created with a NaN taxes rate.
The goal of this PR is to update them to a 0.0 taxes rate.