### PR TITLE
feat(adyen-partner-info) Add Adyen partner info to all requests

### DIFF
--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -87,7 +87,7 @@ module CreditNotes
 
       def create_adyen_refund
         client.checkout.modifications_api.refund_captured_payment(
-          adyen_refund_params,
+          Lago::Adyen::Params.new(adyen_refund_params).to_h,
           payment.provider_payment_id,
         )
       rescue Adyen::AdyenError => e

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -88,7 +88,9 @@ module Invoices
       end
 
       def update_payment_method_id
-        result = client.checkout.payments_api.payment_methods(payment_method_params).response
+        result = client.checkout.payments_api.payment_methods(
+          Lago::Adyen::Params.new(payment_method_params).to_h,
+        ).response
 
         if (payment_method_id = result['storedPaymentMethods']&.first&.dig('id'))
           customer.adyen_customer.update!(payment_method_id:)
@@ -101,7 +103,7 @@ module Invoices
       def create_adyen_payment
         update_payment_method_id
 
-        client.checkout.payments_api.payments(payment_params).response
+        client.checkout.payments_api.payments(Lago::Adyen::Params.new(payment_params).to_h).response
       rescue Adyen::AdyenError => e
         deliver_error_webhook(e)
         update_invoice_payment_status(payment_status: :failed, deliver_webhook: false)

--- a/app/services/payment_provider_customers/adyen_service.rb
+++ b/app/services/payment_provider_customers/adyen_service.rb
@@ -19,7 +19,7 @@ module PaymentProviderCustomers
     def generate_checkout_url
       return result.not_found_failure!(resource: 'adyen_payment_provider') unless adyen_payment_provider
 
-      res = client.checkout.payment_links_api.payment_links(payment_link_params)
+      res = client.checkout.payment_links_api.payment_links(Lago::Adyen::Params.new(payment_link_params).to_h)
       checkout_url = res.response['url']
 
       SendWebhookJob.perform_later(

--- a/lib/lago/adyen/params.rb
+++ b/lib/lago/adyen/params.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Lago
+  module Adyen
+    class Params
+      attr_reader :params
+
+      def initialize(params = {})
+        @params = params.to_h
+      end
+
+      def to_h
+        default_params.merge(params)
+      end
+
+      private
+
+      def default_params
+        {
+          applicationInfo: {
+            externalPlatform: {
+              name: 'Lago',
+              integrator: 'Lago',
+            },
+            merchantApplication: {
+              name: 'Lago',
+            },
+          },
+        }
+      end
+    end
+  end
+end

--- a/spec/lib/lago/adyen/params_spec.rb
+++ b/spec/lib/lago/adyen/params_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Lago::Adyen::Params do
+  let(:adyen_params) { described_class.new(params) }
+
+  describe '#to_h' do
+    subject(:to_h) { adyen_params.to_h }
+
+    let(:default_params_hash) do
+      {
+        applicationInfo: {
+          externalPlatform: {
+            name: 'Lago',
+            integrator: 'Lago',
+          },
+          merchantApplication: {
+            name: 'Lago',
+          },
+        },
+      }
+    end
+
+    context 'when params are empty hash' do
+      let(:params) { {} }
+
+      it 'returns default params hash' do
+        expect(to_h).to eq(default_params_hash)
+      end
+    end
+
+    context 'when params are nil' do
+      let(:params) { nil }
+
+      it 'returns default params hash' do
+        expect(to_h).to eq(default_params_hash)
+      end
+    end
+
+    context 'when params are present' do
+      let(:params) do
+        {
+          merchantAccount: 'Lago Account',
+          shopperReference: 'Lago123',
+        }
+      end
+
+      let(:merged_params_hash) do
+        default_params_hash.merge(params)
+      end
+
+      it 'returns default params hash merged with given params' do
+        expect(to_h).to eq(merged_params_hash)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Add Adyen's partners info.

## Description

Add Adyen’s partner info to identify Lago as a partner.
https://docs.adyen.com/development-resources/application-information/