### PR TITLE
feat(weighted-sum): Add aggregation logic

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -39,6 +39,7 @@ class Fee < ApplicationRecord
   validates :units, numericality: { greated_than_or_equal_to: 0 }
   validates :events_count, numericality: { greated_than_or_equal_to: 0 }, allow_nil: true
   validates :true_up_fee_id, presence: false, unless: :charge?
+  validates :total_aggregated_units, presence: true, if: :charge?
 
   scope :subscription_kind, -> { where(fee_type: :subscription) }
   scope :charge_kind, -> { where(fee_type: :charge) }

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -10,6 +10,7 @@ class Group < ApplicationRecord
   has_many :children, class_name: 'Group', foreign_key: 'parent_group_id'
   has_many :properties, class_name: 'GroupProperty'
   has_many :fees
+  has_many :quantified_events, dependent: :destroy
 
   validates :key, :value, presence: true
 

--- a/app/models/quantified_event.rb
+++ b/app/models/quantified_event.rb
@@ -7,10 +7,10 @@ class QuantifiedEvent < ApplicationRecord
 
   belongs_to :customer
   belongs_to :billable_metric
+  belongs_to :group, optional: true
 
   has_many :events
 
-  validates :external_id, presence: true
   validates :added_at, presence: true
   validates :external_subscription_id, presence: true
 

--- a/app/models/quantified_event.rb
+++ b/app/models/quantified_event.rb
@@ -5,6 +5,8 @@ class QuantifiedEvent < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
+  RECURRING_TOTAL_UNITS = 'total_aggregated_units'
+
   belongs_to :customer
   belongs_to :billable_metric
   belongs_to :group, optional: true

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -4,13 +4,87 @@ module BillableMetrics
   module Aggregations
     class WeightedSumService < BillableMetrics::Aggregations::BaseService
       def aggregate(options: {})
-        # TODO
-        result.aggregation = 0
+        result.aggregation = compute_aggregation
         result.current_usage_units = 0
         result.count = 0
         result.pay_in_advance_aggregation = BigDecimal(0)
         result.options = { running_total: 0 }
         result
