### PR TITLE
fix(subscription): Activate should take care of past pending subscription and timezone

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -18,7 +18,7 @@ module Clockwork
 
   # NOTE: All clocks run every hour to take customer timezones into account
 
-  every(1.hour, 'schedule:activate_subscriptions', at: '**:30') do
+  every(1.hour, 'schedule:activate_subscriptions', at: '*:30') do
     Clock::ActivateSubscriptionsJob.perform_later
   end
 

--- a/spec/scenarios/subscriptions/activation_spec.rb
+++ b/spec/scenarios/subscriptions/activation_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Subscriptions Activation Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+
+  let(:timezone) { 'America/Bogota' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      interval: 'monthly',
+      pay_in_advance: false,
+    )
+  end
+
+  let(:subscription_at) { DateTime.new(2023, 8, 24, 4, 17) }
+  let(:creation_time) { DateTime.new(2023, 8, 24, 0, 7) }
+
+  it 'activates the subscription when it reaches its subscription date' do
+    subscription = nil
+
+    travel_to(creation_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time: 'calendar',
+          subscription_at: subscription_at.iso8601,
+        },
+      )
+
+      subscription = customer.subscriptions.first
+      expect(subscription).to be_pending
+    end
+
+    travel_to(subscription_at) do
+      Subscriptions::ActivateService.new(timestamp: Time.current.to_i).activate_all_pending
+
+      expect(subscription.reload).to be_active
+    end
+  end
+end

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -34,21 +34,18 @@ RSpec.describe Subscriptions::ActivateService, type: :service do
     end
 
     context 'with customer timezone' do
-      let(:timestamp) { DateTime.parse('2022-10-21 00:30:00') }
+      let(:timestamp) { DateTime.parse('2023-08-24 00:07:00') }
       let(:pending_subscription) { pending_subscriptions.first }
 
       before do
-        active_subscription
-        future_pending_subscriptions
-
-        pending_subscription.customer.update!(timezone: 'America/New_York')
-        pending_subscription.update!(subscription_at: DateTime.parse('2022-10-21'))
+        pending_subscription.customer.update!(timezone: 'America/Bogota')
+        pending_subscription.update!(subscription_at: DateTime.parse('2023-08-24 04:17:00'))
       end
 
       it 'takes timezone into account' do
         expect { activate_service.activate_all_pending }
-          .to change(Subscription.pending, :count).by(-2)
-          .and change(Subscription.active, :count).by(2)
+          .to change(Subscription.pending, :count).by(-3)
+          .and change(Subscription.active, :count).by(3)
       end
     end
   end


### PR DESCRIPTION
## Context

Subscription created with a subscription_at set in the future should be started automatically when the date of subscription_at is reached.

In some cases when customer timezone is `UTC-` the job to activate the subscriptions is not fetching al pending subscription correctly, leaving them in a pending state forever.

## Description

This PR fixes this situation by:
- Adding the correct timezone shift in the `DATE` query condition
- Ensuring pending subscriptions that should have been started in the past are also taken into account. This will ensure that no subscriptions will remain pending forever.
