### PR TITLE
misc: Speedup subscription activation

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -18,7 +18,7 @@ module Clockwork
 
   # NOTE: All clocks run every hour to take customer timezones into account
 
-  every(1.hour, 'schedule:activate_subscriptions', at: '*:30') do
+  every(5.minutes, 'schedule:activate_subscriptions') do
     Clock::ActivateSubscriptionsJob.perform_later
   end
 

--- a/spec/clock_spec.rb
+++ b/spec/clock_spec.rb
@@ -42,7 +42,7 @@ describe Clockwork do
       )
 
       expect(Clockwork::Test).to be_ran_job(job)
-      expect(Clockwork::Test.times_run(job)).to eq(1)
+      expect(Clockwork::Test.times_run(job)).to eq(6)
 
       Clockwork::Test.block_for(job).call
       expect(Clock::ActivateSubscriptionsJob).to have_been_enqueued


### PR DESCRIPTION
## Context

Pending subscription with a subscription_at in the future are started automatically by a clock job that is executed every one hour at *:30

All events sent between the subscription_at and the started_at (activation time) are not passing validation as the subscription is not active from a database perspective.

## Description

A short term fix to reduce this window is to perform the activation job every 5 minutes.
On the long run, with the plans for high event volume feature, a proper change will remove the upfront validation of events. It will fix the current issue.