### PR TITLE
fix (charges): do not bill recurring pay in advance charges upon termination

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -134,7 +134,8 @@ module Invoices
     def should_not_create_charge_fee?(charge, subscription)
       (charge.pay_in_advance? || !charge.prorated?) &&
         charge.billable_metric.recurring? &&
-        subscription.terminated?
+        subscription.terminated? &&
+        (subscription.upgraded? || subscription.next_subscription.nil?)
     end
 
     def should_create_subscription_fee?(subscription)

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -134,8 +134,7 @@ module Invoices
     def should_not_create_charge_fee?(charge, subscription)
       (charge.pay_in_advance? || !charge.prorated?) &&
         charge.billable_metric.recurring? &&
-        subscription.terminated? &&
-        subscription.upgraded?
+        subscription.terminated?
     end
 
     def should_create_subscription_fee?(subscription)

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         end
       end
 
-      context 'charges are pay in advance and billable metric is recurring' do
+      context 'when charges are pay in advance and billable metric is recurring' do
         let(:billable_metric) do
           create(:billable_metric, aggregation_type: 'unique_count_agg', recurring: true, field_name: 'item_id')
         end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         end
       end
 
-      context 'when charge is pay_in_advance, not recurring and invoiceable ' do
+      context 'when charge is pay_in_advance, not recurring and invoiceable' do
         let(:charge) do
           create(
             :standard_charge,
@@ -113,7 +113,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         end
       end
 
-      context 'when charge is pay_in_advance, recurring and invoiceable ' do
+      context 'when charge is pay_in_advance, recurring and invoiceable' do
         let(:billable_metric) do
           create(:billable_metric, aggregation_type: 'unique_count_agg', recurring: true, field_name: 'item_id')
         end
@@ -234,6 +234,32 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             to_datetime: match_datetime(terminated_at),
             from_datetime: match_datetime(terminated_at.beginning_of_month),
           )
+        end
+      end
+
+      context 'charges are pay in advance and billable metric is recurring' do
+        let(:billable_metric) do
+          create(:billable_metric, aggregation_type: 'unique_count_agg', recurring: true, field_name: 'item_id')
+        end
+        let(:charge) do
+          create(
+            :standard_charge,
+            :pay_in_advance,
+            plan: subscription.plan,
+            charge_model: 'standard',
+            invoiceable: true,
+            billable_metric:,
+          )
+        end
+
+        it 'does not create a charge fee' do
+          result = invoice_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(invoice.fees.charge_kind.count).to eq(0)
+          end
         end
       end
 


### PR DESCRIPTION
## Description

When billable metric is recurring and charge is pay in advance, we do not want to bill such charges upon subscription termination