### PR TITLE
feat(billable metric): Refact aggregator initializers

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -135,10 +135,11 @@ class Invoice < ApplicationRecord
       billable_metric: fee.charge.billable_metric,
       subscription: fee.subscription,
       group: fee.group,
-    ).breakdown(
-      from_datetime: DateTime.parse(fee.properties['charges_from_datetime']),
-      to_datetime: DateTime.parse(fee.properties['charges_to_datetime']),
-    ).breakdown
+      boundaries: {
+        from_datetime: DateTime.parse(fee.properties['charges_from_datetime']),
+        to_datetime: DateTime.parse(fee.properties['charges_to_datetime']),
+      },
+    ).breakdown.breakdown
   end
 
   def charge_pay_in_advance_proration_range(fee, timestamp)

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -3,23 +3,32 @@
 module BillableMetrics
   module Aggregations
     class BaseService < ::BaseService
-      def initialize(billable_metric:, subscription:, group: nil, event: nil)
+      def initialize(billable_metric:, subscription:, boundaries:, group: nil, event: nil)
         super(nil)
         @billable_metric = billable_metric
         @subscription = subscription
         @group = group
         @event = event
+        @boundaries = boundaries
       end
 
-      def aggregate(from_date:, to_date:, options: {})
+      def aggregate(options: {})
         raise(NotImplementedError)
       end
 
       protected
 
-      attr_accessor :billable_metric, :subscription, :group, :event
+      attr_accessor :billable_metric, :subscription, :group, :event, :boundaries
 
       delegate :customer, to: :subscription
+
+      def from_datetime
+        boundaries[:from_datetime]
+      end
+
+      def to_datetime
+        boundaries[:to_datetime]
+      end
 
       def events_scope(from_datetime:, to_datetime:)
         events = subscription.events

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -3,7 +3,7 @@
 module BillableMetrics
   module Aggregations
     class CountService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_datetime:, to_datetime:, options: {})
+      def aggregate(options: {})
         result.aggregation = events_scope(from_datetime:, to_datetime:).count
         result.current_usage_units = result.aggregation
         result.count = result.aggregation

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -3,7 +3,7 @@
 module BillableMetrics
   module Aggregations
     class MaxService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_datetime:, to_datetime:, options: {})
+      def aggregate(options: {})
         events = events_scope(from_datetime:, to_datetime:)
           .where("#{sanitized_field_name} IS NOT NULL")
 

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -3,20 +3,14 @@
 module BillableMetrics
   module Aggregations
     class RecurringCountService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_datetime:, to_datetime:, options: {})
-        @from_datetime = from_datetime
-        @to_datetime = to_datetime
-
+      def aggregate(options: {})
         result.aggregation = compute_aggregation.ceil(5)
         result.count = result.aggregation
         result.options = options
         result
       end
 
-      def breakdown(from_datetime:, to_datetime:)
-        @from_datetime = from_datetime
-        @to_datetime = to_datetime
-
+      def breakdown
         breakdown = persisted_breakdown
         breakdown += added_breakdown
         breakdown += removed_breadown
@@ -28,8 +22,6 @@ module BillableMetrics
       end
 
       private
-
-      attr_reader :from_datetime, :to_datetime
 
       def from_date_in_customer_timezone
         from_datetime.in_time_zone(customer.applicable_timezone).to_date

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -3,10 +3,7 @@
 module BillableMetrics
   module Aggregations
     class SumService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_datetime:, to_datetime:, options: {})
-        @from_datetime = from_datetime
-        @to_datetime = to_datetime
-
+      def aggregate(options: {})
         aggregation = events.sum("(#{sanitized_field_name})::numeric")
 
         if options[:is_pay_in_advance] && options[:is_current_usage]
@@ -89,8 +86,6 @@ module BillableMetrics
       end
 
       protected
-
-      attr_reader :from_datetime, :to_datetime
 
       def events
         @events ||= begin

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -3,10 +3,7 @@
 module BillableMetrics
   module Aggregations
     class UniqueCountService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_datetime:, to_datetime:, options: {})
