### PR TITLE
feat(charge): GrapgQL types for graduated percentage

### DIFF
--- a/app/graphql/types/charges/graduated_percentage_range.rb
+++ b/app/graphql/types/charges/graduated_percentage_range.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  module Charges
+    class GraduatedPercentageRange < Types::BaseObject
+      field :from_value, GraphQL::Types::BigInt, null: false
+      field :to_value, GraphQL::Types::BigInt, null: true
+
+      field :fixed_amount, String, null: false
+      field :flat_amount, String, null: false
+      field :rate, String, null: false
+    end
+  end
+end

--- a/app/graphql/types/charges/graduated_percentage_range_input.rb
+++ b/app/graphql/types/charges/graduated_percentage_range_input.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  module Charges
+    class GraduatedPercentageRangeInput < Types::BaseInputObject
+      argument :from_value, GraphQL::Types::BigInt, required: true
+      argument :to_value, GraphQL::Types::BigInt, required: false
+
+      argument :fixed_amount, String, required: true
+      argument :flat_amount, String, required: true
+      argument :rate, String, required: true
+    end
+  end
+end

--- a/app/graphql/types/charges/properties.rb
+++ b/app/graphql/types/charges/properties.rb
@@ -9,6 +9,9 @@ module Types
       # NOTE: Graduated charge model
       field :graduated_ranges, [Types::Charges::GraduatedRange], null: true, hash_key: :graduated_ranges
 
+      # NOTE: Graduated percentage modle
+      field :graduated_percentage_ranges, [Types::Charges::GraduatedPercentageRange], null: true
+
       # NOTE: Package charge model
       field :free_units, GraphQL::Types::BigInt, null: true, hash_key: :free_units
       field :package_size, GraphQL::Types::BigInt, null: true, hash_key: :package_size

--- a/app/graphql/types/charges/properties_input.rb
+++ b/app/graphql/types/charges/properties_input.rb
@@ -9,6 +9,9 @@ module Types
       # NOTE: Graduated charge model
       argument :graduated_ranges, [Types::Charges::GraduatedRangeInput], required: false
 
+      # NOTE: Graduated percentage charge model
+      argument :graduated_percentage_ranges, [Types::Charges::GraduatedPercentageRangeInput], required: false
+
       # NOTE: Package charge model
       argument :free_units, GraphQL::Types::BigInt, required: false
       argument :package_size, GraphQL::Types::BigInt, required: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -3028,6 +3028,22 @@ type GocardlessProvider {
   webhookSecret: String
 }
 
+type GraduatedPercentageRange {
+  fixedAmount: String!
+  flatAmount: String!
+  fromValue: BigInt!
+  rate: String!
+  toValue: BigInt
+}
+
+input GraduatedPercentageRangeInput {
+  fixedAmount: String!
+  flatAmount: String!
+  fromValue: BigInt!
+  rate: String!
+  toValue: BigInt
+}
+
 type GraduatedRange {
   flatAmount: String!
   fromValue: BigInt!
@@ -3983,6 +3999,7 @@ type Properties {
   freeUnits: BigInt
   freeUnitsPerEvents: BigInt
   freeUnitsPerTotalAggregation: String
+  graduatedPercentageRanges: [GraduatedPercentageRange!]
   graduatedRanges: [GraduatedRange!]
   packageSize: BigInt
   rate: String
@@ -3995,6 +4012,7 @@ input PropertiesInput {
   freeUnits: BigInt
   freeUnitsPerEvents: BigInt
   freeUnitsPerTotalAggregation: String
+  graduatedPercentageRanges: [GraduatedPercentageRangeInput!]
   graduatedRanges: [GraduatedRangeInput!]
   packageSize: BigInt
   rate: String

--- a/schema.json
+++ b/schema.json
@@ -11182,6 +11182,192 @@
         },
         {
           "kind": "OBJECT",
+          "name": "GraduatedPercentageRange",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "fixedAmount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "flatAmount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fromValue",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "rate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "toValue",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "GraduatedPercentageRangeInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "fromValue",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "toValue",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fixedAmount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "flatAmount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "GraduatedRange",
           "description": null,
           "interfaces": [
@@ -16697,6 +16883,28 @@
               ]
             },
             {
+              "name": "graduatedPercentageRanges",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "GraduatedPercentageRange",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "graduatedRanges",
               "description": null,
               "type": {
@@ -16804,6 +17012,26 @@
                   "ofType": {
                     "kind": "INPUT_OBJECT",
                     "name": "GraduatedRangeInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "graduatedPercentageRanges",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "GraduatedPercentageRangeInput",
                     "ofType": null
                   }
                 }


### PR DESCRIPTION
## Context

The objective of this feature is to introduce a new graduated percentage charge model similar to the current graduated charge model but applying a rate to the units rather than an amount.

## Description

This PR adds the GraphQL types definition to create and update graduated percentage charge models.
