### PR TITLE
feat (billable metrics): add validations for latest agg

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -90,7 +90,7 @@ class BillableMetric < ApplicationRecord
 
   def validate_recurring
     return unless recurring?
-    return unless count_agg? || max_agg? || recurring_count_agg?
+    return unless count_agg? || max_agg? || latest_agg? || recurring_count_agg?
 
     errors.add(:recurring, :not_compatible_with_aggregation_type)
   end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -91,7 +91,9 @@ class Charge < ApplicationRecord
   # - charge model is volume
   def validate_pay_in_advance
     return unless pay_in_advance?
-    return unless billable_metric.recurring_count_agg? || billable_metric.max_agg? || volume?
+    unless billable_metric.recurring_count_agg? || billable_metric.max_agg? || billable_metric.latest_agg? || volume?
+      return
+    end
 
     errors.add(:pay_in_advance, :invalid_aggregation_type_or_charge_model)
   end

--- a/app/services/charges/validators/graduated_percentage_service.rb
+++ b/app/services/charges/validators/graduated_percentage_service.rb
@@ -6,6 +6,8 @@ module Charges
       include ::Validators::RangeBoundsValidator
 
       def valid?
+        validate_billable_metric
+
         if ranges.blank?
           add_error(field: :graduated_percentage_ranges, error_code: 'missing_graduated_percentage_ranges')
         else
@@ -26,6 +28,12 @@ module Charges
       end
 
       private
+
+      def validate_billable_metric
+        return unless charge.billable_metric.latest_agg?
+
+        add_error(field: :billable_metric, error_code: 'invalid_value')
+      end
 
       def ranges
         charge.properties['graduated_percentage_ranges'].map(&:with_indifferent_access)

--- a/app/services/charges/validators/percentage_service.rb
+++ b/app/services/charges/validators/percentage_service.rb
@@ -4,6 +4,7 @@ module Charges
   module Validators
     class PercentageService < Charges::Validators::BaseService
       def valid?
+        validate_billable_metric
         validate_rate
         validate_fixed_amount
         validate_free_units_per_events
@@ -17,6 +18,12 @@ module Charges
 
       def rate
         properties['rate']
+      end
+
+      def validate_billable_metric
+        return unless charge.billable_metric.latest_agg?
+
+        add_error(field: :billable_metric, error_code: 'invalid_value')
       end
 
       def validate_rate

--- a/app/services/events/validate_creation_service.rb
+++ b/app/services/events/validate_creation_service.rb
@@ -88,7 +88,7 @@ module Events
     # This validation checks only field_name value since it is important for aggregation DB query integrity.
     # Other checks are performed later and presented in debugger
     def valid_properties?
-      return true unless billable_metric.max_agg? || billable_metric.sum_agg?
+      return true unless billable_metric.max_agg? || billable_metric.sum_agg? || billable_metric.latest_agg?
 
       valid_number?((params[:properties] || {})[billable_metric.field_name.to_sym])
     end

--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -51,6 +51,18 @@ RSpec.describe BillableMetric, type: :model do
         end
       end
     end
+
+    context 'when recurring is true and aggregation type is latest_agg' do
+      let(:billable_metric) { build(:latest_billable_metric, recurring:) }
+      let(:recurring) { true }
+
+      it 'returns an error' do
+        aggregate_failures do
+          expect(billable_metric).not_to be_valid
+          expect(billable_metric.errors.messages[:recurring]).to include('not_compatible_with_aggregation_type')
+        end
+      end
+    end
   end
 
   describe '#selectable_groups' do

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe Charge, type: :model do
     end
   end
 
-  describe '#validate_instant' do
+  describe '#validate_pay_in_advance' do
     it 'does not return an error' do
       expect(build(:standard_charge)).to be_valid
     end
@@ -389,6 +389,18 @@ RSpec.describe Charge, type: :model do
     context 'when billable metric is max_agg' do
       it 'returns an error' do
         billable_metric = create(:max_billable_metric)
+        charge = build(:standard_charge, :pay_in_advance, billable_metric:)
+
+        aggregate_failures do
+          expect(charge).not_to be_valid
+          expect(charge.errors.messages[:pay_in_advance]).to include('invalid_aggregation_type_or_charge_model')
+        end
+      end
+    end
+
+    context 'when billable metric is latest_agg' do
+      it 'returns an error' do
+        billable_metric = create(:latest_billable_metric)
         charge = build(:standard_charge, :pay_in_advance, billable_metric:)
 
         aggregate_failures do

--- a/spec/services/charges/validators/graduated_percentage_service_spec.rb
+++ b/spec/services/charges/validators/graduated_percentage_service_spec.rb
@@ -15,6 +15,25 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
   let(:ranges) { {} }
 
   describe '.valid?' do
+    context 'when billable metric is latest_agg' do
+      let(:billable_metric) { create(:latest_billable_metric) }
+      let(:charge) { build(:graduated_percentage_charge, properties: graduated_percentage_ranges, billable_metric:) }
+      let(:graduated_percentage_ranges) do
+        {
+          graduated_percentage_ranges: ranges,
+        }
+      end
+
+      it 'is invalid' do
+        aggregate_failures do
+          expect(graduated_percentage_service).not_to be_valid
+          expect(graduated_percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(graduated_percentage_service.result.error.messages.keys).to include(:billable_metric)
+          expect(graduated_percentage_service.result.error.messages[:billable_metric]).to include('invalid_value')
+        end
+      end
+    end
+
     context 'with ranges validation' do
       it 'ensures the presences of ranges' do
         aggregate_failures do

--- a/spec/services/charges/validators/percentage_service_spec.rb
+++ b/spec/services/charges/validators/percentage_service_spec.rb
@@ -17,6 +17,26 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
   describe '.valid?' do
     it { expect(percentage_service).to be_valid }
 
+    context 'when billable metric is latest_agg' do
+      let(:billable_metric) { create(:latest_billable_metric) }
+      let(:charge) { build(:percentage_charge, properties: percentage_properties, billable_metric:) }
+      let(:percentage_properties) do
+        {
+          rate: 0.25,
+          fixed_amount: '2',
+        }
+      end
+
+      it 'is invalid' do
+        aggregate_failures do
+          expect(percentage_service).not_to be_valid
+          expect(percentage_service.result.error).to be_a(BaseService::ValidationFailure)
+          expect(percentage_service.result.error.messages.keys).to include(:billable_metric)
+          expect(percentage_service.result.error.messages[:billable_metric]).to include('invalid_value')
+        end
+      end
+    end
+
     context 'without rate' do
       let(:percentage_properties) do
         {


### PR DESCRIPTION
## Context

When user is pre-aggregating number of units on their side, there’s no aggregation type allowing Lago to take in consideration the last unit number received. 

## Description

This PR adds validations for new billable metric aggregation type