### PR TITLE
feat (subscriptions): update termination alert webhook

### DIFF
--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -11,7 +11,7 @@ module Clock
                "webhooks.webhook_type = 'subscription.termination_alert'")
         .active
         .where(
-          "DATE(subscriptions.ending_at::timestamptz) IN (?)",
+          'DATE(subscriptions.ending_at::timestamptz) IN (?)',
           [(Time.current + 45.days).to_date, (Time.current + 15.days).to_date],
         )
         .where('webhooks.id IS NULL OR webhooks.created_at::date != ?', Time.current.to_date)

--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -14,7 +14,7 @@ module Clock
           "DATE(subscriptions.ending_at::timestamptz) IN (?)",
           [(Time.current + 45.days).to_date, (Time.current + 15.days).to_date],
         )
-        .where('webhooks.id IS NULL OR webhooks.created_at::date != ?', Time.current)
+        .where('webhooks.id IS NULL OR webhooks.created_at::date != ?', Time.current.to_date)
         .find_each do |subscription|
           if subscription.customer.organization.webhook_endpoints.any?
             SendWebhookJob.perform_later('subscription.termination_alert', subscription)

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -105,8 +105,8 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
             described_class.perform_now
           end
             .to have_enqueued_job(SendWebhookJob)
-              .with('subscription.termination_alert', Subscription)
-              .exactly(:once)
+            .with('subscription.termination_alert', Subscription)
+            .exactly(:once)
         end
       end
     end

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -42,9 +42,30 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
       end
     end
 
-    context 'when the same alert webhook had been already triggered' do
+    context 'when current date is 45 before subscription ending_at' do
+      it 'sends webhook that subscription is going to be terminated for the right subscriptions' do
+        current_date = ending_at - 45.days
+
+        travel_to(current_date) do
+          expect do
+            described_class.perform_now
+          end
+            .to have_enqueued_job(SendWebhookJob)
+            .with('subscription.termination_alert', Subscription)
+            .exactly(:once)
+        end
+      end
+    end
+
+    context 'when the same alert webhook had been already triggered on the same day' do
       let(:webhook_alert1) do
-        create(:webhook, :succeeded, object_id: subscription1.id, webhook_type: 'subscription.termination_alert')
+        create(
+          :webhook,
+          :succeeded,
+          object_id: subscription1.id,
+          webhook_type: 'subscription.termination_alert',
+          created_at: Time.current + 2.months,
+        )
       end
 
       before { webhook_alert1 }
@@ -63,14 +84,20 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
       end
     end
 
-    context 'with customer timezone' do
-      let(:ending_at) { DateTime.parse('2022-10-21 00:30:00') }
-
-      before do
-        subscription1.customer.update!(timezone: 'America/New_York')
+    context 'when the same alert webhook has already been triggered 30 days ago' do
+      let(:webhook_alert1) do
+        create(
+          :webhook,
+          :succeeded,
+          object_id: subscription1.id,
+          webhook_type: 'subscription.termination_alert',
+          created_at: ending_at - 45.days,
+        )
       end
 
-      it 'takes timezone into account' do
+      before { webhook_alert1 }
+
+      it 'sends webhook that subscription is going to be terminated for the right subscriptions' do
         current_date = ending_at - 15.days
 
         travel_to(current_date) do
@@ -78,8 +105,8 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
             described_class.perform_now
           end
             .to have_enqueued_job(SendWebhookJob)
-            .with('subscription.termination_alert', Subscription)
-            .exactly(0).times
+              .with('subscription.termination_alert', Subscription)
+              .exactly(:once)
         end
       end
     end


### PR DESCRIPTION
## Context

The goal of this PR is to extend logic for termination alert webhook. We want to trigger this webhook not only 15 days before subscription ending but also 45 days before.

