### PR TITLE
fix: update scope for count unique prorated charges with groups

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -68,6 +68,13 @@ module BillableMetrics
         events.where('events.properties @> ?', { group.parent.key.to_s => group.parent.value }.to_json)
       end
 
+      def count_unique_group_scope(events)
+        events = events.where('quantified_events.properties @> ?', { group.key.to_s => group.value }.to_json)
+        return events unless group.parent
+
+        events.where('quantified_events.properties @> ?', { group.parent.key.to_s => group.parent.value }.to_json)
+      end
+
       def sanitized_name(property)
         ActiveRecord::Base.sanitize_sql_for_conditions(
           ['events.properties->>?', property],

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -160,13 +160,6 @@ module BillableMetrics
       def sanitized_operation_type
         ActiveRecord::Base.sanitize_sql_for_conditions(['events.properties->>operation_type'])
       end
-
-      def count_unique_group_scope(events)
-        events = events.where('quantified_events.properties @> ?', { group.key.to_s => group.value }.to_json)
-        return events unless group.parent
-
-        events.where('quantified_events.properties @> ?', { group.parent.key.to_s => group.parent.value }.to_json)
-      end
     end
   end
 end

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -100,7 +100,7 @@ module BillableMetrics
 
         return quantified_events unless group
 
-        group_scope(quantified_events)
+        count_unique_group_scope(quantified_events)
       end
 
       # NOTE: Compute pro-rata of the duration in days between the datetimes over the duration of the billing period

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -143,6 +143,28 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
         end
       end
 
+      context 'when dimensions are used' do
+        let(:quantified_event) do
+          create(
+            :quantified_event,
+            customer:,
+            added_at:,
+            removed_at:,
+            external_subscription_id: subscription.external_id,
+            billable_metric:,
+            properties: { unique_id: '111', region: 'europe' },
+          )
+        end
+
+        let(:group) do
+          create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+        end
+
+        it 'returns the number of persisted metric' do
+          expect(result.aggregation).to eq(1)
+        end
+      end
+
       context 'when plan is pay in advance' do
         before do
           subscription.plan.update!(pay_in_advance: true)


### PR DESCRIPTION
If prorated count unique charges have dimensions, aggregation scope is not valid