### PR TITLE
feat(event): Add external customer_id and external_subscription_id

### DIFF
--- a/app/models/events_record.rb
+++ b/app/models/events_record.rb
@@ -3,5 +3,5 @@
 class EventsRecord < ApplicationRecord
   self.abstract_class = true
 
-  connects_to database: { writing: :primary, reading: :events }
+  connects_to database: { writing: :events, reading: :events }
 end

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -47,7 +47,9 @@ module Events
           event.code = params[:code]
           event.transaction_id = params[:transaction_id]
           event.customer_id = customer.id
+          event.external_customer_id = customer.external_id
           event.subscription_id = subscription.id
+          event.external_subscription_id = subscription.external_id
           event.properties = params[:properties] || {}
           event.metadata = metadata || {}
 

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -45,7 +45,9 @@ module Events
         event.code = params[:code]
         event.transaction_id = params[:transaction_id]
         event.customer_id = customer.id
+        event.external_customer_id = customer.external_id
         event.subscription_id = subscriptions.first.id
+        event.external_subscription_id = subscriptions.first.external_id
         event.properties = params[:properties] || {}
         event.metadata = metadata || {}
         event.timestamp = event_timestamp

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,14 +4,14 @@ default: &default
 development:
   primary:
     <<: *default
-    host: localhost
+    host: db
     username: lago
     password: changeme
     database: lago
     port: 5432
   events:
     <<: *default
-    host: localhost
+    host: db
     username: lago
     password: changeme
     database: lago

--- a/db/migrate/20220704145333_fill_event_timestamps.rb
+++ b/db/migrate/20220704145333_fill_event_timestamps.rb
@@ -2,7 +2,6 @@
 
 class FillEventTimestamps < ActiveRecord::Migration[7.0]
   def change
-    LagoApi::Application.load_tasks
-    Rake::Task['events:fill_timestamp'].invoke
+    # NOTE: kept here for legacy reasons
   end
 end

--- a/db/migrate/20220722123417_add_subscription_id_to_events.rb
+++ b/db/migrate/20220722123417_add_subscription_id_to_events.rb
@@ -7,8 +7,5 @@ class AddSubscriptionIdToEvents < ActiveRecord::Migration[7.0]
     add_reference :events, :subscription, type: :uuid, foreign_key: true
     add_index :events, %i[subscription_id code]
     add_index :events, %i[subscription_id transaction_id], unique: true
-
-    LagoApi::Application.load_tasks
-    Rake::Task['events:fill_subscription'].invoke
   end
 end

--- a/db/migrate/20230926132500_add_external_ids_to_events.rb
+++ b/db/migrate/20230926132500_add_external_ids_to_events.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddExternalIdsToEvents < ActiveRecord::Migration[7.0]
+  def change
+    change_table :events, bulk: true do |t|
+      t.string :external_customer_id
+      t.string :external_subscription_id
+    end
+
+    change_column_null :events, :customer_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_22_064617) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_26_132500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -322,7 +322,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_22_064617) do
 
   create_table "events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "organization_id", null: false
-    t.uuid "customer_id", null: false
+    t.uuid "customer_id"
     t.string "transaction_id", null: false
     t.string "code", null: false
     t.jsonb "properties", default: {}, null: false
@@ -333,6 +333,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_22_064617) do
     t.uuid "subscription_id"
     t.datetime "deleted_at"
     t.uuid "quantified_event_id"
+    t.string "external_customer_id"
+    t.string "external_subscription_id"
     t.index ["customer_id"], name: "index_events_on_customer_id"
     t.index ["deleted_at"], name: "index_events_on_deleted_at"
     t.index ["organization_id", "code"], name: "index_events_on_organization_id_and_code"

--- a/db/seeds/base.rb
+++ b/db/seeds/base.rb
@@ -73,16 +73,16 @@ Charge.create_with(
     plan:,
   )
 
