### PR TITLE
feat(tax): Rename credit#before_vat into credit#before_taxes

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -149,7 +149,9 @@ class Invoice < ApplicationRecord
   def refundable_amount_cents
     return 0 if version_number < CREDIT_NOTES_MIN_VERSION || credit? || draft? || !succeeded?
 
-    amount = creditable_amount_cents - credits.where(before_vat: false).sum(:amount_cents) - prepaid_credit_amount_cents
+    amount = creditable_amount_cents -
+             credits.where(before_taxes: false).sum(:amount_cents) -
+             prepaid_credit_amount_cents
     amount.negative? ? 0 : amount
   end
 

--- a/app/serializers/v1/credit_serializer.rb
+++ b/app/serializers/v1/credit_serializer.rb
@@ -7,7 +7,7 @@ module V1
         lago_id: model.id,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,
-        before_vat: model.before_vat,
+        before_taxes: model.before_taxes,
         item: {
           lago_id: model.item_id,
           type: model.item_type,
@@ -18,7 +18,13 @@ module V1
           lago_id: model.invoice_id,
           payment_status: model.invoice.payment_status,
         },
-      }
+      }.merge(legacy_values)
+    end
+
+    private
+
+    def legacy_values
+      ::V1::Legacy::CreditSerializer.new(model).serialize
     end
   end
 end

--- a/app/serializers/v1/legacy/credit_serializer.rb
+++ b/app/serializers/v1/legacy/credit_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module V1
+  module Legacy
+    class CreditSerializer < ModelSerializer
+      def serialize
+        {
+          before_vat: model.before_taxes,
+        }
+      end
+    end
+  end
+end

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -22,7 +22,7 @@ module Credits
         applied_coupon:,
         amount_cents: credit_amount,
         amount_currency: invoice.currency,
-        before_vat: false, # NOTE: will turn to true with invoice v3
+        before_taxes: true,
       )
 
       applied_coupon.frequency_duration_remaining -= 1 if applied_coupon.recurring?

--- a/app/services/credits/credit_note_service.rb
+++ b/app/services/credits/credit_note_service.rb
@@ -26,7 +26,7 @@ module Credits
             credit_note:,
             amount_cents: credit_amount,
             amount_currency: invoice.currency,
-            before_vat: false,
+            before_taxes: false,
           )
 
           # NOTE: Consume remaining credit on the credit note

--- a/db/migrate/20230713122526_rename_credit_before_vat.rb
+++ b/db/migrate/20230713122526_rename_credit_before_vat.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameCreditBeforeVat < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :credits, :before_vat, :before_taxes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_04_150108) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_13_122526) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -237,7 +237,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_04_150108) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "credit_note_id"
-    t.boolean "before_vat", default: false, null: false
+    t.boolean "before_taxes", default: false, null: false
     t.index ["applied_coupon_id"], name: "index_credits_on_applied_coupon_id"
     t.index ["credit_note_id"], name: "index_credits_on_credit_note_id"
     t.index ["invoice_id"], name: "index_credits_on_invoice_id"
@@ -338,9 +338,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_04_150108) do
     t.uuid "group_id"
     t.uuid "pay_in_advance_event_id"
     t.integer "payment_status", default: 0, null: false
-    t.datetime "succeeded_at", precision: nil
-    t.datetime "failed_at", precision: nil
-    t.datetime "refunded_at", precision: nil
+    t.datetime "succeeded_at"
+    t.datetime "failed_at"
+    t.datetime "refunded_at"
     t.uuid "true_up_parent_fee_id"
     t.uuid "add_on_id"
     t.string "description"
@@ -428,11 +428,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_04_150108) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "recurring"
-    t.datetime "timestamp", precision: nil
-    t.datetime "from_datetime", precision: nil
-    t.datetime "to_datetime", precision: nil
-    t.datetime "charges_from_datetime", precision: nil
-    t.datetime "charges_to_datetime", precision: nil
+    t.datetime "timestamp"
+    t.datetime "from_datetime"
+    t.datetime "to_datetime"
+    t.datetime "charges_from_datetime"
+    t.datetime "charges_to_datetime"
     t.index ["invoice_id"], name: "index_invoice_subscriptions_on_invoice_id"
     t.index ["subscription_id", "charges_from_datetime", "charges_to_datetime"], name: "index_invoice_subscriptions_on_charges_from_and_to_datetime", unique: true, where: "((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE))"
     t.index ["subscription_id", "from_datetime", "to_datetime"], name: "index_invoice_subscriptions_on_from_and_to_datetime", unique: true, where: "((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE))"
@@ -502,6 +502,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_04_150108) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "api_key"
+    t.string "webhook_url"
     t.float "vat_rate", default: 0.0, null: false
     t.string "country"
     t.string "address_line1"
@@ -519,7 +520,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_04_150108) do
     t.string "document_locale", default: "en", null: false
     t.string "email_settings", default: [], null: false, array: true
     t.string "tax_identification_number"
-    t.string "webhook_url"
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"
   end

--- a/spec/serializers/v1/credit_serializer_spec.rb
+++ b/spec/serializers/v1/credit_serializer_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ::V1::CreditSerializer do
       expect(result['credit']['lago_id']).to eq(credit.id)
       expect(result['credit']['amount_cents']).to eq(credit.amount_cents)
       expect(result['credit']['amount_currency']).to eq(credit.amount_currency)
+      expect(result['credit']['before_taxes']).to eq(false)
       expect(result['credit']['item']['lago_id']).to eq(credit.item_id)
       expect(result['credit']['item']['type']).to eq(credit.item_type)
       expect(result['credit']['item']['code']).to eq(credit.item_code)

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Credits::AppliedCouponService do
         expect(result.credit.amount_currency).to eq('EUR')
         expect(result.credit.invoice).to eq(invoice)
         expect(result.credit.applied_coupon).to eq(applied_coupon)
+        expect(result.credit.before_taxes).to eq(true)
       end
     end
 

--- a/spec/services/credits/credit_note_service_spec.rb
+++ b/spec/services/credits/credit_note_service_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Credits::CreditNoteService do
         expect(credit1.credit_note).to eq(credit_note1)
         expect(credit1.amount_cents).to eq(20)
         expect(credit1.amount_currency).to eq('EUR')
+        expect(credit1.before_taxes).to eq(false)
         expect(credit_note1.reload.balance_amount_cents).to be_zero
         expect(credit_note1).to be_consumed
 
@@ -63,6 +64,7 @@ RSpec.describe Credits::CreditNoteService do
         expect(credit2.credit_note).to eq(credit_note2)
         expect(credit2.amount_cents).to eq(50)
         expect(credit2.amount_currency).to eq('EUR')
+        expect(credit2.before_taxes).to eq(false)
         expect(credit_note2.reload.balance_amount_cents).to be_zero
         expect(credit_note1).to be_consumed
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at plans or charge levels

## Description

This PR renames `Credit#before_vat` into `Credit#before_taxes` to allign with the lastest changes regarding taxes