### PR TITLE
refactor(plan): expose parent object instead of only it's ID

### DIFF
--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -16,7 +16,7 @@ module Types
       field :interval, Types::Plans::IntervalEnum, null: false
       field :invoice_display_name, String
       field :name, String, null: false
-      field :parent_id, ID, null: true
+      field :parent, Types::Plans::Object, null: true
       field :pay_in_advance, Boolean, null: false
       field :trial_period, Float
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -3962,7 +3962,7 @@ type Plan {
   invoiceDisplayName: String
   name: String!
   organization: Organization
-  parentId: ID
+  parent: Plan
   payInAdvance: Boolean!
   subscriptionsCount: Int!
   taxes: [Tax!]

--- a/schema.json
+++ b/schema.json
@@ -16649,11 +16649,11 @@
               ]
             },
             {
-              "name": "parentId",
+              "name": "parent",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "ID",
+                "kind": "OBJECT",
+                "name": "Plan",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/graphql/types/plans/object_spec.rb
+++ b/spec/graphql/types/plans/object_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Types::Plans::Object do
   it { is_expected.to have_field(:interval).of_type('PlanInterval!') }
   it { is_expected.to have_field(:invoice_display_name).of_type('String') }
   it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:parent_id).of_type('ID') }
+  it { is_expected.to have_field(:parent).of_type('Plan') }
   it { is_expected.to have_field(:pay_in_advance).of_type('Boolean!') }
   it { is_expected.to have_field(:trial_period).of_type('Float') }
   it { is_expected.to have_field(:charges).of_type('[Charge!]') }


### PR DESCRIPTION
## Context

We need access to all the plan's parent information for future development.

Currently, the `plan.parent_id` is not used in the front-end application.

## Description

This PR updated the plan Object to reflect this change and expose the new schema updated