### PR TITLE
feat(tax): Apply taxes to add on fees

### DIFF
--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -52,6 +52,7 @@ module Fees
     end
 
     def applicable_taxes
+      return fee.add_on.taxes if fee.add_on? && fee.add_on.taxes.any?
       return fee.charge.taxes if fee.charge? && fee.charge.taxes.any?
       return fee.subscription.plan.taxes if (fee.charge? || fee.subscription?) && fee.subscription.plan.taxes.any?
       return customer.taxes if customer.taxes.any?

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
             unit_amount_cents: 1200,
             units: 2,
             description: 'desc-123',
+            tax_codes: [tax.code],
           },
           {
             add_on_code: add_on_second.code,


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/create-several-tax-rates](https://getlago.canny.io/feature-requests/p/create-several-tax-rates)

## Context

After the delivery of the "multiple taxes" feature https://github.com/getlago/lago-api/pull/1104, we now want to be able to define taxes at add ons level.

## Description

This PR permits to apply taxes from add-on.