### PR TITLE
feat(weighted-sum): Update invoice PDF template

### DIFF
--- a/app/views/templates/invoices/_subscription_details.slim
+++ b/app/views/templates/invoices/_subscription_details.slim
@@ -54,10 +54,14 @@
                     td style="padding-left: 16px;"
                       .body-1 = fee.group.name
                       - unless fee.billable_metric.recurring_count_agg?
-                        .body-3
-                          - if fee.charge.percentage?
-                            = I18n.t('invoice.total_events', count: fee.events_count)
-                    td.body-2 = fee.units
+                        - if fee.billable_metric.weighted_sum_agg?
+                          .body-3 = I18n.t('invoice.units_per_second')
+                        - if fee.charge.percentage?
+                          .body-3 = I18n.t('invoice.total_events', count: fee.events_count)
+                    td
+                      .body-2 = fee.units
+                      - if fee.billable_metric.weighted_sum_agg?
+                        .body-2 = fee.total_aggregated_units.round(15)
                     td.body-2 == TaxHelper.applied_taxes(fee)
                     td.body-2 = MoneyHelper.format(fee.amount)
 
@@ -71,10 +75,14 @@
                   td
                     .body-1 = fee.billable_metric.name
                     - unless fee.billable_metric.recurring_count_agg?
-                        .body-3
-                          - if fee.charge.percentage?
-                            = I18n.t('invoice.total_events', count: fee.events_count)
-                  td.body-2 = fees.sum(&:units)
+                      - if fee.billable_metric.weighted_sum_agg?
+                        .body-3 = I18n.t('invoice.units_per_second')
+                      - if fee.charge.percentage?
+                        .body-3 = I18n.t('invoice.total_events', count: fee.events_count)
+                  td
+                    .body-2 = fees.sum(&:units)
+                    - if fee.billable_metric.weighted_sum_agg?
+                      .body-2 = fees.sum(&:total_aggregated_units).round(15)
                   td.body-2 == TaxHelper.applied_taxes(fee)
                   td.body-2 = MoneyHelper.format(fees.sum(&:amount))
 
@@ -114,10 +122,14 @@
                     td style="padding-left: 16px;"
                       .body-1 = fee.group.name
                       - unless fee.billable_metric.recurring_count_agg?
-                        .body-3
-                          - if fee.charge.percentage?
-                            = I18n.t('invoice.total_events', count: fee.events_count)
-                    td.body-2 = fee.units
+                        - if fee.billable_metric.weighted_sum_agg?
+                          .body-3 = I18n.t('invoice.units_per_second')
+                        - if fee.charge.percentage?
+                          .body-3 = I18n.t('invoice.total_events', count: fee.events_count)
+                    td
+                      .body-2 = fee.units
+                      - if fee.billable_metric.weighted_sum_agg?
+                        .body-2 = fee.total_aggregated_units.round(15)
                     td.body-2 == TaxHelper.applied_taxes(fee)
                     td.body-2 = MoneyHelper.format(fee.amount)
 
@@ -131,10 +143,14 @@
                   td
                     .body-1 = fee.billable_metric.name
                     - unless fee.billable_metric.recurring_count_agg?
-                        .body-3
-                          - if fee.charge.percentage?
-                            = I18n.t('invoice.total_events', count: fee.events_count)
-                  td.body-2 = fees.sum(&:units)
+                      - if fee.billable_metric.weighted_sum_agg?
+                        .body-3 = I18n.t('invoice.units_per_second')
+                      - if fee.charge.percentage?
+                        .body-3 = I18n.t('invoice.total_events', count: fee.events_count)
+                  td
+                    .body-2 = fees.sum(&:units)
+                    - if fee.billable_metric.weighted_sum_agg?
+                      .body-2 = fees.sum(&:total_aggregated_units).round(15)
                   td.body-2 == TaxHelper.applied_taxes(fee)
                   td.body-2 = MoneyHelper.format(fees.sum(&:amount))
 

