### PR TITLE
feat(webhooks): Add subscription.started webhook

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -25,6 +25,7 @@ class SendWebhookJob < ApplicationJob
     'credit_note.generated' => Webhooks::CreditNotes::GeneratedService,
     'credit_note.provider_refund_failure' => Webhooks::CreditNotes::PaymentProviderRefundFailureService,
     'subscription.terminated' => Webhooks::Subscriptions::TerminatedService,
+    'subscription.started' => Webhooks::Subscriptions::StartedService,
   }.freeze
 
   def perform(webhook_type, object, options = {}, webhook_id = nil)

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -3,7 +3,7 @@
 module V1
   class SubscriptionSerializer < ModelSerializer
     def serialize
-      {
+      payload = {
         lago_id: model.id,
         external_id: model.external_id,
         lago_customer_id: model.customer_id,
@@ -21,12 +21,25 @@ module V1
         next_plan_code: model.next_subscription&.plan&.code,
         downgrade_plan_date: model.downgrade_plan_date&.iso8601,
       }.merge(legacy_values)
+
+      payload = payload.merge(customer:) if include?(:customer)
+      payload = payload.merge(plan:) if include?(:plan)
+
+      payload
     end
 
     private
 
     def legacy_values
       ::V1::Legacy::SubscriptionSerializer.new(model).serialize
+    end
+
+    def customer
+      ::V1::CustomerSerializer.new(model.customer).serialize
+    end
+
+    def plan
+      ::V1::PlanSerializer.new(model.plan).serialize
     end
   end
 end

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -17,7 +17,9 @@ module Subscriptions
         .find_each do |subscription|
           subscription.mark_as_active!(Time.zone.at(timestamp))
 
-          BillSubscriptionJob.perform_later([subscription], timestamp) if subscription.plan.pay_in_advance?
+          SendWebhookJob.perform_later('subscription.started', subscription)
+
+          BillSubscriptionJob.perform_later([subscription], timestamp) if subscription.plan.pay_in_advance?   
         end
     end
 

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -19,7 +19,7 @@ module Subscriptions
 
           SendWebhookJob.perform_later('subscription.started', subscription)
 
-          BillSubscriptionJob.perform_later([subscription], timestamp) if subscription.plan.pay_in_advance?   
+          BillSubscriptionJob.perform_later([subscription], timestamp) if subscription.plan.pay_in_advance?
         end
     end
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -105,6 +105,8 @@ module Subscriptions
           )
       end
 
+      SendWebhookJob.perform_later('subscription.started', new_subscription) if new_subscription.active?
+
       new_subscription
     end
 

--- a/app/services/webhooks/subscriptions/started_service.rb
+++ b/app/services/webhooks/subscriptions/started_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Subscriptions
+    class StartedService < Webhooks::BaseService
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::SubscriptionSerializer.new(
+          object,
+          root_name: 'subscription',
+          includes: %i[plan customer],
+        )
+      end
+
+      def webhook_type
+        'subscription.started'
+      end
+
+      def object_type
+        'subscription'
+      end
+    end
+  end
+end

--- a/app/services/webhooks/subscriptions/terminated_service.rb
+++ b/app/services/webhooks/subscriptions/terminated_service.rb
@@ -11,6 +11,7 @@ module Webhooks
         ::V1::SubscriptionSerializer.new(
           object,
           root_name: 'subscription',
+          includes: %i[plan customer],
         )
       end
 

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -366,4 +366,26 @@ RSpec.describe SendWebhookJob, type: :job do
         .to raise_error(NotImplementedError)
     end
   end
+
+  context 'when webhook type is subscription.started' do
+    let(:webhook_service) { instance_double(Webhooks::Subscriptions::StartedService) }
+    let(:subscription) { create(:subscription) }
+
+    before do
+      allow(Webhooks::Subscriptions::StartedService).to receive(:new)
+        .with(object: subscription, options: {}, webhook_id: nil)
+        .and_return(webhook_service)
+      allow(webhook_service).to receive(:call)
+    end
+
+    it 'calls the webhook service' do
+      send_webhook_job.perform_now(
+        'subscription.started',
+        subscription,
+      )
+
+      expect(Webhooks::Subscriptions::StartedService).to have_received(:new)
+      expect(webhook_service).to have_received(:call)
+    end
+  end
 end

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -11,17 +11,20 @@ RSpec.describe ::V1::SubscriptionSerializer do
     result = JSON.parse(serializer.to_json)
 
     aggregate_failures do
