### PR TITLE
feat(group): Use default properties when creating fees for groups

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -36,7 +36,6 @@ class Charge < ApplicationRecord
   validates :min_amount_cents, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
   validates :charge_model, presence: true
 
-  validate :validate_group_properties
   validate :validate_pay_in_advance
   validate :validate_prorated
   validate :validate_min_amount_cents
@@ -84,14 +83,6 @@ class Charge < ApplicationRecord
     instance.result.error.messages.map { |_, codes| codes }
       .flatten
       .each { |code| errors.add(:properties, code) }
-  end
-
-  def validate_group_properties
-    # Group properties should be set for all the selectable groups of a BM
-    bm_group_ids = billable_metric.selectable_groups.pluck(:id).sort
-    gp_group_ids = group_properties.map { |gp| gp[:group_id] }.compact.sort
-
-    errors.add(:group_properties, :values_not_all_present) if bm_group_ids != gp_group_ids
   end
 
   # NOTE: An pay_in_advance charge cannot be created in the following cases:

--- a/app/services/charges/build_default_properties_service.rb
+++ b/app/services/charges/build_default_properties_service.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Charges
+  class BuildDefaultPropertiesService < BaseService
+    def initialize(charge_model)
+      @charge_model = charge_model
+      super
+    end
+
+    def call
+      case charge_model.to_sym
+      when :standard then default_standard_properties
+      when :graduated then default_graduated_properties
+      when :package then default_package_properties
+      when :percentage then default_percentage_properties
+      when :volume then default_volume_properties
+      when :graduated_percentage then default_graduated_percentage_properties
+      end
+    end
+
+    private
+
+    attr_reader :charge_model
+
+    def default_standard_properties
+      { 'amount': '0' }
+    end
+
+    def default_graduated_properties
+      {
+        'graduated_ranges': [
+          {
+            'from_value': 0,
+            'to_value': nil,
+            'per_unit_amount': '0',
+            'flat_amount': '0',
+          },
+        ],
+      }
+    end
+
+    def default_package_properties
+      {
+        'package_size': 1,
+        'amount': '0',
+        'free_units': 0,
+      }
+    end
+
+    def default_percentage_properties
+      { 'rate': '0' }
+    end
+
+    def default_volume_properties
+      {
+        'volume_ranges': [
+          {
+            'from_value': 0,
+            'to_value': nil,
+            'per_unit_amount': '0',
+            'flat_amount': '0',
+          },
+        ],
+      }
+    end
+
+    def default_graduated_percentage_properties
+      {
+        'graduated_percentage_ranges': [
+          {
+            'from_value': 0,
+            'to_value': nil,
+            'rate': '0',
+            'fixed_amount': '0',
+            'flat_amount': '0',
+          },
+        ],
+      }
+    end
+  end
+end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -42,13 +42,19 @@ module Fees
     def init_fees
       result.fees = []
 
-      if charge.group_properties.blank?
-        init_fee(properties: charge.properties)
-      else
+      if billable_metric.selectable_groups.any?
+        # NOTE: Create a fee for each groups defined on the charge.
         charge.group_properties.each do |group_properties|
           group = billable_metric.selectable_groups.find_by(id: group_properties.group_id)
           init_fee(properties: group_properties.values, group:)
         end
+
+        # NOTE: Create a fee for groups not defined (with default properties).
+        billable_metric.selectable_groups.where.not(id: charge.group_properties.pluck(:group_id)).each do |group|
+          init_fee(properties: charge.properties, group:)
+        end
+      else
+        init_fee(properties: charge.properties)
       end
     end
 

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -60,7 +60,7 @@ module Plans
         charge_model: charge_model(args),
         pay_in_advance: args[:pay_in_advance] || false,
         prorated: args[:prorated] || false,
