### PR TITLE
feat (invoice): New invoice template changes for recurring case

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -109,7 +109,7 @@ class Invoice < ApplicationRecord
     subscription_fees(subscription_id)
       .joins(charge: :billable_metric)
       .where(billable_metric: { recurring: true })
-      .where(billable_metric: { aggregation_type: [1, 3] })
+      .where(billable_metric: { aggregation_type: %i[sum_agg unique_count_agg] })
       .where(charge: { pay_in_advance: false })
   end
 
@@ -147,7 +147,7 @@ class Invoice < ApplicationRecord
     number_of_seconds = date_service.charges_to_datetime.in_time_zone(customer.applicable_timezone) -
                         event.timestamp.in_time_zone(customer.applicable_timezone)
 
-    number_of_days = number_of_seconds.fdiv(86_400).round
+    number_of_days = number_of_seconds.fdiv(1.day).round
 
     {
       number_of_days:,

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -116,9 +116,9 @@ class Invoice < ApplicationRecord
   def recurring_breakdown(fee)
     service = case fee.charge.billable_metric.aggregation_type.to_sym
               when :sum_agg
-                 BillableMetrics::Breakdown::SumService
+                BillableMetrics::Breakdown::SumService
               when :unique_count_agg
-                 BillableMetrics::Breakdown::UniqueCountService
+                BillableMetrics::Breakdown::UniqueCountService
               else
                 raise(NotImplementedError)
               end

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -46,13 +46,13 @@ module BillableMetrics
         date_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'events.timestamp')
 
         added_list = period_query.group(Arel.sql("DATE(#{date_field})"))
-                                 .order(Arel.sql("DATE(#{date_field}) ASC"))
-                                 .pluck(Arel.sql(
-                                   [
-                                     "DATE(#{date_field}) as date",
-                                     "SUM(CAST(#{sanitized_field_name} AS FLOAT))::numeric",
-                                   ].join(', '),
-                                 ))
+          .order(Arel.sql("DATE(#{date_field}) ASC"))
+          .pluck(Arel.sql(
+            [
+              "DATE(#{date_field}) as date",
+              "SUM(CAST(#{sanitized_field_name} AS FLOAT))::numeric",
+            ].join(', '),
+          ))
 
         added_list.map do |aggregation|
           OpenStruct.new(

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -45,7 +45,7 @@ module BillableMetrics
       def period_breakdown
         date_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'events.timestamp')
 
-        added_list = period_query.group(Arel.sql("DATE(#{date_field})"))
+        list = period_query.group(Arel.sql("DATE(#{date_field})"))
           .order(Arel.sql("DATE(#{date_field}) ASC"))
           .pluck(Arel.sql(
             [
@@ -54,7 +54,7 @@ module BillableMetrics
             ].join(', '),
           ))
 
-        added_list.map do |aggregation|
+        list.map do |aggregation|
           OpenStruct.new(
             date: aggregation.first.to_date,
             action: aggregation.last.negative? ? 'remove' : 'add',

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module BillableMetrics
+  module Breakdown
+    class SumService < BillableMetrics::ProratedAggregations::SumService
+      def breakdown(from_datetime:, to_datetime:)
+        @from_datetime = from_datetime
+        @to_datetime = to_datetime
+
+        breakdown = persisted_breakdown
+        breakdown += period_breakdown
+
+        # NOTE: in the breakdown, dates are in customer timezone
+        result.breakdown = breakdown.sort_by(&:date)
+        result
+      end
+
+      private
+
+      attr_reader :from_datetime, :to_datetime
+
+      def from_date_in_customer_timezone
+        from_datetime.in_time_zone(customer.applicable_timezone).to_date
+      end
+
+      def to_date_in_customer_timezone
+        to_datetime.in_time_zone(customer.applicable_timezone).to_date
+      end
+
+      def persisted_breakdown
+        persisted_sum = persisted_query.sum("(#{sanitized_field_name})::numeric")
+        return [] if persisted_sum.zero?
+
+        [
+          OpenStruct.new(
+            date: from_date_in_customer_timezone,
+            action: persisted_sum.negative? ? 'remove' : 'add',
+            amount: persisted_sum,
+            duration: (to_date_in_customer_timezone + 1.day - from_date_in_customer_timezone).to_i,
+            total_duration: period_duration,
+          ),
+        ]
+      end
+
+      def period_breakdown
+        date_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'events.timestamp')
+
+        added_list = period_query.group(Arel.sql("DATE(#{date_field})"))
+                                 .order(Arel.sql("DATE(#{date_field}) ASC"))
+                                 .pluck(Arel.sql(
+                                   [
+                                     "DATE(#{date_field}) as date",
+                                     "SUM(CAST(#{sanitized_field_name} AS FLOAT))::numeric",
+                                   ].join(', '),
+                                 ))
+
+        added_list.map do |aggregation|
+          OpenStruct.new(
+            date: aggregation.first.to_date,
+            action: aggregation.last.negative? ? 'remove' : 'add',
+            amount: aggregation.last,
+            duration: (to_date_in_customer_timezone + 1.day - aggregation.first).to_i,
+            total_duration: period_duration,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/billable_metrics/breakdown/unique_count_service.rb
+++ b/app/services/billable_metrics/breakdown/unique_count_service.rb
@@ -48,13 +48,13 @@ module BillableMetrics
         date_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'quantified_events.added_at')
 
         added_list = prorated_added_query.group(Arel.sql("DATE(#{date_field})"))
