### PR TITLE
feat(tax): Add Plan::AppliedTax and Charge::AppliedTax models

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -12,6 +12,9 @@ class Charge < ApplicationRecord
   has_many :fees
   has_many :group_properties, dependent: :destroy
 
+  has_many :applied_taxes, class_name: 'Charge::AppliedTax', dependent: :destroy
+  has_many :taxes, through: :applied_taxes
+
   CHARGE_MODELS = %i[
     standard
     graduated

--- a/app/models/charge/applied_tax.rb
+++ b/app/models/charge/applied_tax.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Charge
+  class AppliedTax < ApplicationRecord
+    self.table_name = 'charges_taxes'
+
+    include PaperTrailTraceable
+
+    belongs_to :charge
+    belongs_to :tax
+  end
+end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -17,6 +17,9 @@ class Plan < ApplicationRecord
   has_many :coupon_targets
   has_many :coupons, through: :coupon_targets
 
+  has_many :applied_taxes, class_name: 'Plan::AppliedTax', dependent: :destroy
+  has_many :taxes, through: :applied_taxes
+
   INTERVALS = %i[
     weekly
     monthly

--- a/app/models/plan/applied_tax.rb
+++ b/app/models/plan/applied_tax.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Plan
+  class AppliedTax < ApplicationRecord
+    self.table_name = 'plans_taxes'
+
+    include PaperTrailTraceable
+
+    belongs_to :plan
+    belongs_to :tax
+  end
+end

--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -12,6 +12,10 @@ class Tax < ApplicationRecord
   has_many :invoices, through: :invoices_taxes
   has_many :credit_notes_taxes, class_name: 'CreditNote::AppliedTax', dependent: :destroy
   has_many :credit_notes, through: :credit_notes_taxes
+  has_many :plans_taxes, class_name: 'Plan::AppliedTax', dependent: :destroy
+  has_many :plans, through: :plans_taxes
+  has_many :charges_taxes, class_name: 'Charge::AppliedTax', dependent: :destroy
+  has_many :charges, through: :charges_taxes
 
   belongs_to :organization
 

--- a/db/migrate/20230704144027_create_plans_taxes.rb
+++ b/db/migrate/20230704144027_create_plans_taxes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreatePlansTaxes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :plans_taxes, id: :uuid do |t|
+      t.references :plan, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :tax, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230704150108_create_charges_taxes.rb
+++ b/db/migrate/20230704150108_create_charges_taxes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateChargesTaxes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :charges_taxes, id: :uuid do |t|
+      t.references :charge, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :tax, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_04_112230) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_04_150108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -118,6 +118,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_04_112230) do
     t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"
     t.index ["deleted_at"], name: "index_charges_on_deleted_at"
     t.index ["plan_id"], name: "index_charges_on_plan_id"
+  end
+
+  create_table "charges_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "charge_id", null: false
+    t.uuid "tax_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["charge_id"], name: "index_charges_taxes_on_charge_id"
+    t.index ["tax_id"], name: "index_charges_taxes_on_tax_id"
   end
 
   create_table "coupon_targets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -603,6 +612,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_04_112230) do
     t.index ["parent_id"], name: "index_plans_on_parent_id"
   end
 
+  create_table "plans_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "plan_id", null: false
+    t.uuid "tax_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["plan_id"], name: "index_plans_taxes_on_plan_id"
+    t.index ["tax_id"], name: "index_plans_taxes_on_tax_id"
+  end
+
   create_table "refunds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "payment_id", null: false
     t.uuid "credit_note_id", null: false
@@ -729,6 +747,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_04_112230) do
   add_foreign_key "billable_metrics", "organizations"
   add_foreign_key "charges", "billable_metrics"
   add_foreign_key "charges", "plans"
+  add_foreign_key "charges_taxes", "charges"
+  add_foreign_key "charges_taxes", "taxes"
   add_foreign_key "coupon_targets", "billable_metrics"
   add_foreign_key "coupon_targets", "coupons"
   add_foreign_key "coupon_targets", "plans"
@@ -781,6 +801,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_04_112230) do
   add_foreign_key "persisted_events", "customers"
   add_foreign_key "plans", "organizations"
   add_foreign_key "plans", "plans", column: "parent_id"
+  add_foreign_key "plans_taxes", "plans"
+  add_foreign_key "plans_taxes", "taxes"
   add_foreign_key "refunds", "credit_notes"
   add_foreign_key "refunds", "payment_provider_customers"
   add_foreign_key "refunds", "payment_providers"

--- a/spec/factories/charge_applied_taxes.rb
+++ b/spec/factories/charge_applied_taxes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :charge_applied_tax, class: 'Charge::AppliedTax' do
+    charge
+    tax
+  end
+end

--- a/spec/factories/plan_applied_taxes.rb
+++ b/spec/factories/plan_applied_taxes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :plan_applied_tax, class: 'Plan::AppliedTax' do
+    plan
+    tax
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at plans or charge levels

## Description

This PR add two new tables and the related models:
- `plans_taxes`, `Plan::AppliedTax`
- `charges_taxes`, `Charge::AppliedTax`