### PR TITLE
fix: Migration tasks for primary database

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Generate RSA keys
         run: ./scripts/generate.rsa.sh
       - name: Set up database schema
-        run: bin/rails db:schema:load
+        run: bin/rails db:schema:load:primary
       - name: Run tests
         run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /tmp/storage/*
 !/tmp/storage/
 !/tmp/storage/.keep
+db/events_schema.rb
 
 .env
 .byebug_history

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,7 +16,6 @@ development:
     password: changeme
     database: lago
     port: 5432
-    database_tasks: false
 
 test:
   primary:
@@ -25,7 +24,6 @@ test:
   events:
     <<: *default
     url: <%= ENV['DATABASE_TEST_URL'].presence || ENV['DATABASE_URL'] %>
-    database_tasks: false
 
 staging:
   primary:


### PR DESCRIPTION
## Context

In some context, due to the newly released multi-db approach for the event storage, it was impossible to perform reset migration task on the development database.

## Description

This PR fixes this problem by enabling the `primary` suffix on migration tasks.

With this fix, to reset the dabatase, just run `bundle exec rails db:reset:primary`