### PR TITLE
feat(override-plan): Ability to update plan overrides

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -20,7 +20,7 @@ module Api
       end
 
       def update
-        plan = current_organization.plans.find_by(code: params[:code])
+        plan = current_organization.plans.parents.find_by(code: params[:code])
         result = ::Plans::UpdateService.call(plan:, params: input_params)
 
         if result.success?
@@ -31,7 +31,7 @@ module Api
       end
 
       def destroy
-        plan = current_organization.plans.find_by(code: params[:code])
+        plan = current_organization.plans.parents.find_by(code: params[:code])
         result = ::Plans::PrepareDestroyService.call(plan:)
 
         if result.success?
@@ -42,17 +42,14 @@ module Api
       end
 
       def show
-        plan = current_organization.plans.find_by(
-          code: params[:code],
-        )
-
+        plan = current_organization.plans.parents.find_by(code: params[:code])
         return not_found_error(resource: 'plan') unless plan
 
         render_plan(plan)
       end
 
       def index
-        plans = current_organization.plans
+        plans = current_organization.plans.parents
           .order(created_at: :desc)
           .page(params[:page])
           .per(params[:per_page] || PER_PAGE)

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -49,11 +49,9 @@ module Api
       end
 
       def update
-        service = Subscriptions::UpdateService.new
-
-        result = service.update(
+        result = Subscriptions::UpdateService.call(
           subscription: current_organization.subscriptions.find_by(external_id: params[:external_id]),
-          args: SubscriptionLegacyInput.new(
+          params: SubscriptionLegacyInput.new(
             current_organization,
             update_params,
           ).update_input,
@@ -113,30 +111,40 @@ module Api
             :subscription_date,
             :subscription_at,
             :ending_at,
-            plan_overrides: [
-              :amount_cents,
-              :amount_currency,
-              :description,
-              :invoice_display_name,
-              :name,
-              :trial_period,
-              { tax_codes: [] },
-              {
-                charges: [
-                  :id,
-                  :min_amount_cents,
-                  :invoice_display_name,
-                  { properties: {} },
-                  { group_properties: [] },
-                  { tax_codes: [] },
-                ],
-              },
-            ],
+            plan_overrides:,
           )
       end
 
       def update_params
-        params.require(:subscription).permit(:name, :subscription_date, :subscription_at, :ending_at)
+        params.require(:subscription).permit(
+          :name,
+          :subscription_date,
+          :subscription_at,
+          :ending_at,
+          plan_overrides:,
+        )
+      end
+
+      def plan_overrides
+        [
+          :amount_cents,
+          :amount_currency,
+          :description,
+          :name,
+          :invoice_display_name,
+          :trial_period,
+          { tax_codes: [] },
+          {
+            charges: [
+              :id,
+              :min_amount_cents,
+              :invoice_display_name,
+              { properties: {} },
+              { group_properties: [] },
+              { tax_codes: [] },
+            ],
+          },
+        ]
       end
 
       def index_filters

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -116,7 +116,9 @@ module Api
             plan_overrides: [
               :amount_cents,
               :amount_currency,
+              :description,
               :invoice_display_name,
+              :name,
               :trial_period,
               { tax_codes: [] },
               {

--- a/app/graphql/mutations/subscriptions/update.rb
+++ b/app/graphql/mutations/subscriptions/update.rb
@@ -14,13 +14,7 @@ module Mutations
 
       def resolve(**args)
         subscription = context[:current_user].subscriptions.find_by(id: args[:id])
-
-        result = ::Subscriptions::UpdateService
-          .new(context[:current_user])
-          .update(
-            subscription:,
-            args:,
-          )
+        result = ::Subscriptions::UpdateService.call(subscription:, params: args)
 
         result.success? ? result.subscription : result_error(result)
       end

--- a/app/graphql/types/subscriptions/plan_overrides_input.rb
+++ b/app/graphql/types/subscriptions/plan_overrides_input.rb
@@ -6,7 +6,9 @@ module Types
       argument :amount_cents, GraphQL::Types::BigInt, required: false
       argument :amount_currency, Types::CurrencyEnum, required: false
       argument :charges, [Types::Subscriptions::ChargeOverridesInput], required: false
+      argument :description, String, required: false
       argument :invoice_display_name, String, required: false
+      argument :name, String, required: false
       argument :tax_codes, [String], required: false
       argument :trial_period, Float, required: false
     end

--- a/app/graphql/types/subscriptions/update_subscription_input.rb
+++ b/app/graphql/types/subscriptions/update_subscription_input.rb
@@ -9,6 +9,7 @@ module Types
 
       argument :ending_at, GraphQL::Types::ISO8601DateTime, required: false
       argument :name, String, required: false
+      argument :plan_overrides, Types::Subscriptions::PlanOverridesInput, required: false
       argument :subscription_at, GraphQL::Types::ISO8601DateTime, required: false
     end
   end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -38,6 +38,7 @@ class Plan < ApplicationRecord
   validate :validate_code_unique
 
   default_scope -> { kept }
+  scope :parents, -> { where(parent_id: nil) }
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[name code]

--- a/app/queries/plans_query.rb
+++ b/app/queries/plans_query.rb
@@ -17,7 +17,7 @@ class PlansQuery < BaseQuery
   attr_reader :search_term
 
   def base_scope
-    Plan.where(organization:).where(pending_deletion: false).ransack(search_params)
+    Plan.parents.where(organization:).where(pending_deletion: false).ransack(search_params)
   end
 
   def search_params

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -39,6 +39,13 @@ module V1
       ).serialize
     end
 
+    def customers_count
+      customers_count = model.subscriptions.active.select(:customer_id).distinct.count
+      return customers_count unless model.children
+
+      customers_count + model.children.sum { |c| c.subscriptions.active.select(:customer_id).distinct.count }
+    end
+
     def active_subscriptions_count
       model.subscriptions.active.count
     end

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -39,13 +39,6 @@ module V1
       ).serialize
     end
 
-    def customers_count
-      customers_count = model.subscriptions.active.select(:customer_id).distinct.count
-      return customers_count unless model.children
-
-      customers_count + model.children.sum { |c| c.subscriptions.active.select(:customer_id).distinct.count }
-    end
-
     def active_subscriptions_count
       model.subscriptions.active.count
     end

--- a/app/services/plans/override_service.rb
+++ b/app/services/plans/override_service.rb
@@ -16,7 +16,9 @@ module Plans
         new_plan = plan.dup.tap do |p|
           p.amount_cents = params[:amount_cents] if params.key?(:amount_cents)
           p.amount_currency = params[:amount_currency] if params.key?(:amount_currency)
+          p.description = params[:description] if params.key?(:description)
           p.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
+          p.name = params[:name] if params.key?(:name)
           p.trial_period = params[:trial_period] if params.key?(:trial_period)
           p.parent_id = plan.id
         end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3984,7 +3984,9 @@ input PlanOverridesInput {
   amountCents: BigInt
   amountCurrency: CurrencyEnum
   charges: [ChargeOverridesInput!]
+  description: String
   invoiceDisplayName: String
+  name: String
   taxCodes: [String!]
   trialPeriod: Float
 }
@@ -5546,6 +5548,7 @@ input UpdateSubscriptionInput {
   endingAt: ISO8601DateTime
   id: ID!
   name: String
+  planOverrides: PlanOverridesInput
   subscriptionAt: ISO8601DateTime
 }
 

--- a/schema.json
+++ b/schema.json
@@ -16865,7 +16865,31 @@
               "deprecationReason": null
             },
             {
+              "name": "description",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -23303,6 +23327,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "planOverrides",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "PlanOverridesInput",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
         ending_at:,
         plan_overrides: {
           amount_cents: 100,
+          name: 'overridden name'
         },
       }
     end
@@ -52,6 +53,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       )
       expect(json[:subscription][:plan]).to include(
         amount_cents: 100,
+        name: 'overridden name',
       )
     end
 

--- a/spec/services/plans/override_service_spec.rb
+++ b/spec/services/plans/override_service_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe Plans::OverrideService, type: :service do
         amount_cents: 300,
         amount_currency: 'USD',
         invoice_display_name: 'invoice display name',
+        name: 'overridden name',
+        description: 'overridden description',
         trial_period: 20,
         tax_codes: [tax.code],
         charges: charges_params,
@@ -60,8 +62,6 @@ RSpec.describe Plans::OverrideService, type: :service do
       plan = Plan.order(:created_at).last
       expect(plan).to have_attributes(
         organization_id: organization.id,
-        name: parent_plan.name,
-        description: parent_plan.description,
         bill_charges_monthly: parent_plan.bill_charges_monthly,
         code: parent_plan.code,
         interval: parent_plan.interval,
@@ -71,7 +71,9 @@ RSpec.describe Plans::OverrideService, type: :service do
         # Overriden attributes
         amount_cents: 300,
         amount_currency: 'USD',
+        description: 'overridden description',
         invoice_display_name: 'invoice display name',
+        name: 'overridden name',
         trial_period: 20,
       )
 


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

The goal of this PR is to:
- be able to update plan overrides on `PUT /subscriptions/:external_id`
- be able to override name and description of plans
