### PR TITLE
misc(stripe-unauthorized): Rescue Stripe::AuthenticationError error

### DIFF
--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -13,11 +13,11 @@ module ApiErrors
     )
   end
 
-  def unauthorized_error
+  def unauthorized_error(message: 'Unauthorized')
     render(
       json: {
         status: 401,
-        error: 'Unauthorized',
+        error: message,
       },
       status: :unauthorized,
     )
@@ -67,6 +67,8 @@ module ApiErrors
       validation_errors(errors: error_result.error.messages)
     when BaseService::ForbiddenFailure
       forbidden_error(code: error_result.error.code)
+    when BaseService::UnauthorizedFailure
+      unauthorized_error(message: error_result.error.message)
     else
       raise(error_result.error)
     end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -73,11 +73,7 @@ class BaseService
   end
 
   class UnauthorizedFailure < FailedResult
-    attr_reader :code
-
     def initialize(result, message:)
-      @message = message
-
       super(result, message)
     end
   end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -72,6 +72,16 @@ class BaseService
     end
   end
 
+  class UnauthorizedFailure < FailedResult
+    attr_reader :code
+
+    def initialize(result, message:)
+      @message = message
+
+      super(result, message)
+    end
+  end
+
   class Result < OpenStruct
     attr_reader :error
 
@@ -119,6 +129,10 @@ class BaseService
 
     def forbidden_failure!(code: 'feature_unavailable')
       fail_with_error!(ForbiddenFailure.new(self, code:))
+    end
+
+    def unauthorized_failure!(message: 'unauthorized')
+      fail_with_error!(UnauthorizedFailure.new(self, message:))
     end
 
     def raise_if_error!

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -181,7 +181,7 @@ module Customers
 
       customer.document_locale = billing[:document_locale] if billing.key?(:document_locale)
 
-      if new_customer
+      if new_customer || should_create_billing_configuration?(billing, customer)
         create_billing_configuration(customer, billing)
         customer.save!
         return
@@ -258,6 +258,10 @@ module Customers
         .find_or_create_by!(code: "tax_#{vat_rate}")
 
       Customers::ApplyTaxesService.call(customer:, tax_codes: [tax.code])
+    end
+
+    def should_create_billing_configuration?(billing, customer)
+      billing[:sync_with_provider] && customer.provider_customer&.provider_customer_id.nil?
     end
   end
 end

--- a/app/services/payment_provider_customers/create_service.rb
+++ b/app/services/payment_provider_customers/create_service.rb
@@ -91,8 +91,5 @@ module PaymentProviderCustomers
     def should_generate_checkout_url?
       result.provider_customer.provider_customer_id? && result.provider_customer.sync_with_provider.blank?
     end
-
-    def assign_provider_payment_methods()
-    end
   end
 end

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -68,8 +68,6 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
       end
 
       it 'delivers an error webhook' do
-        stripe_service.create
-
         expect { stripe_service.create }.to enqueue_job(SendWebhookJob)
           .with(
             'customer.payment_provider_error',

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -51,6 +51,37 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
       end
     end
 
+    context 'when payment provider has incorrect API key' do
+      before do
+        allow(Stripe::Customer).to receive(:create)
+          .and_raise(Stripe::AuthenticationError.new('API key invalid.'))
+      end
+
+      it 'returns an unauthorized error' do
+        result = stripe_service.create
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::UnauthorizedFailure)
+          expect(result.error.message).to eq('Stripe authentication failed. API key invalid.')
+        end
+      end
+
+      it 'delivers an error webhook' do
+        stripe_service.create
+
+        expect { stripe_service.create }.to enqueue_job(SendWebhookJob)
+          .with(
+            'customer.payment_provider_error',
+            customer,
+            provider_error: {
+              message: 'API key invalid.',
+              error_code: nil,
+            },
+          ).on_queue(:webhook)
+      end
+    end
+
     context 'when failing to create the customer' do
       it 'delivers an error webhook' do
         allow(Stripe::Customer).to receive(:create)


### PR DESCRIPTION
## Context

When Stripe hasn’t been set up in the settings, or the Stripe API key is invalid, and the user tries to create a customer account through integration, the API returns a 500.

## Description

Return a 401 error with a message that Stripe authentication failed.