-        @from_datetime = from_datetime
-        @to_datetime = to_datetime
-
+      def aggregate(options: {})
         aggregation = compute_aggregation.ceil(5)
 
         if options[:is_pay_in_advance] && options[:is_current_usage]
@@ -65,8 +62,6 @@ module BillableMetrics
       end
 
       protected
-
-      attr_reader :from_datetime, :to_datetime
 
       # This method fetches the latest event in current period. If such a event exists we know that metadata
       # with previous aggregation and previous maximum aggregation are stored there. Fetching these metadata values

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -3,10 +3,7 @@
 module BillableMetrics
   module Breakdown
     class SumService < BillableMetrics::ProratedAggregations::SumService
-      def breakdown(from_datetime:, to_datetime:)
-        @from_datetime = from_datetime
-        @to_datetime = to_datetime
-
+      def breakdown
         breakdown = persisted_breakdown
         breakdown += period_breakdown
 
@@ -16,8 +13,6 @@ module BillableMetrics
       end
 
       private
-
-      attr_reader :from_datetime, :to_datetime
 
       def from_date_in_customer_timezone
         from_datetime.in_time_zone(customer.applicable_timezone).to_date

--- a/app/services/billable_metrics/breakdown/unique_count_service.rb
+++ b/app/services/billable_metrics/breakdown/unique_count_service.rb
@@ -3,10 +3,7 @@
 module BillableMetrics
   module Breakdown
     class UniqueCountService < BillableMetrics::ProratedAggregations::UniqueCountService
-      def breakdown(from_datetime:, to_datetime:)
-        @from_datetime = from_datetime
-        @to_datetime = to_datetime
-
+      def breakdown
         breakdown = persisted_breakdown
         breakdown += added_breakdown
         breakdown += removed_breadown
@@ -18,8 +15,6 @@ module BillableMetrics
       end
 
       private
-
-      attr_reader :from_datetime, :to_datetime
 
       def from_date_in_customer_timezone
         from_datetime.in_time_zone(customer.applicable_timezone).to_date

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -4,7 +4,7 @@ module BillableMetrics
   module ProratedAggregations
     class BaseService < BillableMetrics::Aggregations::BaseService
       def aggregation_without_proration
-        @aggregation_without_proration ||= base_aggregator.aggregate(from_datetime:, to_datetime:, options:)
+        @aggregation_without_proration ||= base_aggregator.aggregate(options:)
       end
 
       def previous_event

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -9,9 +9,7 @@ module BillableMetrics
         super(**args)
       end
 
-      def aggregate(from_datetime:, to_datetime:, options: {})
-        @from_datetime = from_datetime
-        @to_datetime = to_datetime
+      def aggregate(options: {})
         @options = options
 
         # For charges that are pay in advance on billing date we always bill full amount
@@ -36,7 +34,7 @@ module BillableMetrics
 
       protected
 
-      attr_reader :from_datetime, :to_datetime, :options
+      attr_reader :options
 
       def compute_aggregation
         ActiveRecord::Base.connection.execute(aggregation_query).first['aggregation_result']

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -9,9 +9,7 @@ module BillableMetrics
         super(**args)
       end
 
-      def aggregate(from_datetime:, to_datetime:, options: {})
-        @from_datetime = from_datetime
-        @to_datetime = to_datetime
+      def aggregate(options: {})
         @options = options
 
         # For charges that are pay in advance on billing date we always bill full amount
@@ -34,7 +32,7 @@ module BillableMetrics
 
       protected
 
-      attr_reader :from_datetime, :to_datetime, :options
+      attr_reader :options
 
       def compute_prorated_aggregation
         ActiveRecord::Base.connection.execute(prorated_aggregation_query).first['aggregation_result']

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -13,12 +13,17 @@ module Charges
     end
 
     def call
