### PR TITLE
feat (billable metrics): Add setup for latest aggregation BM

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -90,7 +90,7 @@ class BillableMetric < ApplicationRecord
 
   def validate_recurring
     return unless recurring?
-    return unless count_agg? || max_agg? || recurring_count_agg?
+    return unless count_agg? || max_agg? || latest_agg? || recurring_count_agg?
 
     errors.add(:recurring, :not_compatible_with_aggregation_type)
   end

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -18,6 +18,7 @@ class BillableMetric < ApplicationRecord
     count_agg
     sum_agg
     max_agg
+    latest_agg
     unique_count_agg
     recurring_count_agg
   ].freeze

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -91,7 +91,9 @@ class Charge < ApplicationRecord
   # - charge model is volume
   def validate_pay_in_advance
     return unless pay_in_advance?
-    return unless billable_metric.recurring_count_agg? || billable_metric.max_agg? || volume?
+    unless billable_metric.recurring_count_agg? || billable_metric.max_agg? || billable_metric.latest_agg? || volume?
+      return
+    end
 
     errors.add(:pay_in_advance, :invalid_aggregation_type_or_charge_model)
   end

--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -24,12 +24,14 @@ module BillableMetrics
       end
 
       def compute_aggregation(latest_event)
-        if latest_event.present?
+        result = if latest_event.present?
           value = latest_event.properties.fetch(billable_metric.field_name, 0).to_s
-          BigDecimal(value).negative? ? BigDecimal(0) : BigDecimal(value)
+          BigDecimal(value).negative? ? 0 : value
         else
           0
         end
+
+        BigDecimal(result)
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -20,7 +20,7 @@ module BillableMetrics
         @events ||=
           events_scope(from_datetime:, to_datetime:)
             .where("#{sanitized_field_name} IS NOT NULL")
-            .reorder(timestamp: :desc)
+            .reorder(timestamp: :desc, created_at: :desc)
       end
 
       def compute_aggregation(latest_event)

--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -11,12 +11,13 @@ module BillableMetrics
           result.aggregation = 0
           result.count = 0
           result.options = options
+        else
+          latest_event = events.first
 
-        latest_event = events.first
-
-        result.aggregation = latest_event&.properties&.fetch(billable_metric.field_name, 0)
-        result.count = events.count || 0
-        result.options = options
+          result.aggregation = latest_event&.properties&.fetch(billable_metric.field_name, 0)
+          result.count = events.count || 0
+          result.options = options
+        end
 
         result
       rescue ActiveRecord::StatementInvalid => e

--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -3,25 +3,33 @@
 module BillableMetrics
   module Aggregations
     class LatestService < BillableMetrics::Aggregations::BaseService
-      def aggregate(from_datetime:, to_datetime:, options: {})
-        events = events_scope(from_datetime:, to_datetime:)
-          .where("#{sanitized_field_name} IS NOT NULL").order(timestamp: :desc)
+      def aggregate(options: {})
+        latest_event = events.first
 
-        if events.count == 0
-          result.aggregation = 0
-          result.count = 0
-          result.options = options
-        else
-          latest_event = events.first
-
-          result.aggregation = latest_event&.properties&.fetch(billable_metric.field_name, 0)
-          result.count = events.count || 0
-          result.options = options
-        end
-
+        result.aggregation = compute_aggregation(latest_event)
+        result.count = events.count
+        result.options = options
         result
       rescue ActiveRecord::StatementInvalid => e
         result.service_failure!(code: 'aggregation_failure', message: e.message)
+      end
+
+      private
+
+      def events
+        @events ||=
+          events_scope(from_datetime:, to_datetime:)
+            .where("#{sanitized_field_name} IS NOT NULL")
+            .reorder(timestamp: :desc)
+      end
+
+      def compute_aggregation(latest_event)
+        if latest_event.present?
+          value = latest_event.properties.fetch(billable_metric.field_name, 0).to_s
+          BigDecimal(value).negative? ? BigDecimal(0) : BigDecimal(value)
+        else
+          0
+        end
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -10,6 +10,8 @@ module BillableMetrics
         latest_event = events.first
 
         result.aggregation = latest_event&.properties&.fetch(billable_metric.field_name, 0)
+        result.current_usage_units = result.aggregation
+        result.full_units_number = result.aggregation
         result.count = events.count || 0
         result.options = options
 

