### PR TITLE
feat(tax): coupons pro-rata for fees

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -88,6 +88,10 @@ class Fee < ApplicationRecord
     amount_currency
   end
 
+  def sub_total_excluding_taxes_amount_cents
+    amount_cents - precise_coupons_amount_cents
+  end
+
   def total_amount_cents
     amount_cents + taxes_amount_cents
   end

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -2,18 +2,17 @@
 
 module Credits
   class AppliedCouponService < BaseService
-    def initialize(invoice:, applied_coupon:, base_amount_cents:)
+    def initialize(invoice:, applied_coupon:)
       @invoice = invoice
       @applied_coupon = applied_coupon
-      # base_amount_cents represents maximum value that can be credited. It is either equal to invoice
-      # total_amount_cents or sum of the fees related to some plan (for coupons with plan limitations)
-      @base_amount_cents = base_amount_cents
 
       super(nil)
     end
 
-    def create
+    def call
+      return result unless matches_currency?
       return result if already_applied?
+      return result unless fees.any?
 
       credit_amount = compute_amount
 
@@ -25,12 +24,20 @@ module Credits
         before_taxes: true,
       )
 
+      fees.each do |fee|
+        fee.precise_coupons_amount_cents += (credit_amount * fee.amount_cents).fdiv(base_amount_cents)
+        fee.save!
+      end
+
       applied_coupon.frequency_duration_remaining -= 1 if applied_coupon.recurring?
       if should_terminate_applied_coupon?(credit_amount)
         applied_coupon.mark_as_terminated!
       elsif applied_coupon.recurring?
         applied_coupon.save!
       end
+
+      invoice.coupons_amount_cents += new_credit.amount_cents
+      invoice.sub_total_excluding_taxes_amount_cents -= new_credit.amount_cents
 
       result.credit = new_credit
       result
@@ -40,9 +47,15 @@ module Credits
 
     private
 
-    attr_accessor :invoice, :applied_coupon, :base_amount_cents
+    attr_accessor :invoice, :applied_coupon
 
     delegate :coupon, to: :applied_coupon
+
+    def matches_currency?
+      return true unless applied_coupon.coupon.fixed_amount?
+
+      applied_coupon.amount_currency == invoice.currency
+    end
 
     def already_applied?
       invoice.credits.where(applied_coupon_id: applied_coupon.id).exists?
@@ -81,6 +94,36 @@ module Credits
       else
         applied_coupon.frequency_duration_remaining <= 0
       end
+    end
+
+    # TODO: ensure targeted amount is right with BM/plan limitation
+    def base_amount_cents
+      if applied_coupon.coupon.limited_billable_metrics? || applied_coupon.coupon.limited_plans?
+        return fees.sum(:amount_cents)
+      end
+
+      invoice.sub_total_excluding_taxes_amount_cents
+    end
+
+    def fees
+      @fees ||= if applied_coupon.coupon.limited_billable_metrics?
+        billable_metric_related_fees
+      elsif applied_coupon.coupon.limited_plans?
+        plan_related_fees
+      else
+        invoice.fees
+      end
+    end
+
+    def plan_related_fees
+      invoice.fees.joins(subscription: :plan).where(plan: { id: applied_coupon.coupon.coupon_targets.select(:plan_id) })
+    end
+
+    def billable_metric_related_fees
+      invoice
+        .fees
+        .joins(charge: :billable_metric)
+        .where(billable_metric: { id: applied_coupon.coupon.coupon_targets.select(:billable_metric_id) })
     end
   end
 end

--- a/app/services/credits/applied_coupons_service.rb
+++ b/app/services/credits/applied_coupons_service.rb
@@ -35,10 +35,12 @@ module Credits
     def applied_coupons
       return @applied_coupons if @applied_coupons
 
+      # NOTE: We want to apply first coupons limited to the billable metrics, then the ones limited to the plans
+      #       and finally the ones with no limitation
       @applied_coupons = customer
         .applied_coupons.active
         .joins(:coupon)
-        .order(created_at: :asc)
+        .order('coupons.limited_billable_metrics DESC, coupons.limited_plans DESC, applied_coupons.created_at ASC')
     end
   end
 end

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -25,7 +25,7 @@ module Fees
         )
         fee.applied_taxes << applied_tax
 
-        tax_amount_cents = (fee.amount_cents * tax.rate).fdiv(100)
+        tax_amount_cents = (fee.sub_total_excluding_taxes_amount_cents * tax.rate).fdiv(100)
         applied_tax.amount_cents = tax_amount_cents.round
         applied_tax.save! if fee.persisted?
 

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -87,9 +87,6 @@ module Fees
         taxes_amount_cents: 0,
       )
 
-      taxes_result = Fees::ApplyTaxesService.call(fee: new_fee)
-      taxes_result.raise_if_error!
-
       result.fees << new_fee
     end
 

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -62,10 +62,13 @@ module Fees
           pay_in_advance_event_id: event.id,
           payment_status: :pending,
           pay_in_advance: true,
+          taxes_amount_cents: 0,
         )
 
