### PR TITLE
fix(past-usage): Fix for invoiceable payd in advance charges

### DIFF
--- a/app/queries/past_usage_query.rb
+++ b/app/queries/past_usage_query.rb
@@ -27,6 +27,7 @@ class PastUsageQuery < BaseQuery
 
   def query
     base_query = InvoiceSubscription.joins(subscription: :customer)
+      .where.not(from_datetime: nil)
       .where(customers: { external_id: filters.external_customer_id, organization_id: organization.id })
       .where(subscriptions: { external_id: filters.external_subscription_id })
       .order(from_datetime: :desc)


### PR DESCRIPTION
## Context

Past usage is sometime failing when invoiceable payed in advnaces chages were previously invoiced. The reason behind this is that those invoice does not have boundaries, leading to an error during the serialization.

## Description

This PR ensures that only invoices with proper boundaries are taken into account for the past usage
