### PR TITLE
fix(subscriptions) return active subscriptions by default

### DIFF
--- a/app/queries/subscriptions_query.rb
+++ b/app/queries/subscriptions_query.rb
@@ -2,7 +2,8 @@
 
 class SubscriptionsQuery < BaseQuery
   def call
-    subscriptions = paginate(organization.subscriptions.active)
+    subscriptions = paginate(organization.subscriptions)
+    subscriptions = with_status(subscriptions) if filters.status.present? && valid_status?
     subscriptions = subscriptions.order(started_at: :asc)
 
     subscriptions = with_external_customer(subscriptions) if filters.external_customer_id
@@ -18,5 +19,13 @@ class SubscriptionsQuery < BaseQuery
 
   def with_plan_code(scope)
     scope.joins(:plan).where(plans: { code: filters.plan_code })
+  end
+
+  def with_status(scope)
+    scope.where(status: filters.status)
+  end
+
+  def valid_status?
+    filters.status.all? { |s| Subscription.statuses.key?(s) }
   end
 end

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe SubscriptionsQuery, type: :query do
       end
     end
 
-    context 'with status filter' do
+    context 'with multiple status filter' do
       let(:query_filters) { { status: [:active, :pending] } }
 
       it 'returns correct subscriptions' do
@@ -86,17 +86,34 @@ RSpec.describe SubscriptionsQuery, type: :query do
       end
     end
 
-    context 'with pending subscription' do
-      it 'returns both active and pending subscriptions' do
+    context 'with pending status filter' do
+      let(:query_filters) { { status: [:pending] } }
+
+      it 'returns only pending subscriptions' do
         create(:pending_subscription, customer:, plan:)
 
         result = subscriptions_query.call
 
         aggregate_failures do
           expect(result).to be_success
-          expect(result.subscriptions.count).to eq(2)
-          expect(result.subscriptions.active.count).to eq(1)
+          expect(result.subscriptions.count).to eq(1)
+          expect(result.subscriptions.active.count).to eq(0)
           expect(result.subscriptions.pending.count).to eq(1)
+        end
+      end
+    end
+
+    context 'with no status filter' do
+      it 'returns only active subscriptions' do
+        create(:pending_subscription, customer:, plan:)
+
+        result = subscriptions_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.subscriptions.count).to eq(1)
+          expect(result.subscriptions.active.count).to eq(1)
+          expect(result.subscriptions.pending.count).to eq(0)
         end
       end
     end


### PR DESCRIPTION
## Context

We introduced a breaking change in the last release

`GET /subscription` was now returning all subscriptions no matter their `status`. But this endpoint is used to return only `active` ones.

## Description

This PR does fix that by 
1. returning only `active` subscription by default
2. keep allowing users to filter subscriptions by `status` and get the list is they want