### PR TITLE
feat(tax): Add fields for coupons pro-rata

### DIFF
--- a/app/models/invoice/applied_tax.rb
+++ b/app/models/invoice/applied_tax.rb
@@ -9,7 +9,10 @@ class Invoice
     belongs_to :invoice
     belongs_to :tax
 
-    monetize :amount_cents
+    monetize :amount_cents,
+             :fees_amount_cents,
+             with_model_currency: :amount_currency
+
     validates :amount_cents, numericality: { greater_than_or_equal_to: 0 }
   end
 end

--- a/db/migrate/20230717090135_add_precise_coupons_amount_cents_to_fees.rb
+++ b/db/migrate/20230717090135_add_precise_coupons_amount_cents_to_fees.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddPreciseCouponsAmountCentsToFees < ActiveRecord::Migration[7.0]
+  def change
+    add_column :fees, :precise_coupons_amount_cents, :decimal, precision: 30, scale: 5, null: false, default: 0
+    add_column :invoices_taxes, :fees_amount_cents, :bigint, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_13_122526) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_17_090135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -346,6 +346,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_122526) do
     t.string "description"
     t.bigint "unit_amount_cents", default: 0, null: false
     t.boolean "pay_in_advance", default: false, null: false
+    t.decimal "precise_coupons_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
@@ -480,6 +481,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_122526) do
     t.string "amount_currency", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "fees_amount_cents", default: 0, null: false
     t.index ["invoice_id"], name: "index_invoices_taxes_on_invoice_id"
     t.index ["tax_id"], name: "index_invoices_taxes_on_tax_id"
   end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at plans or charge levels

## Description

This PR adds two new fields to the database:
- `fees#precise_coupons_amount_cents` to store the pro-rata of coupons applied to a fee
- `invoices_taxes#fees_amount_cents` to store the fees amount related to a specific tax rate at invoice level