### PR TITLE
feat(weighted-sum): Finalize the feature

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -109,10 +109,14 @@ class Charge < ApplicationRecord
   # NOTE: A prorated charge cannot be created in the following cases:
   # - for pay_in_arrear, price model cannot be package, graduated and percentage
   # - for pay_in_idvance, price model cannot be package, graduated, percentage and volume
+  # - for weighted_sum aggregation as it already apply pro-ration logic
   def validate_prorated
     return unless prorated?
-    return if billable_metric.recurring? && pay_in_advance? && standard?
-    return if billable_metric.recurring? && !pay_in_advance? && (standard? || volume?)
+
+    unless billable_metric.weighted_sum_agg?
+      return if billable_metric.recurring? && pay_in_advance? && standard?
+      return if billable_metric.recurring? && !pay_in_advance? && (standard? || volume?)
+    end
 
     errors.add(:prorated, :invalid_billable_metric_or_charge_model)
   end

--- a/app/serializers/v1/billable_metric_serializer.rb
+++ b/app/serializers/v1/billable_metric_serializer.rb
@@ -9,6 +9,7 @@ module V1
         code: model.code,
         description: model.description,
         aggregation_type: model.aggregation_type,
+        weighted_interval: model.weighted_interval,
         recurring: model.recurring,
         created_at: model.created_at.iso8601,
         field_name: model.field_name,

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -30,6 +30,7 @@ module BillableMetrics
 
         billable_metric.code = params[:code] if params.key?(:code)
         billable_metric.aggregation_type = params[:aggregation_type]&.to_sym if params.key?(:aggregation_type)
+        billable_metric.weighted_interval = params[:weighted_interval]&.to_sym if params.key?(:weighted_interval)
         billable_metric.field_name = params[:field_name] if params.key?(:field_name)
         billable_metric.recurring = params[:recurring] if params.key?(:recurring)
         billable_metric.weighted_interval = params[:weighted_interval]&.to_sym if params.key?(:weighted_interval)

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -492,6 +492,19 @@ RSpec.describe Charge, type: :model do
         end
       end
     end
+
+    context 'when billable metric is weighted sum' do
+      let(:billable_metric) { create(:weighted_sum_billable_metric) }
+
+      it 'returns an error' do
+        charge = build(:percentage_charge, prorated: true, billable_metric:)
+
+        aggregate_failures do
+          expect(charge).not_to be_valid
+          expect(charge.errors.messages[:prorated]).to include('invalid_billable_metric_or_charge_model')
+        end
+      end
+    end
   end
 
   describe '#validate_uniqueness_group_properties' do

--- a/spec/scenarios/billable_metrics/weighted_sum_spec.rb
+++ b/spec/scenarios/billable_metrics/weighted_sum_spec.rb
@@ -37,7 +37,7 @@ describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request do
 
       fetch_current_usage(customer:)
       expect(json[:customer_usage][:total_amount_cents]).to eq(116)
-      expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.00116')
+      expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.00115740794324441817')
     end
 
     travel_to(DateTime.new(2023, 4, 1)) do
@@ -53,7 +53,7 @@ describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request do
 
     fee = invoice.fees.charge.first
     expect(fee.amount_cents).to eq(116)
-    expect(fee.units).to eq(0.00116)
+    expect(fee.units.round(5)).to eq(0.00116)
     expect(fee.total_aggregated_units).to eq(2500)
 
     quantified_event = QuantifiedEvent.last
@@ -82,7 +82,7 @@ describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request do
 
       fetch_current_usage(customer:)
       expect(json[:customer_usage][:total_amount_cents]).to eq(1268)
-      expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.01268')
+      expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.01267746920010291043')
     end
 
     travel_to(DateTime.new(2023, 5, 1)) do
@@ -98,7 +98,7 @@ describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request do
 
     fee = invoice.fees.charge.first
     expect(fee.amount_cents).to eq(1268)
-    expect(fee.units).to eq(0.01268)
+    expect(fee.units.round(5)).to eq(0.01268)
     expect(fee.total_aggregated_units).to eq(300)
 
     quantified_event = QuantifiedEvent.order(:created_at).last

