### PR TITLE
feat (graduated-prorated): add logic for graduated prorated charge model

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -115,7 +115,7 @@ class Charge < ApplicationRecord
 
     unless billable_metric.weighted_sum_agg?
       return if billable_metric.recurring? && pay_in_advance? && standard?
-      return if billable_metric.recurring? && !pay_in_advance? && (standard? || volume?)
+      return if billable_metric.recurring? && !pay_in_advance? && (standard? || volume? || graduated?)
     end
 
     errors.add(:prorated, :invalid_billable_metric_or_charge_model)

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -86,7 +86,11 @@ module BillableMetrics
       end
 
       def compute_per_event_aggregation
-        events_scope(from_datetime:, to_datetime:).pluck(Arel.sql("COALESCE((#{sanitized_field_name})::numeric, 0)"))
+        if billable_metric.recurring?
+          recurring_events_scope(to_datetime:).pluck(Arel.sql("COALESCE((#{sanitized_field_name})::numeric, 0)"))
+        else
+          events_scope(from_datetime:, to_datetime:).pluck(Arel.sql("COALESCE((#{sanitized_field_name})::numeric, 0)"))
+        end
       end
 
       protected

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -86,11 +86,7 @@ module BillableMetrics
       end
 
       def compute_per_event_aggregation
-        if billable_metric.recurring?
-          recurring_events_scope(to_datetime:).pluck(Arel.sql("COALESCE((#{sanitized_field_name})::numeric, 0)"))
-        else
-          events_scope(from_datetime:, to_datetime:).pluck(Arel.sql("COALESCE((#{sanitized_field_name})::numeric, 0)"))
-        end
+        events_scope(from_datetime:, to_datetime:).pluck(Arel.sql("COALESCE((#{sanitized_field_name})::numeric, 0)"))
       end
 
       protected

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -104,6 +104,13 @@ module BillableMetrics
         ((to_datetime.to_time - from_datetime.to_time) / 1.day).ceil.fdiv(period_duration)
       end
 
+      def per_event_aggregation
+        Result.new.tap do |result|
+          result.event_aggregation = base_aggregator.compute_per_event_aggregation
+          result.event_prorated_aggregation = compute_per_event_prorated_aggregation
+        end
+      end
+
       private
 
       attr_reader :base_aggregator

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -105,15 +105,30 @@ module BillableMetrics
       end
 
       def per_event_aggregation
+        recurring_value = previous_charge_fee&.units
+        recurring_aggregation = recurring_value ? [BigDecimal(recurring_value) * persisted_pro_rata] : []
+
         Result.new.tap do |result|
-          result.event_aggregation = base_aggregator.compute_per_event_aggregation
-          result.event_prorated_aggregation = compute_per_event_prorated_aggregation
+          result.event_aggregation = recurring_aggregation + base_aggregator.compute_per_event_aggregation
+          result.event_prorated_aggregation = recurring_aggregation + compute_per_event_prorated_aggregation
         end
       end
 
       private
 
       attr_reader :base_aggregator
+
+      def previous_charge_fee
+        subscription_ids = customer.subscriptions
+          .where(external_id: subscription.external_id)
+          .pluck(:id)
+
+        Fee.joins(:charge)
+          .where(charge: { billable_metric_id: billable_metric.id })
+          .where(subscription_id: subscription_ids, fee_type: :charge, group_id: group&.id)
+          .order(created_at: :desc)
+          .first
+      end
     end
   end
 end

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -127,6 +127,7 @@ module BillableMetrics
           .where(charge: { billable_metric_id: billable_metric.id })
           .where(charge: { prorated: true })
           .where(subscription_id: subscription_ids, fee_type: :charge, group_id: group&.id)
+          .where("CAST(fees.properties->>'charges_to_datetime' AS timestamp) < ?", boundaries[:to_datetime])
           .order(created_at: :desc)
           .first
       end

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -125,6 +125,7 @@ module BillableMetrics
 
         Fee.joins(:charge)
           .where(charge: { billable_metric_id: billable_metric.id })
+          .where(charge: { prorated: true })
           .where(subscription_id: subscription_ids, fee_type: :charge, group_id: group&.id)
           .order(created_at: :desc)
           .first

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -42,7 +42,7 @@ module BillableMetrics
           .pluck(
             Arel.sql(
               "(COALESCE((#{sanitized_field_name})::numeric, 0)) * "\
-              "(#{duration_ratio_sql('events.timestamp', to_datetime)})::numeric"
+              "(#{duration_ratio_sql('events.timestamp', to_datetime)})::numeric",
             ),
           )
 

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -40,8 +40,10 @@ module BillableMetrics
 
         period_events = period_query
           .pluck(
-            Arel.sql("(COALESCE((#{sanitized_field_name})::numeric, 0)) * "\
-                     "(#{duration_ratio_sql('events.timestamp', to_datetime)})::numeric"),
+            Arel.sql(
+              "(COALESCE((#{sanitized_field_name})::numeric, 0)) * "\
+              "(#{duration_ratio_sql('events.timestamp', to_datetime)})::numeric"
+            ),
           )
 
         persisted_events + period_events

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -36,10 +36,11 @@ module BillableMetrics
         persisted_events = persisted_query
           .pluck(Arel.sql("(COALESCE((#{sanitized_field_name})::numeric, 0)) * (#{persisted_pro_rata})::numeric"))
 
-          # NOTE: Added during the period
         period_events = period_query
-          .pluck(Arel.sql("(COALESCE((#{sanitized_field_name})::numeric, 0)) * "\
-                 "(#{duration_ratio_sql('events.timestamp', to_datetime)})::numeric"))
+          .pluck(
+            Arel.sql("(COALESCE((#{sanitized_field_name})::numeric, 0)) * "\
+                     "(#{duration_ratio_sql('events.timestamp', to_datetime)})::numeric")
+          )
 
         persisted_events + period_events
       end

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -39,7 +39,7 @@ module BillableMetrics
         period_events = period_query
           .pluck(
             Arel.sql("(COALESCE((#{sanitized_field_name})::numeric, 0)) * "\
-                     "(#{duration_ratio_sql('events.timestamp', to_datetime)})::numeric")
+                     "(#{duration_ratio_sql('events.timestamp', to_datetime)})::numeric"),
           )
 
         persisted_events + period_events

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -34,7 +34,9 @@ module BillableMetrics
 
       def compute_per_event_prorated_aggregation
         persisted_events = persisted_query
