### PR TITLE
feat(override-plan): Services for overriding a plan

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -32,11 +32,11 @@ class Plan < ApplicationRecord
 
   monetize :amount_cents
 
-  validates :name, presence: true
+  validates :name, :code, presence: true
   validates :amount_currency, inclusion: { in: currency_list }
   validates :code,
-            presence: true,
-            uniqueness: { conditions: -> { where(deleted_at: nil) }, scope: :organization_id }
+            uniqueness: { scope: :organization_id },
+            unless: -> { deleted_at? || parent_id? }
   validates :pay_in_advance, inclusion: { in: [true, false] }
 
   default_scope -> { kept }

--- a/app/services/charges/override_service.rb
+++ b/app/services/charges/override_service.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Charges
+  class OverrideService < BaseService
+    def initialize(charge:, params:)
+      @charge = charge
+      @params = params
+
+      super
+    end
+
+    def call
+      return result unless License.premium?
+
+      ActiveRecord::Base.transaction do
+        new_charge = charge.dup.tap do |c|
+          c.properties = params[:properties] if params.key?(:properties)
+          c.min_amount_cents = params[:min_amount_cents] if params.key?(:min_amount_cents)
+          # c.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+          c.group_properties = charge.group_properties.map(&:dup)
+          c.plan_id = params[:plan_id]
+        end
+        new_charge.save!
+
+        if params.key?(:group_properties)
+          group_result = GroupProperties::CreateOrUpdateBatchService.call(
+            charge: new_charge,
+            properties_params: params[:group_properties],
+          )
+          return group_result if group_result.error
+        end
+
+        if params.key?(:tax_codes)
+          taxes_result = Charges::ApplyTaxesService.call(charge: new_charge, tax_codes: params[:tax_codes])
+          taxes_result.raise_if_error!
+        end
+
+        result.charge = new_charge
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :charge, :params
+  end
+end

--- a/app/services/charges/override_service.rb
+++ b/app/services/charges/override_service.rb
@@ -16,7 +16,7 @@ module Charges
         new_charge = charge.dup.tap do |c|
           c.properties = params[:properties] if params.key?(:properties)
           c.min_amount_cents = params[:min_amount_cents] if params.key?(:min_amount_cents)
-          # c.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+          c.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
           c.group_properties = charge.group_properties.map(&:dup)
           c.plan_id = params[:plan_id]
         end

--- a/app/services/plans/override_service.rb
+++ b/app/services/plans/override_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Plans
+  class OverrideService < BaseService
+    def initialize(plan:, params:)
+      @plan = plan
+      @params = params
+
+      super
+    end
+
+    def call
+      return result unless License.premium?
+
+      ActiveRecord::Base.transaction do
+        new_plan = plan.dup.tap do |p|
+          p.amount_cents = params[:amount_cents] if params.key?(:amount_cents)
+          p.amount_currency = params[:amount_currency] if params.key?(:amount_currency)
+          # p.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+          p.trial_period = params[:trial_period] if params.key?(:trial_period)
+          p.parent_id = plan.id
+        end
+        new_plan.save!
+
+        if params[:tax_codes]
+          taxes_result = Plans::ApplyTaxesService.call(plan: new_plan, tax_codes: params[:tax_codes])
+          return taxes_result unless taxes_result.success?
+        end
+
+        plan.charges.each do |charge|
+          charge_params = (
+            params[:charges].find { |p| p[:id] == charge.id } || {}
+          ).merge(plan_id: new_plan.id)
+          Charges::OverrideService.call(charge:, params: charge_params)
+        end
+
+        result.plan = new_plan
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :plan, :params
+  end
+end

--- a/app/services/plans/override_service.rb
+++ b/app/services/plans/override_service.rb
@@ -16,7 +16,7 @@ module Plans
         new_plan = plan.dup.tap do |p|
           p.amount_cents = params[:amount_cents] if params.key?(:amount_cents)
           p.amount_currency = params[:amount_currency] if params.key?(:amount_currency)
-          # p.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+          p.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
           p.trial_period = params[:trial_period] if params.key?(:trial_period)
           p.parent_id = plan.id
         end

