### PR TITLE
fix(tax): Organization default vat_rate migration

### DIFF
--- a/db/migrate/20230704112230_fix_organizations_taxes.rb
+++ b/db/migrate/20230704112230_fix_organizations_taxes.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class FixOrganizationsTaxes < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE taxes
+          SET applied_to_organization = true
+          FROM organizations
+          WHERE organizations.id = taxes.organization_id
+            AND organizations.vat_rate = taxes.rate
+            AND applied_to_organization = false;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_29_100018) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_04_112230) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
## Context

An issue as been identified in the organization default tax rate migration.

See https://github.com/getlago/lago-api/blob/main/db/migrate/20230626124005_migrate_organization_taxes.rb#L25

The migration is creating the tax if it does exists with the `applied_to_organization`  set to true. But if it does find it, it does not mark the tax as applied to the organization.

## Description

This pull requests ensure the vat rate is applied by default to the organization