### PR TITLE
feat(event): Add migration to fill external ids

### DIFF
--- a/db/migrate/20230926144126_fill_event_external_ids.rb
+++ b/db/migrate/20230926144126_fill_event_external_ids.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class FillEventExternalIds < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          WITH events_external_ids AS (
+            SELECT
+              events.id AS event_id,
+              customers.external_id AS external_customer_id,
+              subscriptions.external_id AS external_subscription_id
+            FROM events
+              INNER JOIN customers ON customers.id = events.customer_id
+              INNER JOIN subscriptions ON subscriptions.id = events.subscription_id
+            WHERE events.external_customer_id IS NULL
+              AND events.external_subscription_id IS NULL
+          )
+
+          UPDATE events
+          SET
+            external_customer_id = events_external_ids.external_customer_id,
+            external_subscription_id = events_external_ids.external_subscription_id
+          FROM events_external_ids
+          WHERE events_external_ids.event_id = events.id
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_26_132500) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_26_144126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
## Context

On the path for high volume improvements, we need to adapt the structure of the events table for better performance.

## Description

This PR adds a migration to populate new `events#external_customer_id` and `events#external_subscription_id`
