### PR TITLE
feat(override-plan): Add subscriptions graphql resolver

### DIFF
--- a/app/graphql/resolvers/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/subscriptions_resolver.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class SubscriptionsResolver < GraphQL::Schema::Resolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description 'Query subscriptions of an organization'
+
+    argument :limit, Integer, required: false
+    argument :page, Integer, required: false
+    argument :plan_code, String, required: false
+
+    type Types::Subscriptions::Object.collection_type, null: false
+
+    def resolve(page: nil, limit: nil, plan_code: nil)
+      validate_organization!
+
+      result = SubscriptionsQuery.call(
+        organization: current_organization,
+        pagination: BaseQuery::Pagination.new(page:, limit:),
+        filters: BaseQuery::Filters.new({ plan_code: }),
+      )
+
+      result.subscriptions
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -37,6 +37,7 @@ module Types
     field :plan, resolver: Resolvers::PlanResolver
     field :plans, resolver: Resolvers::PlansResolver
     field :subscription, resolver: Resolvers::SubscriptionResolver
+    field :subscriptions, resolver: Resolvers::SubscriptionsResolver
     field :tax, resolver: Resolvers::TaxResolver
     field :taxes, resolver: Resolvers::TaxesResolver
     field :wallet_transactions, resolver: Resolvers::WalletTransactionsResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -4333,6 +4333,11 @@ type Query {
   ): Subscription
 
   """
+  Query subscriptions of an organization
+  """
+  subscriptions(limit: Int, page: Int, planCode: String): SubscriptionCollection!
+
+  """
   Query a single tax of an organization
   """
   tax(
@@ -4564,6 +4569,11 @@ type Subscription {
   subscriptionAt: ISO8601DateTime
   terminatedAt: ISO8601DateTime
   updatedAt: ISO8601DateTime!
+}
+
+type SubscriptionCollection {
+  collection: [Subscription!]!
+  metadata: CollectionMetadata!
 }
 
 type Tax {

--- a/schema.json
+++ b/schema.json
@@ -19087,6 +19087,59 @@
               ]
             },
             {
+              "name": "subscriptions",
+              "description": "Query subscriptions of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "SubscriptionCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "planCode",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "tax",
               "description": "Query a single tax of an organization",
               "type": {
@@ -20515,6 +20568,63 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SubscriptionCollection",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Subscription",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
                   "ofType": null
                 }
               },

--- a/spec/graphql/resolvers/subscriptions_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscriptions_resolver_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::SubscriptionsResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query {
+        subscriptions(limit: 5, planCode: "#{plan.code}") {
+          collection { id externalId plan { code } }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:plan) { create(:plan, organization:) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+
+  before do
+    customer
+  end
+
+  it 'returns a list of subscriptions' do
+    first_subcription = create(:subscription, customer:, plan:)
+    second_subcription = create(:subscription, customer:, plan:)
+    create(:subscription, customer:)
+
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+    )
+    response = result['data']['subscriptions']
+
+    aggregate_failures do
+      expect(response['collection'].count).to eq(2)
+      expect(response['collection'].map { |s| s['id'] }).to contain_exactly(
+        first_subcription.id,
+        second_subcription.id,
+      )
+      expect(response['collection'].first['plan']).to include(
+        'code' => plan.code,
+      )
+
+      expect(response['metadata']['currentPage']).to eq(1)
+      expect(response['metadata']['totalCount']).to eq(2)
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(current_user: membership.user, query:)
+
+      expect_graphql_error(result:, message: 'Missing organization id')
+    end
+  end
+
+  context 'when not member of the organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: create(:organization),
+        query:,
+      )
+
+      expect_graphql_error(result:, message: 'Not in organization')
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to improve the way we are overriding a plan. Without working as a duplicate, by adding the logic for managing parent and children of plans.

## Description

The goal of this PR is to be able to fetch subscriptions via graphql in order to create the plan's page.