-        properties: args[:properties] || {},
+        properties: args[:properties] || Charges::BuildDefaultPropertiesService.call(charge_model(args)),
         group_properties: (args[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )
 

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -60,7 +60,7 @@ module Plans
         charge_model: charge_model(args),
         pay_in_advance: args[:pay_in_advance] || false,
         prorated: args[:prorated] || false,
-        properties: args[:properties] || Charges::BuildDefaultPropertiesService.call(charge_model(args)),
+        properties: args[:properties].presence || Charges::BuildDefaultPropertiesService.call(charge_model(args)),
         group_properties: (args[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -69,7 +69,7 @@ module Plans
         charge_model: charge_model(params),
         pay_in_advance: params[:pay_in_advance] || false,
         prorated: params[:prorated] || false,
-        properties: params[:properties] || {},
+        properties: params[:properties] || Charges::BuildDefaultPropertiesService.call(charge_model(params)),
         group_properties: (params[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )
 
@@ -110,9 +110,11 @@ module Plans
             invoiceable = payload_charge.delete(:invoiceable)
             min_amount_cents = payload_charge.delete(:min_amount_cents)
             tax_codes = payload_charge.delete(:tax_codes)
+            properties = payload_charge.delete(:properties)
 
             charge.invoiceable = invoiceable if License.premium? && !invoiceable.nil?
             charge.min_amount_cents = min_amount_cents || 0 if License.premium?
+            charge.properties = properties || Charges::BuildDefaultPropertiesService.call(payload_charge[:charge_model])
 
             charge.update!(payload_charge)
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -69,7 +69,7 @@ module Plans
         charge_model: charge_model(params),
         pay_in_advance: params[:pay_in_advance] || false,
         prorated: params[:prorated] || false,
-        properties: params[:properties] || Charges::BuildDefaultPropertiesService.call(charge_model(params)),
+        properties: params[:properties].presence || Charges::BuildDefaultPropertiesService.call(charge_model(params)),
         group_properties: (params[:group_properties] || []).map { |gp| GroupProperty.new(gp) },
       )
 
@@ -114,7 +114,7 @@ module Plans
 
             charge.invoiceable = invoiceable if License.premium? && !invoiceable.nil?
             charge.min_amount_cents = min_amount_cents || 0 if License.premium?
-            charge.properties = properties || Charges::BuildDefaultPropertiesService.call(payload_charge[:charge_model])
+            charge.properties = properties.presence || Charges::BuildDefaultPropertiesService.call(payload_charge[:charge_model])
 
             charge.update!(payload_charge)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,5 +44,4 @@ en:
         not_compatible_with_pay_in_advance: not_compatible_with_pay_in_advance
         value_already_exist: value_already_exist
         too_long: value_is_too_long
-        values_not_all_present: values_not_all_present
         unsupported_value: unsupported_value

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -369,40 +369,6 @@ RSpec.describe Charge, type: :model do
     end
   end
 
-  describe '#validate_group_properties' do
-    context 'without groups' do
-      it 'does not return an error' do
-        expect(build(:standard_charge)).to be_valid
-      end
-    end
-
-    context 'with group properties missing for some groups' do
-      it 'returns an error' do
-        create(:group, billable_metric: charge.billable_metric)
-
-        expect(charge).not_to be_valid
-        expect(charge.errors.messages.keys).to include(:group_properties)
-        expect(charge.errors.messages[:group_properties]).to include('values_not_all_present')
-      end
-    end
-
-    context 'with group properties for all groups' do
-      it 'does not return an error' do
-        metric = create(:billable_metric)
-        group = create(:group, billable_metric: metric)
-
-        charge = create(
-          :standard_charge,
-          billable_metric: metric,
-          properties: {},
-          group_properties: [build(:group_property, group:)],
-        )
-
-        expect(charge).to be_valid
-      end
-    end
-  end
-
   describe '#validate_instant' do
     it 'does not return an error' do
       expect(build(:standard_charge)).to be_valid

--- a/spec/services/charges/build_default_properties_service_spec.rb
+++ b/spec/services/charges/build_default_properties_service_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::BuildDefaultPropertiesService, type: :service do
+  subject(:service) { described_class.new(charge_model) }
+
+  describe 'call' do
+    context 'when standard charge model' do
+      let(:charge_model) { :standard }
+
+      it 'returns standard default properties' do
+        expect(service.call).to eq({ 'amount': '0' })
+      end
+    end
+
+    context 'when graduated charge model' do
+      let(:charge_model) { :graduated }
+
+      it 'returns graduated default properties' do
+        expect(service.call).to eq(
+          {
+            'graduated_ranges': [
+              {
+                'from_value': 0,
+                'to_value': nil,
+                'per_unit_amount': '0',
+                'flat_amount': '0',
+              },
+            ],
+          },
+        )
+      end
+    end
+
+    context 'when package charge model' do
+      let(:charge_model) { :package }
+
+      it 'returns package default properties' do
+        expect(service.call).to eq(
+          {
+            'package_size': 1,
+            'amount': '0',
+            'free_units': 0,
+          },
+        )
+      end
+    end
+
+    context 'when percentage charge model' do
+      let(:charge_model) { :percentage }
+
+      it 'returns percentage default properties' do
+        expect(service.call).to eq({ 'rate': '0' })
+      end
+    end
+
+    context 'when volume charge model' do
+      let(:charge_model) { :volume }
+
+      it 'returns volume default properties' do
+        expect(service.call).to eq(
+          {
+            'volume_ranges': [
+              {
+                'from_value': 0,
+                'to_value': nil,
+                'per_unit_amount': '0',
+                'flat_amount': '0',
+              },
+            ],
+          },
+        )
+      end
+    end
+
+    context 'when graduated_percentage charge model' do
+      let(:charge_model) { :graduated_percentage }
+
+      it 'returns graduated_percentage default properties' do
+        expect(service.call).to eq(
+          {
+            'graduated_percentage_ranges': [
+              {
+                'from_value': 0,
+                'to_value': nil,
+                'rate': '0',
+                'fixed_amount': '0',
+                'flat_amount': '0',
+              },
+            ],
+          },
+        )
+      end
+    end
+  end
+end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -226,6 +226,7 @@ RSpec.describe Fees::ChargeService do
           :standard_charge,
           plan: subscription.plan,
           billable_metric:,
+          properties: { amount: '10' },
           group_properties: [
             build(
               :group_property,
@@ -243,19 +244,13 @@ RSpec.describe Fees::ChargeService do
                 amount_currency: 'EUR',
               },
             ),
-            build(
-              :group_property,
-              group: france,
-              values: {
-                amount: '40',
-                amount_currency: 'EUR',
-              },
-            ),
           ],
         )
       end
 
       before do
+        france
+
         create(
           :event,
           organization: subscription.organization,
@@ -323,7 +318,7 @@ RSpec.describe Fees::ChargeService do
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 4000,
+            amount_cents: 1000,
             units: 1,
           )
         end
@@ -358,7 +353,7 @@ RSpec.describe Fees::ChargeService do
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 20_000,
+            amount_cents: 5000,
             units: 5,
           )
         end
