### PR TITLE
feat: add payment_due_date and display on invoices

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -32,6 +32,7 @@ module Types
       field :total_amount_cents, GraphQL::Types::BigInt, null: false
 
       field :issuing_date, GraphQL::Types::ISO8601Date, null: false
+      field :payment_due_date, GraphQL::Types::ISO8601Date, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -48,6 +48,7 @@ class Customer < ApplicationRecord
             presence: true,
             uniqueness: { conditions: -> { where(deleted_at: nil) }, scope: :organization_id }
   validates :invoice_grace_period, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :net_payment_term, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validates :payment_provider, inclusion: { in: PAYMENT_PROVIDERS }, allow_nil: true
   validates :timezone, timezone: true, allow_nil: true
   validates :vat_rate, numericality: { less_than_or_equal_to: 100, greater_than_or_equal_to: 0 }, allow_nil: true
@@ -70,6 +71,12 @@ class Customer < ApplicationRecord
     return invoice_grace_period if invoice_grace_period.present?
 
     organization.invoice_grace_period
+  end
+
+  def applicable_net_payment_term
+    return net_payment_term if net_payment_term.present?
+
+    organization.net_payment_term
   end
 
   def editable?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -43,6 +43,7 @@ class Organization < ApplicationRecord
   validates :email, email: true, if: :email?
   validates :invoice_footer, length: { maximum: 600 }
   validates :invoice_grace_period, numericality: { greater_than_or_equal_to: 0 }
+  validates :net_payment_term, numericality: { greater_than_or_equal_to: 0 }
   validates :logo,
             image: { authorized_content_type: %w[image/png image/jpg image/jpeg], max_size: 800.kilobytes },
             if: :logo?

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -8,6 +8,7 @@ module V1
         sequential_id: model.sequential_id,
         number: model.number,
         issuing_date: model.issuing_date.iso8601,
+        payment_due_date: model.payment_due_date.iso8601,
         invoice_type: model.invoice_type,
         status: model.status,
         payment_status: model.payment_status,

--- a/app/services/customers/update_invoice_grace_period_service.rb
+++ b/app/services/customers/update_invoice_grace_period_service.rb
@@ -20,6 +20,7 @@ module Customers
         # NOTE: Update issuing_date on draft invoices.
         customer.invoices.draft.each do |invoice|
           invoice.update!(issuing_date: grace_period_issuing_date(invoice))
+          invoice.update!(payment_due_date: grace_period_payment_due_date(invoice))
         end
 
         result.customer = customer
@@ -37,6 +38,10 @@ module Customers
 
     def grace_period_issuing_date(invoice)
       invoice_created_at(invoice) + customer.applicable_invoice_grace_period.days
+    end
+
+    def grace_period_payment_due_date(invoice)
+      invoice.issuing_date + customer.applicable_net_payment_term.days
     end
   end
 end

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -16,6 +16,7 @@ module Invoices
           organization: customer.organization,
           customer:,
           issuing_date:,
+          payment_due_date:,
           invoice_type: :add_on,
           payment_status: :pending,
           currency:,
@@ -91,6 +92,10 @@ module Invoices
     # NOTE: accounting date must be in customer timezone
     def issuing_date
       datetime.in_time_zone(customer.applicable_timezone).to_date
+    end
+
+    def payment_due_date
+      (issuing_date + customer.applicable_net_payment_term.days).to_date
     end
 
     def should_deliver_email?

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -16,6 +16,7 @@ module Invoices
           organization: event.organization,
           customer:,
           issuing_date:,
+          payment_due_date:,
           invoice_type: :subscription,
           payment_status: :pending,
           currency: customer.currency,
@@ -85,6 +86,10 @@ module Invoices
     # NOTE: accounting date must be in customer timezone
     def issuing_date
       Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone).to_date
+    end
+
+    def payment_due_date
+      (issuing_date + customer.applicable_net_payment_term.days).to_date
     end
 
     def should_deliver_email?

