### PR TITLE
feat(charge): Apply per transaction min/max in percentage charge model

### DIFF
--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -31,6 +31,10 @@ module Types
       field :draft_invoices_count, Integer, null: false
       field :subscriptions_count, Integer, null: false
 
+      def charges
+        object.charges.order(created_at: :asc)
+      end
+
       def charge_count
         object.charges.count
       end

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -10,6 +10,8 @@ module BillableMetrics
         @group = group
         @event = event
         @boundaries = boundaries
+
+        result.aggregator = self
       end
 
       def aggregate(options: {})

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -58,8 +58,13 @@ module Charges
       previous_result.aggregation = aggregation_result.aggregation - aggregation_result.pay_in_advance_aggregation
       previous_result.count = aggregation_result.count - 1
       previous_result.options = aggregation_result.options
+      previous_result.aggregator = aggregation_result.aggregator
 
-      charge_model.apply(charge:, aggregation_result: previous_result, properties:).amount
+      charge_model.apply(
+        charge:,
+        aggregation_result: previous_result,
+        properties: (properties || {}).merge(ignore_last_event: true),
+      ).amount
     end
 
     def currency

--- a/spec/scenarios/charge_models/percentage_spec.rb
+++ b/spec/scenarios/charge_models/percentage_spec.rb
@@ -319,5 +319,77 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
         end
       end
     end
+
+    describe 'with min and max per transaction amount' do
+      around { |test| lago_premium!(&test) }
+
+      it 'returns the expected customer usage' do
+        travel_to(DateTime.new(2023, 3, 5)) do
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code,
+            },
+          )
+        end
+
+        create(
+          :percentage_charge,
+          plan:,
+          billable_metric:,
+          properties: {
+            rate: '1',
+            fixed_amount: '1',
+            per_transaction_max_amount: '12',
+            per_transaction_min_amount: '1.75',
+          },
+        )
+
+        travel_to(DateTime.new(2023, 3, 6)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '100' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:total_amount_cents]).to eq(240)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('100.0')
+          expect(json[:customer_usage][:charges_usage][0][:amount_cents]).to eq(200)
+
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '1000' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:total_amount_cents]).to eq(1560)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1100.0')
+          expect(json[:customer_usage][:charges_usage][0][:amount_cents]).to eq(1300)
+
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '10000' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:total_amount_cents]).to eq(3000)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('11100.0')
+          expect(json[:customer_usage][:charges_usage][0][:amount_cents]).to eq(2500)
+        end
+      end
+    end
   end
 end

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -12,9 +12,18 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService, type: :service do
       result.pay_in_advance_aggregation = 1
       result.count = 5
       result.options = {}
+      result.aggregator = aggregator
     end
   end
   let(:properties) { {} }
+
+  let(:aggregator) do
+    BillableMetrics::Aggregations::CountService.new(
+      billable_metric: charge.billable_metric,
+      subscription: nil,
+      boundaries: nil,
+    )
+  end
 
   describe '#call' do
     context 'when charge is not pay_in_advance' do
@@ -38,6 +47,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService, type: :service do
           result.aggregation = 9
           result.count = 4
           result.options = {}
+          result.aggregator = aggregator
         end
 
         allow(charge_model_class).to receive(:apply)
@@ -45,7 +55,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService, type: :service do
           .and_return(BaseService::Result.new.tap { |r| r.amount = 10 })
 
         allow(charge_model_class).to receive(:apply)
-          .with(charge:, aggregation_result: previous_agg_result, properties:)
+          .with(charge:, aggregation_result: previous_agg_result, properties: properties.merge(ignore_last_event: true))
           .and_return(BaseService::Result.new.tap { |r| r.amount = 8 })
 
         result = charge_service.call


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/apply-price-floorcap-on-transactions

## Context

Fintech users want to be able to cap a transaction to a maximum amount or to flour it to a minimum amount.

This feature will apply this logic to the `percentage` charge model.

## Description

This PR is the last one for the feature. It uses the previously added `per_event_aggregation` to apply the min/max amount in the percentage charge model service