-        taxes_result = Fees::ApplyTaxesService.call(fee:)
-        taxes_result.raise_if_error!
+        if estimate || invoice.nil?
+          taxes_result = Fees::ApplyTaxesService.call(fee:)
+          taxes_result.raise_if_error!
+        end
 
         fee.save! unless estimate
 

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -22,9 +22,6 @@ module Fees
         f.true_up_parent_fee = fee
       end
 
-      taxes_result = Fees::ApplyTaxesService.call(fee: true_up_fee)
-      taxes_result.raise_if_error!
-
       result.true_up_fee = true_up_fee
       result
     end

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -33,10 +33,8 @@ module Fees
             invoiceable: add_on,
             units:,
             payment_status: :pending,
+            taxes_amount_cents: 0,
           )
-
-          taxes_result = Fees::ApplyTaxesService.call(fee:)
-          taxes_result.raise_if_error!
 
           fee.save!
 

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -15,7 +15,7 @@ module Fees
 
       new_amount_cents = compute_amount
 
-      new_fee = Fee.new(
+      new_fee = Fee.create!(
         invoice:,
         subscription:,
         amount_cents: new_amount_cents.round,
@@ -26,12 +26,8 @@ module Fees
         units: 1,
         properties: boundaries.to_h,
         payment_status: :pending,
+        taxes_amount_cents: 0,
       )
-
-      taxes_result = Fees::ApplyTaxesService.call(fee: new_fee)
-      taxes_result.raise_if_error!
-
-      new_fee.save!
 
       result.fee = new_fee
       result

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -41,13 +41,14 @@ module Invoices
 
           create_subscription_fee(subscription, boundaries) if should_create_subscription_fee?(subscription)
           create_charges_fees(subscription, boundaries) if should_create_charge_fees?(subscription)
+
+          invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
+          invoice.sub_total_excluding_taxes_amount_cents = invoice.fees.sum(:amount_cents)
+          Credits::AppliedCouponsService.call(invoice:) if should_create_coupon_credit?
+
+          Invoices::ComputeAmountsFromFees.call(invoice:)
         end
 
-        invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
-        invoice.sub_total_excluding_taxes_amount_cents = invoice.fees.sum(:amount_cents)
-        Credits::AppliedCouponsService.call(invoice:) if should_create_coupon_credit?
-
-        Invoices::ComputeAmountsFromFees.call(invoice:)
         create_credit_note_credit if should_create_credit_note_credit?
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
 

--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -8,6 +8,12 @@ module Invoices
     end
 
     def call
+      invoice.fees.each do |fee|
+        taxes_result = Fees::ApplyTaxesService.call(fee:)
+        taxes_result.raise_if_error!
+        fee.save!
+      end
+
       invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
       invoice.coupons_amount_cents = invoice.credits.coupon_kind.sum(:amount_cents)
       invoice.sub_total_excluding_taxes_amount_cents = (

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -97,6 +97,11 @@ module Invoices
     def compute_amounts
       invoice.fees_amount_cents = invoice.fees.sum(&:amount_cents)
 
+      invoice.fees.each do |fee|
+        taxes_result = Fees::ApplyTaxesService.call(fee:)
+        taxes_result.raise_if_error!
+      end
+
       taxes_result = Invoices::ApplyTaxesService.call(invoice:)
       taxes_result.raise_if_error!
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -80,7 +80,7 @@ module Plans
 
       charge.save!
 
-      if params[:tax_codes].present?
+      if params[:tax_codes]
         taxes_result = Charges::ApplyTaxesService.call(charge:, tax_codes: params[:tax_codes])
         taxes_result.raise_if_error!
       end
@@ -109,7 +109,7 @@ module Plans
 
             charge.update!(payload_charge)
 
-            if tax_codes.present?
+            if tax_codes
               taxes_result = Charges::ApplyTaxesService.call(charge:, tax_codes:)
               taxes_result.raise_if_error!
             end

--- a/spec/scenarios/taxes_on_invoice_spec.rb
+++ b/spec/scenarios/taxes_on_invoice_spec.rb
@@ -40,6 +40,7 @@ describe 'Taxes on Invoice Scenarios', :scenarios, type: :request do
             amount_cents: 10_000,
             amount_currency: 'EUR',
             pay_in_advance: false,
+            tax_codes: ['banking_rates'],
             charges: [
               {
                 billable_metric_id: fx_transfers.id,
@@ -57,7 +58,6 @@ describe 'Taxes on Invoice Scenarios', :scenarios, type: :request do
             ],
           },
         )
-        create_plan_applied_tax('plan_code', 'banking_rates')
         plan = organization.plans.find_by(code: 'plan_code')
 
         create_subscription(

--- a/spec/scenarios/taxes_on_invoice_spec.rb
+++ b/spec/scenarios/taxes_on_invoice_spec.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Taxes on Invoice Scenarios', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  before do
+    organization
+
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+  end
+
+  around { |test| lago_premium!(&test) }
+
+  context 'when timezone is negative and not the same day as UTC' do
+    it 'creates an invoice for the expected period' do
+      travel_to(DateTime.new(2023, 1, 1)) do
+        create_tax(name: 'Banking rates', code: 'banking_rates', rate: 10.0)
+        create_tax(name: 'Sales tax - FR', code: 'sales_tax_fr', rate: 0.0)
+        create_tax(name: 'Sales tax', code: 'sales_tax', rate: 20.0)
+
+        create_or_update_customer(external_id: 'customer-1')
+
+        create_metric(name: 'FX Transfers', code: 'fx_transfers', aggregation_type: 'sum_agg', field_name: 'total')
+        fx_transfers = organization.billable_metrics.find_by(code: 'fx_transfers')
+        create_metric(name: 'Cards', code: 'cards', aggregation_type: 'count_agg')
+        cards = organization.billable_metrics.find_by(code: 'cards')
+
+        create_plan(
+          {
+            name: 'P1',
+            code: 'plan_code',
+            interval: 'monthly',
+            amount_cents: 10_000,
+            amount_currency: 'EUR',
+            pay_in_advance: false,
+            charges: [
+              {
+                billable_metric_id: fx_transfers.id,
+                charge_model: 'standard',
+                properties: { amount: '1' },
+                tax_codes: [organization.taxes.find_by(code: 'sales_tax_fr').code],
+              },
+              {
+                billable_metric_id: cards.id,
+                charge_model: 'standard',
+                min_amount_cents: 5000,
+                properties: { amount: '30' },
+                tax_codes: [organization.taxes.find_by(code: 'sales_tax').code],
+              },
+            ],
+          },
+        )
+        create_plan_applied_tax('plan_code', 'banking_rates')
+        plan = organization.plans.find_by(code: 'plan_code')
+
+        create_subscription(
+          {
+            external_customer_id: 'customer-1',
+            external_id: 'sub_external_id',
+            plan_code: plan.code,
+          },
+        )
+
+        create_coupon(
+          {
+            name: 'coupon1',
+            code: 'coupon1_code',
+            coupon_type: 'fixed_amount',
+            frequency: 'once',
+            amount_cents: 1000,
+            amount_currency: 'EUR',
+            expiration: 'time_limit',
+            expiration_at: Time.current + 15.days,
+            reusable: false,
+          },
+        )
+        apply_coupon({ external_customer_id: 'customer-1', coupon_code: 'coupon1_code' })
+
+        create_event(
+          {
+            code: fx_transfers.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: 'sub_external_id',
+            properties: { total: 50 },
+          },
+        )
+
+        create_event(
+          {
+            code: cards.code,
+            transaction_id: SecureRandom.uuid,
+            external_subscription_id: 'sub_external_id',
+          },
+        )
+      end
+
+      travel_to(DateTime.new(2023, 2, 1)) do
+        perform_billing
+      end
+
+      customer = organization.customers.find_by(external_id: 'customer-1')
+      invoice = customer.invoices.first
+      fees = invoice.fees
+
+      expect(invoice.fees.count).to eq(4)
+
+      # Subscription fee
+      expect(fees.subscription.first).to have_attributes(
+        amount_cents: 10_000,
+        taxes_amount_cents: 950,
+        taxes_rate: 10.0,
+        # fee amount cents * coupon amount / total fees amount (100 * 10 / 200)
+        precise_coupons_amount_cents: 500,
+      )
+
+      fx_transfers = organization.billable_metrics.find_by(code: 'fx_transfers')
+      cards = organization.billable_metrics.find_by(code: 'cards')
+
+      # FX Transfers fee
+      fx_transfers_fee = fees.charge.find_by(charge: fx_transfers.charges.first)
+      expect(fx_transfers_fee).to have_attributes(
+        amount_cents: 5000,
+        taxes_amount_cents: 0,
+        taxes_rate: 0.0,
+        precise_coupons_amount_cents: 250, # 50 * 10 / 200
+        events_count: 1,
+        units: 50,
+      )
+
+      # Cards fee
+      cards_fee = fees.charge.where(true_up_parent_fee_id: nil).find_by(charge: cards.charges.first)
+      expect(cards_fee).to have_attributes(
+        amount_cents: 3000,
+        taxes_amount_cents: 570,
+        taxes_rate: 20.0,
+        precise_coupons_amount_cents: 150, # 30 * 10 / 200
+        events_count: 1,
+        units: 1,
+      )
+
+      # True up - Cards fee
+      true_up_cards_fee = fees.charge.where.not(true_up_parent_fee_id: nil).find_by(charge: cards.charges.first)
+      expect(true_up_cards_fee).to have_attributes(
+        amount_cents: 2000,
+        taxes_amount_cents: 380,
+        taxes_rate: 20.0,
+        precise_coupons_amount_cents: 100, # 20 * 10 / 200
+        events_count: 0,
+        units: 1,
+      )
+
+      expect(invoice).to have_attributes(
+        fees_amount_cents: 20_000,
+        coupons_amount_cents: 1000,
+        taxes_amount_cents: 1900,
+        sub_total_excluding_taxes_amount_cents: 19_000,
+        sub_total_including_taxes_amount_cents: 20_900,
+        total_amount_cents: 20_900,
+      )
+    end
+  end
+end

--- a/spec/services/credit_notes/apply_taxes_service_spec.rb
+++ b/spec/services/credit_notes/apply_taxes_service_spec.rb
@@ -23,16 +23,58 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
       version_number: 3,
     )
   end
-  let(:fee1) { create(:fee, invoice:, amount_cents: 100, taxes_amount_cents: 12, taxes_rate: 12) }
-  let(:fee2) { create(:fee, invoice:, amount_cents: 20, taxes_amount_cents: 4, taxes_rate: 20) }
+
+  let(:fee1) do
+    create(
+      :fee,
+      invoice:,
+      amount_cents: 100,
+      taxes_amount_cents: 12,
+      taxes_rate: 12,
+      precise_coupons_amount_cents: (20 * 100).fdiv(120),
+    )
+  end
+
+  let(:fee2) do
+    create(
+      :fee,
+      invoice:,
+      amount_cents: 20,
+      taxes_amount_cents: 4,
+      taxes_rate: 20,
+      precise_coupons_amount_cents: (20 * 20).fdiv(120),
+    )
+  end
 
   let(:tax1) { create(:tax, organization:, rate: 12) }
   let(:tax2) { create(:tax, organization:, rate: 8) }
 
-  let(:applied_tax1) { create(:fee_applied_tax, tax: tax1, fee: fee1, amount_cents: 12) }
+  let(:applied_tax11) do
+    create(
+      :fee_applied_tax,
+      tax: tax1,
+      fee: fee1,
+      amount_cents: (fee1.sub_total_excluding_taxes_amount_cents * tax1.rate).fdiv(100),
+    )
+  end
 
-  let(:applied_tax21) { create(:fee_applied_tax, tax: tax1, fee: fee2, amount_cents: 2) }
-  let(:applied_tax22) { create(:fee_applied_tax, tax: tax2, fee: fee2, amount_cents: 2) }
+  let(:applied_tax21) do
+    create(
+      :fee_applied_tax,
+      tax: tax1,
+      fee: fee2,
+      amount_cents: (fee2.sub_total_excluding_taxes_amount_cents * tax1.rate).fdiv(100),
+    )
+  end
+
+  let(:applied_tax22) do
+    create(
+      :fee_applied_tax,
+      tax: tax2,
+      fee: fee2,
+      amount_cents: (fee2.sub_total_excluding_taxes_amount_cents * tax2.rate).fdiv(100),
+    )
+  end
 
   let(:items) do
     [
@@ -56,7 +98,7 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
   end
 
   before do
-    applied_tax1
+    applied_tax11
     applied_tax21
     applied_tax22
   end

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -383,6 +383,20 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
         )
       end
 
+      let(:subscription_fee) do
+        create(
+          :fee,
+          subscription:,
+          invoice:,
+          amount_cents: 100,
+          taxes_amount_cents: 20,
+          invoiceable_type: 'Subscription',
+          invoiceable_id: subscription.id,
+          taxes_rate: 20,
+          precise_coupons_amount_cents: 10,
+        )
+      end
+
       it 'takes the coupon into account' do
         result = create_service.call
 

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -369,6 +369,14 @@ RSpec.describe CreditNotes::CreateService, type: :service do
         )
       end
 
