### PR TITLE
fix(invoice): Fix URL when API URL is not a domain

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -103,7 +103,12 @@ class Invoice < ApplicationRecord
   def file_url
     return if file.blank?
 
-    Rails.application.routes.url_helpers.rails_blob_url(file, host: ENV['LAGO_API_URL'])
+    blob_path = Rails.application.routes.url_helpers.rails_blob_path(
+      file,
+      host: 'void',
+    )
+
+    File.join(ENV['LAGO_API_URL'], blob_path)
   end
 
   def fee_total_amount_cents

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Invoice, type: :model do
-  subject(:invite) { create(:invite) }
+  subject(:invoice) { create(:invoice) }
 
   it_behaves_like 'paper_trail traceable'
 
@@ -469,6 +469,23 @@ RSpec.describe Invoice, type: :model do
       it 'returns the expected creditable amount in cents' do
         expect(invoice.creditable_amount_cents).to eq(216)
       end
+    end
+  end
+
+  describe '.file_url' do
+    before do
+      invoice.file.attach(
+        io: StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))),
+        filename: 'invoice.pdf',
+        content_type: 'application/pdf',
+      )
+    end
+
+    it 'returns the file url' do
+      file_url = invoice.file_url
+
+      expect(file_url).to be_present
+      expect(file_url).to include(ENV['LAGO_API_URL'])
     end
   end
 end


### PR DESCRIPTION
- Invoice URL is not working when using `LAGO_API_URL` with port or subpath