### PR TITLE
fix(usage): wrong datatype for events_count

### DIFF
--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -9,7 +9,7 @@ module V1
 
           {
             units: fees.map { |f| BigDecimal(f.units) }.sum.to_s,
-            events_count: fees.map { |f| BigDecimal(f.events_count || 0) }.sum,
+            events_count: fees.map { |f| f.events_count&.to_i || 0 }.sum,
             amount_cents: fees.sum(&:amount_cents),
             amount_currency: fee.amount_currency,
             charge: {


### PR DESCRIPTION
## Context

Some errors were reported by user on python client. The issue is related with the new `events_count` field added in the customer current and past usage. This field is expected to be an integer but is serialized as a float in lago api.

## Description

This PR fixes the output format