### PR TITLE
fix(coupon): Add missing coupons#terminated_at in serializer

### DIFF
--- a/app/serializers/v1/coupon_serializer.rb
+++ b/app/serializers/v1/coupon_serializer.rb
@@ -22,6 +22,7 @@ module V1
         created_at: model.created_at.iso8601,
         expiration: model.expiration,
         expiration_at: model.expiration_at&.iso8601,
+        terminated_at: model.terminated_at&.iso8601,
       }.merge(legacy_values)
     end
 

--- a/spec/serializers/v1/coupon_serializer_spec.rb
+++ b/spec/serializers/v1/coupon_serializer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe ::V1::CouponSerializer do
       expect(result['coupon']['expiration']).to eq(coupon.expiration)
       expect(result['coupon']['expiration_at']).to eq(coupon.expiration_at&.iso8601)
       expect(result['coupon']['created_at']).to eq(coupon.created_at.iso8601)
+      expect(result['coupon']['terminated_at']).to eq(coupon.terminated_at&.iso8601)
       expect(result['coupon']['plan_codes'].first).to eq(coupon_plan.plan.code)
       expect(result['coupon']['billable_metric_codes']).to eq([])
     end


### PR DESCRIPTION
## Context

Call to `GET /v1/api/coupons/:code` is missing the `terminated_at` value

## Description

This PR is adding the missing field in the `V1::CouponSerializer`