### PR TITLE
feat(tax): Add add_ons_count to tax

### DIFF
--- a/app/graphql/types/taxes/object.rb
+++ b/app/graphql/types/taxes/object.rb
@@ -18,9 +18,14 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      field :add_ons_count, Integer, null: false, description: 'Number of add ons using this tax'
       field :charges_count, Integer, null: false, description: 'Number of charges using this tax'
       field :customers_count, Integer, null: false, description: 'Number of customers using this tax'
       field :plans_count, Integer, null: false, description: 'Number of plans using this tax'
+
+      def add_ons_count
+        object.add_ons.count
+      end
 
       def charges_count
         object.charges.count

--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -12,6 +12,8 @@ class Tax < ApplicationRecord
   has_many :invoices, through: :invoices_taxes
   has_many :credit_notes_taxes, class_name: 'CreditNote::AppliedTax', dependent: :destroy
   has_many :credit_notes, through: :credit_notes_taxes
+  has_many :add_ons_taxes, class_name: 'AddOn::AppliedTax', dependent: :destroy
+  has_many :add_ons, through: :add_ons_taxes
   has_many :plans_taxes, class_name: 'Plan::AppliedTax', dependent: :destroy
   has_many :plans, through: :plans_taxes
   has_many :charges_taxes, class_name: 'Charge::AppliedTax', dependent: :destroy

--- a/app/serializers/v1/tax_serializer.rb
+++ b/app/serializers/v1/tax_serializer.rb
@@ -10,6 +10,7 @@ module V1
         rate: model.rate,
         description: model.description,
         applied_to_organization: model.applied_to_organization,
+        add_ons_count: model.add_ons.count,
         customers_count: model.customers_count,
         plans_count: model.plans.count,
         charges_count: model.charges.count,

--- a/schema.graphql
+++ b/schema.graphql
@@ -4499,6 +4499,10 @@ type Subscription {
 }
 
 type Tax {
+  """
+  Number of add ons using this tax
+  """
+  addOnsCount: Int!
   appliedToOrganization: Boolean!
 
   """

--- a/schema.json
+++ b/schema.json
@@ -19672,6 +19672,24 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "addOnsCount",
+              "description": "Number of add ons using this tax",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "appliedToOrganization",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/taxes/create_spec.rb
+++ b/spec/graphql/mutations/taxes/create_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Mutations::Taxes::Create, type: :graphql do
     <<-GQL
       mutation($input: TaxCreateInput!) {
         createTax(input: $input) {
-          id name code description rate plansCount chargesCount customersCount
+          id name code description rate addOnsCount plansCount chargesCount customersCount
         }
       }
     GQL

--- a/spec/serializers/v1/tax_serializer_spec.rb
+++ b/spec/serializers/v1/tax_serializer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ::V1::TaxSerializer do
       'code' => tax.code,
       'rate' => tax.rate,
       'description' => tax.description,
+      'add_ons_count' => 0,
       'customers_count' => 0,
       'plans_count' => 0,
       'charges_count' => 0,


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at add ons level.

## Description

This PR adds the ability to return the number of add ons impacted by a tax.