### PR TITLE
feat(tax): Expose plan and charge taxes in the API

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -63,7 +63,7 @@ module Api
             ::V1::PlanSerializer,
             collection_name: 'plans',
             meta: pagination_metadata(plans),
-            includes: %i[charges],
+            includes: %i[charges taxes],
           ),
         )
       end
@@ -106,7 +106,7 @@ module Api
           json: ::V1::PlanSerializer.new(
             plan,
             root_name: 'plan',
-            includes: %i[charges],
+            includes: %i[charges taxes],
           ),
         )
       end

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -3,7 +3,7 @@
 module V1
   class ChargeSerializer < ModelSerializer
     def serialize
-      {
+      payload = {
         lago_id: model.id,
         lago_billable_metric_id: model.billable_metric_id,
         billable_metric_code: model.billable_metric.code,
@@ -13,7 +13,13 @@ module V1
         pay_in_advance: model.pay_in_advance,
         min_amount_cents: model.min_amount_cents,
         properties: model.properties,
-      }.merge(group_properties)
+      }
+
+      payload.merge!(group_properties)
+
+      payload.merge!(taxes) if include?(:taxes)
+
+      payload
     end
 
     private
@@ -23,6 +29,14 @@ module V1
         model.group_properties,
         ::V1::GroupPropertiesSerializer,
         collection_name: 'group_properties',
+      ).serialize
+    end
+
+    def taxes
+      ::CollectionSerializer.new(
+        model.taxes,
+        ::V1::TaxSerializer,
+        collection_name: 'taxes',
       ).serialize
     end
   end

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -19,7 +19,8 @@ module V1
         draft_invoices_count:,
       }
 
-      payload = payload.merge(charges) if include?(:charges)
+      payload.merge!(charges) if include?(:charges)
+      payload.merge!(taxes) if include?(:taxes)
 
       payload
     end
@@ -27,7 +28,12 @@ module V1
     private
 
     def charges
-      ::CollectionSerializer.new(model.charges, ::V1::ChargeSerializer, collection_name: 'charges').serialize
+      ::CollectionSerializer.new(
+        model.charges,
+        ::V1::ChargeSerializer,
+        collection_name: 'charges',
+        includes: include?(:taxes) ? %i[taxes] : [],
+      ).serialize
     end
 
     def active_subscriptions_count
@@ -41,6 +47,14 @@ module V1
         .select(:invoice_id)
         .distinct
         .count
+    end
+
+    def taxes
+      ::CollectionSerializer.new(
+        model.taxes,
+        ::V1::TaxSerializer,
+        collection_name: 'taxes',
+      ).serialize
     end
   end
 end

--- a/spec/serializers/v1/charge_serializer_spec.rb
+++ b/spec/serializers/v1/charge_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ::V1::ChargeSerializer do
-  subject(:serializer) { described_class.new(charge, root_name: 'charge') }
+  subject(:serializer) { described_class.new(charge, root_name: 'charge', includes: %i[taxes]) }
 
   let(:charge) { create(:standard_charge) }
 
@@ -18,6 +18,8 @@ RSpec.describe ::V1::ChargeSerializer do
       expect(result['charge']['charge_model']).to eq(charge.charge_model)
       expect(result['charge']['pay_in_advance']).to eq(charge.pay_in_advance)
       expect(result['charge']['properties']).to eq(charge.properties)
+
+      expect(result['charge']['taxes']).to eq([])
     end
   end
 end

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe ::V1::PlanSerializer do
-  subject(:serializer) { described_class.new(plan, root_name: 'plan', includes: %i[charges]) }
+  subject(:serializer) { described_class.new(plan, root_name: 'plan', includes: %i[charges taxes]) }
 
   let(:plan) { create(:plan) }
   let(:charge) { create(:standard_charge, plan:) }
@@ -29,6 +29,8 @@ RSpec.describe ::V1::PlanSerializer do
       expect(result['plan']['draft_invoices_count']).to eq(0)
       expect(result['plan']['charges'].first['lago_id']).to eq(charge.id)
       expect(result['plan']['charges'].first['group_properties']).to eq([])
+
+      expect(result['plan']['taxes']).to eq([])
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at plans or charge levels

## Description

This PR exposes the taxes in the public API for plans and charges objects