### PR TITLE
fix(timezone): Correct calculation for true-up fee with timezone

### DIFF
--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -33,11 +33,10 @@ module Fees
     delegate :charge, :subscription, to: :fee
 
     def prorated_min_amount_cents
-      from_date = boundaries.charges_from_datetime.to_date
-      to_date = boundaries.charges_to_datetime.to_date
-
       # NOTE: number of days between beginning of the period and the termination date
-      number_of_day_to_bill = (to_date + 1.day - from_date).to_i
+      from_datetime = boundaries.charges_from_datetime.to_time
+      to_datetime = boundaries.charges_to_datetime.to_time
+      number_of_day_to_bill = (to_datetime - from_datetime).fdiv(1.day).ceil
 
       date_service.charge_single_day_price(charge:) * number_of_day_to_bill
     end

--- a/spec/scenarios/spending_minimum_spec.rb
+++ b/spec/scenarios/spending_minimum_spec.rb
@@ -26,7 +26,7 @@ describe 'Spending Minimum Scenarios', :scenarios, type: :request do
 
     it 'creates expected credit note and invoice' do
       ### 8 Jan: Create subscription
-      travel_to(DateTime.new(2023, 1, 8)) do
+      travel_to(DateTime.new(2023, 1, 8, 8)) do
         expect {
           create_subscription(
             {
@@ -51,7 +51,7 @@ describe 'Spending Minimum Scenarios', :scenarios, type: :request do
       expect(sub_invoice.total_amount_cents).to eq(4645) # 60 / 31 * 24
 
       ### 25 Feb: Create event and Terminate subscription
-      travel_to(DateTime.new(2023, 2, 25)) do
+      travel_to(DateTime.new(2023, 2, 25, 6)) do
         create_event(
           {
             code: metric.code,
@@ -183,7 +183,7 @@ describe 'Spending Minimum Scenarios', :scenarios, type: :request do
       expect(sub_invoice.total_amount_cents).to eq(4645) # 60 / 31 * 24
 
       ### 25 Feb: Create event and Terminate subscription
-      travel_to(DateTime.new(2023, 2, 25)) do
+      travel_to(DateTime.new(2023, 2, 25, 8)) do
         create_event(
           {
             code: metric.code,


### PR DESCRIPTION
The goal of this PR is to fix the billing calculation for a true-up fee when customer has a timezone.