### PR TITLE
fix(adyen): Change error to webhook_error when organization is not found

### DIFF
--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -34,7 +34,7 @@ module PaymentProviders
 
     def handle_incoming_webhook(organization_id:, body:)
       organization = Organization.find_by(id: organization_id)
-      return result.not_found_failure!(resource: 'organization') unless organization
+      return result.service_failure!(code: 'webhook_error', message: 'Organization not found') unless organization
 
       validator = ::Adyen::Utils::HmacValidator.new
       hmac_key = organization.adyen_payment_provider.hmac_key

--- a/spec/services/payment_providers/adyen_service_spec.rb
+++ b/spec/services/payment_providers/adyen_service_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe PaymentProviders::AdyenService, type: :service do
       it 'returns an error' do
         aggregate_failures do
           expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::NotFoundFailure)
-          expect(result.error.resource).to eq('organization')
-          expect(result.error.error_code).to eq('organization_not_found')
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq('webhook_error')
+          expect(result.error.error_message).to eq('Organization not found')
         end
       end
     end


### PR DESCRIPTION
## Description

Change error to webhook_error when organization is not found.
The previous implementation raised NotFoundFailure which has different api: `error_code` instead of `code`.