### PR TITLE
fix(invoice): Align fees#item and credits#item seializers

### DIFF
--- a/app/serializers/v1/credit_serializer.rb
+++ b/app/serializers/v1/credit_serializer.rb
@@ -9,7 +9,7 @@ module V1
         amount_currency: model.amount_currency,
         before_taxes: model.before_taxes,
         item: {
-          lago_id: model.item_id,
+          lago_item_id: model.item_id,
           type: model.item_type,
           code: model.item_code,
           name: model.item_name,
@@ -18,7 +18,7 @@ module V1
           lago_id: model.invoice_id,
           payment_status: model.invoice.payment_status,
         },
-      }.merge(legacy_values)
+      }.deep_merge(legacy_values)
     end
 
     private

--- a/app/serializers/v1/legacy/credit_serializer.rb
+++ b/app/serializers/v1/legacy/credit_serializer.rb
@@ -6,6 +6,9 @@ module V1
       def serialize
         {
           before_vat: model.before_taxes,
+          item: {
+            lago_id: model.item_id,
+          },
         }
       end
     end

--- a/spec/serializers/v1/credit_serializer_spec.rb
+++ b/spec/serializers/v1/credit_serializer_spec.rb
@@ -15,12 +15,16 @@ RSpec.describe ::V1::CreditSerializer do
       expect(result['credit']['amount_cents']).to eq(credit.amount_cents)
       expect(result['credit']['amount_currency']).to eq(credit.amount_currency)
       expect(result['credit']['before_taxes']).to eq(false)
-      expect(result['credit']['item']['lago_id']).to eq(credit.item_id)
+      expect(result['credit']['item']['lago_item_id']).to eq(credit.item_id)
       expect(result['credit']['item']['type']).to eq(credit.item_type)
       expect(result['credit']['item']['code']).to eq(credit.item_code)
       expect(result['credit']['item']['name']).to eq(credit.item_name)
       expect(result['credit']['invoice']['payment_status']).to eq(credit.invoice.payment_status)
       expect(result['credit']['invoice']['lago_id']).to eq(credit.invoice.id)
+
+      # NOTE: legacy fields
+      expect(result['credit']['before_vat']).to eq(false)
+      expect(result['credit']['item']['lago_id']).to eq(credit.item_id)
     end
   end
 end


### PR DESCRIPTION
## Context

A pull request has been opened on the python client to rename for the `invoice_item#lago_item_id` field into `invoice_item#lago_id`.

See https://github.com/getlago/lago-python-client/pull/187

After investigation, it appears that `fees#items` and `credits#items` serializers does not share the same format:
- Fee is using `lago_item_id`
- Credit is using `lago_id`

## Description

This PR is:
- Adding `lago_item_id` is the credit serializer
- Moving `lago_id` in the legacy serializer to prevent breaking the existing implementation
