### PR TITLE
feat(override-plan): Include overridden plans to plan's counters

### DIFF
--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -41,15 +41,10 @@ module Types
       end
 
       def subscriptions_count
-        object.subscriptions.count
-      end
+        count = object.subscriptions.count
+        return count unless object.children
 
-      def draft_invoices_count
-        object.subscriptions.joins(:invoices)
-          .merge(Invoice.draft)
-          .select(:invoice_id)
-          .distinct
-          .count
+        count + object.children.joins(:subscriptions).select('subscriptions.id').distinct.count
       end
     end
   end

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -44,10 +44,6 @@ module Types
         object.subscriptions.count
       end
 
-      def active_subscriptions_count
-        object.subscriptions.active.count
-      end
-
       def draft_invoices_count
         object.subscriptions.joins(:invoices)
           .merge(Invoice.draft)

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -75,16 +75,21 @@ class Plan < ApplicationRecord
     count = subscriptions.active.count
     return count unless children
 
-    count + children.joins(:subscriptions).where(subscriptions: { status: :active }).count
+    count + children.joins(:subscriptions).merge(Subscription.active).select('subscriptions.id').distinct.count
   end
 
   def customers_count
     count = subscriptions.active.select(:customer_id).distinct.count
     return count unless children
 
-    count + children.joins(:subscriptions).where(
-      subscriptions: { status: :active },
-    ).select('distinct(customer_id)').count
+    count + children.joins(:subscriptions).merge(Subscription.active).select(:customer_id).distinct.count
+  end
+
+  def draft_invoices_count
+    count = subscriptions.joins(:invoices).merge(Invoice.draft).select(:invoice_id).distinct.count
+    return count unless children
+
+    count + children.joins(:subscriptions).joins(:invoices).merge(Invoice.draft).select(:invoice_id).distinct.count
   end
 
   private

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -71,6 +71,13 @@ class Plan < ApplicationRecord
     amount_cents * 52
   end
 
+  def active_subscriptions_count
+    count = subscriptions.active.count
+    return count unless children
+
+    count + children.joins(:subscriptions).where(subscriptions: { status: :active }).count
+  end
+
   def customers_count
     count = subscriptions.active.select(:customer_id).distinct.count
     return count unless children

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -17,7 +17,7 @@ module V1
         pay_in_advance: model.pay_in_advance,
         bill_charges_monthly: model.bill_charges_monthly,
         customers_count: model.customers_count,
-        active_subscriptions_count:,
+        active_subscriptions_count: model.active_subscriptions_count,
         draft_invoices_count:,
         parent_id: model.parent_id,
       }
@@ -39,8 +39,11 @@ module V1
       ).serialize
     end
 
-    def active_subscriptions_count
-      model.subscriptions.active.count
+    def customers_count
+      customers_count = model.subscriptions.active.select(:customer_id).distinct.count
+      return customers_count unless model.children
+
+      customers_count + model.children.sum { |c| c.subscriptions.active.select(:customer_id).distinct.count }
     end
 
     def draft_invoices_count

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -18,7 +18,7 @@ module V1
         bill_charges_monthly: model.bill_charges_monthly,
         customers_count: model.customers_count,
         active_subscriptions_count: model.active_subscriptions_count,
-        draft_invoices_count:,
+        draft_invoices_count: model.draft_invoices_count,
         parent_id: model.parent_id,
       }
 
@@ -44,15 +44,6 @@ module V1
       return customers_count unless model.children
 
       customers_count + model.children.sum { |c| c.subscriptions.active.select(:customer_id).distinct.count }
-    end
-
-    def draft_invoices_count
-      model.subscriptions
-        .joins(:invoices)
-        .merge(Invoice.draft)
-        .select(:invoice_id)
-        .distinct
-        .count
     end
 
     def taxes

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -77,6 +77,18 @@ RSpec.describe Plan, type: :model do
     end
   end
 
+  describe '#active_subscriptions_count' do
+    let(:plan) { create(:plan) }
+
+    it 'returns the number of impacted customers' do
+      create(:subscription, plan:)
+      overridden_plan = create(:plan, parent_id: plan.id)
+      create(:subscription, plan: overridden_plan)
+
+      expect(plan.active_subscriptions_count).to eq(2)
+    end
+  end
+
   describe '#customers_count' do
     let(:customer) { create(:customer) }
     let(:plan) { create(:plan) }

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Plan, type: :model do
   describe '#active_subscriptions_count' do
     let(:plan) { create(:plan) }
 
-    it 'returns the number of impacted customers' do
+    it 'returns the number of active subscriptions' do
       create(:subscription, plan:)
       overridden_plan = create(:plan, parent_id: plan.id)
       create(:subscription, plan: overridden_plan)
@@ -100,6 +100,23 @@ RSpec.describe Plan, type: :model do
       create(:subscription, customer: customer2, plan: overridden_plan)
 
       expect(plan.customers_count).to eq(2)
+    end
+  end
+
+  describe '#draft_invoices_count' do
+    let(:plan) { create(:plan) }
+
+    it 'returns the number draft invoices' do
+      subscription = create(:subscription, plan:)
+      invoice = create(:invoice, :draft)
+      create(:invoice_subscription, invoice:, subscription:)
+
+      overridden_plan = create(:plan, parent_id: plan.id)
+      subscription2 = create(:subscription, plan: overridden_plan)
+      invoice2 = create(:invoice, :draft)
+      create(:invoice_subscription, invoice: invoice2, subscription: subscription2)
+
+      expect(plan.draft_invoices_count).to eq(2)
     end
   end
 end

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ::V1::PlanSerializer do
       'pay_in_advance' => plan.pay_in_advance,
       'bill_charges_monthly' => plan.bill_charges_monthly,
       'customers_count' => 2,
-      'active_subscriptions_count' => 1,
+      'active_subscriptions_count' => 2,
       'draft_invoices_count' => 0,
       'parent_id' => nil,
       'taxes' => [],


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

The goal of this PR is to include overridden plans to plan's counters.