--- a/spec/scenarios/billable_metrics/weighted_sum_spec.rb
+++ b/spec/scenarios/billable_metrics/weighted_sum_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:plan) { create(:plan, organization:, amount_cents: 0) }
+  let(:billable_metric) { create(:weighted_sum_billable_metric, :recurring, organization:) }
+  let(:charge) { create(:standard_charge, plan:, billable_metric:, properties: { amount: '1000' }) }
+
+  before { charge }
+
+  it 'creates fees and keeps the units between periods' do
+    travel_to(DateTime.new(2023, 3, 5)) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+        },
+      )
+    end
+
+    subscription = customer.subscriptions.first
+
+    travel_to(DateTime.new(2023, 3, 7)) do
+      create_event(
+        {
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { value: '2500' },
+        },
+      )
+
+      fetch_current_usage(customer:)
+      expect(json[:customer_usage][:total_amount_cents]).to eq(116)
+      expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.00116')
+    end
+
+    travel_to(DateTime.new(2023, 4, 1)) do
+      expect do
+        Subscriptions::BillingService.new.call
+        perform_all_enqueued_jobs
+      end.to change { subscription.reload.invoices.count }.from(0).to(1)
+        .and change { customer.reload.quantified_events.count }.from(0).to(1)
+    end
+
+    invoice = subscription.invoices.first
+    expect(invoice.fees.charge.count).to eq(1)
+
+    fee = invoice.fees.charge.first
+    expect(fee.amount_cents).to eq(116)
+    expect(fee.units).to eq(0.00116)
+    expect(fee.total_aggregated_units).to eq(2500)
+
+    quantified_event = QuantifiedEvent.last
+    expect(quantified_event.properties['total_aggregated_units']).to eq('2500.0')
+
+    travel_to(DateTime.new(2023, 4, 4)) do
+      create_event(
+        {
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { value: '-2000' },
+        },
+      )
+    end
+
+    travel_to(DateTime.new(2023, 4, 6)) do
+      create_event(
+        {
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { value: '-200' },
+        },
+      )
+
+      fetch_current_usage(customer:)
+      expect(json[:customer_usage][:total_amount_cents]).to eq(1268)
+      expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.01268')
+    end
+
+    travel_to(DateTime.new(2023, 5, 1)) do
+      expect do
+        Subscriptions::BillingService.new.call
+        perform_all_enqueued_jobs
+      end.to change { subscription.reload.invoices.count }.from(1).to(2)
+        .and change { customer.reload.quantified_events.count }.from(1).to(2)
+    end
+
+    invoice = subscription.invoices.order(:created_at).last
+    expect(invoice.fees.charge.count).to eq(1)
+
+    fee = invoice.fees.charge.first
+    expect(fee.amount_cents).to eq(1268)
+    expect(fee.units).to eq(0.01268)
+    expect(fee.total_aggregated_units).to eq(300)
+
+    quantified_event = QuantifiedEvent.order(:created_at).last
+    expect(quantified_event.properties['total_aggregated_units']).to eq('300.0')
+  end
+end

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
   it 'aggregates the events' do
     result = aggregator.aggregate
 
-    expect(result.aggregation.round(5).to_s).to eq('0.0125')
+    expect(result.aggregation.round(5).to_s).to eq('0.01251')
     expect(result.count).to eq(7)
   end
 
@@ -69,7 +69,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
     it 'aggregates the events' do
       result = aggregator.aggregate
 
-      expect(result.aggregation.round(5).to_s).to eq('0.00037')
+      expect(result.aggregation.round(5).to_s).to eq('0.00038')
       expect(result.count).to eq(1)
     end
   end
@@ -106,7 +106,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
     it 'uses the persisted recurring value as initial value' do
       result = aggregator.aggregate
 
-      expect(result.aggregation.round(5).to_s).to eq('0.00037')
+      expect(result.aggregation.round(5).to_s).to eq('0.00038')
       expect(result.count).to eq(0)
       expect(result.variation).to eq(0)
       expect(result.total_aggregated_units).to eq(1000)
@@ -164,7 +164,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
     it 'aggregates the events' do
       result = aggregator.aggregate
 
-      expect(result.aggregation.round(5).to_s).to eq('0.00037')
+      expect(result.aggregation.round(5).to_s).to eq('0.00038')
       expect(result.count).to eq(1)
     end
   end

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
   it 'aggregates the events' do
     result = aggregator.aggregate
 
-    expect(result.aggregation.round(5).to_s).to eq('0.01251')
+    expect(result.aggregation.round(5).to_s).to eq('0.0125')
     expect(result.count).to eq(7)
   end
 
@@ -69,7 +69,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
     it 'aggregates the events' do
       result = aggregator.aggregate
 
-      expect(result.aggregation.round(5).to_s).to eq('0.00038')
+      expect(result.aggregation.round(5).to_s).to eq('0.00037')
       expect(result.count).to eq(1)
     end
   end
@@ -106,7 +106,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
     it 'uses the persisted recurring value as initial value' do
       result = aggregator.aggregate
 
-      expect(result.aggregation.round(5).to_s).to eq('0.00038')
+      expect(result.aggregation.round(5).to_s).to eq('0.00037')
       expect(result.count).to eq(0)
       expect(result.variation).to eq(0)
       expect(result.total_aggregated_units).to eq(1000)
@@ -164,7 +164,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
     it 'aggregates the events' do
       result = aggregator.aggregate
 
-      expect(result.aggregation.round(5).to_s).to eq('0.00038')
+      expect(result.aggregation.round(5).to_s).to eq('0.00037')
       expect(result.count).to eq(1)
     end
   end


### PR DESCRIPTION
## Context

For metrics that are charged upon a time frame, Lago is not able to calculate correctly the charge. For instance, imagine you want to price the number of GB/seconds used by a server. Currently, you can either calculate the number of seconds used, or the number of Gigabytes used, but not both at the same time.

## Description

This PR is the last one for the feature, it adds:
- A validation rule ensuring that a charge cannot be prorated if it is attached to a weighted_sum billable metric
- A fix for weighted_interval update on BM
- `weighted_interval` in the billable metric serializer
- A complete scenario for weighted sum billable metric
