### PR TITLE
feat(invoice) display net payment term

### DIFF
--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -9,6 +9,7 @@ module V1
         number: model.number,
         issuing_date: model.issuing_date.iso8601,
         payment_due_date: model.payment_due_date.iso8601,
+        net_payment_term: model.net_payment_term,
         invoice_type: model.invoice_type,
         status: model.status,
         payment_status: model.payment_status,

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -17,6 +17,7 @@ module Invoices
           customer:,
           issuing_date:,
           payment_due_date:,
+          net_payment_term: customer.applicable_net_payment_term,
           invoice_type: :add_on,
           payment_status: :pending,
           currency:,

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -17,6 +17,7 @@ module Invoices
           customer:,
           issuing_date:,
           payment_due_date:,
+          net_payment_term: customer.applicable_net_payment_term,
           invoice_type: :subscription,
           payment_status: :pending,
           currency: customer.currency,

--- a/app/services/invoices/one_off_service.rb
+++ b/app/services/invoices/one_off_service.rb
@@ -27,6 +27,7 @@ module Invoices
           customer:,
           issuing_date:,
           payment_due_date:,
+          net_payment_term: customer.applicable_net_payment_term,
           invoice_type: :one_off,
           currency:,
           timezone: customer.applicable_timezone,

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -17,6 +17,7 @@ module Invoices
           customer:,
           issuing_date:,
           payment_due_date: issuing_date,
+          net_payment_term: customer.applicable_net_payment_term,
           invoice_type: :credit,
           payment_status: :pending,
           currency:,

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -16,7 +16,7 @@ module Invoices
           organization: customer.organization,
           customer:,
           issuing_date:,
-          payment_due_date: issuing_date,
+          payment_due_date:,
           net_payment_term: customer.applicable_net_payment_term,
           invoice_type: :credit,
           payment_status: :pending,
@@ -96,6 +96,10 @@ module Invoices
 
     def issuing_date
       Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone).to_date
+    end
+
+    def payment_due_date
+      (issuing_date + customer.applicable_net_payment_term.days).to_date
     end
 
     def should_deliver_email?

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -29,6 +29,7 @@ module Invoices
           customer:,
           issuing_date:,
           payment_due_date:,
+          net_payment_term: customer.applicable_net_payment_term,
           invoice_type: :subscription,
           currency:,
           timezone: customer.applicable_timezone,

--- a/app/views/templates/invoices/charge.slim
+++ b/app/views/templates/invoices/charge.slim
@@ -349,6 +349,9 @@ html
             tr
               td.body-1 = I18n.t('invoice.issue_date')
               td.body-2 = I18n.l(issuing_date, format: :default)
+            tr
+              td.body-1 = I18n.t('invoice.payment_term')
+              td.body-2 = I18n.t('invoice.payment_term_days', net_payment_term:)
         .invoice-information-column
           table.invoice-information-table
             - if customer.metadata.displayable.any?

--- a/app/views/templates/invoices/one_off.slim
+++ b/app/views/templates/invoices/one_off.slim
@@ -350,6 +350,9 @@ html
             tr
               td.body-1 = I18n.t('invoice.issue_date')
               td.body-2 = I18n.l(issuing_date, format: :default)
+            tr
+              td.body-1 = I18n.t('invoice.payment_term')
+              td.body-2 = I18n.t('invoice.payment_term_days', net_payment_term:)
         .invoice-information-column
           table.invoice-information-table
             - if customer.metadata.displayable.any?

--- a/app/views/templates/invoices/v3.slim
+++ b/app/views/templates/invoices/v3.slim
@@ -355,6 +355,9 @@ html
             tr
               td.body-1 = I18n.t('invoice.issue_date')
               td.body-2 = I18n.l(issuing_date, format: :default)
+            tr
+              td.body-1 = I18n.t('invoice.payment_term')
+              td.body-2 = I18n.t('invoice.payment_term_days', net_payment_term:)
         .invoice-information-column
           table.invoice-information-table
             - if customer.metadata.displayable.any?

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -3,6 +3,8 @@ de:
     document_name: Rechnung
     invoice_number: Rechnungsnummer
     issue_date: Ausgabedatum
+    payment_term: Zahlungsfrist
+    payment_term_days: "%{net_payment_term} Tage"
     bill_from: Von
     bill_to: An
     due_date: Fälligkeit %{date}

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -3,6 +3,8 @@ en:
     document_name: Invoice
     invoice_number: Invoice Number
     issue_date: Issue Date
+    payment_term: Payment term
+    payment_term_days: "%{net_payment_term} days"
     bill_from: From
     bill_to: Bill to
     due_date: Due %{date}

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -3,6 +3,8 @@ fr:
     document_name: Facture
     invoice_number: Nº de facture
     issue_date: Date d'émission
+    payment_term: Délai de paiement
+    payment_term_days: "%{net_payment_term} jours"
     bill_from: De
     bill_to: Facturé à
     due_date: Date d'échéance le %{date}

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -3,6 +3,8 @@ nb:
     document_name: Faktura
     invoice_number: Fakturanummer
     issue_date: Dato
+    payment_term: Betalingsperiode
+    payment_term_days: "%{net_payment_term} dager"
     bill_from: Fra
     bill_to: Til
     due_date: Forfallsdato %{date}

--- a/db/migrate/20230731135721_add_net_payment_term_to_invoice.rb
+++ b/db/migrate/20230731135721_add_net_payment_term_to_invoice.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddNetPaymentTermToInvoice < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invoices, :net_payment_term, :integer, default: 0, null: false
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          ALTER TABLE invoices
+            ADD CONSTRAINT check_organizations_on_net_payment_term
+            CHECK (net_payment_term >= 0);
+        SQL
+      end
+
+      dir.down do
+        execute <<-SQL
+          ALTER TABLE invoices DROP CONSTRAINT check_organizations_on_net_payment_term;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_31_095510) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_31_135721) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -481,8 +481,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_31_095510) do
     t.bigint "sub_total_excluding_taxes_amount_cents", default: 0, null: false
     t.bigint "sub_total_including_taxes_amount_cents", default: 0, null: false
     t.date "payment_due_date"
+    t.integer "net_payment_term", default: 0, null: false
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
+    t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"
   end
 
   create_table "invoices_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe ::V1::InvoiceSerializer do
         'number' => invoice.number,
         'issuing_date' => invoice.issuing_date.iso8601,
         'payment_due_date' => invoice.payment_due_date.iso8601,
+        'net_payment_term' => invoice.net_payment_term,
         'invoice_type' => invoice.invoice_type,
         'status' => invoice.status,
         'payment_status' => invoice.payment_status,


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/define-invoice-due-date

## Context

We want to allow defining a payment due date that is different than the invoice issuing date

## Description

This PR does
- add the net_payment_term on the invoice
- make the payment_due_date dynamic on prepaid credits invoices (was forgotten in previous PR)