-      aggregator = aggregator_service.new(billable_metric:, subscription:, group:, event:)
-      aggregator.aggregate(
-        from_datetime: boundaries[:charges_from_datetime],
-        to_datetime: boundaries[:charges_to_datetime],
-        options: aggregation_options,
+      aggregator = aggregator_service.new(
+        billable_metric:,
+        subscription:,
+        group:,
+        event:,
+        boundaries: {
+          from_datetime: boundaries[:charges_from_datetime],
+          to_datetime: boundaries[:charges_to_datetime],
+        },
       )
+      aggregator.aggregate(options: aggregation_options)
     end
 
     private

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -96,11 +96,7 @@ module Fees
     end
 
     def compute_amount(properties:, group: nil)
-      aggregation_result = aggregator(group:).aggregate(
-        from_datetime: boundaries.charges_from_datetime,
-        to_datetime: boundaries.charges_to_datetime,
-        options: options(properties),
-      )
+      aggregation_result = aggregator(group:).aggregate(options: options(properties))
       return aggregation_result unless aggregation_result.success?
 
       apply_charge_model_service(aggregation_result, properties)
@@ -149,7 +145,15 @@ module Fees
                              raise(NotImplementedError)
       end
 
-      @aggregator = aggregator_service.new(billable_metric:, subscription:, group:)
+      @aggregator = aggregator_service.new(
+        billable_metric:,
+        subscription:,
+        group:,
+        boundaries: {
+          from_datetime: boundaries.charges_from_datetime,
+          to_datetime: boundaries.charges_to_datetime,
+        },
+      )
     end
 
     def apply_charge_model_service(aggregation_result, properties)

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       subscription:,
       group:,
       event: pay_in_advance_event,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
     )
   end
 
@@ -42,7 +46,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
   end
 
   it 'aggregates the events' do
-    result = count_service.aggregate(from_datetime:, to_datetime:)
+    result = count_service.aggregate
 
     expect(result.aggregation).to eq(4)
   end
@@ -51,7 +55,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
     let(:to_datetime) { Time.zone.now - 2.days }
 
     it 'does not take events into account' do
-      result = count_service.aggregate(from_datetime:, to_datetime:)
+      result = count_service.aggregate
 
       expect(result.aggregation).to eq(0)
     end
@@ -114,7 +118,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
     end
 
     it 'aggregates the events' do
-      result = count_service.aggregate(from_datetime:, to_datetime:)
+      result = count_service.aggregate
 
       expect(result.aggregation).to eq(2)
     end
@@ -124,7 +128,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
     let(:pay_in_advance_event) { create(:event, subscription:, customer:) }
 
     it 'assigns an pay_in_advance aggregation' do
-      result = count_service.aggregate(from_datetime:, to_datetime:)
+      result = count_service.aggregate
 
       expect(result.pay_in_advance_aggregation).to eq(1)
     end

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       billable_metric:,
       subscription:,
       group:,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
     )
   end
 
@@ -54,7 +58,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
   end
 
   it 'aggregates the events' do
-    result = max_service.aggregate(from_datetime:, to_datetime:)
+    result = max_service.aggregate
 
     expect(result.aggregation).to eq(12)
     expect(result.count).to eq(5)
@@ -64,7 +68,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     let(:to_datetime) { Time.zone.now - 2.days }
 
     it 'does not take events into account' do
-      result = max_service.aggregate(from_datetime:, to_datetime:)
+      result = max_service.aggregate
 
       expect(result.aggregation).to eq(0)
       expect(result.count).to eq(0)
@@ -77,7 +81,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     end
 
     it 'counts as zero' do
-      result = max_service.aggregate(from_datetime:, to_datetime:)
+      result = max_service.aggregate
 
       expect(result.aggregation).to eq(0)
       expect(result.count).to eq(0)
@@ -99,7 +103,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     end
 
     it 'aggregates the events' do
-      result = max_service.aggregate(from_datetime:, to_datetime:)
+      result = max_service.aggregate
 
       expect(result.aggregation).to eq(14.2)
     end