@@ -393,7 +388,7 @@ RSpec.describe Fees::ChargeService do
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 20_000,
+            amount_cents: 5000,
             units: 5,
           )
         end
@@ -505,7 +500,7 @@ RSpec.describe Fees::ChargeService do
 
             expect(created_fees.third).to have_attributes(
               group: france,
-              amount_cents: 4000,
+              amount_cents: 1000,
               units: 1,
             )
           end
@@ -591,7 +586,7 @@ RSpec.describe Fees::ChargeService do
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 4000,
+            amount_cents: 1000,
             units: 1,
           )
         end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe Plans::CreateService, type: :service do
         prorated: false,
         min_amount_cents: 0,
         invoiceable: true,
+        properties: { 'amount' => '0' },
       )
       expect(standard_charge.taxes.pluck(:code)).to eq([charge_tax.code])
       expect(standard_charge.group_properties.first).to have_attributes(

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -267,8 +267,11 @@ RSpec.describe Plans::UpdateService, type: :service do
         expect { plans_service.call }
           .to change(GroupProperty, :count).by(1)
 
-        expect(existing_charge.reload.prorated).to eq(true)
-        expect(existing_charge.reload.group_properties.first).to have_attributes(
+        expect(existing_charge.reload).to have_attributes(
+          prorated: true,
+          properties: { 'amount' => '0' },
+        )
+        expect(existing_charge.group_properties.first).to have_attributes(
           group_id: group.id,
           values: { 'amount' => '100' },
         )


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/edit-groups-associated-with-billable-metrics

## Context

We want to be able to set a default price on charges with groups.

## Description

The goal of this PR is to use the default properties when creating fees for undefined groups.
