### PR TITLE
feat(group): Populate default properties on existing charges

### DIFF
--- a/app/controllers/api/v1/billable_metrics/groups_controller.rb
+++ b/app/controllers/api/v1/billable_metrics/groups_controller.rb
@@ -8,7 +8,8 @@ module Api
           metric = current_organization.billable_metrics.find_by(code: params[:code])
           return not_found_error(resource: 'billable_metric') unless metric
 
-          groups = metric.selectable_groups.page(params[:page]).per(params[:per_page] || PER_PAGE)
+          groups = metric.selectable_groups
+            .page(params[:page]).per(params[:per_page] || PER_PAGE)
 
           render(
             json: ::CollectionSerializer.new(

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -31,7 +31,7 @@ module Types
       def group_properties
         scope = object.group_properties
         scope = scope.with_discarded if object.discarded?
-        scope
+        scope.includes(:group).sort_by { |gp| gp.group&.name }
       end
     end
   end

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -55,7 +55,8 @@ class BillableMetric < ApplicationRecord
 
   # NOTE: 1 dimension: all groups, 2 dimensions: all children.
   def selectable_groups
-    active_groups.children.exists? ? active_groups.children : active_groups
+    groups = active_groups.children.exists? ? active_groups.children : active_groups
+    groups.includes(:parent).reorder('parent.value', 'groups.value')
   end
 
   def active_groups_as_tree

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -39,6 +39,7 @@ class Charge < ApplicationRecord
   validate :validate_pay_in_advance
   validate :validate_prorated
   validate :validate_min_amount_cents
+  validate :validate_uniqueness_group_properties
 
   monetize :min_amount_cents, with_currency: ->(charge) { charge.plan.amount_currency }
 
@@ -110,5 +111,10 @@ class Charge < ApplicationRecord
     return if billable_metric.recurring? && !pay_in_advance? && (standard? || volume?)
 
     errors.add(:prorated, :invalid_billable_metric_or_charge_model)
+  end
+
+  def validate_uniqueness_group_properties
+    group_ids = group_properties.map(&:group_id)
+    errors.add(:group_properties, :taken) if group_ids.size > group_ids.uniq.size
   end
 end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -36,7 +36,6 @@ class Charge < ApplicationRecord
   validates :min_amount_cents, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validates :charge_model, presence: true
 
-  validate :validate_group_properties
   validate :validate_pay_in_advance
   validate :validate_prorated
   validate :validate_min_amount_cents
@@ -84,14 +83,6 @@ class Charge < ApplicationRecord
     instance.result.error.messages.map { |_, codes| codes }
       .flatten
       .each { |code| errors.add(:properties, code) }
-  end
-
-  def validate_group_properties
-    # Group properties should be set for all the selectable groups of a BM
-    bm_group_ids = billable_metric.selectable_groups.pluck(:id).sort
-    gp_group_ids = group_properties.map { |gp| gp[:group_id] }.compact.sort
-
-    errors.add(:group_properties, :values_not_all_present) if bm_group_ids != gp_group_ids
   end
 
   # NOTE: An pay_in_advance charge cannot be created in the following cases:

--- a/app/models/group_property.rb
+++ b/app/models/group_property.rb
@@ -9,6 +9,7 @@ class GroupProperty < ApplicationRecord
   belongs_to :group
 
   validates :values, presence: true
+  validates :group_id, presence: true, uniqueness: { scope: :charge_id }
 
   default_scope -> { kept }
 end

--- a/app/serializers/v1/charge_usage_serializer.rb
+++ b/app/serializers/v1/charge_usage_serializer.rb
@@ -19,7 +19,7 @@ module V1
           code: model.billable_metric.code,
           aggregation_type: model.billable_metric.aggregation_type,
         },
-        groups: model.groups.map do |group|
+        groups: model.groups.sort_by(&:name).map do |group|
           {
             lago_id: group.id,
             key: group.key,

--- a/app/services/charges/build_default_properties_service.rb
+++ b/app/services/charges/build_default_properties_service.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Charges
+  class BuildDefaultPropertiesService < BaseService
+    def initialize(charge_model)
+      @charge_model = charge_model
+      super
+    end
+
+    def call
+      case charge_model.to_sym
+      when :standard then default_standard_properties
+      when :graduated then default_graduated_properties
+      when :package then default_package_properties
+      when :percentage then default_percentage_properties
+      when :volume then default_volume_properties
+      when :graduated_percentage then default_graduated_percentage_properties
+      end
+    end
+
+    private
+
+    attr_reader :charge_model
+
+    def default_standard_properties
+      { 'amount': '0' }
+    end
+
+    def default_graduated_properties
+      {
+        'graduated_ranges': [
+          {
+            'from_value': 0,
+            'to_value': nil,
+            'per_unit_amount': '0',
+            'flat_amount': '0',
+          },
+        ],
+      }
+    end
+
+    def default_package_properties
+      {
+        'package_size': 1,
+        'amount': '0',
+        'free_units': 0,
+      }
+    end
+
+    def default_percentage_properties
+      { 'rate': '0' }
+    end
+
+    def default_volume_properties
+      {
+        'volume_ranges': [
+          {
+            'from_value': 0,
+            'to_value': nil,
+            'per_unit_amount': '0',
+            'flat_amount': '0',
+          },
+        ],
+      }
+    end
+
+    def default_graduated_percentage_properties
+      {
+        'graduated_percentage_ranges': [
+          {
+            'from_value': 0,
+            'to_value': nil,
+            'rate': '0',
+            'fixed_amount': '0',
+            'flat_amount': '0',
+          },
+        ],
+      }
+    end
+  end
+end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -42,13 +42,19 @@ module Fees
     def init_fees
       result.fees = []
 
-      if charge.group_properties.blank?
-        init_fee(properties: charge.properties)
-      else
+      if billable_metric.selectable_groups.any?
+        # NOTE: Create a fee for each groups defined on the charge.
         charge.group_properties.each do |group_properties|
           group = billable_metric.selectable_groups.find_by(id: group_properties.group_id)
           init_fee(properties: group_properties.values, group:)
         end
+
+        # NOTE: Create a fee for groups not defined (with default properties).
+        billable_metric.selectable_groups.where.not(id: charge.group_properties.pluck(:group_id)).each do |group|
+          init_fee(properties: charge.properties, group:)
+        end
+      else
+        init_fee(properties: charge.properties)
       end
     end
 

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -165,12 +165,12 @@ module Invoices
               code: fee.billable_metric.code,
               aggregation_type: fee.billable_metric.aggregation_type,
             },
-            groups: fees.map do |f|
+            groups: fees.sort_by { |f| f.group&.name }.map do |f|
               next unless f.group
 
               {
                 id: f.group.id,
-                key: f.group.parent&.value,
+                key: f.group.parent&.value || f.group.key,
                 value: f.group.value,
                 units: f.units,
                 amount_cents: f.amount_cents,

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -60,7 +60,7 @@ module Plans
         charge_model: charge_model(args),
         pay_in_advance: args[:pay_in_advance] || false,
         prorated: args[:prorated] || false,
-        properties: args[:properties] || {},
+        properties: args[:properties] || Charges::BuildDefaultPropertiesService.call(charge_model(args)),
         group_properties: (args[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )
 

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -60,7 +60,7 @@ module Plans
         charge_model: charge_model(args),
         pay_in_advance: args[:pay_in_advance] || false,
         prorated: args[:prorated] || false,
-        properties: args[:properties] || Charges::BuildDefaultPropertiesService.call(charge_model(args)),
+        properties: args[:properties].presence || Charges::BuildDefaultPropertiesService.call(charge_model(args)),
         group_properties: (args[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -69,7 +69,7 @@ module Plans
         charge_model: charge_model(params),
         pay_in_advance: params[:pay_in_advance] || false,
         prorated: params[:prorated] || false,
-        properties: params[:properties] || {},
+        properties: params[:properties] || Charges::BuildDefaultPropertiesService.call(charge_model(params)),
         group_properties: (params[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )
 
@@ -110,9 +110,11 @@ module Plans
             invoiceable = payload_charge.delete(:invoiceable)
             min_amount_cents = payload_charge.delete(:min_amount_cents)
             tax_codes = payload_charge.delete(:tax_codes)
+            properties = payload_charge.delete(:properties)
 
             charge.invoiceable = invoiceable if License.premium? && !invoiceable.nil?
             charge.min_amount_cents = min_amount_cents || 0 if License.premium?
+            charge.properties = properties || Charges::BuildDefaultPropertiesService.call(payload_charge[:charge_model])
 
             charge.update!(payload_charge)
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -69,7 +69,7 @@ module Plans
         charge_model: charge_model(params),
         pay_in_advance: params[:pay_in_advance] || false,
         prorated: params[:prorated] || false,
-        properties: params[:properties] || Charges::BuildDefaultPropertiesService.call(charge_model(params)),
+        properties: params[:properties].presence || Charges::BuildDefaultPropertiesService.call(charge_model(params)),
         group_properties: (params[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )
 
@@ -114,7 +114,7 @@ module Plans
 
             charge.invoiceable = invoiceable if License.premium? && !invoiceable.nil?
             charge.min_amount_cents = min_amount_cents || 0 if License.premium?
-            charge.properties = properties || Charges::BuildDefaultPropertiesService.call(payload_charge[:charge_model])
+            charge.properties = properties.presence || Charges::BuildDefaultPropertiesService.call(payload_charge[:charge_model])
 
             charge.update!(payload_charge)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,5 +44,4 @@ en:
         not_compatible_with_pay_in_advance: not_compatible_with_pay_in_advance
         value_already_exist: value_already_exist
         too_long: value_is_too_long
-        values_not_all_present: values_not_all_present
         unsupported_value: unsupported_value

--- a/config/locales/en/charge.yml
+++ b/config/locales/en/charge.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        charge:
+          attributes:
+            group_properties:
+              taken: is duplicated

--- a/db/migrate/20230817092555_set_default_properties_to_charges.rb
+++ b/db/migrate/20230817092555_set_default_properties_to_charges.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class SetDefaultPropertiesToCharges < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          -- Standard charges
+          UPDATE charges
+          SET properties = '{
+            "amount":"0"
+          }'
+          WHERE charge_model = 0
+          AND length(properties::text) = 2;
+
+          -- Graduated charges
+          UPDATE charges
+          SET properties = '{
+            "amount": "",
+            "graduated_ranges": [
+              {
+                "from_value": 0,
+                "to_value": null,
+                "per_unit_amount": "0",
+                "flat_amount": "0"
+              }
+            ]
+          }'
+          WHERE charge_model = 1
+          AND length(properties::text) = 2;
+
+          -- Package charges
+          UPDATE charges
+          SET properties = '{
+            "package_size": 1,
+            "amount": "0",
+            "free_units": 0
+          }'
+          WHERE charge_model = 2
+          AND length(properties::text) = 2;
+
+          -- Percentage charges
+          UPDATE charges
+          SET properties = '{
+            "rate": "0"
+          }'
+          WHERE charge_model = 3
+          AND length(properties::text) = 2;
+
+          -- Volume charges
+          UPDATE charges
+          SET properties = '{
+            "amount": "",
+            "volume_ranges": [
+              {
+                "from_value": 0,
+                "to_value": null,
+                "per_unit_amount": "0",
+                "flat_amount": "0"
+              }
+            ]
+          }'
+          WHERE charge_model = 4
+          AND length(properties::text) = 2;
+
+          -- Graduated Percentage charges
+          UPDATE charges
+          SET properties = '{
+            "graduated_percentage_ranges": [
+              {
+                "from_value": 0,
+                "to_value": null,
+                "rate": "0",
+                "fixed_amount": "0",
+                "flat_amount": "0"
+              }
+            ]
+          }'
+          WHERE charge_model = 5
+          AND length(properties::text) = 2;
+        SQL
+      end
+    end
+  end
+end

--- a/db/migrate/20230821135235_add_unique_constraint_to_group_properties.rb
+++ b/db/migrate/20230821135235_add_unique_constraint_to_group_properties.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueConstraintToGroupProperties < ActiveRecord::Migration[7.0]
+  def change
+    add_index :group_properties, %i[charge_id group_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_16_091053) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_17_092555) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_17_092555) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_21_135235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -395,6 +395,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_17_092555) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.index ["charge_id", "group_id"], name: "index_group_properties_on_charge_id_and_group_id", unique: true
     t.index ["charge_id"], name: "index_group_properties_on_charge_id"
     t.index ["deleted_at"], name: "index_group_properties_on_deleted_at"
     t.index ["group_id"], name: "index_group_properties_on_group_id"

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -176,12 +176,12 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
         expect(groups_usage).to contain_exactly(
           {
             'id' => aws.id,
-            'key' => nil,
+            'key' => 'cloud',
             'value' => 'aws',
             'units' => 3,
             'amountCents' => '3000',
           },
-          { 'id' => google.id, 'key' => nil, 'value' => 'google', 'units' => 1, 'amountCents' => '2000' },
+          { 'id' => google.id, 'key' => 'cloud', 'value' => 'google', 'units' => 1, 'amountCents' => '2000' },
         )
       end
     end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -369,40 +369,6 @@ RSpec.describe Charge, type: :model do
     end
   end
 
