### PR TITLE
fix (invoices): update condition when to bill charges

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -145,7 +145,18 @@ module Invoices
 
       charge.billable_metric.recurring? &&
         subscription.terminated? &&
-        subscription.upgraded?
+        subscription.upgraded? &&
+        charge_included_in_next_subscription?(charge, subscription)
+    end
+
+    def charge_included_in_next_subscription?(charge, subscription)
+      return false if subscription.next_subscription.nil?
+
+      next_subscription_charges = subscription.next_subscription.plan.charges
+
+      return false if next_subscription_charges.blank?
+
+      next_subscription_charges.pluck(:billable_metric_id).include?(charge.billable_metric_id)
     end
 
     def should_create_subscription_fee?(subscription)

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -149,6 +149,8 @@ module Invoices
         charge_included_in_next_subscription?(charge, subscription)
     end
 
+    # NOTE: If same charge is NOT included in upgraded plan we still want to bill it. However if new plan is using
+    # the same charge it should not be billed since it is recurring and will be billed at the end of period
     def charge_included_in_next_subscription?(charge, subscription)
       return false if subscription.next_subscription.nil?
 


### PR DESCRIPTION
## Context

This PR fix condition when to bill charges.

For recurring pay in arrear charges (non-prorated) we want to skip billing charges upon upgrade. However, this should happen only if upgraded plan contains charge with the same billable metric