### PR TITLE
feat(tax): Add AddOn::AppliedTax

### DIFF
--- a/app/models/add_on.rb
+++ b/app/models/add_on.rb
@@ -12,6 +12,9 @@ class AddOn < ApplicationRecord
   has_many :customers, through: :applied_add_ons
   has_many :fees
 
+  has_many :applied_taxes, class_name: 'AddOn::AppliedTax', dependent: :destroy
+  has_many :taxes, through: :applied_taxes
+
   monetize :amount_cents
 
   validates :name, presence: true

--- a/app/models/add_on/applied_tax.rb
+++ b/app/models/add_on/applied_tax.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddOn
+  class AppliedTax < ApplicationRecord
+    self.table_name = 'add_ons_taxes'
+
+    belongs_to :add_on
+    belongs_to :tax
+  end
+end

--- a/db/migrate/20230727163611_create_add_ons_taxes.rb
+++ b/db/migrate/20230727163611_create_add_ons_taxes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateAddOnsTaxes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :add_ons_taxes, id: :uuid do |t|
+      t.references :add_on, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :tax, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_21_073114) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_27_163611) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -56,6 +56,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_21_073114) do
     t.index ["deleted_at"], name: "index_add_ons_on_deleted_at"
     t.index ["organization_id", "code"], name: "index_add_ons_on_organization_id_and_code", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_add_ons_on_organization_id"
+  end
+
+  create_table "add_ons_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "add_on_id", null: false
+    t.uuid "tax_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["add_on_id"], name: "index_add_ons_taxes_on_add_on_id"
+    t.index ["tax_id"], name: "index_add_ons_taxes_on_tax_id"
   end
 
   create_table "applied_add_ons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -757,6 +766,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_21_073114) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "add_ons", "organizations"
+  add_foreign_key "add_ons_taxes", "add_ons"
+  add_foreign_key "add_ons_taxes", "taxes"
   add_foreign_key "applied_add_ons", "add_ons"
   add_foreign_key "applied_add_ons", "customers"
   add_foreign_key "billable_metrics", "organizations"

--- a/spec/factories/add_on_applied_taxes.rb
+++ b/spec/factories/add_on_applied_taxes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :add_on_applied_tax, class: 'AddOn::AppliedTax' do
+    add_on
+    tax
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at add ons level.

## Description

This PR adds the `AddOn::AppliedTax` resource.