### PR TITLE
feat(charge): Add graduated percentage charge model validation

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -21,6 +21,7 @@ class Charge < ApplicationRecord
     package
     percentage
     volume
+    graduated_percentage
   ].freeze
 
   enum charge_model: CHARGE_MODELS
@@ -30,6 +31,7 @@ class Charge < ApplicationRecord
   validate :validate_package, if: -> { package? && group_properties.empty? }
   validate :validate_percentage, if: -> { percentage? && group_properties.empty? }
   validate :validate_volume, if: -> { volume? && group_properties.empty? }
+  validate :validate_graduated_percentage, if: -> { graduated_percentage? && group_properties.empty? }
 
   validates :min_amount_cents, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 
@@ -68,6 +70,10 @@ class Charge < ApplicationRecord
 
   def validate_volume
     validate_charge_model(Charges::Validators::VolumeService)
+  end
+
+  def validate_graduated_percentage
+    validate_charge_model(Charges::Validators::GraduatedPercentageService)
   end
 
   def validate_charge_model(validator)

--- a/app/services/charges/validators/graduated_percentage_service.rb
+++ b/app/services/charges/validators/graduated_percentage_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Charges
+  module Validators
+    class GraduatedPercentageService < Charges::Validators::BaseService
+      include ::Validators::RangeBoundsValidator
+
+      def valid?
+        if ranges.blank?
+          add_error(field: :graduated_percentage_ranges, error_code: 'missing_graduated_percentage_ranges')
+        else
+          next_from_value = 0
+
+          ranges.each_with_index do |range, index|
+            validate_rate_and_amounts(range)
+
+            unless valid_bounds?(range, index, next_from_value)
+              add_error(field: :graduated_percentage_ranges, error_code: 'invalid_graduated_percentage_ranges')
+            end
+
+            next_from_value = (range[:to_value] || 0) + 1
+          end
+        end
+
+        super
+      end
+
+      private
+
+      def ranges
+        charge.properties['graduated_percentage_ranges'].map(&:with_indifferent_access)
+      end
+
+      def validate_rate_and_amounts(range)
+        unless ::Validators::DecimalAmountService.valid_amount?(range[:fixed_amount])
+          add_error(field: :fixed_amount, error_code: 'invalid_amount')
+        end
+
+        unless ::Validators::DecimalAmountService.valid_amount?(range[:flat_amount])
+          add_error(field: :flat_amount, error_code: 'invalid_amount')
+        end
+
+        return if ::Validators::DecimalAmountService.valid_amount?(range[:rate])
+
+        add_error(field: :rate, error_code: 'invalid_rate')
+      end
+    end
+  end
+end

--- a/app/services/charges/validators/graduated_service.rb
+++ b/app/services/charges/validators/graduated_service.rb
@@ -3,6 +3,8 @@
 module Charges
   module Validators
     class GraduatedService < Charges::Validators::BaseService
+      include ::Validators::RangeBoundsValidator
+
       def valid?
         if ranges.blank?
           add_error(field: :graduated_ranges, error_code: 'missing_graduated_ranges')
@@ -36,13 +38,6 @@ module Charges
         return if ::Validators::DecimalAmountService.new(range[:flat_amount]).valid_amount?
 
         add_error(field: :flat_amount, error_code: 'invalid_amount')
-      end
-
-      def valid_bounds?(range, index, next_from_value)
-        range[:from_value] == (next_from_value) && (
-          index == (ranges.size - 1) && range[:to_value].nil? ||
-          index < (ranges.size - 1) && (range[:to_value] || 0) > range[:from_value]
-        )
       end
     end
   end

--- a/app/services/charges/validators/volume_service.rb
+++ b/app/services/charges/validators/volume_service.rb
@@ -3,6 +3,8 @@
 module Charges
   module Validators
     class VolumeService < Charges::Validators::BaseService
+      include ::Validators::RangeBoundsValidator
+
       def valid?
         if ranges.blank?
           add_error(field: :volume_ranges, error_code: 'missing_volume_ranges')
@@ -35,13 +37,6 @@ module Charges
         return if ::Validators::DecimalAmountService.new(range[:flat_amount]).valid_amount?
 
         add_error(field: :flat_amount, error_code: 'invalid_amount')
