### PR TITLE
fix(credit): Migrate v3 credits with wrong before taxes flag

### DIFF
--- a/db/migrate/20230721073114_fix_credit_before_taxes.rb
+++ b/db/migrate/20230721073114_fix_credit_before_taxes.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class FixCreditBeforeTaxes < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          WITH wrong_before_vat_credits AS (
+            SELECT credits.id AS credit_id
+            FROM credits
+            INNER JOIN invoices ON credits.invoice_id = invoices.id
+            WHERE invoices.version_number = 3
+              AND credits.before_taxes IS false
+              AND credits.applied_coupon_id IS NOT NULL
+          )
+
+          UPDATE credits
+          SET before_taxes = true
+          FROM wrong_before_vat_credits
+            WHERE wrong_before_vat_credits.credit_id = credits.id;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_17_090135) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_21_073114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
## Context

### Issue

---

I create an invoice link to a subscription like this

```
Subscription fee        $100.00
-------------------------------
Coupon                  -$10.00
Substotal (excl. tax)    $90.00  
Tax (10%)                $ 9.00
Subtotal (incl. tax)     $99.00
-------------------------------
Prepaid credits         -$ 5.00
-------------------------------
Total due                $94.00
```

When I’m creating a credit note through the UI, it tells me that the maximum refundable amount is $84.00.

When I’m creating a credit note through the API, it tells me that the maximum refundable amount is $94.00

### Expected behaviour

---

When I’m creating a credit note through the UI, the maximum refundable amount should be $94.00.

## Description

The issue is related to a bug with the `credits.before_taxes` flag. It was introduced to quickly identify credits coming from coupons applied after taxes (invoice v2) from the coupons applied before taxes (invoice v3).

The flag was wrongly set to false since the deploy of invoice v3, leading to the creation of many credits with the wrong flag.

The bug itself was fixed recently via https://github.com/getlago/lago-api/pull/1174, but the created credits must be updated to make sure the flag is correct.