### PR TITLE
feat(weighted-sum): Expose weighted interval in API

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -100,6 +100,7 @@ module Api
           :code,
           :description,
           :aggregation_type,
+          :weighted_interval,
           :recurring,
           :field_name,
           group: {},

--- a/app/serializers/v1/billable_metric_serializer.rb
+++ b/app/serializers/v1/billable_metric_serializer.rb
@@ -13,6 +13,7 @@ module V1
         created_at: model.created_at.iso8601,
         field_name: model.field_name,
         group: model.active_groups_as_tree,
+        weighted_interval: model.weighted_interval,
         active_subscriptions_count:,
         draft_invoices_count:,
         plans_count:,

--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -17,6 +17,7 @@ module BillableMetrics
           recurring: args[:recurring] || false,
           aggregation_type: args[:aggregation_type]&.to_sym,
           field_name: args[:field_name],
+          weighted_interval: args[:weighted_interval]&.to_sym,
         )
 
         if args[:group].present?

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -32,6 +32,7 @@ module BillableMetrics
         billable_metric.aggregation_type = params[:aggregation_type]&.to_sym if params.key?(:aggregation_type)
         billable_metric.field_name = params[:field_name] if params.key?(:field_name)
         billable_metric.recurring = params[:recurring] if params.key?(:recurring)
+        billable_metric.weighted_interval = params[:weighted_interval]&.to_sym if params.key?(:weighted_interval)
       end
 
       billable_metric.save!

--- a/spec/requests/api/v1/billable_metrics_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_spec.rb
@@ -65,6 +65,31 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
         end
       end
     end
+
+    context 'with weighted sum aggregation' do
+      let(:create_params) do
+        {
+          name: 'BM1',
+          code: 'BM1_code',
+          description: 'description',
+          aggregation_type: 'weighted_sum_agg',
+          field_name: 'amount_sum',
+          recurring: true,
+          weighted_interval: 'seconds',
+        }
+      end
+
+      it 'creates a billable_metric' do
+        post_with_token(organization, '/api/v1/billable_metrics', { billable_metric: create_params })
+
+        expect(response).to have_http_status(:success)
+        expect(json[:billable_metric][:lago_id]).to be_present
+        expect(json[:billable_metric][:recurring]).to eq(create_params[:recurring
+          ])
+        expect(json[:billable_metric][:aggregation_type]).to eq('weighted_sum_agg')
+        expect(json[:billable_metric][:weighted_interval]).to eq('seconds')
+      end
+    end
   end
 
   describe 'update' do
@@ -143,6 +168,34 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
         )
 
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'with weighted sum aggregation' do
+      let(:update_params) do
+        {
+          name: 'BM1',
+          code: 'BM1_code',
+          description: 'description',
+          aggregation_type: 'weighted_sum_agg',
+          field_name: 'amount_sum',
+          recurring: true,
+          weighted_interval: 'seconds',
+        }
+      end
+
+      it 'updates a billable_metric' do
+        put_with_token(
+          organization,
+          "/api/v1/billable_metrics/#{billable_metric.code}",
+          { billable_metric: update_params },
+        )
+
+        expect(response).to have_http_status(:success)
+        expect(json[:billable_metric][:lago_id]).to be_present
+        expect(json[:billable_metric][:recurring]).to be_truthy
+        expect(json[:billable_metric][:aggregation_type]).to eq('weighted_sum_agg')
+        expect(json[:billable_metric][:weighted_interval]).to eq('seconds')
       end
     end
   end

--- a/spec/serializers/v1/billable_metric_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ::V1::BillableMetricSerializer do
   subject(:serializer) { described_class.new(billable_metric, root_name: 'billable_metric') }
 
-  let(:billable_metric) { create(:billable_metric) }
+  let(:billable_metric) { create(:weighted_sum_billable_metric) }
   let(:result) { JSON.parse(serializer.to_json) }
 
   it 'serializes the object' do
@@ -17,6 +17,7 @@ RSpec.describe ::V1::BillableMetricSerializer do
       expect(result['billable_metric']['aggregation_type']).to eq(billable_metric.aggregation_type)
       expect(result['billable_metric']['field_name']).to eq(billable_metric.field_name)
       expect(result['billable_metric']['created_at']).to eq(billable_metric.created_at.iso8601)
+      expect(result['billable_metric']['weighted_interval']).to eq(billable_metric.weighted_interval)
       expect(result['billable_metric']['group']).to eq({})
       expect(result['billable_metric']['active_subscriptions_count']).to eq(0)
       expect(result['billable_metric']['draft_invoices_count']).to eq(0)


### PR DESCRIPTION
## Context

For metrics that are charged upon a time frame, Lago is not able to calculate correctly the charge. For instance, imagine you want to price the number of GB/seconds used by a server. Currently, you can either calculate the number of seconds used, or the number of Gigabytes used, but not both at the same time.

## Description

This PR exposes the `billable_metrics#weighted_interval` into the public API