-  describe '#validate_group_properties' do
-    context 'without groups' do
-      it 'does not return an error' do
-        expect(build(:standard_charge)).to be_valid
-      end
-    end
-
-    context 'with group properties missing for some groups' do
-      it 'returns an error' do
-        create(:group, billable_metric: charge.billable_metric)
-
-        expect(charge).not_to be_valid
-        expect(charge.errors.messages.keys).to include(:group_properties)
-        expect(charge.errors.messages[:group_properties]).to include('values_not_all_present')
-      end
-    end
-
-    context 'with group properties for all groups' do
-      it 'does not return an error' do
-        metric = create(:billable_metric)
-        group = create(:group, billable_metric: metric)
-
-        charge = create(
-          :standard_charge,
-          billable_metric: metric,
-          properties: {},
-          group_properties: [build(:group_property, group:)],
-        )
-
-        expect(charge).to be_valid
-      end
-    end
-  end
-
   describe '#validate_instant' do
     it 'does not return an error' do
       expect(build(:standard_charge)).to be_valid

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -469,4 +469,19 @@ RSpec.describe Charge, type: :model do
       end
     end
   end
+
+  describe '#validate_uniqueness_group_properties' do
+    subject(:charge) do
+      build(:standard_charge, group_properties: [build(:group_property, group:), build(:group_property, group:)])
+    end
+
+    let(:group) { create(:group) }
+
+    it 'returns an error for a duplicate' do
+      aggregate_failures do
+        expect(charge).not_to be_valid
+        expect(charge.errors.messages[:group_properties]).to include('is duplicated')
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/customers_spec.rb
+++ b/spec/requests/api/v1/customers_spec.rb
@@ -359,12 +359,12 @@ RSpec.describe Api::V1::CustomersController, type: :request do
           expect(groups_usage).to contain_exactly(
             {
               lago_id: aws.id,
-              key: nil,
+              key: 'cloud',
               value: 'aws',
               units: '3.0',
               amount_cents: 3000,
             },
-            { lago_id: google.id, key: nil, value: 'google', units: '1.0', amount_cents: 2000 },
+            { lago_id: google.id, key: 'cloud', value: 'google', units: '1.0', amount_cents: 2000 },
           )
         end
       end

