### PR TITLE
fix: Improve validations when creating an event

### DIFF
--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -93,7 +93,7 @@ module Events
     def subscriptions(organization:, customer:, params:, timestamp:)
       return @subscriptions if defined? @subscriptions
 
-      subscriptions = if customer
+      subscriptions = if customer && params[:external_subscription_id].blank?
         customer.subscriptions
       else
         organization.subscriptions.where(external_id: params[:external_subscription_id])

--- a/app/services/fees/estimate_pay_in_advance_service.rb
+++ b/app/services/fees/estimate_pay_in_advance_service.rb
@@ -66,7 +66,7 @@ module Fees
       return @subscriptions if defined? @subscriptions
 
       timestamp = Time.current
-      subscriptions = if customer
+      subscriptions = if customer && params[:external_subscription_id].blank?
         customer.subscriptions
       else
         organization.subscriptions.where(external_id: params[:external_subscription_id])

--- a/app/services/fees/estimate_pay_in_advance_service.rb
+++ b/app/services/fees/estimate_pay_in_advance_service.rb
@@ -10,7 +10,7 @@ module Fees
     end
 
     def call
-      Events::ValidateCreationService.call(organization:, params:, customer:, result:)
+      Events::ValidateCreationService.call(organization:, params:, customer:, subscriptions:, result:)
       return result unless result.success?
 
       if charges.none?
@@ -45,7 +45,7 @@ module Fees
       @event = organization.events.new(
         code: params[:code],
         customer:,
-        subscription:,
+        subscription: subscriptions.first,
         properties: params[:properties] || {},
         transaction_id: SecureRandom.uuid,
         timestamp: Time.current,
@@ -62,14 +62,20 @@ module Fees
       end
     end
 
-    def subscription
-      organization
-        .subscriptions
-        .active
-        .where(external_id: params[:external_subscription_id])
-        .where('started_at <= ?', Time.current)
+    def subscriptions
+      return @subscriptions if defined? @subscriptions
+
+      timestamp = Time.current
+      subscriptions = if customer
+        customer.subscriptions
+      else
+        organization.subscriptions.where(external_id: params[:external_subscription_id])
+      end
+      return unless subscriptions
+
+      @subscriptions = subscriptions.where('started_at <= ?', timestamp)
+        .where('terminated_at IS NULL OR terminated_at >= ?', timestamp)
         .order(started_at: :desc)
-        .first || customer&.active_subscriptions&.first
     end
 
     def charges

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
 
     factory :active_subscription do
       status { :active }
-      started_at { Time.zone.now }
+      started_at { 1.day.ago }
     end
 
     factory :pending_subscription do

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
   let(:customer) { create(:customer, organization:) }
   let(:metric) { create(:billable_metric, organization:) }
   let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:active_subscription, customer:, organization:, plan:) }
+  let(:subscription) { create(:active_subscription, customer:, organization:, plan:, started_at: 1.month.ago) }
 
   before { subscription }
 
@@ -20,7 +20,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
           code: metric.code,
           transaction_id: SecureRandom.uuid,
           external_customer_id: customer.external_id,
-          timestamp: Time.zone.now.to_i,
+          timestamp: Time.current.to_i,
           properties: {
             foo: 'bar',
           },

--- a/spec/scenarios/create_event_spec.rb
+++ b/spec/scenarios/create_event_spec.rb
@@ -120,6 +120,25 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
     end
   end
 
