### PR TITLE
fix(invoice): Ensure mailer can be sent for deleted charges/plans

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -6,8 +6,8 @@ class Charge < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
-  belongs_to :plan, touch: true
-  belongs_to :billable_metric
+  belongs_to :plan, -> { with_discarded }, touch: true
+  belongs_to :billable_metric, -> { with_discarded }
 
   has_many :fees
   has_many :group_properties, dependent: :destroy


### PR DESCRIPTION
## Context

Some invoice mailer failed to execute because they were related to deleted plans, leading to a `NoMethodError: undefined method amount_currency for nil:NilClass`

## Description

This PR ensures that the plan `amount_currency` is accessible in `monetize :min_amount_cents` at charge level even if the related plan is soft deleted