### PR TITLE
fix (subscriptions): do not raise duplicated_invoice error for yearly plan case

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -91,12 +91,22 @@ module Invoices
       return false unless recurring
 
       subscriptions_boundaries.any? do |subscription_id, boundaries|
-        InvoiceSubscription
+        subscription = Subscription.includes(:plan).find(subscription_id)
+
+        base_query = InvoiceSubscription
+          .includes(subscription: :plan)
           .where(subscription_id:)
           .recurring
           .where(from_datetime: boundaries[:from_datetime])
           .where(to_datetime: boundaries[:to_datetime])
-          .exists?
+
+        if subscription.plan.yearly? && subscription.plan.bill_charges_monthly?
+          base_query = base_query
+            .where(charges_from_datetime: boundaries[:charges_from_datetime])
+            .where(charges_to_datetime: boundaries[:charges_to_datetime])
+        end
+
+        base_query.exists?
       end
     end
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -94,7 +94,6 @@ module Invoices
         subscription = Subscription.includes(:plan).find(subscription_id)
 
         base_query = InvoiceSubscription
-          .includes(subscription: :plan)
           .where(subscription_id:)
           .recurring
           .where(from_datetime: boundaries[:from_datetime])

--- a/db/migrate/20230731095510_remove_index_from_invoice_subscriptions.rb
+++ b/db/migrate/20230731095510_remove_index_from_invoice_subscriptions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveIndexFromInvoiceSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :invoice_subscriptions,
+                 %i[subscription_id from_datetime to_datetime],
+                 name: 'index_invoice_subscriptions_on_from_and_to_datetime'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_27_163611) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_31_095510) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -451,7 +451,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_27_163611) do
     t.datetime "charges_to_datetime"
     t.index ["invoice_id"], name: "index_invoice_subscriptions_on_invoice_id"
     t.index ["subscription_id", "charges_from_datetime", "charges_to_datetime"], name: "index_invoice_subscriptions_on_charges_from_and_to_datetime", unique: true, where: "((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE))"
-    t.index ["subscription_id", "from_datetime", "to_datetime"], name: "index_invoice_subscriptions_on_from_and_to_datetime", unique: true, where: "((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE))"
     t.index ["subscription_id"], name: "index_invoice_subscriptions_on_subscription_id"
   end
 


### PR DESCRIPTION
## Context

If plan interval is `yearly` and `bill_charges_monthly` is `true` we do not want to raise `duplicated_invoice` error since on multiple invoices we can have the same `from_datetime` and `to_datetime` values but different `charges_from_datetime` and `charges_to_datetime`