+      end
+
+      private
+
+      def compute_aggregation
+        # query_result = ActiveRecord::Base.connection.select_all(aggregation_sql)
+        # query_result
+
+        # byebug
+
+        query_result = ActiveRecord::Base.connection.select_one(aggregation_sql)
+        query_result['aggregation']
+      end
+
+      def aggregation_sql
+        <<-SQL
+          WITH events_data AS (
+            (#{initial_value})
+            UNION
+            (#{
+              events_scope(from_datetime:, to_datetime:)
+                .select("timestamp, (#{sanitized_field_name})::numeric AS difference")
+                .to_sql
+            })
+            UNION
+            (#{end_of_period_value})
+          )
+
+          SELECT SUM(period_ratio) as aggregation
+          FROM (
+            SELECT
+              -- TODO: remove when finished
+              timestamp,
+              difference,
+              sum(difference) OVER (ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) as cumul,
+              EXTRACT(epoch FROM lead(timestamp, 1, '#{to_datetime}') OVER (ORDER BY timestamp) - timestamp) AS second_duration,
+              --
+
+            (
+              -- NOTE: duration in seconds between current event and next one
+              -- TODO: takes weighted interval into account (+ group per interval in CTE ??)
+              CASE WHEN EXTRACT(EPOCH FROM LEAD(timestamp, 1, '#{to_datetime}') OVER (ORDER BY timestamp) - timestamp) = 0
+              THEN
+                0 -- NOTE: duration was null so usage is null
+              ELSE
+                -- NOTE: cumulative sum from previous events in the period
+                (sum(difference) OVER (ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))
+                /
+                -- NOTE: duration in seconds between current event and next one - using end of period as final boundaries
+                EXTRACT(EPOCH FROM LEAD(timestamp, 1, '#{to_datetime}') OVER (ORDER BY timestamp) - timestamp)
+              END
+            ) AS period_ratio
+            FROM events_data
+          ) cumulated_ratios
+        SQL
+      end
+
+      def initial_value
+        initial_value = 0 # TODO: when recurring, get last cumul
+
+        <<-SQL
+          SELECT *
+          FROM (
+            VALUES (timestamp without time zone '#{from_datetime}', #{initial_value})
+          ) AS t(timestamp, difference)
+        SQL
+      end
+
+      def end_of_period_value
+        <<-SQL
+          SELECT *
+          FROM (
+            VALUES (timestamp without time zone '#{to_datetime}', 0)
+          ) AS t(timestamp, difference)
+        SQL
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -12,6 +12,7 @@ module BillableMetrics
         if billable_metric.recurring?
           result.variation = events.sum("(#{sanitized_field_name})::numeric") || 0
           result.recurring_value = latest_value + result.variation
+          result.recurring_updated_at = events.last&.timestamp || from_datetime
         end
 
         result

--- a/app/services/charges/charge_models/base_service.rb
+++ b/app/services/charges/charge_models/base_service.rb
@@ -20,7 +20,10 @@ module Charges
         result.full_units_number = aggregation_result.full_units_number
         result.count = aggregation_result.count
         result.amount = compute_amount
-        result.total_aggregated_units = aggregation_result.total_aggregated_units if aggregation_result.total_aggregated_units
+
+        if aggregation_result.total_aggregated_units
+          result.total_aggregated_units = aggregation_result.total_aggregated_units
+        end
 
         result
       end

--- a/app/services/charges/charge_models/base_service.rb
+++ b/app/services/charges/charge_models/base_service.rb
@@ -20,6 +20,8 @@ module Charges
         result.full_units_number = aggregation_result.full_units_number
         result.count = aggregation_result.count
         result.amount = compute_amount
+        result.total_aggregated_units = aggregation_result.total_aggregated_units if aggregation_result.total_aggregated_units
+
         result
       end
 

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -199,7 +199,7 @@ module Fees
       result.quantified_events << QuantifiedEvent.find_or_initialize_by(
         customer_id: customer.id,
         external_subscription_id: subscription.external_id,
-        external_id: group&.id || customer.external_id, # TODO
+        group_id: group&.id,
         billable_metric_id: billable_metric.id,
         added_at: aggregation_result.recurring_updated_at,
       ) do |event|

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -56,6 +56,7 @@ module Fees
           fee_type: :charge,
           invoiceable: charge,
           units: result.units,
+          total_aggregated_units: result.units,
           properties: boundaries,
           events_count: result.count,
           group_id: group&.id,

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -17,6 +17,7 @@ module Fees
       true_up_fee = fee.dup.tap do |f|
         f.amount_cents = prorated_min_amount_cents - amount_cents
         f.units = 1
+        f.total_aggregated_units = 1
         f.events_count = 0
         f.group_id = nil
         f.true_up_parent_fee = fee

--- a/db/migrate/20230907153404_add_group_id_to_quantified_events.rb
+++ b/db/migrate/20230907153404_add_group_id_to_quantified_events.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddGroupIdToQuantifiedEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :quantified_events, :group, type: :uuid, foreign_key: true, index: true
+    change_column_null :quantified_events, :external_id, true
+  end
+end

--- a/db/migrate/20230911083923_add_total_aggregated_units_to_fees.rb
+++ b/db/migrate/20230911083923_add_total_aggregated_units_to_fees.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddTotalAggregatedUnitsToFees < ActiveRecord::Migration[7.0]
+  def change
+    add_column :fees, :total_aggregated_units, :decimal
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE fees
+          SET total_aggregated_units = units
+          WHERE fee_type = 0;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -372,6 +372,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_11_185900) do
     t.bigint "unit_amount_cents", default: 0, null: false
     t.boolean "pay_in_advance", default: false, null: false
     t.decimal "precise_coupons_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
+    t.decimal "total_aggregated_units"
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
@@ -640,7 +641,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_11_185900) do
   create_table "quantified_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "customer_id", null: false
     t.string "external_subscription_id", null: false
-    t.string "external_id", null: false
+    t.string "external_id"
     t.datetime "added_at", null: false
     t.datetime "removed_at"
     t.datetime "created_at", null: false
@@ -648,11 +649,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_11_185900) do
     t.uuid "billable_metric_id"
     t.jsonb "properties", default: {}, null: false
     t.datetime "deleted_at"
