### PR TITLE
feat(override-plan): Ability to override invoice display name of a charge

### DIFF
--- a/app/graphql/types/subscriptions/charge_overrides_input.rb
+++ b/app/graphql/types/subscriptions/charge_overrides_input.rb
@@ -3,7 +3,10 @@
 module Types
   module Subscriptions
     class ChargeOverridesInput < Types::BaseInputObject
+      argument :id, ID, required: true
+
       argument :group_properties, [Types::Charges::GroupPropertiesInput], required: false
+      argument :invoice_display_name, String, required: false
       argument :min_amount_cents, GraphQL::Types::BigInt, required: false
       argument :properties, Types::Charges::PropertiesInput, required: false
       argument :tax_codes, [String], required: false

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -77,4 +77,8 @@ class Coupon < ApplicationRecord
     self.terminated_at ||= timestamp
     terminated!
   end
+
+  def parent_and_overriden_plans
+    (plans + plans.map(&:children)).flatten
+  end
 end

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -117,7 +117,10 @@ module Credits
     end
 
     def plan_related_fees
-      invoice.fees.joins(subscription: :plan).where(plan: { id: applied_coupon.coupon.coupon_targets.select(:plan_id) })
+      invoice
+        .fees
+        .joins(subscription: :plan)
+        .where(plan: { id: applied_coupon.coupon.parent_and_overriden_plans.map(&:id) })
     end
 
     def billable_metric_related_fees

--- a/schema.graphql
+++ b/schema.graphql
@@ -215,6 +215,8 @@ enum ChargeModelEnum {
 
 input ChargeOverridesInput {
   groupProperties: [GroupPropertiesInput!]
+  id: ID!
+  invoiceDisplayName: String
   minAmountCents: BigInt
   properties: PropertiesInput
   taxCodes: [String!]

--- a/schema.json
+++ b/schema.json
@@ -2095,6 +2095,22 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "groupProperties",
               "description": null,
               "type": {
@@ -2109,6 +2125,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization:) }
+  let(:charge) { create(:standard_charge, plan:) }
   let(:ending_at) { Time.current.beginning_of_day + 1.year }
   let(:customer) { create(:customer, organization:) }
   let(:mutation) do
@@ -43,12 +44,16 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
         input: {
           customerId: customer.id,
           planId: plan.id,
-          name: 'invoice display name',
+          name: 'name',
           externalId: 'custom-external-id',
           billingTime: 'anniversary',
           endingAt: ending_at.iso8601,
           planOverrides: {
             amountCents: 100,
+            charges: [
+              id: charge.id,
+              invoiceDisplayName: 'invoice display name',
+            ],
           },
         },
       },
@@ -59,7 +64,7 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
     expect(result_data).to include(
       'id' => String,
       'status' => 'active',
-      'name' => 'invoice display name',
+      'name' => 'name',
       'externalId' => 'custom-external-id',
       'startedAt' => String,
       'billingTime' => 'anniversary',


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

The goal of this PR is to be able to override invoice display name on a specific charge via graphql.
