### PR TITLE
fix(register): Do not permit signup when disabled

### DIFF
--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -17,6 +17,8 @@ class UsersService < BaseService
   end
 
   def register(email, password, organization_name)
+    return result.not_allowed_failure!(code: 'signup is disabled') if ENV.fetch('LAGO_SIGNUP_DISABLED', 'false') == 'true'
+
     result.user = User.find_or_initialize_by(email:)
 
     if result.user.id

--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -17,7 +17,9 @@ class UsersService < BaseService
   end
 
   def register(email, password, organization_name)
-    return result.not_allowed_failure!(code: 'signup is disabled') if ENV.fetch('LAGO_SIGNUP_DISABLED', 'false') == 'true'
+    if ENV.fetch('LAGO_SIGNUP_DISABLED', 'false') == 'true'
+      return result.not_allowed_failure!(code: 'signup is disabled')
+    end
 
     result.user = User.find_or_initialize_by(email:)
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -613,6 +613,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_095510) do
     t.index ["parent_id"], name: "index_plans_on_parent_id"
   end
 
+  create_table "plans_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "plan_id", null: false
+    t.uuid "tax_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["plan_id"], name: "index_plans_taxes_on_plan_id"
+    t.index ["tax_id"], name: "index_plans_taxes_on_tax_id"
+  end
+
   create_table "quantified_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "customer_id", null: false
     t.string "external_subscription_id", null: false
@@ -629,15 +638,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_095510) do
     t.index ["customer_id"], name: "index_quantified_events_on_customer_id"
     t.index ["deleted_at"], name: "index_quantified_events_on_deleted_at"
     t.index ["external_id"], name: "index_quantified_events_on_external_id"
-  end
-
-  create_table "plans_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "plan_id", null: false
-    t.uuid "tax_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["plan_id"], name: "index_plans_taxes_on_plan_id"
-    t.index ["tax_id"], name: "index_plans_taxes_on_tax_id"
   end
 
   create_table "refunds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -746,6 +746,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_095510) do
     t.string "webhook_url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "signature_algo", default: 0, null: false
     t.index ["organization_id"], name: "index_webhook_endpoints_on_organization_id"
     t.index ["webhook_url", "organization_id"], name: "index_webhook_endpoints_on_webhook_url_and_organization_id", unique: true
   end
@@ -830,9 +831,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_095510) do
   add_foreign_key "payments", "payment_providers"
   add_foreign_key "plans", "organizations"
   add_foreign_key "plans", "plans", column: "parent_id"
-  add_foreign_key "quantified_events", "customers"
   add_foreign_key "plans_taxes", "plans"
   add_foreign_key "plans_taxes", "taxes"
+  add_foreign_key "quantified_events", "customers"
   add_foreign_key "refunds", "credit_notes"
   add_foreign_key "refunds", "payment_provider_customers"
   add_foreign_key "refunds", "payment_providers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -613,15 +613,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_095510) do
     t.index ["parent_id"], name: "index_plans_on_parent_id"
   end
 
-  create_table "plans_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "plan_id", null: false
-    t.uuid "tax_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["plan_id"], name: "index_plans_taxes_on_plan_id"
-    t.index ["tax_id"], name: "index_plans_taxes_on_tax_id"
-  end
-
   create_table "quantified_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "customer_id", null: false
     t.string "external_subscription_id", null: false
@@ -638,6 +629,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_095510) do
     t.index ["customer_id"], name: "index_quantified_events_on_customer_id"
     t.index ["deleted_at"], name: "index_quantified_events_on_deleted_at"
     t.index ["external_id"], name: "index_quantified_events_on_external_id"
+  end
+
+  create_table "plans_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "plan_id", null: false
+    t.uuid "tax_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["plan_id"], name: "index_plans_taxes_on_plan_id"
+    t.index ["tax_id"], name: "index_plans_taxes_on_tax_id"
   end
 
   create_table "refunds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -746,7 +746,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_095510) do
     t.string "webhook_url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "signature_algo", default: 0, null: false
     t.index ["organization_id"], name: "index_webhook_endpoints_on_organization_id"
     t.index ["webhook_url", "organization_id"], name: "index_webhook_endpoints_on_webhook_url_and_organization_id", unique: true
   end
@@ -831,9 +830,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_095510) do
   add_foreign_key "payments", "payment_providers"
   add_foreign_key "plans", "organizations"
   add_foreign_key "plans", "plans", column: "parent_id"
+  add_foreign_key "quantified_events", "customers"
   add_foreign_key "plans_taxes", "plans"
   add_foreign_key "plans_taxes", "taxes"
-  add_foreign_key "quantified_events", "customers"
   add_foreign_key "refunds", "credit_notes"
   add_foreign_key "refunds", "payment_provider_customers"
   add_foreign_key "refunds", "payment_providers"

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -51,6 +51,25 @@ RSpec.describe UsersService, type: :service do
         end
       end
     end
+
+    context 'when signup is disabled' do
+      before do
+        ENV['LAGO_SIGNUP_DISABLED'] = 'true'
+      end
+
+      after do
+        ENV['LAGO_SIGNUP_DISABLED'] = nil
+      end
+
+      it 'returns a not allowed error' do
+        result = user_service.register('email', 'password', 'organization_name')
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.message).to eq('signup is disabled')
+        end
+      end
+    end
   end
 
   describe 'register_from_invite' do


### PR DESCRIPTION
## Context

https://github.com/getlago/lago/issues/220

## Description

- Do not permit register (signup) when its disabled with `LAGO_SIGNUP_DISABLED` env var is set to `true`