--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -7,11 +7,14 @@ module BillableMetrics
         events = events_scope(from_datetime:, to_datetime:)
           .where("#{sanitized_field_name} IS NOT NULL").order(timestamp: :desc)
 
+        if events.count == 0
+          result.aggregation = 0
+          result.count = 0
+          result.options = options
+
         latest_event = events.first
 
         result.aggregation = latest_event&.properties&.fetch(billable_metric.field_name, 0)
-        result.current_usage_units = result.aggregation
-        result.full_units_number = result.aggregation
         result.count = events.count || 0
         result.options = options
 

--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module BillableMetrics
+  module Aggregations
+    class LatestService < BillableMetrics::Aggregations::BaseService
+      def aggregate(from_datetime:, to_datetime:, options: {})
+        events = events_scope(from_datetime:, to_datetime:)
+          .where("#{sanitized_field_name} IS NOT NULL").order(timestamp: :desc)
+
+        latest_event = events.first
+
+        result.aggregation = latest_event&.properties&.fetch(billable_metric.field_name, 0)
+        result.count = events.count || 0
+        result.options = options
+
+        result
+      rescue ActiveRecord::StatementInvalid => e
+        result.service_failure!(code: 'aggregation_failure', message: e.message)
+      end
+    end
+  end
+end

--- a/app/services/charges/validators/graduated_percentage_service.rb
+++ b/app/services/charges/validators/graduated_percentage_service.rb
@@ -6,6 +6,8 @@ module Charges
       include ::Validators::RangeBoundsValidator
 
       def valid?
+        validate_billable_metric
+
         if ranges.blank?
           add_error(field: :graduated_percentage_ranges, error_code: 'missing_graduated_percentage_ranges')
         else
@@ -26,6 +28,12 @@ module Charges
       end
 
       private
+
+      def validate_billable_metric
+        return unless charge.billable_metric.latest_agg?
+
+        add_error(field: :billable_metric, error_code: 'invalid_value')
+      end
 
       def ranges
         charge.properties['graduated_percentage_ranges'].map(&:with_indifferent_access)

--- a/app/services/charges/validators/percentage_service.rb
+++ b/app/services/charges/validators/percentage_service.rb
@@ -4,6 +4,7 @@ module Charges
   module Validators
     class PercentageService < Charges::Validators::BaseService
       def valid?
+        validate_billable_metric
         validate_rate
         validate_fixed_amount
         validate_free_units_per_events
@@ -17,6 +18,12 @@ module Charges
 
       def rate
         properties['rate']
+      end
+
+      def validate_billable_metric
+        return unless charge.billable_metric.latest_agg?
+
+        add_error(field: :billable_metric, error_code: 'invalid_value')
       end
 
       def validate_rate

--- a/app/services/events/validate_creation_service.rb
+++ b/app/services/events/validate_creation_service.rb
@@ -88,7 +88,7 @@ module Events
     # This validation checks only field_name value since it is important for aggregation DB query integrity.
     # Other checks are performed later and presented in debugger
     def valid_properties?
-      return true unless billable_metric.max_agg? || billable_metric.sum_agg?
+      return true unless billable_metric.max_agg? || billable_metric.sum_agg? || billable_metric.latest_agg?
 
       valid_number?((params[:properties] || {})[billable_metric.field_name.to_sym])
     end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -131,6 +131,8 @@ module Fees
       aggregator_service = case billable_metric.aggregation_type.to_sym
                            when :count_agg
                              BillableMetrics::Aggregations::CountService
+                           when :latest_agg
+                             BillableMetrics::Aggregations::LatestService
                            when :max_agg
                              BillableMetrics::Aggregations::MaxService
                            when :sum_agg