--- a/app/views/templates/invoices/_subscription_details.slim
+++ b/app/views/templates/invoices/_subscription_details.slim
@@ -6,6 +6,7 @@
       - else
         h2.title-2.mb-24 class="#{'invoice-details-title' if subscriptions.count > 1}" = I18n.t('invoice.details', resource: subscription.plan.name)
 
+    / Subscription fee section
     .invoice-resume.overflow-auto class="#{'mb-24' if subscription_fees(subscription.id).charge_kind.any?}"
       table.invoice-resume-table width="100%"
         tr
@@ -19,127 +20,130 @@
           td.body-2 == TaxHelper.applied_taxes(invoice_subscription(subscription.id).subscription_fee)
           td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).subscription_amount)
 
-    - if subscription? && subscription_fees(subscription.id).charge_kind.any? && (subscription.plan.charges.where(pay_in_advance: false).any? || (subscription.plan.charges.where(pay_in_advance: true).any? && subscription.plan.pay_in_advance?))
-      .invoice-resume.overflow-auto
-        table.invoice-resume-table width="100%"
-          tr
-            td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date, format: :default), to_date: I18n.l(invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date, format: :default))
-            td.body-2 = I18n.t('invoice.unit')
-            td.body-2 = I18n.t('invoice.tax_rate')
-            td.body-2 = I18n.t('invoice.amount_without_tax')
-          - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).group_by(&:charge_id).each do |_charge_id, fees|
-            - fee = fees.first
-            - next if fee.charge.pay_in_advance? && !fee.charge.plan.pay_in_advance?
+    / Charge fees section for subsctiption invoice
+    - if subscription? && subscription_fees(subscription.id).charge_kind.any?
 
-            - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
-              tr
-                td
-                  .body-1 = fee.billable_metric.name
-                  .body-3
-                    - if fee.charge.percentage?
-                      = I18n.t('invoice.total_events', count: fees.sum(&:events_count))
-                td
-                td
-                td
-              - fees.select { |f| f.units.positive? }.each do |fee|
-                tr
-                  td style="padding-left: 16px;"
-                    .body-1 = fee.group.name
-                    - unless fee.billable_metric.recurring_count_agg?
-                      .body-3
-                        - if fee.charge.percentage?
-                          = I18n.t('invoice.total_events', count: fee.events_count)
-                  td.body-2 = fee.units
-                  td.body-2 == TaxHelper.applied_taxes(fee)
-                  td.body-2 = MoneyHelper.format(fee.amount)
-              - fees.select { |f| f.true_up_fee.present? }.each do |fee|
-                tr
-                  td
-                    .body-1 = I18n.t('invoice.true_up_metric', metric: fee.billable_metric.name)
-                    .body-3 = I18n.t('invoice.true_up_details', min_amount: MoneyHelper.format(fee.charge.min_amount))
-                  td.body-2 = fee.true_up_fee.units
-                  td.body-2 == TaxHelper.applied_taxes(fee.true_up_fee)
-                  td.body-2 = MoneyHelper.format(fee.true_up_fee.amount)
-            - else
-              tr
-                td
-                  .body-1 = fee.billable_metric.name
-                  - unless fee.billable_metric.recurring_count_agg?
-                      .body-3
-                        - if fee.charge.percentage?
-                          = I18n.t('invoice.total_events', count: fee.events_count)
-                td.body-2 = fees.sum(&:units)
-                td.body-2 == TaxHelper.applied_taxes(fee)
-                td.body-2 = MoneyHelper.format(fees.sum(&:amount))
-              - if fee.true_up_fee.present?
-                tr
-                  td
-                    .body-1 = I18n.t('invoice.true_up_metric', metric: fee.billable_metric.name)
-                    .body-3 = I18n.t('invoice.true_up_details', min_amount: MoneyHelper.format(fee.charge.min_amount))
-                  td.body-2 = fee.true_up_fee.units
-                  td.body-2 == TaxHelper.applied_taxes(fee.true_up_fee)
-                  td.body-2 = MoneyHelper.format(fee.true_up_fee.amount)
-    - if subscription? && subscription_fees(subscription.id).charge_kind.any? && subscription.plan.charges.where(pay_in_advance: true).any? && !subscription.plan.pay_in_advance?
-      .invoice-resume.overflow-auto
-        table.invoice-resume-table width="100%"
-          tr
-            - pay_in_advance_interval = charge_pay_in_advance_interval(invoice_subscription(subscription.id).timestamp, subscription)
-            td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(pay_in_advance_interval[:charges_from_date], format: :default), to_date: I18n.l(pay_in_advance_interval[:charges_to_date], format: :default))
-            td.body-2 = I18n.t('invoice.unit')
-            td.body-2 = I18n.t('invoice.tax_rate')
-            td.body-2 = I18n.t('invoice.amount_without_tax')
-          - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).group_by(&:charge_id).each do |_charge_id, fees|
-            - fee = fees.first
-            - next unless fee.charge.pay_in_advance?
+      / Charges payed in arrears OR charges and plan payed in advance
+      - if (subscription.plan.charges.where(pay_in_advance: false).any? || (subscription.plan.charges.where(pay_in_advance: true).any? && subscription.plan.pay_in_advance?))
+        .invoice-resume.overflow-auto
+          table.invoice-resume-table width="100%"
+            tr
+              td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date, format: :default), to_date: I18n.l(invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date, format: :default))
+              td.body-2 = I18n.t('invoice.unit')
+              td.body-2 = I18n.t('invoice.tax_rate')
+              td.body-2 = I18n.t('invoice.amount_without_tax')
 
