### PR TITLE
fix (migration): fix failing migration

### DIFF
--- a/db/migrate/20221021135946_fill_properties_on_persisted_events.rb
+++ b/db/migrate/20221021135946_fill_properties_on_persisted_events.rb
@@ -3,6 +3,6 @@
 class FillPropertiesOnPersistedEvents < ActiveRecord::Migration[7.0]
   def change
     # NOTE: Wait to ensure workers are loaded with the added tasks
-    MigrationTaskJob.set(wait: 20.seconds).perform_later('events:fill_persisted_properties')
+    MigrationTaskJob.set(wait: 40.seconds).perform_later('events:fill_persisted_properties')
   end
 end

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -25,7 +25,7 @@ namespace :events do
 
   desc 'Fill missing properties on persisted_events'
   task fill_persisted_properties: :environment do
-    PersistedEvent.unscoped.find_each do |persisted_event|
+    QuantifiedEvent.unscoped.find_each do |persisted_event|
       event = Event.unscoped.where(
         organization_id: persisted_event.billable_metric.organization_id,
         customer_id: persisted_event.customer_id,


### PR DESCRIPTION
## Context

`PersistedEvent` model does not exist anymore. In order to perform migration correctly, we increased delay time for background job in order to renaming migration can finish before. Also, we are are using renamed model inside the task - `QuantifiedEvent`