@@ -120,7 +124,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     end
 
     it 'returns a failed result' do
-      result = max_service.aggregate(from_datetime:, to_datetime:)
+      result = max_service.aggregate
 
       aggregate_failures do
         expect(result).not_to be_success
@@ -143,7 +147,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     end
 
     it 'ignore the event' do
-      result = max_service.aggregate(from_datetime:, to_datetime:)
+      result = max_service.aggregate
 
       expect(result).to be_success
       expect(result.aggregation).to eq(12)
@@ -194,7 +198,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     end
 
     it 'aggregates the events' do
-      result = max_service.aggregate(from_datetime:, to_datetime:)
+      result = max_service.aggregate
 
       expect(result.aggregation).to eq(12)
       expect(result.count).to eq(2)

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       billable_metric:,
       subscription:,
       group:,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
     )
   end
 
@@ -54,7 +58,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
   before { quantified_event }
 
   describe '#aggregate' do
-    let(:result) { recurring_service.aggregate(from_datetime:, to_datetime:) }
+    let(:result) { recurring_service.aggregate }
 
     context 'with persisted metric on full period' do
       it 'returns the number of persisted metric' do
@@ -179,7 +183,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
   end
 
   describe '#breakdown' do
-    let(:result) { recurring_service.breakdown(from_datetime:, to_datetime:).breakdown }
+    let(:result) { recurring_service.breakdown.breakdown }
 
     context 'with persisted metric on full period' do
       it 'returns the detail the persisted metrics' do
@@ -457,7 +461,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       end
 
       it 'aggregates the events' do
-        result = recurring_service.aggregate(from_datetime:, to_datetime:)
+        result = recurring_service.aggregate
 
         expect(result.aggregation).to eq(2)
       end

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       subscription:,
       group:,
       event: pay_in_advance_event,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
     )
   end
 
@@ -66,7 +70,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
   end
 
   it 'aggregates the events' do
-    result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+    result = sum_service.aggregate(options:)
 
     expect(result.aggregation).to eq(48)
     expect(result.pay_in_advance_aggregation).to be_zero
@@ -78,7 +82,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     before { billable_metric.update!(recurring: true) }
 
     it 'aggregates the events' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
 
       expect(result.aggregation).to eq(53)
       expect(result.pay_in_advance_aggregation).to be_zero
@@ -91,7 +95,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     let(:options) { {} }
 
     it 'returns an empty running total array' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
       expect(result.options).to eq({ running_total: [] })
     end
   end
@@ -102,7 +106,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'returns an empty running total array' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
       expect(result.options).to eq({ running_total: [] })
     end
   end
@@ -113,7 +117,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'returns running total based on per total aggregation' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
       expect(result.options).to eq({ running_total: [12, 24, 36] })
     end
   end
@@ -124,7 +128,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'returns running total based on per events' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
       expect(result.options).to eq({ running_total: [12, 24] })
     end
   end
@@ -145,7 +149,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'does not take events into account' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:)
+      result = sum_service.aggregate
 
       expect(result.aggregation).to eq(0)
       expect(result.count).to eq(0)
@@ -159,7 +163,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'counts as zero' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:)
+      result = sum_service.aggregate
 
       expect(result.aggregation).to eq(0)
       expect(result.count).to eq(0)
@@ -182,7 +186,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'aggregates the events' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:)
+      result = sum_service.aggregate
 
       expect(result.aggregation).to eq(52.5)
     end
@@ -203,7 +207,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'returns a failed result' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:)
+      result = sum_service.aggregate
 
       aggregate_failures do
         expect(result).not_to be_success
@@ -238,7 +242,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     before { billable_metric.update!(recurring: true) }
 
     it 'returns period maximum as aggregation' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
 
       expect(result.aggregation).to eq(11)
     end
@@ -249,7 +253,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       before { billable_metric.update!(recurring: false) }
 
       it 'returns zero as aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+        result = sum_service.aggregate(options:)
 
         expect(result.aggregation).to eq(0)
       end
