### PR TITLE
fix(coupons): fix coupon base amount for multiple subscriptions

### DIFF
--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -24,7 +24,7 @@ module Credits
         before_taxes: true,
       )
 
-      fees.each do |fee|
+      fees.reload.each do |fee|
         fee.precise_coupons_amount_cents += (credit_amount * fee.amount_cents).fdiv(base_amount_cents)
         fee.precise_coupons_amount_cents = fee.amount_cents if fee.amount_cents < fee.precise_coupons_amount_cents
         fee.save!

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -43,7 +43,8 @@ module Invoices
           create_charges_fees(subscription, boundaries) if should_create_charge_fees?(subscription)
 
           invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
-          invoice.sub_total_excluding_taxes_amount_cents = invoice.fees.sum(:amount_cents)
+          invoice.sub_total_excluding_taxes_amount_cents = invoice.fees.sum(:amount_cents) -
+                                                           invoice.coupons_amount_cents
           Credits::AppliedCouponsService.call(invoice:) if should_create_coupon_credit?
 
           Invoices::ComputeAmountsFromFees.call(invoice:)


### PR DESCRIPTION
## Description

Invoice `sub_total_excluding_taxes_amount_cents` was not correctly calculated and because of that coupon base amount was wrong (applied coupons amount was higher than invoice fees). Applying coupons with limitations are not affected here since we have validation that prevents applying coupons with same limitations on the given invoice