### PR TITLE
fix(group_invoice_display_name): Add group_invoice_display_name to fe…

### DIFF
--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -14,6 +14,7 @@ module V1
           code: model.item_code,
           name: model.item_name,
           invoice_display_name: model.invoice_name,
+          group_invoice_display_name: model.group_name,
           lago_item_id: model.item_id,
           item_type: model.item_type,
         },

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe ::V1::FeeSerializer do
   end
 
   context 'when fee is charge' do
-    let(:charge) { create(:standard_charge) }
+    let(:charge) { group_property.charge }
+    let(:group_property) { create(:group_property) }
+
     let(:fee) do
       create(
         :charge_fee,
@@ -72,6 +74,15 @@ RSpec.describe ::V1::FeeSerializer do
     it 'serializes the fees with dates boundaries' do
       expect(result['fee']['from_date']).not_to be_nil
       expect(result['fee']['to_date']).not_to be_nil
+      expect(result['fee']['item']).to include(
+        'type' => fee.fee_type,
+        'code' => fee.item_code,
+        'name' => fee.item_name,
+        'invoice_display_name' => fee.invoice_name,
+        'group_invoice_display_name' => fee.group_name,
+        'lago_item_id' => fee.item_id,
+        'item_type' => fee.item_type,
+      )
     end
   end
 


### PR DESCRIPTION
## Context

Name and invoice display name is missing for groups. 

## Description

The invoice object and related invoice webhook messages (e.g. invoice.drafted and invoice.created) include the name and invoice_display_name of subscription and usage-based charges, but this information is not available for groups.
We're adding group_invoice_display_name attribute.