@@ -300,7 +304,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'aggregates the events' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
 
       expect(result.aggregation).to eq(20)
       expect(result.count).to eq(2)
@@ -338,7 +342,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     end
 
     it 'returns the correct number' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
 
       expect(result.aggregation).to eq(63)
     end
@@ -361,7 +365,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
     let(:properties) { { total_count: 10 } }
 
     it 'assigns a pay_in_advance aggregation' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:)
+      result = sum_service.aggregate
 
       expect(result.pay_in_advance_aggregation).to eq(10)
     end
@@ -385,7 +389,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       end
 
       it 'assigns a pay_in_advance aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:)
+        result = sum_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to eq(4)
       end
@@ -411,7 +415,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       end
 
       it 'assigns a pay_in_advance aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:)
+        result = sum_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to eq(0)
       end
@@ -421,7 +425,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       let(:properties) { { total_count: 12.4 } }
 
       it 'assigns a pay_in_advance aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:)
+        result = sum_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to eq(12.4)
       end
@@ -431,7 +435,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       let(:properties) { { final_count: 10 } }
 
       it 'assigns 0 as pay_in_advance aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:)
+        result = sum_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to be_zero
       end
@@ -441,7 +445,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
       let(:properties) { {} }
 
       it 'assigns 0 as pay_in_advance aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:)
+        result = sum_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to be_zero
       end

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       subscription:,
       group:,
       event: pay_in_advance_event,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
     )
   end
 
@@ -67,7 +71,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
   before { unique_count_event }
 
   describe '#aggregate' do
-    let(:result) { count_service.aggregate(from_datetime:, to_datetime:) }
+    let(:result) { count_service.aggregate }
 
     context 'when there is persisted event and event added in period' do
       let(:new_quantified_event) do
@@ -293,7 +297,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       before { previous_event }
 
       it 'returns period maximum as aggregation' do
-        result = count_service.aggregate(from_datetime:, to_datetime:, options:)
+        result = count_service.aggregate(options:)
 
         expect(result.aggregation).to eq(4)
       end
@@ -304,7 +308,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         before { billable_metric.update!(recurring: false) }
 
         it 'returns zero as aggregation' do
-          result = count_service.aggregate(from_datetime:, to_datetime:, options:)
+          result = count_service.aggregate(options:)
 
           expect(result.aggregation).to eq(0)
         end
@@ -338,7 +342,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       before { pay_in_advance_event }
 
       it 'assigns an pay_in_advance aggregation' do
-        result = count_service.aggregate(from_datetime:, to_datetime:)
+        result = count_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to eq(1)
       end
@@ -351,7 +355,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         end
 
         it 'assigns an pay_in_advance aggregation' do
-          result = count_service.aggregate(from_datetime:, to_datetime:)
+          result = count_service.aggregate
 
           expect(result.pay_in_advance_aggregation).to eq(1)
         end
@@ -361,7 +365,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         let(:properties) { {} }
 
         it 'assigns 0 as pay_in_advance aggregation' do
-          result = count_service.aggregate(from_datetime:, to_datetime:)
+          result = count_service.aggregate
 
           expect(result.pay_in_advance_aggregation).to be_zero
         end
@@ -400,7 +404,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         before { previous_event }
 
         it 'assigns a pay_in_advance aggregation' do
-          result = count_service.aggregate(from_datetime:, to_datetime:)
+          result = count_service.aggregate
 
           expect(result.pay_in_advance_aggregation).to eq(1)
         end
@@ -439,7 +443,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         before { previous_event }
 
         it 'assigns a pay_in_advance aggregation' do
-          result = count_service.aggregate(from_datetime:, to_datetime:)
+          result = count_service.aggregate
 
           expect(result.pay_in_advance_aggregation).to eq(0)
         end

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service do
       billable_metric:,
       subscription:,
       group:,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
     )
   end
 
@@ -71,7 +75,7 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service do
   end
 
   describe '#breakdown' do