-          .pluck(Arel.sql("(COALESCE((#{sanitized_field_name})::numeric, 0)) * (#{persisted_pro_rata})::numeric"))
+          .pluck(
+            Arel.sql("(COALESCE((#{sanitized_field_name})::numeric, 0)) * (#{persisted_pro_rata})::numeric"),
+          )
 
         period_events = period_query
           .pluck(

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -17,7 +17,6 @@ module BillableMetrics
 
         aggregation = compute_aggregation.ceil(5)
         result.full_units_number = aggregation_without_proration.aggregation if event.nil?
-        result.recurring_updated_at = from_datetime if event.nil?
 
         if options[:is_current_usage]
           handle_current_usage(aggregation, options[:is_pay_in_advance])

--- a/app/services/charges/charge_models/prorated_graduated_service.rb
+++ b/app/services/charges/charge_models/prorated_graduated_service.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Charges
+  module ChargeModels
+    class ProratedGraduatedService < Charges::ChargeModels::BaseService
+      protected
+
+      def ranges
+        properties['graduated_ranges']&.map(&:with_indifferent_access)
+      end
+
+      def compute_amount
+        full_units = per_event_aggregation_result.event_aggregation
+        prorated_units = per_event_aggregation_result.event_prorated_aggregation
+
+        index = 0
+        full_sum = 0
+        overflow = 0
+        ranges.reduce(0) do |result_amount, range|
+          prorated_sum = 0
+          flat_amount = BigDecimal(range[:flat_amount])
+          per_unit_amount = BigDecimal(range[:per_unit_amount])
+
+          # NOTE: Add flat amount to the total
+          result_amount += flat_amount unless units.zero?
+
+          # Calculate prorated value inside the range. Which events are taken into account
+          # for certain range depends on comparing full number of units and range boundaries
+          while true
+            # Overflow can happen in scenarios where event covers part of lower range and part of higher range.
+            # Here is applied overflow from previous range
+            unless overflow.zero?
+              prorated_coefficient = prorated_units[index - 1].fdiv(full_units[index - 1])
+              prorated_sum += overflow * prorated_coefficient
+              full_sum += overflow
+              overflow = 0
+            end
+
+            # If we are into highest range, the exit condition should happen only if iteration has been performed over
+            # all events in this range
+            if prorated_units[index].nil?
+              result_amount += prorated_sum * per_unit_amount
+
+              return result_amount
+            end
+
+            full_sum += full_units[index]
+            prorated_sum += prorated_units[index]
+
+            index += 1
+
+            # Calculating overflow if any and aligning current period with overflow amount
+            if range[:to_value] && full_sum >= range[:to_value]
+              overflow = full_sum - range[:to_value]
+              prorated_coefficient = prorated_units[index - 1].fdiv(full_units[index - 1])
+              prorated_sum -= overflow * prorated_coefficient
+              full_sum -= overflow
+
+              break
+            end
+          end
+
+          result_amount += prorated_sum * per_unit_amount
+
+          result_amount
+        end
+      end
+
+      def per_event_aggregation_result
+        @per_event_aggregation_result ||= aggregation_result.aggregator.per_event_aggregation
+      end
+    end
+  end
+end

--- a/app/services/charges/charge_models/prorated_graduated_service.rb
+++ b/app/services/charges/charge_models/prorated_graduated_service.rb
@@ -14,64 +14,101 @@ module Charges
         prorated_units = per_event_aggregation_result.event_prorated_aggregation
         units_count = prorated_units.count
         index = 0
-        full_sum = 0
         overflow = 0
+        full_sum = 0
+        prorated_sum = 0
+        result_amount = 0
 
-        # From each tier correct amounts need to be fetched
-        ranges.reduce(0) do |result_amount, range|
-          prorated_sum = 0
-          flat_amount = BigDecimal(range[:flat_amount])
-          per_unit_amount = BigDecimal(range[:per_unit_amount])
+        # Calculate total prorated value inside the tier. The goal is to iterate over both arrays (prorated and full)
+        # and determine which prorated events goes into certain tier. Full units sum determines tier while
+        # prorated units sum determines amount that is going to be used for price calculation inside the tier.
+        # Overflow can happen if event value covers partially both lower and higher tier
+        while (index < units_count) || !overflow.zero?
+          range = range(full_sum, overflow, full_units[index])
 
-          # NOTE: Add flat amount to the total
-          result_amount += flat_amount if !units.zero? && (!overflow.zero? || prorated_units[index])
+          # Here is applied overflow from previous iteration (if any)
+          unless overflow.zero?
+            prorated_sum += overflow * prorated_coefficient(prorated_units[index - 1], full_units[index - 1])
+            # This condition handles multiple overflows. E.g. We have two tiers: 0 - 5, 6 - inf.
+            # There is only one event whose value is 75. There will be overflow for each tier and we need to
+            # calculate it for each tier
+            if range[:to_value] && full_sum >= range[:to_value]
+              overflow = full_sum - range[:to_value]
+              prorated_sum -= overflow * prorated_coefficient(prorated_units[index - 1], full_units[index - 1])
+              result_amount += prorated_sum * BigDecimal(range[:per_unit_amount])
+              prorated_sum = 0
 
-          # Calculate total prorated value inside the tier. The goal is to iterate over both arrays (prorated and full)
-          # and determine which prorated events goes into certain tier. Full units sum determines tier while
-          # prorated units sum determines amount that is going to be used for price calculation inside the tier.
-          # Overflow can happen if event value covers partially both lower and higher tier
-          while (index < units_count) || !overflow.zero?
-            # Here is applied overflow from previous iteration (if any)
-            unless overflow.zero?
-              prorated_sum += overflow * prorated_coefficient(prorated_units[index - 1], full_units[index - 1])
-
-              # This condition handles multiple overflows. E.g. We have two tiers: 0 - 5, 6 - inf.
-              # There is only one event whose value is 75. There will be overflow for each tier and we need to
-              # calculate it for each tier
-              if range[:to_value] && full_sum >= range[:to_value]
-                overflow = full_sum - range[:to_value]
-                prorated_sum -= overflow * prorated_coefficient(prorated_units[index - 1], full_units[index - 1])
-
-                break
-              end
-
-              overflow = 0
+              next
             end
 
-            # If we are into highest range and overflow is handled we should exit the loop if there is no more events
-            break if prorated_units[index].nil?
-
-            full_sum += full_units[index]
-            prorated_sum += prorated_units[index]
-
-            index += 1
-
-            next unless range[:to_value] && full_sum >= range[:to_value]
-
-            # Calculating overflow (if any) and aligning current invalid prorated sum with prorated overflow amount
-            overflow = full_sum - range[:to_value]
-            prorated_sum -= overflow * prorated_coefficient(prorated_units[index - 1], full_units[index - 1])
-
-            break
+            overflow = 0
           end
 
-          result_amount += prorated_sum * per_unit_amount
+          # If we are into highest range and overflow is handled we should exit the loop if there is no more events
+          break if prorated_units[index].nil?
 
-          result_amount
+          full_sum += full_units[index]
+          prorated_sum += prorated_units[index]
+
+          index += 1
+
+          next if skip_overflow_calculation?(full_sum, range[:to_value], range[:from_value])
+
+          # Calculating overflow (if any) and aligning current invalid prorated sum with prorated overflow amount
+          overflow = calculate_overflow(full_sum, range[:to_value], range[:from_value])
+          prorated_sum -= overflow * prorated_coefficient(prorated_units[index - 1], full_units[index - 1])
+
+          result_amount += prorated_sum * BigDecimal(range[:per_unit_amount])
+          prorated_sum = 0
         end
+
+        result_amount += prorated_sum * BigDecimal(range[:per_unit_amount]) # Applying units from highest range
+
+        result_with_flat_amount(result_amount, full_sum)
       end
 
       private
+
+      def result_with_flat_amount(result, total_full_units)
+        return 0 if units.zero? || total_full_units <= 0
+
+        flat_amount = 0
+        result = 0 if result.negative?
+
+        ranges.each do |range|
+          flat_amount += BigDecimal(range[:flat_amount])
+
+          return result + flat_amount if range[:to_value].nil? || total_full_units <= range[:to_value]
+        end
+      end
+
+      def range(full_units, overflow, next_full_unit)
+        return ranges[0] if full_units <= 0
+
+        units = if overflow.zero?
+          full_units
+        else
+          overflow.positive? ? (full_units - overflow + 1) : (full_units + overflow)
+        end
+
+        ranges.each_with_index do |range, index|
+          return ranges[index + 1] if units == range[:to_value] && next_full_unit&.positive?
+          return range if units == range[:to_value]
+          return range if units >= range[:from_value] && (range[:to_value].nil? || units < range[:to_value])
+        end
+
+        ranges[0]
+      end
+
+      def calculate_overflow(full_sum, to_value, from_value)
+        return full_sum - from_value + 1 if to_value.nil?
+
+        if full_sum >= to_value
+          full_sum - to_value
+        else
+          full_sum - from_value + 1
+        end
+      end
 
       def per_event_aggregation_result
         @per_event_aggregation_result ||= aggregation_result.aggregator.per_event_aggregation
@@ -79,6 +116,12 @@ module Charges
 
       def prorated_coefficient(prorated_value, full_value)
         prorated_value.fdiv(full_value)
+      end
+
+      def skip_overflow_calculation?(full_sum, to_value, from_value)
+        return full_sum >= from_value - 1 if to_value.nil?
+
+        full_sum < to_value && full_sum >= from_value
       end
     end
   end

--- a/app/services/charges/charge_models/prorated_graduated_service.rb
+++ b/app/services/charges/charge_models/prorated_graduated_service.rb
@@ -16,8 +16,11 @@ module Charges
         index = 0
         overflow = 0
         full_sum = 0
+        max_full_sum = 0
         prorated_sum = 0
         result_amount = 0
+
+        return 0 if units.zero?
 
         # Calculate total prorated value inside the tier. The goal is to iterate over both arrays (prorated and full)
         # and determine which prorated events goes into certain tier. Full units sum determines tier while
@@ -48,6 +51,7 @@ module Charges
           break if prorated_units[index].nil?
 
           full_sum += full_units[index]
+          max_full_sum = full_sum if full_sum > max_full_sum
           prorated_sum += prorated_units[index]
 
           index += 1
@@ -64,13 +68,13 @@ module Charges
 
         result_amount += prorated_sum * BigDecimal(range[:per_unit_amount]) # Applying units from highest range
 
-        result_with_flat_amount(result_amount, full_sum)
+        result_with_flat_amount(result_amount, full_sum, max_full_sum)
       end
 
       private
 
-      def result_with_flat_amount(result, total_full_units)
-        return 0 if units.zero? || total_full_units <= 0
+      def result_with_flat_amount(result, total_full_units, max_full_units)
+        return 0 if units.zero? || total_full_units.negative?
 
         flat_amount = 0
         result = 0 if result.negative?
@@ -78,7 +82,7 @@ module Charges
         ranges.each do |range|
           flat_amount += BigDecimal(range[:flat_amount])
 
-          return result + flat_amount if range[:to_value].nil? || total_full_units <= range[:to_value]
+          return result + flat_amount if range[:to_value].nil? || max_full_units <= range[:to_value]
         end
       end
 

--- a/app/services/charges/charge_models/prorated_graduated_service.rb
+++ b/app/services/charges/charge_models/prorated_graduated_service.rb
@@ -33,6 +33,16 @@ module Charges
               prorated_coefficient = prorated_units[index - 1].fdiv(full_units[index - 1])
               prorated_sum += overflow * prorated_coefficient
               full_sum += overflow
+
+              if range[:to_value] && full_sum >= range[:to_value]
+                overflow = full_sum - range[:to_value]
+                prorated_coefficient = prorated_units[index - 1].fdiv(full_units[index - 1])
+                prorated_sum -= overflow * prorated_coefficient
+                full_sum -= overflow
+
+                break
+              end
+
               overflow = 0
             end
 

--- a/app/services/charges/charge_models/prorated_graduated_service.rb
+++ b/app/services/charges/charge_models/prorated_graduated_service.rb
@@ -12,10 +12,12 @@ module Charges
       def compute_amount
         full_units = per_event_aggregation_result.event_aggregation
         prorated_units = per_event_aggregation_result.event_prorated_aggregation
-
+        units_count = prorated_units.count
         index = 0
         full_sum = 0
         overflow = 0
+
+        # From each tier correct amounts need to be fetched
         ranges.reduce(0) do |result_amount, range|
           prorated_sum = 0
           flat_amount = BigDecimal(range[:flat_amount])
@@ -24,21 +26,21 @@ module Charges
           # NOTE: Add flat amount to the total
           result_amount += flat_amount if !units.zero? && (!overflow.zero? || prorated_units[index])
 
-          # Calculate prorated value inside the range. Which events are taken into account
-          # for certain range depends on comparing full number of units and range boundaries
-          loop do
-            # Overflow can happen in scenarios where event covers part of lower range and part of higher range.
-            # Here is applied overflow from previous range
+          # Calculate total prorated value inside the tier. The goal is to iterate over both arrays (prorated and full)
+          # and determine which prorated events goes into certain tier. Full units sum determines tier while
+          # prorated units sum determines amount that is going to be used for price calculation inside the tier.
+          # Overflow can happen if event value covers partially both lower and higher tier
+          while (index < units_count) || (!overflow.zero?)
+            # Here is applied overflow from previous iteration (if any)
             unless overflow.zero?
-              prorated_coefficient = prorated_units[index - 1].fdiv(full_units[index - 1])
-              prorated_sum += overflow * prorated_coefficient
-              full_sum += overflow
+              prorated_sum += overflow * prorated_coefficient(prorated_units[index - 1], full_units[index - 1])
 
+              # This condition handles multiple overflows. E.g. We have two tiers: 0 - 5, 6 - inf.
+              # There is only one event whose value is 75. There will be overflow for each tier and we need to
+              # calculate it for each tier
               if range[:to_value] && full_sum >= range[:to_value]
                 overflow = full_sum - range[:to_value]
-                prorated_coefficient = prorated_units[index - 1].fdiv(full_units[index - 1])
-                prorated_sum -= overflow * prorated_coefficient
-                full_sum -= overflow
+                prorated_sum -= overflow * prorated_coefficient(prorated_units[index - 1], full_units[index - 1])
 
                 break
               end
@@ -46,13 +48,8 @@ module Charges
               overflow = 0
             end
 
-            # If we are into highest range, the exit condition should happen only if iteration has been performed over
-            # all events in this range
-            if prorated_units[index].nil?
-              result_amount += prorated_sum * per_unit_amount
-
-              return result_amount
-            end
+            # If we are into highest range and overflow is handled we should exit the loop if there is no more events
+            break if prorated_units[index].nil?
 
             full_sum += full_units[index]
             prorated_sum += prorated_units[index]
@@ -61,13 +58,9 @@ module Charges
 
             next unless range[:to_value] && full_sum >= range[:to_value]
 
-            # Calculating overflow (if any) and aligning current invalid prorated sum with overflow amount
+            # Calculating overflow (if any) and aligning current invalid prorated sum with prorated overflow amount
             overflow = full_sum - range[:to_value]
-            prorated_coefficient = prorated_units[index - 1].fdiv(full_units[index - 1])
-            prorated_sum -= overflow * prorated_coefficient
-            full_sum -= overflow
-
-            break
+            prorated_sum -= overflow * prorated_coefficient(prorated_units[index - 1], full_units[index - 1])
           end
 
           result_amount += prorated_sum * per_unit_amount
@@ -76,8 +69,14 @@ module Charges
         end
       end
 
+      private
+
       def per_event_aggregation_result
         @per_event_aggregation_result ||= aggregation_result.aggregator.per_event_aggregation
+      end
+
+      def prorated_coefficient(prorated_value, full_value)
+        prorated_value.fdiv(full_value)
       end
     end
   end

--- a/app/services/charges/charge_models/prorated_graduated_service.rb
+++ b/app/services/charges/charge_models/prorated_graduated_service.rb
@@ -30,7 +30,7 @@ module Charges
           # and determine which prorated events goes into certain tier. Full units sum determines tier while
           # prorated units sum determines amount that is going to be used for price calculation inside the tier.
           # Overflow can happen if event value covers partially both lower and higher tier
-          while (index < units_count) || (!overflow.zero?)
+          while (index < units_count) || !overflow.zero?
             # Here is applied overflow from previous iteration (if any)
             unless overflow.zero?
               prorated_sum += overflow * prorated_coefficient(prorated_units[index - 1], full_units[index - 1])
@@ -61,6 +61,8 @@ module Charges
             # Calculating overflow (if any) and aligning current invalid prorated sum with prorated overflow amount
             overflow = full_sum - range[:to_value]
             prorated_sum -= overflow * prorated_coefficient(prorated_units[index - 1], full_units[index - 1])
+
+            break
           end
 
           result_amount += prorated_sum * per_unit_amount

--- a/app/services/charges/charge_models/prorated_graduated_service.rb
+++ b/app/services/charges/charge_models/prorated_graduated_service.rb
@@ -26,7 +26,7 @@ module Charges
 
           # Calculate prorated value inside the range. Which events are taken into account
           # for certain range depends on comparing full number of units and range boundaries
-          while true
+          loop do
             # Overflow can happen in scenarios where event covers part of lower range and part of higher range.
             # Here is applied overflow from previous range
             unless overflow.zero?
@@ -49,15 +49,15 @@ module Charges
 
             index += 1
 
-            # Calculating overflow if any and aligning current period with overflow amount
-            if range[:to_value] && full_sum >= range[:to_value]
-              overflow = full_sum - range[:to_value]
-              prorated_coefficient = prorated_units[index - 1].fdiv(full_units[index - 1])
-              prorated_sum -= overflow * prorated_coefficient
-              full_sum -= overflow
+            next unless range[:to_value] && full_sum >= range[:to_value]
 
-              break
-            end
+            # Calculating overflow (if any) and aligning current invalid prorated sum with overflow amount
+            overflow = full_sum - range[:to_value]
+            prorated_coefficient = prorated_units[index - 1].fdiv(full_units[index - 1])
+            prorated_sum -= overflow * prorated_coefficient
+            full_sum -= overflow
+
+            break
           end
 
           result_amount += prorated_sum * per_unit_amount

--- a/app/services/charges/charge_models/prorated_graduated_service.rb
+++ b/app/services/charges/charge_models/prorated_graduated_service.rb
@@ -22,7 +22,7 @@ module Charges
           per_unit_amount = BigDecimal(range[:per_unit_amount])
 
           # NOTE: Add flat amount to the total
-          result_amount += flat_amount unless units.zero?
+          result_amount += flat_amount if !units.zero? && (!overflow.zero? || prorated_units[index])
 
           # Calculate prorated value inside the range. Which events are taken into account
           # for certain range depends on comparing full number of units and range boundaries

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -174,7 +174,11 @@ module Fees
                       when :standard
                         Charges::ChargeModels::StandardService
                       when :graduated
-                        Charges::ChargeModels::GraduatedService
+                        if charge.prorated?
+                          Charges::ChargeModels::ProratedGraduatedService
+                        else
+                          Charges::ChargeModels::GraduatedService
+                        end
                       when :graduated_percentage
                         Charges::ChargeModels::GraduatedPercentageService
                       when :package

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -103,8 +103,8 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
           )
 
           fetch_current_usage(customer:)