-                                         .order(Arel.sql("DATE(#{date_field}) ASC"))
-                                         .pluck(Arel.sql(
-                                           [
-                                             "DATE(#{date_field}) as date",
-                                             'COUNT(quantified_events.id) as metric_count',
-                                          ].join(', '),
-                                         ))
+          .order(Arel.sql("DATE(#{date_field}) ASC"))
+          .pluck(Arel.sql(
+            [
+              "DATE(#{date_field}) as date",
+              'COUNT(quantified_events.id) as metric_count',
+            ].join(', '),
+          ))
 
         added_list.map do |aggregation|
           OpenStruct.new(
@@ -71,13 +71,13 @@ module BillableMetrics
         date_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'quantified_events.removed_at')
 
         removed_list = prorated_removed_query.group(Arel.sql("DATE(#{date_field})"))
-                                             .order(Arel.sql("DATE(#{date_field}) ASC"))
-                                             .pluck(Arel.sql(
-                                              [
-                                                "DATE(#{date_field}) as date",
-                                                'COUNT(quantified_events.id) as metric_count',
-                                              ].join(', '),
-                                              ))
+          .order(Arel.sql("DATE(#{date_field}) ASC"))
+          .pluck(Arel.sql(
+            [
+              "DATE(#{date_field}) as date",
+              'COUNT(quantified_events.id) as metric_count',
+            ].join(', '),
+          ))
 
         removed_list.map do |aggregation|
           OpenStruct.new(
@@ -96,9 +96,9 @@ module BillableMetrics
 
         added_and_removed_list = prorated_added_and_removed_query.group(
           Arel.sql("DATE(#{added_field}), DATE(#{removed_field})"),
-          ).order(
+        ).order(
           Arel.sql("DATE(#{added_field}) ASC, DATE(#{removed_field}) ASC"),
-          ).pluck(Arel.sql(
+        ).pluck(Arel.sql(
           [
             "DATE(#{added_field}) as added_at",
             "DATE(#{removed_field}) as removed_at",

--- a/app/services/billable_metrics/breakdown/unique_count_service.rb
+++ b/app/services/billable_metrics/breakdown/unique_count_service.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+module BillableMetrics
+  module Breakdown
+    class UniqueCountService < BillableMetrics::ProratedAggregations::UniqueCountService
+      def breakdown(from_datetime:, to_datetime:)
+        @from_datetime = from_datetime
+        @to_datetime = to_datetime
+
+        breakdown = persisted_breakdown
+        breakdown += added_breakdown
+        breakdown += removed_breadown
+        breakdown += added_and_removed_breakdown
+
+        # NOTE: in the breakdown, dates are in customer timezone
+        result.breakdown = breakdown.sort_by(&:date)
+        result
+      end
+
+      private
+
+      attr_reader :from_datetime, :to_datetime
+
+      def from_date_in_customer_timezone
+        from_datetime.in_time_zone(customer.applicable_timezone).to_date
+      end
+
+      def to_date_in_customer_timezone
+        to_datetime.in_time_zone(customer.applicable_timezone).to_date
+      end
+
+      def persisted_breakdown
+        persisted_count = prorated_persisted_query.count
+        return [] if persisted_count.zero?
+
+        [
+          OpenStruct.new(
+            date: from_date_in_customer_timezone,
+            action: 'add',
+            amount: persisted_count,
+            duration: (to_date_in_customer_timezone + 1.day - from_date_in_customer_timezone).to_i,
+            total_duration: period_duration,
+          ),
+        ]
+      end
+
+      def added_breakdown
+        date_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'quantified_events.added_at')
+
+        added_list = prorated_added_query.group(Arel.sql("DATE(#{date_field})"))
+                                         .order(Arel.sql("DATE(#{date_field}) ASC"))
+                                         .pluck(Arel.sql(
+                                           [
+                                             "DATE(#{date_field}) as date",
+                                             'COUNT(quantified_events.id) as metric_count',
+                                          ].join(', '),
+                                         ))
+
+        added_list.map do |aggregation|
+          OpenStruct.new(
+            date: aggregation.first.to_date,
+            action: 'add',
+            amount: aggregation.last,
+            duration: (to_date_in_customer_timezone + 1.day - aggregation.first).to_i,
+            total_duration: period_duration,
+          )
+        end
+      end
+
+      def removed_breadown
+        date_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'quantified_events.removed_at')
+
+        removed_list = prorated_removed_query.group(Arel.sql("DATE(#{date_field})"))
+                                             .order(Arel.sql("DATE(#{date_field}) ASC"))
+                                             .pluck(Arel.sql(
+                                              [
+                                                "DATE(#{date_field}) as date",
+                                                'COUNT(quantified_events.id) as metric_count',
+                                              ].join(', '),
+                                              ))
+
+        removed_list.map do |aggregation|
+          OpenStruct.new(
+            date: aggregation.first.to_date,
+            action: 'remove',
+            amount: aggregation.last,
+            duration: (aggregation.first + 1.day - from_date_in_customer_timezone).to_i,
+            total_duration: period_duration,
+          )
+        end
+      end
+
+      def added_and_removed_breakdown
+        added_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'quantified_events.added_at')
+        removed_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'quantified_events.removed_at')
+
+        added_and_removed_list = prorated_added_and_removed_query.group(
+          Arel.sql("DATE(#{added_field}), DATE(#{removed_field})"),
+          ).order(
+          Arel.sql("DATE(#{added_field}) ASC, DATE(#{removed_field}) ASC"),
+          ).pluck(Arel.sql(
+          [
+            "DATE(#{added_field}) as added_at",
+            "DATE(#{removed_field}) as removed_at",
+            'COUNT(quantified_events.id) as metric_count',
+          ].join(', '),
+        ))
+
+        added_and_removed_list.map do |aggregation|
+          OpenStruct.new(
+            date: aggregation.first.to_date,
+            action: 'add_and_removed',
+            amount: aggregation.last,
+            duration: (aggregation.second.to_date + 1.day - aggregation.first.to_date).to_i,
+            total_duration: period_duration,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -34,7 +34,7 @@ module BillableMetrics
         result.service_failure!(code: 'aggregation_failure', message: e.message)
       end
 
-      private
+      protected
 
       attr_reader :from_datetime, :to_datetime, :options
 

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -32,7 +32,7 @@ module BillableMetrics
         result
       end
 
-      private
+      protected
 
       attr_reader :from_datetime, :to_datetime, :options
 

--- a/app/views/templates/invoices/_subscription_details.slim
+++ b/app/views/templates/invoices/_subscription_details.slim
@@ -18,9 +18,8 @@
           td.body-2 = 1
           td.body-2 == TaxHelper.applied_taxes(invoice_subscription(subscription.id).subscription_fee)
           td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).subscription_amount)
