### PR TITLE
misc: Add GIN index to events properties

### DIFF
--- a/db/migrate/20230920083133_add_gin_index_to_events.rb
+++ b/db/migrate/20230920083133_add_gin_index_to_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGinIndexToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_index(:events, :properties, using: 'gin', opclass: :jsonb_path_ops)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_18_090426) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_20_083133) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -337,6 +337,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_18_090426) do
     t.index ["deleted_at"], name: "index_events_on_deleted_at"
     t.index ["organization_id", "code"], name: "index_events_on_organization_id_and_code"
     t.index ["organization_id"], name: "index_events_on_organization_id"
+    t.index ["properties"], name: "index_events_on_properties", opclass: :jsonb_path_ops, using: :gin
     t.index ["quantified_event_id"], name: "index_events_on_quantified_event_id"
     t.index ["subscription_id", "code", "timestamp"], name: "index_events_on_subscription_id_and_code_and_timestamp", where: "(deleted_at IS NULL)"
     t.index ["subscription_id", "transaction_id"], name: "index_events_on_subscription_id_and_transaction_id", unique: true


### PR DESCRIPTION
## Context

Current usage is slow for organization with a lot of events.
One of the issue is related to the queries looking into the jsonb properties field.

## Description

This PR is adding a GIN index to the events#properties field to speed up queries into this field.

See https://www.postgresql.org/docs/current/datatype-json.html#JSON-INDEXING
