### PR TITLE
fix(webhook): Handle auto retry with EOFError

### DIFF
--- a/app/services/webhooks/base_service.rb
+++ b/app/services/webhooks/base_service.rb
@@ -65,7 +65,7 @@ module Webhooks
       response = http_client.post_with_response(payload, headers)
 
       succeed_webhook(webhook, response)
-    rescue LagoHttpClient::HttpError, Net::ReadTimeout, Errno::ECONNRESET, SocketError => e
+    rescue LagoHttpClient::HttpError, Net::ReadTimeout, Errno::ECONNRESET, SocketError, EOFError => e
       fail_webhook(webhook, e)
 
       # NOTE: By default, Lago is retrying 3 times a webhook


### PR DESCRIPTION
## Context

Some webhooks are failing to deliver with an `EOFError` error.

This error appears when the webhook clients tries to read in a network socket that has been closed by the server.

## Description

Has the only possible way to handle this kind of error is to retry to send the webhook, this PR adds the `EOFError` to the list of rescued and retried errors.