-          expect(json[:customer_usage][:amount_cents].round(2)).to eq(17_300)
-          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(17_300)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(11_567)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(11_567)
           expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1.0')
         end
 
@@ -119,8 +119,8 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
           )
 
           fetch_current_usage(customer:)
-          expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_300)
-          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_300)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(17_967)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(17_967)
           expect(json[:customer_usage][:charges_usage][0][:units]).to eq('11.0')
         end
 
@@ -135,8 +135,8 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
           )
 
           fetch_current_usage(customer:)
-          expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_633)
-          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_633)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_300)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_300)
           expect(json[:customer_usage][:charges_usage][0][:units]).to eq('15.0')
         end
 
@@ -151,8 +151,8 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
           )
 
           fetch_current_usage(customer:)
-          expect(json[:customer_usage][:amount_cents].round(2)).to eq(19_033)
-          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(19_033)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_700)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_700)
           expect(json[:customer_usage][:charges_usage][0][:units]).to eq('75.0')
         end
 
@@ -165,7 +165,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
           invoice = subscription.invoices.first
 
           aggregate_failures do
-            expect(invoice.total_amount_cents).to eq(19_033)
+            expect(invoice.total_amount_cents).to eq(18_700)
             expect(subscription.reload.invoices.count).to eq(1)
           end
         end