-            - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
-              tr
-                td
-                  .body-1 = fee.billable_metric.name
-                  .body-3
-                    - if fee.charge.percentage?
-                      = I18n.t('invoice.total_events', count: fees.sum(&:events_count))
-                td
-                td
-                td
-              - fees.select { |f| f.units.positive? }.each do |fee|
+            / Loop over all top level fees
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).group_by(&:charge_id).each do |_charge_id, fees|
+              - fee = fees.first
+              - next if fee.charge.pay_in_advance? && !fee.charge.plan.pay_in_advance?
+
+              / Fees for groups
+              - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
                 tr
-                  td style="padding-left: 16px;"
-                    .body-1 = fee.group.name
+                  td
+                    .body-1 = fee.billable_metric.name
+                    .body-3
+                      - if fee.charge.percentage?
+                        = I18n.t('invoice.total_events', count: fees.sum(&:events_count))
+                  td
+                  td
+                  td
+                - fees.select { |f| f.units.positive? }.each do |fee|
+                  tr
+                    td style="padding-left: 16px;"
+                      .body-1 = fee.group.name
+                      - unless fee.billable_metric.recurring_count_agg?
+                        .body-3
+                          - if fee.charge.percentage?
+                            = I18n.t('invoice.total_events', count: fee.events_count)
+                    td.body-2 = fee.units
+                    td.body-2 == TaxHelper.applied_taxes(fee)
+                    td.body-2 = MoneyHelper.format(fee.amount)
+
+                / True up fees attached to the fee
+                - fees.select { |f| f.true_up_fee.present? }.each do |fee|
+                  == SlimHelper.render('templates/invoices/fees/_true_up_fee', fee: fee)
+
+              / Fees without group
+              - else
+                tr
+                  td
+                    .body-1 = fee.billable_metric.name
                     - unless fee.billable_metric.recurring_count_agg?
-                      .body-3
-                        - if fee.charge.percentage?
-                          = I18n.t('invoice.total_events', count: fee.events_count)
-                  td.body-2 = fee.units
+                        .body-3
+                          - if fee.charge.percentage?
+                            = I18n.t('invoice.total_events', count: fee.events_count)
+                  td.body-2 = fees.sum(&:units)
                   td.body-2 == TaxHelper.applied_taxes(fee)
