### PR TITLE
feat(tax): Populate missing pro-rated coupon taxes amounts

### DIFF
--- a/db/migrate/20230720081854_populate_fees_precise_coupons_amount_cents.rb
+++ b/db/migrate/20230720081854_populate_fees_precise_coupons_amount_cents.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class PopulateFeesPreciseCouponsAmountCents < ActiveRecord::Migration[7.0]
+  # NOTE: redifine models to prevent schema issue in the future
+  class Subscription < ApplicationRecord; end
+  class CouponTarget < ApplicationRecord; end
+  class Charge < ApplicationRecord; end
+
+  class Coupon < ApplicationRecord
+    has_many :coupon_targets
+  end
+
+  class Fee < ApplicationRecord
+    belongs_to :subscription, optional: true
+    belongs_to :charge, optional: true
+  end
+
+  class AppliedCoupon < ApplicationRecord
+    belongs_to :coupon
+  end
+
+  class Invoice < ApplicationRecord
+    has_many :fees
+  end
+
+  class Credit < ApplicationRecord
+    belongs_to :invoice
+    belongs_to :applied_coupon
+  end
+
+  def change
+    reversible do |dir|
+      dir.up do
+        credits = Credit
+          .joins(:invoice)
+          .joins(applied_coupon: :coupon)
+          .where('credits.amount_cents > 0')
+          .where(invoice: { version_number: 3 })
+          .includes(:invoice, applied_coupon: :coupon)
+          .order('credits.created_at ASC')
+
+        credits.each do |credit|
+          if credit.applied_coupon.coupon.limited_plans
+            fees = credit.invoice.fees
+              .joins(:subscription)
+              .where(subscription: { plan_id: credit.coupon_targets.where.not(plan_id: nil).select(:plan_id) })
+
+            fees.find_each do |fee|
+              base_amount_cents = fees.sum(:amount_cents)
+
+              fee.precise_coupons_amount_cents += (credit.amount_cents * fee.amount_cents).fdiv(base_amount_cents)
+            end
+
+          elsif credit.applied_coupon.limited_billable_metrics
+            fees = credit.invoice.fees
+              .joins(:charge)
+              .where(charge: {
+                billable_metric_id: credit.coupon_targets.not(billable_metric_id: nil).select(:billable_metric_id),
+              })
+
+            fees.find_each do |fee|
+              base_amount_cents = fees.sum(:amount_cents)
+
+              fee.precise_coupons_amount_cents += (credit.amount_cents * fee.amount_cents).fdiv(base_amount_cents)
+            end
+          else
+            fees = credit.invoice.fees
+
+            fees.find_each do |fee|
+              base_amount_cents = Fee.where(invoice_id: fee.invoice.id)
+                .sum('fees.amount_cents - fees.precise_coupons_amount_cents')
+
+              fee.precise_coupons_amount_cents += (credit.amount_cents * fee.amount_cents).fdiv(base_amount_cents)
+              fee.save!
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20230720120622_populate_fees_amount_cents_in_invoice_taxes.rb
+++ b/db/migrate/20230720120622_populate_fees_amount_cents_in_invoice_taxes.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class PopulateFeesAmountCentsInInvoiceTaxes < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          WITH invoice_fees_amounts AS (
+            SELECT
+              invoices.id AS invoice_id,
+              fees_taxes.tax_id,
+              SUM(fees.amount_cents - fees.precise_coupons_amount_cents) AS fees_total_amount
+            FROM fees
+              INNER JOIN invoices ON invoices.id = fees.invoice_id
+              INNER JOIN fees_taxes ON fees_taxes.fee_id = fees.id
+            GROUP BY invoices.id, fees_taxes.tax_id
+          )
+
+          UPDATE invoices_taxes
+          SET fees_amount_cents = invoice_fees_amounts.fees_total_amount
+          FROM invoice_fees_amounts
+            WHERE invoice_fees_amounts.invoice_id = invoices_taxes.invoice_id
+            AND invoice_fees_amounts.tax_id = invoices_taxes.tax_id
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_17_090135) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_20_120622) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at plans or charge levels

## Description

This PR adds a migration to populate added in a previous PR: https://github.com/getlago/lago-api/pull/1178