### PR TITLE
feat(weighted-sum): Expose new fields into GraphQL

### DIFF
--- a/app/graphql/types/billable_metrics/create_input.rb
+++ b/app/graphql/types/billable_metrics/create_input.rb
@@ -12,6 +12,7 @@ module Types
       argument :group, GraphQL::Types::JSON, required: false
       argument :name, String, required: true
       argument :recurring, Boolean, required: false
+      argument :weighted_interval, Types::BillableMetrics::WeightedIntervalEnum, required: false
     end
   end
 end

--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -16,6 +16,7 @@ module Types
 
       field :aggregation_type, Types::BillableMetrics::AggregationTypeEnum, null: false
       field :field_name, String, null: true
+      field :weighted_interval, Types::BillableMetrics::WeightedIntervalEnum, null: true
 
       field :flat_groups, [Types::Groups::Object], null: true, method: :selectable_groups
       field :group, GraphQL::Types::JSON, null: true, method: :active_groups_as_tree

--- a/app/graphql/types/billable_metrics/weighted_interval_enum.rb
+++ b/app/graphql/types/billable_metrics/weighted_interval_enum.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module BillableMetrics
+    class WeightedIntervalEnum < Types::BaseEnum
+      BillableMetric::WEIGHTED_INTERVAL.values.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -158,6 +158,7 @@ type BillableMetric {
   recurring: Boolean!
   subscriptionsCount: Int!
   updatedAt: ISO8601DateTime!
+  weightedInterval: WeightedIntervalEnum
 }
 
 type BillableMetricCollection {
@@ -1578,6 +1579,7 @@ input CreateBillableMetricInput {
   group: JSON
   name: String!
   recurring: Boolean
+  weightedInterval: WeightedIntervalEnum
 }
 
 """
@@ -5678,4 +5680,8 @@ enum WebhookStatusEnum {
   failed
   pending
   succeeded
+}
+
+enum WeightedIntervalEnum {
+  seconds
 }

--- a/schema.json
+++ b/schema.json
@@ -1482,6 +1482,20 @@
               "args": [
 
               ]
+            },
+            {
+              "name": "weightedInterval",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "WeightedIntervalEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
             }
           ],
           "inputFields": null,
@@ -4631,6 +4645,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "weightedInterval",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "WeightedIntervalEnum",
                 "ofType": null
               },
               "defaultValue": null,
@@ -24608,6 +24634,23 @@
             },
             {
               "name": "failed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "WeightedIntervalEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "seconds",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/mutations/billable_metrics/create_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/create_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Mutations::BillableMetrics::Create, type: :graphql do
           recurring
           organization { id },
           group
+          weightedInterval
         }
       }
     GQL
@@ -46,6 +47,7 @@ RSpec.describe Mutations::BillableMetrics::Create, type: :graphql do
       expect(result_data['aggregationType']).to eq('count_agg')
       expect(result_data['recurring']).to eq(false)
       expect(result_data['group']).to eq({})
+      expect(result_data['weightedInterval']).to be_nil
     end
   end
 


### PR DESCRIPTION
## Context

For metrics that are charged upon a time frame, Lago is not able to calculate correctly the charge. For instance, imagine you want to price the number of GB/seconds used by a server. Currently, you can either calculate the number of seconds used, or the number of Gigabytes used, but not both at the same time.

## Description

This PR exposes the `weighted_sum_agg` and `weighted_interval` into GraphQL API
