### PR TITLE
feat(event): Ensure only one active subscription is active in post-processing

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -114,10 +114,10 @@ class Subscription < ApplicationRecord
 
   def validate_external_id
     return unless active?
+    return unless organization.subscriptions.active.exists?(external_id:)
 
     # NOTE: We want unique external id per organization.
-    used_ids = organization.subscriptions.active.pluck(:external_id)
-    errors.add(:external_id, :value_already_exist) if used_ids&.include?(external_id)
+    errors.add(:external_id, :value_already_exist)
   end
 
   def downgrade_plan_date

--- a/app/services/fees/estimate_pay_in_advance_service.rb
+++ b/app/services/fees/estimate_pay_in_advance_service.rb
@@ -11,7 +11,9 @@ module Fees
     end
 
     def call
-      Events::ValidateCreationService.call(organization:, params:, customer:, subscriptions:, result:, send_webhook: false)
+      Events::ValidateCreationService.call(
+        organization:, params:, customer:, subscriptions:, result:, send_webhook: false,
+      )
       return result unless result.success?
 
       if charges.none?

--- a/app/services/fees/estimate_pay_in_advance_service.rb
+++ b/app/services/fees/estimate_pay_in_advance_service.rb
@@ -11,7 +11,7 @@ module Fees
     end
 
     def call
-      Events::ValidateCreationService.call(organization:, params:, customer:, subscriptions:, result:)
+      Events::ValidateCreationService.call(organization:, params:, customer:, subscriptions:, result:, send_webhook: false)
       return result unless result.success?
 
       if charges.none?

--- a/spec/services/events/post_process_service_spec.rb
+++ b/spec/services/events/post_process_service_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Events::PostProcessService, type: :service do
       end
 
       context 'with multiple active subscription' do
-        let(:second_subscription) { create(:subscription, :terminated, organization:, customer:, started_at:) }
+        let(:second_subscription) { create(:subscription, organization:, customer:, started_at:) }
 
         before { second_subscription }
 
@@ -160,7 +160,23 @@ RSpec.describe Events::PostProcessService, type: :service do
         end
       end
 
-      # TODO: test case with multiple active subscription
+      context 'with multiple active subscription' do
+        let(:second_subscription) { create(:subscription, organization:, customer:, started_at:) }
+
+        before { second_subscription }
+
+        it 'assigns the subscription' do
+          result = process_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(event.reload.customer_id).to eq(customer.id)
+            expect(event.external_customer_id).to eq(customer.external_id)
+            expect(event.subscription_id).to be_nil
+          end
+        end
+      end
     end
 
     context 'when event code matches a recurring billable metric' do


### PR DESCRIPTION
## Context

On the path for high volume improvements, we need to adapt the structure of the events table for better performance.

## Description

This PR add a check on the number of active subscriptions when post-processing an event. If multiple subscriptions are identified, the event is not attached to any subscription.