--- a/spec/services/charges/build_default_properties_service_spec.rb
+++ b/spec/services/charges/build_default_properties_service_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::BuildDefaultPropertiesService, type: :service do
+  subject(:service) { described_class.new(charge_model) }
+
+  describe 'call' do
+    context 'when standard charge model' do
+      let(:charge_model) { :standard }
+
+      it 'returns standard default properties' do
+        expect(service.call).to eq({ 'amount': '0' })
+      end
+    end
+
+    context 'when graduated charge model' do
+      let(:charge_model) { :graduated }
+
+      it 'returns graduated default properties' do
+        expect(service.call).to eq(
+          {
+            'graduated_ranges': [
+              {
+                'from_value': 0,
+                'to_value': nil,
+                'per_unit_amount': '0',
+                'flat_amount': '0',
+              },
+            ],
+          },
+        )
+      end
+    end
+
+    context 'when package charge model' do
+      let(:charge_model) { :package }
+
+      it 'returns package default properties' do
+        expect(service.call).to eq(
+          {
+            'package_size': 1,
+            'amount': '0',
+            'free_units': 0,
+          },
+        )
+      end
+    end
+
+    context 'when percentage charge model' do
+      let(:charge_model) { :percentage }
+
+      it 'returns percentage default properties' do
+        expect(service.call).to eq({ 'rate': '0' })
+      end
+    end
+
+    context 'when volume charge model' do
+      let(:charge_model) { :volume }
+
+      it 'returns volume default properties' do
+        expect(service.call).to eq(
+          {
+            'volume_ranges': [
+              {
+                'from_value': 0,
+                'to_value': nil,
+                'per_unit_amount': '0',
+                'flat_amount': '0',
+              },
+            ],
+          },
+        )
+      end
+    end
+
+    context 'when graduated_percentage charge model' do
+      let(:charge_model) { :graduated_percentage }
+
+      it 'returns graduated_percentage default properties' do
+        expect(service.call).to eq(
+          {
+            'graduated_percentage_ranges': [
+              {
+                'from_value': 0,
+                'to_value': nil,
+                'rate': '0',
+                'fixed_amount': '0',
+                'flat_amount': '0',
+              },
+            ],
+          },
+        )
+      end
+    end
+  end
+end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -226,6 +226,7 @@ RSpec.describe Fees::ChargeService do
           :standard_charge,
           plan: subscription.plan,
           billable_metric:,
