### PR TITLE
fix(tax): Taxes should not be reapplied to fee if it already has taxes

### DIFF
--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -11,6 +11,8 @@ module Fees
 
     def call
       result.applied_taxes = []
+      return result if fee.applied_taxes.any?
+
       applied_taxes_amount_cents = 0
       applied_taxes_rate = 0
 

--- a/spec/services/fees/apply_taxes_service_spec.rb
+++ b/spec/services/fees/apply_taxes_service_spec.rb
@@ -271,5 +271,17 @@ RSpec.describe Fees::ApplyTaxesService, type: :service do
         )
       end
     end
+
+    context 'when fee already have taxes' do
+      before { create(:fee_applied_tax, fee:, tax: tax1) }
+
+      it 'does not reaply taxes' do
+        expect do
+          result = apply_service.call
+
+          expect(result).to be_success
+        end.not_to change { fee.applied_taxes.count }
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

In some cases, we are trying to reapply multiple time the same tax to a fee, leading to a database error, because an index was recently added to prevent duplicated taxes.

## Description

This PR, adds a guard to the `Fees::ApplyTaxesService` to return immediately if the fee is already attached to taxes