### PR TITLE
feat(tax): Add taxes to graphql add_ons create/update

### DIFF
--- a/app/graphql/mutations/add_ons/create.rb
+++ b/app/graphql/mutations/add_ons/create.rb
@@ -9,11 +9,7 @@ module Mutations
       graphql_name 'CreateAddOn'
       description 'Creates a new add-on'
 
-      argument :amount_cents, GraphQL::Types::BigInt, required: true
-      argument :amount_currency, Types::CurrencyEnum, required: true
-      argument :code, String, required: true
-      argument :description, String, required: false
-      argument :name, String, required: true
+      input_object_class Types::AddOns::CreateInput
 
       type Types::AddOns::Object
 

--- a/app/graphql/mutations/add_ons/update.rb
+++ b/app/graphql/mutations/add_ons/update.rb
@@ -8,12 +8,7 @@ module Mutations
       graphql_name 'UpdateAddOn'
       description 'Update an existing add-on'
 
-      argument :amount_cents, GraphQL::Types::BigInt, required: true
-      argument :amount_currency, Types::CurrencyEnum, required: true
-      argument :code, String, required: true
-      argument :description, String, required: false
-      argument :id, ID, required: true
-      argument :name, String, required: true
+      input_object_class Types::AddOns::UpdateInput
 
       type Types::AddOns::Object
 

--- a/app/graphql/types/add_ons/create_input.rb
+++ b/app/graphql/types/add_ons/create_input.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Types
+  module AddOns
+    class CreateInput < Types::BaseInputObject
+      graphql_name 'CreateAddOnInput'
+
+      argument :amount_cents, GraphQL::Types::BigInt, required: true
+      argument :amount_currency, Types::CurrencyEnum, required: true
+      argument :code, String, required: true
+      argument :description, String, required: false
+      argument :name, String, required: true
+      argument :tax_codes, [String], required: false
+    end
+  end
+end

--- a/app/graphql/types/add_ons/object.rb
+++ b/app/graphql/types/add_ons/object.rb
@@ -22,6 +22,8 @@ module Types
       field :applied_add_ons_count, Integer, null: false
       field :customer_count, Integer, null: false, description: 'Number of customers using this add-on'
 
+      field :taxes, [Types::Taxes::Object]
+
       def customer_count
         object.applied_add_ons.select(:customer_id).distinct.count
       end

--- a/app/graphql/types/add_ons/update_input.rb
+++ b/app/graphql/types/add_ons/update_input.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Types
+  module AddOns
+    class UpdateInput < Types::BaseInputObject
+      graphql_name 'UpdateAddOnInput'
+
+      argument :amount_cents, GraphQL::Types::BigInt, required: true
+      argument :amount_currency, Types::CurrencyEnum, required: true
+      argument :code, String, required: true
+      argument :description, String, required: false
+      argument :id, ID, required: true
+      argument :name, String, required: true
+      argument :tax_codes, [String], required: false
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1538,6 +1538,7 @@ input CreateAddOnInput {
   code: String!
   description: String
   name: String!
+  taxCodes: [String!]
 }
 
 """
@@ -5301,6 +5302,7 @@ input UpdateAddOnInput {
   description: String
   id: ID!
   name: String!
+  taxCodes: [String!]
 }
 
 """

--- a/schema.graphql
+++ b/schema.graphql
@@ -58,6 +58,7 @@ type AddOn {
   id: ID!
   name: String!
   organization: Organization
+  taxes: [Tax!]
   updatedAt: ISO8601DateTime!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -390,6 +390,28 @@
               ]
             },
             {
+              "name": "taxes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Tax",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "updatedAt",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -4270,18 +4270,6 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "clientMutationId",
-              "description": "A unique identifier for the client performing the mutation.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "amountCents",
               "description": null,
               "type": {
@@ -4352,6 +4340,38 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxCodes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -21126,18 +21146,6 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "clientMutationId",
-              "description": "A unique identifier for the client performing the mutation.",
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "amountCents",
               "description": null,
               "type": {
@@ -21224,6 +21232,38 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxCodes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientMutationId",
+              "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/mutations/add_ons/create_spec.rb
+++ b/spec/graphql/mutations/add_ons/create_spec.rb
@@ -4,6 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Mutations::AddOns::Create, type: :graphql do
   let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:tax) { create(:tax, organization:) }
   let(:mutation) do
     <<-GQL
       mutation($input: CreateAddOnInput!) {
@@ -13,7 +15,8 @@ RSpec.describe Mutations::AddOns::Create, type: :graphql do
           code,
           description,
           amountCents,
-          amountCurrency
+          amountCurrency,
+          taxes { id code rate }
         }
       }
     GQL
@@ -31,6 +34,7 @@ RSpec.describe Mutations::AddOns::Create, type: :graphql do
           description: 'some text',
           amountCents: 5000,
           amountCurrency: 'EUR',
+          taxCodes: [tax.code],
         },
       },
     )
@@ -44,6 +48,7 @@ RSpec.describe Mutations::AddOns::Create, type: :graphql do
       expect(result_data['description']).to eq('some text')
       expect(result_data['amountCents']).to eq('5000')
       expect(result_data['amountCurrency']).to eq('EUR')
+      expect(result_data['taxes'].map { |t| t['code'] }).to contain_exactly(tax.code)
     end
   end
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at add ons level.

## Description

This PR adds the ability to send `taxCodes` as a parameter of add-on resource, and returns `taxes`.