### PR TITLE
feat (charges): add support for prorated field

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -86,6 +86,7 @@ module Api
             :billable_metric_id,
             :charge_model,
             :pay_in_advance,
+            :prorated,
             :invoiceable,
             :min_amount_cents,
             {

--- a/app/graphql/types/charges/input.rb
+++ b/app/graphql/types/charges/input.rb
@@ -11,6 +11,7 @@ module Types
       argument :invoiceable, Boolean, required: false
       argument :min_amount_cents, GraphQL::Types::BigInt, required: false
       argument :pay_in_advance, Boolean, required: false
+      argument :prorated, Boolean, required: false
 
       argument :group_properties, [Types::Charges::GroupPropertiesInput], required: false
       argument :properties, Types::Charges::PropertiesInput, required: false

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -13,6 +13,7 @@ module Types
       field :min_amount_cents, GraphQL::Types::BigInt, null: false
       field :pay_in_advance, Boolean, null: false
       field :properties, Types::Charges::Properties, null: true
+      field :prorated, Boolean, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -105,9 +105,9 @@ class Charge < ApplicationRecord
   # - for pay_in_idvance, price model cannot be package and percentage and volume
   def validate_prorated
     return unless prorated?
-    return if pay_in_advance? && (standard? || graduated?)
-    return if !pay_in_advance? && (standard? || graduated? || volume?)
+    return if billable_metric.recurring? && pay_in_advance? && (standard? || graduated?)
+    return if billable_metric.recurring? && !pay_in_advance? && (standard? || graduated? || volume?)
 
-    errors.add(:prorated, :invalid_aggregation_type_or_charge_model)
+    errors.add(:prorated, :invalid_billable_metric_or_charge_model)
   end
 end

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -11,6 +11,7 @@ module V1
         charge_model: model.charge_model,
         invoiceable: model.invoiceable,
         pay_in_advance: model.pay_in_advance,
+        prorated: model.prorated,
         min_amount_cents: model.min_amount_cents,
         properties: model.properties,
       }.merge(group_properties)

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -45,6 +45,7 @@ module Plans
         billable_metric_id: args[:billable_metric_id],
         charge_model: args[:charge_model]&.to_sym,
         pay_in_advance: args[:pay_in_advance] || false,
+        prorated: args[:prorated] || false,
         properties: args[:properties] || {},
         group_properties: (args[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -63,6 +63,7 @@ module Plans
         amount_currency: params[:amount_currency],
         charge_model: params[:charge_model]&.to_sym,
         pay_in_advance: params[:pay_in_advance] || false,
+        prorated: params[:prorated] || false,
         properties: params[:properties] || {},
         group_properties: (params[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
         missing_graduated_ranges: missing_graduated_ranges
         missing_volume_ranges: missing_volume_ranges
         invalid_aggregation_type_or_charge_model: invalid_aggregation_type_or_charge_model
+        invalid_billable_metric_or_charge_model: invalid_billable_metric_or_charge_model
         invalid_amount: invalid_amount
         invalid_flat_amount: invalid_flat_amount
         invalid_per_unit_amount: invalid_per_unit_amount

--- a/db/migrate/20230627080605_add_prorated_to_charges.rb
+++ b/db/migrate/20230627080605_add_prorated_to_charges.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProratedToCharges < ActiveRecord::Migration[7.0]
+  def change
+    add_column :charges, :prorated, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_19_101701) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_27_080605) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -116,6 +116,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_19_101701) do
     t.boolean "pay_in_advance", default: false, null: false
     t.bigint "min_amount_cents", default: 0, null: false
     t.boolean "invoiceable", default: true, null: false
+    t.boolean "prorated", default: false, null: false
     t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"
     t.index ["deleted_at"], name: "index_charges_on_deleted_at"
     t.index ["plan_id"], name: "index_charges_on_plan_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -179,6 +179,7 @@ type Charge {
   minAmountCents: BigInt!
   payInAdvance: Boolean!
   properties: Properties
+  prorated: Boolean!
   updatedAt: ISO8601DateTime!
 }
 
