### PR TITLE
feat(override-plan): Add GET single subscription endpoint

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -67,7 +67,10 @@ module Api
       end
 
       def show
-        subscription = current_organization.subscriptions.find_by(external_id: params[:external_id])
+        subscription = current_organization.subscriptions.find_by(
+          external_id: params[:external_id],
+          status: params[:status] || :active,
+        )
         return not_found_error(resource: 'subscription') unless subscription
 
         render_subscription(subscription)

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -24,12 +24,7 @@ module Api
         )
 
         if result.success?
-          render(
-            json: ::V1::SubscriptionSerializer.new(
-              result.subscription,
-              root_name: 'subscription',
-            ),
-          )
+          render_subscription(result.subscription)
         else
           render_error_response(result)
         end
@@ -47,12 +42,7 @@ module Api
         result = Subscriptions::TerminateService.call(subscription:)
 
         if result.success?
-          render(
-            json: ::V1::SubscriptionSerializer.new(
-              result.subscription,
-              root_name: 'subscription',
-            ),
-          )
+          render_subscription(result.subscription)
         else
           render_error_response(result)
         end
@@ -70,15 +60,17 @@ module Api
         )
 
         if result.success?
-          render(
-            json: ::V1::SubscriptionSerializer.new(
-              result.subscription,
-              root_name: 'subscription',
-            ),
-          )
+          render_subscription(result.subscription)
         else
           render_error_response(result)
         end
+      end
+
+      def show
+        subscription = current_organization.subscriptions.find_by(external_id: params[:external_id])
+        return not_found_error(resource: 'subscription') unless subscription
+
+        render_subscription(subscription)
       end
 
       def index
@@ -127,6 +119,15 @@ module Api
 
       def index_filters
         params.permit(:external_customer_id, :plan_code, status: [])
+      end
+
+      def render_subscription(subscription)
+        render(
+          json: ::V1::SubscriptionSerializer.new(
+            subscription,
+            root_name: 'subscription',
+          ),
+        )
       end
     end
   end

--- a/app/graphql/resolvers/subscription_resolver.rb
+++ b/app/graphql/resolvers/subscription_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class SubscriptionResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description 'Query a single subscription of an organization'
+
+    argument :id, ID, required: true, description: 'Uniq ID of the subscription'
+
+    type Types::Subscriptions::Object, null: true
+
+    def resolve(id: nil)
+      validate_organization!
+
+      current_organization.subscriptions.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: 'subscription')
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -36,6 +36,7 @@ module Types
     field :password_reset, resolver: Resolvers::PasswordResetResolver
     field :plan, resolver: Resolvers::PlanResolver
     field :plans, resolver: Resolvers::PlansResolver
+    field :subscription, resolver: Resolvers::SubscriptionResolver
     field :tax, resolver: Resolvers::TaxResolver
     field :taxes, resolver: Resolvers::TaxesResolver
     field :wallet_transactions, resolver: Resolvers::WalletTransactionsResolver

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :subscriptions, only: %i[create update index], param: :external_id
+      resources :subscriptions, only: %i[create update show index], param: :external_id
       delete '/subscriptions/:external_id', to: 'subscriptions#terminate', as: :terminate
 
       resources :add_ons, param: :code

--- a/schema.graphql
+++ b/schema.graphql
@@ -4288,6 +4288,16 @@ type Query {
   ): PlanCollection!
 
   """
+  Query a single subscription of an organization
+  """
+  subscription(
+    """
+    Uniq ID of the subscription
+    """
+    id: ID!
+  ): Subscription
+
+  """
   Query a single tax of an organization
   """
   tax(

--- a/schema.json
+++ b/schema.json
@@ -18624,6 +18624,35 @@
               ]
             },
             {
+              "name": "subscription",
+              "description": "Query a single subscription of an organization",
+              "type": {
+                "kind": "OBJECT",
+                "name": "Subscription",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the subscription",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "tax",
               "description": "Query a single tax of an organization",
               "type": {

--- a/spec/graphql/resolvers/subscription_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscription_resolver_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::SubscriptionResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($subscriptionId: ID!) {
+        subscription(id: $subscriptionId) {
+          id
+          name
+          startedAt
+          endingAt
+          plan {
+            id
+            code
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:) }
+
+  before do
+    customer
+  end
+
+  it 'returns a single subscription', :aggregate_failures do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+      variables: { subscriptionId: subscription.id },
+    )
+
+    subscription_response = result['data']['subscription']
+    expect(subscription_response).to include(
+      'id' => subscription.id,
+      'name' => subscription.name,
+      'startedAt' => subscription.started_at,
+      'endingAt' => subscription.ending_at,
+    )
+
+    expect(subscription_response['plan']).to include(
+      'id' => subscription.plan.id,
+      'code' => subscription.plan.code,
+    )
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query:,
+        variables: { subscriptionId: subscription.id },
+      )
+
+      expect_graphql_error(result:, message: 'Missing organization id')
+    end
+  end
+
+  context 'when subscription is not found' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: { subscriptionId: 'foo' },
+      )
+
+      expect_graphql_error(result:, message: 'Resource not found')
+    end
+  end
+end

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -189,6 +189,19 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
         expect(response).to have_http_status(:not_found)
       end
     end
+
+    context 'when status is given' do
+      it 'returns the subscription with the given status' do
+        pending = create(:subscription, customer:, plan:, status: :pending, external_id: subscription.external_id)
+        get_with_token(organization, "/api/v1/subscriptions/#{subscription.external_id}?status=pending")
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscription]).to include(
+          lago_id: pending.id,
+          external_id: pending.external_id,
+        )
+      end
+    end
   end
 
   describe 'index' do

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -170,6 +170,27 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
     end
   end
 
+  describe 'show' do
+    let(:subscription) { create(:subscription, customer:, plan:) }
+
+    it 'returns a subscription' do
+      get_with_token(organization, "/api/v1/subscriptions/#{subscription.external_id}")
+
+      expect(response).to have_http_status(:success)
+      expect(json[:subscription]).to include(
+        lago_id: subscription.id,
+        external_id: subscription.external_id,
+      )
+    end
+
+    context 'when subscription does not exist' do
+      it 'returns not found' do
+        get_with_token(organization, '/api/v1/subscriptions/555')
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe 'index' do
     let(:subscription1) { create(:subscription, customer:, plan:) }
 


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

The goal of this PR is to:
- add the endpoint `GET /api/v1/subscriptions/:external_id`
- add the GraphQL resolver for fetching a single subscription
