### PR TITLE
feat: cancel pending subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -119,7 +119,7 @@ module Api
       end
 
       def index_filters
-        params.permit(:external_customer_id, :plan_code)
+        params.permit(:external_customer_id, :plan_code, status: [])
       end
     end
   end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -37,7 +37,13 @@ module Api
 
       # NOTE: We can't destroy a subscription, it will terminate it
       def terminate
-        subscription = current_organization.subscriptions.active.find_by(external_id: params[:external_id])
+        query = current_organization.subscriptions.where(external_id: params[:external_id])
+        subscription = if params[:status] == 'pending'
+          query.pending
+        else
+          query.active
+        end.first
+
         result = Subscriptions::TerminateService.call(subscription:)
 
         if result.success?

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -26,6 +26,7 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       field :next_plan, Types::Plans::Object
+      field :next_subscription, Types::Subscriptions::Object
 
       field :fees, [Types::Fees::Object], null: true
 

--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -2,7 +2,8 @@
 
 class SubscriptionsQuery < BaseQuery
   def call
-    subscriptions = paginate(organization.subscriptions.active)
+    subscriptions = paginate(organization.subscriptions)
+    subscriptions = with_status(subscriptions) if filters.status.present? && valid_status?
     subscriptions = subscriptions.order(started_at: :asc)
 
     subscriptions = with_external_customer(subscriptions) if filters.external_customer_id
@@ -18,5 +19,13 @@ class SubscriptionsQuery < BaseQuery
 
   def with_plan_code(scope)
     scope.joins(:plan).where(plans: { code: filters.plan_code })
+  end
+
+  def with_status(scope)
+    scope.where(status: filters.status)
+  end
+
+  def valid_status?
+    filters.status.all? { |s| Subscription.statuses.key?(s) }
   end
 end

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -14,6 +14,8 @@ module Subscriptions
 
       if subscription.starting_in_the_future?
         subscription.mark_as_terminated!
+      elsif subscription.pending?
+        subscription.mark_as_canceled!
       elsif !subscription.terminated?
         subscription.mark_as_terminated!
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -4519,6 +4519,7 @@ type Subscription {
   nextName: String
   nextPendingStartDate: ISO8601Date
   nextPlan: Plan
+  nextSubscription: Subscription
   periodEndDate: ISO8601Date
   plan: Plan!
   startedAt: ISO8601DateTime

--- a/schema.json
+++ b/schema.json
@@ -19499,6 +19499,20 @@
               ]
             },
             {
+              "name": "nextSubscription",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Subscription",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "periodEndDate",
               "description": null,
               "type": {

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -67,5 +67,38 @@ RSpec.describe SubscriptionsQuery, type: :query do
         end
       end
     end
+
+    context 'with status filter' do
+      let(:query_filters) { { status: [:active, :pending] } }
+
+      it 'returns correct subscriptions' do
+        create(:pending_subscription, customer:, plan:)
+        create(:subscription, customer:, plan:, status: :canceled)
+        result = subscriptions_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.subscriptions.count).to eq(2)
+          expect(result.subscriptions.active.count).to eq(1)
+          expect(result.subscriptions.pending.count).to eq(1)
+          expect(result.subscriptions.canceled.count).to eq(0)
+        end
+      end
+    end
+
+    context 'with pending subscription' do
+      it 'returns both active and pending subscriptions' do
+        create(:pending_subscription, customer:, plan:)
+
+        result = subscriptions_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.subscriptions.count).to eq(2)
+          expect(result.subscriptions.active.count).to eq(1)
+          expect(result.subscriptions.pending.count).to eq(1)
+        end
+      end
+    end
   end
 end

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe Subscriptions::TerminateService do
       end
     end
 
+    context 'when downgrade subscription is pending' do
+      let(:subscription) { create(:pending_subscription, previous_subscription: create(:subscription)) }
+
+      it 'does cancel it' do
+        result = terminate_service.call
+
+        aggregate_failures do
+          expect(result.subscription).to be_present
+          expect(result.subscription).to be_canceled
+          expect(result.subscription.canceled_at).to be_present
+        end
+      end
+    end
+
     context 'when subscription is not found' do
       let(:subscription) { nil }
 


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/retrieve-andor-cancel-pending-subscriptions

## Context

We want to allow canceling a pending subscription, either because they are planned in the future alone or due to a downgrade

## Description

This PR allows such action

Better review commit-by-commit