-                  td.body-2 = MoneyHelper.format(fee.amount)
-              - fees.select { |f| f.true_up_fee.present? }.each do |fee|
+                  td.body-2 = MoneyHelper.format(fees.sum(&:amount))
+
+                / True up fees attached to the fee
+                - if fee.true_up_fee.present?
+                  == SlimHelper.render('templates/invoices/fees/_true_up_fee', fee: fee)
+
+      / Charges payed in advance on payed in arrears plan
+      - if subscription.plan.charges.where(pay_in_advance: true).any? && !subscription.plan.pay_in_advance?
+        .invoice-resume.overflow-auto
+          table.invoice-resume-table width="100%"
+            tr
+              - pay_in_advance_interval = charge_pay_in_advance_interval(invoice_subscription(subscription.id).timestamp, subscription)
+              td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(pay_in_advance_interval[:charges_from_date], format: :default), to_date: I18n.l(pay_in_advance_interval[:charges_to_date], format: :default))
+              td.body-2 = I18n.t('invoice.unit')
+              td.body-2 = I18n.t('invoice.tax_rate')
+              td.body-2 = I18n.t('invoice.amount_without_tax')
+
+            / Loop over all top level fees
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).group_by(&:charge_id).each do |_charge_id, fees|
+              - fee = fees.first
+              - next unless fee.charge.pay_in_advance?
+
+              / Fees for groups
+              - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
                 tr
                   td
-                    .body-1 = I18n.t('invoice.true_up_metric', metric: fee.billable_metric.name)
-                    .body-3 = I18n.t('invoice.true_up_details', min_amount: MoneyHelper.format(fee.charge.min_amount))
-                  td.body-2 = fee.true_up_fee.units
-                  td.body-2 == TaxHelper.applied_taxes(fee.true_up_fee)
-                  td.body-2 = MoneyHelper.format(fee.true_up_fee.amount)
-            - else
-              tr
-                td
-                  .body-1 = fee.billable_metric.name
-                  - unless fee.billable_metric.recurring_count_agg?
-                      .body-3
-                        - if fee.charge.percentage?
-                          = I18n.t('invoice.total_events', count: fee.events_count)
-                td.body-2 = fees.sum(&:units)
-                td.body-2 == TaxHelper.applied_taxes(fee)
-                td.body-2 = MoneyHelper.format(fees.sum(&:amount))
-              - if fee.true_up_fee.present?
+                    .body-1 = fee.billable_metric.name
+                    .body-3
+                      - if fee.charge.percentage?
+                        = I18n.t('invoice.total_events', count: fees.sum(&:events_count))
+                  td
+                  td
+                  td
+                - fees.select { |f| f.units.positive? }.each do |fee|
+                  tr
+                    td style="padding-left: 16px;"
+                      .body-1 = fee.group.name
+                      - unless fee.billable_metric.recurring_count_agg?
+                        .body-3
+                          - if fee.charge.percentage?
+                            = I18n.t('invoice.total_events', count: fee.events_count)
+                    td.body-2 = fee.units
+                    td.body-2 == TaxHelper.applied_taxes(fee)
+                    td.body-2 = MoneyHelper.format(fee.amount)
+
+                / True up fees attached to the fee
+                - fees.select { |f| f.true_up_fee.present? }.each do |fee|
+                  == SlimHelper.render('templates/invoices/fees/_true_up_fee', fee: fee)
+
+              / Fees without group
+              - else
                 tr
                   td
-                    .body-1 = I18n.t('invoice.true_up_metric', metric: fee.billable_metric.name)
-                    .body-3 = I18n.t('invoice.true_up_details', min_amount: MoneyHelper.format(fee.charge.min_amount))
-                  td.body-2 = fee.true_up_fee.units
-                  td.body-2 == TaxHelper.applied_taxes(fee.true_up_fee)
-                  td.body-2 = MoneyHelper.format(fee.true_up_fee.amount)
+                    .body-1 = fee.billable_metric.name
+                    - unless fee.billable_metric.recurring_count_agg?
+                        .body-3
+                          - if fee.charge.percentage?
+                            = I18n.t('invoice.total_events', count: fee.events_count)
+                  td.body-2 = fees.sum(&:units)
+                  td.body-2 == TaxHelper.applied_taxes(fee)
+                  td.body-2 = MoneyHelper.format(fees.sum(&:amount))
+
+                / True up fees attached to the fee
+                - if fee.true_up_fee.present?
+                  == SlimHelper.render('templates/invoices/fees/_true_up_fee', fee: fee)
+
+
+    / Total section
     .invoice-resume.overflow-auto
       table.total-table width="100%"
         - if subscriptions.count == 1