--- a/app/services/invoices/finalize_service.rb
+++ b/app/services/invoices/finalize_service.rb
@@ -14,7 +14,7 @@ module Invoices
         self.result = Invoices::RefreshDraftService.call(invoice:, context: :finalize)
         result.raise_if_error!
 
-        invoice.update!(status: :finalized, issuing_date:)
+        invoice.update!(status: :finalized, issuing_date:, payment_due_date:)
 
         invoice.credit_notes.each(&:finalized!)
       end
@@ -38,6 +38,10 @@ module Invoices
 
     def issuing_date
       @issuing_date ||= Time.current.in_time_zone(invoice.customer.applicable_timezone).to_date
+    end
+
+    def payment_due_date
+      @payment_due_date ||= issuing_date + invoice.customer.applicable_net_payment_term.days
     end
 
     def track_invoice_created(invoice)

--- a/app/services/invoices/one_off_service.rb
+++ b/app/services/invoices/one_off_service.rb
@@ -26,6 +26,7 @@ module Invoices
           organization: customer.organization,
           customer:,
           issuing_date:,
+          payment_due_date:,
           invoice_type: :one_off,
           currency:,
           timezone: customer.applicable_timezone,
@@ -78,6 +79,10 @@ module Invoices
     # NOTE: accounting date must be in customer timezone
     def issuing_date
       Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone).to_date
+    end
+
+    def payment_due_date
+      (issuing_date + customer.applicable_net_payment_term.days).to_date
     end
 
     def should_deliver_email?

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -16,6 +16,7 @@ module Invoices
           organization: customer.organization,
           customer:,
           issuing_date:,
+          payment_due_date: issuing_date,
           invoice_type: :credit,
           payment_status: :pending,
           currency:,

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -28,6 +28,7 @@ module Invoices
           organization: customer.organization,
           customer:,
           issuing_date:,
+          payment_due_date:,
           invoice_type: :subscription,
           currency:,
           timezone: customer.applicable_timezone,
@@ -67,6 +68,10 @@ module Invoices
       return issuing_date unless grace_period?
 
       issuing_date + customer.applicable_invoice_grace_period.days
+    end
+
+    def payment_due_date
+      (issuing_date + customer.applicable_net_payment_term.days).to_date
     end
 
     def grace_period?

--- a/app/services/organizations/update_invoice_grace_period_service.rb
+++ b/app/services/organizations/update_invoice_grace_period_service.rb
@@ -20,6 +20,7 @@ module Organizations
         # NOTE: Update issuing_date on draft invoices.
         organization.invoices.draft.each do |invoice|
           invoice.update!(issuing_date: grace_period_issuing_date(invoice))
+          invoice.update!(payment_due_date: grace_period_payment_due_date(invoice))
         end
 
         result.organization = organization
@@ -37,6 +38,10 @@ module Organizations
 
     def grace_period_issuing_date(invoice)
       invoice_created_at(invoice) + invoice.customer.applicable_invoice_grace_period.days
+    end
+
+    def grace_period_payment_due_date(invoice)
+      invoice.issuing_date + invoice.customer.applicable_net_payment_term.days
     end
   end
 end

--- a/app/views/templates/invoices/charge.slim
+++ b/app/views/templates/invoices/charge.slim
@@ -410,7 +410,7 @@ html
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(total_amount)
-        .body-1 = I18n.t('invoice.due_date', date: I18n.l(issuing_date, format: :default))
+        .body-1 = I18n.t('invoice.due_date', date: I18n.l(payment_due_date, format: :default))
 
       .invoice-resume.mb-24.overflow-auto
         table.invoice-resume-table width="100%"

--- a/app/views/templates/invoices/one_off.slim
+++ b/app/views/templates/invoices/one_off.slim
@@ -411,7 +411,7 @@ html
 
       .mb-24
         h2.title-2.mb-4 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
-        .body-1 = I18n.t('invoice.due_date', date: I18n.l(issuing_date, format: :default))
+        .body-1 = I18n.t('invoice.due_date', date: I18n.l(payment_due_date, format: :default))
 
       .invoice-resume.mb-24.overflow-auto
         table.invoice-resume-table width="100%"

