### PR TITLE
fix(tax): fee estimate with applied taxes

### DIFF
--- a/app/serializers/v1/fees/applied_tax_serializer.rb
+++ b/app/serializers/v1/fees/applied_tax_serializer.rb
@@ -14,7 +14,7 @@ module V1
           tax_description: model.tax_description,
           amount_cents: model.amount_cents,
           amount_currency: model.amount_currency,
-          created_at: model.created_at.iso8601,
+          created_at: model.created_at&.iso8601,
         }
       end
     end

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -150,8 +150,12 @@ RSpec.describe Api::V1::EventsController, type: :request do
 
   describe 'POST /events/estimate_fees' do
     let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric: metric) }
+    let(:tax) { create(:tax, organization:) }
 
-    before { charge }
+    before do
+      charge
+      tax
+    end
 
     it 'returns a success' do
       post_with_token(


### PR DESCRIPTION
## Context

Event estimate is failing when a taxes is assigned to a customer or an organization, because the serializer is expecting for a `creatied_at` field to be present on the `applied_taxes` object. Since the fees and related applied_taxes are not persisted, the `created_at` field is null.

## Description

This PR fixes this by using the ruby safe navigation operator.  