### PR TITLE
feat(override-plan): Remove parent_id from graphql

### DIFF
--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -17,7 +17,6 @@ module Mutations
       argument :interval, Types::Plans::IntervalEnum, required: true
       argument :invoice_display_name, String, required: false
       argument :name, String, required: true
-      argument :parent_id, ID, required: false
       argument :pay_in_advance, Boolean, required: true
       argument :tax_codes, [String], required: false
       argument :trial_period, Float, required: false

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -9,7 +9,6 @@ module Plans
         invoice_display_name: args[:invoice_display_name],
         code: args[:code],
         description: args[:description],
-        parent_id: args[:parent_id],
         interval: args[:interval]&.to_sym,
         pay_in_advance: args[:pay_in_advance],
         amount_cents: args[:amount_cents],

--- a/db/migrate/20230922064617_remove_parent_id_from_plans.rb
+++ b/db/migrate/20230922064617_remove_parent_id_from_plans.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class RemoveParentIdFromPlans < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE plans
+          SET parent_id = NULL
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_20_083133) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_22_064617) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1759,7 +1759,6 @@ input CreatePlanInput {
   interval: PlanInterval!
   invoiceDisplayName: String
   name: String!
-  parentId: ID
   payInAdvance: Boolean!
   taxCodes: [String!]
   trialPeriod: Float

--- a/schema.json
+++ b/schema.json
@@ -5937,18 +5937,6 @@
               "deprecationReason": null
             },
             {
-              "name": "parentId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "payInAdvance",
               "description": null,
               "type": {


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

We want to prevent duplicating a plan by linking it to another plan, thanks to the property `parent_id`.
Overriding a plan will be done thanks to the `POST /api/v1/subscriptions` endpoint.

⚠️ Do not merge until the release of the feature.
