### PR TITLE
feat(override-plan): Discard plan and children

### DIFF
--- a/app/jobs/plans/destroy_job.rb
+++ b/app/jobs/plans/destroy_job.rb
@@ -5,6 +5,11 @@ module Plans
     queue_as 'default'
 
     def perform(plan)
+      plan.children.each do |children_plan|
+        children_result = Plans::DestroyService.call(plan: children_plan)
+        children_result.raise_if_error!
+      end
+
       result = Plans::DestroyService.call(plan:)
       result.raise_if_error!
     end

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -101,6 +101,7 @@ module Plans
           nb_graduated_charges: count_by_charge_model['graduated'] || 0,
           nb_package_charges: count_by_charge_model['package'] || 0,
           organization_id: plan.organization_id,
+          parent_id: plan.parent_id,
         },
       )
     end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -30,7 +30,7 @@ module Subscriptions
       ActiveRecord::Base.transaction do
         currency_result = Customers::UpdateService.new(nil).update_currency(
           customer:,
-          currency: plan.amount_currency,
+          currency: params.dig(:plan_overrides, :amount_currency) || plan.amount_currency,
         )
         return currency_result unless currency_result.success?
 
@@ -120,7 +120,7 @@ module Subscriptions
 
       new_subscription = Subscription.new(
         customer:,
-        plan:,
+        plan: params.key?(:plan_overrides) ? override_plan(plan) : plan,
         name:,
         external_id: current_subscription.external_id,
         previous_subscription_id: current_subscription.id,
@@ -180,7 +180,7 @@ module Subscriptions
       #       until the next billing day. The new subscription will become active at this date
       Subscription.create!(
         customer:,
-        plan:,
+        plan: params.key?(:plan_overrides) ? override_plan(plan) : plan,
         name:,
         external_id: current_subscription.external_id,
         previous_subscription_id: current_subscription.id,

--- a/spec/requests/api/v1/plans_spec.rb
+++ b/spec/requests/api/v1/plans_spec.rb
@@ -327,6 +327,13 @@ RSpec.describe Api::V1::PlansController, type: :request do
         .to change { plan.reload.pending_deletion }.from(false).to(true)
     end
 
+    it 'marks children plan as pending_deletion' do
+      children_plan = create(:plan, parent_id: plan.id)
+
+      expect { delete_with_token(organization, "/api/v1/plans/#{plan.code}") }
+        .to change { children_plan.reload.pending_deletion }.from(false).to(true)
+    end
+
     it 'returns deleted plan' do
       delete_with_token(organization, "/api/v1/plans/#{plan.code}")
 

--- a/spec/scenarios/delete_plan_spec.rb
+++ b/spec/scenarios/delete_plan_spec.rb
@@ -22,6 +22,7 @@ describe 'Delete Plan Scenarios', :scenarios, type: :request do
       )
 
       create(:standard_charge, plan:, billable_metric: metric, properties: { amount: '3' })
+      create(:plan, pay_in_advance: true, organization:, amount_cents: 1000, parent_id: plan.id)
     end
 
     subscription = customer.subscriptions.first
@@ -43,16 +44,20 @@ describe 'Delete Plan Scenarios', :scenarios, type: :request do
     jan20 = DateTime.new(2023, 1, 20)
 
     travel_to(jan20) do
+      overridden_plan = plan.children.first
       delete_plan(plan)
 
       # Plan is pending deletion
       expect(plan.reload).to be_pending_deletion
+      expect(overridden_plan.reload).to be_pending_deletion
 
       perform_all_enqueued_jobs
 
       # Plan is now discarded
       expect(plan.reload).not_to be_pending_deletion
+      expect(overridden_plan.reload).not_to be_pending_deletion
       expect(plan).to be_discarded
+      expect(overridden_plan).to be_discarded
 
       # Subscription is terminated
       expect(subscription.reload).to be_terminated

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe Plans::CreateService, type: :service do
           nb_graduated_charges: 1,
           nb_package_charges: 0,
           organization_id: plan.organization_id,
+          parent_id: nil,
         },
       )
     end


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

The goal of this PR is to:
- track overridden plans on Segment 
- be able to discard a plan and children
