### PR TITLE
fix: Run migration without a transaction

### DIFF
--- a/db/migrate/20230920083133_add_gin_index_to_events.rb
+++ b/db/migrate/20230920083133_add_gin_index_to_events.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AddGinIndexToEvents < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
   def change
     add_index(:events, :properties, using: 'gin', opclass: :jsonb_path_ops, algorithm: :concurrently)
   end


### PR DESCRIPTION
Before:

```
Migrating to AddGinIndexToEvents (20230920083133)
== 20230920083133 AddGinIndexToEvents: migrating ==============================
-- add_index(:events, :properties, {:using=>"gin", :opclass=>:jsonb_path_ops, :algorithm=>:concurrently})
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::ActiveSqlTransaction: ERROR:  CREATE INDEX CONCURRENTLY cannot run inside a transaction block
/app/db/migrate/20230920083133_add_gin_index_to_events.rb:5:in `change'

Caused by:
ActiveRecord::StatementInvalid: PG::ActiveSqlTransaction: ERROR:  CREATE INDEX CONCURRENTLY cannot run inside a transaction block
/app/db/migrate/20230920083133_add_gin_index_to_events.rb:5:in `change'

Caused by:
PG::ActiveSqlTransaction: ERROR:  CREATE INDEX CONCURRENTLY cannot run inside a transaction block
/app/db/migrate/20230920083133_add_gin_index_to_events.rb:5:in `change'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```