### PR TITLE
feat(override-plan): Ability to override plan on API subscription creation

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -113,6 +113,23 @@ module Api
             :subscription_date,
             :subscription_at,
             :ending_at,
+            plan_overrides: [
+              :amount_cents,
+              :amount_currency,
+              :invoice_display_name,
+              :trial_period,
+              { tax_codes: [] },
+              {
+                charges: [
+                  :id,
+                  :min_amount_cents,
+                  :invoice_display_name,
+                  { properties: {} },
+                  { group_properties: [] },
+                  { tax_codes: [] },
+                ],
+              },
+            ],
           )
       end
 
@@ -129,6 +146,7 @@ module Api
           json: ::V1::SubscriptionSerializer.new(
             subscription,
             root_name: 'subscription',
+            includes: %i[plan],
           ),
         )
       end

--- a/app/graphql/types/subscriptions/charge_overrides_input.rb
+++ b/app/graphql/types/subscriptions/charge_overrides_input.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  module Subscriptions
+    class ChargeOverridesInput < Types::BaseInputObject
+      argument :group_properties, [Types::Charges::GroupPropertiesInput]
+      argument :min_amount_cents, GraphQL::Types::BigInt
+      argument :properties, Types::Charges::PropertiesInput
+      argument :tax_codes, [String]
+    end
+  end
+end

--- a/app/graphql/types/subscriptions/charge_overrides_input.rb
+++ b/app/graphql/types/subscriptions/charge_overrides_input.rb
@@ -3,10 +3,10 @@
 module Types
   module Subscriptions
     class ChargeOverridesInput < Types::BaseInputObject
-      argument :group_properties, [Types::Charges::GroupPropertiesInput]
-      argument :min_amount_cents, GraphQL::Types::BigInt
-      argument :properties, Types::Charges::PropertiesInput
-      argument :tax_codes, [String]
+      argument :group_properties, [Types::Charges::GroupPropertiesInput], required: false
+      argument :min_amount_cents, GraphQL::Types::BigInt, required: false
+      argument :properties, Types::Charges::PropertiesInput, required: false
+      argument :tax_codes, [String], required: false
     end
   end
 end

--- a/app/graphql/types/subscriptions/create_subscription_input.rb
+++ b/app/graphql/types/subscriptions/create_subscription_input.rb
@@ -12,6 +12,7 @@ module Types
 
       argument :customer_id, ID, required: true
       argument :plan_id, ID, required: true
+      argument :plan_overrides, Types::Subscriptions::PlanOverridesInput, required: false
 
       argument :billing_time, Types::Subscriptions::BillingTimeEnum, required: true
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false

--- a/app/graphql/types/subscriptions/plan_overrides_input.rb
+++ b/app/graphql/types/subscriptions/plan_overrides_input.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  module Subscriptions
+    class PlanOverridesInput < Types::BaseInputObject
+      argument :amount_cents, GraphQL::Types::BigInt
+      argument :amount_currency, Types::CurrencyEnum
+      argument :charges, [Types::Subscriptions::ChargeOverridesInput]
+      argument :invoice_display_name, String
+      argument :tax_codes, [String]
+      argument :trial_period, Float
+    end
+  end
+end

--- a/app/graphql/types/subscriptions/plan_overrides_input.rb
+++ b/app/graphql/types/subscriptions/plan_overrides_input.rb
@@ -3,12 +3,12 @@
 module Types
   module Subscriptions
     class PlanOverridesInput < Types::BaseInputObject
-      argument :amount_cents, GraphQL::Types::BigInt
-      argument :amount_currency, Types::CurrencyEnum
-      argument :charges, [Types::Subscriptions::ChargeOverridesInput]
-      argument :invoice_display_name, String
-      argument :tax_codes, [String]
-      argument :trial_period, Float
+      argument :amount_cents, GraphQL::Types::BigInt, required: false
+      argument :amount_currency, Types::CurrencyEnum, required: false
+      argument :charges, [Types::Subscriptions::ChargeOverridesInput], required: false
+      argument :invoice_display_name, String, required: false
+      argument :tax_codes, [String], required: false
+      argument :trial_period, Float, required: false
     end
   end
 end

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -18,6 +18,7 @@ module V1
         bill_charges_monthly: model.bill_charges_monthly,
         active_subscriptions_count:,
         draft_invoices_count:,
