### PR TITLE
misc(hide-aasm-warnings): Hide aasm warnings

### DIFF
--- a/config/initializers/aasm.rb
+++ b/config/initializers/aasm.rb
@@ -1,0 +1,1 @@
+AASM::Configuration.hide_warnings = true

--- a/config/initializers/aasm.rb
+++ b/config/initializers/aasm.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 AASM::Configuration.hide_warnings = true


### PR DESCRIPTION
## Context

AASM gem displays warnings like:
```
W, [2023-10-17T08:44:50.999036 #326]  WARN -- : Invoice: overriding method 'draft?'!
W, [2023-10-17T08:44:50.999271 #326]  WARN -- : Invoice: overriding method 'finalized?'!
W, [2023-10-17T08:44:50.999487 #326]  WARN -- : Invoice: overriding method 'voided?'!
```

## Description

Lets hide these warnings:
https://github.com/aasm/aasm/issues/361#issuecomment-1157454157