### PR TITLE
fix: Quarterly anniversary current usage should take care of the month

### DIFF
--- a/app/services/subscriptions/dates/quarterly_service.rb
+++ b/app/services/subscriptions/dates/quarterly_service.rb
@@ -111,7 +111,7 @@ module Subscriptions
           month = billing_months[3]
           day = Time.days_in_month(month, year) if last_day_of_month?(subscription_at)
         # In case of termination that is in the middle of the year, previous period anniversary date has to be returned
-        elsif should_find_previous_billing_date?(date, day)
+        elsif should_find_previous_billing_date?(date, billing_months, day)
           year = date.year
           month = billing_months.reverse.find { |m| m < date.month }
           day = Time.days_in_month(month, year) if last_day_of_month?(subscription_at)
@@ -126,15 +126,16 @@ module Subscriptions
       def should_find_billing_date_in_previous_year?(date, billing_months, day)
         return true if date.month < billing_months[0]
 
-        (date.month == billing_months[0]) && should_find_previous_billing_date?(date, day)
+        (date.month == billing_months[0]) && should_find_previous_billing_date?(date, billing_months, day)
       end
 
-      def should_find_previous_billing_date?(date, day)
+      def should_find_previous_billing_date?(date, billing_months, day)
         return false if last_day_of_month?(date) && last_day_of_month?(subscription_at)
 
         return true if date.day < day && terminated_pay_in_arrear?
         return true if (date.day + 1) < day && last_day_of_month?(subscription_at)
         return true if date.day < day && !last_day_of_month?(subscription_at)
+        return true if date.day > day && billing_months.exclude?(date.month)
 
         false
       end

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
-  subject(:date_service) { described_class.new(subscription, billing_at, false) }
+  subject(:date_service) { described_class.new(subscription, billing_at, current_usage) }
 
   let(:subscription) do
     create(
@@ -19,6 +19,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
   let(:customer) { create(:customer, timezone:) }
   let(:plan) { create(:plan, interval: :monthly, pay_in_advance:) }
   let(:pay_in_advance) { false }
+  let(:current_usage) { false }
 
   let(:subscription_at) { DateTime.parse('02 Feb 2021') }
   let(:billing_at) { DateTime.parse('07 Mar 2022') }
@@ -156,6 +157,16 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
 
         it 'returns the current day' do
           expect(result).to eq('2021-04-30 00:00:00 UTC')
+        end
+      end
+
+      context 'when date is not on a billing month' do
+        let(:billing_at) { DateTime.parse('8 Aug 2023') }
+        let(:subscription_at) { DateTime.parse('6 Apr 2023') }
+        let(:current_usage) { true }
+
+        it 'returns the date in previous billing month' do
+          expect(result).to eq('2023-07-06 00:00:00 UTC')
         end
       end
     end


### PR DESCRIPTION
## Context

Quarterly anniversary with subscription date in the past does not have the right boundaries on current usage

## Description

The PR adds a test case on the current month to check that it is a billing month, otherwise, if returns the previous billing month.