+        parent_id: model.parent_id,
       }
 
       payload.merge!(charges) if include?(:charges)

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -79,7 +79,7 @@ module Subscriptions
     def create_subscription
       new_subscription = Subscription.new(
         customer:,
-        plan:,
+        plan: params.key?(:plan_overrides) ? override_plan(plan) : plan,
         subscription_at:,
         name:,
         external_id:,
@@ -244,6 +244,10 @@ module Subscriptions
       @editable_subscriptions ||= customer.subscriptions.active
         .or(customer.subscriptions.starting_in_the_future)
         .order(started_at: :desc)
+    end
+
+    def override_plan(plan)
+      Plans::OverrideService.call(plan:, params: params[:plan_overrides].with_indifferent_access).plan
     end
   end
 end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -247,7 +247,7 @@ module Subscriptions
     end
 
     def override_plan(plan)
-      Plans::OverrideService.call(plan:, params: params[:plan_overrides].with_indifferent_access).plan
+      Plans::OverrideService.call(plan:, params: params[:plan_overrides].to_h.with_indifferent_access).plan
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -211,10 +211,10 @@ enum ChargeModelEnum {
 }
 
 input ChargeOverridesInput {
-  groupProperties: [GroupPropertiesInput!]!
-  minAmountCents: BigInt!
-  properties: PropertiesInput!
-  taxCodes: [String!]!
+  groupProperties: [GroupPropertiesInput!]
+  minAmountCents: BigInt
+  properties: PropertiesInput
+  taxCodes: [String!]
 }
 
 type ChargeUsage {
@@ -3982,12 +3982,12 @@ enum PlanInterval {
 }
 
 input PlanOverridesInput {
-  amountCents: BigInt!
-  amountCurrency: CurrencyEnum!
-  charges: [ChargeOverridesInput!]!
-  invoiceDisplayName: String!
-  taxCodes: [String!]!
-  trialPeriod: Float!
+  amountCents: BigInt
+  amountCurrency: CurrencyEnum
+  charges: [ChargeOverridesInput!]
+  invoiceDisplayName: String
+  taxCodes: [String!]
+  trialPeriod: Float
 }
 
 type Properties {

--- a/schema.graphql
+++ b/schema.graphql
@@ -210,6 +210,13 @@ enum ChargeModelEnum {
   volume
 }
 
+input ChargeOverridesInput {
+  groupProperties: [GroupPropertiesInput!]!
+  minAmountCents: BigInt!
+  properties: PropertiesInput!
+  taxCodes: [String!]!
+}
+
 type ChargeUsage {
   amountCents: BigInt!
   billableMetric: BillableMetric!
@@ -1773,6 +1780,7 @@ input CreateSubscriptionInput {
   externalId: String
   name: String
   planId: ID!
+  planOverrides: PlanOverridesInput
   subscriptionAt: ISO8601DateTime
   subscriptionId: ID
 }
@@ -3971,6 +3979,15 @@ enum PlanInterval {
   quarterly
   weekly
   yearly
+}
+
+input PlanOverridesInput {
+  amountCents: BigInt!
+  amountCurrency: CurrencyEnum!
+  charges: [ChargeOverridesInput!]!
+  invoiceDisplayName: String!
+  taxCodes: [String!]!
+  trialPeriod: Float!
 }
 
 type Properties {

--- a/schema.json
+++ b/schema.json
@@ -2047,6 +2047,97 @@
           ]
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "ChargeOverridesInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "groupProperties",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "GroupPropertiesInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "properties",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PropertiesInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxCodes",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
           "kind": "OBJECT",
           "name": "ChargeUsage",
           "description": null,
@@ -6031,6 +6122,18 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "planOverrides",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PlanOverridesInput",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -16736,6 +16839,129 @@
               "deprecationReason": null
             }
           ]
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "PlanOverridesInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "charges",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ChargeOverridesInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxCodes",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "trialPeriod",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
         },
         {
           "kind": "OBJECT",

--- a/schema.json
+++ b/schema.json
@@ -2058,19 +2058,15 @@
               "name": "groupProperties",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
+                  "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "GroupPropertiesInput",
-                      "ofType": null
-                    }
+                    "kind": "INPUT_OBJECT",
+                    "name": "GroupPropertiesInput",
+                    "ofType": null
                   }
                 }
               },