+      let(:fee1) do
+        create(:fee, invoice:, amount_cents: 10, taxes_amount_cents: 1, taxes_rate: 20, precise_coupons_amount_cents: 5)
+      end
+
+      let(:fee2) do
+        create(:fee, invoice:, amount_cents: 10, taxes_amount_cents: 1, taxes_rate: 20, precise_coupons_amount_cents: 5)
+      end
+
       let(:credit_amount_cents) { 6 }
       let(:refund_amount_cents) { 3 }
       let(:items) do

--- a/spec/services/credit_notes/refresh_draft_service_spec.rb
+++ b/spec/services/credit_notes/refresh_draft_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe CreditNotes::RefreshDraftService, type: :service do
         total_amount_cents: 100,
       )
     end
-    let(:fee) { create(:fee, invoice:, taxes_rate: 20) }
+    let(:fee) { create(:fee, invoice:, taxes_rate: 20, amount_cents: 100, precise_coupons_amount_cents: 20) }
     let(:applied_tax) { create(:fee_applied_tax, tax:, fee:, amount_cents: 0) }
 
     before do

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe Fees::ChargeService do
   let(:customer) { create(:customer) }
   let(:organization) { customer.organization }
 
-  let(:tax) { create(:tax, rate: 20, organization:) }
-
   let(:subscription) do
     create(
       :subscription,
@@ -47,8 +45,6 @@ RSpec.describe Fees::ChargeService do
     )
   end
 