@@ -306,8 +306,8 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             )
 
             fetch_current_usage(customer:)
-            expect(json[:customer_usage][:amount_cents].round(2)).to eq(19_033)
-            expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(19_033)
+            expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_700)
+            expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_700)
             expect(json[:customer_usage][:charges_usage][0][:units]).to eq('75.0')
           end
 
@@ -320,7 +320,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             invoice = subscription.invoices.first
 
             aggregate_failures do
-              expect(invoice.total_amount_cents).to eq(19_033)
+              expect(invoice.total_amount_cents).to eq(18_700)
               expect(subscription.reload.invoices.count).to eq(1)
             end
           end
@@ -392,7 +392,8 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
 
             invoice = subscription.invoices.order(created_at: :desc).first
             expect(invoice.fees.charge_kind.count).to eq(1)
-            expect(invoice.total_amount_cents).to eq(30_484) # 30226 + 2.58 (prorated event in termination period)
+            # 30226 (17 / 31 * 75 units) + 2.58 = 2 / 31 * 20 units (prorated event in termination period)
+            expect(invoice.total_amount_cents).to eq(30_484)
           end
 
           travel_to(DateTime.new(2023, 11, 1)) do

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -1,0 +1,399 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:, name: 'aaaaaabcd') }
+  let(:tax) { create(:tax, organization:, rate: 0) }
+
+  let(:plan) { create(:plan, organization:, amount_cents: 0) }
+  let(:billable_metric) { create(:billable_metric, recurring: true, organization:, aggregation_type:, field_name:) }
+
+  before { tax }
+
+  describe 'with sum_agg' do
+    let(:aggregation_type) { 'sum_agg' }
+    let(:field_name) { 'amount' }
+
+    describe 'three ranges and one overflow case' do
+      it 'returns the expected invoice and usage amounts' do
+        Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+        WebhookEndpoint.destroy_all
+
+        travel_to(DateTime.new(2023, 9, 1)) do
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code,
+            },
+          )
+        end
+
+        create(
+          :graduated_charge,
+          billable_metric:,
+          prorated: true,
+          plan:,
+          properties: {
+            graduated_ranges: [
+              {
+                from_value: 0,
+                to_value: 5,
+                per_unit_amount: '10',
+                flat_amount: '100',
+              },
+              {
+                from_value: 6,
+                to_value: 15,
+                per_unit_amount: '5',
+                flat_amount: '50',
+              },
+              {
+                from_value: 16,
+                to_value: nil,
+                per_unit_amount: '2',
+                flat_amount: '0',
+              },
+            ],
+          },
+        )
+
+        travel_to(DateTime.new(2023, 9, 10)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '2' },
+            },
+          )
+        end
+
+        travel_to(DateTime.new(2023, 9, 16)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '5' },
+            },
+          )
+        end
+
+        travel_to(DateTime.new(2023, 9, 20)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '-6' },
+            },
+          )
+        end
+
+        travel_to(DateTime.new(2023, 9, 25)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '10' },
+            },
+          )
+        end
+
+        travel_to(DateTime.new(2023, 9, 26)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '4' },
+            },
+          )
+        end
+
+        travel_to(DateTime.new(2023, 9, 30)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '60' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(19_033)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(19_033)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('75.0')
+        end
+
+        travel_to(DateTime.new(2023, 10, 1)) do
+          Subscriptions::BillingService.new.call
+
+          perform_all_enqueued_jobs
+
+          subscription = customer.subscriptions.first
+          invoice = subscription.invoices.first
+
+          aggregate_failures do
+            expect(invoice.total_amount_cents).to eq(19_033)
+            expect(subscription.reload.invoices.count).to eq(1)
+          end
+        end
+
+        travel_to(DateTime.new(2023, 10, 5)) do
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(37_000)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(37_000)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('75.0')
+        end
+
+        travel_to(DateTime.new(2023, 10, 17)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '20' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(38_935)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(38_935)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('95.0')
+        end
+      end
+
+      context 'when upgrade is performed' do
+        let(:plan_new) { create(:plan, organization:, amount_cents: 100) }
+
+        it 'returns expected invoice and usage amounts' do
+          Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+          WebhookEndpoint.destroy_all
+
+          travel_to(DateTime.new(2023, 9, 1)) do
+            create_subscription(
+              {
+                external_customer_id: customer.external_id,
+                external_id: customer.external_id,
+                plan_code: plan.code,
+              },
+            )
+          end
+
+          create(
+            :graduated_charge,
+            billable_metric:,
+            prorated: true,
+            plan:,
+            properties: {
+              graduated_ranges: [
+                {
+                  from_value: 0,
+                  to_value: 5,
+                  per_unit_amount: '10',
+                  flat_amount: '100',
+                },
+                {
+                  from_value: 6,
+                  to_value: 15,
+                  per_unit_amount: '5',
+                  flat_amount: '50',
+                },
+                {
+                  from_value: 16,
+                  to_value: nil,
+                  per_unit_amount: '2',
+                  flat_amount: '0',
+                },
+              ],
+            },
+          )
+
+          travel_to(DateTime.new(2023, 9, 10)) do
+            create_event(
+              {
+                code: billable_metric.code,
+                transaction_id: SecureRandom.uuid,
+                external_customer_id: customer.external_id,
+                properties: { amount: '2' },
+              },
+            )
+          end
+
+          travel_to(DateTime.new(2023, 9, 16)) do
+            create_event(
+              {
+                code: billable_metric.code,
+                transaction_id: SecureRandom.uuid,
+                external_customer_id: customer.external_id,
+                properties: { amount: '5' },
+              },
+            )
+          end
+
+          travel_to(DateTime.new(2023, 9, 20)) do
+            create_event(
+              {
+                code: billable_metric.code,
+                transaction_id: SecureRandom.uuid,
+                external_customer_id: customer.external_id,
+                properties: { amount: '-6' },
+              },
+            )
+          end
+
+          travel_to(DateTime.new(2023, 9, 25)) do
+            create_event(
+              {
+                code: billable_metric.code,
+                transaction_id: SecureRandom.uuid,
+                external_customer_id: customer.external_id,
+                properties: { amount: '10' },
+              },
+            )
+          end
+
+          travel_to(DateTime.new(2023, 9, 26)) do
+            create_event(
+              {
+                code: billable_metric.code,
+                transaction_id: SecureRandom.uuid,
+                external_customer_id: customer.external_id,
+                properties: { amount: '4' },
+              },
+            )
+          end
+
+          travel_to(DateTime.new(2023, 9, 30)) do
+            create_event(
+              {
+                code: billable_metric.code,
+                transaction_id: SecureRandom.uuid,
+                external_customer_id: customer.external_id,
+                properties: { amount: '60' },
+              },
+            )
+
+            fetch_current_usage(customer:)
+            expect(json[:customer_usage][:amount_cents].round(2)).to eq(19_033)
+            expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(19_033)
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('75.0')
+          end
+
+          travel_to(DateTime.new(2023, 10, 1)) do
+            Subscriptions::BillingService.new.call
+
+            perform_all_enqueued_jobs
+
+            subscription = customer.subscriptions.first
+            invoice = subscription.invoices.first
+
+            aggregate_failures do
+              expect(invoice.total_amount_cents).to eq(19_033)
+              expect(subscription.reload.invoices.count).to eq(1)
+            end
+          end
+
+          travel_to(DateTime.new(2023, 10, 5)) do
+            fetch_current_usage(customer:)
+            expect(json[:customer_usage][:amount_cents].round(2)).to eq(37_000)
+            expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(37_000)
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('75.0')
+          end
+
+          travel_to(DateTime.new(2023, 10, 17)) do
+            create_event(
+              {
+                code: billable_metric.code,
+                transaction_id: SecureRandom.uuid,
+                external_customer_id: customer.external_id,
+                properties: { amount: '20' },
+              },
+            )
+
+            fetch_current_usage(customer:)
+            expect(json[:customer_usage][:amount_cents].round(2)).to eq(38_935)
+            expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(38_935)
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('95.0')
+          end
+
+          subscription = customer.subscriptions.first
+
+          travel_to(DateTime.new(2023, 10, 18)) do
+            create(
+              :graduated_charge,
+              billable_metric:,
+              prorated: true,
+              plan: plan_new,
+              properties: {
+                graduated_ranges: [
+                  {
+                    from_value: 0,
+                    to_value: 5,
+                    per_unit_amount: '10',
+                    flat_amount: '100',
+                  },
+                  {
+                    from_value: 6,
+                    to_value: 15,
+                    per_unit_amount: '5',
+                    flat_amount: '50',
+                  },
+                  {
+                    from_value: 16,
+                    to_value: nil,
+                    per_unit_amount: '2',
+                    flat_amount: '0',
+                  },
+                ],
+              },
+            )
+            expect {
+              create_subscription(
+                {
+                  external_customer_id: customer.external_id,
+                  external_id: customer.external_id,
+                  plan_code: plan_new.code,
+                },
+              )
+            }.to change { subscription.reload.status }.from('active').to('terminated')
+              .and change { subscription.invoices.count }.from(1).to(2)
+
+            invoice = subscription.invoices.order(created_at: :desc).first
+            expect(invoice.fees.charge_kind.count).to eq(1)
+            expect(invoice.total_amount_cents).to eq(30_484) # 30226 + 2.58 (prorated event in termination period)
+          end
+
+          travel_to(DateTime.new(2023, 11, 1)) do
+            Subscriptions::BillingService.new.call
+
+            perform_all_enqueued_jobs
+
+            subscription = customer.subscriptions.order(created_at: :desc).first
+            invoice = subscription.invoices.order(created_at: :desc).first
+
+            aggregate_failures do
+              # (95 units * 14/31) -> 30581 - charge fee
+              # 100 * 14/31 -> 45 -> subscription fee
+              expect(invoice.total_amount_cents).to eq(30_581 + 45)
+              expect(subscription.reload.invoices.count).to eq(1)
+            end
+          end
+
+          travel_to(DateTime.new(2023, 11, 5)) do
+            fetch_current_usage(customer:)
+            expect(json[:customer_usage][:amount_cents].round(2)).to eq(41_000)
+            expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(41_000)
+            expect(json[:customer_usage][:charges_usage][0][:units]).to eq('95.0')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -103,8 +103,8 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
           )
 
           fetch_current_usage(customer:)
-          expect(json[:customer_usage][:amount_cents].round(2)).to eq(11_567)
-          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(11_567)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(16_567)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(16_567)
           expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1.0')
         end
 
@@ -418,6 +418,341 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(41_000)
             expect(json[:customer_usage][:charges_usage][0][:units]).to eq('95.0')
           end
+        end
+      end
+    end
+  end
+
+  describe 'with unique_count_agg' do
+    let(:aggregation_type) { 'unique_count_agg' }
+    let(:field_name) { 'amount' }
+
+    describe 'two ranges' do
+      it 'returns the expected invoice and usage amounts' do
+        Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+        WebhookEndpoint.destroy_all
+
+        travel_to(DateTime.new(2023, 9, 1)) do
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code,
+            },
+          )
+        end
+
+        create(
+          :graduated_charge,
+          billable_metric:,
+          prorated: true,
+          plan:,
+          properties: {
+            graduated_ranges: [
+              {
+                from_value: 0,
+                to_value: 1,
+                per_unit_amount: '10',
+                flat_amount: '100',
+              },
+              {
+                from_value: 2,
+                to_value: nil,
+                per_unit_amount: '5',
+                flat_amount: '50',
+              },
+            ],
+          },
+        )
+
+        travel_to(DateTime.new(2023, 9, 10)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '1111', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(10_700)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(10_700)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1.0')
+        end
+
+        travel_to(DateTime.new(2023, 9, 12)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '1111', operation_type: 'remove' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(10_100)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(10_100)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.0')
+        end
+
+        travel_to(DateTime.new(2023, 9, 14)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '1111', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(15_383)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(15_383)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1.0')
+        end
+
+        travel_to(DateTime.new(2023, 9, 15)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '2222', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(15_650)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(15_650)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('2.0')
+        end
+
+        travel_to(DateTime.new(2023, 9, 16)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '2222', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(15_650)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(15_650)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('2.0')
+        end
+
+        travel_to(DateTime.new(2023, 9, 20)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '3333', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(15_833)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(15_833)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('3.0')
+        end
+
+        travel_to(DateTime.new(2023, 10, 1)) do
+          Subscriptions::BillingService.new.call
+
+          perform_all_enqueued_jobs
+
+          subscription = customer.subscriptions.first
+          invoice = subscription.invoices.first
+
+          aggregate_failures do
+            expect(invoice.total_amount_cents).to eq(15_833)
+            expect(subscription.reload.invoices.count).to eq(1)
+          end
+        end
+
+        travel_to(DateTime.new(2023, 10, 5)) do
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(17_000)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(17_000)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('3.0')
+        end
+
+        travel_to(DateTime.new(2023, 10, 17)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '4444', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(17_242)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(17_242)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('4.0')
+        end
+      end
+    end
+
+    context 'with multiple events on the same day' do
+      it 'returns the expected invoice and usage amounts' do
+        Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
+        WebhookEndpoint.destroy_all
+
+        travel_to(DateTime.new(2023, 9, 1)) do
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code,
+            },
+          )
+        end
+
+        create(
+          :graduated_charge,
+          billable_metric:,
+          prorated: true,
+          plan:,
+          properties: {
+            graduated_ranges: [
+              {
+                from_value: 0,
+                to_value: 5,
+                per_unit_amount: '10',
+                flat_amount: '100',
+              },
+              {
+                from_value: 6,
+                to_value: nil,
+                per_unit_amount: '5',
+                flat_amount: '50',
+              },
+            ],
+          },
+        )
+
+        travel_to(DateTime.new(2023, 10, 10)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '1111', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(10_710)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(10_710)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1.0')
+        end
+
+        travel_to(DateTime.new(2023, 10, 20)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '2222', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(11_097)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(11_097)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('2.0')
+        end
+
+        travel_to(DateTime.new(2023, 10, 20)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '3333', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(11_484)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(11_484)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('3.0')
+        end
+
+        travel_to(DateTime.new(2023, 10, 20)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '4444', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(11_871)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(11_871)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('4.0')
+        end
+
+        travel_to(DateTime.new(2023, 10, 20)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '5555', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(12_258)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(12_258)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('5.0')
+        end
+
+        travel_to(DateTime.new(2023, 10, 25)) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { amount: '6666', operation_type: 'add' },
+            },
+          )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(17_371)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(17_371)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('6.0')
+        end
+
+        travel_to(DateTime.new(2023, 11, 1)) do
+          Subscriptions::BillingService.new.call
+
+          perform_all_enqueued_jobs
+
+          subscription = customer.subscriptions.first
+          invoice = subscription.invoices.first
+
+          aggregate_failures do
+            expect(invoice.total_amount_cents).to eq(17_371)
+            expect(subscription.reload.invoices.count).to eq(1)
+          end
+        end
+
+        travel_to(DateTime.new(2023, 11, 5)) do
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(20_500)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(20_500)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('6.0')
         end
       end
     end

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -69,6 +69,11 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               properties: { amount: '2' },
             },
           )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(11_400)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(11_400)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('2.0')
         end
 
         travel_to(DateTime.new(2023, 9, 16)) do
@@ -80,6 +85,11 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               properties: { amount: '5' },
             },
           )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_400)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_400)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('7.0')
         end
 
         travel_to(DateTime.new(2023, 9, 20)) do
@@ -91,6 +101,11 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               properties: { amount: '-6' },
             },
           )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(17_300)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(17_300)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('1.0')
         end
 
         travel_to(DateTime.new(2023, 9, 25)) do