@@ -2082,13 +2078,9 @@
               "name": "minAmountCents",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -2098,13 +2090,9 @@
               "name": "properties",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "PropertiesInput",
-                  "ofType": null
-                }
+                "kind": "INPUT_OBJECT",
+                "name": "PropertiesInput",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -2114,19 +2102,15 @@
               "name": "taxCodes",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
+                  "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   }
                 }
               },
@@ -16852,13 +16836,9 @@
               "name": "amountCents",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "BigInt",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -16868,13 +16848,9 @@
               "name": "amountCurrency",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "CurrencyEnum",
-                  "ofType": null
-                }
+                "kind": "ENUM",
+                "name": "CurrencyEnum",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -16884,19 +16860,15 @@
               "name": "charges",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
+                  "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "ChargeOverridesInput",
-                      "ofType": null
-                    }
+                    "kind": "INPUT_OBJECT",
+                    "name": "ChargeOverridesInput",
+                    "ofType": null
                   }
                 }
               },
@@ -16908,13 +16880,9 @@
               "name": "invoiceDisplayName",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -16924,19 +16892,15 @@
               "name": "taxCodes",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
+                "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
+                  "kind": "NON_NULL",
                   "name": null,
                   "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   }
                 }
               },
@@ -16948,13 +16912,9 @@
               "name": "trialPeriod",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
     it 'returns a success', :aggregate_failures do
       post_with_token(organization, '/api/v1/subscriptions', { subscription: params })
 
-        expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:ok)
 
       expect(json[:subscription]).to include(
         lago_id: String,

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -10,28 +10,31 @@ RSpec.describe ::V1::PlanSerializer do
 
   before { charge }
 
-  it 'serializes the object' do
+  it 'serializes the object', :aggregate_failures do
     result = JSON.parse(serializer.to_json)
 
-    aggregate_failures do
-      expect(result['plan']['lago_id']).to eq(plan.id)
-      expect(result['plan']['name']).to eq(plan.name)
-      expect(result['plan']['invoice_display_name']).to eq(plan.invoice_display_name)
-      expect(result['plan']['created_at']).to eq(plan.created_at.iso8601)
-      expect(result['plan']['code']).to eq(plan.code)
-      expect(result['plan']['interval']).to eq(plan.interval)
-      expect(result['plan']['description']).to eq(plan.description)
-      expect(result['plan']['amount_cents']).to eq(plan.amount_cents)
-      expect(result['plan']['amount_currency']).to eq(plan.amount_currency)
-      expect(result['plan']['trial_period']).to eq(plan.trial_period)
-      expect(result['plan']['pay_in_advance']).to eq(plan.pay_in_advance)
-      expect(result['plan']['bill_charges_monthly']).to eq(plan.bill_charges_monthly)
-      expect(result['plan']['active_subscriptions_count']).to eq(0)
-      expect(result['plan']['draft_invoices_count']).to eq(0)
-      expect(result['plan']['charges'].first['lago_id']).to eq(charge.id)
-      expect(result['plan']['charges'].first['group_properties']).to eq([])
+    expect(result['plan']).to include(
+      'lago_id' => plan.id,
+      'name' => plan.name,
+      'invoice_display_name' => plan.invoice_display_name,
+      'created_at' => plan.created_at.iso8601,
+      'code' => plan.code,
+      'interval' => plan.interval,
+      'description' => plan.description,
+      'amount_cents' => plan.amount_cents,
+      'amount_currency' => plan.amount_currency,
+      'trial_period' => plan.trial_period,
+      'pay_in_advance' => plan.pay_in_advance,
+      'bill_charges_monthly' => plan.bill_charges_monthly,
+      'active_subscriptions_count' => 0,
+      'draft_invoices_count' => 0,
+      'parent_id' => nil,
+      'taxes' => [],
+    )
 
-      expect(result['plan']['taxes']).to eq([])
-    end
+    expect(result['plan']['charges'].first).to include(
+      'lago_id' => charge.id,
+      'group_properties' => [],
+    )
   end
 end


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

The goal of this PR is to:
- Return parent_id on Plan serializer
- Add plan overrides to subscriptions controller
- Add plan overrides to create subscription graphql input 