-  before { tax }
-
   describe '.create' do
     context 'without group properties' do
       it 'creates a fee' do
@@ -65,10 +61,6 @@ RSpec.describe Fees::ChargeService do
           expect(created_fee.units).to eq(0)
           expect(created_fee.events_count).to eq(0)
           expect(created_fee.payment_status).to eq('pending')
-
-          expect(created_fee.taxes_amount_cents).to eq(0)
-          expect(created_fee.taxes_rate).to eq(20.0)
-          expect(created_fee.applied_taxes.count).to eq(1)
         end
       end
 
@@ -116,10 +108,6 @@ RSpec.describe Fees::ChargeService do
             expect(created_fee.amount_cents).to eq(5)
             expect(created_fee.amount_currency).to eq('EUR')
             expect(created_fee.units.to_s).to eq('4.0')
-
-            expect(created_fee.taxes_amount_cents).to eq(1)
-            expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.applied_taxes.count).to eq(1)
           end
         end
       end
@@ -177,10 +165,6 @@ RSpec.describe Fees::ChargeService do
             expect(created_fee.amount_cents).to eq(2000)
             expect(created_fee.amount_currency).to eq('EUR')
             expect(created_fee.units).to eq(1)
-
-            expect(created_fee.taxes_amount_cents).to eq(400)
-            expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.applied_taxes.count).to eq(1)
           end
         end
       end