@@ -102,6 +117,11 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               properties: { amount: '10' },
             },
           )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_300)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_300)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('11.0')
         end
 
         travel_to(DateTime.new(2023, 9, 26)) do
@@ -113,6 +133,11 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               properties: { amount: '4' },
             },
           )
+
+          fetch_current_usage(customer:)
+          expect(json[:customer_usage][:amount_cents].round(2)).to eq(18_633)
+          expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(18_633)
+          expect(json[:customer_usage][:charges_usage][0][:units]).to eq('15.0')
         end
 
         travel_to(DateTime.new(2023, 9, 30)) do

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -469,8 +469,8 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     it 'aggregates per events' do
       result = sum_service.per_event_aggregation
 
-      expect(result.event_aggregation).to eq([2.5, 2.5, 12, 12])
-      expect(result.event_prorated_aggregation.map { |el| el.round(5) }).to eq([2.5, 2.5, 2.32258, 2.32258])
+      expect(result.event_aggregation).to eq([12, 12])
+      expect(result.event_prorated_aggregation.map { |el| el.round(5) }).to eq([2.32258, 2.32258])
     end
   end
 end

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -464,4 +464,13 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       end
     end
   end
+
+  describe '.per_event_aggregation' do
+    it 'aggregates per events' do
+      result = sum_service.per_event_aggregation
+
+      expect(result.event_aggregation).to eq([2.5, 2.5, 12, 12])
+      expect(result.event_prorated_aggregation.map { |el| el.round(5) }).to eq([2.5, 2.5, 2.32258, 2.32258])
+    end
+  end
 end