--- a/db/migrate/20230915073205_update_code_index_on_plans.rb
+++ b/db/migrate/20230915073205_update_code_index_on_plans.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class UpdateCodeIndexOnPlans < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :plans, %i[organization_id code]
+
+    add_index :plans,
+              %i[organization_id code],
+              unique: true,
+              where: 'deleted_at IS NULL AND parent_id IS NULL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -624,7 +624,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_090426) do
     t.boolean "pending_deletion", default: false, null: false
     t.string "invoice_display_name"
     t.index ["deleted_at"], name: "index_plans_on_deleted_at"
-    t.index ["organization_id", "code"], name: "index_plans_on_organization_id_and_code", unique: true, where: "(deleted_at IS NULL)"
+    t.index ["organization_id", "code"], name: "index_plans_on_organization_id_and_code", unique: true, where: "((deleted_at IS NULL) AND (parent_id IS NULL))"
     t.index ["organization_id"], name: "index_plans_on_organization_id"
     t.index ["parent_id"], name: "index_plans_on_parent_id"
   end

--- a/spec/services/charges/override_service_spec.rb
+++ b/spec/services/charges/override_service_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Charges::OverrideService, type: :service do
       {
         id: charge.id,
         plan_id: plan.id,
+        # invoice_display_name: 'invoice display name',
         min_amount_cents: 1000,
         properties: { amount: '200' },
         tax_codes: [tax.code],
@@ -80,6 +81,7 @@ RSpec.describe Charges::OverrideService, type: :service do
           prorated: charge.prorated,
           # Overriden attributes
           plan_id: plan.id,
+          # invoice_display_name: 'invoice display name',
           min_amount_cents: 1000,
           properties: { 'amount' => '200' },
         )

