### PR TITLE
feat(weighted-sum): Add charge validation rule preventing pay_in_advance

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -87,11 +87,16 @@ class Charge < ApplicationRecord
   end
 
   # NOTE: An pay_in_advance charge cannot be created in the following cases:
-  # - billable metric aggregation type is max_agg or recurring_count_agg
+  # - billable metric aggregation type is max_agg, recurring_count_agg or weighted_sum_agg
   # - charge model is volume
   def validate_pay_in_advance
     return unless pay_in_advance?
-    return unless billable_metric.recurring_count_agg? || billable_metric.max_agg? || volume?
+
+    unless %w[recurring_count_agg max_add weighted_sum_agg].include?(billable_metric.aggregation_type) ||
+           billable_metric.max_agg? ||
+           volume?
+      return
+    end
 
     errors.add(:pay_in_advance, :invalid_aggregation_type_or_charge_model)
   end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -398,6 +398,18 @@ RSpec.describe Charge, type: :model do
       end
     end
 
+    context 'when billable metric is weighted_sum_agg' do
+      it 'returns an error' do
+        billable_metric = create(:weighted_sum_billable_metric)
+        charge = build(:standard_charge, :pay_in_advance, billable_metric:)
+
+        aggregate_failures do
+          expect(charge).not_to be_valid
+          expect(charge.errors.messages[:pay_in_advance]).to include('invalid_aggregation_type_or_charge_model')
+        end
+      end
+    end
+
     context 'when charge model is volume' do
       it 'returns an error' do
         charge = build(:volume_charge, :pay_in_advance)


### PR DESCRIPTION
## Context

For metrics that are charged upon a time frame, Lago is not able to calculate correctly the charge. For instance, imagine you want to price the number of GB/seconds used by a server. Currently, you can either calculate the number of seconds used, or the number of Gigabytes used, but not both at the same time.

## Description

This PR adds validation rule to ensure a charge attached to a weighted sum aggregation cannot be payed in advance
