### PR TITLE
feat(past_usage): Add base query to fetch past usage

### DIFF
--- a/app/queries/past_usage_query.rb
+++ b/app/queries/past_usage_query.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class PastUsageQuery < BaseQuery
+  def call
+    validate_filters
+    return result if result.error.present?
+
+    result.usage = query
+    result
+  end
+
+  private
+
+  def query
+    base_query = InvoiceSubscription.joins(subscription: :customer)
+      .where(customers: { external_id: filters.external_customer_id, organization_id: organization.id })
+      .where(subscriptions: { external_id: filters.external_subscription_id })
+      .order(from_datetime: :desc)
+      .includes(:invoice)
+
+    paginate(base_query)
+  end
+
+  def validate_filters
+    if filters.external_customer_id.blank?
+      return result.single_validation_failure!(
+        field: :external_customer_id,
+        error_code: 'value_is_mandatory',
+      )
+    end
+
+    return if filters.external_subscription_id.present?
+
+    result.single_validation_failure!(
+      field: :external_subscription_id,
+      error_code: 'value_is_mandatory',
+    )
+  end
+end

--- a/app/queries/past_usage_query.rb
+++ b/app/queries/past_usage_query.rb
@@ -5,7 +5,13 @@ class PastUsageQuery < BaseQuery
     validate_filters
     return result if result.error.present?
 
-    result.usage = query
+    result.usage = query.map do |invoice_subscription|
+      OpenStruct.new(
+        invoice_subscription:,
+        fees: fees_query(invoice_subscription.invoice),
+      )
+    end
+
     result
   end
 
@@ -18,7 +24,16 @@ class PastUsageQuery < BaseQuery
       .order(from_datetime: :desc)
       .includes(:invoice)
 
-    paginate(base_query)
+    base_query = paginate(base_query)
+    base_query = base_query.limit(filters.periods_count) if filters.periods_count
+    base_query
+  end
+
+  def fees_query(invoice)
+    query = invoice.fees.charge
+    return query unless filters.billable_metric_code
+
+    query.joins(:charge).where(charges: { billable_metric_id: billable_metric.id })
   end
 
   def validate_filters
@@ -29,11 +44,19 @@ class PastUsageQuery < BaseQuery
       )
     end
 
-    return if filters.external_subscription_id.present?
+    if filters.external_subscription_id.blank?
+      return result.single_validation_failure!(
+        field: :external_subscription_id,
+        error_code: 'value_is_mandatory',
+      )
+    end
 
-    result.single_validation_failure!(
-      field: :external_subscription_id,
-      error_code: 'value_is_mandatory',
-    )
+    return if filters.billable_metric_code.blank?
+
+    result.not_found_failure!(resource: 'billable_metric') if billable_metric.blank?
+  end
+
+  def billable_metric
+    @billable_metric ||= organization.billable_metrics.find_by(code: filters.billable_metric_code)
   end
 end

--- a/spec/queries/past_usage_query_spec.rb
+++ b/spec/queries/past_usage_query_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe PastUsageQuery, type: :query do
   let(:filters) { BaseQuery::Filters.new(query_filters) }
 
   let(:customer) { create(:customer, organization:) }
-  let(:subscription) { create(:subscription, customer:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, customer:, plan:) }
 
   let(:query_filters) do
     {
@@ -78,6 +79,90 @@ RSpec.describe PastUsageQuery, type: :query do
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages.keys).to include(:external_subscription_id)
           expect(result.error.messages[:external_subscription_id]).to include('value_is_mandatory')
