### PR TITLE
feat(invoice_display_name_plan): Add invoice display name to plan

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -73,6 +73,7 @@ module Api
       def input_params
         params.require(:plan).permit(
           :name,
+          :invoice_display_name,
           :code,
           :interval,
           :description,

--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -15,6 +15,7 @@ module Mutations
       argument :code, String, required: true
       argument :description, String, required: false
       argument :interval, Types::Plans::IntervalEnum, required: true
+      argument :invoice_display_name, String, required: false
       argument :name, String, required: true
       argument :parent_id, ID, required: false
       argument :pay_in_advance, Boolean, required: true

--- a/app/graphql/mutations/plans/update.rb
+++ b/app/graphql/mutations/plans/update.rb
@@ -15,6 +15,7 @@ module Mutations
       argument :description, String, required: false
       argument :id, String, required: true
       argument :interval, Types::Plans::IntervalEnum, required: true
+      argument :invoice_display_name, String, required: false
       argument :name, String, required: true
       argument :pay_in_advance, Boolean, required: true
       argument :tax_codes, [String], required: false

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -14,6 +14,7 @@ module Types
       field :code, String, null: false
       field :description, String
       field :interval, Types::Plans::IntervalEnum, null: false
+      field :invoice_display_name, String
       field :name, String, null: false
       field :parent_id, ID, null: true
       field :pay_in_advance, Boolean, null: false

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -57,6 +57,10 @@ class Plan < ApplicationRecord
     trial_period.present? && trial_period.positive?
   end
 
+  def invoice_name
+    invoice_display_name.presence || name
+  end
+
   # NOTE: Method used to compare plan for upgrade / downgrade on
   #       a same duration basis. It is not intended to be used
   #       directly for billing/invoicing purpose

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -131,4 +131,8 @@ class Subscription < ApplicationRecord
   def display_name
     name.presence || plan.name
   end
+
+  def invoice_name
+    name.presence || plan.invoice_name
+  end
 end

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -6,6 +6,7 @@ module V1
       payload = {
         lago_id: model.id,
         name: model.name,
+        invoice_display_name: model.invoice_display_name,
         created_at: model.created_at.iso8601,
         code: model.code,
         interval: model.interval,

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -6,6 +6,7 @@ module Plans
       plan = Plan.new(
         organization_id: args[:organization_id],
         name: args[:name],
+        invoice_display_name: args[:invoice_display_name],
         code: args[:code],
         description: args[:description],
         parent_id: args[:parent_id],
@@ -89,6 +90,7 @@ module Plans
         properties: {
           code: plan.code,
           name: plan.name,
+          invoice_display_name: plan.invoice_display_name,
           description: plan.description,
           plan_interval: plan.interval,
           plan_amount_cents: plan.amount_cents,

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -12,6 +12,7 @@ module Plans
       return result.not_found_failure!(resource: 'plan') unless plan
 
       plan.name = params[:name] if params.key?(:name)
+      plan.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
       plan.description = params[:description] if params.key?(:description)
 
       # NOTE: Only name and description are editable if plan

--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -392,7 +392,7 @@ html
               - if subscription_item(subscription_id).amount.positive?
                 tr
                   td.body-1 width="60%"
-                    | #{I18n.t('credit_note.subscription')} - #{Subscription.find_by(id: subscription_id)&.display_name}
+                    | #{I18n.t('credit_note.subscription')} - #{Subscription.find_by(id: subscription_id)&.invoice_name}
                   td.body-2 width="20%" == TaxHelper.applied_taxes(subscription_item(subscription_id))
                   td.body-2 width="20%" = MoneyHelper.format(subscription_item(subscription_id).amount)
               - subscription_charge_items(subscription_id).where(fees: { true_up_parent_fee: nil }).group_by { |i| i.fee.charge_id }.each do |_charge_id, items|

--- a/app/views/templates/invoices/_subscription_details.slim
+++ b/app/views/templates/invoices/_subscription_details.slim
@@ -214,10 +214,7 @@
         - recurring_fees(subscription.id).group_by(&:charge_id).each do |_charge_id, fees|
           - next unless fees.sum(&:units) > 0
 
-          - if subscription.name.present?
-            h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.name)
-          - else
-            h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.plan.name)
+          h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.invoice_name)
 
           - number_of_days_in_period = 0
 

--- a/app/views/templates/invoices/_subscription_details.slim
+++ b/app/views/templates/invoices/_subscription_details.slim
@@ -1,10 +1,7 @@
 - if subscription?
   - subscriptions.each do |subscription|
     - if subscriptions.count > 1
-      - if subscription.name.present?
-        h2.title-2.mb-24 class="#{'invoice-details-title' if subscriptions.count > 1}" = I18n.t('invoice.details', resource: subscription.name)
-      - else
-        h2.title-2.mb-24 class="#{'invoice-details-title' if subscriptions.count > 1}" = I18n.t('invoice.details', resource: subscription.plan.name)
+      h2.title-2.mb-24 class="#{'invoice-details-title' if subscriptions.count > 1}" = I18n.t('invoice.details', resource: subscription.invoice_name)
 
     / Subscription fee section
     .invoice-resume.overflow-auto class="#{'mb-24' if subscription_fees(subscription.id).charge_kind.any?}"
@@ -15,7 +12,7 @@
           td.body-2 = I18n.t('invoice.tax_rate')
           td.body-2 = I18n.t('invoice.amount_without_tax')
         tr
-          td.body-1 = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.name)
+          td.body-1 = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.invoice_name)
           td.body-2 = 1
           td.body-2 == TaxHelper.applied_taxes(invoice_subscription(subscription.id).subscription_fee)
           td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).subscription_amount)

