### PR TITLE
feat(override-plan): Take into consideration children for customers_count

### DIFF
--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -41,7 +41,12 @@ module Types
       end
 
       def customers_count
-        object.subscriptions.active.select(:customer_id).distinct.count
+        customers_count = object.subscriptions.active.select(:customer_id).distinct.count
+        return customers_count unless object.children
+
+        customers_count + model.children.joins(:subscriptions).where(
+          subscriptions: { status: :active },
+        ).select('distinct(customer_id)').count
       end
 
       def subscriptions_count

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -40,15 +40,6 @@ module Types
         object.charges.count
       end
 
-      def customers_count
-        customers_count = object.subscriptions.active.select(:customer_id).distinct.count
-        return customers_count unless object.children
-
-        customers_count + model.children.joins(:subscriptions).where(
-          subscriptions: { status: :active },
-        ).select('distinct(customer_id)').count
-      end
-
       def subscriptions_count
         object.subscriptions.count
       end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -70,6 +70,15 @@ class Plan < ApplicationRecord
     amount_cents * 52
   end
 
+  def customers_count
+    count = subscriptions.active.select(:customer_id).distinct.count
+    return count unless children
+
+    count + children.joins(:subscriptions).where(
+      subscriptions: { status: :active },
+    ).select('distinct(customer_id)').count
+  end
+
   private
 
   def validate_code_unique

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -16,6 +16,7 @@ module V1
         trial_period: model.trial_period,
         pay_in_advance: model.pay_in_advance,
         bill_charges_monthly: model.bill_charges_monthly,
+        customers_count:,
         active_subscriptions_count:,
         draft_invoices_count:,
         parent_id: model.parent_id,
@@ -36,6 +37,15 @@ module V1
         collection_name: 'charges',
         includes: include?(:taxes) ? %i[taxes] : [],
       ).serialize
+    end
+
+    def customers_count
+      customers_count = model.subscriptions.active.select(:customer_id).distinct.count
+      return customers_count unless model.children
+
+      customers_count + model.children.joins(:subscriptions).where(
+        subscriptions: { status: :active },
+      ).select('distinct(customer_id)').count
     end
 
     def active_subscriptions_count

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -16,7 +16,7 @@ module V1
         trial_period: model.trial_period,
         pay_in_advance: model.pay_in_advance,
         bill_charges_monthly: model.bill_charges_monthly,
-        customers_count:,
+        customers_count: model.customers_count,
         active_subscriptions_count:,
         draft_invoices_count:,
         parent_id: model.parent_id,
@@ -37,15 +37,6 @@ module V1
         collection_name: 'charges',
         includes: include?(:taxes) ? %i[taxes] : [],
       ).serialize
-    end
-
-    def customers_count
-      customers_count = model.subscriptions.active.select(:customer_id).distinct.count
-      return customers_count unless model.children
-
-      customers_count + model.children.joins(:subscriptions).where(
-        subscriptions: { status: :active },
-      ).select('distinct(customer_id)').count
     end
 
     def active_subscriptions_count

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -76,4 +76,18 @@ RSpec.describe Plan, type: :model do
       end
     end
   end
+
+  describe '#customers_count' do
+    let(:customer) { create(:customer) }
+    let(:plan) { create(:plan) }
+
+    it 'returns the number of impacted customers' do
+      create(:subscription, customer:, plan:)
+      overridden_plan = create(:plan, parent_id: plan.id)
+      customer2 = create(:customer, organization: plan.organization)
+      create(:subscription, customer: customer2, plan: overridden_plan)
+
+      expect(plan.customers_count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

the goal of this PR is to include customers using overridden plans on `customers_count` of the parent plan.