--- a/app/views/templates/invoices/v3.slim
+++ b/app/views/templates/invoices/v3.slim
@@ -416,7 +416,7 @@ html
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(total_amount)
-        .body-1 = I18n.t('invoice.due_date', date: I18n.l(issuing_date, format: :default))
+        .body-1 = I18n.t('invoice.due_date', date: I18n.l(payment_due_date, format: :default))
 
       .invoice-resume.mb-24.overflow-auto
         - if credit?

--- a/db/migrate/20230726165711_add_net_payment_term_on_organization_and_customer.rb
+++ b/db/migrate/20230726165711_add_net_payment_term_on_organization_and_customer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class AddNetPaymentTermOnOrganizationAndCustomer < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :net_payment_term, :integer, default: 0, null: false
+    add_column :customers, :net_payment_term, :integer, default: nil, null: true
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          ALTER TABLE organizations
+            ADD CONSTRAINT check_organizations_on_net_payment_term
+            CHECK (net_payment_term >= 0);
+          ALTER TABLE customers
+            ADD CONSTRAINT check_customers_on_net_payment_term
+            CHECK (net_payment_term >= 0);
+        SQL
+      end
+
+      dir.down do
+        execute <<-SQL
+          ALTER TABLE organizations DROP CONSTRAINT check_organizations_on_net_payment_term;
+          ALTER TABLE customers DROP CONSTRAINT check_customers_on_net_payment_term;
+        SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20230726171737_add_payment_due_date_to_invoice.rb
+++ b/db/migrate/20230726171737_add_payment_due_date_to_invoice.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPaymentDueDateToInvoice < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invoices, :payment_due_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -293,10 +293,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_163611) do
     t.datetime "deleted_at"
     t.string "document_locale"
     t.string "tax_identification_number"
+    t.integer "net_payment_term"
     t.index ["deleted_at"], name: "index_customers_on_deleted_at"
     t.index ["external_id", "organization_id"], name: "index_customers_on_external_id_and_organization_id", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_customers_on_organization_id"
     t.check_constraint "invoice_grace_period >= 0", name: "check_customers_on_invoice_grace_period"
+    t.check_constraint "net_payment_term >= 0", name: "check_customers_on_net_payment_term"
   end
 
   create_table "customers_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -479,6 +481,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_163611) do
     t.bigint "prepaid_credit_amount_cents", default: 0, null: false
     t.bigint "sub_total_excluding_taxes_amount_cents", default: 0, null: false
     t.bigint "sub_total_including_taxes_amount_cents", default: 0, null: false
+    t.date "payment_due_date"
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
   end
@@ -535,8 +538,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_163611) do
     t.string "document_locale", default: "en", null: false
     t.string "email_settings", default: [], null: false, array: true
     t.string "tax_identification_number"
+    t.integer "net_payment_term", default: 0, null: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"
+    t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"
   end
 
   create_table "password_resets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/schema.graphql