@@ -203,10 +187,6 @@ RSpec.describe Fees::ChargeService do
               expect(created_fee.amount_cents).to eq(0)
               expect(created_fee.amount_currency).to eq('EUR')
               expect(created_fee.units).to eq(0)
-
-              expect(created_fee.taxes_amount_cents).to eq(0)
-              expect(created_fee.taxes_rate).to eq(20.0)
-              expect(created_fee.applied_taxes.count).to eq(1)
             end
           end
         end
@@ -327,32 +307,25 @@ RSpec.describe Fees::ChargeService do
               invoice_id: invoice.id,
               charge_id: charge.id,
               amount_currency: 'EUR',
-              taxes_rate: 20.0,
             ),
           )
           expect(created_fees.first).to have_attributes(
             group: europe,
             amount_cents: 4000,
-            taxes_amount_cents: 800,
             units: 2,
           )
-          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 5000,
-            taxes_amount_cents: 1000,
             units: 1,
           )
-          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 4000,
-            taxes_amount_cents: 800,
             units: 1,
           )
-          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
 
@@ -369,32 +342,25 @@ RSpec.describe Fees::ChargeService do
               invoice_id: invoice.id,
               charge_id: charge.id,
               amount_currency: 'EUR',
-              taxes_rate: 20.0,
             ),
           )
           expect(created_fees.first).to have_attributes(
             group: europe,
             amount_cents: 30_000,
-            taxes_amount_cents: 6000,
             units: 15,
           )
-          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 60_000,
-            taxes_amount_cents: 12_000,
             units: 12,
           )
-          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 20_000,
-            taxes_amount_cents: 4000,
             units: 5,
           )
-          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
 
@@ -411,32 +377,25 @@ RSpec.describe Fees::ChargeService do
               invoice_id: invoice.id,
               charge_id: charge.id,
               amount_currency: 'EUR',
-              taxes_rate: 20.0,
             ),
           )
           expect(created_fees.first).to have_attributes(
             group: europe,
             amount_cents: 20_000,
-            taxes_amount_cents: 4000,
             units: 10,
           )
-          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 60_000,
-            taxes_amount_cents: 12_000,
             units: 12,
           )
-          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 20_000,
-            taxes_amount_cents: 4000,
             units: 5,
           )
-          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
 
@@ -530,32 +489,25 @@ RSpec.describe Fees::ChargeService do
                 invoice_id: invoice.id,
                 charge_id: charge.id,
                 amount_currency: 'EUR',
-                taxes_rate: 20.0,
               ),
             )
             expect(created_fees.first).to have_attributes(
               group: europe,
               amount_cents: 2000,
-              taxes_amount_cents: 400,
               units: 1,
             )
-            expect(created_fees.first.applied_taxes.count).to eq(1)
 
             expect(created_fees.second).to have_attributes(
               group: usa,
               amount_cents: 5000,
-              taxes_amount_cents: 1000,
               units: 1,
             )
-            expect(created_fees.second.applied_taxes.count).to eq(1)
 
             expect(created_fees.third).to have_attributes(
               group: france,
               amount_cents: 4000,
-              taxes_amount_cents: 800,
               units: 1,
             )
-            expect(created_fees.third.applied_taxes.count).to eq(1)
           end
         end
       end
@@ -623,32 +575,25 @@ RSpec.describe Fees::ChargeService do
               invoice_id: invoice.id,
               charge_id: charge.id,
               amount_currency: 'EUR',
-              taxes_rate: 20.0,
             ),
           )
           expect(created_fees.first).to have_attributes(
             group: europe,
             amount_cents: 2000,
-            taxes_amount_cents: 400,
             units: 1,
           )
-          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 5000,
-            taxes_amount_cents: 1000,
             units: 1,
           )
-          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 4000,
-            taxes_amount_cents: 800,
             units: 1,
           )
-          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -755,32 +700,24 @@ RSpec.describe Fees::ChargeService do
               invoice_id: invoice.id,
               charge_id: charge.id,
               amount_currency: 'EUR',
-              taxes_rate: 20.0,
             ),
           )
           expect(created_fees.first).to have_attributes(
             group: europe,
-            amount_cents: 10_000,
-            taxes_amount_cents: 2000,
             units: 2,
           )
-          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 5000,
-            taxes_amount_cents: 1000,
             units: 1,
           )
-          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 0,
-            taxes_amount_cents: 0,
             units: 1,
           )
