### PR TITLE
fix(customer): prevent updating provider customer on partial update

### DIFF
--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -81,8 +81,10 @@ module Customers
         end
 
         # NOTE: if payment provider is updated, we need to create/update the provider customer
-        payment_provider = old_payment_provider || customer.payment_provider
-        create_or_update_provider_customer(customer, payment_provider, args[:provider_customer])
+        if args.key?(:provider_customer) || args.key?(:payment_provider)
+          payment_provider = old_payment_provider || customer.payment_provider
+          create_or_update_provider_customer(customer, payment_provider, args[:provider_customer])
+        end
       end
 
       result.customer = customer


### PR DESCRIPTION
## Context

Today partially updating a customer (updating taxes, grace period...) is changing Stripe customer’s payment method, leading to failures in invoice payments

## Description

This PR ensures that stripe provider customer is updated only if `provider_customer` or `payment_provider` arguments is provider.