### PR TITLE
feat(taxes): Ability to assign and unassign taxes to a plan

### DIFF
--- a/app/controllers/api/v1/plans/applied_taxes_controller.rb
+++ b/app/controllers/api/v1/plans/applied_taxes_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Plans
+      class AppliedTaxesController < Api::BaseController
+        def create
+          tax = current_organization.taxes.find_by(code: input_params[:tax_code])
+          result = ::Plans::AppliedTaxes::CreateService.call(plan:, tax:)
+          if result.success?
+            render(json: ::V1::Plans::AppliedTaxSerializer.new(result.applied_tax, root_name: 'applied_tax'))
+          else
+            render_error_response(result)
+          end
+        end
+
+        def destroy
+          tax = current_organization.taxes.find_by(code: params[:tax_code])
+          applied_tax = Plan::AppliedTax.find_by(plan:, tax:)
+          result = ::Plans::AppliedTaxes::DestroyService.call(applied_tax:)
+          if result.success?
+            render(json: ::V1::Plans::AppliedTaxSerializer.new(result.applied_tax, root_name: 'applied_tax'))
+          else
+            render_error_response(result)
+          end
+        end
+
+        private
+
+        def plan
+          @plan ||= current_organization.plans.find_by(code: params[:plan_code])
+        end
+
+        def input_params
+          params.require(:applied_tax).permit(:tax_code)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class PlansController < Api::BaseController
       def create
-        service = Plans::CreateService.new
+        service = ::Plans::CreateService.new
         result = service.create(
           **input_params
             .merge(organization_id: current_organization.id)
@@ -21,7 +21,7 @@ module Api
 
       def update
         plan = current_organization.plans.find_by(code: params[:code])
-        result = Plans::UpdateService.call(plan:, params: input_params)
+        result = ::Plans::UpdateService.call(plan:, params: input_params)
 
         if result.success?
           render_plan(result.plan)
@@ -32,7 +32,7 @@ module Api
 
       def destroy
         plan = current_organization.plans.find_by(code: params[:code])
-        result = Plans::PrepareDestroyService.call(plan:)
+        result = ::Plans::PrepareDestroyService.call(plan:)
 
         if result.success?
           render_plan(result.plan)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -16,6 +16,7 @@ class Plan < ApplicationRecord
   has_many :children, class_name: 'Plan', foreign_key: :parent_id
   has_many :coupon_targets
   has_many :coupons, through: :coupon_targets
+  has_many :invoices, through: :subscriptions
 
   has_many :applied_taxes, class_name: 'Plan::AppliedTax', dependent: :destroy
   has_many :taxes, through: :applied_taxes

--- a/app/serializers/v1/plans/applied_tax_serializer.rb
+++ b/app/serializers/v1/plans/applied_tax_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Plans
+    class AppliedTaxSerializer < ModelSerializer
+      def serialize
+        {
+          lago_id: model.id,
+          lago_plan_id: model.plan.id,
+          lago_tax_id: model.tax.id,
+          tax_code: model.tax.code,
+          plan_code: model.plan.code,
+          created_at: model.created_at.iso8601,
+        }
+      end
+    end
+  end
+end

--- a/app/services/plans/applied_taxes/create_service.rb
+++ b/app/services/plans/applied_taxes/create_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Plans
+  module AppliedTaxes
+    class CreateService < BaseService
+      def initialize(plan:, tax:)
+        @plan = plan
+        @tax = tax
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: 'plan') unless plan
+        return result.not_found_failure!(resource: 'tax') unless tax
+
+        applied_tax = plan.applied_taxes.find_or_create_by!(tax:)
+        Invoices::RefreshBatchJob.perform_later(plan.invoices.draft.pluck(:id))
+
+        result.applied_tax = applied_tax
+        result
+      end
+
+      private
+
+      attr_reader :plan, :tax
+    end
+  end
+end

--- a/app/services/plans/applied_taxes/create_service.rb
+++ b/app/services/plans/applied_taxes/create_service.rb
@@ -13,8 +13,9 @@ module Plans
         return result.not_found_failure!(resource: 'plan') unless plan
         return result.not_found_failure!(resource: 'tax') unless tax
 