--- a/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::ChargeModels::ProratedGraduatedService, type: :service do
+  subject(:apply_graduated_service) do
+    described_class.apply(
+      charge:,
+      aggregation_result:,
+      properties: charge.properties,
+    )
+  end
+
+  let(:aggregation_result) { BaseService::Result.new }
+  let(:billable_metric) { create(:sum_billable_metric, recurring: true) }
+  let(:aggregation) { 5.96667 }
+  let(:aggregator) do
+    BillableMetrics::ProratedAggregations::SumService.new(billable_metric:, subscription: nil, boundaries: nil)
+  end
+  let(:per_event_aggregation) do
+    BaseService::Result.new.tap do |r|
+      r.event_aggregation = [5, 5, 10, -6]
+      r.event_prorated_aggregation = [3.5, 2.66667, 2, -2.2]
+    end
+  end
+  let(:charge) do
+    create(
+      :graduated_charge,
+      billable_metric:,
+      properties: {
+        graduated_ranges: [
+          {
+            from_value: 0,
+            to_value: 5,
+            per_unit_amount: '10',
+            flat_amount: '100',
+          },
+          {
+            from_value: 6,
+            to_value: nil,
+            per_unit_amount: '5',
+            flat_amount: '50',
+          },
+        ],
+      },
+    )
+  end
+
+  before do
+    aggregation_result.aggregator = aggregator
+    aggregation_result.aggregation = aggregation
+    aggregation_result.full_units_number = 14
+    aggregation_result.current_usage_units = 14
+
+    allow(aggregator).to receive(:per_event_aggregation).and_return(per_event_aggregation)
+  end
+
+  it 'calculates the amount correctly' do
+    expect(apply_graduated_service.amount.round(2)).to eq(197.33)
+  end
+
+  context 'with event that cannot be fully placed into the range' do
+    let(:aggregation) { 3.86667 }
+    let(:per_event_aggregation) do
+      BaseService::Result.new.tap do |r|
+        r.event_aggregation = [2, 5, 10, -6]
+        r.event_prorated_aggregation = [1.4, 2.66667, 2, -2.2]
+      end
+    end
+
+    before do
+      aggregation_result.aggregation = aggregation
+      aggregation_result.full_units_number = 11
+      aggregation_result.current_usage_units = 11
+    end
+
+    it 'calculates the amount correctly' do
+      expect(apply_graduated_service.amount.round(2)).to eq(184.33)
+    end
+  end
+
+  context 'with three ranges and one overflow' do
+    let(:aggregation) { 7.2 }
+    let(:per_event_aggregation) do
+      BaseService::Result.new.tap do |r|
+        r.event_aggregation = [2, 5, -6, 10, 4, 60]
+        r.event_prorated_aggregation = [1.4, 2.5, -2.2, 2, 0.667, 2]
+      end
+    end
+    let(:charge) do
+      create(
+        :graduated_charge,
+        billable_metric:,
+        properties: {
+          graduated_ranges: [
+            {
+              from_value: 0,
+              to_value: 5,
+              per_unit_amount: '10',
+              flat_amount: '100',
+            },
+            {
+              from_value: 6,
+              to_value: 15,
+              per_unit_amount: '5',
+              flat_amount: '50',
+            },
+            {
+              from_value: 16,
+              to_value: nil,
+              per_unit_amount: '2',
+              flat_amount: '0',
+            },
+          ],
+        },
+      )
+    end
+
+    before do
+      aggregation_result.aggregation = aggregation
+      aggregation_result.full_units_number = 80
+      aggregation_result.current_usage_units = 80
+    end
+
+    it 'calculates the amount correctly' do
+      expect(apply_graduated_service.amount.round(2)).to eq(190.33)
+    end
+  end
+end

