### PR TITLE
fix(stripe): Prevent new payment attempt when invoice is not in the right status

### DIFF
--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -197,7 +197,12 @@ module PaymentProviderCustomers
     end
 
     def reprocess_pending_invoices(customer)
-      customer.invoices.pending.find_each do |invoice|
+      invoices = customer.invoices
+        .pending
+        .where(ready_for_payment_processing: true)
+        .where(status: 'finalized')
+
+      invoices.find_each do |invoice|
         Invoices::Payments::StripeCreateJob.perform_later(invoice)
       end
     end


### PR DESCRIPTION
## Context

We are receiving A LOT of `ActiveJob::Uniqueness::JobNotUnique` on ` PaymentProviders::Stripe::HandleEventJob`.

It happens when we tries to reprocess pending invoices for a customer after receiving a Stripe `setup_intent.succeeded`.

## Description

This PR is an attempt to reduce the noise in the Sidekiq dead queue by ensuring only finalized and ready for processing invoices are being retried.