### PR TITLE
fix (invoice): bill correctly termination on billing day case

### DIFF
--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -138,10 +138,10 @@ module Fees
       number_of_day_to_bill = (to_datetime - from_datetime).fdiv(1.day).ceil
 
       number_of_day_to_bill *
-      single_day_price(
-        subscription,
-        optional_from_date: from_datetime.in_time_zone(customer.applicable_timezone).to_date,
-      )
+        single_day_price(
+          subscription,
+          optional_from_date: from_datetime.in_time_zone(customer.applicable_timezone).to_date,
+        )
     end
 
     def upgraded_amount

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -137,6 +137,10 @@ module Fees
       # NOTE: number of days between beginning of the period and the termination date
       number_of_day_to_bill = (to_datetime - from_datetime).fdiv(1.day).ceil
 
+      # Remove later customer timezone fix while passing optional_from_date
+      # single_day_price method should return correct amount even without the timezone fix since
+      # date service should not calculate single_day_price based on difference between dates but more as a
+      # difference between date-times
       number_of_day_to_bill *
         single_day_price(
           subscription,

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -104,11 +104,7 @@ module Invoices
     end
 
     def create_subscription_fee(subscription, boundaries)
-      fee_result = Fees::SubscriptionService.new(
-        invoice:,
-        subscription:,
-        boundaries:,
-      ).create
+      fee_result = Fees::SubscriptionService.new(invoice:, subscription:, boundaries:).create
 
       fee_result.raise_if_error!
     end

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -44,10 +44,7 @@ module Invoices
             recurring:,
           )
 
-          if should_create_subscription_fee?(subscription)
-            create_subscription_fee(subscription, boundaries, termination_boundaries.present?)
-          end
-
+          create_subscription_fee(subscription, boundaries) if should_create_subscription_fee?(subscription)
           create_charges_fees(subscription, boundaries) if should_create_charge_fees?(subscription)
         end
 
@@ -106,12 +103,11 @@ module Invoices
       end
     end
 
-    def create_subscription_fee(subscription, boundaries, terminated_on_billing_day)
+    def create_subscription_fee(subscription, boundaries)
       fee_result = Fees::SubscriptionService.new(
         invoice:,
         subscription:,
         boundaries:,
-        terminated_on_billing_day:,
       ).create
 
       fee_result.raise_if_error!

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -105,7 +105,6 @@ module Invoices
 
     def create_subscription_fee(subscription, boundaries)
       fee_result = Fees::SubscriptionService.new(invoice:, subscription:, boundaries:).create
-
       fee_result.raise_if_error!
     end
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -286,7 +286,7 @@ module Invoices
 
     # This method calculates boundaries for terminated subscription. If termination is happening on billing date
     # new boundaries will be calculated only if there is no invoice subscription object for previous period.
-    # If subscription is happening on any other day method is returning nil and boundaries are calculate with existing
+    # If subscription is happening on any other day method is returning nil and boundaries are calculated with existing
     # algorithm
     def new_termination_boundaries(subscription)
       # Date service has various checks for terminated subscriptions. We want to avoid it and fetch boundaries
@@ -300,6 +300,7 @@ module Invoices
       one_day_ago = (current_time.in_time_zone(customer.applicable_timezone) - 1.day).to_date
       return nil if dates_service.charges_to_datetime.to_date != one_day_ago
 
+      # We should calculate boundaries as if subscription was not terminated
       dates_service = Subscriptions::DatesService.new_instance(duplicate, current_time, current_usage: false)
 
       boundaries = {

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -293,11 +293,12 @@ module Invoices
       duplicate = subscription.dup.tap { |s| s.status = :active }
 
       current_time = Time.zone.at(timestamp)
+      current_time_in_timezone = Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone)
 
       dates_service = Subscriptions::DatesService.new_instance(duplicate, current_time - 1.day, current_usage: true)
 
-      one_day_ago = (current_time.in_time_zone(customer.applicable_timezone) - 1.day).to_date
-      return boundaries if dates_service.charges_to_datetime.to_date != one_day_ago
+      return boundaries if current_time_in_timezone < dates_service.charges_to_datetime
+      return boundaries unless (current_time_in_timezone - dates_service.charges_to_datetime) < 1.day
 
       # We should calculate boundaries as if subscription was not terminated
       dates_service = Subscriptions::DatesService.new_instance(duplicate, current_time, current_usage: false)

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -28,7 +28,7 @@ module Invoices
         subscriptions.each do |subscription|
           boundaries = subscriptions_boundaries[subscription.id]
 