-        /* TODO: tr charge pay in advance */
 
-    - if subscription? && subscription_fees(subscription.id).charge_kind.any?
+    - if subscription? && subscription_fees(subscription.id).charge_kind.any? && subscription.plan.charges.where(pay_in_advance: false).any?
       .invoice-resume.overflow-auto
         table.invoice-resume-table width="100%"
           tr
@@ -30,6 +29,69 @@
             td.body-2 = I18n.t('invoice.amount_without_tax')
           - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).group_by(&:charge_id).each do |_charge_id, fees|
             - fee = fees.first
+            - next if fee.charge.pay_in_advance?
+
+            - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
+              tr
+                td
+                  .body-1 = fee.billable_metric.name
+                  .body-3
+                    - if fee.charge.percentage?
+                      = I18n.t('invoice.total_events', count: fees.sum(&:events_count))
+                td
+                td
+                td
+              - fees.select { |f| f.units.positive? }.each do |fee|
+                tr
+                  td style="padding-left: 16px;"
+                    .body-1 = fee.group.name
+                    - unless fee.billable_metric.recurring_count_agg?
+                      .body-3
+                        - if fee.charge.percentage?
+                          = I18n.t('invoice.total_events', count: fee.events_count)
+                  td.body-2 = fee.units
+                  td.body-2 == TaxHelper.applied_taxes(fee)
+                  td.body-2 = MoneyHelper.format(fee.amount)
+              - fees.select { |f| f.true_up_fee.present? }.each do |fee|
+                tr
+                  td
+                    .body-1 = I18n.t('invoice.true_up_metric', metric: fee.billable_metric.name)
+                    .body-3 = I18n.t('invoice.true_up_details', min_amount: MoneyHelper.format(fee.charge.min_amount))
+                  td.body-2 = fee.true_up_fee.units
+                  td.body-2 == TaxHelper.applied_taxes(fee.true_up_fee)
+                  td.body-2 = MoneyHelper.format(fee.true_up_fee.amount)
+            - else
+              tr
+                td
+                  .body-1 = fee.billable_metric.name
+                  - unless fee.billable_metric.recurring_count_agg?
+                      .body-3
+                        - if fee.charge.percentage?
+                          = I18n.t('invoice.total_events', count: fee.events_count)
+                td.body-2 = fees.sum(&:units)
+                td.body-2 == TaxHelper.applied_taxes(fee)
+                td.body-2 = MoneyHelper.format(fees.sum(&:amount))
+              - if fee.true_up_fee.present?
+                tr
+                  td
+                    .body-1 = I18n.t('invoice.true_up_metric', metric: fee.billable_metric.name)
+                    .body-3 = I18n.t('invoice.true_up_details', min_amount: MoneyHelper.format(fee.charge.min_amount))
+                  td.body-2 = fee.true_up_fee.units
+                  td.body-2 == TaxHelper.applied_taxes(fee.true_up_fee)
+                  td.body-2 = MoneyHelper.format(fee.true_up_fee.amount)
+    - if subscription? && subscription_fees(subscription.id).charge_kind.any? && subscription.plan.charges.where(pay_in_advance: true).any?
+      .invoice-resume.overflow-auto
+        table.invoice-resume-table width="100%"
+          tr
+            - pay_in_advance_interval = charge_pay_in_advance_interval(invoice_subscription(subscription.id).timestamp, subscription)
+            td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(pay_in_advance_interval[:charges_from_date], format: :default), to_date: I18n.l(pay_in_advance_interval[:charges_to_date], format: :default))
+            td.body-2 = I18n.t('invoice.unit')
+            td.body-2 = I18n.t('invoice.tax_rate')
+            td.body-2 = I18n.t('invoice.amount_without_tax')
+          - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).group_by(&:charge_id).each do |_charge_id, fees|
+            - fee = fees.first
+            - next unless fee.charge.pay_in_advance?
+
             - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
               tr
                 td
@@ -146,16 +208,16 @@
                   table.breakdown-details-table width="100%"
                     - recurring_breakdown(fee).each do |breakdown|
                       tr