-        applied_tax = plan.applied_taxes.find_or_create_by!(tax:)
-        Invoices::RefreshBatchJob.perform_later(plan.invoices.draft.pluck(:id))
+        applied_tax = plan.applied_taxes.find_or_create_by!(tax:) do |_applied_tax|
+          Invoices::RefreshBatchJob.perform_later(plan.invoices.draft.pluck(:id))
+        end
 
         result.applied_tax = applied_tax
         result

--- a/app/services/plans/applied_taxes/destroy_service.rb
+++ b/app/services/plans/applied_taxes/destroy_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Plans
+  module AppliedTaxes
+    class DestroyService < BaseService
+      def initialize(applied_tax:)
+        @applied_tax = applied_tax
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: 'applied_tax') unless applied_tax
+
+        applied_tax.destroy!
+
+        Invoices::RefreshBatchJob.perform_later(applied_tax.plan.invoices.draft.pluck(:id))
+
+        result.applied_tax = applied_tax
+        result
+      end
+
+      private
+
+      attr_reader :applied_tax
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,11 @@ Rails.application.routes.draw do
         put :refresh, on: :member
         put :finalize, on: :member
       end
-      resources :plans, param: :code
+      resources :plans, param: :code do
+        scope module: :plans do
+          resources :applied_taxes, only: %i[create destroy], param: :tax_code
+        end
+      end
       resources :taxes, param: :code
       resources :wallet_transactions, only: :create
       get '/wallets/:id/wallet_transactions', to: 'wallet_transactions#index'

--- a/spec/requests/api/v1/plans/applied_taxes_spec.rb
+++ b/spec/requests/api/v1/plans/applied_taxes_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::Plans::AppliedTaxesController, type: :request do
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:, organization:, plan:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:tax) { create(:tax, organization:) }
+
+  before { subscription }
+
+  describe 'POST /applied_taxes' do
+    it 'creates an applied tax' do
+      expect do
+        post_with_token(
+          organization,
+          "/api/v1/plans/#{plan.code}/applied_taxes",
+          { applied_tax: { tax_code: tax.code } },
+        )
+      end.to change(Plan::AppliedTax, :count).by(1)
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:applied_tax][:lago_id]).to be_present
+        expect(json[:applied_tax][:lago_plan_id]).to eq(plan.id)
+        expect(json[:applied_tax][:lago_tax_id]).to eq(tax.id)
+      end
+    end
+
+    context 'when plan does not exist' do
+      it 'returns not_found error' do
+        post_with_token(organization, '/api/v1/plans/unknown/applied_taxes', { applied_tax: { tax_code: '' } })
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when tax does not exist' do
+      it 'returns not_found error' do
+        post_with_token(
+          organization,
+          "/api/v1/plans/#{plan.code}/applied_taxes",
+          { applied_tax: { tax_code: 'unknown' } },
+        )
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'DELETE /applied_taxes/:tax_code' do
+    let(:applied_tax) { create(:plan_applied_tax, plan:, tax:) }
+
+    before { applied_tax }
+
+    it 'deletes an applied tax' do
+      expect do
+        delete_with_token(
+          organization,
+          "/api/v1/plans/#{plan.code}/applied_taxes/#{tax.code}",
+        )
+      end.to change(Plan::AppliedTax, :count).by(-1)
+    end
+
+    it 'returns the deleted applied tax' do
+      delete_with_token(
+        organization,
+        "/api/v1/plans/#{plan.code}/applied_taxes/#{tax.code}",
+      )
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(json[:applied_tax][:lago_plan_id]).to eq(plan.id)
+        expect(json[:applied_tax][:lago_tax_id]).to eq(tax.id)
+        expect(json[:applied_tax][:plan_code]).to eq(plan.code)
+        expect(json[:applied_tax][:tax_code]).to eq(tax.code)
+      end
+    end
+
+    context 'when plan does not exist' do
+      it 'returns not_found error' do
+        delete_with_token(organization, "/api/v1/plans/unknown/applied_taxes/#{tax.code}")
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when tax does not exist' do
+      it 'returns not_found error' do
+        delete_with_token(organization, "/api/v1/customers/#{customer.external_id}/applied_taxes/unknown")
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when applied tax does not exist' do
+      let(:applied_tax) { nil }
+
+      it 'returns not_found error' do
+        delete_with_token(organization, "/api/v1/plans/#{plan.code}/applied_taxes/#{tax.code}")
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/services/plans/applied_taxes/create_service_spec.rb
+++ b/spec/services/plans/applied_taxes/create_service_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Plans::AppliedTaxes::CreateService, type: :service do
+  subject(:create_service) { described_class.new(plan:, tax:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:, organization:) }
+  let(:plan) { subscription.plan }
+  let(:tax) { create(:tax, organization:) }
+
+  before { subscription }
+
+  describe '#call' do
+    it 'creates an applied tax' do
+      expect { create_service.call }.to change(Plan::AppliedTax, :count).by(1)
+    end
+
+    it 'refreshes draft invoices' do
+      draft_invoice = create(:invoice, :draft, organization:)
+      create(:invoice_subscription, invoice: draft_invoice, subscription:)
+
+      expect do
+        create_service.call
+      end.to have_enqueued_job(Invoices::RefreshBatchJob).with([draft_invoice.id])
+    end
+
+    context 'when already applied to the plan' do
+      it 'does not apply the tax once again' do
+        create(:plan_applied_tax, tax:, plan:)
+        expect { create_service.call }.not_to change(Plan::AppliedTax, :count)
+      end
+    end
+
+    context 'when plan is not found' do
+      let(:plan) { nil }
+
+      it 'returns an error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('plan_not_found')
+        end
+      end
+    end
+
+    context 'when tax is not found' do
+      let(:tax) { nil }
+
+      it 'returns an error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('tax_not_found')
+        end
+      end
+    end
+  end
+end