-          if subscription.terminated? && subscription.next_subscription.nil?
+          if subscription.terminated? && subscription.next_subscription.nil? && subscription.plan.pay_in_arrear?
             boundaries = new_termination_boundaries(subscription) || boundaries
           end
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -28,7 +28,7 @@ module Invoices
         subscriptions.each do |subscription|
           boundaries = subscriptions_boundaries[subscription.id]
 
-          if subscription.terminated? && subscription.next_subscription.nil? && subscription.plan.pay_in_arrear?
+          if subscription.terminated? && subscription.next_subscription.nil?
             boundaries = new_termination_boundaries(subscription) || boundaries
           end
 
@@ -293,26 +293,24 @@ module Invoices
       # for current usage (current period) but when subscription was active (one day ago)
       duplicate = subscription.dup.tap { |s| s.status = :active }
 
-      service = Subscriptions::DatesService.new_instance(
-        duplicate,
-        Time.zone.at(timestamp) - 1.day,
-        current_usage: true,
-      )
+      current_time = Time.zone.at(timestamp)
 
-      one_day_ago = (Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone) - 1.day).to_date
-      return nil if service.to_datetime.to_date != one_day_ago
+      dates_service = Subscriptions::DatesService.new_instance(duplicate, current_time - 1.day, current_usage: true)
+
+      one_day_ago = (current_time.in_time_zone(customer.applicable_timezone) - 1.day).to_date
+      return nil if dates_service.charges_to_datetime.to_date != one_day_ago
+
+      dates_service = Subscriptions::DatesService.new_instance(duplicate, current_time, current_usage: false)
 
       boundaries = {
-        from_datetime: service.from_datetime,
-        to_datetime: service.to_datetime,
-        charges_from_datetime: service.charges_from_datetime,
-        charges_to_datetime: service.charges_to_datetime,
-        timestamp: Time.zone.at(timestamp) - 1.day,
+        from_datetime: dates_service.from_datetime,
+        to_datetime: dates_service.to_datetime,
+        charges_from_datetime: dates_service.charges_from_datetime,
+        charges_to_datetime: dates_service.charges_to_datetime,
+        timestamp: current_time,
       }
 
-      return nil if matching_invoice_subscription?(subscription, boundaries)
-
-      boundaries
+      matching_invoice_subscription?(subscription, boundaries) ? nil : boundaries
     end
   end
 end

