### PR TITLE
Misc events attributes

### DIFF
--- a/db/migrate/20230921094357_add_external_ids_to_events.rb
+++ b/db/migrate/20230921094357_add_external_ids_to_events.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddExternalIdsToEvents < ActiveRecord::Migration[7.0]
+  def change
+    change_table :events, bulk: true do |t|
+      t.string :external_customer_id
+      t.string :external_subscription_id
+      t.decimal :value
+    end
+  end
+end

--- a/db/migrate/20230921094357_add_external_ids_to_events.rb
+++ b/db/migrate/20230921094357_add_external_ids_to_events.rb
@@ -5,7 +5,7 @@ class AddExternalIdsToEvents < ActiveRecord::Migration[7.0]
     change_table :events, bulk: true do |t|
       t.string :external_customer_id
       t.string :external_subscription_id
-      t.decimal :value
+      t.string :value
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_20_083133) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_21_094357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -333,6 +333,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_20_083133) do
     t.uuid "subscription_id"
     t.datetime "deleted_at"
     t.uuid "quantified_event_id"
+    t.string "external_customer_id"
+    t.string "external_subscription_id"
+    t.decimal "value"
     t.index ["customer_id"], name: "index_events_on_customer_id"
     t.index ["deleted_at"], name: "index_events_on_deleted_at"
     t.index ["organization_id", "code"], name: "index_events_on_organization_id_and_code"

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -164,6 +164,9 @@ RSpec.describe Events::CreateService, type: :service do
           expect(event.code).to eq(billable_metric.code)
           expect(event.subscription_id).to eq(subscription.id)
           expect(event.timestamp).to be_a(Time)
+          expect(event.external_customer_id).to eq(customer.external_id)
+          expect(event.external_subscription_id).to eq(subscription.external_id)
+          expect(event.value).to be_nil
         end
       end
     end
@@ -207,6 +210,9 @@ RSpec.describe Events::CreateService, type: :service do
           expect(event.code).to eq(billable_metric.code)
           expect(event.subscription_id).to eq(active_subscription.id)
           expect(event.timestamp).to be_a(Time)
+          expect(event.external_customer_id).to eq(customer.external_id)
+          expect(event.external_subscription_id).to eq(subscription.external_id)
+          expect(event.value).to be_nil
         end
       end
     end
@@ -230,6 +236,9 @@ RSpec.describe Events::CreateService, type: :service do
           expect(event.code).to eq(billable_metric.code)
           expect(event.subscription_id).to eq(subscription.id)
           expect(event.timestamp).to be_a(Time)
+          expect(event.external_customer_id).to eq(customer.external_id)
+          expect(event.external_subscription_id).to eq(subscription.external_id)
+          expect(event.value).to be_nil
         end
       end
     end
@@ -263,6 +272,9 @@ RSpec.describe Events::CreateService, type: :service do
           expect(event.code).to eq(billable_metric.code)
           expect(event.subscription_id).to eq(subscription.id)
           expect(event.timestamp).to be_a(Time)
+          expect(event.external_customer_id).to eq(customer.external_id)
+          expect(event.external_subscription_id).to eq(subscription.external_id)
+          expect(event.value).to be_nil
         end
       end
     end
@@ -353,6 +365,48 @@ RSpec.describe Events::CreateService, type: :service do
           expect(event.subscription_id).to eq(subscription.id)
           expect(event.timestamp).to be_a(Time)
           expect(event.properties).to eq({})
+          expect(event.external_customer_id).to eq(customer.external_id)
+          expect(event.external_subscription_id).to eq(subscription.external_id)
+          expect(event.value).to be_nil
+        end
+      end
+    end
+
+    context 'when billable metric has a field name' do
+      let(:billable_metric) { create(:sum_billable_metric, organization:) }
+
+      let(:create_args) do
+        {
+          external_customer_id: customer.external_id,
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          timestamp:,
+          properties: { billable_metric.field_name => 42.42 },
+        }
+      end
+
+      it 'creates a new event' do
+        result = create_service.call(
+          organization:,
+          params: create_args,
+          timestamp:,
+          metadata: {},
+        )
+
+        expect(result).to be_success
+
+        event = result.event
+
+        aggregate_failures do
+          expect(event.customer_id).to eq(customer.id)
+          expect(event.organization_id).to eq(organization.id)
+          expect(event.code).to eq(billable_metric.code)
+          expect(event.subscription_id).to eq(subscription.id)
+          expect(event.timestamp).to be_a(Time)
+          expect(event.properties).to eq({ billable_metric.field_name => 42.42 })
+          expect(event.external_customer_id).to eq(customer.external_id)
+          expect(event.external_subscription_id).to eq(subscription.external_id)
+          expect(event.value).to eq('42.42')
         end
       end
     end


### PR DESCRIPTION
## Context

This PRs follows https://github.com/getlago/lago-api/pull/1337

## Description

This PR starts filling the external_customer_id, external_subscription_id and value fields on the events table