### PR TITLE
fix(webhook): Handle Net::OpenTimeout in auto-retry

### DIFF
--- a/app/services/webhooks/base_service.rb
+++ b/app/services/webhooks/base_service.rb
@@ -65,7 +65,7 @@ module Webhooks
       response = http_client.post_with_response(payload, headers)
 
       succeed_webhook(webhook, response)
-    rescue LagoHttpClient::HttpError, Net::ReadTimeout, Errno::ECONNRESET, SocketError, EOFError => e
+    rescue LagoHttpClient::HttpError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, SocketError, EOFError => e
       fail_webhook(webhook, e)
 
       # NOTE: By default, Lago is retrying 3 times a webhook


### PR DESCRIPTION
## Description

`Net::OpenTimeout` should be handled by the auto retry / error management system of the webhooks 