### PR TITLE
fix(invoice): revert changes for payment_due_date on templates

### DIFF
--- a/app/views/templates/invoices/charge.slim
+++ b/app/views/templates/invoices/charge.slim
@@ -410,7 +410,7 @@ html
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(total_amount)
-        .body-1 = I18n.t('invoice.due_date', date: I18n.l(payment_due_date, format: :default))
+        .body-1 = I18n.t('invoice.due_date', date: I18n.l(issuing_date, format: :default))
 
       .invoice-resume.mb-24.overflow-auto
         table.invoice-resume-table width="100%"

--- a/app/views/templates/invoices/one_off.slim
+++ b/app/views/templates/invoices/one_off.slim
@@ -411,7 +411,7 @@ html
 
       .mb-24
         h2.title-2.mb-4 = total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
-        .body-1 = I18n.t('invoice.due_date', date: I18n.l(payment_due_date, format: :default))
+        .body-1 = I18n.t('invoice.due_date', date: I18n.l(issuing_date, format: :default))
 
       .invoice-resume.mb-24.overflow-auto
         table.invoice-resume-table width="100%"

--- a/app/views/templates/invoices/v3.slim
+++ b/app/views/templates/invoices/v3.slim
@@ -416,7 +416,7 @@ html
 
       .mb-24
         h2.title-2.mb-4 = MoneyHelper.format(total_amount)
-        .body-1 = I18n.t('invoice.due_date', date: I18n.l(payment_due_date, format: :default))
+        .body-1 = I18n.t('invoice.due_date', date: I18n.l(issuing_date, format: :default))
 
       .invoice-resume.mb-24.overflow-auto
         - if credit?


### PR DESCRIPTION
## Context

Since the merge of https://github.com/getlago/lago-api/pull/1193, it is not possible to generate the PDF for invoice created before the release.

The reason behind this is that the template now rely on the `payment_due_date` field but this field was not filled for existing invoice

## Description

The fix for now is to rollback to the previous state on invoice template using `issuing_date` field