### PR TITLE
fix: Ability to start the subscription and create an event in the same time

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -14,7 +14,7 @@ module Api
         Events::CreateJob.perform_later(
           current_organization,
           create_params,
-          Time.zone.now.to_i,
+          Time.current.to_i,
           event_metadata,
         )
 

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -100,8 +100,9 @@ module Events
       end
       return unless subscriptions
 
-      @subscriptions = subscriptions.where('started_at <= ?', timestamp)
-        .where('terminated_at IS NULL OR terminated_at >= ?', timestamp)
+      @subscriptions = subscriptions
+        .where('started_at::timestamp(0) <= ?', timestamp)
+        .where('terminated_at IS NULL OR terminated_at::timestamp(0) >= ?', timestamp)
         .order(started_at: :desc)
     end
 

--- a/spec/scenarios/create_event_spec.rb
+++ b/spec/scenarios/create_event_spec.rb
@@ -80,17 +80,37 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
     let(:subscription) { create(:active_subscription, customer:, started_at: 1.day.from_now) }
 
     it 'returns a subscription not found error' do
-      result = create_event params
+      result = create_event(params.merge(external_subscription_id: subscription.external_id))
       expect(result['code']).to eq('subscription_not_found')
     end
   end
 
+  context 'with subscription started in the same second' do
+    let(:subscription) { create(:active_subscription, customer:, started_at: Time.current) }
+
+    it 'creates the event successfully' do
+      expect do
+        create_event(params.merge(external_subscription_id: subscription.external_id))
+      end.to change(Event, :count)
+    end
+  end
+
   context 'with terminated subscription' do
-    let(:subscription) { create(:terminated_subscription, customer:) }
+    let(:subscription) { create(:terminated_subscription, customer:, terminated_at: 1.hour.ago) }
 
     it 'returns a subscription not found error' do
-      result = create_event params
+      result = create_event(params.merge(external_subscription_id: subscription.external_id))
       expect(result['code']).to eq('subscription_not_found')
+    end
+  end
+
+  context 'with subscription terminated in the same second' do
+    let(:subscription) { create(:terminated_subscription, customer:, terminated_at: Time.current) }
+
+    it 'creates the event successfully' do
+      expect do
+        create_event(params.merge(external_subscription_id: subscription.external_id))
+      end.to change(Event, :count)
     end
   end
 


### PR DESCRIPTION
We are using `Time.current.to_i` for the timestamp when creating an event. It does not incllude milliseconds.
When creating a subscription in the same time, sometimes we can have errors on events.

The goal of this PR is to fix this issue.