### PR TITLE
feat(event): Add logical separation between application and events databases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ group :development, :test do
 end
 
 group :test do
+  gem 'database_cleaner-active_record'
   gem 'rspec-graphql_matchers'
   gem 'shoulda-matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,10 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    database_cleaner-active_record (2.1.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.3.3)
     debug (1.6.2)
       irb (>= 1.3.6)
@@ -475,6 +479,7 @@ DEPENDENCIES
   clockwork-test
   coffee-rails
   countries
+  database_cleaner-active_record
   debug
   discard (~> 1.2)
   dotenv

--- a/app/graphql/resolvers/events_resolver.rb
+++ b/app/graphql/resolvers/events_resolver.rb
@@ -15,25 +15,9 @@ module Resolvers
     def resolve(page: nil, limit: nil)
       validate_organization!
 
-      current_organization.events
-        .order(timestamp: :desc)
+      Event.where(organization_id: current_organization.id)
         .includes(:customer)
-        .joins('LEFT OUTER JOIN billable_metrics ON billable_metrics.code = events.code')
-        .where(billable_metrics: { deleted_at: nil })
-        .where(
-          [
-            'billable_metrics.organization_id = ?',
-            'billable_metrics.organization_id IS NULL',
-          ].join(' OR '),
-          current_organization.id,
-        )
-        .select(
-          [
-            'events.*',
-            'billable_metrics.name as billable_metric_name',
-            'billable_metrics.field_name as billable_metric_field_name',
-          ].join(','),
-        )
+        .order(timestamp: :desc)
         .page(page)
         .per(limit)
     end

--- a/app/graphql/types/events/object.rb
+++ b/app/graphql/types/events/object.rb
@@ -48,17 +48,22 @@ module Types
       end
 
       def match_billable_metric
-        object.billable_metric_name.present?
+        object.billable_metric.present?
       end
 
       def match_custom_field
-        return true if object.billable_metric_field_name.blank?
+        return true if object.billable_metric.blank?
+        return true if object.billable_metric.field_name.blank?
 
-        object.properties.key?(object.billable_metric_field_name)
+        object.properties.key?(object.billable_metric.field_name)
       end
 
       def customer_timezone
         object.customer.applicable_timezone
+      end
+
+      def billable_metric_name
+        object.billable_metric&.name
       end
     end
   end

--- a/app/jobs/billable_metrics/delete_events_job.rb
+++ b/app/jobs/billable_metrics/delete_events_job.rb
@@ -9,9 +9,10 @@ module BillableMetrics
 
       deleted_at = Time.current
 