--- a/spec/services/charges/override_service_spec.rb
+++ b/spec/services/charges/override_service_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::OverrideService, type: :service do
+  subject(:override_service) { described_class.new(charge:, params:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+
+  describe '#call' do
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:group) { create(:group, billable_metric:) }
+    let(:group2) { create(:group, billable_metric:) }
+    let(:tax) { create(:tax, organization:) }
+
+    let(:charge) do
+      create(
+        :standard_charge,
+        billable_metric:,
+        properties: { amount: '300' },
+        group_properties: [
+          build(
+            :group_property,
+            group:,
+            values: { amount: '10', amount_currency: 'EUR' },
+          ),
+          build(
+            :group_property,
+            group: group2,
+            values: { amount: '20', amount_currency: 'EUR' },
+          ),
+        ],
+      )
+    end
+
+    let(:plan) { create(:plan, organization:) }
+    let(:params) do
+      {
+        id: charge.id,
+        plan_id: plan.id,
+        min_amount_cents: 1000,
+        properties: { amount: '200' },
+        tax_codes: [tax.code],
+        group_properties: [
+          {
+            group_id: group.id,
+            values: { amount: '100' },
+          },
+        ],
+      }
+    end
+
+    before { charge }
+
+    context 'when lago freemium' do
+      it 'returns without overriding the charge' do
+        expect { override_service.call }.not_to change(Charge, :count)
+      end
+    end
+
+    context 'when lago premium' do
+      around { |test| lago_premium!(&test) }
+
+      it 'creates a charge based on the given charge', :aggregate_failures do
+        applied_tax = create(:charge_applied_tax, charge:)
+
+        expect(charge.group_properties.count).to eq(2)
+        expect(charge.taxes).to contain_exactly(applied_tax.tax)
+
+        expect { override_service.call }.to change(Charge, :count).by(1)
+
+        charge = Charge.order(:created_at).last
+        expect(charge).to have_attributes(
+          amount_currency: charge.amount_currency,
+          billable_metric_id: charge.billable_metric.id,
+          charge_model: charge.charge_model,
+          invoiceable: charge.invoiceable,
+          pay_in_advance: charge.pay_in_advance,
+          prorated: charge.prorated,
+          # Overriden attributes
+          plan_id: plan.id,
+          min_amount_cents: 1000,
+          properties: { 'amount' => '200' },
+        )
+        expect(charge.group_properties.count).to eq(1)
+        expect(charge.group_properties.with_discarded.discarded.count).to eq(1)
+        expect(charge.group_properties.first).to have_attributes(
+          {
+            group_id: group.id,
+            values: { 'amount' => '100' },
+          },
+        )
+        expect(charge.taxes).to contain_exactly(tax)
+      end
+    end
+  end
+end

--- a/spec/services/plans/override_service_spec.rb
+++ b/spec/services/plans/override_service_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Plans::OverrideService, type: :service do
+  subject(:override_service) { described_class.new(plan: parent_plan, params:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+
+  describe '#call' do
+    let(:parent_plan) { create(:plan, organization:) }
+    let(:billable_metric) { create(:billable_metric, organization:) }
+    let(:group) { create(:group, billable_metric:) }
+    let(:tax) { create(:tax, organization:) }
+
+    let(:charge) do
+      create(
+        :standard_charge,
+        plan: parent_plan,
+        billable_metric:,
+        properties: { amount: '300' },
+        group_properties: [
+          build(
+            :group_property,
+            group:,
+            values: { amount: '10', amount_currency: 'EUR' },
+          ),
+        ],
+      )
+    end
+
+    let(:params) do
+      {
+        amount_cents: 300,
+        amount_currency: 'USD',
+        invoice_display_name: 'invoice display name',
+        trial_period: 20,
+        tax_codes: [tax.code],
+        charges: charges_params,
+      }
+    end
+
+    let(:charges_params) do
+      [
+        {
+          id: charge.id,
+          min_amount_cents: 1000,
+        },
+      ]
+    end
+
+    around { |test| lago_premium!(&test) }
+
+    before { charge }
+
+    it 'creates a plan based from the parent plan', :aggregate_failures do
+      expect { override_service.call }.to change(Plan, :count).by(1)
+
+      plan = Plan.order(:created_at).last
+      expect(plan).to have_attributes(
+        organization_id: organization.id,
+        name: parent_plan.name,
+        description: parent_plan.description,
+        bill_charges_monthly: parent_plan.bill_charges_monthly,
+        code: parent_plan.code,
+        interval: parent_plan.interval,
+        pay_in_advance: parent_plan.pay_in_advance,
+        # Parent id
+        parent_id: parent_plan.id,
+        # Overriden attributes
+        amount_cents: 300,
+        amount_currency: 'USD',
+        trial_period: 20,
+      )
+
+      expect(plan.taxes).to contain_exactly(tax)
+    end
+
+    it 'creates charges based from the parent plan', :aggregate_failures do
+      charge2 = create(
+        :graduated_charge,
+        plan: parent_plan,
+        billable_metric:,
+        properties: {
+          graduated_ranges: [
+            {
+              from_value: 0,
+              to_value: nil,
+              per_unit_amount: '0.01',
+              flat_amount: '0.01',
+            },
+          ],
+        },
+      )
+
+      expect { override_service.call }.to change(Plan, :count).by(1)
+
+      plan = Plan.order(:created_at).last
+      expect(plan.charges.count).to eq(2)
+
+      graduated = plan.charges.graduated.first
+      expect(graduated).to have_attributes(
+        plan_id: plan.id,
+        min_amount_cents: charge2.min_amount_cents,
+        properties: charge2.properties,
+      )
+
+      standard = plan.charges.standard.first
+      expect(standard).to have_attributes(
+        amount_currency: charge.amount_currency,
+        billable_metric_id: billable_metric.id,
+        charge_model: charge.charge_model,
+        invoiceable: charge.invoiceable,
+        pay_in_advance: charge.pay_in_advance,
+        prorated: charge.prorated,
+        properties: charge.properties,
+        # Overriden attributes
+        plan_id: plan.id,
+        min_amount_cents: 1000,
+      )
+    end
+  end
+end

--- a/spec/services/plans/override_service_spec.rb
+++ b/spec/services/plans/override_service_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Plans::OverrideService, type: :service do
         # Overriden attributes
         amount_cents: 300,
         amount_currency: 'USD',
+        invoice_display_name: 'invoice display name',
         trial_period: 20,
       )
 


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

The goal of this PR is to:
- change validation on plan's code to be unique if `parent_id` is `nil`
- add service to override a charge
- add service to override a plan
