### PR TITLE
fix(stripe): Turn off duplicated payement errors when retries from webhooks

### DIFF
--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -204,6 +204,9 @@ module PaymentProviderCustomers
 
       invoices.find_each do |invoice|
         Invoices::Payments::StripeCreateJob.perform_later(invoice)
+      rescue ActiveJob::Uniqueness::JobNotUnique
+        # NOTE: Payment is already enqueued for processing
+        Rails.logger.warn("Duplicated payment attempt for invoice #{invoice.id}")
       end
     end
 


### PR DESCRIPTION
## Context

A lot of noise is generated by dead job with `ActiveJob::Uniqueness::JobNotUnique` when we try to reprocess pending invoices at reception of a Stripe webhook.

This happen because multiple stripe webhooks can be received during the processing of a payment and the application only allows one processing job per invoice to prevent duplicated payments.

## Description

Since nothing can be done for those jobs, this PR simply prevent the job handing from failing and logs a message.

In a future a proper `processing` payment status should be introduced to reduce this window of `duplication risk`.