### PR TITLE
feat(weighted-sum): Add missing weighted interval for BM update in GraphQL

### DIFF
--- a/app/graphql/types/billable_metrics/update_input.rb
+++ b/app/graphql/types/billable_metrics/update_input.rb
@@ -14,6 +14,7 @@ module Types
       argument :group, GraphQL::Types::JSON, required: false
       argument :name, String, required: true
       argument :recurring, Boolean, required: false
+      argument :weighted_interval, Types::BillableMetrics::WeightedIntervalEnum, required: false
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -5342,6 +5342,7 @@ input UpdateBillableMetricInput {
   id: String!
   name: String!
   recurring: Boolean
+  weightedInterval: WeightedIntervalEnum
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -21754,6 +21754,18 @@
               "deprecationReason": null
             },
             {
+              "name": "weightedInterval",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "WeightedIntervalEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {

--- a/spec/graphql/mutations/billable_metrics/update_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/update_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Mutations::BillableMetrics::Update, type: :graphql do
   let(:membership) { create(:membership) }
-  let(:billable_metric) { create(:billable_metric, organization: membership.organization) }
+  let(:billable_metric) { create(:weighted_sum_billable_metric, organization: membership.organization) }
   let(:mutation) do
     <<-GQL
       mutation($input: UpdateBillableMetricInput!) {
@@ -13,6 +13,7 @@ RSpec.describe Mutations::BillableMetrics::Update, type: :graphql do
           name,
           code,
           aggregationType,
+          weightedInterval
           recurring
           organization { id },
           group
@@ -33,6 +34,7 @@ RSpec.describe Mutations::BillableMetrics::Update, type: :graphql do
           description: 'New metric description',
           aggregationType: 'count_agg',
           recurring: false,
+          weightedInterval: 'seconds',
         },
       },
     )
@@ -45,6 +47,7 @@ RSpec.describe Mutations::BillableMetrics::Update, type: :graphql do
       expect(result_data['code']).to eq('new_metric')
       expect(result_data['organization']['id']).to eq(membership.organization_id)
       expect(result_data['aggregationType']).to eq('count_agg')
+      expect(result_data['weightedInterval']).to eq('seconds')
       expect(result_data['recurring']).to eq(false)
     end
   end


### PR DESCRIPTION
## Context

For metrics that are charged upon a time frame, Lago is not able to calculate correctly the charge. For instance, imagine you want to price the number of GB/seconds used by a server. Currently, you can either calculate the number of seconds used, or the number of Gigabytes used, but not both at the same time.

## Description

This PR add the `weightedInterval` argument in the `Types::BillableMetrics::UpdateInput` GraphQL type