@@ -191,56 +195,62 @@
             td.body-1
               = MoneyHelper.format(invoice_subscription(subscription.id).total_amount)
 
+    / Recuring fees breakdown
     - if subscription? && subscription_fees(subscription.id).charge_kind.any?
       .invoice-resume.mb-24.overflow-auto
         - recurring_fees(subscription.id).group_by(&:charge_id).each do |_charge_id, fees|
-          - if fees.sum(&:units) > 0
-            - if subscription.name.present?
-              h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.name)
-            - else
-              h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.plan.name)
+          - next unless fees.sum(&:units) > 0
 
-            - number_of_days_in_period = 0
-            - if fees.all? { |f| f.group_id? }
-              - fees.select { |f| f.units.positive? }.each do |fee|
-                .body-3 = fees.first.billable_metric.name
-                .body-1.mb-24 = I18n.t('invoice.breakdown_of', fee_group_name: fee.group.name)
-                .breakdown-details.mb-24
-                  table.breakdown-details-table width="100%"
-                    - recurring_breakdown(fee).each do |breakdown|
-                      - number_of_days_in_period = breakdown.total_duration
-                      tr
-                        td width="20%"
-                          .body-1 = I18n.l(breakdown.date, format: :default)
-                          .body-3 = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
-                        td.body-1 width="80%"
-                          - if breakdown.action.to_sym == :add
-                            | +#{breakdown.amount} #{fee.item_name}
-                          - elsif breakdown.action.to_sym == :remove
-                            | #{breakdown.amount.negative? ? '' : '-'}#{breakdown.amount} #{fee.item_name}
-                          - else
-                            | +/-#{breakdown.amount} #{fee.item_name}
-            - else
+          - if subscription.name.present?
+            h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.name)
+          - else
+            h2.invoice-details-title.title-2.mb-24 = I18n.t('invoice.details', resource: subscription.plan.name)
+
+          - number_of_days_in_period = 0
+
+          / Fees for groups
+          - if fees.all? { |f| f.group_id? }
+            - fees.select { |f| f.units.positive? }.each do |fee|
               .body-3 = fees.first.billable_metric.name
-              .body-1.mb-24 = I18n.t('invoice.breakdown')
+              .body-1.mb-24 = I18n.t('invoice.breakdown_of', fee_group_name: fee.group.name)
               .breakdown-details.mb-24
                 table.breakdown-details-table width="100%"
-                  - fees.each do |fee|
-                    - recurring_breakdown(fee).each do |breakdown|
-                      - number_of_days_in_period = breakdown.total_duration
-                      tr
-                        td width="20%"
-                          .body-1 = breakdown.date.strftime('%b %d, %Y')
-                          .body-3 = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
-                        td.body-1 width="80%"
-                          - if breakdown.action.to_sym == :add
-                            | +#{breakdown.amount} #{fee.item_name}
-                          - elsif breakdown.action.to_sym == :remove
-                            | #{breakdown.amount.negative? ? '' : '-'}#{breakdown.amount} #{fee.item_name}
-                          - else
-                            | +/-#{breakdown.amount} #{fee.item_name}
+                  - recurring_breakdown(fee).each do |breakdown|
+                    - number_of_days_in_period = breakdown.total_duration
+                    tr
+                      td width="20%"
+                        .body-1 = I18n.l(breakdown.date, format: :default)
+                        .body-3 = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
+                      td.body-1 width="80%"
+                        - if breakdown.action.to_sym == :add
+                          | +#{breakdown.amount} #{fee.item_name}
+                        - elsif breakdown.action.to_sym == :remove
+                          | #{breakdown.amount.negative? ? '' : '-'}#{breakdown.amount} #{fee.item_name}
+                        - else
+                          | +/-#{breakdown.amount} #{fee.item_name}
 
