### PR TITLE
feat(event): Improve indexes to speed up current usage computation

### DIFF
--- a/db/migrate/20230918090426_add_index_to_events.rb
+++ b/db/migrate/20230918090426_add_index_to_events.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIndexToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_index :events, %w[subscription_id code timestamp], where: 'deleted_at IS NULL'
+    remove_index :events, %w[subscription_id code]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_11_185900) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_18_090426) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -338,7 +338,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_11_185900) do
     t.index ["organization_id", "code"], name: "index_events_on_organization_id_and_code"
     t.index ["organization_id"], name: "index_events_on_organization_id"
     t.index ["quantified_event_id"], name: "index_events_on_quantified_event_id"
-    t.index ["subscription_id", "code"], name: "index_events_on_subscription_id_and_code"
+    t.index ["subscription_id", "code", "timestamp"], name: "index_events_on_subscription_id_and_code_and_timestamp", where: "(deleted_at IS NULL)"
     t.index ["subscription_id", "transaction_id"], name: "index_events_on_subscription_id_and_transaction_id", unique: true
     t.index ["subscription_id"], name: "index_events_on_subscription_id"
   end


### PR DESCRIPTION
## Context

Current usage retrieval could be slow for users with a lot of events.

## Description

This PR updates of the `events` table to change the indexes. It ensures the `timestamp` is taken into account in the index along with `code` and `subscription_id`
