### PR TITLE
fix(stripe): Prevent issue when refreshing payment method on deleted stripe customer

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -118,6 +118,8 @@ module Invoices
             api_key: stripe_api_key,
           },
         )
+        # TODO: stripe customer should be updated/deleted
+        return if result.deleted?
 
         if (payment_method_id = result.invoice_settings.default_payment_method || result.default_source)
           customer.stripe_customer.update!(payment_method_id:)

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -84,8 +84,8 @@ RSpec.describe Plans::UpdateService, type: :service do
         expect(updated_plan.invoice_display_name).to eq(plan_invoice_display_name)
         expect(updated_plan.taxes.pluck(:code)).to eq([tax2.code])
         expect(plan.charges.count).to eq(2)
-        expect(plan.charges.first.invoice_display_name).to eq('charge2')
-        expect(plan.charges.second.invoice_display_name).to eq('charge1')
+        expect(plan.charges.order(created_at: :asc).first.invoice_display_name).to eq('charge1')
+        expect(plan.charges.order(created_at: :asc).second.invoice_display_name).to eq('charge2')
       end
     end
 


### PR DESCRIPTION
## Description

This PR is a fix for `undefined method `invoice_settings' for #<Stripe::Customer` error.

The error occurs when we try to emit a payment on a customer that was deleted on Stripe side. Before sending the payment, we try to refresh the payment method. When the stripe customer is deleted, Stripe still returns it in the response but with a `deleted` flag and no `invoice_settings`.

When it occurs, we can safely return and let the payment generation failed. It will set the invoice payment status to `failed` and will notify the organization via a webhook.
In the future, we should reflect this status in Lago database to stop emitting payments for this customer.

*NOTE: this PR also contains a fix for some flaky tests*