-          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -875,32 +812,25 @@ RSpec.describe Fees::ChargeService do
               invoice_id: invoice.id,
               charge_id: charge.id,
               amount_currency: 'EUR',
-              taxes_rate: 20.0,
             ),
           )
           expect(created_fees.first).to have_attributes(
             group: europe,
             amount_cents: 200 + 2 * 2,
-            taxes_amount_cents: 41,
             units: 2,
           )
-          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 1 * 1,
-            taxes_amount_cents: 0,
             units: 1,
           )
-          expect(created_fees.second.applied_taxes.count).to eq(1)
 
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 100 + 5 * 1,
-            taxes_amount_cents: 21,
             units: 1,
           )
-          expect(created_fees.third.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -995,24 +925,19 @@ RSpec.describe Fees::ChargeService do
               invoice_id: invoice.id,
               charge_id: charge.id,
               amount_currency: 'EUR',
-              taxes_rate: 20.0,
             ),
           )
           expect(created_fees.first).to have_attributes(
             group: europe,
             amount_cents: 3,
-            taxes_amount_cents: 1,
             units: 2,
           )
-          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 4,
-            taxes_amount_cents: 1,
             units: 1,
           )
-          expect(created_fees.second.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -1097,24 +1022,19 @@ RSpec.describe Fees::ChargeService do
               invoice_id: invoice.id,
               charge_id: charge.id,
               amount_currency: 'EUR',
-              taxes_rate: 20.0,
             ),
           )
           expect(created_fees.first).to have_attributes(
             group: europe,
             amount_cents: 1400,
-            taxes_amount_cents: 280,
             units: 2,
           )
-          expect(created_fees.first.applied_taxes.count).to eq(1)
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 1100,
-            taxes_amount_cents: 220,
             units: 1,
           )
-          expect(created_fees.second.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -1224,10 +1144,6 @@ RSpec.describe Fees::ChargeService do
             expect(usage_fee.amount_cents).to eq(0)
             expect(usage_fee.amount_currency).to eq('EUR')
             expect(usage_fee.units).to eq(0)
-
-            expect(usage_fee.taxes_amount_cents).to eq(0)
-            expect(usage_fee.taxes_rate).to eq(20.0)
-            expect(usage_fee.applied_taxes.size).to eq(1)
           end
         end
       end
@@ -1279,10 +1195,6 @@ RSpec.describe Fees::ChargeService do
           expect(usage_fee.amount_cents).to eq(5)
           expect(usage_fee.amount_currency).to eq('EUR')
           expect(usage_fee.units.to_s).to eq('4.0')
-
-          expect(usage_fee.taxes_amount_cents).to eq(1)
-          expect(usage_fee.taxes_rate).to eq(20.0)
-          expect(usage_fee.applied_taxes.size).to eq(1)
         end
       end
     end

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -308,8 +308,6 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
             charge:,
             amount_cents: 10,
             amount_currency: 'EUR',
-            taxes_rate: 20.0,
-            taxes_amount_cents: 2,
             fee_type: 'charge',
             pay_in_advance: true,
             invoiceable: charge,
@@ -319,7 +317,11 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
             group: nil,
             pay_in_advance_event_id: event.id,
             payment_status: 'pending',
+
+            taxes_rate: 0,
+            taxes_amount_cents: 0,
           )
+          expect(result.fees.first.applied_taxes.count).to eq(0)
         end
       end
 

--- a/spec/services/fees/create_true_up_service_spec.rb
+++ b/spec/services/fees/create_true_up_service_spec.rb
@@ -56,9 +56,6 @@ RSpec.describe Fees::CreateTrueUpService, type: :service do
             group: nil,
             amount_cents: 300,
             true_up_parent_fee_id: fee.id,
-
-            taxes_rate: tax.rate,
-            taxes_amount_cents: 60,
           )
         end
       end

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -52,10 +52,6 @@ RSpec.describe Fees::OneOffService do
         expect(first_fee.fee_type).to eq('add_on')
         expect(first_fee.payment_status).to eq('pending')
 
-        expect(first_fee.taxes_amount_cents).to eq(480)
-        expect(first_fee.taxes_rate).to eq(20.0)
-        expect(first_fee.applied_taxes.count).to eq(1)
-
         expect(second_fee.id).not_to be_nil
         expect(second_fee.invoice_id).to eq(invoice.id)
         expect(second_fee.add_on_id).to eq(add_on_second.id)
@@ -66,10 +62,6 @@ RSpec.describe Fees::OneOffService do
         expect(second_fee.amount_currency).to eq('EUR')
         expect(second_fee.fee_type).to eq('add_on')
         expect(second_fee.payment_status).to eq('pending')
-
-        expect(second_fee.taxes_amount_cents).to eq(80)
-        expect(second_fee.taxes_rate).to eq(20.0)
-        expect(second_fee.applied_taxes.count).to eq(1)
       end
     end
 

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -62,10 +62,6 @@ RSpec.describe Fees::SubscriptionService do
         expect(created_fee.units).to eq(1)
         expect(created_fee.events_count).to be_nil
         expect(created_fee.payment_status).to eq('pending')
