### PR TITLE
fix(past_usage): periods count must be converted into integer

### DIFF
--- a/app/queries/past_usage_query.rb
+++ b/app/queries/past_usage_query.rb
@@ -34,7 +34,7 @@ class PastUsageQuery < BaseQuery
       .includes(:invoice)
 
     base_query = paginate(base_query)
-    base_query = base_query.limit(filters.periods_count) if filters.periods_count
+    base_query = base_query.limit(filters.periods_count.to_i) if filters.periods_count
     base_query
   end
 

--- a/spec/requests/api/v1/customers/usage_spec.rb
+++ b/spec/requests/api/v1/customers/usage_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do # rubocop:
       [
         '/api/v1/customers',
         customer.external_id,
-        "past_usage?external_subscription_id=#{subscription.external_id}",
+        "past_usage?external_subscription_id=#{subscription.external_id}&periods_count=2",
       ].join('/')
     end
 


### PR DESCRIPTION
## Context

An issue has been identified with the past usage API end-point when the `periods_count` parameter is passed in the query.

The issue is received as a string when the pagination logic expects for an integer.

## Description

This PR fixes the issue by converting the parameter into an integer.
