### PR TITLE
fix: To datetime boundary on invoice refresh

### DIFF
--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -45,9 +45,10 @@ module Subscriptions
       return @to_datetime if @to_datetime
 
       @to_datetime = customer_timezone_shift(compute_to_date, end_of_day: true)
-      terminated_at = subscription.terminated_at
+      terminated_at = subscription.terminated_at&.change(usec: 0)
+      bill_at = billing_at&.change(usec: 0)
 
-      if subscription.terminated? && @to_datetime > terminated_at && billing_at >= terminated_at
+      if subscription.terminated? && @to_datetime > terminated_at && bill_at && bill_at >= terminated_at
         @to_datetime = terminated_at
       end
 

--- a/spec/services/subscriptions/dates_service_spec.rb
+++ b/spec/services/subscriptions/dates_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Subscriptions::DatesService, type: :service do
   let(:pay_in_advance) { false }
 
   let(:subscription_at) { DateTime.parse('02 Feb 2021') }
-  let(:billing_date) { DateTime.parse('07 Mar 2022') }
+  let(:billing_date) { Time.parse('2022-03-07 04:20:46.011') }
   let(:started_at) { subscription_at }
   let(:interval) { :monthly }
 


### PR DESCRIPTION
The goal of this PR is to fix an issue on the `to_datetime` boundaries when terminating a subscription created in the past, and then refreshing the corresponding draft invoice.

Previously, the boundaries were calculated for the full period instead of using the terminated_at.