-  next if customer.events.exists?
+  next if Event.where(customer_id: customer.id).exists?
 
   # NOTE: Assigns valid events
   5.times do
     time = Time.zone.now - rand(1..20).days
 
     Event.create!(
-      customer:,
-      subscription: sub,
-      organization:,
+      customer_id: customer.id,
+      subscription_id: sub.id,
+      organization_id: organization.id,
       transaction_id: SecureRandom.uuid,
       timestamp: time - rand(0..12).seconds,
       created_at: time,
@@ -102,9 +102,9 @@ Charge.create_with(
     time = Time.zone.now - rand(1..20).days
 
     Event.create!(
-      customer:,
-      subscription: sub,
-      organization:,
+      customer_id: customer.id,
+      subscription_id: sub.id,
+      organization_id: organization.id,
       transaction_id: SecureRandom.uuid,
       timestamp: time - 120.seconds,
       created_at: time,
@@ -122,9 +122,9 @@ Charge.create_with(
     time = Time.zone.now - rand(1..20).days
 
     Event.create!(
-      customer:,
-      subscription: sub,
-      organization:,
+      customer_id: customer.id,
+      subscription_id: sub.id,
+      organization_id: organization.id,
       transaction_id: SecureRandom.uuid,
       timestamp: time - 120.seconds,
       created_at: time,
@@ -179,9 +179,9 @@ organization.customers.find_each do |customer|
     time = Time.zone.now
 
     Event.create!(
-      customer:,
-      subscription: customer.active_subscriptions&.first,
-      organization:,
+      customer_id: customer.id,
+      subscription_id: customer.active_subscriptions&.first&.id,
+      organization_id: organization.id,
       transaction_id: SecureRandom.uuid,
       timestamp: time - rand(0..24).hours,
       created_at: time,

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -2,12 +2,20 @@
 
 FactoryBot.define do
   factory :event do
+    transient do
+      subscription { create(:subscription) }
+      customer { subscription.customer }
+    end
+
     organization_id { create(:organization).id }
-    customer_id { create(:customer).id }
-    subscription_id { create(:subscription).id }
+    customer_id { customer.id }
+    subscription_id { subscription.id }
 
     transaction_id { SecureRandom.uuid }
     code { Faker::Name.name.underscore }
     timestamp { Time.current }
+
+    external_customer_id { customer.external_id }
+    external_subscription_id { subscription.external_id }
   end
 end

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe Events::CreateService, type: :service do
 
         expect(result).to be_success
         expect(result.event.timestamp).to eq(Time.zone.at(timestamp))
+        expect(result.event.external_subscription_id).to eq(subscription.external_id)
+        expect(result.event.external_customer_id).to eq(customer.external_id)
       end
     end
 
@@ -100,6 +102,8 @@ RSpec.describe Events::CreateService, type: :service do
 
         expect(result).to be_success
         expect(result.event.timestamp).to eq(Time.zone.at(timestamp))
+        expect(result.event.external_subscription_id).to eq(subscription.external_id)
+        expect(result.event.external_customer_id).to eq(customer.external_id)
       end
     end
 
@@ -164,6 +168,8 @@ RSpec.describe Events::CreateService, type: :service do
           expect(event.code).to eq(billable_metric.code)
           expect(event.subscription_id).to eq(subscription.id)
           expect(event.timestamp).to be_a(Time)
+          expect(result.event.external_subscription_id).to eq(subscription.external_id)
+          expect(result.event.external_customer_id).to eq(customer.external_id)
         end
       end
     end
@@ -207,6 +213,8 @@ RSpec.describe Events::CreateService, type: :service do
           expect(event.code).to eq(billable_metric.code)
           expect(event.subscription_id).to eq(active_subscription.id)
           expect(event.timestamp).to be_a(Time)
+          expect(result.event.external_subscription_id).to eq(active_subscription.external_id)
+          expect(result.event.external_customer_id).to eq(customer.external_id)
         end
       end
     end
@@ -229,6 +237,8 @@ RSpec.describe Events::CreateService, type: :service do
           expect(event.code).to eq(billable_metric.code)
           expect(event.subscription_id).to eq(subscription.id)
           expect(event.timestamp).to be_a(Time)
+          expect(result.event.external_subscription_id).to eq(subscription.external_id)
+          expect(result.event.external_customer_id).to eq(customer.external_id)
         end
       end
     end
@@ -261,6 +271,8 @@ RSpec.describe Events::CreateService, type: :service do
           expect(event.code).to eq(billable_metric.code)
           expect(event.subscription_id).to eq(subscription.id)
           expect(event.timestamp).to be_a(Time)
+          expect(result.event.external_subscription_id).to eq(subscription.external_id)
+          expect(result.event.external_customer_id).to eq(customer.external_id)
         end
       end
     end
@@ -293,6 +305,8 @@ RSpec.describe Events::CreateService, type: :service do
 
         aggregate_failures do
           expect(event.subscription_id).to eq(subscription2.id)
+          expect(result.event.external_subscription_id).to eq(subscription2.external_id)
+          expect(result.event.external_customer_id).to eq(customer.external_id)
         end
       end
     end
@@ -348,6 +362,8 @@ RSpec.describe Events::CreateService, type: :service do
           expect(event.subscription_id).to eq(subscription.id)
           expect(event.timestamp).to be_a(Time)
           expect(event.properties).to eq({})
+          expect(result.event.external_subscription_id).to eq(subscription.external_id)
+          expect(result.event.external_customer_id).to eq(customer.external_id)
         end
       end
     end


### PR DESCRIPTION
## Context

On the path for high volume improvements, we need to adapt the structure of the events table for better performance.

## Description

This PR adds `events#external_customer_id` and `events#external_subscription_id fields`. Event creations services are also updated in order to fill these fields with the appropriate value.

Note: A DB migration will come right after to populate theses fields for existing events