--- a/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Charges::ChargeModels::ProratedGraduatedService, type: :service d
   end
 
   context 'with three ranges and one overflow' do
-    let(:aggregation) { 7.2 }
+    let(:aggregation) { 6.36 }
     let(:per_event_aggregation) do
       BaseService::Result.new.tap do |r|
         r.event_aggregation = [2, 5, -6, 10, 4, 60]
@@ -118,12 +118,32 @@ RSpec.describe Charges::ChargeModels::ProratedGraduatedService, type: :service d
 
     before do
       aggregation_result.aggregation = aggregation
-      aggregation_result.full_units_number = 80
-      aggregation_result.current_usage_units = 80
+      aggregation_result.full_units_number = 75
+      aggregation_result.current_usage_units = 75
     end
 
     it 'calculates the amount correctly' do
       expect(apply_graduated_service.amount.round(2)).to eq(190.33)
+    end
+
+    context 'when there ate two overflows' do
+      let(:aggregation) { 75 }
+      let(:per_event_aggregation) do
+        BaseService::Result.new.tap do |r|
+          r.event_aggregation = [75]
+          r.event_prorated_aggregation = [75]
+        end
+      end
+
+      before do
+        aggregation_result.aggregation = aggregation
+        aggregation_result.full_units_number = 75
+        aggregation_result.current_usage_units = 75
+      end
+
+      it 'calculates the amount correctly' do
+        expect(apply_graduated_service.amount.round(2)).to eq(370)
+      end
     end
   end
 end