+    t.uuid "group_id"
     t.index ["billable_metric_id"], name: "index_quantified_events_on_billable_metric_id"
     t.index ["customer_id", "external_subscription_id", "billable_metric_id"], name: "index_search_quantified_events"
     t.index ["customer_id"], name: "index_quantified_events_on_customer_id"
     t.index ["deleted_at"], name: "index_quantified_events_on_deleted_at"
     t.index ["external_id"], name: "index_quantified_events_on_external_id"
+    t.index ["group_id"], name: "index_quantified_events_on_group_id"
   end
 
   create_table "refunds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -850,6 +853,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_11_185900) do
   add_foreign_key "plans_taxes", "plans"
   add_foreign_key "plans_taxes", "taxes"
   add_foreign_key "quantified_events", "customers"
+  add_foreign_key "quantified_events", "groups"
   add_foreign_key "refunds", "credit_notes"
   add_foreign_key "refunds", "payment_provider_customers"
   add_foreign_key "refunds", "payment_providers"

--- a/spec/factories/billable_metrics.rb
+++ b/spec/factories/billable_metrics.rb
@@ -9,6 +9,10 @@ FactoryBot.define do
     aggregation_type { 'count_agg' }
     recurring { false }
     properties { {} }
+
+    trait :recurring do
+      recurring { true }
+    end
   end
 
   factory :recurring_billable_metric, parent: :billable_metric do

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -47,6 +47,8 @@ FactoryBot.define do
         'charges_to_datetime' => Date.parse('2022-08-31 23:59:59'),
       }
     end
+
+    total_aggregated_units { 0 }
   end
 
   factory :add_on_fee, class: 'Fee' do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Invoice, type: :model do
     it 'returns the subscriptions amount' do
       create(:fee, invoice:, amount_cents: 200)
       create(:fee, invoice:, amount_cents: 100)
-      create(:fee, invoice:, charge_id: create(:standard_charge).id, fee_type: 'charge')
+      create(:charge_fee, invoice:, charge_id: create(:standard_charge).id)
 
       expect(invoice.subscription_amount.to_s).to eq('3.00')
     end

--- a/spec/models/invoice_subscription_spec.rb
+++ b/spec/models/invoice_subscription_spec.rb
@@ -35,20 +35,18 @@ RSpec.describe InvoiceSubscription, type: :model do
     it 'returns the sum of the related charge fees' do
       charge = create(:standard_charge)
       create(
-        :fee,
+        :charge_fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
         charge:,
-        fee_type: 'charge',
         amount_cents: 100,
       )
 
       create(
-        :fee,
+        :charge_fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
         charge:,
-        fee_type: 'charge',
         amount_cents: 200,
       )
 
@@ -73,11 +71,10 @@ RSpec.describe InvoiceSubscription, type: :model do
       )
 
       create(
-        :fee,
+        :charge_fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
         charge: create(:standard_charge),
-        fee_type: 'charge',
         amount_cents: 200,
       )
 