-                        td.body-3 width="15%" = I18n.l(breakdown.date, format: :default)
-                        td.body-1 width="65%"
+                        td width="20%"
+                          .body-1 = I18n.l(breakdown.date, format: :default)
+                          .body-3 = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
+                        td.body-1 width="80%"
                           - if breakdown.action.to_sym == :add
-                            | +#{breakdown.count} #{fee.item_name}
+                            | +#{breakdown.amount} #{fee.item_name}
                           - elsif breakdown.action.to_sym == :remove
-                            | -#{breakdown.count} #{fee.item_name}
+                            | #{breakdown.amount.negative? ? '' : '-'}#{breakdown.amount} #{fee.item_name}
                           - else
-                            | +/-#{breakdown.count} #{fee.item_name}
-                        td.body-3 width="20%"
-                          = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
+                            | +/-#{breakdown.amount} #{fee.item_name}
             - else
               .body-3 = fees.first.billable_metric.name
               .body-1.mb-24 = I18n.t('invoice.breakdown')
@@ -164,15 +226,18 @@
                   - fees.each do |fee|
                     - recurring_breakdown(fee).each do |breakdown|
                       tr
-                        td.body-3 width="15%" = breakdown.date.strftime('%b %d, %Y')
-                        td.body-1 width="65%"
+                        td width="20%"
+                          .body-1 = breakdown.date.strftime('%b %d, %Y')
+                          .body-3 = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
+                        td.body-1 width="80%"
                           - if breakdown.action.to_sym == :add
-                            | +#{breakdown.count} #{fee.item_name}
+                            | +#{breakdown.amount} #{fee.item_name}
                           - elsif breakdown.action.to_sym == :remove
-                            | -#{breakdown.count} #{fee.item_name}
+                            | #{breakdown.amount.negative? ? '' : '-'}#{breakdown.amount} #{fee.item_name}
                           - else
-                            | +/-#{breakdown.count} #{fee.item_name}
-                        td.body-3 width="20%"
-                          = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
+                            | +/-#{breakdown.amount} #{fee.item_name}
 
-            .alert.body-3 = I18n.t('invoice.notice')
+            - if fees.first.charge.prorated?
+              .alert.body-3 = I18n.t('invoice.notice_prorated')
+            - else
+              .alert.body-3 = I18n.t('invoice.notice_full')

--- a/app/views/templates/invoices/_subscription_details.slim
+++ b/app/views/templates/invoices/_subscription_details.slim
@@ -19,7 +19,7 @@
           td.body-2 == TaxHelper.applied_taxes(invoice_subscription(subscription.id).subscription_fee)
           td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).subscription_amount)
 
-    - if subscription? && subscription_fees(subscription.id).charge_kind.any? && subscription.plan.charges.where(pay_in_advance: false).any?
+    - if subscription? && subscription_fees(subscription.id).charge_kind.any? && (subscription.plan.charges.where(pay_in_advance: false).any? || (subscription.plan.charges.where(pay_in_advance: true).any? && subscription.plan.pay_in_advance?))
       .invoice-resume.overflow-auto
         table.invoice-resume-table width="100%"
           tr
@@ -29,7 +29,7 @@
             td.body-2 = I18n.t('invoice.amount_without_tax')
           - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).group_by(&:charge_id).each do |_charge_id, fees|
             - fee = fees.first
-            - next if fee.charge.pay_in_advance?
+            - next if fee.charge.pay_in_advance? && !fee.charge.plan.pay_in_advance?
 
             - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
               tr
@@ -79,7 +79,7 @@
                   td.body-2 = fee.true_up_fee.units
                   td.body-2 == TaxHelper.applied_taxes(fee.true_up_fee)
                   td.body-2 = MoneyHelper.format(fee.true_up_fee.amount)
-    - if subscription? && subscription_fees(subscription.id).charge_kind.any? && subscription.plan.charges.where(pay_in_advance: true).any?
+    - if subscription? && subscription_fees(subscription.id).charge_kind.any? && subscription.plan.charges.where(pay_in_advance: true).any? && !subscription.plan.pay_in_advance?
       .invoice-resume.overflow-auto
         table.invoice-resume-table width="100%"
           tr
@@ -200,6 +200,7 @@
             - else
               h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.plan.name)
 
+            - number_of_days_in_period = 0
             - if fees.all? { |f| f.group_id? }
               - fees.select { |f| f.units.positive? }.each do |fee|
                 .body-3 = fees.first.billable_metric.name
@@ -207,6 +208,7 @@
                 .breakdown-details.mb-24
                   table.breakdown-details-table width="100%"
                     - recurring_breakdown(fee).each do |breakdown|
+                      - number_of_days_in_period = breakdown.total_duration
                       tr
                         td width="20%"
                           .body-1 = I18n.l(breakdown.date, format: :default)
@@ -225,6 +227,7 @@
                 table.breakdown-details-table width="100%"
                   - fees.each do |fee|
                     - recurring_breakdown(fee).each do |breakdown|
+                      - number_of_days_in_period = breakdown.total_duration
                       tr
                         td width="20%"
                           .body-1 = breakdown.date.strftime('%b %d, %Y')
@@ -238,6 +241,6 @@
                             | +/-#{breakdown.amount} #{fee.item_name}
 
             - if fees.first.charge.prorated?
