### PR TITLE
feat(tax): Expose plans_count and charges_count for taxes in API

### DIFF
--- a/app/graphql/types/taxes/object.rb
+++ b/app/graphql/types/taxes/object.rb
@@ -18,9 +18,17 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
-      field :charges_count, Integer, null: false, description: 'Number fo charges using this tax'
+      field :charges_count, Integer, null: false, description: 'Number of charges using this tax'
       field :customers_count, Integer, null: false, description: 'Number of customers using this tax'
       field :plans_count, Integer, null: false, description: 'Number of plans using this tax'
+
+      def charges_count
+        object.charges.count
+      end
+
+      def plans_count
+        object.plans.count
+      end
     end
   end
 end

--- a/app/graphql/types/taxes/object.rb
+++ b/app/graphql/types/taxes/object.rb
@@ -18,7 +18,9 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      field :charges_count, Integer, null: false, description: 'Number fo charges using this tax'
       field :customers_count, Integer, null: false, description: 'Number of customers using this tax'
+      field :plans_count, Integer, null: false, description: 'Number of plans using this tax'
     end
   end
 end

--- a/app/serializers/v1/tax_serializer.rb
+++ b/app/serializers/v1/tax_serializer.rb
@@ -11,6 +11,8 @@ module V1
         description: model.description,
         applied_to_organization: model.applied_to_organization,
         customers_count: model.customers_count,
+        plans_count: model.plans.count,
+        charges_count: model.charges.count,
         created_at: model.created_at.iso8601,
       }
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4531,6 +4531,11 @@ type Subscription {
 
 type Tax {
   appliedToOrganization: Boolean!
+
+  """
+  Number fo charges using this tax
+  """
+  chargesCount: Int!
   code: String!
   createdAt: ISO8601DateTime!
 
@@ -4542,6 +4547,11 @@ type Tax {
   id: ID!
   name: String!
   organization: Organization
+
+  """
+  Number of plans using this tax
+  """
+  plansCount: Int!
   rate: Float!
   updatedAt: ISO8601DateTime!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -4533,7 +4533,7 @@ type Tax {
   appliedToOrganization: Boolean!
 
   """
-  Number fo charges using this tax
+  Number of charges using this tax
   """
   chargesCount: Int!
   code: String!

--- a/schema.json
+++ b/schema.json
@@ -19650,6 +19650,24 @@
               ]
             },
             {
+              "name": "chargesCount",
+              "description": "Number fo charges using this tax",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "code",
               "description": null,
               "type": {
@@ -19760,6 +19778,24 @@
                 "kind": "OBJECT",
                 "name": "Organization",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "plansCount",
+              "description": "Number of plans using this tax",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/schema.json
+++ b/schema.json
@@ -19651,7 +19651,7 @@
             },
             {
               "name": "chargesCount",
-              "description": "Number fo charges using this tax",
+              "description": "Number of charges using this tax",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,

--- a/spec/graphql/mutations/taxes/create_spec.rb
+++ b/spec/graphql/mutations/taxes/create_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Mutations::Taxes::Create, type: :graphql do
     <<-GQL
       mutation($input: TaxCreateInput!) {
         createTax(input: $input) {
-          id name code description rate
+          id name code description rate plansCount chargesCount customersCount
         }
       }
     GQL

--- a/spec/serializers/v1/tax_serializer_spec.rb
+++ b/spec/serializers/v1/tax_serializer_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe ::V1::TaxSerializer do
       'rate' => tax.rate,
       'description' => tax.description,
       'customers_count' => 0,
+      'plans_count' => 0,
+      'charges_count' => 0,
       'created_at' => tax.created_at.iso8601,
     )
   end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at plans or charge levels

## Description

This PR adds `plans_count` and `charges_count` in both API and GraphQL