### PR TITLE
fix(stripe): Add new filter for missing stripe payment webhooks

### DIFF
--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -140,6 +140,7 @@ module PaymentProviders
       when 'charge.succeeded'
         Invoices::Payments::StripeService
           .new.update_payment_status(
+            organization_id: organization.id,
             provider_payment_id: event.data.object.payment_intent,
             status: 'succeeded',
             metadata: event.data.object.metadata.to_h.symbolize_keys,
@@ -149,6 +150,7 @@ module PaymentProviders
 
         Invoices::Payments::StripeService
           .new.update_payment_status(
+            organization_id: organization.id,
             provider_payment_id: event.data.object.id,
             status:,
             metadata: event.data.object.metadata.to_h.symbolize_keys,

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -266,6 +266,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
 
     it 'updates the payment and invoice status' do
       result = stripe_service.update_payment_status(
+        organization_id: organization.id,
         provider_payment_id: 'ch_123456',
         status: 'succeeded',
       )
@@ -281,6 +282,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
     context 'when status is failed' do
       it 'updates the payment and invoice status' do
         result = stripe_service.update_payment_status(
+          organization_id: organization.id,
           provider_payment_id: 'ch_123456',
           status: 'failed',
         )
@@ -299,6 +301,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
 
       it 'does not update the status of invoice and payment' do
         result = stripe_service.update_payment_status(
+          organization_id: organization.id,
           provider_payment_id: 'ch_123456',
           status: 'succeeded',
         )
@@ -311,6 +314,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
     context 'with invalid status' do
       it 'does not update the status of invoice and payment' do
         result = stripe_service.update_payment_status(
+          organization_id: organization.id,
           provider_payment_id: 'ch_123456',
           status: 'foo-bar',
         )
@@ -329,6 +333,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
 
       it 'returns an empty result' do
         result = stripe_service.update_payment_status(
+          organization_id: organization.id,
           provider_payment_id: 'ch_123456',
           status: 'succeeded',
         )
@@ -342,6 +347,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       context 'with invoice id in metadata' do
         it 'returns an empty result' do
           result = stripe_service.update_payment_status(
+            organization_id: organization.id,
             provider_payment_id: 'ch_123456',
             status: 'succeeded',
             metadata: { lago_invoice_id: SecureRandom.uuid },
@@ -353,11 +359,10 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
           end
         end
 
-        context 'when invoice belongs to lago' do
-          let(:invoice) { create(:invoice) }
-
+        context 'when the invoice is found for organization' do
           it 'returns a not found failure' do
             result = stripe_service.update_payment_status(
+              organization_id: organization.id,
               provider_payment_id: 'ch_123456',
               status: 'succeeded',
               metadata: { lago_invoice_id: invoice.id },

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -242,6 +242,7 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
         expect(Invoices::Payments::StripeService).to have_received(:new)
         expect(payment_service).to have_received(:update_payment_status)
           .with(
+            organization_id: organization.id,
             provider_payment_id: 'pi_1JKS2Y2VYugoKSBzNHPFBNj9',
             status: 'succeeded',
             metadata: {
@@ -268,6 +269,7 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
         expect(Invoices::Payments::StripeService).to have_received(:new)
         expect(payment_service).to have_received(:update_payment_status)
           .with(
+            organization_id: organization.id,
             provider_payment_id: 'pi_123456',
             status: 'succeeded',
             metadata: {},


### PR DESCRIPTION
Same as https://github.com/getlago/lago-api/pull/1231 for Stripe payments

## Context

A lot of dead jobs are related to missing Stripe payments when receiving `payment_intent.payment_failed`, `payment_intent.succeeded` webhooks from Stripe.

One of the reasons for this kind of error is that the same Stripe Secret key could be shared between organizations. As a consequence, we could receive `customner.update` webhooks for customer attached to another organization, leading to `stripe_payment_not_found` error when the invoice is found in database.

## Description

The fix is to scope the invoice lookup in the `handle_missing_invoice` guard to the organization receiving the hook.
