### PR TITLE
misc: remove Segment logs

### DIFF
--- a/config/initializers/analytics_ruby.rb
+++ b/config/initializers/analytics_ruby.rb
@@ -11,6 +11,8 @@ unless ENV['LAGO_DISABLE_SEGMENT'] == 'true'
     end
   end
 
+  Segment::Analytics::Logging.logger = Logger.new(nil)
+
   SEGMENT_CLIENT = Segment::Analytics.new(
     {
       write_key: ENV['SEGMENT_WRITE_KEY'],


### PR DESCRIPTION
## Context

Segment analytics gem generates a lot of logs polluting lago application logs.

Since these logs are mostly useless for us, we can get rid of them

## Description

This PR ensures that segment is no longer generating logs.