### PR TITLE
feat (subscriptions): add job that terminates ended subscriptions

### DIFF
--- a/app/jobs/clock/terminate_ended_subscriptions_job.rb
+++ b/app/jobs/clock/terminate_ended_subscriptions_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Clock
+  class TerminateEndedSubscriptionsJob < ApplicationJob
+    queue_as 'clock'
+
+    def perform
+      Subscription
+        .joins(customer: :organization)
+        .active
+        .where("DATE(#{Subscription.ending_at_in_timezone_sql}) = ?", Time.current.to_date)
+        .find_each do |subscription|
+          Subscriptions::TerminateService.call(subscription:)
+        end
+    end
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -42,6 +42,14 @@ class Subscription < ApplicationRecord
     SQL
   end
 
+  # NOTE: SQL query to get subscription_at into customer timezone
+  def self.ending_at_in_timezone_sql
+    <<-SQL
+      subscriptions.ending_at::timestamptz AT TIME ZONE
+      COALESCE(customers.timezone, organizations.timezone, 'UTC')
+    SQL
+  end
+
   def mark_as_active!(timestamp = Time.current)
     self.started_at ||= timestamp
     active!

--- a/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Clock::TerminateEndedSubscriptionsJob, job: true do
+  subject { described_class }
+
+  describe '.perform' do
+    let(:ending_at) { (Time.current + 2.months).beginning_of_day }
+    let(:subscription1) { create(:active_subscription, ending_at:) }
+    let(:subscription2) { create(:active_subscription, ending_at: ending_at + 1.year) }
+    let(:subscription3) { create(:active_subscription, ending_at: nil) }
+
+    before do
+      subscription1
+      subscription2
+      subscription3
+      allow(Subscriptions::TerminateService).to receive(:call)
+    end
+
+    it 'terminates the subscriptions where ending_at matches current data ' do
+      current_date = Time.current + 2.months
+
+      travel_to(current_date) do
+        described_class.perform_now
+        expect(Subscriptions::TerminateService)
+          .to have_received(:call).with(subscription: subscription1)
+        expect(Subscriptions::TerminateService)
+          .not_to have_received(:call).with(subscription: subscription2)
+        expect(Subscriptions::TerminateService)
+          .not_to have_received(:call).with(subscription: subscription3)
+      end
+    end
+
+    context 'with customer timezone' do
+      let(:ending_at) { DateTime.parse('2022-10-21 00:30:00') }
+
+      before do
+        subscription1.customer.update!(timezone: 'America/New_York')
+      end
+
+      it 'takes timezone into account' do
+        current_date = ending_at
+
+        travel_to(current_date) do
+          described_class.perform_now
+          expect(Subscriptions::TerminateService)
+            .not_to have_received(:call).with(subscription: subscription1)
+          expect(Subscriptions::TerminateService)
+            .not_to have_received(:call).with(subscription: subscription2)
+          expect(Subscriptions::TerminateService)
+            .not_to have_received(:call).with(subscription: subscription3)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently it is not possible to terminate subscriptions automatically

## Description

In this PR new job that terminates ended subscriptions has been added