-      expect(result['subscription']['lago_id']).to eq(subscription.id)
-      expect(result['subscription']['external_id']).to eq(subscription.external_id)
-      expect(result['subscription']['lago_customer_id']).to eq(subscription.customer_id)
-      expect(result['subscription']['external_customer_id']).to eq(subscription.customer.external_id)
-      expect(result['subscription']['name']).to eq(subscription.name)
-      expect(result['subscription']['plan_code']).to eq(subscription.plan.code)
-      expect(result['subscription']['status']).to eq(subscription.status)
-      expect(result['subscription']['billing_time']).to eq(subscription.billing_time)
-      expect(result['subscription']['created_at']).to eq(subscription.created_at.iso8601)
-      expect(result['subscription']['customer']['lago_id']).to eq(subscription.customer.id)
-      expect(result['subscription']['plan']['lago_id']).to eq(subscription.plan.id)
+      expect(result['subscription']).to include(
+        'lago_id' => subscription.id,
+        'external_id' => subscription.external_id,
+        'lago_customer_id' => subscription.customer_id,
+        'external_customer_id' => subscription.customer.external_id,
+        'name' => subscription.name,
+        'plan_code' => subscription.plan.code,
+        'status' => subscription.status,
+        'billing_time' => subscription.billing_time,
+        'created_at' => subscription.created_at.iso8601,
+      )
+
+      expect(result['subscription']['customer']['lago_id']).to be_present
+      expect(result['subscription']['plan']['lago_id']).to be_present
     end
   end
 end

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::SubscriptionSerializer do
+  subject(:serializer) { described_class.new(subscription, root_name: 'subscription', includes: %i[customer plan]) }
+
+  let!(:subscription) { create(:subscription) }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['subscription']['lago_id']).to eq(subscription.id)
+      expect(result['subscription']['external_id']).to eq(subscription.external_id)
+      expect(result['subscription']['lago_customer_id']).to eq(subscription.customer_id)
+      expect(result['subscription']['external_customer_id']).to eq(subscription.customer.external_id)
+      expect(result['subscription']['name']).to eq(subscription.name)
+      expect(result['subscription']['plan_code']).to eq(subscription.plan.code)
+      expect(result['subscription']['status']).to eq(subscription.status)
+      expect(result['subscription']['billing_time']).to eq(subscription.billing_time)
+      expect(result['subscription']['created_at']).to eq(subscription.created_at.iso8601)
+      expect(result['subscription']['customer']['lago_id']).to eq(subscription.customer.id)
+      expect(result['subscription']['plan']['lago_id']).to eq(subscription.plan.id)
+    end
+  end
+end

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Subscriptions::ActivateService, type: :service do
         .and change(Subscription.active, :count).by(3)
     end
 
+    it 'enqueues a SendWebhookJob' do
+      expect do
+        activate_service.activate_all_pending
+      end.to have_enqueued_job(SendWebhookJob).at_least(1).times
+    end
+
     context 'with customer timezone' do
       let(:timestamp) { DateTime.parse('2022-10-21 00:30:00') }
       let(:pending_subscription) { pending_subscriptions.first }

--- a/spec/services/webhooks/subscriptions/started_service_spec.rb
+++ b/spec/services/webhooks/subscriptions/started_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Subscriptions::StartedService do
+  subject(:webhook_service) { described_class.new(object: subscription) }
+
+  let(:subscription) { create(:subscription) }
+  let(:organization) { subscription.organization }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response)
+    end
+
+    it 'builds payload with subscription.started webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+      expect(lago_client).to have_received(:post_with_response) do |payload|
+        expect(payload[:webhook_type]).to eq('subscription.started')
+        expect(payload[:object_type]).to eq('subscription')
+        expect(payload['subscription'][:customer]).to be_present
+        expect(payload['subscription'][:plan]).to be_present
+      end
+    end
+  end
+end

--- a/spec/services/webhooks/subscriptions/terminated_service_spec.rb
+++ b/spec/services/webhooks/subscriptions/terminated_service_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Subscriptions::TerminatedService do
+  subject(:webhook_service) { described_class.new(object: subscription) }
+
+  let(:subscription) { create(:subscription, status: :terminated) }
+  let(:organization) { subscription.organization }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response)
+    end
+
+    it 'builds payload with subscription.started webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+      expect(lago_client).to have_received(:post_with_response) do |payload|
+        expect(payload[:webhook_type]).to eq('subscription.terminated')
+        expect(payload[:object_type]).to eq('subscription')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/receive-a-webhook-when-a-subscription-starts-subscriptionstarted

## Description

- Add the `subscription.started` webhook