### PR TITLE
feat(charge): Add validation for min/max per transaction amount on percentage charge model

### DIFF
--- a/app/services/charges/validators/percentage_service.rb
+++ b/app/services/charges/validators/percentage_service.rb
@@ -8,6 +8,7 @@ module Charges
         validate_fixed_amount
         validate_free_units_per_events
         validate_free_units_per_total_aggregation
+        validate_per_transaction_min_max
 
         super
       end
@@ -55,6 +56,24 @@ module Charges
         return if ::Validators::DecimalAmountService.new(free_units_per_total_aggregation).valid_amount?
 
         add_error(field: :free_units_per_total_aggregation, error_code: 'invalid_free_units_per_total_aggregation')
+      end
+
+      def validate_per_transaction_min_max
+        if properties['per_transaction_min_amount'].present? &&
+           !::Validators::DecimalAmountService.valid_amount?(properties['per_transaction_min_amount'])
+          add_error(field: :per_transaction_min_amount, error_code: 'invalid_amount')
+        end
+
+        if properties['per_transaction_max_amount'].present? &&
+           !::Validators::DecimalAmountService.valid_amount?(properties['per_transaction_max_amount'])
+          add_error(field: :per_transaction_max_amount, error_code: 'invalid_amount')
+        end
+
+        return if properties['per_transaction_min_amount'].nil? || properties['per_transaction_max_amount'].nil?
+        return if BigDecimal(properties['per_transaction_min_amount']) <=
+                  BigDecimal(properties['per_transaction_max_amount'])
+
+        add_error(field: :per_transaction_max_amount, error_code: 'per_transaction_max_lower_than_per_transaction_min')
       end
     end
   end

--- a/app/services/charges/validators/percentage_service.rb
+++ b/app/services/charges/validators/percentage_service.rb
@@ -59,6 +59,8 @@ module Charges
       end
 
       def validate_per_transaction_min_max
+        return unless License.premium?
+
         if properties['per_transaction_min_amount'].present? &&
            !::Validators::DecimalAmountService.valid_amount?(properties['per_transaction_min_amount'])
           add_error(field: :per_transaction_min_amount, error_code: 'invalid_amount')

--- a/spec/services/charges/validators/percentage_service_spec.rb
+++ b/spec/services/charges/validators/percentage_service_spec.rb
@@ -246,5 +246,102 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
 
       it { expect(percentage_service).to be_valid }
     end
+
+    context 'with per_transaction_min_amount' do
+      let(:percentage_properties) do
+        {
+          rate: '0.25',
+          fixed_amount: '2',
+          per_transaction_min_amount:,
+        }
+      end
+
+      context 'when it is not a string' do
+        let(:per_transaction_min_amount) { 2 }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(percentage_service).not_to be_valid
+            expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(percentage_service.result.error.messages.keys).to include(:per_transaction_min_amount)
+            expect(percentage_service.result.error.messages[:per_transaction_min_amount])
+              .to include('invalid_amount')
+          end
+        end
+      end
+
+      context 'when it is negative' do
+        let(:per_transaction_min_amount) { '-3' }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(percentage_service).not_to be_valid
+            expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(percentage_service.result.error.messages.keys).to include(:per_transaction_min_amount)
+            expect(percentage_service.result.error.messages[:per_transaction_min_amount])
+              .to include('invalid_amount')
+          end
+        end
+      end
+    end
+
+    context 'with per_transaction_max_amount' do
+      let(:percentage_properties) do
+        {
+          rate: '0.25',
+          fixed_amount: '2',
+          per_transaction_max_amount:,
+        }
+      end
+
+      context 'when it is not a string' do
+        let(:per_transaction_max_amount) { 2 }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(percentage_service).not_to be_valid
+            expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(percentage_service.result.error.messages.keys).to include(:per_transaction_max_amount)
+            expect(percentage_service.result.error.messages[:per_transaction_max_amount])
+              .to include('invalid_amount')
+          end
+        end
+      end
+
+      context 'when it is negative' do
+        let(:per_transaction_max_amount) { '-3' }
+
+        it 'is invalid' do
+          aggregate_failures do
+            expect(percentage_service).not_to be_valid
+            expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+            expect(percentage_service.result.error.messages.keys).to include(:per_transaction_max_amount)
+            expect(percentage_service.result.error.messages[:per_transaction_max_amount])
+              .to include('invalid_amount')
+          end
+        end
+      end
+    end
+
+    context 'with both per_transaction_min_amount and per_transaction_max_amount' do
+      let(:percentage_properties) do
+        {
+          rate: '0.25',
+          fixed_amount: '2',
+          per_transaction_min_amount: '3',
+          per_transaction_max_amount: '2',
+        }
+      end
+
+      it 'ensures that max is higher than min' do
+        aggregate_failures do
+          expect(percentage_service).not_to be_valid
+          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(percentage_service.result.error.messages.keys).to include(:per_transaction_max_amount)
+          expect(percentage_service.result.error.messages[:per_transaction_max_amount])
+            .to include('per_transaction_max_lower_than_per_transaction_min')
+        end
+      end
+    end
   end
 end

--- a/spec/services/charges/validators/percentage_service_spec.rb
+++ b/spec/services/charges/validators/percentage_service_spec.rb
@@ -248,6 +248,8 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
     end
 
     context 'with per_transaction_min_amount' do
+      around { |test| lago_premium!(&test) }
+
       let(:percentage_properties) do
         {
           rate: '0.25',
@@ -286,6 +288,8 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
     end
 
     context 'with per_transaction_max_amount' do
+      around { |test| lago_premium!(&test) }
+
       let(:percentage_properties) do
         {
           rate: '0.25',
@@ -324,6 +328,8 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
     end
 
     context 'with both per_transaction_min_amount and per_transaction_max_amount' do
+      around { |test| lago_premium!(&test) }
+
       let(:percentage_properties) do
         {
           rate: '0.25',


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/apply-price-floorcap-on-transactions

## Context

Fintech users want to be able to cap a transaction to a maximum amount or to flour it to a minimum amount.

This feature will apply this logic to the `percentage` charge model.

## Description

This PR is the first for this feature. It adds the validation rules for the `per_transaction_min_amount` and `per_transaction_max_amount` fields on the `percentage` charge model.

The validation is performed only if the application is premium