@@ -96,20 +93,18 @@ RSpec.describe InvoiceSubscription, type: :model do
       )
 
       create(
-        :fee,
+        :charge_fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
         charge:,
-        fee_type: 'charge',
         amount_cents: 200,
       )
 
       create(
-        :fee,
+        :charge_fee,
         subscription_id: subscription.id,
         invoice_id: invoice.id,
         charge:,
-        fee_type: 'charge',
         amount_cents: 100,
       )
 

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -59,8 +59,7 @@ RSpec.describe ::V1::FeeSerializer do
     let(:charge) { create(:standard_charge) }
     let(:fee) do
       create(
-        :fee,
-        fee_type: 'charge',
+        :charge_fee,
         charge:,
         properties: {
           from_datetime: Time.current,
@@ -104,7 +103,7 @@ RSpec.describe ::V1::FeeSerializer do
     let(:event) { create(:event, subscription:, organization:, customer:) }
 
     let(:fee) do
-      create(:fee, fee_type: 'charge', pay_in_advance: true, subscription:, charge:, pay_in_advance_event_id: event.id)
+      create(:charge_fee, pay_in_advance: true, subscription:, charge:, pay_in_advance_event_id: event.id)
     end
 
     it 'serializes the pay_in_advance charge attributes' do

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
         customer:,
         external_subscription_id: subscription.external_id,
         added_at: from_datetime - 1.day,
-        properties: { recurring_value: 1000 },
+        properties: { QuantifiedEvent::RECURRING_TOTAL_UNITS => 1000 },
       )
     end
 
@@ -109,7 +109,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
       expect(result.aggregation.round(5).to_s).to eq('0.00037')
       expect(result.count).to eq(0)
       expect(result.variation).to eq(0)
-      expect(result.recurring_value).to eq(1000)
+      expect(result.total_aggregated_units).to eq(1000)
       expect(result.recurring_updated_at).to eq(from_datetime)
     end
 
@@ -122,7 +122,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
         expect(result.aggregation.round(5).to_s).to eq('0.0')
         expect(result.count).to eq(0)
         expect(result.variation).to eq(0)
-        expect(result.recurring_value).to eq(0)
+        expect(result.total_aggregated_units).to eq(0)
         expect(result.recurring_updated_at).to eq(from_datetime)
       end
     end
@@ -146,7 +146,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
         expect(result.aggregation.round(5).to_s).to eq('2.37399')
         expect(result.count).to eq(7)
         expect(result.variation).to eq(0)
-        expect(result.recurring_value).to eq(1000)
+        expect(result.total_aggregated_units).to eq(1000)
         expect(result.recurring_updated_at).to eq('2023-08-01 05:30:00')
       end
     end

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service do
+  subject(:aggregator) do
+    described_class.new(
+      billable_metric:,
+      subscription:,
+      group:,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
+    )
+  end
+
+  let(:subscription) { create(:subscription, started_at: DateTime.parse('2023-04-01 22:22:22')) }
+  let(:organization) { subscription.organization }
+  let(:customer) { subscription.customer }
+  let(:group) { nil }
+
+  let(:billable_metric) { create(:weighted_sum_billable_metric, organization:) }
+
+  let(:from_datetime) { DateTime.parse('2023-08-01 00:00:00.000') }
+  let(:to_datetime) { DateTime.parse('2023-08-31 23:59:59.999') }
+
+  let(:events_values) do
+    [
+      { timestamp: DateTime.parse('2023-08-01 00:00:00.000'), value: 2 },
+      { timestamp: DateTime.parse('2023-08-01 01:00:00'), value: 3 },
+      { timestamp: DateTime.parse('2023-08-01 01:30:00'), value: 1 },
+      { timestamp: DateTime.parse('2023-08-01 02:00:00'), value: -4 },
+      { timestamp: DateTime.parse('2023-08-01 04:00:00'), value: -2 },
+      { timestamp: DateTime.parse('2023-08-01 05:00:00'), value: 10 },
+      { timestamp: DateTime.parse('2023-08-01 05:30:00'), value: -10 },
+    ]
+  end
+
+  before do
+    events_values.each do |values|
+      create(
+        :event,
+        code: billable_metric.code,
+        subscription:,
+        timestamp: values[:timestamp],
+        properties: { value: values[:value] },
+      )
+    end
+  end
+
+  it 'aggregates the events' do
+    result = aggregator.aggregate
+
+    expect(result.aggregation.round(5).to_s).to eq('0.0125')
+  end
+
+  context 'with a single event' do
+    let(:events_values) do
+      [
+        { timestamp: DateTime.parse('2023-08-01 00:00:00.000'), value: 1000 },
+      ]
+    end
+
+    it 'aggregates the events' do
+      result = aggregator.aggregate
+
+      expect(result.aggregation.round(5).to_s).to eq('0.00037')
+    end
+  end
+
+  context 'with no events' do
+    let(:events_values) { [] }
+
+    it 'aggregates the events' do
+      result = aggregator.aggregate
+
+      expect(result.aggregation.round(5).to_s).to eq('0')
+    end
+  end
+end

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -81,4 +81,68 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
       expect(result.count).to eq(0)
     end
   end
+
+  context 'when billable metric is recurring' do
+    let(:billable_metric) { create(:weighted_sum_billable_metric, :recurring, organization:) }
+
+    let(:events_values) { [] }
+
+    let(:quantified_event) do
+      create(
+        :quantified_event,
+        billable_metric:,
+        customer:,
+        external_subscription_id: subscription.external_id,
+        added_at: from_datetime - 1.day,
+        properties: { recurring_value: 1000 },
+      )
+    end
+
+    before { quantified_event }
+
+    it 'uses the persisted recurring value as initial value' do
+      result = aggregator.aggregate
+
+      expect(result.aggregation.round(5).to_s).to eq('0.00037')
+      expect(result.count).to eq(0)
+      expect(result.variation).to eq(0)
+      expect(result.recurring_value).to eq(1000)
+    end
+
+    context 'without quantified events' do
+      let(:quantified_event) {}
+
+      it 'falls back on 0' do
+        result = aggregator.aggregate
+
+        expect(result.aggregation.round(5).to_s).to eq('0.0')
+        expect(result.count).to eq(0)
+        expect(result.variation).to eq(0)
+        expect(result.recurring_value).to eq(0)
+      end
+    end
+
+    context 'with events' do
+      let(:events_values) do
+        [
+          { timestamp: DateTime.parse('2023-08-01 00:00:00.000'), value: 2 },
+          { timestamp: DateTime.parse('2023-08-01 01:00:00'), value: 3 },
+          { timestamp: DateTime.parse('2023-08-01 01:30:00'), value: 1 },
+          { timestamp: DateTime.parse('2023-08-01 02:00:00'), value: -4 },
+          { timestamp: DateTime.parse('2023-08-01 04:00:00'), value: -2 },
+          { timestamp: DateTime.parse('2023-08-01 05:00:00'), value: 10 },
+          { timestamp: DateTime.parse('2023-08-01 05:30:00'), value: -10 },
+        ]
+      end
+
+      it 'aggregates the events' do
+        result = aggregator.aggregate
+
+        expect(result.aggregation.round(5).to_s).to eq('2.37399')
+        expect(result.count).to eq(7)
+        expect(result.variation).to eq(0)
+        expect(result.recurring_value).to eq(1000)
+      end
+    end
+  end
 end

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
     result = aggregator.aggregate
 
     expect(result.aggregation.round(5).to_s).to eq('0.0125')
+    expect(result.count).to eq(7)
   end
 
   context 'with a single event' do
@@ -66,6 +67,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
       result = aggregator.aggregate
 
       expect(result.aggregation.round(5).to_s).to eq('0.00037')
+      expect(result.count).to eq(1)
     end
   end
 
@@ -75,7 +77,8 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
     it 'aggregates the events' do
       result = aggregator.aggregate
 
-      expect(result.aggregation.round(5).to_s).to eq('0')
+      expect(result.aggregation.round(5).to_s).to eq('0.0')
+      expect(result.count).to eq(0)
     end
   end
 end

--- a/spec/services/charges/charge_models/standard_service_spec.rb
+++ b/spec/services/charges/charge_models/standard_service_spec.rb
@@ -13,10 +13,7 @@ RSpec.describe Charges::ChargeModels::StandardService, type: :service do
 
   before do
     aggregation_result.aggregation = aggregation
-
-    if total_aggregated_units
-      aggregation_result.total_aggregated_units = total_aggregated_units
-    end
+    aggregation_result.total_aggregated_units = total_aggregated_units if total_aggregated_units
   end
 
   let(:aggregation_result) { BaseService::Result.new }

--- a/spec/services/charges/charge_models/standard_service_spec.rb
+++ b/spec/services/charges/charge_models/standard_service_spec.rb
@@ -13,10 +13,15 @@ RSpec.describe Charges::ChargeModels::StandardService, type: :service do
 
   before do
     aggregation_result.aggregation = aggregation
+
+    if total_aggregated_units
+      aggregation_result.total_aggregated_units = total_aggregated_units
+    end
   end
 
   let(:aggregation_result) { BaseService::Result.new }
   let(:aggregation) { 10 }
+  let(:total_aggregated_units) { nil }
 
   let(:charge) do
     create(
@@ -30,5 +35,13 @@ RSpec.describe Charges::ChargeModels::StandardService, type: :service do
 
   it 'applies the charge model to the value' do
     expect(apply_standard_service.amount).to eq(5000)
+  end
+
+  context 'when aggregation result contains total_aggregated_units' do
+    let(:total_aggregated_units) { 10 }
+
+    it 'assigns the total_aggregated_units to the result' do
+      expect(apply_standard_service.total_aggregated_units).to eq(total_aggregated_units)
+    end
   end
 end

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -412,7 +412,7 @@ RSpec.describe Events::CreateService, type: :service do
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
             properties: {
-              'operation_type' => 'add',
+              'operation_type' => 'unknown',
             },
             timestamp:,
           }

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -1212,7 +1212,8 @@ RSpec.describe Fees::ChargeService do
           expect(quantified_event.id).not_to be_nil
           expect(quantified_event.customer_id).to eq(customer.id)
           expect(quantified_event.external_subscription_id).to eq(subscription.external_id)
-          expect(quantified_event.external_id).to eq(customer.external_id)
+          expect(quantified_event.external_id).to be_nil
+          expect(quantified_event.group_id).to be_nil
           expect(quantified_event.billable_metric_id).to eq(billable_metric.id)
           expect(quantified_event.added_at).to eq(boundaries[:from_datetime])
           expect(quantified_event.properties['recurring_value']).to eq(0)

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -1206,6 +1206,7 @@ RSpec.describe Fees::ChargeService do
           expect(created_fee.amount_cents).to eq(0)
           expect(created_fee.amount_currency).to eq('EUR')
           expect(created_fee.units).to eq(0)
+          expect(created_fee.total_aggregated_units).to eq(0)
           expect(created_fee.events_count).to eq(0)
           expect(created_fee.payment_status).to eq('pending')
 
@@ -1216,7 +1217,7 @@ RSpec.describe Fees::ChargeService do
           expect(quantified_event.group_id).to be_nil
           expect(quantified_event.billable_metric_id).to eq(billable_metric.id)
           expect(quantified_event.added_at).to eq(boundaries[:from_datetime])
-          expect(quantified_event.properties['recurring_value']).to eq(0)
+          expect(quantified_event.properties[QuantifiedEvent::RECURRING_TOTAL_UNITS]).to eq('0.0')
         end
       end
     end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -1190,6 +1190,36 @@ RSpec.describe Fees::ChargeService do
       end
     end
 
+    context 'with recurring weighted sum aggregation' do
+      let(:billable_metric) { create(:weighted_sum_billable_metric, :recurring, organization:) }
+
+      it 'creates a fee and a quantified event' do
+        result = charge_subscription_service.create
+        expect(result).to be_success
+        created_fee = result.fees.first
+        quantified_event = result.quantified_events.first
+
+        aggregate_failures do
+          expect(created_fee.id).not_to be_nil
+          expect(created_fee.invoice_id).to eq(invoice.id)
+          expect(created_fee.charge_id).to eq(charge.id)
+          expect(created_fee.amount_cents).to eq(0)
+          expect(created_fee.amount_currency).to eq('EUR')
+          expect(created_fee.units).to eq(0)
+          expect(created_fee.events_count).to eq(0)
+          expect(created_fee.payment_status).to eq('pending')
+
+          expect(quantified_event.id).not_to be_nil
+          expect(quantified_event.customer_id).to eq(customer.id)
+          expect(quantified_event.external_subscription_id).to eq(subscription.external_id)
+          expect(quantified_event.external_id).to eq(customer.external_id)
+          expect(quantified_event.billable_metric_id).to eq(billable_metric.id)
+          expect(quantified_event.added_at).to eq(boundaries[:from_datetime])
+          expect(quantified_event.properties['recurring_value']).to eq(0)
+        end
+      end
+    end
+
     context 'with aggregation error' do
       let(:billable_metric) do
         create(


### PR DESCRIPTION
## Context

For metrics that are charged upon a time frame, Lago is not able to calculate correctly the charge. For instance, imagine you want to price the number of GB/seconds used by a server. Currently, you can either calculate the number of seconds used, or the number of Gigabytes used, but not both at the same time.

## Description

This PR adds:
- the aggregation logic for the weighted sum billable metrics.
- it persists the units in `quantified_events` table when the billable metric is recurring
- it stores the units before the application of the `weigthed_interval` to be able to display it on the invoice