--- a/app/services/subscriptions/billing_service.rb
+++ b/app/services/subscriptions/billing_service.rb
@@ -74,6 +74,10 @@ module Subscriptions
           already_billed_today.invoiced_count IS NULL
           -- Do not bill subscriptions that started this day, they are billed by another job
           AND DATE(subscriptions.started_at#{at_time_zone}) != DATE(:today#{at_time_zone})
+          AND (
+            subscriptions.ending_at IS NULL OR
+            DATE(subscriptions.ending_at#{at_time_zone}) != DATE(:today#{at_time_zone})
+          )
         GROUP BY subscriptions.id
       SQL
 

--- a/clock.rb
+++ b/clock.rb
@@ -22,7 +22,7 @@ module Clockwork
     Clock::ActivateSubscriptionsJob.perform_later
   end
 
-  every(1.hour, 'schedule:terminate_ended_subscriptions', at: '*:5') do
+  every(1.hour, 'schedule:terminate_ended_subscriptions', at: '*:05') do
     Clock::TerminateEndedSubscriptionsJob.perform_later
   end
 

--- a/clock.rb
+++ b/clock.rb
@@ -22,6 +22,10 @@ module Clockwork
     Clock::ActivateSubscriptionsJob.perform_later
   end
 
+  every(1.hour, 'schedule:terminate_ended_subscriptions', at: '*:5') do
+    Clock::TerminateEndedSubscriptionsJob.perform_later
+  end
+
   every(1.hour, 'schedule:bill_customers', at: '*:10') do
     Clock::SubscriptionsBillerJob.perform_later
   end
@@ -36,6 +40,10 @@ module Clockwork
 
   every(1.hour, 'schedule:terminate_wallets', at: '*:45') do
     Clock::TerminateWalletsJob.perform_later
+  end
+
+  every(1.hour, 'schedule:termination_alert', at: '*:50') do
+    Clock::SubscriptionsToBeTerminatedJob.perform_later
   end
 
   every(1.day, 'schedule:clean_webhooks', at: '01:00') do

--- a/spec/scenarios/subscriptions/terminate_ended_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_spec.rb
@@ -238,15 +238,13 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             expect(subscription).to be_active
           end
 
-          Organization.update_all(webhook_url: nil)
+          Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
           WebhookEndpoint.destroy_all
 
           travel_to(ending_at + 5.minutes) do
             Subscriptions::BillingService.new.call
 
             perform_all_enqueued_jobs
-
-            invoice = subscription.invoices.order(created_at: :desc).first
 
             aggregate_failures do
               expect(subscription.reload).to be_active
@@ -291,7 +289,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             expect(subscription).to be_active
           end
 
-          Organization.update_all(webhook_url: nil)
+          Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidationss
           WebhookEndpoint.destroy_all
 
           travel_to(ending_at + 5.minutes) do

--- a/spec/scenarios/subscriptions/terminate_ended_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_spec.rb
@@ -172,7 +172,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
         aggregate_failures do
           expect(subscription.reload).to be_terminated
           expect(subscription.reload.invoices.count).to eq(1)
-          expect(invoice.total_amount_cents).to eq(1000)
+          expect(invoice.total_amount_cents).to eq(968)
           expect(invoice.issuing_date.iso8601).to eq('2023-10-05')
         end
       end
@@ -212,7 +212,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
           aggregate_failures do
             expect(subscription.reload).to be_terminated
             expect(subscription.reload.invoices.count).to eq(1)
-            expect(invoice.total_amount_cents).to eq(1000)
+            expect(invoice.total_amount_cents).to eq(968)
             expect(invoice.issuing_date.iso8601).to eq('2023-10-01')
           end
         end

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Fees::SubscriptionService do
   let(:started_at) { Time.zone.parse('2022-01-01 00:01') }
   let(:created_at) { started_at }
   let(:subscription_at) { started_at }
+
   let(:plan) do
     create(
       :plan,

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Fees::SubscriptionService do
       invoice:,
       subscription:,
       boundaries:,
+      terminated_on_billing_day:,
     )
   end
 
@@ -17,6 +18,7 @@ RSpec.describe Fees::SubscriptionService do
   let(:started_at) { Time.zone.parse('2022-01-01 00:01') }
   let(:created_at) { started_at }
   let(:subscription_at) { started_at }
+  let(:terminated_on_billing_day) { false }
 
   let(:plan) do
     create(
@@ -798,6 +800,22 @@ RSpec.describe Fees::SubscriptionService do
         expect(created_fee.invoice_id).to eq(invoice.id)
         expect(created_fee.amount_cents).to eq(65)
         expect(created_fee.amount_currency).to eq(plan.amount_currency)
+      end
+    end
+
+    context 'when terminated on billing day' do
+      let(:terminated_on_billing_day) { true }
+
+      it 'creates a fee' do
+        result = fees_subscription_service.create
+        created_fee = result.fee
+
+        aggregate_failures do
+          expect(created_fee.id).not_to be_nil
+          expect(created_fee.invoice_id).to eq(invoice.id)
+          expect(created_fee.amount_cents).to eq(100)
+          expect(created_fee.amount_currency).to eq(plan.amount_currency)
+        end
       end
     end
 

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Fees::SubscriptionService do
       invoice:,
       subscription:,
       boundaries:,
-      terminated_on_billing_day:,
     )
   end
 
@@ -18,8 +17,6 @@ RSpec.describe Fees::SubscriptionService do
   let(:started_at) { Time.zone.parse('2022-01-01 00:01') }
   let(:created_at) { started_at }
   let(:subscription_at) { started_at }
-  let(:terminated_on_billing_day) { false }
-
   let(:plan) do
     create(
       :plan,
@@ -800,22 +797,6 @@ RSpec.describe Fees::SubscriptionService do
         expect(created_fee.invoice_id).to eq(invoice.id)
         expect(created_fee.amount_cents).to eq(65)
         expect(created_fee.amount_currency).to eq(plan.amount_currency)
-      end
-    end
-
-    context 'when terminated on billing day' do
-      let(:terminated_on_billing_day) { true }
-
-      it 'creates a fee' do
-        result = fees_subscription_service.create
-        created_fee = result.fee
-
-        aggregate_failures do
-          expect(created_fee.id).not_to be_nil
-          expect(created_fee.invoice_id).to eq(invoice.id)
-          expect(created_fee.amount_cents).to eq(100)
-          expect(created_fee.amount_currency).to eq(plan.amount_currency)
-        end
       end
     end
 


### PR DESCRIPTION
## Context

If termination happens on billing day before actual billing job has been processed, we will bill only one day instead of previous period for pay in arrears case.

This is especially important for subscription ending feature since termination can be automatically performed with such a feature.

NOTE: This PR also serves as QA branch so `clock.rb` is also updated. Once this case is QA validated this branch will be merged and subscription ending date feature completed

## Description

The solution here is to check if we are on the beginning of period and also to check if there is any `InvoiceSubscription` object for previous period