### PR TITLE
fix (subscription): fix billing boundaries for termination case

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -75,6 +75,12 @@ class Subscription < ApplicationRecord
     initial_started_at.to_date + plan.trial_period.days
   end
 
+  def trial_end_datetime
+    return unless plan.has_trial?
+
+    initial_started_at + plan.trial_period.days
+  end
+
   def started_in_past?
     started_at.to_date < created_at.to_date
   end

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -125,41 +125,40 @@ module Fees
     #       **day_cost** = (plan amount_cents / full period duration)
     #       amount_to_bill = (nb_day * day_cost)
     def terminated_amount
-      from_date = boundaries.from_datetime.to_date
-      to_date = boundaries.to_datetime.to_date
+      from_datetime = boundaries.from_datetime
+      to_datetime = boundaries.to_datetime
 
       if plan.has_trial?
         # NOTE: amount is 0 if trial cover the full period
-        return 0 if subscription.trial_end_date >= to_date
+        return 0 if subscription.trial_end_datetime >= to_datetime
 
         # NOTE: from_date is the trial end date if it happens during the period
-        if (subscription.trial_end_date > from_date) && (subscription.trial_end_date < to_date)
-          from_date = subscription.trial_end_date
+        if (subscription.trial_end_datetime > from_datetime) && (subscription.trial_end_datetime < to_datetime)
+          from_datetime = subscription.trial_end_datetime
         end
       end
 
       # NOTE: number of days between beginning of the period and the termination date
-      number_of_day_to_bill = (to_date + 1.day - from_date).to_i
+      number_of_day_to_bill = (to_datetime - from_datetime).fdiv(1.day).ceil
 
       number_of_day_to_bill * single_day_price(subscription)
     end
 
     def upgraded_amount
-      from_date = boundaries.from_datetime.to_date
-      to_date = boundaries.to_datetime.to_date
+      from_datetime = boundaries.from_datetime
+      to_datetime = boundaries.to_datetime
 
       if plan.has_trial?
-        from_date = to_date + 1.day if subscription.trial_end_date >= to_date
+        return 0 if subscription.trial_end_datetime >= to_datetime
 
         # NOTE: from_date is the trial end date if it happens during the period
-        if (subscription.trial_end_date > from_date) && (subscription.trial_end_date < to_date)
-          from_date = subscription.trial_end_date
+        if (subscription.trial_end_datetime > from_datetime) && (subscription.trial_end_datetime < to_datetime)
+          from_datetime = subscription.trial_end_datetime
         end
       end
 
       # NOTE: number of days between the upgrade and the end of the period
-      number_of_day_to_bill = (to_date + 1.day - from_date).to_i
-
+      number_of_day_to_bill = (to_datetime - from_datetime).fdiv(1.day).ceil
       # NOTE: Subscription is upgraded from another plan
       #       We only bill the days between the upgrade date and the end of the period
       #       A credit note will apply automatically the amount of days from previous plan that were not consumed

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Subscription, type: :model do
           plan:,
           external_id: 'sub_id',
           customer: previous_subscription.customer,
-          )
+        )
       end
       let(:previous_subscription) do
         create(:subscription, started_at: Time.current.last_month, external_id: 'sub_id', status: :terminated)

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -135,6 +135,53 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
+  describe '#trial_end_datetime' do
+    let(:plan) { create(:plan, trial_period: 3) }
+    let(:started_at) { subscription.initial_started_at }
+
+    it 'returns the trial end datetime' do
+      trial_end_datetime = subscription.trial_end_datetime
+
+      aggregate_failures do
+        expect(trial_end_datetime).to be_present
+        expect(trial_end_datetime).to eq(started_at + 3.days)
+      end
+    end
+
+    context 'when plan has no trial' do
+      let(:plan) { create(:plan) }
+
+      it 'returns nil' do
+        expect(subscription.trial_end_datetime).to be_nil
+      end
+    end
+
+    context 'with a previous subscription' do
+      let(:subscription) do
+        create(
+          :active_subscription,
+          previous_subscription:,
+          started_at: Time.zone.yesterday,
+          plan:,
+          external_id: 'sub_id',
+          customer: previous_subscription.customer,
+          )
+      end
+      let(:previous_subscription) do
+        create(:subscription, started_at: Time.current.last_month, external_id: 'sub_id', status: :terminated)
+      end
+
+      it 'takes previous subscription started_at into account' do
+        trial_end_datetime = subscription.trial_end_datetime
+
+        aggregate_failures do
+          expect(trial_end_datetime).to be_present
+          expect(trial_end_datetime).to eq(started_at + 3.days)
+        end
+      end
+    end
+  end
+
   describe '#initial_started_at' do
     let(:customer) { create(:customer) }
     let(:subscription) do

--- a/spec/scenarios/invoices_spec.rb
+++ b/spec/scenarios/invoices_spec.rb
@@ -124,7 +124,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
 
       ### 20 Dec: Terminate subscription + refresh.
-      dec20 = DateTime.new(2022, 12, 20)
+      dec20 = DateTime.parse('2022-12-20 06:00:00')
 
       travel_to(dec20) do
         expect {

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -212,8 +212,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
       end
 
       context 'when subscription is billed on anniversary date' do
-        let(:timestamp) { DateTime.parse('07 Mar 2022') }
-        let(:started_at) { DateTime.parse('06 Jun 2021').to_date }
+        let(:timestamp) { DateTime.parse('22 Mar 2022') }
+        let(:started_at) { DateTime.parse('2021-06-06 05:00:00') }
         let(:subscription_at) { started_at }
         let(:billing_time) { 'anniversary' }
 


### PR DESCRIPTION
## Context

Fix billing boundaries for termination case if there is customer timezone

## Description

If customer timezone is set, in case of termination wrong number of days was calculated and therefore proration coefficient was incorrect