### PR TITLE
fix (charges): refactor paid in advance processing

### DIFF
--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -114,6 +114,10 @@ module BillableMetrics
             events_scope(from_datetime:, to_datetime:)
           end
           scope = query.where("#{sanitized_field_name} IS NOT NULL")
+
+          # Events without attached right metadata are ignored since such events cannot be processed correctly.
+          # Could happen in race condition when event is stored but metadata in async job are attached later.
+          # In the meantime we want to avoid any issues with not attached metadata.
           scope = scope.where("events.metadata->>'current_aggregation' IS NOT NULL")
           scope = scope.where("events.metadata->>'max_aggregation' IS NOT NULL")
 

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -114,6 +114,8 @@ module BillableMetrics
             events_scope(from_datetime:, to_datetime:)
           end
           scope = query.where("#{sanitized_field_name} IS NOT NULL")
+          scope = scope.where("events.metadata->>'current_aggregation' IS NOT NULL")
+          scope = scope.where("events.metadata->>'max_aggregation' IS NOT NULL")
 
           scope = scope.where.not(id: event.id) if event.present?
 

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -80,6 +80,8 @@ module BillableMetrics
           query = query
             .joins(:quantified_event)
             .where("#{sanitized_field_name} IS NOT NULL")
+            .where("events.metadata->>'current_aggregation' IS NOT NULL")
+            .where("events.metadata->>'max_aggregation' IS NOT NULL")
             .where('quantified_events.added_at::timestamp(0) >= ?', from_datetime)
             .where('quantified_events.added_at::timestamp(0) <= ?', to_datetime)
 


### PR DESCRIPTION
Usecase:
1. Pay in advance event is stored
2. Current usage requested and fails (there is no metadata attached on event and those data are needed for pay in advance current usage)
3. Async job that process pay in advance invoices attaches metadata on event

In order to avoid this race condition, this fix is added. We are ignoring pay in advance events that are not in valid state