### PR TITLE
feat(tax): Expose invoices_taxes#fees_amount_cents in API

### DIFF
--- a/app/graphql/types/invoices/applied_taxes/object.rb
+++ b/app/graphql/types/invoices/applied_taxes/object.rb
@@ -8,6 +8,8 @@ module Types
         implements Types::Taxes::AppliedTax
 
         field :invoice, Types::Invoices::Object, null: false
+
+        field :fees_amount_cents, GraphQL::Types::BigInt, null: false
       end
     end
   end

--- a/app/serializers/v1/invoices/applied_tax_serializer.rb
+++ b/app/serializers/v1/invoices/applied_tax_serializer.rb
@@ -14,6 +14,7 @@ module V1
           tax_description: model.tax_description,
           amount_cents: model.amount_cents,
           amount_currency: model.amount_currency,
+          fees_amount_cents: model.fees_amount_cents,
           created_at: model.created_at.iso8601,
         }
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3190,6 +3190,7 @@ type InvoiceAppliedTax implements AppliedTax {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   createdAt: ISO8601DateTime!
+  feesAmountCents: BigInt!
   id: ID!
   invoice: Invoice!
   tax: Tax!

--- a/schema.json
+++ b/schema.json
@@ -12734,6 +12734,24 @@
               ]
             },
             {
+              "name": "feesAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {

--- a/spec/serializers/v1/invoices/applied_tax_serializer_spec.rb
+++ b/spec/serializers/v1/invoices/applied_tax_serializer_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ::V1::Invoices::AppliedTaxSerializer do
       expect(result['applied_tax']['tax_description']).to eq(applied_tax.tax_description)
       expect(result['applied_tax']['amount_cents']).to eq(applied_tax.amount_cents)
       expect(result['applied_tax']['amount_currency']).to eq(applied_tax.amount_currency)
+      expect(result['applied_tax']['fees_amount_cents']).to eq(applied_tax.fees_amount_cents)
       expect(result['applied_tax']['created_at']).to eq(applied_tax.created_at.iso8601)
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at plans or charge levels

## Description

This PR exposes `invoices_taxes#fees_amount_cents` in both GraphQL and public API