### PR TITLE
fix(stripe): Retry not found payment intent update

### DIFF
--- a/app/jobs/payment_providers/stripe/handle_event_job.rb
+++ b/app/jobs/payment_providers/stripe/handle_event_job.rb
@@ -5,6 +5,9 @@ module PaymentProviders
     class HandleEventJob < ApplicationJob
       queue_as 'providers'
 
+      # NOTE: Sometimes, the stripe webhook is received before the DB update of the impacted resource
+      retry_on BaseService::NotFoundFailure
+
       def perform(organization:, event:)
         result = PaymentProviders::StripeService.new.handle_event(
           organization:,


### PR DESCRIPTION
## Context

Stripe webhook for payment intent creation might sometimes be received before the persistence of the corresponding payment in Lago database, leading to a `BaseService::NotFoundFailure`

## Description

This PR adds retry logic for the `PaymentProviders::Stripe::HandleEventJob`