@@ -191,6 +192,7 @@ input ChargeInput {
   minAmountCents: BigInt
   payInAdvance: Boolean
   properties: PropertiesInput
+  prorated: Boolean
 }
 
 enum ChargeModelEnum {

--- a/schema.json
+++ b/schema.json
@@ -1735,6 +1735,24 @@
               ]
             },
             {
+              "name": "prorated",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "updatedAt",
               "description": null,
               "type": {
@@ -1834,6 +1852,18 @@
             },
             {
               "name": "payInAdvance",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "prorated",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -403,28 +403,43 @@ RSpec.describe Charge, type: :model do
   end
 
   describe '#validate_prorated' do
+    let(:billable_metric) { create(:sum_billable_metric, recurring: true) }
+
     it 'does not return error if prorated is false and price model is percentage' do
       expect(build(:percentage_charge, prorated: false)).to be_valid
     end
 
-    context 'when charge is package, pay_in_advance and prorated' do
+    context 'when charge is standard, pay_in_advance, prorated but BM is not recurring' do
+      let(:billable_metric) { create(:billable_metric, recurring: false) }
+
       it 'returns an error' do
-        charge = build(:package_charge, :pay_in_advance, prorated: true)
+        charge = build(:standard_charge, :pay_in_advance, prorated: true, billable_metric:)
 
         aggregate_failures do
           expect(charge).not_to be_valid
-          expect(charge.errors.messages[:prorated]).to include('invalid_aggregation_type_or_charge_model')
+          expect(charge.errors.messages[:prorated]).to include('invalid_billable_metric_or_charge_model')
         end
       end
     end
 
-    context 'when charge is percentage, pay_in_arrear and prorated' do
+    context 'when charge is package, pay_in_advance, prorated and BM is recurring' do
       it 'returns an error' do
-        charge = build(:percentage_charge, prorated: true)
+        charge = build(:package_charge, :pay_in_advance, prorated: true, billable_metric:)
 
         aggregate_failures do
           expect(charge).not_to be_valid
-          expect(charge.errors.messages[:prorated]).to include('invalid_aggregation_type_or_charge_model')
+          expect(charge.errors.messages[:prorated]).to include('invalid_billable_metric_or_charge_model')
+        end
+      end
+    end
+
+    context 'when charge is percentage, pay_in_arrear, prorated and BM is recurring' do
+      it 'returns an error' do
+        charge = build(:percentage_charge, prorated: true, billable_metric:)
+
+        aggregate_failures do
+          expect(charge).not_to be_valid
+          expect(charge.errors.messages[:prorated]).to include('invalid_billable_metric_or_charge_model')
         end
       end
     end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -401,4 +401,32 @@ RSpec.describe Charge, type: :model do
       end
     end
   end
+
+  describe '#validate_prorated' do
+    it 'does not return error if prorated is false and price model is percentage' do
+      expect(build(:percentage_charge, prorated: false)).to be_valid
+    end
+
+    context 'when charge is package, pay_in_advance and prorated' do
+      it 'returns an error' do
+        charge = build(:package_charge, :pay_in_advance, prorated: true)
+
+        aggregate_failures do
+          expect(charge).not_to be_valid
+          expect(charge.errors.messages[:prorated]).to include('invalid_aggregation_type_or_charge_model')
+        end
+      end
+    end
+
+    context 'when charge is percentage, pay_in_arrear and prorated' do
+      it 'returns an error' do
+        charge = build(:percentage_charge, prorated: true)
+
+        aggregate_failures do
+          expect(charge).not_to be_valid
+          expect(charge.errors.messages[:prorated]).to include('invalid_aggregation_type_or_charge_model')
+        end
+      end
+    end
+  end
 end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -10,8 +10,9 @@ RSpec.describe Plans::CreateService, type: :service do
 
   describe 'create' do
     let(:plan_name) { 'Some plan name' }
-    let(:billable_metrics) { create_list(:billable_metric, 2, organization:) }
-    let(:group) { create(:group, billable_metric: billable_metrics.first) }
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:sum_billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
+    let(:group) { create(:group, billable_metric:) }
     let(:create_args) do
       {
         name: plan_name,
@@ -23,7 +24,7 @@ RSpec.describe Plans::CreateService, type: :service do
         amount_currency: 'EUR',
         charges: [
           {
-            billable_metric_id: billable_metrics.first.id,
+            billable_metric_id: billable_metric.id,
             charge_model: 'standard',
             min_amount_cents: 100,
             group_properties: [
@@ -34,7 +35,7 @@ RSpec.describe Plans::CreateService, type: :service do
             ],
           },
           {
-            billable_metric_id: billable_metrics.last.id,
+            billable_metric_id: sum_billable_metric.id,
             charge_model: 'graduated',
             pay_in_advance: true,
             invoiceable: false,
@@ -167,7 +168,7 @@ RSpec.describe Plans::CreateService, type: :service do
     end
 
     context 'with metrics from other organization' do
-      let(:billable_metrics) { create_list(:billable_metric, 2) }
+      let(:billable_metric) { create(:billable_metric) }
 
       it 'returns an error' do
         result = plans_service.create(**create_args)

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Plans::CreateService, type: :service do
             charge_model: 'graduated',
             pay_in_advance: true,
             invoiceable: false,
+            prorated: true,
             properties: {
               graduated_ranges: [
                 {
@@ -77,7 +78,12 @@ RSpec.describe Plans::CreateService, type: :service do
       standard_charge = plan.charges.standard.first
       graduated_charge = plan.charges.graduated.first
 
-      expect(standard_charge).to have_attributes(pay_in_advance: false, min_amount_cents: 0, invoiceable: true)
+      expect(standard_charge).to have_attributes(
+        pay_in_advance: false,
+        prorated: false,
+        min_amount_cents: 0,
+        invoiceable: true,
+      )
       expect(standard_charge.group_properties.first).to have_attributes(
         {
           group_id: group.id,
@@ -85,7 +91,7 @@ RSpec.describe Plans::CreateService, type: :service do
         },
       )
 
-      expect(graduated_charge).to have_attributes(pay_in_advance: true, invoiceable: true)
+      expect(graduated_charge).to have_attributes(pay_in_advance: true, invoiceable: true, prorated: true)
     end
 
     it 'calls SegmentTrackJob' do

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -164,6 +164,7 @@ RSpec.describe Plans::UpdateService, type: :service do
               billable_metric_id: billable_metrics.first.id,
               charge_model: 'standard',
               pay_in_advance: true,
+              prorated: true,
               invoiceable: false,
               group_properties: [
                 {
@@ -189,10 +190,11 @@ RSpec.describe Plans::UpdateService, type: :service do
           .to change(Charge, :count).by(1)
       end
 
-      it 'updates group properties' do
+      it 'updates existing charge' do
         expect { plans_service.call }
           .to change(GroupProperty, :count).by(1)
 
+        expect(existing_charge.reload.prorated).to eq(true)
         expect(existing_charge.reload.group_properties.first).to have_attributes(
           group_id: group.id,
           values: { 'amount' => '100' },


### PR DESCRIPTION
## Context

As part of charges pay in advance feature it will be also possible to choose whether to prorate aggregation or not.

## Description

This feature adds support for `prorated` boolean field on charges
