### PR TITLE
feat(group): Remove status from groups

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -48,7 +48,7 @@ class BillableMetric < ApplicationRecord
   end
 
   def active_groups
-    scope = groups.active.order(created_at: :asc)
+    scope = groups.order(created_at: :asc)
     scope = scope.with_discarded if discarded?
     scope
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,14 +5,11 @@ class Group < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
-  belongs_to :billable_metric
-  belongs_to :parent, class_name: 'Group', foreign_key: 'parent_group_id', optional: true
+  belongs_to :billable_metric, -> { with_discarded }
+  belongs_to :parent, -> { with_discarded }, class_name: 'Group', foreign_key: 'parent_group_id', optional: true
   has_many :children, class_name: 'Group', foreign_key: 'parent_group_id'
   has_many :properties, class_name: 'GroupProperty'
   has_many :fees
-
-  STATUS = %i[active inactive].freeze
-  enum status: STATUS
 
   validates :key, :value, presence: true
 

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -48,7 +48,7 @@ module BillableMetrics
 
     def update_groups(metric, group_params)
       ActiveRecord::Base.transaction do
-        metric.groups.each(&:inactive!)
+        metric.groups.discard_all
 
         Groups::CreateBatchService.call(
           billable_metric: metric,

--- a/db/migrate/20230830120517_remove_status_from_groups.rb
+++ b/db/migrate/20230830120517_remove_status_from_groups.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class RemoveStatusFromGroups < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE groups
+          SET deleted_at = updated_at
+          WHERE deleted_at IS NULL
+          AND groups.status = 1
+        SQL
+      end
+    end
+
+    remove_column :groups, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_21_135235) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_30_120517) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -406,7 +406,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_135235) do
     t.uuid "parent_group_id"
     t.string "key", null: false
     t.string "value", null: false
-    t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -5,6 +5,5 @@ FactoryBot.define do
     billable_metric
     key { 'region' }
     value { 'europe' }
-    status { 'active' }
   end
 end

--- a/spec/requests/api/v1/billable_metrics/groups_spec.rb
+++ b/spec/requests/api/v1/billable_metrics/groups_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Api::V1::BillableMetrics::GroupsController, type: :request do
       it 'returns all billable metric\'s active groups' do
         one = create(:group, billable_metric:)
         second = create(:group, billable_metric:)
-        create(:group, billable_metric:, status: :inactive)
+        create(:group, billable_metric:, deleted_at: Time.current)
 
         get_with_token(organization, "/api/v1/billable_metrics/#{billable_metric.code}/groups")
 
@@ -65,7 +65,7 @@ RSpec.describe Api::V1::BillableMetrics::GroupsController, type: :request do
         parent = create(:group, billable_metric:)
         children1 = create(:group, billable_metric:, parent_group_id: parent.id)
         children2 = create(:group, billable_metric:, parent_group_id: parent.id)
-        create(:group, billable_metric:, parent_group_id: parent.id, status: :inactive)
+        create(:group, billable_metric:, parent_group_id: parent.id, deleted_at: Time.current)
 
         get_with_token(organization, "/api/v1/billable_metrics/#{billable_metric.code}/groups")
 


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/edit-groups-associated-with-billable-metrics

## Context

We want to be able to edit billable metric groups.

## Description

The goal of this PR is to remove useless column `status` from `groups`.
