### PR TITLE
fix: Handle ActionController::ParameterMissing error

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -10,6 +10,8 @@ module Api
     before_action :set_context_source
     include Trackable
 
+    rescue_from ActionController::ParameterMissing, with: :bad_request_error
+
     private
 
     def authenticate

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -3,6 +3,16 @@
 module ApiErrors
   extend ActiveSupport::Concern
 
+  def bad_request_error(error)
+    render(
+      json: {
+        status: 400,
+        error: "BadRequest: #{error.message}",
+      },
+      status: :bad_request,
+    )
+  end
+
   def unauthorized_error
     render(
       json: {

--- a/spec/requests/api/base_spec.rb
+++ b/spec/requests/api/base_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe Api::BaseController, type: :controller do
     def index
       render nothing: true
     end
+
+    def create
+      params.require(:input).permit(:value)
+      render nothing: true
+    end
   end
 
   let(:organization) { create(:organization) }
@@ -35,5 +40,17 @@ RSpec.describe Api::BaseController, type: :controller do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+  end
+
+  it 'catches the missing parameters error' do
+    request.headers['Authorization'] = "Bearer #{organization.api_key}"
+
+    post :create
+
+    expect(response).to have_http_status(:bad_request)
+
+    json = JSON.parse(response.body, symbolize_names: true)
+    expect(json[:status]).to eq(400)
+    expect(json[:error]).to eq('BadRequest: param is missing or the value is empty: input')
   end
 end


### PR DESCRIPTION
## Context

When a request is missing an expected argument, Rails is raising an `ActionController::ParameterMissing`.

Today this error is not captured leads to an HTTP 500 error from the application

## Description

This PR makes sure that the error is catched and renders a proper HTTP 400 error.