### PR TITLE
feat(charge): Add per transaction min/max amounts to GraphQL percentage charge model fields

### DIFF
--- a/app/graphql/types/charges/properties.rb
+++ b/app/graphql/types/charges/properties.rb
@@ -17,10 +17,12 @@ module Types
       field :package_size, GraphQL::Types::BigInt, null: true, hash_key: :package_size
 
       # NOTE: Percentage charge model
-      field :fixed_amount, String, null: true, hash_key: :fixed_amount
-      field :free_units_per_events, GraphQL::Types::BigInt, null: true, hash_key: :free_units_per_events
-      field :free_units_per_total_aggregation, String, null: true, hash_key: :free_units_per_total_aggregation
-      field :rate, String, null: true, hash_key: :rate
+      field :fixed_amount, String, null: true
+      field :free_units_per_events, GraphQL::Types::BigInt, null: true
+      field :free_units_per_total_aggregation, String, null: true
+      field :per_transaction_max_amount, String, null: true
+      field :per_transaction_min_amount, String, null: true
+      field :rate, String, null: true
 
       # NOTE: Volume charge model
       field :volume_ranges, [Types::Charges::VolumeRange], null: true, hash_key: :volume_ranges

--- a/app/graphql/types/charges/properties_input.rb
+++ b/app/graphql/types/charges/properties_input.rb
@@ -20,6 +20,8 @@ module Types
       argument :fixed_amount, String, required: false
       argument :free_units_per_events, GraphQL::Types::BigInt, required: false
       argument :free_units_per_total_aggregation, String, required: false
+      argument :per_transaction_max_amount, String, required: false
+      argument :per_transaction_min_amount, String, required: false
       argument :rate, String, required: false
 
       # NOTE: Volume charge model

--- a/schema.graphql
+++ b/schema.graphql
@@ -4000,6 +4000,8 @@ type Properties {
   graduatedPercentageRanges: [GraduatedPercentageRange!]
   graduatedRanges: [GraduatedRange!]
   packageSize: BigInt
+  perTransactionMaxAmount: String
+  perTransactionMinAmount: String
   rate: String
   volumeRanges: [VolumeRange!]
 }
@@ -4013,6 +4015,8 @@ input PropertiesInput {
   graduatedPercentageRanges: [GraduatedPercentageRangeInput!]
   graduatedRanges: [GraduatedRangeInput!]
   packageSize: BigInt
+  perTransactionMaxAmount: String
+  perTransactionMinAmount: String
   rate: String
   volumeRanges: [VolumeRangeInput!]
 }

--- a/schema.json
+++ b/schema.json
@@ -16907,6 +16907,34 @@
               ]
             },
             {
+              "name": "perTransactionMaxAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "perTransactionMinAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "rate",
               "description": null,
               "type": {
@@ -17056,6 +17084,30 @@
             },
             {
               "name": "freeUnitsPerTotalAggregation",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "perTransactionMaxAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "perTransactionMinAmount",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
               graduatedRanges { fromValue, toValue }
               volumeRanges { fromValue, toValue }
               graduatedPercentageRanges { fromValue toValue }
+              perTransactionMaxAmount
+              perTransactionMinAmount
             }
             groupProperties {
               groupId,
@@ -113,6 +115,8 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
                     fixedAmount: '2',
                     freeUnitsPerEvents: 5,
                     freeUnitsPerTotalAggregation: '50',
+                    perTransactionMaxAmount: '20',
+                    perTransactionMinAmount: '10',
                   },
                 },
               ],


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/apply-price-floorcap-on-transactions

## Context

Fintech users want to be able to cap a transaction to a maximum amount or to flour it to a minimum amount.

This feature will apply this logic to the `percentage` charge model.

## Description

This PR exposes the `per_transaction_max_amount`/`per_transaction_min_amount` for charge model properties in GraphQL api