-              .alert.body-3 = I18n.t('invoice.notice_prorated')
+              .alert.body-3 = I18n.t('invoice.notice_prorated', days_in_month: number_of_days_in_period)
             - else
               .alert.body-3 = I18n.t('invoice.notice_full')

--- a/app/views/templates/invoices/charge.slim
+++ b/app/views/templates/invoices/charge.slim
@@ -421,7 +421,14 @@ html
             td.body-2 = I18n.t('invoice.amount_without_tax')
           - fees.each do |fee|
             tr
-              td.body-1 = fee.billable_metric.name
+              - if fee.charge.prorated?
+                - pay_in_advance_range = charge_pay_in_advance_proration_range(fee, invoice_subscription(fee.subscription.id).timestamp)
+                td
+                  .body-1 = fee.billable_metric.name
+                  .body-3 = I18n.t('invoice.breakdown_for_days', breakdown_duration: pay_in_advance_range[:number_of_days], breakdown_total_duration: pay_in_advance_range[:period_duration])
+              - else
+                td
+                  .body-1 = fee.billable_metric.name
               td.body-2 = fee.units
               td.body-2 == TaxHelper.applied_taxes(fee)
               td.body-2 = MoneyHelper.format(fee.amount)

--- a/app/views/templates/invoices/v3.slim
+++ b/app/views/templates/invoices/v3.slim
@@ -300,15 +300,21 @@ html
       .breakdown-details table {
         border-collapse: collapse;
       }
+      .breakdown-details {
+        margin-top: -15px;
+      }
       .breakdown-details-table tr td {
-        padding-bottom: 12px;
+        padding-bottom: 8px;
+        padding-top: 8px;
       }
       .breakdown-details-table tr td:last-child {
         text-align: right;
       }