-    let(:result) { service.breakdown(from_datetime:, to_datetime:).breakdown }
+    let(:result) { service.breakdown.breakdown }
 
     context 'with persisted metric on full period' do
       it 'returns the detail the persisted metrics' do

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
       billable_metric:,
       subscription:,
       group:,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
     )
   end
 
@@ -54,7 +58,7 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
   before { quantified_event }
 
   describe '#breakdown' do
-    let(:result) { service.breakdown(from_datetime:, to_datetime:).breakdown }
+    let(:result) { service.breakdown.breakdown }
 
     context 'with persisted metric on full period' do
       it 'returns the detail the persisted metrics' do

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       subscription:,
       group:,
       event: pay_in_advance_event,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
     )
   end
 
@@ -65,7 +69,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
   end
 
   it 'aggregates the events' do
-    result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+    result = sum_service.aggregate(options:)
 
     expect(result.aggregation).to eq(9.64517) # 5 + (12*6/31) + (12*6/31)
     expect(result.pay_in_advance_aggregation).to be_zero
@@ -78,7 +82,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     end
 
     it 'aggregates the events without proration' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
 
       expect(result.aggregation).to eq(29)
       expect(result.pay_in_advance_aggregation).to be_zero
@@ -102,7 +106,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     end
 
     it 'does not take events into account' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:)
+      result = sum_service.aggregate
 
       expect(result.aggregation).to eq(5)
       expect(result.count).to eq(2)
@@ -115,7 +119,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     end
 
     it 'counts as zero' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:)
+      result = sum_service.aggregate
 
       expect(result.aggregation).to eq(0)
       expect(result.count).to eq(0)
@@ -137,7 +141,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     end
 
     it 'aggregates the events' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:)
+      result = sum_service.aggregate
 
       expect(result.aggregation).to eq(9.64517 + 0.14516)
     end
@@ -158,7 +162,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     end
 
     it 'returns a failed result' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:)
+      result = sum_service.aggregate
 
       aggregate_failures do
         expect(result).not_to be_success
@@ -175,7 +179,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     end
 
     it 'returns period maximum as aggregation' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
 
       expect(result.aggregation).to eq(9.64517)
       expect(result.current_usage_units).to eq(29)
@@ -205,7 +209,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     end
 
     it 'returns period maximum as aggregation' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
 
       expect(result.aggregation).to eq(8.8)
       expect(result.current_usage_units).to eq(9)
@@ -215,7 +219,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       let(:latest_events) { nil }
 
       it 'returns zero as aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+        result = sum_service.aggregate(options:)
 
         expect(result.aggregation).to eq(5)
         expect(result.current_usage_units).to eq(5)
@@ -231,7 +235,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     let(:latest_events) { nil }
 
     it 'returns correct values' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
 
       expect(result.aggregation).to eq((5 * 17.fdiv(31)).ceil(5))
       expect(result.current_usage_units).to eq(5)
@@ -262,7 +266,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     end
 
     it 'returns correct values' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
 
       expect(result.aggregation).to eq((5 * 17.fdiv(31)).ceil(5) + 3.8)
       expect(result.current_usage_units).to eq(9)
@@ -313,7 +317,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     end
 
     it 'aggregates the events' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
 
       expect(result.aggregation).to eq(0.64517) # (1/31 * 8) + (1/31 * 12)
       expect(result.count).to eq(2)
@@ -349,7 +353,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     end
 
     it 'returns the correct number' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:, options:)
+      result = sum_service.aggregate(options:)
 
       expect(result.aggregation).to eq(19.64517) # 10 + 5 + (6/31*12) + (6/31*12)
     end
@@ -372,7 +376,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     let(:properties) { { total_count: 10 } }
 
     it 'assigns a pay_in_advance aggregation' do
-      result = sum_service.aggregate(from_datetime:, to_datetime:)
+      result = sum_service.aggregate
 
       expect(result.pay_in_advance_aggregation).to eq(0.64517)
     end
