### PR TITLE
feat: Send started and terminated subscription webhooks

### DIFF
--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -148,8 +148,9 @@ module Subscriptions
       # NOTE: When upgrading, the new subscription becomes active immediatly
       #       The previous one must be terminated
       Subscriptions::TerminateService.call(subscription: current_subscription)
+
       new_subscription.mark_as_active!
-      SendWebhookJob.perform_later('subscription.started', new_subscription)
+      perform_later(job_class: SendWebhookJob, arguments: ['subscription.started', new_subscription])
 
       if plan.pay_in_advance?
         # NOTE: Since job is launched from inside a db transaction

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
             it 'enqueues a job to bill the existing subscription' do
               create_service.call
-              expect(BillSubscriptionJob).to have_been_enqueued.at_least(2).times
+              expect(BillSubscriptionJob).to have_been_enqueued.at_least(1).times
             end
           end
 
@@ -459,7 +459,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
             it 'enqueues a job to bill the existing subscription' do
               create_service.call
-              expect(BillSubscriptionJob).to have_been_enqueued.at_least(1).times
+              expect(BillSubscriptionJob).to have_been_enqueued.at_least(2).times
             end
           end
 

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -158,9 +158,9 @@ RSpec.describe Subscriptions::TerminateService do
     end
 
     it 'enqueues a SendWebhookJob' do
-      expect do
-        terminate_service.terminate_and_start_next(timestamp:)
-      end.to have_enqueued_job(SendWebhookJob)
+      terminate_service.terminate_and_start_next(timestamp:)
+      expect(SendWebhookJob).to have_been_enqueued.with('subscription.terminated', subscription)
+      expect(SendWebhookJob).to have_been_enqueued.with('subscription.started', next_subscription)
     end
 
     context 'when terminated subscription is payed in arrear' do


### PR DESCRIPTION
The goal of this PR is to send `subscription.started` and `subscription.terminated` on upgrade and downgrade.