### PR TITLE
misc: Add sidekiq config to increase max dead job limit

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -16,6 +16,7 @@ Sidekiq.configure_server do |config|
   config.redis = redis_config
   config.logger = Rails.logger
   config[:max_retries] = 0
+  config[:dead_max_jobs] = 100_000
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
## Context

Current dead job limit is 10 000. In some cases it is not enough as we could loose some dead job in case of spike of error.

## Description

This PR increase the limit to 100 000 dead job at max