-            - if fees.first.charge.prorated?
-              .alert.body-3 = I18n.t('invoice.notice_prorated', days_in_month: number_of_days_in_period)
-            - else
-              .alert.body-3 = I18n.t('invoice.notice_full')
+          / Fees without group
+          - else
+            .body-3 = fees.first.billable_metric.name
+            .body-1.mb-24 = I18n.t('invoice.breakdown')
+            .breakdown-details.mb-24
+              table.breakdown-details-table width="100%"
+                - fees.each do |fee|
+                  - recurring_breakdown(fee).each do |breakdown|
+                    - number_of_days_in_period = breakdown.total_duration
+                    tr
+                      td width="20%"
+                        .body-1 = breakdown.date.strftime('%b %d, %Y')
+                        .body-3 = I18n.t('invoice.breakdown_for_days', breakdown_duration: breakdown.duration, breakdown_total_duration: breakdown.total_duration)
+                      td.body-1 width="80%"
+                        - if breakdown.action.to_sym == :add
+                          | +#{breakdown.amount} #{fee.item_name}
+                        - elsif breakdown.action.to_sym == :remove
+                          | #{breakdown.amount.negative? ? '' : '-'}#{breakdown.amount} #{fee.item_name}
+                        - else
+                          | +/-#{breakdown.amount} #{fee.item_name}
+
+          - if fees.first.charge.prorated?
+            .alert.body-3 = I18n.t('invoice.notice_prorated', days_in_month: number_of_days_in_period)
+          - else
+            .alert.body-3 = I18n.t('invoice.notice_full')

--- a/app/views/templates/invoices/fees/_true_up_fee.slim
+++ b/app/views/templates/invoices/fees/_true_up_fee.slim
@@ -1,0 +1,7 @@
+tr
+  td
+    .body-1 = I18n.t('invoice.true_up_metric', metric: fee.billable_metric.name)
+    .body-3 = I18n.t('invoice.true_up_details', min_amount: MoneyHelper.format(fee.charge.min_amount))
+  td.body-2 = fee.true_up_fee.units
+  td.body-2 == TaxHelper.applied_taxes(fee.true_up_fee)
+  td.body-2 = MoneyHelper.format(fee.true_up_fee.amount)

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -24,6 +24,7 @@ de:
     item: Artikel
     unit: Einheit
     unit_price: Stückpreis
+    units_per_second: Einheiten pro Sekunde
     amount: Betrag
     amount_with_tax: Betrag (inkl. Steuern)
     amount_without_tax: Betrag (ohne Steuern)

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -24,6 +24,7 @@ en:
     item: Item
     unit: Unit
     unit_price: Unit price
+    units_per_second: Units per second
     amount: Amount
     amount_with_tax: Amount (incl. tax)
     amount_without_tax: Amount (excl. tax)

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -24,6 +24,7 @@ fr:
     item: Article
     unit: Unité
     unit_price: Prix unitaire
+    units_per_second: Unités par seconde
     amount: Montant
     amount_with_tax: Montant (TTC)
     amount_without_tax: Montant (HT)

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -24,6 +24,7 @@ it:
     item: Articolo
     unit: Unità
     unit_price: Prezzo unitario
+    units_per_second: Unità al secondo
     amount: Importo
     amount_with_tax: Importo (incl. tasse)
     amount_without_tax: Importo (escl. tasse)

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -24,6 +24,7 @@ nb:
     item: Vare
     unit: Enhet
     unit_price: Enhetspris
+    units_per_second: Enheter per sekund
     amount: Beløp
     amount_with_tax: Beløp (inkl. MVA)
     amount_without_tax: Beløp (ekskl. MVA)


### PR DESCRIPTION
## Context

For metrics that are charged upon a time frame, Lago is not able to calculate correctly the charge. For instance, imagine you want to price the number of GB/seconds used by a server. Currently, you can either calculate the number of seconds used, or the number of Gigabytes used, but not both at the same time.

## Description

This PR updates the PDF template to expose the total number of units before applying the weighting interval 
