### PR TITLE
feat (charges): pass charge to aggregation services

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -112,7 +112,7 @@ class Invoice < ApplicationRecord
 
   def recurring_breakdown(fee)
     result = BillableMetrics::Aggregations::RecurringCountService.new(
-      billable_metric: fee.charge.billable_metric,
+      charge: fee.charge,
       subscription: fee.subscription,
       group: fee.group,
     ).breakdown(

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -3,9 +3,9 @@
 module BillableMetrics
   module Aggregations
     class BaseService < ::BaseService
-      def initialize(billable_metric:, subscription:, group: nil, event: nil)
+      def initialize(charge:, subscription:, group: nil, event: nil)
         super(nil)
-        @billable_metric = billable_metric
+        @charge = charge
         @subscription = subscription
         @group = group
         @event = event
@@ -17,9 +17,10 @@ module BillableMetrics
 
       protected
 
-      attr_accessor :billable_metric, :subscription, :group, :event
+      attr_accessor :charge, :subscription, :group, :event
 
       delegate :customer, to: :subscription
+      delegate :billable_metric, to: :charge
 
       def events_scope(from_datetime:, to_datetime:)
         events = subscription.events

--- a/app/services/billable_metrics/pay_in_advance_aggregation_service.rb
+++ b/app/services/billable_metrics/pay_in_advance_aggregation_service.rb
@@ -2,8 +2,8 @@
 
 module BillableMetrics
   class PayInAdvanceAggregationService < BaseService
-    def initialize(billable_metric:, boundaries:, properties:, event:, group: nil)
-      @billable_metric = billable_metric
+    def initialize(charge:, boundaries:, properties:, event:, group: nil)
+      @charge = charge
       @boundaries = boundaries
       @properties = properties
       @event = event
@@ -13,7 +13,7 @@ module BillableMetrics
     end
 
     def call
-      aggregator = aggregator_service.new(billable_metric:, subscription:, group:, event:)
+      aggregator = aggregator_service.new(charge:, subscription:, group:, event:)
       aggregator.aggregate(
         from_datetime: boundaries[:charges_from_datetime],
         to_datetime: boundaries[:charges_to_datetime],
@@ -23,9 +23,10 @@ module BillableMetrics
 
     private
 
-    attr_reader :billable_metric, :boundaries, :group, :properties, :event
+    attr_reader :charge, :boundaries, :group, :properties, :event
 
     delegate :subscription, to: :event
+    delegate :billable_metric, to: :charge
 
     def aggregator_service
       @aggregator_service ||= case billable_metric.aggregation_type.to_sym

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -134,7 +134,7 @@ module Fees
                              raise(NotImplementedError)
       end
 
-      @aggregator = aggregator_service.new(billable_metric:, subscription:, group:)
+      @aggregator = aggregator_service.new(charge:, subscription:, group:)
     end
 
     def apply_charge_model_service(aggregation_result, properties)

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -100,7 +100,7 @@ module Fees
 
     def aggregate(properties:, group:)
       aggregation_result = BillableMetrics::PayInAdvanceAggregationService.call(
-        billable_metric:, boundaries:, group:, properties:, event:,
+        charge:, boundaries:, group:, properties:, event:,
       )
       aggregation_result.raise_if_error!
       aggregation_result

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
   subject(:count_service) do
     described_class.new(
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       event: pay_in_advance_event,
@@ -16,6 +16,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:group) { nil }
+  let(:charge) { create(:standard_charge, billable_metric:) }
 
   let(:billable_metric) do
     create(

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
   subject(:max_service) do
     described_class.new(
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
     )
@@ -15,6 +15,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:group) { nil }
+  let(:charge) { create(:standard_charge, billable_metric:) }
 
   let(:billable_metric) do
     create(

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :service do
   subject(:recurring_service) do
     described_class.new(
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
     )
@@ -25,6 +25,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:group) { nil }
+  let(:charge) { create(:standard_charge, billable_metric:) }
 
   let(:billable_metric) do
     create(

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
   subject(:sum_service) do
     described_class.new(
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       event: pay_in_advance_event,
@@ -16,6 +16,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:group) { nil }
+  let(:charge) { create(:standard_charge, billable_metric:) }
 
   let(:billable_metric) do
     create(

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service do
   subject(:count_service) do
     described_class.new(
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       event: pay_in_advance_event,
@@ -27,6 +27,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:group) { nil }
+  let(:charge) { create(:standard_charge, billable_metric:) }
 
   let(:billable_metric) do
     create(

--- a/spec/services/billable_metrics/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/billable_metrics/pay_in_advance_aggregation_service_spec.rb
@@ -4,10 +4,11 @@ require 'rails_helper'
 
 RSpec.describe BillableMetrics::PayInAdvanceAggregationService, type: :service do
   subject(:agg_service) do
-    described_class.new(billable_metric:, boundaries:, group:, properties:, event:)
+    described_class.new(charge:, boundaries:, group:, properties:, event:)
   end
 
   let(:billable_metric) { create(:billable_metric, aggregation_type:, field_name: 'item_id') }
+  let(:charge) { create(:standard_charge, billable_metric:) }
   let(:group) { create(:group) }
   let(:aggregation_type) { 'count_agg' }
   let(:event) { create(:event, subscription:) }
@@ -36,7 +37,7 @@ RSpec.describe BillableMetrics::PayInAdvanceAggregationService, type: :service d
         agg_service.call
 
         expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
-          .with(billable_metric:, subscription:, group:, event:)
+          .with(charge:, subscription:, group:, event:)
 
         expect(count_service).to have_received(:aggregate).with(
           from_datetime: boundaries[:charges_from_datetime],
@@ -59,7 +60,7 @@ RSpec.describe BillableMetrics::PayInAdvanceAggregationService, type: :service d
         agg_service.call
 
         expect(BillableMetrics::Aggregations::SumService).to have_received(:new)
-          .with(billable_metric:, subscription:, group:, event:)
+          .with(charge:, subscription:, group:, event:)
 
         expect(sum_service).to have_received(:aggregate).with(
           from_datetime: boundaries[:charges_from_datetime],
@@ -81,7 +82,7 @@ RSpec.describe BillableMetrics::PayInAdvanceAggregationService, type: :service d
         agg_service.call
 
         expect(BillableMetrics::Aggregations::UniqueCountService).to have_received(:new)
-          .with(billable_metric:, subscription:, group:, event:)
+          .with(charge:, subscription:, group:, event:)
 
         expect(unique_count_service).to have_received(:aggregate).with(
           from_datetime: boundaries[:charges_from_datetime],

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
 
     before do
       allow(BillableMetrics::PayInAdvanceAggregationService).to receive(:call)
-        .with(billable_metric:, boundaries: Hash, group:, properties: Hash, event:)
+        .with(charge:, boundaries: Hash, group:, properties: Hash, event:)
         .and_return(aggregation_result)
 
       allow(Charges::ApplyPayInAdvanceChargeModelService).to receive(:call)

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
 
     before do
       allow(BillableMetrics::PayInAdvanceAggregationService).to receive(:call)
-        .with(billable_metric:, boundaries: Hash, group:, properties: Hash, event:)
+        .with(charge:, boundaries: Hash, group:, properties: Hash, event:)
         .and_return(aggregation_result)
 
       allow(Charges::ApplyPayInAdvanceChargeModelService).to receive(:call)


### PR DESCRIPTION
## Context

As part of charges paid in advance we want to allow users to select if they want to allow proration or not

## Description

This PR passes `charge` object to aggregation services instead of billable metric. In aggregation services we need access to `charge` object since prorated field (but also pay_in_advance) is attached on it. However we can also fetch billable metric directly from charge object.
