### PR TITLE
fix: update draft invoice net_payment_term on customer update

### DIFF
--- a/app/services/customers/update_invoice_payment_due_date_service.rb
+++ b/app/services/customers/update_invoice_payment_due_date_service.rb
@@ -12,9 +12,7 @@ module Customers
       ActiveRecord::Base.transaction do
         # NOTE: Update payment_due_date if net_payment_term changed
         customer.invoices.draft.each do |invoice|
-          if customer.net_payment_term != net_payment_term
-            invoice.update!(payment_due_date: invoice_payment_due_date(invoice))
-          end
+          invoice.update!(net_payment_term:, payment_due_date: invoice_payment_due_date(invoice))
         end
 
         result.customer = customer


### PR DESCRIPTION
## Context

We have an issue when a customer updates it's `net_payment_term` value while having draft invoices.

Those invoices hold their own value of `net_payment_term` but this on was not updated when the customer one was updated.

This update should only concern draft invoices

## Description

This PR removes a check that was systematically false.

The reason is that before calling this service, the customer `net_payment_term` was already updated with the new values from the params, leading to the condition always being false.

So I removed it. Having to parse all draft invoices each time won't be that costly in terms of performance.