+          properties: { amount: '10' },
           group_properties: [
             build(
               :group_property,
@@ -243,19 +244,13 @@ RSpec.describe Fees::ChargeService do
                 amount_currency: 'EUR',
               },
             ),
-            build(
-              :group_property,
-              group: france,
-              values: {
-                amount: '40',
-                amount_currency: 'EUR',
-              },
-            ),
           ],
         )
       end
 
       before do
+        france
+
         create(
           :event,
           organization: subscription.organization,
@@ -323,7 +318,7 @@ RSpec.describe Fees::ChargeService do
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 4000,
+            amount_cents: 1000,
             units: 1,
           )
         end
@@ -358,7 +353,7 @@ RSpec.describe Fees::ChargeService do
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 20_000,
+            amount_cents: 5000,
             units: 5,
           )
         end
@@ -393,7 +388,7 @@ RSpec.describe Fees::ChargeService do
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 20_000,
+            amount_cents: 5000,
             units: 5,
           )
         end
@@ -505,7 +500,7 @@ RSpec.describe Fees::ChargeService do
 
             expect(created_fees.third).to have_attributes(
               group: france,
-              amount_cents: 4000,
+              amount_cents: 1000,
               units: 1,
             )
           end
@@ -591,7 +586,7 @@ RSpec.describe Fees::ChargeService do
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 4000,
+            amount_cents: 1000,
             units: 1,
           )
         end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe Plans::CreateService, type: :service do
         prorated: false,
         min_amount_cents: 0,
         invoiceable: true,
+        properties: { 'amount' => '0' },
       )
       expect(standard_charge.taxes.pluck(:code)).to eq([charge_tax.code])
       expect(standard_charge.group_properties.first).to have_attributes(

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -267,8 +267,11 @@ RSpec.describe Plans::UpdateService, type: :service do
         expect { plans_service.call }
           .to change(GroupProperty, :count).by(1)
 
-        expect(existing_charge.reload.prorated).to eq(true)
-        expect(existing_charge.reload.group_properties.first).to have_attributes(
+        expect(existing_charge.reload).to have_attributes(
+          prorated: true,
+          properties: { 'amount' => '0' },
+        )
+        expect(existing_charge.group_properties.first).to have_attributes(
           group_id: group.id,
           values: { 'amount' => '100' },
         )


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/edit-groups-associated-with-billable-metrics

## Context

We want to be able to set a default price on charges with groups.

## Description

The goal of this PR is to migrate existing charges by adding default properties on charges with dimensions.

⚠️ This PR can only be merged when the default price feature will be released.
