### PR TITLE
feat(event): Move cached in advance aggregation into a proper model

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -106,10 +106,10 @@ module BillableMetrics
       end
 
       def handle_in_advance_current_usage(total_aggregation)
-        if previous_event
+        if cached_aggregation
           aggregation = total_aggregation -
-                        BigDecimal(previous_event.metadata['current_aggregation']) +
-                        BigDecimal(previous_event.metadata['max_aggregation'])
+                        BigDecimal(cached_aggregation.current_aggregation) +
+                        BigDecimal(cached_aggregation.max_aggregation)
 
           result.aggregation = aggregation
         else
@@ -122,11 +122,11 @@ module BillableMetrics
         result.current_usage_units = 0 if result.current_usage_units.negative?
       end
 
-      def get_previous_event_in_interval(from_datetime:, to_datetime:)
+      def get_cached_aggregation_in_interval(from_datetime:, to_datetime:)
         @from_datetime = from_datetime
         @to_datetime = to_datetime
 
-        previous_event
+        cached_aggregation
       end
     end
   end

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -113,7 +113,7 @@ module BillableMetrics
         query = CachedAggregation
           .where(organization_id: billable_metric.organization_id)
           .where(external_subscription_id: subscription.external_id)
-          .where(billable_metric_id: billable_metric.id)
+          .where(charge_id: charge.id)
           .from_datetime(from_datetime)
           .to_datetime(to_datetime)
           .order(timestamp: :desc)

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -60,16 +60,16 @@ module BillableMetrics
 
         value = event.properties.fetch(billable_metric.field_name, 0).to_s
 
-        unless previous_event
+        unless cached_aggregation
           return_value = BigDecimal(value).negative? ? '0' : value
           handle_event_metadata(current_aggregation: value, max_aggregation: value, units_applied: value)
 
           return BigDecimal(return_value)
         end
 
-        current_aggregation = BigDecimal(previous_event.metadata['current_aggregation']) + BigDecimal(value)
+        current_aggregation = BigDecimal(cached_aggregation.current_aggregation) + BigDecimal(value)
 
-        old_max = BigDecimal(previous_event.metadata['max_aggregation'])
+        old_max = BigDecimal(cached_aggregation.max_aggregation)
 
         result = if current_aggregation > old_max
           diff = [current_aggregation, current_aggregation - old_max].max
@@ -104,28 +104,24 @@ module BillableMetrics
         end
       end
 
-      # This method fetches the latest event in current period. If such a event exists we know that metadata
-      # with previous aggregation and previous maximum aggregation are stored there. Fetching these metadata values
+      # This method fetches the latest cached aggregation in current period. If such a record exists we know that
+      # previous aggregation and previous maximum aggregation are stored there. Fetching these values
       # would help us in pay in advance value calculation without iterating through all events in current period
-      def previous_event
-        @previous_event ||= begin
-          query = if billable_metric.recurring?
-            recurring_events_scope(to_datetime:, from_datetime:)
-          else
-            events_scope(from_datetime:, to_datetime:)
-          end
-          scope = query.where(field_presence_condition).where(field_numeric_condition)
+      def cached_aggregation
+        return @cached_aggregation if @cached_aggregation
 
-          # Events without attached right metadata are ignored since such events cannot be processed correctly.
-          # Could happen in race condition when event is stored but metadata in async job are attached later.
-          # In the meantime we want to avoid any issues with not attached metadata.
-          scope = scope.where("events.metadata->>'current_aggregation' IS NOT NULL")
-          scope = scope.where("events.metadata->>'max_aggregation' IS NOT NULL")
+        query = CachedAggregation
+          .where(organization_id: billable_metric.organization_id)
+          .where(external_subscription_id: subscription.external_id)
+          .where(billable_metric_id: billable_metric.id)
+          .from_datetime(from_datetime)
+          .to_datetime(to_datetime)
+          .order(timestamp: :desc)
 
-          scope = scope.where.not(id: event.id) if event.present?
+        query = query.where.not(event_id: event.id) if event.present?
+        query = query.where(group_id: group.id) if group
 
-          scope.reorder(created_at: :desc).first
-        end
+        @cached_aggregation = query.first
       end
 
       def handle_event_metadata(current_aggregation: nil, max_aggregation: nil, units_applied: nil)

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -76,7 +76,7 @@ module BillableMetrics
         query = CachedAggregation
           .where(organization_id: billable_metric.organization_id)
           .where(external_subscription_id: subscription.external_id)
-          .where(billable_metric_id: billable_metric.id)
+          .where(charge_id: charge.id)
           .from_datetime(from_datetime)
           .to_datetime(to_datetime)
           .order(timestamp: :desc)

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -81,6 +81,21 @@ module BillableMetrics
           .to_datetime(to_datetime)
           .order(timestamp: :desc)
 