-
-        expect(created_fee.taxes_amount_cents).to eq(20)
-        expect(created_fee.taxes_rate).to eq(20.0)
-        expect(created_fee.applied_taxes.count).to eq(1)
       end
     end
 
@@ -136,10 +132,6 @@ RSpec.describe Fees::SubscriptionService do
             expect(created_fee.amount_cents).to eq(plan.amount_cents)
             expect(created_fee.amount_currency).to eq(plan.amount_currency)
             expect(created_fee.units).to eq(1)
-
-            expect(created_fee.taxes_amount_cents).to eq(20)
-            expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.applied_taxes.count).to eq(1)
           end
         end
 
@@ -220,10 +212,6 @@ RSpec.describe Fees::SubscriptionService do
             expect(created_fee.amount_cents).to eq(71)
             expect(created_fee.amount_currency).to eq(plan.amount_currency)
             expect(created_fee.units).to eq(1)
-
-            expect(created_fee.taxes_amount_cents).to eq(14)
-            expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.applied_taxes.count).to eq(1)
           end
         end
 
@@ -338,10 +326,6 @@ RSpec.describe Fees::SubscriptionService do
             expect(created_fee.amount_cents).to eq(plan.amount_cents)
             expect(created_fee.amount_currency).to eq(plan.amount_currency)
             expect(created_fee.units).to eq(1)
-
-            expect(created_fee.taxes_amount_cents).to eq(20)
-            expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.applied_taxes.count).to eq(1)
           end
         end
 
@@ -429,10 +413,6 @@ RSpec.describe Fees::SubscriptionService do
             expect(created_fee.amount_cents).to eq(55)
             expect(created_fee.amount_currency).to eq(plan.amount_currency)
             expect(created_fee.units).to eq(1)
-
-            expect(created_fee.taxes_amount_cents).to eq(11)
-            expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.applied_taxes.count).to eq(1)
           end
         end
 
@@ -576,10 +556,6 @@ RSpec.describe Fees::SubscriptionService do
             expect(created_fee.invoice_id).to eq(invoice.id)
             expect(created_fee.amount_cents).to eq(plan.amount_cents)
             expect(created_fee.amount_currency).to eq(plan.amount_currency)
-
-            expect(created_fee.taxes_amount_cents).to eq(20)
-            expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.applied_taxes.count).to eq(1)
           end
         end
 
@@ -617,10 +593,6 @@ RSpec.describe Fees::SubscriptionService do
             expect(created_fee.invoice_id).to eq(invoice.id)
             expect(created_fee.amount_cents).to eq(80)
             expect(created_fee.amount_currency).to eq(plan.amount_currency)
-
-            expect(created_fee.taxes_amount_cents).to eq(16)
-            expect(created_fee.taxes_rate).to eq(20.0)
-            expect(created_fee.applied_taxes.count).to eq(1)
           end
         end
 
@@ -826,10 +798,6 @@ RSpec.describe Fees::SubscriptionService do
         expect(created_fee.invoice_id).to eq(invoice.id)
         expect(created_fee.amount_cents).to eq(65)
         expect(created_fee.amount_currency).to eq(plan.amount_currency)
-
-        expect(created_fee.taxes_amount_cents).to eq(13)
-        expect(created_fee.taxes_rate).to eq(20.0)
-        expect(created_fee.applied_taxes.count).to eq(1)
       end
     end
 
@@ -888,10 +856,6 @@ RSpec.describe Fees::SubscriptionService do
           expect(created_fee.invoice_id).to eq(invoice.id)
           expect(created_fee.amount_cents).to eq(43)
           expect(created_fee.amount_currency).to eq(plan.amount_currency)
