### PR TITLE
fix (billable-metrics): temporary block recurring_count_agg aggregation type

### DIFF
--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -3,6 +3,11 @@
 module BillableMetrics
   class CreateService < BaseService
     def create(**args)
+      # Blocking recurring_count_agg in transition period. It will be removed completely in the future.
+      if args[:aggregation_type] && args[:aggregation_type]&.to_sym == :recurring_count_agg
+        return result.not_allowed_failure!(code: 'invalid_aggregation_type')
+      end
+
       ActiveRecord::Base.transaction do
         metric = BillableMetric.create!(
           organization_id: args[:organization_id],

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -18,6 +18,11 @@ module BillableMetrics
       # NOTE: Only name and description are editable if billable metric
       #       is attached to a plan
       unless billable_metric.plans.exists?
+        # Blocking recurring_count_agg in transition period. It will be removed completely in the future.
+        if params.key?(:aggregation_type) && params[:aggregation_type]&.to_sym == :recurring_count_agg
+          return result.not_allowed_failure!(code: 'invalid_aggregation_type')
+        end
+
         billable_metric.code = params[:code] if params.key?(:code)
         billable_metric.aggregation_type = params[:aggregation_type]&.to_sym if params.key?(:aggregation_type)
         billable_metric.field_name = params[:field_name] if params.key?(:field_name)

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -29,6 +29,29 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
         .to change(BillableMetric, :count).by(1)
     end
 
+    context 'when aggregation_type is recurring_count_agg' do
+      let(:create_args) do
+        {
+          name: 'New Metric',
+          code: 'new_metric',
+          description: 'New metric description',
+          organization_id: organization.id,
+          aggregation_type: 'recurring_count_agg',
+          recurring: true,
+        }
+      end
+
+      it 'returns an error' do
+        result = create_service.create(**create_args)
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(result.error.code).to eq('invalid_aggregation_type')
+        end
+      end
+    end
+
     context 'with code already used by a deleted metric' do
       it 'creates a billable metric with the same code' do
         create(:billable_metric, organization:, code: 'new_metric', deleted_at: Time.current)

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -110,6 +110,29 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       end
     end
 
+    context 'when aggregation_type is recurring_count_agg' do
+      let(:params) do
+        {
+          name: 'New Metric',
+          code: 'new_metric',
+          description: 'New metric description',
+          aggregation_type: 'recurring_count_agg',
+          field_name: 'field_value',
+          recurring: true,
+        }.tap { |p| p[:group] = group unless group.nil? }
+      end
+
+      it 'returns an error' do
+        result = update_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+          expect(result.error.code).to eq('invalid_aggregation_type')
+        end
+      end
+    end
+
     context 'when billable metric is linked to plan' do
       let(:plan) { create(:plan, organization:) }
       let(:charge) { create(:standard_charge, billable_metric:, plan:) }


### PR DESCRIPTION
## Context

We don't accept from now on `recurring_count_agg` aggregation type. It is migrated to `count_unique` type with `recurring` = `true` and `prorated` = `true` (on related charge). In the future (after new feature gets released completely) we will remove this type completely from the codebase.

## Description

Block `recurring_count_agg` aggregation type on the API side.