+        # NOTE: For now we are using the relation between event and quantified event, but
+        #       this relation will be removed in a comming refactor as it will not possible
+        #       to handle clickhouse events that way
+        query = query
+          .joins('INNER JOIN events ON events.id = cached_aggregations.event_id')
+          .joins('INNER JOIN quantified_events ON events.quantified_event_id = quantified_events.id')
+          .where('quantified_events.added_at::timestamp(0) >= ?', from_datetime)
+          .where('quantified_events.added_at::timestamp(0) <= ?', to_datetime)
+          .where('quantified_events.removed_at::timestamp(0) IS NULL')
+          .or(
+            query
+              .where('quantified_events.removed_at::timestamp(0) >= ?', from_datetime)
+              .where('quantified_events.removed_at::timestamp(0) <= ?', to_datetime),
+          )
+
         query = query.where.not(event_id: event.id) if event.present?
         query = query.where(group_id: group.id) if group
 

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -24,7 +24,7 @@ module BillableMetrics
 
         newly_applied_units = (operation_type == :add) ? 1 : 0
 
-        unless previous_event
+        unless cached_aggregation
           handle_event_metadata(
             current_aggregation: newly_applied_units,
             max_aggregation: newly_applied_units,
@@ -34,8 +34,8 @@ module BillableMetrics
           return newly_applied_units
         end
 
-        old_aggregation = BigDecimal(previous_event.metadata['current_aggregation'])
-        old_max = BigDecimal(previous_event.metadata['max_aggregation'])
+        old_aggregation = BigDecimal(cached_aggregation.current_aggregation)
+        old_max = BigDecimal(cached_aggregation.max_aggregation)
 
         current_aggregation = (operation_type == :add) ? (old_aggregation + 1) : (old_aggregation - 1)
 
@@ -67,36 +67,24 @@ module BillableMetrics
 
       protected
 
-      # This method fetches the latest event in current period. If such a event exists we know that metadata
-      # with previous aggregation and previous maximum aggregation are stored there. Fetching these metadata values
+      # This method fetches the latest cached aggregation in current period. If such a record exists we know that
+      # previous aggregation and previous maximum aggregation are stored there. Fetching these values
       # would help us in pay in advance value calculation without iterating through all events in current period
-      def previous_event
-        @previous_event ||= begin
-          query = if billable_metric.recurring?
-            recurring_events_scope(to_datetime:, from_datetime:)
-          else
-            events_scope(from_datetime:, to_datetime:)
-          end
-          query = query
-            .joins(:quantified_event)
-            .where(field_presence_condition)
-            .where("events.metadata->>'current_aggregation' IS NOT NULL")
-            .where("events.metadata->>'max_aggregation' IS NOT NULL")
-            .where('quantified_events.added_at::timestamp(0) >= ?', from_datetime)
-            .where('quantified_events.added_at::timestamp(0) <= ?', to_datetime)
+      def cached_aggregation
+        return @cached_aggregation if @cached_aggregation
 
-          query = query.where.not(id: event.id) if event.present?
-          query = query.reorder(created_at: :desc)
+        query = CachedAggregation
+          .where(organization_id: billable_metric.organization_id)
+          .where(external_subscription_id: subscription.external_id)
+          .where(billable_metric_id: billable_metric.id)
+          .from_datetime(from_datetime)
+          .to_datetime(to_datetime)
+          .order(timestamp: :desc)
 
-          query
-            .where('quantified_events.removed_at::timestamp(0) IS NULL')
-            .or(
-              query
-                .where('quantified_events.removed_at::timestamp(0) >= ?', from_datetime)
-                .where('quantified_events.removed_at::timestamp(0) <= ?', to_datetime),
-            )
-            .first
-        end
+        query = query.where.not(event_id: event.id) if event.present?
+        query = query.where(group_id: group.id) if group
+
+        @cached_aggregation = query.first
       end
 
       def operation_type

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -157,14 +157,14 @@ module Fees
     def cache_aggregation_result(aggregation_result:, group:)
       return unless aggregation_result.current_aggregation.present? ||
                     aggregation_result.max_aggregation.present? ||
-                    aggregation_result.max_aggregation_with_proration
+                    aggregation_result.max_aggregation_with_proration.present?
 
       CachedAggregation.create!(
         organization_id: event.organization_id,
         event_id: event.id,
         timestamp: event.timestamp,
         external_subscription_id: event.external_subscription_id,
-        billable_metric_id: billable_metric.id,
+        charge_id: charge.id,
         group_id: group&.id,
         current_aggregation: aggregation_result.current_aggregation,
         max_aggregation: aggregation_result.max_aggregation,

--- a/db/migrate/20231017082921_fill_cached_aggregations.rb
+++ b/db/migrate/20231017082921_fill_cached_aggregations.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+class FillCachedAggregations < ActiveRecord::Migration[7.0]
+  class CachedAggregation < ApplicationRecord; end
+
+  class Group < ApplicationRecord
+    belongs_to :parent, class_name: 'Group', foreign_key: 'parent_group_id'
+    has_many :children, class_name: 'Group', foreign_key: 'parent_group_id'
+  end
+
+  class BillableMetric < ApplicationRecord
+    has_many :groups
+  end
+
+  def change
+    reversible do |dir|
+      dir.up do
+        sql = <<-SQL
+          WITH ordered_billable_metric AS (
+            SELECT
+              *,
+              ROW_NUMBER() OVER (
+                PARTITION BY billable_metrics.code
+                ORDER BY billable_metrics.deleted_at DESC NULLS FIRST
+              ) AS row_number
+            FROM billable_metrics
+          ),
+          last_billable_metrics AS (
+              SELECT
+                ordered_billable_metric.id,
+                ordered_billable_metric.organization_id,
+                ordered_billable_metric.code,
+                COUNT(groups.id) AS group_count
+              FROM ordered_billable_metric
+                LEFT JOIN groups ON ordered_billable_metric.id = groups.billable_metric_id
+              WHERE ordered_billable_metric.row_number = 1
+              GROUP BY
+                ordered_billable_metric.id,
+                ordered_billable_metric.organization_id,
+                ordered_billable_metric.code
+          )
+
+          SELECT
+            events.id AS event_id,
+            events.timestamp,
+            events.external_subscription_id,
+            events.organization_id,
+            last_billable_metrics.id AS billable_metric_id,
+            last_billable_metrics.group_count AS group_count,
+            events.properties,
+            events.metadata->>'current_aggregation',
+            events.metadata->>'max_aggregation',
+            events.metadata->>'max_aggregation_with_proration',
+            events.created_at
+          FROM events
+            INNER JOIN last_billable_metrics
+              ON last_billable_metrics.organization_id = events.organization_id
+              AND last_billable_metrics.code = events.code
+          WHERE
+            events.metadata->>'current_aggregation' IS NOT NULL
+            OR events.metadata->>'max_aggregation' IS NOT NULL
+            OR events.metadata->>'max_aggregation_with_proration' IS NOT NULL
+        SQL
+
+        records = ActiveRecord::Base.connection.exec_query(sql)
+        records.each do |event|
+          if event['group_count'].zero?
+            CachedAggregation.create_with(
+              timestamp: event['timestamp'],
+              current_aggregation: event['current_aggregation'],
+              max_aggregation: event['max_aggregation'],
+              max_aggregation_with_proration: event['max_aggregation_with_proration'],
+            ).find_or_create_with(
+              organization_id: event['organization_id'],
+              event_id: event['event_id'],
+              group_id: nil,
+              external_subscription_id: event['external_subscription_id'],
+              billable_metric_id: event['billable_metric_id'],
+            )
+          else
+            billable_metric = BillableMetric.find_by(id: event['billable_metric_id'])
+            next unless billable_metric
+
+            billable_metric.groups.where(parent_id: nil).find_each do |group|
+              next unless JSON.parse(event['properties'])[group.key][group.value]
+
+              if group.children.any?
+                group.children.find_each do |child|
+                  next unless JSON.parse(event['properties'])[child.key][child.value]
+
+                  CachedAggregation.create_with(
+                    timestamp: event['timestamp'],
+                    current_aggregation: event['current_aggregation'],
+                    max_aggregation: event['max_aggregation'],
+                    max_aggregation_with_proration: event['max_aggregation_with_proration'],
+                  ).find_or_create_with(
+                    organization_id: event['organization_id'],
+                    event_id: event['event_id'],
+                    group_id: child.id,
+                    external_subscription_id: event['external_subscription_id'],
+                    billable_metric_id: event['billable_metric_id'],
+                  )
+                end
+              else
+                CachedAggregation.create_with(
+                  timestamp: event['timestamp'],
+                  current_aggregation: event['current_aggregation'],
+                  max_aggregation: event['max_aggregation'],
+                  max_aggregation_with_proration: event['max_aggregation_with_proration'],
+                ).find_or_create_with(
+                  organization_id: event['organization_id'],
+                  event_id: event['event_id'],
+                  group_id: group.id,
+                  external_subscription_id: event['external_subscription_id'],
+                  billable_metric_id: event['billable_metric_id'],
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20231017082921_fill_cached_aggregations.rb
+++ b/db/migrate/20231017082921_fill_cached_aggregations.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FillCachedAggregations < ActiveRecord::Migration[7.0]
+  class Subscription < ApplicationRecord; end
+  class Event < ApplicationRecord; end
   class CachedAggregation < ApplicationRecord; end
 
   class Group < ApplicationRecord
@@ -12,108 +14,103 @@ class FillCachedAggregations < ActiveRecord::Migration[7.0]
     has_many :groups
   end
 
+  class Charge < ApplicationRecord; end
+
   def change
     reversible do |dir|
       dir.up do
         sql = <<-SQL
-          WITH ordered_billable_metric AS (
-            SELECT
-              *,
-              ROW_NUMBER() OVER (
-                PARTITION BY billable_metrics.code
-                ORDER BY billable_metrics.deleted_at DESC NULLS FIRST
-              ) AS row_number
-            FROM billable_metrics
-          ),
-          last_billable_metrics AS (
-              SELECT
-                ordered_billable_metric.id,
-                ordered_billable_metric.organization_id,
-                ordered_billable_metric.code,
-                COUNT(groups.id) AS group_count
-              FROM ordered_billable_metric
-                LEFT JOIN groups ON ordered_billable_metric.id = groups.billable_metric_id
-              WHERE ordered_billable_metric.row_number = 1
-              GROUP BY
-                ordered_billable_metric.id,
-                ordered_billable_metric.organization_id,
-                ordered_billable_metric.code
-          )
-
-          SELECT
-            events.id AS event_id,
-            events.timestamp,
-            events.external_subscription_id,
-            events.organization_id,
-            last_billable_metrics.id AS billable_metric_id,
-            last_billable_metrics.group_count AS group_count,
-            events.properties,
-            events.metadata->>'current_aggregation',
-            events.metadata->>'max_aggregation',
-            events.metadata->>'max_aggregation_with_proration',
-            events.created_at
+          SELECT *
           FROM events
-            INNER JOIN last_billable_metrics
-              ON last_billable_metrics.organization_id = events.organization_id
-              AND last_billable_metrics.code = events.code
-          WHERE
+          WHERE (
             events.metadata->>'current_aggregation' IS NOT NULL
             OR events.metadata->>'max_aggregation' IS NOT NULL
             OR events.metadata->>'max_aggregation_with_proration' IS NOT NULL
+          )
+          AND events.deleted_at IS NULL
         SQL
 
-        records = ActiveRecord::Base.connection.exec_query(sql)
-        records.each do |event|
-          if event['group_count'].zero?
-            CachedAggregation.create_with(
-              timestamp: event['timestamp'],
-              current_aggregation: event['current_aggregation'],
-              max_aggregation: event['max_aggregation'],
-              max_aggregation_with_proration: event['max_aggregation_with_proration'],
-            ).find_or_create_with(
-              organization_id: event['organization_id'],
-              event_id: event['event_id'],
-              group_id: nil,
-              external_subscription_id: event['external_subscription_id'],
-              billable_metric_id: event['billable_metric_id'],
+        Event.find_by_sql([sql]).each do |event|
+          subscription = Subscription
+            .joins('INNER JOIN customers ON customers.id = subscriptions.customer_id')
+            .where('customers.organization_id = ?', event.organization_id)
+            .where("date_trunc('second', started_at::timestamp) <= ?::timestamp", event.timestamp)
+            .where(
+              "terminated_at IS NULL OR date_trunc('second', terminated_at::timestamp) >= ?",
+              event.timestamp,
             )
-          else
-            billable_metric = BillableMetric.find_by(id: event['billable_metric_id'])
-            next unless billable_metric
+            .order('terminated_at DESC NULLS FIRST, started_at DESC')
+            .first
+          next unless subscription
 
-            billable_metric.groups.where(parent_id: nil).find_each do |group|
-              next unless JSON.parse(event['properties'])[group.key][group.value]
+          billable_metric = BillableMetric
+            .where(organization_id: event.organization_id)
+            .where(code: event.code)
+            .where(
+              'billable_metrics.deleted_at IS NULL OR deleted_at > ?', event.timestamp
+            )
+            .where('billable_metrics.created_at < ?', event.timestamp)
+            .order('billable_metrics.deleted_at DESC NULLS FIRST')
+            .first
+          next unless billable_metric
 
-              if group.children.any?
-                group.children.find_each do |child|
-                  next unless JSON.parse(event['properties'])[child.key][child.value]
+          charges = Charge.where(plan_id: subscription.plan_id)
+            .where(billable_metric_id: billable_metric.id)
 
+          charges.each do |charge|
+            # NOTE: billable metric without groups
+            parent_groups = billable_metric.groups.where(parent_group_id: nil).to_a
+
+            if parent_groups.count.zero?
+              CachedAggregation.create_with(
+                timestamp: event.timestamp,
+                current_aggregation: event.metadata['current_aggregation'],
+                max_aggregation: event.metadata['max_aggregation'],
+                max_aggregation_with_proration: event.metadata['max_aggregation_with_proration'],
+              ).find_or_create_with(
+                organization_id: event.organization_id,
+                event_id: event.id,
+                group_id: nil,
+                external_subscription_id: event.external_subscription_id,
+                charge_id: charge.id,
+              )
+            else
+              parent_groups.each do |group|
+                next unless event.properties[group.key] == group.value
+
+                child_group = group.children.all
+
+                if child_group.any?
+                  child_group.each do |child|
+                    next unless event.properties[child.key] == child.value
+
+                    CachedAggregation.create_with(
+                      timestamp: event.timestamp,
+                      current_aggregation: event.metadata['current_aggregation'],
+                      max_aggregation: event.metadata['max_aggregation'],
+                      max_aggregation_with_proration: event.metadata['max_aggregation_with_proration'],
+                    ).find_or_create_with(
+                      organization_id: event.organization_id,
+                      event_id: event.id,
+                      group_id: child.id,
+                      external_subscription_id: event.external_subscription_id,
+                      charge_id: charge.id,
+                    )
+                  end
+                else
                   CachedAggregation.create_with(
-                    timestamp: event['timestamp'],
-                    current_aggregation: event['current_aggregation'],
-                    max_aggregation: event['max_aggregation'],
-                    max_aggregation_with_proration: event['max_aggregation_with_proration'],
+                    timestamp: event.timestamp,
+                    current_aggregation: event.metadata['current_aggregation'],
+                    max_aggregation: event.metadata['max_aggregation'],
+                    max_aggregation_with_proration: event.metadata['max_aggregation_with_proration'],
                   ).find_or_create_with(
-                    organization_id: event['organization_id'],
-                    event_id: event['event_id'],
-                    group_id: child.id,
-                    external_subscription_id: event['external_subscription_id'],
-                    billable_metric_id: event['billable_metric_id'],
+                    organization_id: event.organization_id,
+                    event_id: event.id,
+                    group_id: group.id,
+                    external_subscription_id: event.external_subscription_id,
+                    charge_id: charge.id,
                   )
                 end
-              else
-                CachedAggregation.create_with(
-                  timestamp: event['timestamp'],
-                  current_aggregation: event['current_aggregation'],
-                  max_aggregation: event['max_aggregation'],
-                  max_aggregation_with_proration: event['max_aggregation_with_proration'],
-                ).find_or_create_with(
-                  organization_id: event['organization_id'],
-                  event_id: event['event_id'],
-                  group_id: group.id,
-                  external_subscription_id: event['external_subscription_id'],
-                  billable_metric_id: event['billable_metric_id'],
-                )
               end
             end
           end

--- a/db/migrate/20231017082921_fill_cached_aggregations.rb
+++ b/db/migrate/20231017082921_fill_cached_aggregations.rb
@@ -19,97 +19,91 @@ class FillCachedAggregations < ActiveRecord::Migration[7.0]
   def change
     reversible do |dir|
       dir.up do
-        sql = <<-SQL
-          SELECT *
-          FROM events
-          WHERE (
-            events.metadata->>'current_aggregation' IS NOT NULL
-            OR events.metadata->>'max_aggregation' IS NOT NULL
-            OR events.metadata->>'max_aggregation_with_proration' IS NOT NULL
-          )
-          AND events.deleted_at IS NULL
-        SQL
+        Organization.order(name: :asc).pluck(:id).each do |organization_id|
+          billable_metrics = BillableMetric.where(organization_id:)
+            .where('billable_metrics.aggregation_type IN (0, 1, 3, 4)')
 
-        Event.find_by_sql([sql]).each do |event|
-          subscription = Subscription
-            .joins('INNER JOIN customers ON customers.id = subscriptions.customer_id')
-            .where('customers.organization_id = ?', event.organization_id)
-            .where("date_trunc('second', started_at::timestamp) <= ?::timestamp", event.timestamp)
-            .where(
-              "terminated_at IS NULL OR date_trunc('second', terminated_at::timestamp) >= ?",
-              event.timestamp,
-            )
-            .order('terminated_at DESC NULLS FIRST, started_at DESC')
-            .first
-          next unless subscription
+          billable_metrics.find_each do |billable_metric|
+            events = Event.where(deleted_at: nil)
+              .where(organization_id:)
+              .where(code: billable_metric.code)
+              .where([
+                "metadata->>'current_aggregation' IS NOT NULL",
+                "metadata->>'max_aggregation' IS NOT NULL",
+                "metadata->>'max_aggregation_with_proration' IS NOT NULL",
+              ].join(' OR '))
 
-          billable_metric = BillableMetric
-            .where(organization_id: event.organization_id)
-            .where(code: event.code)
-            .where(
-              'billable_metrics.deleted_at IS NULL OR deleted_at > ?', event.timestamp
-            )
-            .where('billable_metrics.created_at < ?', event.timestamp)
-            .order('billable_metrics.deleted_at DESC NULLS FIRST')
-            .first
-          next unless billable_metric
+            events.find_each do |event|
+              subscription = Subscription
+                .joins('INNER JOIN customers ON customers.id = subscriptions.customer_id')
+                .where('customers.organization_id = ?', organization_id)
+                .where("date_trunc('second', started_at::timestamp) <= ?::timestamp", event.timestamp)
+                .where(
+                  "terminated_at IS NULL OR date_trunc('second', terminated_at::timestamp) >= ?",
+                  event.timestamp,
+                )
+                .order('terminated_at DESC NULLS FIRST, started_at DESC')
+                .first
+              next unless subscription
 
-          charges = Charge.where(plan_id: subscription.plan_id)
-            .where(billable_metric_id: billable_metric.id)
+              charges = Charge.where(plan_id: subscription.plan_id)
+                .where(billable_metric_id: billable_metric.id)
 
-          charges.each do |charge|
-            # NOTE: billable metric without groups
-            parent_groups = billable_metric.groups.where(parent_group_id: nil).to_a
+              charges.each do |charge|
+                # NOTE: billable metric without groups
+                parent_groups = billable_metric.groups.where(parent_group_id: nil).to_a
 
-            if parent_groups.count.zero?
-              CachedAggregation.create_with(
-                timestamp: event.timestamp,
-                current_aggregation: event.metadata['current_aggregation'],
-                max_aggregation: event.metadata['max_aggregation'],
-                max_aggregation_with_proration: event.metadata['max_aggregation_with_proration'],
-              ).find_or_create_with(
-                organization_id: event.organization_id,
-                event_id: event.id,
-                group_id: nil,
-                external_subscription_id: event.external_subscription_id,
-                charge_id: charge.id,
-              )
-            else
-              parent_groups.each do |group|
-                next unless event.properties[group.key] == group.value
-
-                child_group = group.children.all
-
-                if child_group.any?
-                  child_group.each do |child|
-                    next unless event.properties[child.key] == child.value
-
-                    CachedAggregation.create_with(
-                      timestamp: event.timestamp,
-                      current_aggregation: event.metadata['current_aggregation'],
-                      max_aggregation: event.metadata['max_aggregation'],
-                      max_aggregation_with_proration: event.metadata['max_aggregation_with_proration'],
-                    ).find_or_create_with(
-                      organization_id: event.organization_id,
-                      event_id: event.id,
-                      group_id: child.id,
-                      external_subscription_id: event.external_subscription_id,
-                      charge_id: charge.id,
-                    )
-                  end
-                else
+                if parent_groups.count.zero?
                   CachedAggregation.create_with(
                     timestamp: event.timestamp,
                     current_aggregation: event.metadata['current_aggregation'],
                     max_aggregation: event.metadata['max_aggregation'],
                     max_aggregation_with_proration: event.metadata['max_aggregation_with_proration'],
-                  ).find_or_create_with(
-                    organization_id: event.organization_id,
+                  ).find_or_create_by(
+                    organization_id:,
                     event_id: event.id,
-                    group_id: group.id,
+                    group_id: nil,
                     external_subscription_id: event.external_subscription_id,
                     charge_id: charge.id,
                   )
+                else
+                  parent_groups.each do |group|
+                    next unless event.properties[group.key] == group.value
+
+                    child_group = group.children.all
+
+                    if child_group.any?
+                      child_group.each do |child|
+                        next unless event.properties[child.key] == child.value
+
+                        CachedAggregation.create_with(
+                          timestamp: event.timestamp,
+                          current_aggregation: event.metadata['current_aggregation'],
+                          max_aggregation: event.metadata['max_aggregation'],
+                          max_aggregation_with_proration: event.metadata['max_aggregation_with_proration'],
+                        ).find_or_create_by(
+                          organization_id:,
+                          event_id: event.id,
+                          group_id: child.id,
+                          external_subscription_id: event.external_subscription_id,
+                          charge_id: charge.id,
+                        )
+                      end
+                    else
+                      CachedAggregation.create_with(
+                        timestamp: event.timestamp,
+                        current_aggregation: event.metadata['current_aggregation'],
+                        max_aggregation: event.metadata['max_aggregation'],
+                        max_aggregation_with_proration: event.metadata['max_aggregation_with_proration'],
+                      ).find_or_create_by(
+                        organization_id:,
+                        event_id: event.id,
+                        group_id: group.id,
+                        external_subscription_id: event.external_subscription_id,
+                        charge_id: charge.id,
+                      )
+                    end
+                  end
                 end
               end
             end

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -430,7 +430,8 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
           )
 
           expect(subscription.reload.fees.count).to eq(1)
-          expect(Event.find_by(transaction_id:).metadata['current_aggregation']).to eq('10')
+          event = Event.find_by(transaction_id:)
+          expect(CachedAggregation.find_by(event_id: event.id).current_aggregation).to eq(10)
 
           fee = subscription.fees.first
 
@@ -553,7 +554,8 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             },
           )
 
-          expect(Event.find_by(transaction_id:).metadata['current_aggregation']).to eq('2')
+          event = Event.find_by(transaction_id:)
+          expect(CachedAggregation.find_by(event_id: event.id).current_aggregation).to eq(2)
           expect(subscription.reload.fees.count).to eq(1)
 
           fee = subscription.fees.first
@@ -622,7 +624,8 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             },
           )
 
