### PR TITLE
feat(charge): Allow creation of graduated percentage charges

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -34,6 +34,7 @@ class Charge < ApplicationRecord
   validate :validate_graduated_percentage, if: -> { graduated_percentage? && group_properties.empty? }
 
   validates :min_amount_cents, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :charge_model, presence: true
 
   validate :validate_group_properties
   validate :validate_pay_in_advance

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -57,7 +57,7 @@ module Plans
     def create_charge(plan, args)
       charge = plan.charges.new(
         billable_metric_id: args[:billable_metric_id],
-        charge_model: args[:charge_model]&.to_sym,
+        charge_model: charge_model(args),
         pay_in_advance: args[:pay_in_advance] || false,
         prorated: args[:prorated] || false,
         properties: args[:properties] || {},
@@ -71,6 +71,13 @@ module Plans
 
       charge.save!
       charge
+    end
+
+    def charge_model(args)
+      model = args[:charge_model]&.to_sym
+      return if model == :graduated_percentage && !License.premium?
+
+      model
     end
 
     def track_plan_created(plan)

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -66,7 +66,7 @@ module Plans
       charge = plan.charges.new(
         billable_metric_id: params[:billable_metric_id],
         amount_currency: params[:amount_currency],
-        charge_model: params[:charge_model]&.to_sym,
+        charge_model: charge_model(params),
         pay_in_advance: params[:pay_in_advance] || false,
         prorated: params[:prorated] || false,
         properties: params[:properties] || {},
@@ -86,6 +86,13 @@ module Plans
       end
 
       charge
+    end
+
+    def charge_model(params)
+      model = params[:charge_model]&.to_sym
+      return if model == :graduated_percentage && !License.premium?
+
+      model
     end
 
     def process_charges(plan, params_charges)


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a new graduated percentage charge model similar to the current graduated charge model but applying a rate to the units rather than an amount.

## Description

This PR allow the creation of graduated percentage charge as a premium feature