--- a/app/views/templates/invoices/_subscriptions_summary.slim
+++ b/app/views/templates/invoices/_subscriptions_summary.slim
@@ -4,7 +4,7 @@ table.invoice-resume-table width="100%"
     td.body-2 = I18n.t('invoice.amount_without_tax')
   - subscriptions.each do |subscription|
     tr
-      td.body-1 = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.name)
+      td.body-1 = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.invoice_name)
       td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).total_amount)
 
 table.total-table width="100%"

--- a/app/views/templates/invoices/v1.slim
+++ b/app/views/templates/invoices/v1.slim
@@ -505,10 +505,7 @@ html
 
       - if subscription?
         - subscriptions.each do |subscription|
-          - if subscription.name.present?
-            h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.name)
-          - else
-            h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.plan.name)
+          h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.invoice_name)
           .body-1 = I18n.t('invoice.subscription')
           .mb-24.body-3
             | #{I18n.t('invoice.date_from')} #{I18n.l(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date, format: :default)} #{I18n.t('invoice.date_to')} #{I18n.l(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date, format: :default)}
@@ -518,7 +515,7 @@ html
               tr
                 td width="70%"
                   .body-1
-                    = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.name)
+                    = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.invoice_name)
                 td.body-1 style="text-align: right;" width="30%"
                   = subscription_fees(subscription.id).subscription_kind.first&.amount&.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
             table.total-table width="100%"
@@ -583,10 +580,7 @@ html
 
             - recurring_fees(subscription.id).group_by(&:charge_id).each do |_charge_id, fees|
               - if fees.sum(&:units) > 0
-                - if subscription.name.present?
-                  h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.name)
-                - else
-                  h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.plan.name)
+                h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.invoice_name)
 
                 - if fees.all? { |f| f.group_id? }
                   - fees.select { |f| f.units.positive? }.each do |fee|

--- a/app/views/templates/invoices/v2.slim
+++ b/app/views/templates/invoices/v2.slim
@@ -514,10 +514,7 @@ html
 
       - if subscription?
         - subscriptions.each do |subscription|
-          - if subscription.name.present?
-            h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.name)
-          - else
-            h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.plan.name)
+          h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.invoice_name)
           .body-1 = I18n.t('invoice.subscription')
           .mb-24.body-3
             | #{I18n.t('invoice.date_from')} #{I18n.l(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date, format: :default)} #{I18n.t('invoice.date_to')} #{I18n.l(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date, format: :default)}