-          expect(Event.find_by(transaction_id:).metadata['current_aggregation']).to eq('2')
+          event = Event.find_by(transaction_id:)
+          expect(CachedAggregation.find_by(event_id: event.id).current_aggregation).to eq(2)
           expect(subscription.reload.fees.count).to eq(1)
 
           fee = subscription.fees.first

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
       create(
         :cached_aggregation,
         organization:,
-        billable_metric:,
+        charge:,
         event_id: latest_events.id,
         external_subscription_id: subscription.external_id,
         timestamp: to_datetime - 3.days,
@@ -411,7 +411,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
         create(
           :cached_aggregation,
           organization:,
-          billable_metric:,
+          charge:,
           external_subscription_id: subscription.external_id,
           timestamp: to_datetime - 3.days,
           current_aggregation: '4',
@@ -447,7 +447,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
         create(
           :cached_aggregation,
           organization:,
-          billable_metric:,
+          charge:,
           event_id: latest_events.id,
           external_subscription_id: subscription.external_id,
           timestamp: to_datetime - 3.days,

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -283,12 +283,9 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
           properties: {
             unique_id: '000',
           },
-          metadata: {
-            current_aggregation: '1',
-            max_aggregation: '3',
-          },
         )
       end
+
       let(:previous_quantified_event) do
         create(
           :quantified_event,
@@ -300,7 +297,20 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         )
       end
 
-      before { previous_event }
+      let(:cached_aggregation) do
+        create(
+          :cached_aggregation,
+          organization:,
+          billable_metric:,
+          event_id: previous_event.id,
+          external_subscription_id: subscription.external_id,
+          timestamp: previous_event.timestamp,
+          current_aggregation: '1',
+          max_aggregation: '3',
+        )
+      end
+
+      before { cached_aggregation }
 
       it 'returns period maximum as aggregation' do
         result = count_service.aggregate(options:)
@@ -308,7 +318,8 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         expect(result.aggregation).to eq(4)
       end
 
-      context 'when previous event does not exist' do
+      context 'when cached aggregation does not exist' do
+        let(:cached_aggregation) { nil }
         let(:previous_quantified_event) { nil }
 
         before { billable_metric.update!(recurring: false) }
@@ -388,12 +399,9 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
             properties: {
               unique_id: '000',
             },
-            metadata: {
-              current_aggregation: '7',
-              max_aggregation: '7',
-            },
           )
         end
+
         let(:previous_quantified_event) do
           create(
             :quantified_event,
@@ -405,7 +413,20 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
           )
         end
 
-        before { previous_event }
+        let(:cached_aggregation) do
+          create(
+            :cached_aggregation,
+            organization:,
+            billable_metric:,
+            event_id: previous_event.id,
+            external_subscription_id: subscription.external_id,
+            timestamp: previous_event.timestamp,
+            current_aggregation: '7',
+            max_aggregation: '7',
+          )
+        end
+
+        before { cached_aggregation }
 
         it 'assigns a pay_in_advance aggregation' do
           result = count_service.aggregate
@@ -426,12 +447,9 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
             properties: {
               unique_id: '000',
             },
-            metadata: {
-              current_aggregation: '4',
-              max_aggregation: '7',
-            },
           )
         end
