### PR TITLE
misc: Add granular caching for current usage

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -5,8 +5,9 @@ module Api
     class EventsController < Api::BaseController
       def create
         # NOTE: Properties validations will be returned on the debugger.
-        validate_result = Events::CreateService.new.validate_params(
+        validate_result = Events::CreateService.new(
           organization: current_organization,
+        ).validate_params(
           params: create_params,
         )
         return render_error_response(validate_result) unless validate_result.success?

--- a/app/jobs/events/create_job.rb
+++ b/app/jobs/events/create_job.rb
@@ -5,8 +5,9 @@ module Events
     queue_as :default
 
     def perform(organization, params, timestamp, metadata)
-      result = Events::CreateService.new.call(
+      result = Events::CreateService.new(
         organization:,
+      ).call(
         params:,
         timestamp: Time.zone.at(timestamp.to_f),
         metadata:,

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -27,32 +27,30 @@ module Invoices
       result
     end
 
-    # NOTE: Since computing customer usage could take some time as it as to
-    #       loop over a lot of records in database, the result is stored in a cache store.
-    #       - The cache expiration is at most, the end date of the billing period
-    #         + 1 day to handle cache generated on the last billing period
-    #       - The cache key includes the customer id and the creation date of the last customer event
-    def compute_usage
-      Rails.cache.fetch(current_cache_key, expires_in: cache_expiration) do
-        @invoice = Invoice.new(
-          organization: subscription.organization,
-          customer: subscription.customer,
-          issuing_date: boundaries[:issuing_date],
-          currency: plan.amount_currency,
-        )
-
-        add_charge_fees
-        compute_amounts
-
-        format_usage
-      end
-    end
-
     private
 
     attr_reader :invoice, :subscription
 
     delegate :plan, to: :subscription
+
+    # NOTE: Since computing customer usage could take some time as it as to
+    #       loop over a lot of records in database, the result is stored in a cache store.
+    #       - Each charge result is stored in its own fragmented cache
+    #       - The cache expiration is set to the end of the billing period
+    #       - Cache will be automatically cleared if a new event is sent for a specific charge
+    def compute_usage
+      @invoice = Invoice.new(
+        organization: subscription.organization,
+        customer: subscription.customer,
+        issuing_date: boundaries[:issuing_date],
+        currency: plan.amount_currency,
+      )
+
+      add_charge_fees
+      compute_amounts
+
+      format_usage
+    end
 
     def customer(customer_id: nil)
       @customer ||= Customer.find_by(
@@ -65,15 +63,21 @@ module Invoices
       query = subscription.plan.charges.joins(:billable_metric)
         .order(Arel.sql('lower(unaccent(billable_metrics.name)) ASC'))
 
-      query.each do |charge|
+      query.each { |charge| invoice.fees << charge_usage(charge) }
+    end
+
+    def charge_usage(charge)
+      json = Rails.cache.fetch(charge_cache_key(charge), expires_in: charge_cache_expiration) do
         fees_result = Fees::ChargeService.new(
           invoice:, charge:, subscription:, boundaries:,
         ).current_usage
 
         fees_result.raise_if_error!
 
-        invoice.fees << fees_result.fees
+        fees_result.fees.to_json
       end
+
+      JSON.parse(json).map { |j| Fee.new(j) }
     end
 
     def boundaries
@@ -109,36 +113,17 @@ module Invoices
       invoice.total_amount_cents = invoice.fees_amount_cents + invoice.taxes_amount_cents
     end
 
-    def current_cache_key
-      return @current_cache_key if @current_cache_key
-
-      last_events = subscription.events.order(created_at: :desc).first(2).pluck(:created_at)
-      expire_cache(cache_key(last_events[1])) if last_events.count > 1
-      last_created_at = last_events.first || subscription.created_at
-
-      @current_cache_key = cache_key(last_created_at)
-    end
-
-    def cache_key(date)
-      # NOTE: charges_to_date is used in key to make sure the cache is reseted when a new
-      #       billing period starts
+    def charge_cache_key(charge)
       [
-        'current_usage',
-        "#{subscription.id}-#{boundaries[:charges_to_datetime].to_date.iso8601}-#{date.iso8601}",
-        plan.updated_at.iso8601,
+        'charge-usage',
+        charge.id,
+        subscription.id,
+        charge.updated_at.iso8601,
       ].join('/')
     end
 
-    def expire_cache(key)
-      Rails.cache.delete(key)
-    end
-
-    def cache_expiration
-      expiration = (boundaries[:charges_to_datetime].to_date - Time.zone.today).to_i + 1
-      return 1.day if expiration < 1
-      return 4.days if expiration > 4
-
-      expiration.days
+    def charge_cache_expiration
+      (boundaries[:charges_to_datetime] - Time.current).to_i.seconds
     end
 
     def format_usage

--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class ChargeCacheService < BaseService
+    def initialize(subscription:, charge:)
+      @subscription = subscription
+      @charge = charge
+
+      super
+    end
+
+    def cache_key
+      [
+        'charge-usage',
+        charge.id,
+        subscription.id,
+        charge.updated_at.iso8601,
+      ].join('/')
+    end
+
+    def expire_cache
+      Rails.cache.delete(cache_key)
+    end
+
+    private
+
+    attr_reader :subscription, :charge
+  end
+end

--- a/spec/jobs/events/create_job_spec.rb
+++ b/spec/jobs/events/create_job_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe Events::CreateJob, type: :job do
   let(:metadata) { { user_agent: 'Lago Ruby v0.0.1', ip_address: '182.11.32.11' } }
 
   it 'calls the event service' do
-    allow(Events::CreateService).to receive(:new).and_return(create_service)
+    allow(Events::CreateService).to receive(:new)
+      .with(organization:)
+      .and_return(create_service)
     allow(create_service).to receive(:call)
-      .with(organization:, params:, timestamp: Time.zone.at(timestamp), metadata:)
+      .with(params:, timestamp: Time.zone.at(timestamp), metadata:)
       .and_return(result)
 
     described_class.perform_now(organization, params, timestamp, metadata)


### PR DESCRIPTION
## Context

Current usage caching is not optimal as it is implemented today.

it keeps the cache for 4 days maximum and expires as soon as a new event is received for a subscription.

## Description

This PR changes the approach by: 
- caching the results at charge level
- keeping it until the end of the billing period
- cleaning automatically the charge cache when a new event matching this charge is received