+  context 'with external_customer_id and external_subscription_id and multiple subscriptions' do
+    let(:subscription2) { create(:active_subscription, customer:, started_at: subscription.started_at - 1.day) }
+
+    before { subscription2 }
+
+    it 'creates the event on the corresponding subscription' do
+      expect do
+        create_event(
+          params.merge(
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription2.external_id,
+          ),
+        )
+      end.to change { subscription2.events.reload.count }
+
+      expect(subscription.events.count).to eq(0)
+    end
+  end
+
   context 'with external_subscription_id but multiple subscriptions' do
     let(:subscription2) do
       create(

--- a/spec/scenarios/create_event_spec.rb
+++ b/spec/scenarios/create_event_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Create Event Scenarios', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:subscription) { create(:active_subscription, customer:) }
+  let(:params) do
+    { code: billable_metric.code, transaction_id: SecureRandom.uuid }
+  end
+
+  before { subscription }
+
+  context 'without external_customer_id and external_subscription_id' do
+    it 'returns a subscription not found error' do
+      result = create_event params
+      expect(result['code']).to eq('subscription_not_found')
+    end
+  end
+
+  context 'with unknown external_customer_id' do
+    it 'returns a customer not found error' do
+      result = create_event(params.merge(external_customer_id: 'unknown'))
+      expect(result['code']).to eq('customer_not_found')
+    end
+  end
+
+  context 'with external_customer_id from another organization' do
+    let(:organization2) { create(:organization, webhook_url: nil) }
+    let(:customer2) { create(:customer, organization: organization2) }
+
+    it 'returns a customer not found error' do
+      result = create_event(params.merge(external_customer_id: customer2.external_id))
+      expect(result['code']).to eq('customer_not_found')
+    end
+  end
+
+  context 'with unknown external_customer_id but valid external_subscription_id' do
+    it 'creates the event successfully' do
+      expect do
+        create_event(
+          params.merge(
+            external_customer_id: 'unknown',
+            external_subscription_id: subscription.external_id,
+          ),
+        )
+      end.to change(Event, :count)
+    end
+  end
+
+  context 'with unknown external_customer_id and unknown external_subscription_id' do
+    it 'returns a customer not found error' do
+      result = create_event(params.merge(external_customer_id: 'unknown', external_subscription_id: 'unknown'))
+      expect(result['code']).to eq('customer_not_found')
+    end
+  end
+
+  context 'with external_subscription_id from another organization' do
+    let(:organization2) { create(:organization, webhook_url: nil) }
+    let(:customer2) { create(:customer, organization: organization2) }
+    let(:subscription2) { create(:active_subscription, customer: customer2) }
+
+    it 'returns a subscription not found error' do
+      result = create_event(params.merge(external_subscription_id: subscription2.external_id))
+      expect(result['code']).to eq('subscription_not_found')
+    end
+  end
+
+  context 'with valid external_subscription_id' do
+    it 'creates the event successfully' do
+      expect do
+        create_event(params.merge(external_subscription_id: subscription.external_id))
+      end.to change(Event, :count)
+    end
+  end
+
+  context 'with not yet started subscription' do
+    let(:subscription) { create(:active_subscription, customer:, started_at: 1.day.from_now) }
+
+    it 'returns a subscription not found error' do
+      result = create_event params
+      expect(result['code']).to eq('subscription_not_found')
+    end
+  end
+
+  context 'with terminated subscription' do
+    let(:subscription) { create(:terminated_subscription, customer:) }
+
+    it 'returns a subscription not found error' do
+      result = create_event params
+      expect(result['code']).to eq('subscription_not_found')
+    end
+  end
+
+  context 'with terminated subscription but timestamp when active' do
+    let(:subscription) { create(:terminated_subscription, customer:, terminated_at: 24.hours.ago) }
+
+    it 'creates the event successfully' do
+      expect do
+        create_event(
+          params.merge(
+            external_subscription_id: subscription.external_id,
+            timestamp: 24.hours.ago.to_i,
+          ),
+        )
+      end.to change(Event, :count)
+    end
+  end
+
+  context 'with external_customer_id but multiple subscriptions' do
+    let(:subscription2) { create(:active_subscription, customer:, started_at: subscription.started_at - 1.day) }
+
+    before { subscription2 }
+
+    it 'returns a subscription not found error' do
+      result = create_event(params.merge(external_customer_id: customer.external_id))
+      expect(result['code']).to eq('subscription_not_found')
+    end
+  end
+
+  context 'with external_subscription_id but multiple subscriptions' do
+    let(:subscription2) do
+      create(
+        :pending_subscription,
+        customer:,
+        external_id: subscription.external_id,
+      )
+    end
+
+    before { subscription2 }
+
+    it 'creates the event on the active subscription' do
+      expect do
+        create_event(params.merge(external_subscription_id: subscription.external_id))
+      end.to change { subscription.events.reload.count }
+
+      expect(subscription2.events.count).to eq(0)
+    end
+  end
+end

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Events::CreateService, type: :service do
   let(:customer) { create(:customer, organization:) }
 
   describe '#validate_params' do
+    let!(:subscription) { create(:active_subscription, customer:, organization:, started_at: 1.month.ago) }
     let(:params) do
       {
         transaction_id: SecureRandom.uuid,
@@ -19,7 +20,6 @@ RSpec.describe Events::CreateService, type: :service do
     end
 
     before do
-      create(:active_subscription, customer:, organization:)
       allow(Events::ValidateCreationService).to receive(:call).and_call_original
     end
 
@@ -30,6 +30,7 @@ RSpec.describe Events::CreateService, type: :service do
         organization:,
         params:,
         customer:,
+        subscriptions: [subscription],
         result: kind_of(BaseService::Result),
         send_webhook: false,
       )

--- a/spec/services/fees/estimate_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/estimate_pay_in_advance_service_spec.rb
@@ -87,8 +87,9 @@ RSpec.describe Fees::EstimatePayInAdvanceService do
     end
 
     context 'when external customer is not found' do
-      let(:external_customer_id) { nil }
-      let(:external_subscription_id) { nil }
+      let(:params) do
+        { code:, external_customer_id: 'unknown' }
+      end
 
       it 'fails with a not found error' do
         result = estimate_service.call

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -67,8 +67,8 @@ module ScenariosHelper
 
   def create_event(params)
     post_with_token(organization, '/api/v1/events', { event: params })
-
     perform_all_enqueued_jobs
+    JSON.parse(response.body) unless response.body.empty?
   end
 
   # This performs any enqueued-jobs, and continues doing so until the queue is empty.


### PR DESCRIPTION
The goal of this PR is to:
- add the ability to create an event on a terminated subscription by passing `external_customer_id`
- add scenarios for validating event creation
 