-      end
-
-      def valid_bounds?(range, index, next_from_value)
-        range[:from_value] == (next_from_value) && (
-          index == (ranges.size - 1) && range[:to_value].nil? ||
-          index < (ranges.size - 1) && (range[:to_value] || 0) > range[:from_value]
-        )
       end
     end
   end

--- a/app/services/validators/decimal_amount_service.rb
+++ b/app/services/validators/decimal_amount_service.rb
@@ -2,6 +2,14 @@
 
 module Validators
   class DecimalAmountService
+    def self.valid_amount?(amount)
+      new(amount).valid_amount?
+    end
+
+    def self.valid_positive_amount?(amount)
+      new(amount).valid_positive_amount?
+    end
+
     def initialize(amount)
       @amount = amount
     end

--- a/app/services/validators/range_bounds_validator.rb
+++ b/app/services/validators/range_bounds_validator.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Validators
+  module RangeBoundsValidator
+    def valid_bounds?(range, index, next_from_value)
+      range[:from_value] == (next_from_value) && (
+        index == (ranges.size - 1) && range[:to_value].nil? ||
+        index < (ranges.size - 1) && (range[:to_value] || 0) > range[:from_value]
+      )
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -200,6 +200,7 @@ input ChargeInput {
 
 enum ChargeModelEnum {
   graduated
+  graduated_percentage
   package
   percentage
   standard

--- a/schema.json
+++ b/schema.json
@@ -2011,6 +2011,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "graduated_percentage",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -52,6 +52,30 @@ FactoryBot.define do
       end
     end
 
+    factory :graduated_percentage_charge do
+      charge_model { 'graduated_percentage' }
+      properties do
+        {
+          graduated_percentage_ranges: [
+            {
+              from_value: 0,
+              to_value: 10,
+              rate: '0',
+              fixed_amount: '0.00010',
+              flat_amount: '200',
+            },
+            {
+              from_value: 11,
+              to_value: null,
+              rate: '0',
+              fixed_amount: '0.00010',
+              flat_amount: '300',
+            },
+          ],
+        }
+      end
+    end
+
     trait :pay_in_advance do
       pay_in_advance { true }
     end

--- a/spec/services/charges/validators/graduated_percentage_service_spec.rb
+++ b/spec/services/charges/validators/graduated_percentage_service_spec.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service do
+  subject(:graduated_percentage_service) { described_class.new(charge:) }
+
+  let(:charge) do
+    build(
+      :graduated_percentage_charge,
+      properties: { graduated_percentage_ranges: ranges },
+    )
+  end
+
+  let(:ranges) { {} }
+
+  describe '.valid?' do
+    context 'with ranges validation' do
+      it 'ensures the presences of ranges' do
+        aggregate_failures do
+          expect(graduated_percentage_service).not_to be_valid
+          expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(graduated_percentage_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
+          expect(graduated_percentage_service.result.error.messages[:graduated_percentage_ranges])
+            .to include('missing_graduated_percentage_ranges')
+        end
+      end
+
+      context 'when ranges does not starts at 0' do
+        let(:ranges) { [{ from_value: -1, to_value: 100 }] }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
+            expect(graduated_percentage_service.result.error.messages[:graduated_percentage_ranges])
+              .to include('invalid_graduated_percentage_ranges')
+          end
+        end
+      end
+
+      context 'when ranges does not ends at infinity' do
+        let(:ranges) { [{ from_value: 0, to_value: 100 }] }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
+            expect(graduated_percentage_service.result.error.messages[:graduated_percentage_ranges])
+              .to include('invalid_graduated_percentage_ranges')
+          end
+        end
+      end
+
+      context 'when ranges have holes' do
+        let(:ranges) do
+          [
+            { from_value: 0, to_value: 100 },
+            { from_value: 120, to_value: 1000 },
+          ]
+        end
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
+            expect(graduated_percentage_service.result.error.messages[:graduated_percentage_ranges])
+              .to include('invalid_graduated_percentage_ranges')
+          end
+        end
+      end
+
+      context 'when ranges are overlapping' do
+        let(:ranges) do
+          [
+            { from_value: 0, to_value: 100 },
+            { from_value: 90, to_value: 1000 },
+          ]
+        end
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:graduated_percentage_ranges)
+            expect(graduated_percentage_service.result.error.messages[:graduated_percentage_ranges])
+              .to include('invalid_graduated_percentage_ranges')
+          end
+        end
+      end
+    end
+
+    context 'with rate validation' do
+      let(:ranges) { [{ from_value: 0, to_value: nil, rate:, flat_amount: '0', fixed_amount: '0' }] }
+
+      context 'with no range rate' do
+        let(:rate) { nil }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:rate)
+            expect(graduated_percentage_service.result.error.messages[:rate]).to include('invalid_rate')
+          end
+        end
+      end
+
+      context 'with invalid range rate' do
+        let(:rate) { 'foo' }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:rate)
+            expect(graduated_percentage_service.result.error.messages[:rate]).to include('invalid_rate')
+          end
+        end
+      end
+
+      context 'with negative range rate' do
+        let(:rate) { '-2' }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:rate)
+            expect(graduated_percentage_service.result.error.messages[:rate]).to include('invalid_rate')
+          end
+        end
+      end
+    end
+
+    context 'with flat amount validation' do
+      let(:ranges) { [{ from_value: 0, to_value: nil, rate: 2, flat_amount:, fixed_amount: '0' }] }
+
+      context 'with no range flat amount' do
+        let(:flat_amount) { nil }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:flat_amount)
+            expect(graduated_percentage_service.result.error.messages[:flat_amount]).to include('invalid_amount')
+          end
+        end
+      end
+
+      context 'with invalid range flat amount' do
+        let(:flat_amount) { 'foo' }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:flat_amount)
+            expect(graduated_percentage_service.result.error.messages[:flat_amount]).to include('invalid_amount')
+          end
+        end
+      end
+
+      context 'with negative range flat amount' do
+        let(:flat_amount) { '-4' }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:flat_amount)
+            expect(graduated_percentage_service.result.error.messages[:flat_amount]).to include('invalid_amount')
+          end
+        end
+      end
+    end
+
+    context 'with fixed amount validation' do
+      let(:ranges) { [{ from_value: 0, to_value: nil, rate: 2, flat_amount: '2', fixed_amount: }] }
+
+      context 'with no range fixed amount' do
+        let(:fixed_amount) { nil }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:fixed_amount)
+            expect(graduated_percentage_service.result.error.messages[:fixed_amount]).to include('invalid_amount')
+          end
+        end
+      end
+
+      context 'with invalid range fixed amount' do
+        let(:fixed_amount) { 'foo' }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:fixed_amount)
+            expect(graduated_percentage_service.result.error.messages[:fixed_amount]).to include('invalid_amount')
+          end
+        end
+      end
+
+      context 'with negative range fixed amount' do
+        let(:fixed_amount) { '-4' }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(graduated_percentage_service).not_to be_valid
+            expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(graduated_percentage_service.result.error.messages.keys).to include(:fixed_amount)
+            expect(graduated_percentage_service.result.error.messages[:fixed_amount]).to include('invalid_amount')
+          end
+        end
+      end
+    end
+
+    context 'with applicable ranges' do
+      let(:ranges) do
+        [
+          {
+            from_value: 0,
+            to_value: 10,
+            rate: '3',
+            fixed_amount: '0',
+            flat_amount: '0',
+          },
+          {
+            from_value: 11,
+            to_value: 20,
+            rate: '2',
+            fixed_amount: '10',
+            flat_amount: '20',
+          },
+          {
+            from_value: 21,
+            to_value: nil,
+            rate: '1',
+            fixed_amount: '15',
+            flat_amount: '30',
+          },
+        ]
+      end
+
+      it { expect(graduated_percentage_service).to be_valid }
+    end
+  end
+end


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a new graduated percentage charge model similar to the current graduated charge model but applying a rate to the units rather than an amount.

## Description

This PR adds:
- The `graduated_percentage` value in `Charge#CHARGE_MODELS` enum as well as in the GraphQL `ChargeModelEnum`
- The charge model validation logic