-      .breakdown-details-table tr:last-child td {
+      .breakdown-details-table tr td {
         border-bottom: 1px solid #d9dee7;
-        padding-bottom: 24px;
+      }
+      .breakdown-details-table tr:first-child td {
+        border-top: 1px solid #d9dee7;
       }
 
       .powered-by {

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -49,7 +49,8 @@ de:
     breakdown: Aufschlüsselung
     breakdown_for_days: "%{breakdown_duration} für %{breakdown_total_duration} Tage"
     breakdown_of: "%{breakdown} für %{fee_group_name}"
-    notice: Wenn beispielsweise eine Einheit mit 15 verbleibenden Tagen in Ihrem Monatsplan hinzugefügt wird, multiplizieren wir den Preis mit 15/31 (verbleibende Tage dividiert durch die Gesamtzahl der Tage in Ihrem Plan), um den anteiligen Preis zu berechnen. Dieselbe Logik greift beim Entfernen einer Einheit, die 10 Tage lang verwendet wurde, wir multiplizieren den Preis mit 10/31.
+    notice_full: Unabhängig davon, wann ein Ereignis empfangen wird, wird die Einheit nicht anteilig berechnet, wir berechnen den vollen Preis.
+    notice_prorated: Wenn eine Einheit während des Abrechnungszeitraums hinzugefügt oder entfernt wird, berechnen wir den anteiligen Preis basierend auf dem Verhältnis der verbleibenden oder genutzten Tage zur Gesamtzahl der Tage im Plan. Zum Beispiel, wenn noch 15 Tage im Plan verbleiben, multiplizieren wir den Preis mit 15/%{days_in_month}, und wenn eine Einheit für 10 Tage genutzt wurde, multiplizieren wir den Preis mit 10/%{days_in_month}.
     true_up_metric: "%{metric} - Kosten für die Anpassung"
     true_up_details: "Mindestausgabe von %{min_amount} anteilig an den Nutzungstagen"
 

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -47,9 +47,10 @@ en:
     total_unit: "Total unit: %{units}"
     total: Total
     breakdown: Breakdown
-    breakdown_for_days: "%{breakdown_duration} of %{breakdown_total_duration} days"
+    breakdown_for_days: "Used %{breakdown_duration} out of %{breakdown_total_duration} days"
     breakdown_of: "Breakdown of %{fee_group_name}"
-    notice: For example, if a unit is added with 15 days left in your monthly plan, we multiply the price by 15/31 (days remaining divided by the total number of days in your plan) to calculate the prorated price. Same logic when removing a unit used during 10 days, we multiply the price by 10/31.
+    notice_prorated: If a unit is added or removed during the monthly plan, we calculate the prorated price based on the ratio of days remaining or used to the total number of days in the plan. For instance, if 15 days are left in the plan, we multiply the price by 15/{nb_days_in_month}, and if a unit was used for 10 days, we multiply the price by 10/{nb_days_in_month}.
+    notice_full: Regardless of when an event is received, the unit is not prorated, we charge the full price.
     true_up_metric: "%{metric} - True-up"
     true_up_details: "Minimum spend of %{min_amount} prorated on days of usage"
 

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -49,7 +49,7 @@ en:
     breakdown: Breakdown
     breakdown_for_days: "Used %{breakdown_duration} out of %{breakdown_total_duration} days"
     breakdown_of: "Breakdown of %{fee_group_name}"
-    notice_prorated: If a unit is added or removed during the monthly plan, we calculate the prorated price based on the ratio of days remaining or used to the total number of days in the plan. For instance, if 15 days are left in the plan, we multiply the price by 15/{nb_days_in_month}, and if a unit was used for 10 days, we multiply the price by 10/{nb_days_in_month}.
+    notice_prorated: If a unit is added or removed during the monthly plan, we calculate the prorated price based on the ratio of days remaining or used to the total number of days in the plan. For instance, if 15 days are left in the plan, we multiply the price by 15/%{days_in_month}, and if a unit was used for 10 days, we multiply the price by 10/%{days_in_month}.
     notice_full: Regardless of when an event is received, the unit is not prorated, we charge the full price.
     true_up_metric: "%{metric} - True-up"
     true_up_details: "Minimum spend of %{min_amount} prorated on days of usage"

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -49,7 +49,8 @@ fr:
     breakdown: Détails de consommation
     breakdown_for_days: "%{breakdown_duration} sur %{breakdown_total_duration} jours"
     breakdown_of: "Détails de consommation de %{fee_group_name}"
-    notice: Par exemple, si une unité est ajoutée alors qu'il reste 15 jours à votre abonnement mensuel et que le mois concerné compte 31 jours, nous multiplions le prix mensuel par 15/31 (nombre de jours restants dans le mois divisé par le nombre total de jours du mois), pour un abonnement mensuel. Le principe est similaire lorsque vous retirez une unité qui n'aura été utilisée que 10 jours dans le mois, nous multiplions le prix par 10/31.
+    notice_prorated: Si une unité est ajoutée ou supprimée pendant la période de facturation, nous calculons le prix au prorata en fonction du ratio des jours restants ou utilisés. Par exemple, s'il reste 15 jours dans le plan, nous multiplions le prix par 15/%{days_in_month}, et si une unité a été utilisée pendant 10 jours, nous multiplions le prix par 10/%{days_in_month}.
+    notice_full: Peu importe quand l’évènement de consommation est reçu, l'unité n'est pas proratisée et nous facturons le prix complet.
     true_up_metric: "%{metric} - Frais d'ajustement"
     true_up_details: "Dépense minimale de %{min_amount} au prorata des jours d'utilisation"
 

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -49,7 +49,8 @@ nb:
     breakdown: Oversikt
     breakdown_for_days: "%{breakdown_duration} av %{breakdown_total_duration} dager"
     breakdown_of: "Fordeling av %{fee_group_name}"
-    notice: For eksempel, hvis en enhet legges til med 15 dager igjen på månedsabonnementet ganger vi prisen med 15/31 (antall dager gjenstående delt på antall dager å abonnementet ditt) for å beregne den rette prisen. Samme logikk benyttes når en enhet fjernes etter f.eks 10 dager, da ganger vi prisen med 10/31.
+    notice_prorated: Hvis en enhet legges til eller fjernes i løpet av faktureringsperioden, beregner vi den proporsjonale prisen basert på forholdet mellom gjenværende eller brukte dager og det totale antallet dager i planen. For eksempel, hvis det er 15 dager igjen i planen, multipliserer vi prisen med 15/%{days_in_month}, og hvis en enhet ble brukt i 10 dager, multipliserer vi prisen med 10/%{days_in_month}.
+    notice_full: Uavhengig av når en hendelse mottas, blir enheten ikke forholdsmessig priset, vi belaster full pris.
     true_up_metric: "%{metric} - Tilpasningskostnader"
     true_up_details: "Minimumsutgift på %{min_amount} beregnet etter antall brukte dager"
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -152,12 +152,20 @@ RSpec.describe Invoice, type: :model do
     let(:invoice_subscription) { create(:invoice_subscription) }
     let(:invoice) { invoice_subscription.invoice }
     let(:subscription) { invoice_subscription.subscription }
-    let(:billable_metric) { create(:recurring_billable_metric, organization: subscription.organization) }
-    let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:) }
+    let(:billable_metric) { create(:sum_billable_metric, organization: subscription.organization, recurring: true) }
+    let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:, pay_in_advance: false) }
     let(:fee) { create(:charge_fee, subscription:, invoice:, charge:) }
 
     it 'returns the fees of the corresponding invoice_subscription' do
       expect(invoice.recurring_fees(subscription.id)).to eq([fee])
+    end
+
+    context 'when charge is pay_in_advance' do
+      let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:, pay_in_advance: true) }
+
+      it 'returns the fees of the corresponding invoice_subscription' do
+        expect(invoice.recurring_fees(subscription.id)).to eq([])
+      end
     end
   end
 
@@ -165,8 +173,8 @@ RSpec.describe Invoice, type: :model do
     let(:invoice_subscription) { create(:invoice_subscription) }
     let(:invoice) { invoice_subscription.invoice }
     let(:subscription) { invoice_subscription.subscription }
-    let(:billable_metric) { create(:recurring_billable_metric, organization: subscription.organization) }
-    let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:) }
+    let(:billable_metric) { create(:sum_billable_metric, organization: subscription.organization, recurring: true) }
+    let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:, pay_in_advance: false) }
     let(:fee) { create(:charge_fee, subscription:, invoice:, charge:) }
 
     it 'returns the fees of the corresponding invoice_subscription' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -195,8 +195,10 @@ RSpec.describe Invoice, type: :model do
     end
 
     it 'returns the fees of the corresponding invoice_subscription' do