--- a/spec/services/plans/applied_taxes/create_service_spec.rb
+++ b/spec/services/plans/applied_taxes/create_service_spec.rb
@@ -28,9 +28,16 @@ RSpec.describe Plans::AppliedTaxes::CreateService, type: :service do
     end
 
     context 'when already applied to the plan' do
+      before { create(:plan_applied_tax, tax:, plan:) }
+
       it 'does not apply the tax once again' do
-        create(:plan_applied_tax, tax:, plan:)
         expect { create_service.call }.not_to change(Plan::AppliedTax, :count)
+      end
+
+      it 'does not refresh draft invoices' do
+        expect do
+          create_service.call
+        end.not_to have_enqueued_job(Invoices::RefreshBatchJob)
       end
     end
 

--- a/spec/services/plans/applied_taxes/destroy_service_spec.rb
+++ b/spec/services/plans/applied_taxes/destroy_service_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Plans::AppliedTaxes::DestroyService, type: :service do
+  subject(:destroy_service) { described_class.new(applied_tax:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:, organization:) }
+  let(:plan) { subscription.plan }
+  let(:applied_tax) { create(:plan_applied_tax, plan:) }
+
+  describe '#call' do
+    before { applied_tax }
+
+    it 'destroys the applied tax' do
+      expect { destroy_service.call }.to change(Plan::AppliedTax, :count).by(-1)
+    end
+
+    it 'refreshes draft invoices' do
+      draft_invoice = create(:invoice, :draft, organization:)
+      create(:invoice_subscription, invoice: draft_invoice, subscription:)
+
+      expect do
+        destroy_service.call
+      end.to have_enqueued_job(Invoices::RefreshBatchJob).with([draft_invoice.id])
+    end
+
+    context 'when applied tax is not found' do
+      let(:applied_tax) { nil }
+
+      it 'returns an error' do
+        result = destroy_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('applied_tax_not_found')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at plans or charge levels

## Description

This PR permits to assign and unassign taxes to a specific plan.