### PR TITLE
misc(fix-pronto) Pin rugged gem version to 1.6.3

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -15,6 +15,7 @@ jobs:
         uses: ruby/setup-ruby@v1
       - name: Setup pronto
         run: |
+          gem install rugged -v 1.6.3
           gem install pronto
           gem install pronto-rubocop
           gem install rubocop -v 1.44.1


### PR DESCRIPTION
## Context

Pronto actions fail after updating rugged gem to 1.7.1