### PR TITLE
fix(adyen-checkout-url): Fix generating adyen checkout url when psp is not present

### DIFF
--- a/app/services/payment_provider_customers/adyen_service.rb
+++ b/app/services/payment_provider_customers/adyen_service.rb
@@ -17,6 +17,8 @@ module PaymentProviderCustomers
     end
 
     def generate_checkout_url
+      return result.not_found_failure!(resource: 'adyen_payment_provider') unless adyen_payment_provider
+
       res = client.checkout.payment_links_api.payment_links(payment_link_params)
       checkout_url = res.response['url']
 


### PR DESCRIPTION
## Description

There is a bug that occurs when payment provider is no longer present.
Generating of a checkout url fails with NoMethodError.