@@ -397,7 +401,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       end
 
       it 'assigns a pay_in_advance aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:)
+        result = sum_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to eq(0.25807) # 4 * (2/31)
       end
@@ -424,7 +428,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       end
 
       it 'assigns a pay_in_advance aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:)
+        result = sum_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to eq(0)
         expect(result.units_applied).to eq('-2')
@@ -435,7 +439,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       let(:properties) { { total_count: 12.4 } }
 
       it 'assigns a pay_in_advance aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:)
+        result = sum_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to eq(0.8) # 2/31*12.4
       end
@@ -445,7 +449,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       let(:properties) { { final_count: 10 } }
 
       it 'assigns 0 as pay_in_advance aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:)
+        result = sum_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to be_zero
       end
@@ -455,7 +459,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       let(:properties) { {} }
 
       it 'assigns 0 as pay_in_advance aggregation' do
-        result = sum_service.aggregate(from_datetime:, to_datetime:)
+        result = sum_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to be_zero
       end

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
       subscription:,
       group:,
       event: pay_in_advance_event,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
     )
   end
 
@@ -58,7 +62,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
   before { quantified_event }
 
   describe '#aggregate' do
-    let(:result) { unique_count_service.aggregate(from_datetime:, to_datetime:, options:) }
+    let(:result) { unique_count_service.aggregate(options:) }
 
     context 'with persisted metric on full period' do
       it 'returns the number of persisted metric' do

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -37,11 +37,18 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
         agg_service.call
 
         expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
-          .with(billable_metric:, subscription:, group:, event:)
+          .with(
+            billable_metric:,
+            subscription:,
+            group:,
+            event:,
+            boundaries: {
+              from_datetime: boundaries[:charges_from_datetime],
+              to_datetime: boundaries[:charges_to_datetime],
+            },
+          )
 
         expect(count_service).to have_received(:aggregate).with(
-          from_datetime: boundaries[:charges_from_datetime],
-          to_datetime: boundaries[:charges_to_datetime],
           options: { free_units_per_events: 0, free_units_per_total_aggregation: 0 },
         )
       end
@@ -60,11 +67,18 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
         agg_service.call
 
         expect(BillableMetrics::Aggregations::SumService).to have_received(:new)
-          .with(billable_metric:, subscription:, group:, event:)
+          .with(
+            billable_metric:,
+            subscription:,
+            group:,
+            event:,
+            boundaries: {
+              from_datetime: boundaries[:charges_from_datetime],
+              to_datetime: boundaries[:charges_to_datetime],
+            },
+          )
 
         expect(sum_service).to have_received(:aggregate).with(
-          from_datetime: boundaries[:charges_from_datetime],
-          to_datetime: boundaries[:charges_to_datetime],
           options: { free_units_per_events: 3, free_units_per_total_aggregation: 50 },
         )
       end
@@ -82,11 +96,18 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
         agg_service.call
 
         expect(BillableMetrics::Aggregations::UniqueCountService).to have_received(:new)
-          .with(billable_metric:, subscription:, group:, event:)
+          .with(
+            billable_metric:,
+            subscription:,
+            group:,
+            event:,
+            boundaries: {
+              from_datetime: boundaries[:charges_from_datetime],
+              to_datetime: boundaries[:charges_to_datetime],
+            },
+          )
 
         expect(unique_count_service).to have_received(:aggregate).with(
-          from_datetime: boundaries[:charges_from_datetime],
-          to_datetime: boundaries[:charges_to_datetime],
           options: { free_units_per_events: 0, free_units_per_total_aggregation: 0 },
         )
       end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/apply-price-floorcap-on-transactions

## Context

Fintech users want to be able to cap a transaction to a maximum amount or to flour it to a minimum amount.

This feature will apply this logic to the `percentage` charge model.

## Description

In order to ease the logic for the min/max per transaction amount on the `percentage` charge model, this PR is refactoring the billable metric aggregator services. It moves the boundaries from the aggregate method calls to the service initializer, to make it easier to call other method on the service if required.