@@ -527,7 +524,7 @@ html
               tr
                 td width="70%"
                   .body-1
-                    = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.name)
+                    = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.invoice_name)
                 td.body-1 style="text-align: right;" width="30%"
                   = subscription_fees(subscription.id).subscription_kind.first&.amount&.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
             table.total-table width="100%"
@@ -604,10 +601,7 @@ html
 
             - recurring_fees(subscription.id).group_by(&:charge_id).each do |_charge_id, fees|
               - if fees.sum(&:units) > 0
-                - if subscription.name.present?
-                  h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.name)
-                - else
-                  h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.plan.name)
+                h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.invoice_name)
 
                 - if fees.all? { |f| f.group_id? }
                   - fees.select { |f| f.units.positive? }.each do |fee|

--- a/db/migrate/20230907064335_add_invoice_display_name_to_plans.rb
+++ b/db/migrate/20230907064335_add_invoice_display_name_to_plans.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddInvoiceDisplayNameToPlans < ActiveRecord::Migration[7.0]
+  def change
+    add_column :plans, :invoice_display_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -622,6 +622,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_11_185900) do
     t.uuid "parent_id"
     t.datetime "deleted_at"
     t.boolean "pending_deletion", default: false, null: false
+    t.string "invoice_display_name"
     t.index ["deleted_at"], name: "index_plans_on_deleted_at"
     t.index ["organization_id", "code"], name: "index_plans_on_organization_id_and_code", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_plans_on_organization_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1750,6 +1750,7 @@ input CreatePlanInput {
   code: String!
   description: String
   interval: PlanInterval!
+  invoiceDisplayName: String
   name: String!
   parentId: ID
   payInAdvance: Boolean!
@@ -3949,6 +3950,7 @@ type Plan {
   draftInvoicesCount: Int!
   id: ID!
   interval: PlanInterval!
+  invoiceDisplayName: String
   name: String!
   organization: Organization
   parentId: ID
@@ -5500,6 +5502,7 @@ input UpdatePlanInput {
   description: String
   id: String!
   interval: PlanInterval!
+  invoiceDisplayName: String
   name: String!
   payInAdvance: Boolean!
   taxCodes: [String!]

--- a/schema.json
+++ b/schema.json
@@ -5834,6 +5834,18 @@
               "deprecationReason": null
             },
             {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "type": {
@@ -16480,6 +16492,20 @@
               ]
             },
             {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "name",
               "description": null,
               "type": {
@@ -22924,6 +22950,18 @@
                   "name": "PlanInterval",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/factories/plans.rb
+++ b/spec/factories/plans.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :plan do
     organization
     name { Faker::TvShows::SiliconValley.app }
+    invoice_display_name { Faker::TvShows::BreakingBad.episode }
     code { Faker::Alphanumeric.alphanumeric(number: 10) }
     interval { 'monthly' }
     pay_in_advance { false }

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
         createPlan(input: $input) {
           id,
           name,
+          invoiceDisplayName,
           code,
           interval,
           payInAdvance,
@@ -77,6 +78,7 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
       variables: {
         input: {
           name: 'New Plan',
+          invoiceDisplayName: 'New Plan Invoice Name',
           code: 'new_plan',
           interval: 'monthly',
           payInAdvance: false,
@@ -191,6 +193,7 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
     aggregate_failures do
       expect(result_data['id']).to be_present
       expect(result_data['name']).to eq('New Plan')
+      expect(result_data['invoiceDisplayName']).to eq('New Plan Invoice Name')
       expect(result_data['code']).to eq('new_plan')
       expect(result_data['interval']).to eq('monthly')
       expect(result_data['payInAdvance']).to eq(false)

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
         updatePlan(input: $input) {
           id,
           name,
+          invoiceDisplayName,
           code,
           interval,
           payInAdvance,
@@ -67,6 +68,7 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
         input: {
           id: plan.id,
           name: 'Updated plan',
+          invoiceDisplayName: 'Updated plan invoice name',
           code: 'new_plan',
           interval: 'monthly',
           payInAdvance: false,
@@ -157,6 +159,7 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
     aggregate_failures do
       expect(result_data['id']).to be_present
       expect(result_data['name']).to eq('Updated plan')
+      expect(result_data['invoiceDisplayName']).to eq('Updated plan invoice name')
       expect(result_data['code']).to eq('new_plan')
       expect(result_data['interval']).to eq('monthly')
       expect(result_data['payInAdvance']).to eq(false)

--- a/spec/graphql/types/plans/object_spec.rb
+++ b/spec/graphql/types/plans/object_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Plans::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type('ID!') }
+  it { is_expected.to have_field(:organization).of_type('Organization') }
+  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:amount_currency).of_type('CurrencyEnum!') }
+  it { is_expected.to have_field(:bill_charges_monthly).of_type('Boolean') }
+  it { is_expected.to have_field(:code).of_type('String!') }
+  it { is_expected.to have_field(:description).of_type('String') }
+  it { is_expected.to have_field(:interval).of_type('PlanInterval!') }
+  it { is_expected.to have_field(:invoice_display_name).of_type('String') }
+  it { is_expected.to have_field(:name).of_type('String!') }
+  it { is_expected.to have_field(:parent_id).of_type('ID') }
+  it { is_expected.to have_field(:pay_in_advance).of_type('Boolean!') }
+  it { is_expected.to have_field(:trial_period).of_type('Float') }
+  it { is_expected.to have_field(:charges).of_type('[Charge!]') }
+  it { is_expected.to have_field(:taxes).of_type('[Tax!]') }
+  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:active_subscriptions_count).of_type('Int!') }
+  it { is_expected.to have_field(:charge_count).of_type('Int!') }
+  it { is_expected.to have_field(:customer_count).of_type('Int!') }
+  it { is_expected.to have_field(:draft_invoices_count).of_type('Int!') }
+  it { is_expected.to have_field(:subscriptions_count).of_type('Int!') }
+end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -56,4 +56,24 @@ RSpec.describe Plan, type: :model do
       it { expect(plan.yearly_amount_cents).to eq(400) }
     end
   end
+
+  describe '#invoice_name' do
+    subject(:plan_invoice_name) { plan.invoice_name }
+
+    context 'when invoice display name is blank' do
+      let(:plan) { build_stubbed(:plan, invoice_display_name: [nil, ''].sample) }
+
+      it 'returns name' do
+        expect(plan_invoice_name).to eq(plan.name)
+      end
+    end
+
+    context 'when invoice display name is present' do
+      let(:plan) { build_stubbed(:plan) }
+
+      it 'returns invoice display name' do
+        expect(plan_invoice_name).to eq(plan.invoice_display_name)
+      end
+    end
+  end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -350,4 +350,50 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe '#invoice_name' do
+    subject(:subscription_invoice_name) { subscription.invoice_name }
+
+    let(:subscription) { build_stubbed(:subscription, plan:, name:) }
+
+    context 'when plan invoice display name is blank' do
+      let(:plan) { build_stubbed(:plan, invoice_display_name: [nil, ''].sample) }
+
+      context 'when subscription name is blank' do
+        let(:name) { [nil, ''].sample }
+
+        it 'returns plan name' do
+          expect(subscription_invoice_name).to eq(plan.name)
+        end
+      end
+
+      context 'when subscription name is present' do
+        let(:name) { Faker::TvShows::GameOfThrones.characters }
+
+        it 'returns subscription name' do
+          expect(subscription_invoice_name).to eq(subscription.name)
+        end
+      end
+    end
+
+    context 'when plan invoice display name is present' do
+      let(:plan) { build_stubbed(:plan) }
+
+      context 'when subscription name is blank' do
+        let(:name) { [nil, ''].sample }
+
+        it 'returns plan invoice display name' do
+          expect(subscription_invoice_name).to eq(plan.invoice_display_name)
+        end
+      end
+
+      context 'when subscription name is present' do
+        let(:name) { Faker::TvShows::GameOfThrones.characters }
+
+        it 'returns subscription name' do
+          expect(subscription_invoice_name).to eq(subscription.name)
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
     let(:create_params) do
       {
         name: 'P1',
+        invoice_display_name: 'P1 invoice name',
         code: 'plan_code',
         interval: 'weekly',
         description: 'description',
@@ -41,6 +42,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
       expect(json[:plan][:lago_id]).to be_present
       expect(json[:plan][:code]).to eq(create_params[:code])
       expect(json[:plan][:name]).to eq(create_params[:name])
+      expect(json[:plan][:invoice_display_name]).to eq(create_params[:invoice_display_name])
       expect(json[:plan][:created_at]).to be_present
       expect(json[:plan][:charges].first[:lago_id]).to be_present
     end

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ::V1::PlanSerializer do
     aggregate_failures do
       expect(result['plan']['lago_id']).to eq(plan.id)
       expect(result['plan']['name']).to eq(plan.name)
+      expect(result['plan']['invoice_display_name']).to eq(plan.invoice_display_name)
       expect(result['plan']['created_at']).to eq(plan.created_at.iso8601)
       expect(result['plan']['code']).to eq(plan.code)
       expect(result['plan']['interval']).to eq(plan.interval)

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Plans::CreateService, type: :service do
 
   describe 'create' do
     let(:plan_name) { 'Some plan name' }
+    let(:plan_invoice_display_name) { 'Some plan invoice name' }
     let(:billable_metric) { create(:billable_metric, organization:) }
     let(:sum_billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
     let(:group) { create(:group, billable_metric:) }
@@ -18,6 +19,7 @@ RSpec.describe Plans::CreateService, type: :service do
     let(:create_args) do
       {
         name: plan_name,
+        invoice_display_name: plan_invoice_display_name,
         organization_id: organization.id,
         code: 'new_plan',
         interval: 'monthly',
@@ -78,6 +80,7 @@ RSpec.describe Plans::CreateService, type: :service do
 
       plan = Plan.order(:created_at).last
       expect(plan.taxes.pluck(:code)).to eq([plan_tax.code])
+      expect(plan.invoice_display_name).to eq(plan_invoice_display_name)
     end
 
     it 'creates charges' do

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe Plans::CreateService, type: :service do
         properties: {
           code: plan.code,
           name: plan.name,
+          invoice_display_name: plan.invoice_display_name,
           description: plan.description,
           plan_interval: plan.interval,
           plan_amount_cents: plan.amount_cents,

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Plans::UpdateService, type: :service do
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization:) }
   let(:plan_name) { 'Updated plan name' }
+  let(:plan_invoice_display_name) { 'Updated plan invoice display name' }
   let(:group) { create(:group, billable_metric: sum_billable_metric) }
   let(:sum_billable_metric) { create(:sum_billable_metric, organization:, recurring: true) }
   let(:billable_metric) { create(:billable_metric, organization:) }
@@ -19,6 +20,7 @@ RSpec.describe Plans::UpdateService, type: :service do
   let(:update_args) do
     {
       name: plan_name,
+      invoice_display_name: plan_invoice_display_name,
       code: 'new_plan',
       interval: 'monthly',
       pay_in_advance: false,
@@ -77,6 +79,7 @@ RSpec.describe Plans::UpdateService, type: :service do
       updated_plan = result.plan
       aggregate_failures do
         expect(updated_plan.name).to eq('Updated plan name')
+        expect(updated_plan.invoice_display_name).to eq(plan_invoice_display_name)
         expect(updated_plan.taxes.pluck(:code)).to eq([tax2.code])
         expect(plan.charges.count).to eq(2)
       end


### PR DESCRIPTION
## Context

Add the ability to overwrite plan’s and subscription’s names in invoices.

## Description

This PR handles only plans and subscriptions invoice display names, charges, fees will be implemented in a follow-up PR.