--- a/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
@@ -79,6 +79,26 @@ RSpec.describe Charges::ChargeModels::ProratedGraduatedService, type: :service d
     end
   end
 
+  context 'with final number of units equals to zero' do
+    let(:aggregation) { 1.613 }
+    let(:per_event_aggregation) do
+      BaseService::Result.new.tap do |r|
+        r.event_aggregation = [1, 4, 1, -5, -1]
+        r.event_prorated_aggregation = [0.7097, 1.54839, 0.2258, -0.80645, -0.0645]
+      end
+    end
+
+    before do
+      aggregation_result.aggregation = aggregation
+      aggregation_result.full_units_number = 0
+      aggregation_result.current_usage_units = 0
+    end
+
+    it 'calculates the amount correctly' do
+      expect(apply_graduated_service.amount.round(2)).to eq(165.81)
+    end
+  end
+
   context 'with negative event that results in changing range' do
     let(:aggregation) { 2.5 }
     let(:per_event_aggregation) do
@@ -114,7 +134,7 @@ RSpec.describe Charges::ChargeModels::ProratedGraduatedService, type: :service d
       end
 
       it 'calculates the amount correctly' do
-        expect(apply_graduated_service.amount.round(2)).to eq(130.5)
+        expect(apply_graduated_service.amount.round(2)).to eq(180.5)
       end
     end
 


### PR DESCRIPTION
## Context

Currently graduated charge model cannot be used with `prorated` = `true`

## Description

This PR covers new charge model service, made especially for this purpose.
Later, the service will be improved with the logic where recurring amount fetched from the DB and computation is done only for current period.
