### PR TITLE
fix: translations on plan interval for invoice template

### DIFF
--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -33,8 +33,8 @@ fr:
     subscription: Abonnement
     date_from: Du
     date_to: au
-    monthly: mensuelle
-    yearly: annuelle
+    monthly: mensuel
+    yearly: annuel
     weekly: hebdomadaire
     sub_total: Sous total
     subscription_interval: Abonnement %{plan_interval} - %{plan_name}


### PR DESCRIPTION
- yearly
<img width="622" alt="Screenshot 2023-07-04 at 10 19 49" src="https://github.com/getlago/lago-api/assets/226046/27d18ac1-03c0-4502-9316-5846a8607b0a">

- weekly
<img width="633" alt="Screenshot 2023-07-04 at 10 19 03" src="https://github.com/getlago/lago-api/assets/226046/538d8f7c-f6e3-4ddf-8b96-f49b24fee347">

- monthly
<img width="619" alt="Screenshot 2023-07-04 at 10 17 53" src="https://github.com/getlago/lago-api/assets/226046/64671fa7-24a0-4e8e-84c2-3f65e4f01d06">