-      expect(invoice.charge_pay_in_advance_proration_range(fee, event.timestamp)[:period_duration]).to eq(31)
-      expect(invoice.charge_pay_in_advance_proration_range(fee, event.timestamp)[:number_of_days]).to eq(7)
+      expect(invoice.charge_pay_in_advance_proration_range(fee, event.timestamp)).to include(
+        period_duration: 31,
+        number_of_days: 7,
+      )
     end
   end
 

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetrics::Breakdown::SumService, type: :service do
+  subject(:service) do
+    described_class.new(
+      billable_metric:,
+      subscription:,
+      group:,
+    )
+  end
+
+  let(:subscription) do
+    create(
+      :subscription,
+      started_at:,
+      subscription_at:,
+      billing_time: :anniversary,
+    )
+  end
+
+  let(:subscription_at) { DateTime.parse('2022-12-01 00:00:00') }
+  let(:started_at) { subscription_at }
+  let(:organization) { subscription.organization }
+  let(:customer) { subscription.customer }
+  let(:group) { nil }
+
+  let(:billable_metric) do
+    create(
+      :billable_metric,
+      organization:,
+      aggregation_type: 'sum_agg',
+      field_name: 'total_count',
+      recurring: true,
+    )
+  end
+
+  let(:from_datetime) { DateTime.parse('2023-05-01 00:00:00') }
+  let(:to_datetime) { DateTime.parse('2023-05-31 23:59:59') }
+
+  let(:old_events) do
+    create_list(
+      :event,
+      2,
+      code: billable_metric.code,
+      customer:,
+      subscription:,
+      timestamp: subscription.started_at + 3.months,
+      properties: {
+        total_count: 2.5,
+      },
+    )
+  end
+  let(:latest_events) do
+    create(
+      :event,
+      code: billable_metric.code,
+      customer:,
+      subscription:,
+      timestamp: from_datetime + 25.days,
+      properties: {
+        total_count: 12,
+      },
+    )
+  end
+
+  before do
+    old_events
+    latest_events
+  end
+
+  describe '#breakdown' do
+    let(:result) { service.breakdown(from_datetime:, to_datetime:).breakdown }
+
+    context 'with persisted metric on full period' do
+      it 'returns the detail the persisted metrics' do
+        aggregate_failures do
+          expect(result.count).to eq(2)
+
+          item = result.first
+          expect(item.date.to_s).to eq(from_datetime.to_date.to_s)
+          expect(item.action).to eq('add')
+          expect(item.amount).to eq(5)
+          expect(item.duration).to eq(31)
+          expect(item.total_duration).to eq(31)
+
+          item = result.last
+          expect(item.date.to_s).to eq((from_datetime + 25.days).to_date.to_s)
+          expect(item.action).to eq('add')
+          expect(item.amount).to eq(12)
+          expect(item.duration).to eq(6)
+          expect(item.total_duration).to eq(31)
+        end
+      end
+
+      context 'when subscription was terminated in the period' do
+        let(:latest_events) { nil }
+        let(:subscription) do
+          create(
+            :subscription,
+            started_at:,
+            subscription_at:,
+            billing_time: :anniversary,
+            terminated_at: to_datetime,
+            status: :terminated,
+          )
+        end
+        let(:to_datetime) { DateTime.parse('2023-05-30 23:59:59') }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(from_datetime.to_date.to_date.to_s)
+            expect(item.action).to eq('add')
+            expect(item.amount).to eq(5)
+            expect(item.duration).to eq(30)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+
+      context 'when subscription was started in the period' do
+        let(:started_at) { DateTime.parse('2023-05-03') }
+        let(:old_events) { nil }
+        let(:from_datetime) { started_at }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq((from_datetime + 25.days).to_date.to_s)
+            expect(item.action).to eq('add')
+            expect(item.amount).to eq(12)
+            expect(item.duration).to eq(4)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -1,0 +1,288 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
+  subject(:service) do
+    described_class.new(
+      billable_metric:,
+      subscription:,
+      group:,
+    )
+  end
+
+  let(:subscription) do
+    create(
+      :subscription,
+      started_at:,
+      subscription_at:,
+      billing_time: :anniversary,
+    )
+  end
+
+  let(:subscription_at) { DateTime.parse('2022-06-09') }
+  let(:started_at) { subscription_at }
+  let(:organization) { subscription.organization }
+  let(:customer) { subscription.customer }
+  let(:group) { nil }
+
+  let(:billable_metric) do
+    create(
+      :billable_metric,
+      organization:,
+      aggregation_type: 'unique_count_agg',
+      field_name: 'unique_id',
+    )
+  end
+
+  let(:from_datetime) { DateTime.parse('2022-07-09 00:00:00 UTC') }
+  let(:to_datetime) { DateTime.parse('2022-08-08 23:59:59 UTC') }
+
+  let(:added_at) { from_datetime - 1.month }
+  let(:removed_at) { nil }
+  let(:quantified_event) do
+    create(
+      :quantified_event,
+      customer:,
+      added_at:,
+      removed_at:,
+      external_subscription_id: subscription.external_id,
+      billable_metric:,
+    )
+  end
+
+  before { quantified_event }
+
+  describe '#breakdown' do
+    let(:result) { service.breakdown(from_datetime:, to_datetime:).breakdown }
+
+    context 'with persisted metric on full period' do
+      it 'returns the detail the persisted metrics' do
+        aggregate_failures do
+          expect(result.count).to eq(1)
+
+          item = result.first
+          expect(item.date.to_s).to eq(from_datetime.to_date.to_s)
+          expect(item.action).to eq('add')
+          expect(item.amount).to eq(1)
+          expect(item.duration).to eq(31)
+          expect(item.total_duration).to eq(31)
+        end
+      end
+
+      context 'when subscription was terminated in the period' do
+        let(:subscription) do
+          create(
+            :subscription,
+            started_at:,
+            subscription_at:,
+            billing_time: :anniversary,
+            terminated_at: to_datetime,
+            status: :terminated,
+          )
+        end
+        let(:to_datetime) { DateTime.parse('2022-07-24 23:59:59') }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(from_datetime.to_date.to_date.to_s)
+            expect(item.action).to eq('add')
+            expect(item.amount).to eq(1)
+            expect(item.duration).to eq(16)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+
+      context 'when subscription was upgraded in the period' do
+        let(:subscription) do
+          create(
+            :subscription,
+            started_at:,
+            subscription_at:,
+            billing_time: :anniversary,
+            terminated_at: to_datetime,
+            status: :terminated,
+          )
+        end
+        let(:to_datetime) { DateTime.parse('2022-07-24 23:59:59') }
+
+        before do
+          create(
+            :subscription,
+            previous_subscription: subscription,
+            organization:,
+            customer:,
+            started_at: to_datetime,
+          )
+        end
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(from_datetime.to_date.to_s)
+            expect(item.action).to eq('add')
+            expect(item.amount).to eq(1)
+            expect(item.duration).to eq(16)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+
+        context 'with calendar subscription and pay in advance' do
+          let(:subscription) do
+            create(
+              :subscription,
+              started_at:,
+              subscription_at:,
+              billing_time: :calendar,
+              terminated_at: to_datetime,
+              status: :terminated,
+            )
+          end
+
+          before { subscription.plan.update!(pay_in_advance: true) }
+
+          it 'returns the detail the persisted metrics' do
+            aggregate_failures do
+              expect(result.count).to eq(1)
+
+              item = result.first
+              expect(item.date.to_s).to eq(from_datetime.to_date.to_s)
+              expect(item.action).to eq('add')
+              expect(item.amount).to eq(1)
+              expect(item.duration).to eq(16)
+              expect(item.total_duration).to eq(31)
+            end
+          end
+        end
+      end
+
+      context 'when subscription was started in the period' do
+        let(:started_at) { DateTime.parse('2022-08-01') }
+        let(:from_datetime) { started_at }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(from_datetime.to_date.to_s)
+            expect(item.action).to eq('add')
+            expect(item.amount).to eq(1)
+            expect(item.duration).to eq(8)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+    end
+
+    context 'with persisted metrics added in the period' do
+      let(:added_at) { from_datetime + 15.days }
+
+      it 'returns the detail the persisted metrics' do
+        aggregate_failures do
+          expect(result.count).to eq(1)
+
+          item = result.first
+          expect(item.date.to_s).to eq(added_at.to_date.to_s)
+          expect(item.action).to eq('add')
+          expect(item.amount).to eq(1)
+          expect(item.duration).to eq(16)
+          expect(item.total_duration).to eq(31)
+        end
+      end
+
+      context 'when added on the first day of the period' do
+        let(:added_at) { from_datetime }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(from_datetime.to_date.to_s)
+            expect(item.action).to eq('add')
+            expect(item.amount).to eq(1)
+            expect(item.duration).to eq(31)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+    end
+
+    context 'with persisted metrics terminated in the period' do
+      let(:removed_at) { to_datetime - 15.days }
+
+      it 'returns the detail the persisted metrics' do
+        aggregate_failures do
+          expect(result.count).to eq(1)
+
+          item = result.first
+          expect(item.date.to_s).to eq(removed_at.to_date.to_s)
+          expect(item.action).to eq('remove')
+          expect(item.amount).to eq(1)
+          expect(item.duration).to eq(16)
+          expect(item.total_duration).to eq(31)
+        end
+      end
+
+      context 'when removed on the last day of the period' do
+        let(:removed_at) { to_datetime }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(to_datetime.to_date.to_s)
+            expect(item.action).to eq('remove')
+            expect(item.amount).to eq(1)
+            expect(item.duration).to eq(31)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+    end
+
+    context 'with persisted metrics added and terminated in the period' do
+      let(:added_at) { from_datetime + 1.day }
+      let(:removed_at) { to_datetime - 1.day }
+
+      it 'returns the detail the persisted metrics' do
+        aggregate_failures do
+          expect(result.count).to eq(1)
+
+          item = result.first
+          expect(item.date.to_s).to eq(added_at.to_date.to_s)
+          expect(item.action).to eq('add_and_removed')
+          expect(item.amount).to eq(1)
+          expect(item.duration).to eq(29)
+          expect(item.total_duration).to eq(31)
+        end
+      end
+
+      context 'when added and removed the same day' do
+        let(:added_at) { from_datetime + 1.day }
+        let(:removed_at) { added_at }
+
+        it 'returns the detail the persisted metrics' do
+          aggregate_failures do
+            expect(result.count).to eq(1)
+
+            item = result.first
+            expect(item.date.to_s).to eq(added_at.to_date.to_s)
+            expect(item.action).to eq('add_and_removed')
+            expect(item.amount).to eq(1)
+            expect(item.duration).to eq(1)
+            expect(item.total_duration).to eq(31)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR adds new invoice template changes for recurring billable metrics.

## Description

This PR adds new invoice template changes for recurring billable metrics.
Most significant change is around breakdown section for charges that are paid in arrears.
Also for pay in advance invoice that is prorated we display now number of days when the service has been used