-
-          expect(created_fee.taxes_amount_cents).to eq(9)
-          expect(created_fee.taxes_rate).to eq(20.0)
-          expect(created_fee.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -910,10 +874,6 @@ RSpec.describe Fees::SubscriptionService do
           expect(created_fee.invoice_id).to eq(invoice.id)
           expect(created_fee.amount_cents).to eq(65)
           expect(created_fee.amount_currency).to eq(plan.amount_currency)
-
-          expect(created_fee.taxes_amount_cents).to eq(13)
-          expect(created_fee.taxes_rate).to eq(20.0)
-          expect(created_fee.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -991,10 +951,6 @@ RSpec.describe Fees::SubscriptionService do
         expect(created_fee.invoice_id).to eq(invoice.id)
         expect(created_fee.amount_cents).to eq(55)
         expect(created_fee.amount_currency).to eq(plan.amount_currency)
-
-        expect(created_fee.taxes_amount_cents).to eq(11)
-        expect(created_fee.taxes_rate).to eq(20.0)
-        expect(created_fee.applied_taxes.count).to eq(1)
       end
     end
 

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -826,10 +826,6 @@ RSpec.describe Fees::SubscriptionService do
           expect(created_fee.invoice_id).to eq(invoice.id)
           expect(created_fee.amount_cents).to eq(65)
           expect(created_fee.amount_currency).to eq(plan.amount_currency)
-
-          expect(created_fee.taxes_amount_cents).to eq(13)
-          expect(created_fee.taxes_rate).to eq(20.0)
-          expect(created_fee.applied_taxes.count).to eq(1)
         end
       end
     end
@@ -979,10 +975,6 @@ RSpec.describe Fees::SubscriptionService do
           expect(created_fee.invoice_id).to eq(invoice.id)
           expect(created_fee.amount_cents).to eq(55)
           expect(created_fee.amount_currency).to eq(plan.amount_currency)
-
-          expect(created_fee.taxes_amount_cents).to eq(11)
-          expect(created_fee.taxes_rate).to eq(20.0)
-          expect(created_fee.applied_taxes.count).to eq(1)
         end
       end
     end

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -6,19 +6,37 @@ RSpec.describe Invoices::ComputeAmountsFromFees, type: :service do
   subject(:compute_amounts) { described_class.new(invoice:) }
 
   let(:organization) { create(:organization) }
-  let(:invoice) { create(:invoice, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
 
   let(:tax1) { create(:tax, organization:, rate: 10) }
   let(:tax2) { create(:tax, organization:, rate: 20) }
 
-  before do
-    fee1 = create(:fee, invoice:, amount_cents: 151, taxes_rate: 10)
-    create(:fee_applied_tax, fee: fee1, tax: tax1, amount_cents: 151, tax_rate: 10)
+  let(:fee1) { create(:fee, invoice:, amount_cents: 151) }
+  let(:fee2) { create(:fee, invoice:, amount_cents: 379, precise_coupons_amount_cents: 100) }
 
-    fee2 = create(:fee, invoice:, amount_cents: 379, taxes_rate: 20)
-    create(:fee_applied_tax, fee: fee2, tax: tax2, amount_cents: 379, tax_rate: 20)
+  before do
+    tax1
+    tax2
+
+    fee1
+    fee2
 
     create(:credit, invoice:, amount_cents: 100)
+  end
+
+  it 'applied taxes to the fees' do
+    compute_amounts.call
+
+    aggregate_failures do
+      expect(fee1.reload.applied_taxes.count).to eq(2)
+      expect(fee1.taxes_rate).to eq(30)
+      expect(fee1.taxes_amount_cents).to eq(45) # 151 * (10 + 20) / 100
+
+      expect(fee2.reload.applied_taxes.count).to eq(2)
+      expect(fee2.taxes_rate).to eq(30)
+      expect(fee2.taxes_amount_cents).to eq(84) # (379 - 100) * (10 + 20) / 100
+    end
   end
 
   it 'sets fees_amount_cents from the list of fees' do
@@ -34,14 +52,14 @@ RSpec.describe Invoices::ComputeAmountsFromFees, type: :service do
   end
 
   it 'sets taxes_amount_cents from the list of fees' do
-    expect { compute_amounts.call }.to change(invoice, :taxes_amount_cents).from(0).to(74)
+    expect { compute_amounts.call }.to change(invoice, :taxes_amount_cents).from(0).to(129)
   end
 
   it 'sets sub_total_including_taxes_amount_cents' do
-    expect { compute_amounts.call }.to change(invoice, :sub_total_including_taxes_amount_cents).from(0).to(504)
+    expect { compute_amounts.call }.to change(invoice, :sub_total_including_taxes_amount_cents).from(0).to(559)
   end
 
   it 'sets total_amount_cents' do
-    expect { compute_amounts.call }.to change(invoice, :total_amount_cents).from(0).to(504)
+    expect { compute_amounts.call }.to change(invoice, :total_amount_cents).from(0).to(559)
   end
 end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module ScenariosHelper
+  ### Billable metrics
+
+  def create_metric(params)
+    post_with_token(organization, '/api/v1/billable_metrics', { billable_metric: params })
+  end
+
   ### Customers
 
   def create_or_update_customer(params)
@@ -20,6 +26,10 @@ module ScenariosHelper
   end
 
   ### Plans
+
+  def create_plan(params)
+    post_with_token(organization, '/api/v1/plans', { plan: params })
+  end
 
   def delete_plan(plan)
     delete_with_token(organization, "/api/v1/plans/#{plan.code}")
@@ -55,6 +65,20 @@ module ScenariosHelper
 
   def apply_coupon(params)
     post_with_token(organization, '/api/v1/applied_coupons', { applied_coupon: params })
+  end
+
+  ### Taxes
+
+  def create_tax(params)
+    post_with_token(organization, '/api/v1/taxes', { tax: params })
+  end
+
+  def create_plan_applied_tax(plan_code, tax_code)
+    post_with_token(
+      organization,
+      "/api/v1/plans/#{plan_code}/applied_taxes",
+      { applied_tax: { tax_code: } },
+    )
   end
 
   ### Wallets

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -73,14 +73,6 @@ module ScenariosHelper
     post_with_token(organization, '/api/v1/taxes', { tax: params })
   end
 
-  def create_plan_applied_tax(plan_code, tax_code)
-    post_with_token(
-      organization,
-      "/api/v1/plans/#{plan_code}/applied_taxes",
-      { applied_tax: { tax_code: } },
-    )
-  end
-
   ### Wallets
 
   def create_wallet(params)


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at plans or charge levels

## Description

This PR adds the logic to compute coupons pro-rata and apply it to fees while computing taxes