+        end
+      end
+    end
+
+    context 'with billable_metric_code' do
+      let(:billable_metric1) { create(:billable_metric, organization:) }
+      let(:billable_metric_code) { billable_metric1&.code }
+
+      let(:billable_metric2) { create(:billable_metric, organization:) }
+
+      let(:charge1) { create(:standard_charge, plan:, billable_metric: billable_metric1) }
+      let(:charge2) { create(:standard_charge, plan:, billable_metric: billable_metric2) }
+
+      let(:fee1) { create(:charge_fee, charge: charge1, invoice: invoice_subscription1.invoice) }
+      let(:fee2) { create(:charge_fee, charge: charge2, invoice: invoice_subscription1.invoice) }
+
+      let(:query_filters) do
+        {
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
+          billable_metric_code:,
+        }
+      end
+
+      before do
+        fee1
+        fee2
+      end
+
+      it 'filters the fees accordingly' do
+        result = usage_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.usage.count).to eq(2)
+          expect(result.usage.first.fees.count).to eq(1)
+        end
+      end
+
+      context 'when billable metric is not found' do
+        let(:billable_metric_code) { 'unknown_code' }
+
+        it 'returns a not found failure' do
+          result = usage_query.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.error_code).to eq('billable_metric_not_found')
+          end
+        end
+      end
+    end
+
+    context 'with periods_count filter' do
+      let(:periods_count) { 1 }
+      let(:query_filters) do
+        {
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
+          periods_count:,
+        }
+      end
+
+      it 'returns last requested periods' do
+        result = usage_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.usage.count).to eq(1)
+          expect(result.usage.first.invoice_subscription).to eq(invoice_subscription1)
+        end
+      end
+
+      context 'when periods_count is higher than billed period count' do
+        let(:periods_count) { 10 }
+
+        it 'returns all periods' do
+          result = usage_query.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.usage.count).to eq(2)
+          end
         end
       end
     end

--- a/spec/queries/past_usage_query_spec.rb
+++ b/spec/queries/past_usage_query_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PastUsageQuery, type: :query do
+  subject(:usage_query) { described_class.new(organization:, pagination:, filters:) }
+
+  let(:organization) { create(:organization) }
+  let(:pagination) { BaseQuery::Pagination.new }
+  let(:filters) { BaseQuery::Filters.new(query_filters) }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:) }
+
+  let(:query_filters) do
+    {
+      external_customer_id: customer.external_id,
+      external_subscription_id: subscription.external_id,
+    }
+  end
+
+  let(:invoice_subscription1) do
+    create(
+      :invoice_subscription,
+      from_datetime: DateTime.parse('2023-08-17T00:00:00'),
+      to_datetime: DateTime.parse('2023-09-16T23:59:59'),
+      subscription:,
+    )
+  end
+
+  let(:invoice_subscription2) do
+    create(
+      :invoice_subscription,
+      from_datetime: DateTime.parse('2023-07-17T00:00:00'),
+      to_datetime: DateTime.parse('2023-08-16T23:59:59'),
+      subscription:,
+    )
+  end
+
+  before do
+    invoice_subscription1
+    invoice_subscription2
+  end
+
+  describe 'call' do
+    it 'returns a list of invoice_subscription' do
+      result = usage_query.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.usage.count).to eq(2)
+      end
+    end
+
+    context 'when external_customer_id is missing' do
+      let(:query_filters) { { external_subscription_id: subscription.external_id } }
+
+      it 'returns a validation failure' do
+        result = usage_query.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to include(:external_customer_id)
+          expect(result.error.messages[:external_customer_id]).to include('value_is_mandatory')
+        end
+      end
+    end
+
+    context 'when external_subscription_id is missing' do
+      let(:query_filters) { { external_customer_id: customer.external_id } }
+
+      it 'returns a validation failure' do
+        result = usage_query.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to include(:external_subscription_id)
+          expect(result.error.messages[:external_subscription_id]).to include('value_is_mandatory')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Some of our users want to retrieve usage in the past. The main problem they are facing is that at the beginning of a new period, they cannot compute usage in third party systems, or see if everything went well as usage for the past period has been removed.

## Description

This PR adds a `PastUsageQuery` to fetch pas usage for a customer/subscription, based on the previous invoices/fees