-      Event.joins(subscription: [:plan]).where(
-        code: metric.code,
-        plan: { id: Charge.with_discarded.where(billable_metric_id: metric.id).pluck(:plan_id) },
+      Event.where(
+        subscription_id: Charge.with_discarded
+          .where(billable_metric_id: metric.id)
+          .joins(plan: :subscriptions).pluck('subscriptions.id'),
       ).update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations
 
       metric.quantified_events.update_all(deleted_at:) # rubocop:disable Rails/SkipsModelValidations

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Event < ApplicationRecord
+class Event < EventsRecord
   include Discard::Model
   self.discard_column = :deleted_at
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -27,4 +27,8 @@ class Event < EventsRecord
   def ip_address
     metadata['ip_address']
   end
+
+  def billable_metric
+    @billable_metric ||= organization.billable_metrics.find_by(code:)
+  end
 end

--- a/app/models/events_record.rb
+++ b/app/models/events_record.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class EventsRecord < ApplicationRecord
+  self.abstract_class = true
+
+  connects_to database: { writing: :primary, reading: :events }
+end

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -50,9 +50,13 @@ module BillableMetrics
       end
 
       def recurring_events_scope(to_datetime:, from_datetime: nil)
-        events = customer.events
-          .joins(:subscription)
-          .where(subscription: { external_id: subscription.external_id })
+        subscription_ids = customer.subscriptions
+          .where(external_id: subscription.external_id)
+          .pluck(:id)
+
+        events = Event
+          .where(customer_id: customer.id)
+          .where(subscription_id: subscription_ids)
           .where(code: billable_metric.code)
           .to_datetime(to_datetime)
         events = events.from_datetime(from_datetime) unless from_datetime.nil?

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,23 +2,49 @@ default: &default
   adapter: postgresql
 
 development:
-  <<: *default
-  host: localhost
-  username: lago
-  password: changeme
-  database: lago
-  port: 5432
+  primary:
+    <<: *default
+    host: localhost
+    username: lago
+    password: changeme
+    database: lago
+    port: 5432
+  events:
+    <<: *default
+    host: localhost
+    username: lago
+    password: changeme
+    database: lago
+    port: 5432
+    database_tasks: false
 
 test:
-  <<: *default
-  url: <%= ENV['DATABASE_TEST_URL'].presence || ENV['DATABASE_URL'] %>
+  primary:
+    <<: *default
+    url: <%= ENV['DATABASE_TEST_URL'].presence || ENV['DATABASE_URL'] %>
+  events:
+    <<: *default
+    url: <%= ENV['DATABASE_TEST_URL'].presence || ENV['DATABASE_URL'] %>
+    database_tasks: false
 
 staging:
-  <<: *default
-  url: <%= ENV['DATABASE_URL'] %>
+  primary:
+    <<: *default
+    url: <%= ENV['DATABASE_URL'] %>
+  events:
+    <<: *default
+    url: <%= ENV['DATABASE_URL'] %>
+    database_tasks: false
 
 production:
-  <<: *default
-  url: <%= ENV['DATABASE_URL'] %>
-  pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
-  prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
+  primary:
+    <<: *default
+    url: <%= ENV['DATABASE_URL'] %>
+    pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
+    prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
+  events:
+    <<: *default
+    url: <%= ENV['DATABASE_URL'] %>
+    pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
+    prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
+    database_tasks: false

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -2,9 +2,9 @@
 
 FactoryBot.define do
   factory :event do
-    organization
-    customer
-    subscription
+    organization_id { create(:organization).id }
+    customer_id { create(:customer).id }
+    subscription_id { create(:subscription).id }
 
     transaction_id { SecureRandom.uuid }
     code { Faker::Name.name.underscore }

--- a/spec/graphql/resolvers/events_resolver_spec.rb
+++ b/spec/graphql/resolvers/events_resolver_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Resolvers::EventsResolver, type: :graphql do
+RSpec.describe Resolvers::EventsResolver, type: :graphql, transaction: false do
   let(:query) do
     <<~GQL
       query {

--- a/spec/jobs/billable_metrics/delete_events_job_spec.rb
+++ b/spec/jobs/billable_metrics/delete_events_job_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BillableMetrics::DeleteEventsJob, type: :job do
+RSpec.describe BillableMetrics::DeleteEventsJob, type: :job, transaction: false do
   let(:billable_metric) { create(:billable_metric, :deleted) }
   let(:subscription) { create(:subscription) }
 

--- a/spec/jobs/billable_metrics/delete_events_job_spec.rb
+++ b/spec/jobs/billable_metrics/delete_events_job_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe BillableMetrics::DeleteEventsJob, type: :job, transaction: false 
 
   it 'deletes related events' do
     create(:standard_charge, plan: subscription.plan, billable_metric:)
-    event = create(:event, code: billable_metric.code, subscription:)
+    event = create(:event, code: billable_metric.code, subscription_id: subscription.id)
     quantified_event = create(:quantified_event, billable_metric:)
 
     freeze_time do

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Invoice, type: :model do
     let(:invoice) { invoice_subscription.invoice }
     let(:subscription) { invoice_subscription.subscription }
     let(:timestamp) { DateTime.parse('2023-07-25 00:00:00 UTC') }
-    let(:event) { create(:event, subscription:, timestamp:) }
+    let(:event) { create(:event, subscription_id: subscription.id, timestamp:) }
     let(:billable_metric) { create(:sum_billable_metric, organization: subscription.organization, recurring: true) }
     let(:fee) { create(:charge_fee, subscription:, invoice:, charge:, pay_in_advance_event_id: event.id) }
     let(:charge) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ require_relative '../config/environment'
 require 'spec_helper'
 require 'simplecov'
 
+DatabaseCleaner.allow_remote_database_url = true
+
 SimpleCov.start do
   enable_coverage :branch
 
@@ -39,6 +41,7 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include GraphQLHelper, type: :graphql
@@ -54,7 +57,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false

--- a/spec/scenarios/billable_metrics/weighted_sum_spec.rb
+++ b/spec/scenarios/billable_metrics/weighted_sum_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request do
+describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request, transaction: false do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/scenarios/invoices_spec.rb
+++ b/spec/scenarios/invoices_spec.rb
@@ -428,8 +428,8 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 17 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 17)) do
-        create(:event, subscription:, code: metric.code)
-        create(:event, subscription:, code: metric.code)
+        create(:event, subscription_id: subscription.id, code: metric.code)
+        create(:event, subscription_id: subscription.id, code: metric.code)
 
         expect {
           refresh_invoice(subscription_invoice)
@@ -512,7 +512,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 17 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 17)) do
-        create(:event, subscription:, code: metric.code)
+        create(:event, subscription_id: subscription.id, code: metric.code)
 
         expect {
           refresh_invoice(subscription_invoice)
@@ -593,7 +593,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 16 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 16)) do
-        create(:event, subscription:, code: metric.code)
+        create(:event, subscription_id: subscription.id, code: metric.code)
 
         # Paid in advance invoice amount does not change.
         expect {
@@ -603,7 +603,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 17 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 17)) do
-        create(:event, subscription:, code: metric.code)
+        create(:event, subscription_id: subscription.id, code: metric.code)
 
         # Paid in advance invoice amount does not change.
         expect {
@@ -620,7 +620,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         expect(new_invoice.total_amount_cents).to eq(1440) # (1000 + 200) * 1.2
 
         # Create event for Dec 18.
-        create(:event, subscription:, timestamp: DateTime.new(2022, 12, 18), code: metric.code)
+        create(:event, subscription_id: subscription.id, timestamp: DateTime.new(2022, 12, 18), code: metric.code)
 
         # Paid in advance invoice amount does not change.
         expect {

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Pay in advance charges Scenarios', :scenarios, type: :request do
+describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transaction: false do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -100,7 +100,15 @@ RSpec.describe ::V1::FeeSerializer do
     let(:plan) { create(:plan, organization:) }
     let(:subscription) { create(:subscription, customer:, organization:, plan:) }
     let(:charge) { create(:standard_charge, :pay_in_advance, plan:) }
-    let(:event) { create(:event, subscription:, organization:, customer:) }
+
+    let(:event) do
+      create(
+        :event,
+        subscription_id: subscription.id,
+        organization_id: organization.id,
+        customer_id: customer.id,
+      )
+    end
 
     let(:fee) do
       create(:charge_fee, pay_in_advance: true, subscription:, charge:, pay_in_advance_event_id: event.id)

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
   end
 
   context 'when pay_in_advance aggregation' do
-    let(:pay_in_advance_event) { create(:event, subscription:, customer:) }
+    let(:pay_in_advance_event) { create(:event, subscription_id: subscription.id, customer_id: customer.id) }
 
     it 'assigns an pay_in_advance aggregation' do
       result = count_service.aggregate

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BillableMetrics::Aggregations::SumService, type: :service do
+RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transaction: false do
   subject(:sum_service) do
     described_class.new(
       billable_metric:,

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service do
+RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service, transaction: false do
   subject(:count_service) do
     described_class.new(
       billable_metric:,

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service do
+RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service, transaction: false do
   subject(:aggregator) do
     described_class.new(
       billable_metric:,

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BillableMetrics::Breakdown::SumService, type: :service do
+RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transaction: false do
   subject(:service) do
     described_class.new(
       billable_metric:,

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service do
+RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service, transaction: false do
   subject(:sum_service) do
     described_class.new(
       billable_metric:,

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: :service do
+RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: :service, transaction: false do
   subject(:unique_count_service) do
     described_class.new(
       billable_metric:,

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
   let(:charge) { create(:standard_charge, billable_metric:) }
   let(:group) { create(:group) }
   let(:aggregation_type) { 'count_agg' }
-  let(:event) { create(:event, subscription:) }
+  let(:event) { create(:event, subscription_id: subscription.id) }
   let(:properties) { {} }
 
   let(:subscription) do

--- a/spec/services/events/validate_creation_service_spec.rb
+++ b/spec/services/events/validate_creation_service_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Events::ValidateCreationService, type: :service do
       end
 
       context 'when transaction_id is already used' do
-        before { create(:event, transaction_id:, subscription:, organization:) }
+        before { create(:event, transaction_id:, subscription_id: subscription.id, organization_id: organization.id) }
 
         it 'returns a validation error' do
           validate_event

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -15,8 +15,16 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
   let(:group) { nil }
 
   let(:charge) { create(:standard_charge, :pay_in_advance, billable_metric:, plan:) }
-  let(:event) { create(:event, subscription:, customer:, organization:) }
   let(:estimate) { false }
+
+  let(:event) do
+    create(
+      :event,
+      subscription_id: subscription.id,
+      customer_id: customer.id,
+      organization_id: organization.id,
+    )
+  end
 
   before { tax }
 

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -14,8 +14,16 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
   let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:active_subscription, organization:, customer:, plan:) }
   let(:charge) { create(:standard_charge, :pay_in_advance, billable_metric:, plan:) }
-  let(:event) { create(:event, subscription:, customer:, organization:) }
   let(:group) { nil }
+
+  let(:event) do
+    create(
+      :event,
+      subscription_id: subscription.id,
+      customer_id: customer.id,
+      organization_id: organization.id,
+    )
+  end
 
   before { create(:tax, organization:, applied_to_organization: true) }
 
@@ -167,8 +175,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
     end
 
     context 'with customer timezone' do
-      before { customer.update!(timezone: 'America/Los_Angeles') }
-
+      let(:customer) { create(:customer, organization:, timezone: 'America/Los_Angeles') }
       let(:timestamp) { DateTime.parse('2022-11-25 01:00:00') }
 
       it 'assigns the issuing date in the customer timezone' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,4 +12,23 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # NOTE: Database cleaner config to turn off/on transactional mode
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:deletion)
+  end
+
+  config.before do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, transaction: false) do
+    DatabaseCleaner.strategy = :deletion
+  end
+
+  config.around do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 end


### PR DESCRIPTION
## Context

On the path for high volume improvements, we need to adapt the structure of the events table for better performance.

## Description

This PR:
- Adds the configuration for a proper events database
- Sends all Event.read queries to the event database
- Clean event related queries to rely on IDs and not Active Record models