### PR TITLE
fix(subscription): Charge to date boundaries for yearly plan

### DIFF
--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -44,7 +44,7 @@ module Subscriptions
           return subscription.anniversary? ? previous_anniversary_day(billing_date) : billing_date.beginning_of_year
         end
 
-        return from_datetime if plan.pay_in_arrear?
+        return compute_from_date if plan.pay_in_arrear?
         return base_date.beginning_of_year if calendar?
 
         previous_anniversary_day(base_date)

--- a/spec/scenarios/customer_usage_spec.rb
+++ b/spec/scenarios/customer_usage_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Customer usage Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:, currency: 'EUR') }
+
+  let(:plan) { create(:plan, organization:, amount_cents: 700, pay_in_advance: false, interval: 'yearly') }
+
+  context 'with start date in the past' do
+    it 'retrieve the customer usage' do
+      travel_to(DateTime.new(2023, 8, 8, 9, 30)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+            subscription_at: DateTime.new(2023, 1, 1, 9, 30).iso8601,
+          },
+        )
+
+        subscription = customer.subscriptions.first
+        fetch_current_usage(customer:, subscription:)
+
+        expect(json[:customer_usage][:from_datetime]).to eq('2023-01-01T00:00:00Z')
+        expect(json[:customer_usage][:to_datetime]).to eq('2023-12-31T23:59:59Z')
+      end
+    end
+
+    context 'with Europe/Berlin timezone' do
+      let(:timezone) { 'Europe/Berlin' }
+
+      it 'retrieve the customer usage' do
+        travel_to(DateTime.new(2023, 8, 8, 9, 30)) do
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code,
+              subscription_at: DateTime.new(2023, 1, 1, 9, 30).iso8601,
+            },
+          )
+
+          subscription = customer.subscriptions.first
+          fetch_current_usage(customer:, subscription:)
+
+          expect(json[:customer_usage][:from_datetime]).to eq('2022-12-31T23:00:00Z')
+          expect(json[:customer_usage][:to_datetime]).to eq('2023-12-31T22:59:59Z')
+        end
+      end
+    end
+
+    context 'with America/Los_Angeles timezone' do
+      let(:timezone) { 'America/Los_Angeles' }
+
+      it 'retrieve the customer usage' do
+        travel_to(DateTime.new(2023, 8, 8, 9, 30)) do
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code,
+              subscription_at: DateTime.new(2023, 1, 1, 9, 30).iso8601,
+            },
+          )
+
+          subscription = customer.subscriptions.first
+          fetch_current_usage(customer:, subscription:)
+
+          expect(json[:customer_usage][:from_datetime]).to eq('2023-01-01T08:00:00Z')
+          expect(json[:customer_usage][:to_datetime]).to eq('2024-01-01T07:59:59Z')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

The `to_datetime` boundary for customer current usage is wrong if the plan is yearly payed in advance and calendar and if the customer have a timezone.

The underlying issue is that the `charges_from_datetime` computation in the yearly date service is using the `from_datetime` method which already takes the customer timezone into account, leading to a wrong result when the timezone is before UTC (example: 'Europe/Berlin').

## Description

The fix is to rely on `compute_from_date` to get the from date before the timezone shift. The next steps of the service are already handling the shift to the customer timezone and started_at/terminated_at