### PR TITLE
fix: retry failed jobs due to ActiveJob::DeserializationError

### DIFF
--- a/app/jobs/bill_subscription_job.rb
+++ b/app/jobs/bill_subscription_job.rb
@@ -3,7 +3,7 @@
 class BillSubscriptionJob < ApplicationJob
   queue_as 'billing'
 
-  retry_on Sequenced::SequenceError
+  retry_on Sequenced::SequenceError, ActiveJob::DeserializationError
 
   def perform(subscriptions, timestamp, recurring: false)
     result = Invoices::SubscriptionService.new(

--- a/app/jobs/payment_provider_customers/adyen_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/adyen_checkout_url_job.rb
@@ -5,6 +5,7 @@ module PaymentProviderCustomers
     queue_as :providers
 
     retry_on Adyen::AdyenError, wait: :exponentially_longer, attempts: 6
+    retry_on ActiveJob::DeserializationError
 
     def perform(adyen_customer)
       result = PaymentProviderCustomers::AdyenService.new(adyen_customer).generate_checkout_url

--- a/app/jobs/payment_provider_customers/adyen_create_job.rb
+++ b/app/jobs/payment_provider_customers/adyen_create_job.rb
@@ -5,6 +5,7 @@ module PaymentProviderCustomers
     queue_as :providers
 
     retry_on Adyen::AdyenError, wait: :exponentially_longer, attempts: 6
+    retry_on ActiveJob::DeserializationError
 
     def perform(adyen_customer)
       result = PaymentProviderCustomers::AdyenService.new(adyen_customer).create

--- a/app/jobs/payment_provider_customers/gocardless_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/gocardless_checkout_url_job.rb
@@ -7,6 +7,7 @@ module PaymentProviderCustomers
     retry_on GoCardlessPro::GoCardlessError, wait: :exponentially_longer, attempts: 6
     retry_on GoCardlessPro::ApiError, wait: :exponentially_longer, attempts: 6
     retry_on GoCardlessPro::RateLimitError, wait: :exponentially_longer, attempts: 6
+    retry_on ActiveJob::DeserializationError
 
     def perform(gocardless_customer)
       result = PaymentProviderCustomers::GocardlessService.new(gocardless_customer).generate_checkout_url

--- a/app/jobs/payment_provider_customers/gocardless_create_job.rb
+++ b/app/jobs/payment_provider_customers/gocardless_create_job.rb
@@ -7,6 +7,7 @@ module PaymentProviderCustomers
     retry_on GoCardlessPro::GoCardlessError, wait: :exponentially_longer, attempts: 6
     retry_on GoCardlessPro::ApiError, wait: :exponentially_longer, attempts: 6
     retry_on GoCardlessPro::RateLimitError, wait: :exponentially_longer, attempts: 6
+    retry_on ActiveJob::DeserializationError
 
     def perform(gocardless_customer)
       result = PaymentProviderCustomers::GocardlessService.new(gocardless_customer).create

--- a/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_checkout_url_job.rb
@@ -7,6 +7,7 @@ module PaymentProviderCustomers
     retry_on Stripe::APIConnectionError, wait: :exponentially_longer, attempts: 6
     retry_on Stripe::APIError, wait: :exponentially_longer, attempts: 6
     retry_on Stripe::RateLimitError, wait: :exponentially_longer, attempts: 6
+    retry_on ActiveJob::DeserializationError
 
     def perform(stripe_customer)
       result = PaymentProviderCustomers::StripeService.new(stripe_customer).generate_checkout_url

--- a/app/jobs/payment_provider_customers/stripe_create_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_create_job.rb
@@ -7,6 +7,7 @@ module PaymentProviderCustomers
     retry_on Stripe::APIConnectionError, wait: :exponentially_longer, attempts: 6
     retry_on Stripe::APIError, wait: :exponentially_longer, attempts: 6
     retry_on Stripe::RateLimitError, wait: :exponentially_longer, attempts: 6
+    retry_on ActiveJob::DeserializationError
 
     def perform(stripe_customer)
       result = PaymentProviderCustomers::StripeService.new(stripe_customer).create

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -96,9 +96,9 @@ module Subscriptions
 
       if new_subscription.active? && new_subscription.subscription_at.today? && plan.pay_in_advance?
         # NOTE: Since job is laucnhed from inside a db transaction
-        #       we must wait for it to be commited before processing the job
+        #       we must wait for it to be commited before processing the job.
+        #       We do not set offset anymore but instead retry jobs
         BillSubscriptionJob
-          .set(wait: 2.seconds)
           .perform_later(
             [new_subscription],
             Time.zone.now.to_i,
@@ -144,7 +144,8 @@ module Subscriptions
       # NOTE: Create an invoice for the terminated subscription
       #       if it has not been billed yet
       #       or only for the charges if subscription was billed in advance
-      BillSubscriptionJob.set(wait: 2.seconds)
+      #       We do not set offset anymore but instead retry jobs
+      BillSubscriptionJob
         .perform_later(
           [current_subscription],
           Time.zone.now.to_i + 1.second, # NOTE: Adding 1 second because of to_i rounding.
@@ -153,8 +154,8 @@ module Subscriptions
       if plan.pay_in_advance?
         # NOTE: Since job is launched from inside a db transaction
         #       we must wait for it to be commited before processing the job
+        #       We do not set offset anymore but instead retry jobs
         BillSubscriptionJob
-          .set(wait: 2.seconds)
           .perform_later(
             [new_subscription],
             Time.zone.now.to_i + 1.second, # NOTE: Adding 1 second because of to_i rounding.


### PR DESCRIPTION
## Context

If jobs are called inside DB transaction `ActiveJob::DeserializationError` is raised. Retry such a jobs since in the meantime probably transaction has been committed. By default sidekiq retries jibs after 3 seconds