### PR TITLE
feat(group): Add unique index on group_properties

### DIFF
--- a/app/models/group_property.rb
+++ b/app/models/group_property.rb
@@ -9,6 +9,7 @@ class GroupProperty < ApplicationRecord
   belongs_to :group
 
   validates :values, presence: true
+  validates :group_id, presence: true, uniqueness: { scope: :charge_id }
 
   default_scope -> { kept }
 end

--- a/db/migrate/20230821135235_add_unique_constraint_to_group_properties.rb
+++ b/db/migrate/20230821135235_add_unique_constraint_to_group_properties.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueConstraintToGroupProperties < ActiveRecord::Migration[7.0]
+  def change
+    add_index :group_properties, %i[charge_id group_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_17_092555) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_21_135235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -395,6 +395,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_17_092555) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.index ["charge_id", "group_id"], name: "index_group_properties_on_charge_id_and_group_id", unique: true
     t.index ["charge_id"], name: "index_group_properties_on_charge_id"
     t.index ["deleted_at"], name: "index_group_properties_on_deleted_at"
     t.index ["group_id"], name: "index_group_properties_on_group_id"


### PR DESCRIPTION
The goal of this PR is to ensure having only one pair `charge_id` / `group_id` on `group_properties`.

I haven't seen any duplications on cloud production, so I decided to not add the logic for cleaning duplicates on the migration for OSS.

`GroupProperty.select(:id, :group_id, :charge_id).group(:group_id, :charge_id).having("count(*) > 1") => 0`