### PR TITLE
feat(event): Refact event queries

### DIFF
--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -62,7 +62,10 @@ module V1
     def pay_in_advance_charge_attributes
       return {} unless model.pay_in_advance?
 
-      event = model.subscription.organization.events.find_by(id: model.pay_in_advance_event_id)
+      event = Event.find_by(
+        organization_id: model.subscription.organization,
+        id: model.pay_in_advance_event_id,
+      )
 
       {
         lago_subscription_id: model.subscription_id,

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -39,7 +39,7 @@ module BillableMetrics
       end
 
       def events_scope(from_datetime:, to_datetime:)
-        events = subscription.events
+        events = Event.where(subscription_id: subscription.id)
           .from_datetime(from_datetime)
           .to_datetime(to_datetime)
           .where(code: billable_metric.code)

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -151,7 +151,11 @@ module BillableMetrics
         quantified_events = if billable_metric.recurring?
           quantified_events.where(external_subscription_id: subscription.external_id)
         else
-          quantified_events.joins(:events).where(events: { subscription_id: subscription.id })
+          quantified_event_ids = Event.where(subscription_id: subscription.id)
+            .where('quantified_event_id IS NOT NULL')
+            .pluck('DISTINCT(quantified_event_id)')
+
+          quantified_events.where(id: quantified_event_ids)
         end
 
         return quantified_events unless group

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -148,9 +148,12 @@ module BillableMetrics
       # NOTE: In case of upgrade/downgrade, if latest value is not persisted yet,
       #       we need to fetch latest value from previous events attached to the same external subscription ID
       def latest_value_from_events
-        scope = customer.events
-          .joins(:subscription)
-          .where(subscription: { external_id: subscription.external_id })
+        subscription_ids = customer.subscriptions
+          .where(external_id: subscription.external_id)
+          .pluck(:id)
+
+        scope = Event.where(customer_id: customer.id)
+          .where(subscription_id: subscription_ids)
           .where(code: billable_metric.code)
           .where(created_at: billable_metric.created_at...)
           .where(timestamp: ..from_datetime)

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -30,7 +30,11 @@ module Events
       ActiveRecord::Base.transaction do
         params[:external_subscription_ids].each do |id|
           subscription = Subscription.find_by(external_id: id)
-          event = organization.events.find_by(transaction_id: params[:transaction_id], subscription_id: subscription.id)
+          event = Event.find_by(
+            organization_id: organization.id,
+            transaction_id: params[:transaction_id],
+            subscription_id: subscription.id,
+          )
 
           if event
             events << event
@@ -38,10 +42,11 @@ module Events
             next
           end
 
-          event = organization.events.new
+          event = Event.new
+          event.organization_id = organization.id
           event.code = params[:code]
           event.transaction_id = params[:transaction_id]
-          event.customer = customer
+          event.customer_id = customer.id
           event.subscription_id = subscription.id
           event.properties = params[:properties] || {}
           event.metadata = metadata || {}

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -40,10 +40,11 @@ module Events
       end
 
       ActiveRecord::Base.transaction do
-        event = organization.events.new
+        event = Event.new
+        event.organization_id = organization.id
         event.code = params[:code]
         event.transaction_id = params[:transaction_id]
-        event.customer = customer
+        event.customer_id = customer.id
         event.subscription_id = subscriptions.first.id
         event.properties = params[:properties] || {}
         event.metadata = metadata || {}

--- a/app/services/events/validate_creation_service.rb
+++ b/app/services/events/validate_creation_service.rb
@@ -77,7 +77,8 @@ module Events
     def valid_transaction_id?
       return false if params[:transaction_id].blank?
 
-      organization.events.where(
+      Event.where(
+        organization_id: organization.id,
         transaction_id: params[:transaction_id],
         subscription_id: subscriptions.first.id,
       ).none?

--- a/app/services/fees/estimate_pay_in_advance_service.rb
+++ b/app/services/fees/estimate_pay_in_advance_service.rb
@@ -43,7 +43,8 @@ module Fees
     def event
       return @event if @event
 
-      @event = organization.events.new(
+      @event = Event.new(
+        organization_id: organization.id,
         code: params[:code],
         customer:,
         subscription: subscriptions.first,

--- a/spec/graphql/resolvers/events_resolver_spec.rb
+++ b/spec/graphql/resolvers/events_resolver_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Resolvers::EventsResolver, type: :graphql, transaction: false do
     events_response = result['data']['events']
 
     aggregate_failures do
-      expect(events_response['collection'].count).to eq(organization.events.count)
+      expect(events_response['collection'].count).to eq(Event.where(organization_id: organization.id).count)
       expect(events_response['collection'].first['id']).to eq(event.id)
       expect(events_response['collection'].first['code']).to eq(event.code)
       expect(events_response['collection'].first['externalCustomerId']).to eq(event.customer.external_id)
@@ -87,7 +87,7 @@ RSpec.describe Resolvers::EventsResolver, type: :graphql, transaction: false do
       events_response = result['data']['events']
 
       aggregate_failures do
-        expect(events_response['collection'].count).to eq(organization.events.count)
+        expect(events_response['collection'].count).to eq(Event.where(organization_id: organization.id).count)
         expect(events_response['collection'].first['id']).to eq(event.id)
       end
     end

--- a/spec/scenarios/create_event_spec.rb
+++ b/spec/scenarios/create_event_spec.rb
@@ -153,9 +153,9 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
             external_subscription_id: subscription2.external_id,
           ),
         )
-      end.to change { subscription2.events.reload.count }
+      end.to change { Event.where(subscription_id: subscription2.id).count }
 
-      expect(subscription.events.count).to eq(0)
+      expect(Event.where(subscription_id: subscription.id).count).to eq(0)
     end
   end
 
@@ -173,9 +173,9 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
     it 'creates the event on the active subscription' do
       expect do
         create_event(params.merge(external_subscription_id: subscription.external_id))
-      end.to change { subscription.events.reload.count }
+      end.to change { Event.where(subscription_id: subscription.id).count }
 
-      expect(subscription2.events.count).to eq(0)
+      expect(Event.where(subscription_id: subscription2.id).count).to eq(0)
     end
   end
 end

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe Events::CreateBatchService, type: :service do
             timestamp:,
             metadata: {},
           )
-        end.to change { organization.events.count }.by(1)
+        end.to change(Event, :count).by(1)
       end
     end
 
@@ -258,9 +258,10 @@ RSpec.describe Events::CreateBatchService, type: :service do
             timestamp:,
             metadata: {},
           )
-        end.to change { organization.events.count }.by(2)
+        end.to change(Event, :count).by(2)
 
-        expect(organization.events.last.timestamp.iso8601(3)).to eq('2023-09-04T15:45:12.344Z')
+        expect(Event.where(organization_id: organization.id).last.timestamp.iso8601(3))
+          .to eq('2023-09-04T15:45:12.344Z')
       end
     end
   end

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe Events::CreateService, type: :service do
             timestamp:,
             metadata: {},
           )
-        end.not_to change { organization.events.count }
+        end.not_to change(Event, :count)
       end
     end
 


### PR DESCRIPTION
## Context

On the path for high volume improvements, we need to adapt the structure of the events table for better performance.

## Description

This PR changes all event related queries to rely only on the event table without joins on other relation