### PR TITLE
feat(tax): Assign taxes on add on creation

### DIFF
--- a/app/controllers/api/v1/add_ons_controller.rb
+++ b/app/controllers/api/v1/add_ons_controller.rb
@@ -63,6 +63,7 @@ module Api
             ::V1::AddOnSerializer,
             collection_name: 'add_ons',
             meta: pagination_metadata(add_ons),
+            includes: %i[taxes],
           ),
         )
       end
@@ -76,6 +77,7 @@ module Api
           :amount_cents,
           :amount_currency,
           :description,
+          tax_codes: [],
         )
       end
 
@@ -84,6 +86,7 @@ module Api
           json: ::V1::AddOnSerializer.new(
             add_on,
             root_name: 'add_on',
+            includes: %i[taxes],
           ),
         )
       end

--- a/app/serializers/v1/add_on_serializer.rb
+++ b/app/serializers/v1/add_on_serializer.rb
@@ -3,7 +3,7 @@
 module V1
   class AddOnSerializer < ModelSerializer
     def serialize
-      {
+      payload = {
         lago_id: model.id,
         name: model.name,
         code: model.code,
@@ -12,6 +12,19 @@ module V1
         created_at: model.created_at.iso8601,
         description: model.description,
       }
+
+      payload.merge!(taxes) if include?(:taxes)
+      payload
+    end
+
+    private
+
+    def taxes
+      ::CollectionSerializer.new(
+        model.taxes,
+        ::V1::TaxSerializer,
+        collection_name: 'taxes',
+      ).serialize
     end
   end
 end

--- a/app/services/add_ons/apply_taxes_service.rb
+++ b/app/services/add_ons/apply_taxes_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module AddOns
+  class ApplyTaxesService < BaseService
+    def initialize(add_on:, tax_codes:)
+      @add_on = add_on
+      @tax_codes = tax_codes
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'add_on') unless add_on
+      return result.not_found_failure!(resource: 'tax') if (tax_codes - taxes.pluck(:code)).present?
+
+      add_on.applied_taxes.where(
+        tax_id: add_on.taxes.where.not(code: tax_codes).pluck(:id),
+      ).destroy_all
+
+      result.applied_taxes = tax_codes.map do |tax_code|
+        add_on.applied_taxes.find_or_create_by!(tax: taxes.find_by(code: tax_code))
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :add_on, :tax_codes
+
+    def taxes
+      @taxes ||= add_on.organization.taxes.where(code: tax_codes)
+    end
+  end
+end

--- a/spec/requests/api/v1/add_ons_spec.rb
+++ b/spec/requests/api/v1/add_ons_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Api::V1::AddOnsController, type: :request do
   let(:organization) { create(:organization) }
+  let(:tax) { create(:tax, organization:) }
 
   describe 'create' do
     let(:create_params) do
@@ -13,6 +14,7 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
         amount_cents: 123,
         amount_currency: 'EUR',
         description: 'description',
+        tax_codes: [tax.code],
       }
     end
 
@@ -25,6 +27,7 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
       expect(json[:add_on][:code]).to eq(create_params[:code])
       expect(json[:add_on][:name]).to eq(create_params[:name])
       expect(json[:add_on][:created_at]).to be_present
+      expect(json[:add_on][:taxes].map { |t| t[:code] }).to contain_exactly(tax.code)
     end
   end
 
@@ -131,8 +134,9 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
 
   describe 'index' do
     let(:add_on) { create(:add_on, organization:) }
+    let(:add_on_applied_tax) { create(:add_on_applied_tax, add_on:, tax:) }
 
-    before { add_on }
+    before { add_on_applied_tax }
 
     it 'returns add-ons' do
       get_with_token(organization, '/api/v1/add_ons')
@@ -141,6 +145,7 @@ RSpec.describe Api::V1::AddOnsController, type: :request do
       expect(json[:add_ons].count).to eq(1)
       expect(json[:add_ons].first[:lago_id]).to eq(add_on.id)
       expect(json[:add_ons].first[:code]).to eq(add_on.code)
+      expect(json[:add_ons].first[:taxes].map { |t| t[:code] }).to contain_exactly(tax.code)
     end
 
     context 'with pagination' do

--- a/spec/services/add_ons/apply_taxes_service_spec.rb
+++ b/spec/services/add_ons/apply_taxes_service_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AddOns::ApplyTaxesService, type: :service do
+  subject(:apply_service) { described_class.new(add_on:, tax_codes:) }
+
+  let(:organization) { create(:organization) }
+  let(:add_on) { create(:add_on, organization:) }
+  let(:tax1) { create(:tax, organization:, code: 'tax1') }
+  let(:tax2) { create(:tax, organization:, code: 'tax2') }
+  let(:tax_codes) { [tax1.code, tax2.code] }
+
+  describe 'call' do
+    it 'applies taxes to the add_on' do
+      expect { apply_service.call }.to change { add_on.applied_taxes.count }.from(0).to(2)
+    end
+
+    it 'returns applied taxes' do
+      result = apply_service.call
+      expect(result.applied_taxes.count).to eq(2)
+    end
+
+    context 'when add_on is not found' do
+      let(:add_on) { nil }
+
+      it 'returns an error' do
+        result = apply_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('add_on_not_found')
+        end
+      end
+    end
+
+    context 'when tax is not found' do
+      let(:tax_codes) { ['unknown'] }
+
+      it 'returns an error' do
+        result = apply_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('tax_not_found')
+        end
+      end
+    end
+
+    context 'when applied tax is already present' do
+      it 'does not create a new applied tax' do
+        create(:add_on_applied_tax, add_on:, tax: tax1)
+        expect { apply_service.call }.to change { add_on.applied_taxes.count }.from(1).to(2)
+      end
+    end
+
+    context 'when trying to apply twice the same tax' do
+      let(:tax_codes) { [tax1.code, tax1.code] }
+
+      it 'assigns it only once' do
+        expect { apply_service.call }.to change { add_on.applied_taxes.count }.from(0).to(1)
+      end
+    end
+  end
+end

--- a/spec/services/add_ons/create_service_spec.rb
+++ b/spec/services/add_ons/create_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe AddOns::CreateService, type: :service do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:add_on_code) { 'free-beer-for-us' }
+  let(:tax) { create(:tax, organization:) }
 
   describe 'create' do
     let(:create_args) do
@@ -18,6 +19,7 @@ RSpec.describe AddOns::CreateService, type: :service do
         organization_id: organization.id,
         amount_cents: 100,
         amount_currency: 'EUR',
+        tax_codes: [tax.code],
       }
     end
 
@@ -28,6 +30,9 @@ RSpec.describe AddOns::CreateService, type: :service do
     it 'creates an add-on' do
       expect { create_service.create(**create_args) }
         .to change(AddOn, :count).by(1)
+
+      add_on = AddOn.order(:created_at).last
+      expect(add_on.taxes.pluck(:code)).to eq([tax.code])
     end
 
     it 'calls SegmentTrackJob' do


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at add ons level.

## Description

This PR adds the ability to assign taxes on add on creation.