+++ b/schema.graphql
@@ -3116,6 +3116,7 @@ type Invoice {
   issuingDate: ISO8601Date!
   metadata: [InvoiceMetadata!]
   number: String!
+  paymentDueDate: ISO8601Date!
   paymentStatus: InvoicePaymentStatusTypeEnum!
   prepaidCreditAmountCents: BigInt!
   refundableAmountCents: BigInt!

--- a/schema.json
+++ b/schema.json
@@ -12149,6 +12149,24 @@
               ]
             },
             {
+              "name": "paymentDueDate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601Date",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "paymentStatus",
               "description": null,
               "type": {

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     organization
 
     issuing_date { Time.zone.now - 1.day }
+    payment_due_date { issuing_date }
     payment_status { 'pending' }
     currency { 'EUR' }
 

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ::V1::InvoiceSerializer do
         'sequential_id' => invoice.sequential_id,
         'number' => invoice.number,
         'issuing_date' => invoice.issuing_date.iso8601,
+        'payment_due_date' => invoice.payment_due_date.iso8601,
         'invoice_type' => invoice.invoice_type,
         'status' => invoice.status,
         'payment_status' => invoice.payment_status,

--- a/spec/services/customers/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/customers/update_invoice_grace_period_service_spec.rb
@@ -47,6 +47,23 @@ RSpec.describe Customers::UpdateInvoiceGracePeriodService, type: :service do
       travel_to(current_date) do
         expect { update_service.call }.to change { invoice_to_not_be_finalized.reload.issuing_date }
           .to(DateTime.parse('23 Jun 2022'))
+          .and change { invoice_to_not_be_finalized.reload.payment_due_date }
+          .to(DateTime.parse('23 Jun 2022'))
+      end
+    end
+
+    context 'when customer has net_payment_term' do
+      let(:customer) { create(:customer, organization:, net_payment_term: 3) }
+
+      it 'updates issuing_date on draft invoices with payment term' do
+        current_date = DateTime.parse('22 Jun 2022')
+
+        travel_to(current_date) do
+          expect { update_service.call }.to change { invoice_to_not_be_finalized.reload.issuing_date }
+            .to(DateTime.parse('23 Jun 2022'))
+            .and change { invoice_to_not_be_finalized.reload.payment_due_date }
+            .to(DateTime.parse('26 Jun 2022'))
+        end
       end
     end
   end

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -55,6 +55,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
         expect(result).to be_success
 
         expect(result.invoice.issuing_date.to_date).to eq(timestamp)
+        expect(result.invoice.payment_due_date.to_date).to eq(timestamp)
         expect(result.invoice.organization_id).to eq(organization.id)
         expect(result.invoice.customer_id).to eq(customer.id)
         expect(result.invoice.invoice_type).to eq('subscription')
@@ -174,6 +175,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
         result = invoice_service.call
 
         expect(result.invoice.issuing_date.to_s).to eq('2022-11-24')
+        expect(result.invoice.payment_due_date.to_s).to eq('2022-11-24')
       end
     end
   end

--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Invoices::FinalizeService, type: :service do
       freeze_time do
         expect { finalize_service.call }
           .to change { invoice.reload.issuing_date }.to(Time.current.to_date)
+          .and change { invoice.reload.payment_due_date }.to(Time.current.to_date)
       end
     end
 

--- a/spec/services/organizations/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/organizations/update_invoice_grace_period_service_spec.rb
@@ -47,6 +47,23 @@ RSpec.describe Organizations::UpdateInvoiceGracePeriodService, type: :service do
       travel_to(current_date) do
         expect { update_service.call }.to change { invoice_to_not_be_finalized.reload.issuing_date }
           .to(DateTime.parse('23 Jun 2022'))
+          .and change { invoice_to_not_be_finalized.reload.payment_due_date }
+          .to(DateTime.parse('23 Jun 2022'))
+      end
+    end
+
+    context 'when customer has net_payment_term' do
+      let(:customer) { create(:customer, organization:, net_payment_term: 3) }
+
+      it 'updates issuing_date on draft invoices' do
+        current_date = DateTime.parse('22 Jun 2022')
+
+        travel_to(current_date) do
+          expect { update_service.call }.to change { invoice_to_not_be_finalized.reload.issuing_date }
+            .to(DateTime.parse('23 Jun 2022'))
+            .and change { invoice_to_not_be_finalized.reload.payment_due_date }
+            .to(DateTime.parse('26 Jun 2022'))
+        end
       end
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-invoice-due-date

## Context

We want to allow defining a payment due date that is different than the invoice issuing date

## Description

This is a non breaking PR. it basically "just" add attributes and logic between them. But the "heart" of the feature (updating the due date) is not done yet

----------
This PR adds a payment_due_date attribute on invoices and display it on templates
It' based on the issuing datre for now

Also, customer and orga has their new net_payment_term attribute added.
Updating this attribute will be possible in following PRs