--- a/schema.graphql
+++ b/schema.graphql
@@ -89,8 +89,8 @@ type AdyenProvider {
 
 enum AggregationTypeEnum {
   count_agg
-  max_agg
   latest_agg
+  max_agg
   recurring_count_agg
   sum_agg
   unique_count_agg

--- a/schema.graphql
+++ b/schema.graphql
@@ -90,6 +90,7 @@ type AdyenProvider {
 enum AggregationTypeEnum {
   count_agg
   max_agg
+  latest_agg
   recurring_count_agg
   sum_agg
   unique_count_agg

--- a/schema.json
+++ b/schema.json
@@ -654,6 +654,12 @@
               "deprecationReason": null
             },
             {
+              "name": "latest_agg",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "max_agg",
               "description": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -654,13 +654,13 @@
               "deprecationReason": null
             },
             {
-              "name": "latest_agg",
+              "name": "max_agg",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "max_agg",
+              "name": "latest_agg",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/factories/billable_metrics.rb
+++ b/spec/factories/billable_metrics.rb
@@ -21,6 +21,11 @@ FactoryBot.define do
     field_name { 'item_id' }
   end
 
+  factory :latest_billable_metric, parent: :billable_metric do
+    aggregation_type { 'latest_agg' }
+    field_name { 'item_id' }
+  end
+
   factory :max_billable_metric, parent: :billable_metric do
     aggregation_type { 'max_agg' }
     field_name { 'item_id' }

--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe BillableMetric, type: :model do
         end
       end
     end
+
+    context 'when recurring is true and aggregation type is latest_agg' do
+      let(:billable_metric) { build(:latest_billable_metric, recurring:) }
+      let(:recurring) { true }
+
+      it 'returns an error' do
+        aggregate_failures do
+          expect(billable_metric).not_to be_valid
+          expect(billable_metric.errors.messages[:recurring]).to include('not_compatible_with_aggregation_type')
+        end
+      end
+    end
   end
 
   describe '#selectable_groups' do

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe Charge, type: :model do
     end
   end
 
-  describe '#validate_instant' do
+  describe '#validate_pay_in_advance' do
     it 'does not return an error' do
       expect(build(:standard_charge)).to be_valid
     end
@@ -389,6 +389,18 @@ RSpec.describe Charge, type: :model do
     context 'when billable metric is max_agg' do
       it 'returns an error' do
         billable_metric = create(:max_billable_metric)
+        charge = build(:standard_charge, :pay_in_advance, billable_metric:)
+
+        aggregate_failures do
+          expect(charge).not_to be_valid
+          expect(charge.errors.messages[:pay_in_advance]).to include('invalid_aggregation_type_or_charge_model')
+        end
+      end
+    end
+
+    context 'when billable metric is latest_agg' do
+      it 'returns an error' do
+        billable_metric = create(:latest_billable_metric)
         charge = build(:standard_charge, :pay_in_advance, billable_metric:)
 
         aggregate_failures do

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
+  subject(:latest_service) do
+    described_class.new(
+      billable_metric:,
+      subscription:,
+      group:,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
+    )
+  end
+
+  let(:subscription) { create(:subscription) }
+  let(:organization) { subscription.organization }
+  let(:customer) { subscription.customer }
+  let(:group) { nil }
+
+  let(:billable_metric) do
+    create(
+      :billable_metric,
+      organization:,
+      aggregation_type: 'latest_agg',
+      field_name: 'total_count',
+    )
+  end
+
+  let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
+  let(:to_datetime) { Time.current.end_of_day }
+
+  before do
+    create_list(
+      :event,
+      4,
+      code: billable_metric.code,
+      customer:,
+      subscription:,
+      timestamp: Time.current - 2.days,
+      properties: {
+        total_count: 18,
+      },
+    )
+
+    create(
+      :event,
+      code: billable_metric.code,
+      customer:,
+      subscription:,
+      timestamp: Time.current - 1.day,
+      properties: {
+        total_count: 14,
+      },
+    )
+  end
+
+  it 'aggregates the events' do
+    result = latest_service.aggregate
+
+    expect(result.aggregation).to eq(14)
+    expect(result.count).to eq(5)
+  end
+
+  context 'when events are out of bounds' do
+    let(:to_datetime) { Time.current - 3.days }
+
+    it 'does not take events into account' do
+      result = latest_service.aggregate
+
+      expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
+    end
+  end
+
+  context 'when properties is not found on events' do
+    before do
+      billable_metric.update!(field_name: 'foo_bar')
+    end
+
+    it 'counts as zero' do
+      result = latest_service.aggregate
+
+      expect(result.aggregation).to eq(0)
+      expect(result.count).to eq(0)
+    end
+  end
+
+  context 'when properties is a float' do
+    before do
+      create(
+        :event,
+        code: billable_metric.code,
+        customer:,
+        subscription:,
+        timestamp: Time.current,
+        properties: {
+          total_count: 14.2,
+        },
+      )
+    end
+
+    it 'aggregates the events' do
+      result = latest_service.aggregate
+
+      expect(result.aggregation).to eq(14.2)
+    end
+  end
+
+  context 'when properties is negative' do
+    before do
+      create(
+        :event,
+        code: billable_metric.code,
+        customer:,
+        subscription:,
+        timestamp: Time.current,
+        properties: {
+          total_count: -5,
+        },
+      )
+    end
+
+    it 'returns zero' do
+      result = latest_service.aggregate
+
+      expect(result.aggregation).to eq(0)
+    end
+  end
+
+  context 'when properties is missing' do
+    before do
+      create(
+        :event,
+        code: billable_metric.code,
+        customer:,
+        subscription:,
+        timestamp: Time.current,
+      )
+    end
+
+    it 'ignores the event' do
+      result = latest_service.aggregate
+
+      expect(result).to be_success
+      expect(result.aggregation).to eq(14)
+    end
+  end
+
+  context 'when group_id is given' do
+    let(:group) do
+      create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+    end
+
+    before do
+      create(
+        :event,
+        code: billable_metric.code,
+        customer:,
+        subscription:,
+        timestamp: Time.current - 2.seconds,
+        properties: {
+          total_count: 12,
+          region: 'europe',
+        },
+      )
+
+      create(
+        :event,
+        code: billable_metric.code,
+        customer:,
+        subscription:,
+        timestamp: Time.current - 1.second,
+        properties: {
+          total_count: 8,
+          region: 'europe',
+        },
+      )
+
+      create(
+        :event,
+        code: billable_metric.code,
+        customer:,
+        subscription:,
+        timestamp: Time.current - 1.second,
+        properties: {
+          total_count: 12,
+          region: 'africa',
+        },
+      )
+    end
+
+    it 'aggregates the events' do
+      result = latest_service.aggregate
+
+      expect(result.aggregation).to eq(8)
+      expect(result.count).to eq(2)
+    end
+  end
+end

--- a/spec/services/charges/validators/graduated_percentage_service_spec.rb
+++ b/spec/services/charges/validators/graduated_percentage_service_spec.rb
@@ -15,6 +15,25 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
   let(:ranges) { {} }
 
   describe '.valid?' do
+    context 'when billable metric is latest_agg' do
+      let(:billable_metric) { create(:latest_billable_metric) }
+      let(:charge) { build(:graduated_percentage_charge, properties: graduated_percentage_ranges, billable_metric:) }
+      let(:graduated_percentage_ranges) do
+        {
+          graduated_percentage_ranges: ranges,
+        }
+      end
+
+      it 'is invalid' do
+        aggregate_failures do
+          expect(graduated_percentage_service).not_to be_valid
+          expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(graduated_percentage_service.result.error.messages.keys).to include(:billable_metric)
+          expect(graduated_percentage_service.result.error.messages[:billable_metric]).to include('invalid_value')
+        end
+      end
+    end
+
     context 'with ranges validation' do
       it 'ensures the presences of ranges' do
         aggregate_failures do

--- a/spec/services/charges/validators/percentage_service_spec.rb
+++ b/spec/services/charges/validators/percentage_service_spec.rb
@@ -17,6 +17,26 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
   describe '.valid?' do
     it { expect(percentage_service).to be_valid }
 
+    context 'when billable metric is latest_agg' do
+      let(:billable_metric) { create(:latest_billable_metric) }
+      let(:charge) { build(:percentage_charge, properties: percentage_properties, billable_metric:) }
+      let(:percentage_properties) do
+        {
+          rate: 0.25,
+          fixed_amount: '2',
+        }
+      end
+
+      it 'is invalid' do
+        aggregate_failures do
+          expect(percentage_service).not_to be_valid
+          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(percentage_service.result.error.messages.keys).to include(:billable_metric)
+          expect(percentage_service.result.error.messages[:billable_metric]).to include('invalid_value')
+        end
+      end
+    end
+
     context 'without rate' do
       let(:percentage_properties) do
         {


### PR DESCRIPTION
## Context

When user is pre-aggregating number of units on their side, there’s no aggregation type allowing Lago to take in consideration the last unit number received. 

## Description

This PR adds new billable metric aggregation type and new aggregation service that handles latest aggregation.

In the following PRs missing validations will be added:

- billable metric model validations (that prevents recurring)
- event validation that check if received property is numeric
- charge validations that prevents percentage and graduated percentage model types
