### PR TITLE
fix: Fix charge boundaries for terminated subscription

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -310,6 +310,7 @@ module Invoices
         charges_from_datetime: dates_service.charges_from_datetime,
         charges_to_datetime: dates_service.charges_to_datetime,
         timestamp: current_time,
+        charges_duration: dates_service.charges_duration_in_days,
       }
 
       matching_invoice_subscription?(subscription, previous_period_boundaries) ? boundaries : previous_period_boundaries


### PR DESCRIPTION
## Context

We have few error on the API: `undefined method `days' for nil:NilClass (NoMethodError)`

It is related to the boundaries on the terminated subscription that is missing the `charges_duration` attribute.

## Description

This PR fixes the issue by adding the missing attribute