### PR TITLE
bug(error) fix typo in error name

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -109,7 +109,7 @@ class Subscription < ApplicationRecord
 
     # NOTE: We want unique external id per organization.
     used_ids = organization.subscriptions.active.pluck(:external_id)
-    errors.add(:external_id, :value_already_exists) if used_ids&.include?(external_id)
+    errors.add(:external_id, :value_already_exist) if used_ids&.include?(external_id)
   end
 
   def downgrade_plan_date

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
         not_compatible_with_aggregation_type: not_compatible_with_aggregation_type
         invalid_timezone: invalid_timezone
         not_compatible_with_pay_in_advance: not_compatible_with_pay_in_advance
-        value_already_exists: value_already_exists
+        value_already_exist: value_already_exist
         too_long: value_is_too_long
         values_not_all_present: values_not_all_present
         unsupported_value: unsupported_value


### PR DESCRIPTION
## Context

While fixing an error on FE side, I noticed and error code was containing a typo. We usually send them without `s`

## Description

This PR fixes the error code to be as all others similar in the app