+
         let(:previous_quantified_event) do
           create(
             :quantified_event,
@@ -443,7 +461,20 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
           )
         end
 
-        before { previous_event }
+        let(:cached_aggregation) do
+          create(
+            :cached_aggregation,
+            organization:,
+            billable_metric:,
+            event_id: previous_event.id,
+            external_subscription_id: subscription.external_id,
+            timestamp: previous_event.timestamp,
+            current_aggregation: '4',
+            max_aggregation: '7',
+          )
+        end
+
+        before { cached_aggregation }
 
         it 'assigns a pay_in_advance aggregation' do
           result = count_service.aggregate

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -301,7 +301,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         create(
           :cached_aggregation,
           organization:,
-          billable_metric:,
+          charge:,
           event_id: previous_event.id,
           external_subscription_id: subscription.external_id,
           timestamp: previous_event.timestamp,
@@ -417,7 +417,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
           create(
             :cached_aggregation,
             organization:,
-            billable_metric:,
+            charge:,
             event_id: previous_event.id,
             external_subscription_id: subscription.external_id,
             timestamp: previous_event.timestamp,
@@ -465,7 +465,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
           create(
             :cached_aggregation,
             organization:,
-            billable_metric:,
+            charge:,
             event_id: previous_event.id,
             external_subscription_id: subscription.external_id,
             timestamp: previous_event.timestamp,

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       create(
         :cached_aggregation,
         organization: billable_metric.organization,
-        billable_metric:,
+        charge:,
         external_subscription_id: subscription.external_id,
         event_id: latest_events.id,
         timestamp: latest_events.timestamp,
@@ -287,7 +287,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       create(
         :cached_aggregation,
         organization: billable_metric.organization,
-        billable_metric:,
+        charge:,
         external_subscription_id: subscription.external_id,
         event_id: latest_events.id,
         timestamp: latest_events.timestamp,
@@ -433,7 +433,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
         create(
           :cached_aggregation,
           organization: billable_metric.organization,
-          billable_metric:,
+          charge:,
           external_subscription_id: subscription.external_id,
           event_id: latest_events.id,
           timestamp: latest_events.timestamp,
@@ -471,7 +471,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
         create(
           :cached_aggregation,
           organization: billable_metric.organization,
-          billable_metric:,
+          charge:,
           external_subscription_id: subscription.external_id,
           event_id: latest_events.id,
           timestamp: latest_events.timestamp,

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     let(:options) do
       { is_pay_in_advance: true, is_current_usage: true }
     end
+
     let(:latest_events) do
       create(
         :event,
@@ -209,13 +210,24 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
         properties: {
           total_count: 4,
         },
-        metadata: {
-          current_aggregation: '4',
-          max_aggregation: '6',
-          max_aggregation_with_proration: '3.8',
-        },
       )
     end
+
+    let(:cached_aggregation) do
+      create(
+        :cached_aggregation,
+        organization: billable_metric.organization,
+        billable_metric:,
+        external_subscription_id: subscription.external_id,
+        event_id: latest_events.id,
+        timestamp: latest_events.timestamp,
+        current_aggregation: '4',
+        max_aggregation: '6',
+        max_aggregation_with_proration: '3.8',
+      )
+    end
+
+    before { cached_aggregation }
 
     it 'returns period maximum as aggregation' do
       result = sum_service.aggregate(options:)
@@ -224,8 +236,9 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       expect(result.current_usage_units).to eq(9)
     end
 
-    context 'when previous event does not exist' do
+    context 'when cached aggregation does not exist' do
       let(:latest_events) { nil }
+      let(:cached_aggregation) { nil }
 
       it 'returns zero as aggregation' do
         result = sum_service.aggregate(options:)
@@ -256,6 +269,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     let(:options) do
       { is_pay_in_advance: true, is_current_usage: true }
     end
+
     let(:latest_events) do
       create(
         :event,
@@ -266,13 +280,24 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
         properties: {
           total_count: 4,
         },
-        metadata: {
-          current_aggregation: '4',
-          max_aggregation: '6',
-          max_aggregation_with_proration: '3.8',
-        },
       )
     end
+
+    let(:cached_aggregation) do
+      create(
+        :cached_aggregation,
+        organization: billable_metric.organization,
+        billable_metric:,
+        external_subscription_id: subscription.external_id,
+        event_id: latest_events.id,
+        timestamp: latest_events.timestamp,
+        current_aggregation: '4',
+        max_aggregation: '6',
+        max_aggregation_with_proration: '3.8',
+      )
+    end
+
+    before { cached_aggregation }
 
     it 'returns correct values' do
       result = sum_service.aggregate(options:)
@@ -401,13 +426,24 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
           properties: {
             total_count: -6,
           },
-          metadata: {
-            current_aggregation: '4',
-            max_aggregation: '10',
-            max_aggregation_with_proration: '3.2',
-          },
         )
       end
+
+      let(:cached_aggregation) do
+        create(
+          :cached_aggregation,
+          organization: billable_metric.organization,
+          billable_metric:,
+          external_subscription_id: subscription.external_id,
+          event_id: latest_events.id,
+          timestamp: latest_events.timestamp,
+          current_aggregation: '4',
+          max_aggregation: '10',
+          max_aggregation_with_proration: '3.2',
+        )
+      end
+
+      before { cached_aggregation }
 
       it 'assigns a pay_in_advance aggregation' do
         result = sum_service.aggregate
@@ -428,13 +464,24 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
           properties: {
             total_count: -6,
           },
-          metadata: {
-            current_aggregation: '4',
-            max_aggregation: '10',
-            max_aggregation_with_proration: '3.2',
-          },
         )
       end
+
+      let(:cached_aggregation) do
+        create(
+          :cached_aggregation,
+          organization: billable_metric.organization,
+          billable_metric:,
+          external_subscription_id: subscription.external_id,
+          event_id: latest_events.id,
+          timestamp: latest_events.timestamp,
+          current_aggregation: '4',
+          max_aggregation: '10',
+          max_aggregation_with_proration: '3.2',
+        )
+      end
+
+      before { cached_aggregation }
 
       it 'assigns a pay_in_advance aggregation' do
         result = sum_service.aggregate

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
         create(
           :cached_aggregation,
           organization:,
-          billable_metric:,
+          charge:,
           event_id: previous_event.id,
           external_subscription_id: subscription.external_id,
           timestamp: from_datetime + 5.days,
@@ -421,7 +421,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
           create(
             :cached_aggregation,
             organization:,
-            billable_metric:,
+            charge:,
             event_id: previous_event.id,
             external_subscription_id: subscription.external_id,
             timestamp: previous_event.timestamp,

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
           expect(cached_aggregation.organization_id).to eq(organization.id)
           expect(cached_aggregation.event_id).to eq(event.id)
           expect(cached_aggregation.timestamp.iso8601(3)).to eq(event.timestamp.iso8601(3))
-          expect(cached_aggregation.billable_metric_id).to eq(billable_metric.id)
+          expect(cached_aggregation.charge_id).to eq(charge.id)
           expect(cached_aggregation.external_subscription_id).to eq(event.external_subscription_id)
           expect(cached_aggregation.group_id).to be_nil
           expect(cached_aggregation.current_aggregation).to eq(9)


### PR DESCRIPTION
## Context

## Context

On the path for high volume improvements, we need to adapt the structure of the events table for better performance.

## Description

This PR moves events#metadata used for in advance aggregation into a new table named `cached_aggregations` to stop writing into events table as it will become impossible in high usage scenarios
