### PR TITLE
feat(credit_note): Add estimate service and API end points

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -123,9 +123,9 @@ module Api
 
         if result.success?
           render(
-            json: ::V1::CreditNoteEstimateSerializer.new(
+            json: ::V1::CreditNotes::EstimateSerializer.new(
               result.credit_note,
-              root_name: 'credit_note',
+              root_name: 'estimated_credit_note',
             ),
           )
         else

--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -114,6 +114,25 @@ module Api
         )
       end
 
+      def estimate
+        service = CreditNotes::EstimateService.new(
+          invoice: current_organization.invoices.find_by(id: estimate_params[:invoice_id]),
+          **estimate_params,
+        )
+        result = service.call
+
+        if result.success?
+          render(
+            json: ::V1::CreditNoteEstimateSerializer.new(
+              result.credit_note,
+              root_name: 'credit_note',
+            ),
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
       private
 
       def input_params
@@ -133,6 +152,17 @@ module Api
 
       def update_params
         params.require(:credit_note).permit(:refund_status)
+      end
+
+      def estimate_params
+        @estimate_params ||= params.require(:credit_note)
+          .permit(
+            :invoice_id,
+            items: [
+              :fee_id,
+              :amount_cents,
+            ],
+          )
       end
     end
   end

--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -115,11 +115,10 @@ module Api
       end
 
       def estimate
-        service = CreditNotes::EstimateService.new(
+        result = CreditNotes::EstimateService.call(
           invoice: current_organization.invoices.find_by(id: estimate_params[:invoice_id]),
-          **estimate_params,
+          items: estimate_params[:items],
         )
-        result = service.call
 
         if result.success?
           render(

--- a/app/graphql/resolvers/credit_notes/estimate_resolver.rb
+++ b/app/graphql/resolvers/credit_notes/estimate_resolver.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module CreditNotes
+    class EstimateResolver < Resolvers::BaseResolver
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      description 'Fetch amounts for credit note creation'
+
+      argument :invoice_id, ID, required: true
+      argument :items, [Types::CreditNoteItems::Input], required: true
+
+      type Types::CreditNotes::Estimate, null: false
+
+      def resolve(invoice_id:, items:)
+        validate_organization!
+
+        result = ::CreditNotes::EstimateService.call(
+          invoice: current_organization.invoices.find_by(id: invoice_id),
+          items:,
+        )
+
+        result.success? ? result.credit_note : result_error(result)
+      end
+    end
+  end
+end

--- a/app/graphql/types/credit_note_items/estimate.rb
+++ b/app/graphql/types/credit_note_items/estimate.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  module CreditNoteItems
+    class Estimate < Types::BaseObject
+      graphql_name 'CreditNoteItemEstimate'
+
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :fee, Types::Fees::Object, null: false
+    end
+  end
+end

--- a/app/graphql/types/credit_notes/estimate.rb
+++ b/app/graphql/types/credit_notes/estimate.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Types
+  module CreditNotes
+    class Estimate < Types::BaseObject
+      description 'Estimate amounts for credit note creation'
+      graphql_name 'CreditNoteEstimate'
+
+      field :currency, Types::CurrencyEnum, null: false
+
+      field :coupons_adjustment_amount_cents, GraphQL::Types::BigInt, null: false
+      field :max_creditable_amount_cents, GraphQL::Types::BigInt, method: :credit_amount_cents, null: false
+      field :sub_total_excluding_taxes_amount_cents, GraphQL::Types::BigInt, null: false
+      field :taxes_amount_cents, GraphQL::Types::BigInt, null: false
+
+      field :taxes_rate, Float, null: false
+
+      field :items, [Types::CreditNoteItems::Estimate], null: false
+
+      field :applied_taxes, [Types::CreditNotes::AppliedTaxes::Object], null: false
+    end
+  end
+end

--- a/app/graphql/types/credit_notes/estimate.rb
+++ b/app/graphql/types/credit_notes/estimate.rb
@@ -10,6 +10,7 @@ module Types
 
       field :coupons_adjustment_amount_cents, GraphQL::Types::BigInt, null: false
       field :max_creditable_amount_cents, GraphQL::Types::BigInt, method: :credit_amount_cents, null: false
+      field :max_refundable_amount_cents, GraphQL::Types::BigInt, method: :refund_amount_cents, null: false
       field :sub_total_excluding_taxes_amount_cents, GraphQL::Types::BigInt, null: false
       field :taxes_amount_cents, GraphQL::Types::BigInt, null: false
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -16,6 +16,7 @@ module Types
     field :coupon, resolver: Resolvers::CouponResolver
     field :coupons, resolver: Resolvers::CouponsResolver
     field :credit_note, resolver: Resolvers::CreditNoteResolver
+    field :credit_note_estimate, resolver: Resolvers::CreditNotes::EstimateResolver
     field :current_version, resolver: Resolvers::VersionResolver
     field :customer, resolver: Resolvers::CustomerResolver
     field :customer_credit_notes, resolver: Resolvers::CustomerCreditNotesResolver

--- a/app/serializers/v1/credit_notes/applied_tax_serializer.rb
+++ b/app/serializers/v1/credit_notes/applied_tax_serializer.rb
@@ -15,7 +15,7 @@ module V1
           base_amount_cents: model.base_amount_cents,
           amount_cents: model.amount_cents,
           amount_currency: model.amount_currency,
-          created_at: model.created_at.iso8601,
+          created_at: model.created_at&.iso8601,
         }
       end
     end

--- a/app/serializers/v1/credit_notes/estimate_serializer.rb
+++ b/app/serializers/v1/credit_notes/estimate_serializer.rb
@@ -24,7 +24,7 @@ module V1
 
       def items
         {
-          'items' => model.items.map { |i| { fee_id: i.fee_id, amount_cents: i.amount_cents } },
+          'items' => model.items.map { |i| { lago_fee_id: i.fee_id, amount_cents: i.amount_cents } },
         }
       end
 

--- a/app/serializers/v1/credit_notes/estimate_serializer.rb
+++ b/app/serializers/v1/credit_notes/estimate_serializer.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module V1
+  module CreditNotes
+    class EstimateSerializer < ModelSerializer
+      def serialize
+        payload = {
+          lago_invoice_id: model.invoice_id,
+          invoice_number: model.invoice.number,
+          currency: model.currency,
+          total_amount_cents: model.total_amount_cents,
+          taxes_amount_cents: model.taxes_amount_cents,
+          sub_total_excluding_taxes_amount_cents: model.sub_total_excluding_taxes_amount_cents,
+          max_creditable_amount_cents: model.credit_amount_cents,
+          max_refundable_amount_cents: model.refund_amount_cents,
+          coupons_adjustment_amount_cents: model.coupons_adjustment_amount_cents,
+          taxes_rate: model.taxes_rate,
+        }
+
+        payload.merge!(items)
+        payload.merge!(applied_taxes)
+
+        payload
+      end
+
+      def items
+        {
+          'items' => model.items.map { |i| { fee_id: i.fee_id, amount_cents: i.amount_cents } },
+        }
+      end
+
+      def applied_taxes
+        collection = ::CollectionSerializer.new(
+          model.applied_taxes,
+          ::V1::CreditNotes::AppliedTaxSerializer,
+        ).serialize[:data]
+
+        {
+          'applied_taxes' => collection.map { |t| t.except(%i[lago_id lago_credit_note_id created_at]) },
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/v1/credit_notes/estimate_serializer.rb
+++ b/app/serializers/v1/credit_notes/estimate_serializer.rb
@@ -11,6 +11,7 @@ module V1
           taxes_amount_cents: model.taxes_amount_cents,
           sub_total_excluding_taxes_amount_cents: model.sub_total_excluding_taxes_amount_cents,
           max_creditable_amount_cents: model.credit_amount_cents,
+          max_refundable_amount_cents: model.refund_amount_cents,
           coupons_adjustment_amount_cents: model.coupons_adjustment_amount_cents,
           taxes_rate: model.taxes_rate,
         }

--- a/app/serializers/v1/credit_notes/estimate_serializer.rb
+++ b/app/serializers/v1/credit_notes/estimate_serializer.rb
@@ -8,11 +8,9 @@ module V1
           lago_invoice_id: model.invoice_id,
           invoice_number: model.invoice.number,
           currency: model.currency,
-          total_amount_cents: model.total_amount_cents,
           taxes_amount_cents: model.taxes_amount_cents,
           sub_total_excluding_taxes_amount_cents: model.sub_total_excluding_taxes_amount_cents,
           max_creditable_amount_cents: model.credit_amount_cents,
-          max_refundable_amount_cents: model.refund_amount_cents,
           coupons_adjustment_amount_cents: model.coupons_adjustment_amount_cents,
           taxes_rate: model.taxes_rate,
         }

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -28,9 +28,6 @@ module CreditNotes
 
       compute_amounts_and_taxes(credit_note)
 
-      # TODO: assign creditable and refundable attribute and return them in a serializer
-      credit_note.refund_amount_cents = 0
-
       result.credit_note = credit_note
       result
     end
@@ -86,6 +83,17 @@ module CreditNotes
         taxes_result.coupons_adjustment_amount_cents +
         taxes_result.taxes_amount_cents
       ).round
+
+      compute_refundable_amount(credit_note)
+    end
+
+    def compute_refundable_amount(credit_note)
+      credit_note.refund_amount_cents = credit_note.credit_amount_cents
+
+      refundable_amount_cents = invoice.refundable_amount_cents
+      return unless credit_note.credit_amount_cents > refundable_amount_cents
+
+      credit_note.refund_amount_cents = refundable_amount_cents
     end
   end
 end

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module CreditNotes
+  class EstimateService < BaseService
+    def initialize(invoice:, items:)
+      @invoice = invoice
+      @items = items
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'invoice') unless invoice
+      return result.forbidden_failure! unless should_create_credit_note?
+      return result.not_allowed_failure!(code: 'invalid_type_or_status') unless valid_type_or_status?
+
+      credit_note = CreditNote.new(
+        customer: invoice.customer,
+        invoice:,
+        total_amount_currency: invoice.currency,
+        vat_amount_currency: invoice.currency,
+        credit_amount_currency: invoice.currency,
+        refund_amount_currency: invoice.currency,
+        balance_amount_currency: invoice.currency,
+      )
+
+      validate_items
+      return result unless result.success?
+
+      credit_note.precise_coupons_adjustment_amount_cents = coupons_adjustment_amount_cents
+      credit_note.coupons_adjustment_amount_cents = credit_note.precise_coupons_adjustment_amount_cents.round
+      credit_note.precise_vat_amount_cents = vat_amount_cents
+      credit_note.vat_amount_cents = credit_note.precise_vat_amount_cents.round
+
+      # TODO: assign creditable and refundable attribute and return them in a serializer
+
+      result.credit_note = credit_note
+      result
+    end
+
+    private
+
+    attr_reader :invoice
+
+    delegate :credit_note, to: :result
+
+    def should_create_credit_note?
+      # NOTE: credit note is a premium feature
+      License.premium?
+    end
+
+    def valid_type_or_status?
+      return false if invoice.credit?
+
+      invoice.version_number >= Invoice::CREDIT_NOTES_MIN_VERSION
+    end
+
+    def validate_items
+      items.each do |item_attr|
+        amount_cents = item_attr[:amount_cents] || 0
+
+        item = credit_note.items.new(
+          fee: invoice.fees.find_by(id: item_attr[:fee_id]),
+          amount_cents: amount_cents.round,
+          precise_amount_cents: amount_cents,
+          amount_currency: invoice.currency,
+        )
+        break unless valid_item?(item)
+      end
+    end
+
+    def valid_item?(item)
+      CreditNote::ValidateItemService.new(result, item:).valid?
+    end
+
+    def coupons_adjustment_amount_cents
+      return 0 if invoice.version_number < Invoice::COUPON_BEFORE_VAT_VERSION
+
+      invoice.coupons_amount_cents.fdiv(invoice.fees_amount_cents) * credit_note.items.sum(&:precise_amount_cents)
+    end
+
+    def vat_amount_cents
+      credit_note.items.sum do |item|
+        # NOTE: Because coupons are applied before VAT,
+        #       we have to discribute the coupon adjustement at prorata of each items
+        #       to compute the VAT
+        item_rate = item.precise_amount_cents.fdiv(credit_note.items.sum(&:precise_amount_cents))
+        prorated_coupon_amount = credit_note.precise_coupons_adjustment_amount_cents * item_rate
+        (item.precise_amount_cents - prorated_coupon_amount) * (item.fee.vat_rate || 0)
+      end.fdiv(100)
+    end
+  end
+end

--- a/app/services/credit_notes/estimate_service.rb
+++ b/app/services/credit_notes/estimate_service.rb
@@ -49,7 +49,7 @@ module CreditNotes
 
     def validate_items(credit_note)
       items.each do |item_attr|
-        amount_cents = item_attr[:amount_cents] || 0
+        amount_cents = item_attr[:amount_cents]&.to_i || 0
 
         item = CreditNoteItem.new(
           fee: invoice.fees.find_by(id: item_attr[:fee_id]),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
       resources :credit_notes, only: %i[create update show index] do
         post :download, on: :member
         put :void, on: :member
-        get :estimate, on: :collection
+        post :estimate, on: :collection
       end
       resources :events, only: %i[create show] do
         post :estimate_fees, on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
       resources :credit_notes, only: %i[create update show index] do
         post :download, on: :member
         put :void, on: :member
+        get :estimate, on: :collection
       end
       resources :events, only: %i[create show] do
         post :estimate_fees, on: :collection

--- a/db/clickhouse_schema.rb
+++ b/db/clickhouse_schema.rb
@@ -10,23 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ClickhouseActiverecord::Schema.define(version: 2023_10_30_163703) do
+ClickhouseActiverecord::Schema.define(version: 2023_10_26_124912) do
 
   # TABLE: events_raw
-  # SQL: CREATE TABLE default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime, `code` String, `properties` Map(String, String) ) ENGINE = MergeTree PRIMARY KEY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) ORDER BY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) TTL timestamp TO VOLUME 'hot', timestamp + toIntervalDay(90) TO VOLUME 'cold' SETTINGS storage_policy = 'hot_cold', index_granularity = 8192
+  # SQL: CREATE TABLE default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime, `code` String, `properties` String ) ENGINE = MergeTree PRIMARY KEY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) ORDER BY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) TTL timestamp TO VOLUME 'hot', timestamp + toIntervalDay(90) TO VOLUME 'cold' SETTINGS storage_policy = 'hot_cold', index_granularity = 8192
   create_table "events_raw", id: false, options: "MergeTree PRIMARY KEY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) ORDER BY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) TTL timestamp TO VOLUME 'hot', timestamp + toIntervalDay(90) TO VOLUME 'cold' SETTINGS storage_policy = 'hot_cold', index_granularity = 8192", force: :cascade do |t|
-    t.string "organization_id", null: false
-    t.string "external_customer_id", null: false
-    t.string "external_subscription_id", null: false
-    t.string "transaction_id", null: false
-    t.datetime "timestamp", precision: nil, null: false
-    t.string "code", null: false
-    t.string "properties", limit: 0, null: false
-  end
-
-  # TABLE: events_raw_queue
-  # SQL: CREATE TABLE default.events_raw_queue ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime, `code` String, `properties` String ) ENGINE = Kafka SETTINGS kafka_broker_list = 'redpanda:9092', kafka_topic_list = 'events-raw', kafka_group_name = 'clickhouse', kafka_format = 'JSONEachRow'
-  create_table "events_raw_queue", id: false, options: "Kafka SETTINGS kafka_broker_list = 'redpanda:9092', kafka_topic_list = 'events-raw', kafka_group_name = 'clickhouse', kafka_format = 'JSONEachRow'", force: :cascade do |t|
     t.string "organization_id", null: false
     t.string "external_customer_id", null: false
     t.string "external_subscription_id", null: false
@@ -36,9 +24,16 @@ ClickhouseActiverecord::Schema.define(version: 2023_10_30_163703) do
     t.string "properties", null: false
   end
 
-  # TABLE: events_raw_mv
-  # SQL: CREATE MATERIALIZED VIEW default.events_raw_mv TO default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime, `code` String, `properties` Map(String, String) ) AS SELECT organization_id, external_customer_id, external_subscription_id, transaction_id, timestamp, code, CAST(JSONExtractKeysAndValuesRaw(properties), 'Map(String, String)') AS properties FROM default.events_raw_queue
-  create_table "events_raw_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_customer_id, external_subscription_id, transaction_id, timestamp, code, CAST(JSONExtractKeysAndValuesRaw(properties), 'Map(String, String)') AS properties FROM default.events_raw_queue", force: :cascade do |t|
+  # TABLE: events_raw_queue
+  # SQL: CREATE TABLE default.events_raw_queue ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime, `code` String, `properties` String ) ENGINE = Kafka SETTINGS kafka_broker_list = '*****', kafka_topic_list = 'events-raw', kafka_group_name = 'clickhouse', kafka_format = 'JSONEachRow'
+  create_table "events_raw_queue", id: false, options: "Kafka SETTINGS kafka_broker_list = '*****', kafka_topic_list = 'events-raw', kafka_group_name = 'clickhouse', kafka_format = 'JSONEachRow'", force: :cascade do |t|
+    t.string "organization_id", null: false
+    t.string "external_customer_id", null: false
+    t.string "external_subscription_id", null: false
+    t.string "transaction_id", null: false
+    t.datetime "timestamp", precision: nil, null: false
+    t.string "code", null: false
+    t.string "properties", null: false
   end
 
 end

--- a/db/clickhouse_schema.rb
+++ b/db/clickhouse_schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ClickhouseActiverecord::Schema.define(version: 2023_10_26_124912) do
+ClickhouseActiverecord::Schema.define(version: 2023_10_30_163703) do
 
   # TABLE: events_raw
-  # SQL: CREATE TABLE default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime, `code` String, `properties` String ) ENGINE = MergeTree PRIMARY KEY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) ORDER BY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) TTL timestamp TO VOLUME 'hot', timestamp + toIntervalDay(90) TO VOLUME 'cold' SETTINGS storage_policy = 'hot_cold', index_granularity = 8192
+  # SQL: CREATE TABLE default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime, `code` String, `properties` Map(String, String) ) ENGINE = MergeTree PRIMARY KEY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) ORDER BY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) TTL timestamp TO VOLUME 'hot', timestamp + toIntervalDay(90) TO VOLUME 'cold' SETTINGS storage_policy = 'hot_cold', index_granularity = 8192
   create_table "events_raw", id: false, options: "MergeTree PRIMARY KEY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) ORDER BY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) TTL timestamp TO VOLUME 'hot', timestamp + toIntervalDay(90) TO VOLUME 'cold' SETTINGS storage_policy = 'hot_cold', index_granularity = 8192", force: :cascade do |t|
     t.string "organization_id", null: false
     t.string "external_customer_id", null: false
@@ -21,12 +21,12 @@ ClickhouseActiverecord::Schema.define(version: 2023_10_26_124912) do
     t.string "transaction_id", null: false
     t.datetime "timestamp", precision: nil, null: false
     t.string "code", null: false
-    t.string "properties", null: false
+    t.string "properties", limit: 0, null: false
   end
 
   # TABLE: events_raw_queue
-  # SQL: CREATE TABLE default.events_raw_queue ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime, `code` String, `properties` String ) ENGINE = Kafka SETTINGS kafka_broker_list = '*****', kafka_topic_list = 'events-raw', kafka_group_name = 'clickhouse', kafka_format = 'JSONEachRow'
-  create_table "events_raw_queue", id: false, options: "Kafka SETTINGS kafka_broker_list = '*****', kafka_topic_list = 'events-raw', kafka_group_name = 'clickhouse', kafka_format = 'JSONEachRow'", force: :cascade do |t|
+  # SQL: CREATE TABLE default.events_raw_queue ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime, `code` String, `properties` String ) ENGINE = Kafka SETTINGS kafka_broker_list = 'redpanda:9092', kafka_topic_list = 'events-raw', kafka_group_name = 'clickhouse', kafka_format = 'JSONEachRow'
+  create_table "events_raw_queue", id: false, options: "Kafka SETTINGS kafka_broker_list = 'redpanda:9092', kafka_topic_list = 'events-raw', kafka_group_name = 'clickhouse', kafka_format = 'JSONEachRow'", force: :cascade do |t|
     t.string "organization_id", null: false
     t.string "external_customer_id", null: false
     t.string "external_subscription_id", null: false

--- a/db/clickhouse_schema.rb
+++ b/db/clickhouse_schema.rb
@@ -36,4 +36,9 @@ ClickhouseActiverecord::Schema.define(version: 2023_10_30_163703) do
     t.string "properties", null: false
   end
 
+  # TABLE: events_raw_mv
+  # SQL: CREATE MATERIALIZED VIEW default.events_raw_mv TO default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime, `code` String, `properties` Map(String, String) ) AS SELECT organization_id, external_customer_id, external_subscription_id, transaction_id, timestamp, code, CAST(JSONExtractKeysAndValuesRaw(properties), 'Map(String, String)') AS properties FROM default.events_raw_queue
+  create_table "events_raw_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_customer_id, external_subscription_id, transaction_id, timestamp, code, CAST(JSONExtractKeysAndValuesRaw(properties), 'Map(String, String)') AS properties FROM default.events_raw_queue", force: :cascade do |t|
+  end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -120,6 +120,26 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_20_091031) do
     t.index ["organization_id"], name: "index_billable_metrics_on_organization_id"
   end
 
+  create_table "cached_aggregations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "organization_id", null: false
+    t.uuid "event_id", null: false
+    t.datetime "timestamp", null: false
+    t.string "external_subscription_id", null: false
+    t.uuid "billable_metric_id", null: false
+    t.uuid "group_id"
+    t.decimal "current_aggregation"
+    t.decimal "max_aggregation"
+    t.decimal "max_aggregation_with_proration"
+    t.datetime "created_at", null: false
+    t.index ["billable_metric_id"], name: "index_cached_aggregations_on_billable_metric_id"
+    t.index ["event_id"], name: "index_cached_aggregations_on_event_id"
+    t.index ["external_subscription_id"], name: "index_cached_aggregations_on_external_subscription_id"
+    t.index ["group_id"], name: "index_cached_aggregations_on_group_id"
+    t.index ["organization_id", "timestamp", "billable_metric_id", "group_id"], name: "index_timestamp_group_lookup"
+    t.index ["organization_id", "timestamp", "billable_metric_id"], name: "index_timestamp_lookup"
+    t.index ["organization_id"], name: "index_cached_aggregations_on_organization_id"
+  end
+
   create_table "charges", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "billable_metric_id"
     t.datetime "created_at", null: false
@@ -804,6 +824,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_20_091031) do
   add_foreign_key "applied_add_ons", "add_ons"
   add_foreign_key "applied_add_ons", "customers"
   add_foreign_key "billable_metrics", "organizations"
+  add_foreign_key "cached_aggregations", "groups"
   add_foreign_key "charges", "billable_metrics"
   add_foreign_key "charges", "plans"
   add_foreign_key "charges_taxes", "charges"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1859,12 +1859,31 @@ enum CreditNoteCreditStatusEnum {
   voided
 }
 
+"""
+Estimate amounts for credit note creation
+"""
+type CreditNoteEstimate {
+  appliedTaxes: [CreditNoteAppliedTax!]!
+  couponsAdjustmentAmountCents: BigInt!
+  currency: CurrencyEnum!
+  items: [CreditNoteItemEstimate!]!
+  maxCreditableAmountCents: BigInt!
+  subTotalExcludingTaxesAmountCents: BigInt!
+  taxesAmountCents: BigInt!
+  taxesRate: Float!
+}
+
 type CreditNoteItem {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   createdAt: ISO8601DateTime!
   fee: Fee!
   id: ID!
+}
+
+type CreditNoteItemEstimate {
+  amountCents: BigInt!
+  fee: Fee!
 }
 
 input CreditNoteItemInput {
@@ -4194,6 +4213,11 @@ type Query {
     """
     id: ID!
   ): CreditNote
+
+  """
+  Fetch amounts for credit note creation
+  """
+  creditNoteEstimate(invoiceId: ID!, items: [CreditNoteItemInput!]!): CreditNoteEstimate!
 
   """
   Retrieves currently connected user

--- a/schema.graphql
+++ b/schema.graphql
@@ -1868,6 +1868,7 @@ type CreditNoteEstimate {
   currency: CurrencyEnum!
   items: [CreditNoteItemEstimate!]!
   maxCreditableAmountCents: BigInt!
+  maxRefundableAmountCents: BigInt!
   subTotalExcludingTaxesAmountCents: BigInt!
   taxesAmountCents: BigInt!
   taxesRate: Float!

--- a/schema.json
+++ b/schema.json
@@ -7114,6 +7114,179 @@
         },
         {
           "kind": "OBJECT",
+          "name": "CreditNoteEstimate",
+          "description": "Estimate amounts for credit note creation",
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "appliedTaxes",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CreditNoteAppliedTax",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "couponsAdjustmentAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "currency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "items",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CreditNoteItemEstimate",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "maxCreditableAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "subTotalExcludingTaxesAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxesAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxesRate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "CreditNoteItem",
           "description": null,
           "interfaces": [
@@ -7202,6 +7375,55 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CreditNoteItemEstimate",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fee",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Fee",
                   "ofType": null
                 }
               },
@@ -18355,6 +18577,63 @@
                       "kind": "SCALAR",
                       "name": "ID",
                       "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "creditNoteEstimate",
+              "description": "Fetch amounts for credit note creation",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CreditNoteEstimate",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "invoiceId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "items",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "CreditNoteItemInput",
+                          "ofType": null
+                        }
+                      }
                     }
                   },
                   "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -7228,6 +7228,24 @@
               ]
             },
             {
+              "name": "maxRefundableAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "subTotalExcludingTaxesAmountCents",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Resolvers::CreditNotes::EstimateResolver, type: :graphql do
     aggregate_failures do
       expect(estimate_response['currency']).to eq('EUR')
       expect(estimate_response['taxesAmountCents']).to eq('0')
-      expect(estimate_response['subTotalExcludingTaxesAmountCents']).to eq('0')
+      expect(estimate_response['subTotalExcludingTaxesAmountCents']).to eq('100')
       expect(estimate_response['maxCreditableAmountCents']).to eq('100')
       expect(estimate_response['maxRefundableAmountCents']).to eq('0')
       expect(estimate_response['couponsAdjustmentAmountCents']).to eq('0')

--- a/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::CreditNotes::EstimateResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($invoiceId: ID!, $items: [CreditNoteItemInput!]!) {
+        creditNoteEstimate(invoiceId: $invoiceId, items: $items) {
+          currency
+          taxesAmountCents
+          subTotalExcludingTaxesAmountCents
+          maxCreditableAmountCents
+          couponsAdjustmentAmountCents
+          taxesRate
+          items { amountCents fee { id } }
+          appliedTaxes { id amountCents }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, organization:, customer:) }
+
+  let(:fees) { create_list(:fee, 2, invoice:, amount_cents: 100) }
+
+  around { |test| lago_premium!(&test) }
+
+  it 'returns the estimate for the credit note creation' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+      variables: {
+        invoiceId: invoice.id,
+        items: fees.map { |f| { feeId: f.id, amountCents: 50 } },
+      },
+    )
+
+    estimate_response = result['data']['creditNoteEstimate']
+
+    aggregate_failures do
+      expect(estimate_response['currency']).to eq('EUR')
+      expect(estimate_response['taxesAmountCents']).to eq('0')
+      expect(estimate_response['subTotalExcludingTaxesAmountCents']).to eq('0')
+      expect(estimate_response['maxCreditableAmountCents']).to eq('100')
+      expect(estimate_response['couponsAdjustmentAmountCents']).to eq('0')
+      expect(estimate_response['items'].first['amountCents']).to eq('50')
+      expect(estimate_response['appliedTaxes']).to be_blank
+    end
+  end
+
+  context 'without current user' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_organization: membership.organization,
+        query:,
+        variables: {
+          invoiceId: invoice.id,
+          items: fees.map { |f| { feeId: f.id, amountCents: 50 } },
+        },
+      )
+
+      expect_unauthorized_error(result)
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query:,
+        variables: {
+          invoiceId: invoice.id,
+          items: fees.map { |f| { feeId: f.id, amountCents: 50 } },
+        },
+      )
+
+      expect_forbidden_error(result)
+    end
+  end
+
+  context 'with invalid invoice' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: {
+          invoiceId: create(:invoice).id,
+          items: fees.map { |f| { feeId: f.id, amountCents: 50 } },
+        },
+      )
+
+      expect_not_found(result)
+    end
+  end
+end

--- a/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Resolvers::CreditNotes::EstimateResolver, type: :graphql do
           taxesAmountCents
           subTotalExcludingTaxesAmountCents
           maxCreditableAmountCents
+          maxRefundableAmountCents
           couponsAdjustmentAmountCents
           taxesRate
           items { amountCents fee { id } }
@@ -47,6 +48,7 @@ RSpec.describe Resolvers::CreditNotes::EstimateResolver, type: :graphql do
       expect(estimate_response['taxesAmountCents']).to eq('0')
       expect(estimate_response['subTotalExcludingTaxesAmountCents']).to eq('0')
       expect(estimate_response['maxCreditableAmountCents']).to eq('100')
+      expect(estimate_response['maxRefundableAmountCents']).to eq('0')
       expect(estimate_response['couponsAdjustmentAmountCents']).to eq('0')
       expect(estimate_response['items'].first['amountCents']).to eq('50')
       expect(estimate_response['appliedTaxes']).to be_blank

--- a/spec/graphql/types/credit_note_items/estimate_spec.rb
+++ b/spec/graphql/types/credit_note_items/estimate_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::CreditNoteItems::Estimate do
+  subject { described_class }
+
+  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:fee).of_type('Fee!') }
+end

--- a/spec/graphql/types/credit_notes/estimate_spec.rb
+++ b/spec/graphql/types/credit_notes/estimate_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Types::CreditNotes::Estimate do
   it { is_expected.to have_field(:taxes_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:sub_total_excluding_taxes_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:max_creditable_amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:max_refundable_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:coupons_adjustment_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:taxes_rate).of_type('Float!') }
   it { is_expected.to have_field(:items).of_type('[CreditNoteItemEstimate!]!') }

--- a/spec/graphql/types/credit_notes/estimate_spec.rb
+++ b/spec/graphql/types/credit_notes/estimate_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::CreditNotes::Estimate do
+  subject { described_class }
+
+  it { is_expected.to have_field(:currency).of_type('CurrencyEnum!') }
+  it { is_expected.to have_field(:taxes_amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:sub_total_excluding_taxes_amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:max_creditable_amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:coupons_adjustment_amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:taxes_rate).of_type('Float!') }
+  it { is_expected.to have_field(:items).of_type('[CreditNoteItemEstimate!]!') }
+  it { is_expected.to have_field(:applied_taxes).of_type('[CreditNoteAppliedTax!]!') }
+end

--- a/spec/requests/api/v1/credit_notes_spec.rb
+++ b/spec/requests/api/v1/credit_notes_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         expect(estimated_credit_note[:taxes_amount_cents]).to eq(0)
         expect(estimated_credit_note[:sub_total_excluding_taxes_amount_cents]).to eq(0)
         expect(estimated_credit_note[:max_creditable_amount_cents]).to eq(100)
-        expect(estimated_credit_note[:max_refundable_amount_cents]).to eq(0)
+        expect(estimated_credit_note[:max_refundable_amount_cents]).to eq(100)
         expect(estimated_credit_note[:coupons_adjustment_amount_cents]).to eq(0)
         expect(estimated_credit_note[:items].first[:amount_cents]).to eq(50)
         expect(estimated_credit_note[:applied_taxes]).to be_blank

--- a/spec/requests/api/v1/credit_notes_spec.rb
+++ b/spec/requests/api/v1/credit_notes_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
     around { |test| lago_premium!(&test) }
 
     it 'returns the computed amounts for credit note creation' do
-      get_with_token(organization, '/api/v1/credit_notes/estimate', { credit_note: estimate_params })
+      post_with_token(organization, '/api/v1/credit_notes/estimate', { credit_note: estimate_params })
 
       aggregate_failures do
         expect(response).to have_http_status(:success)
@@ -379,7 +379,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
       let(:invoice) { create(:invoice) }
 
       it 'returns not found' do
-        get_with_token(organization, '/api/v1/credit_notes/estimate', { credit_note: estimate_params })
+        post_with_token(organization, '/api/v1/credit_notes/estimate', { credit_note: estimate_params })
 
         expect(response).to have_http_status(:not_found)
       end

--- a/spec/requests/api/v1/credit_notes_spec.rb
+++ b/spec/requests/api/v1/credit_notes_spec.rb
@@ -368,6 +368,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         expect(estimated_credit_note[:taxes_amount_cents]).to eq(0)
         expect(estimated_credit_note[:sub_total_excluding_taxes_amount_cents]).to eq(0)
         expect(estimated_credit_note[:max_creditable_amount_cents]).to eq(100)
+        expect(estimated_credit_note[:max_refundable_amount_cents]).to eq(0)
         expect(estimated_credit_note[:coupons_adjustment_amount_cents]).to eq(0)
         expect(estimated_credit_note[:items].first[:amount_cents]).to eq(50)
         expect(estimated_credit_note[:applied_taxes]).to be_blank

--- a/spec/requests/api/v1/credit_notes_spec.rb
+++ b/spec/requests/api/v1/credit_notes_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         expect(estimated_credit_note[:invoice_number]).to eq(invoice.number)
         expect(estimated_credit_note[:currency]).to eq('EUR')
         expect(estimated_credit_note[:taxes_amount_cents]).to eq(0)
-        expect(estimated_credit_note[:sub_total_excluding_taxes_amount_cents]).to eq(0)
+        expect(estimated_credit_note[:sub_total_excluding_taxes_amount_cents]).to eq(100)
         expect(estimated_credit_note[:max_creditable_amount_cents]).to eq(100)
         expect(estimated_credit_note[:max_refundable_amount_cents]).to eq(100)
         expect(estimated_credit_note[:coupons_adjustment_amount_cents]).to eq(0)

--- a/spec/scenarios/credit_note_spec.rb
+++ b/spec/scenarios/credit_note_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Create credit note Scenarios', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:plan1) do
+    create(
+      :plan,
+      organization:,
+      interval: :monthly,
+      amount_cents: 17_900,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:plan2) do
+    create(
+      :plan,
+      organization:,
+      interval: :monthly,
+      amount_cents: 39_900,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:coupon) do
+    create(
+      :coupon,
+      organization:,
+      amount_cents: 20_000,
+      expiration: :no_expiration,
+      coupon_type: :fixed_amount,
+      frequency: :forever,
+      limited_plans: true,
+    )
+  end
+
+  let(:coupon_target) do
+    create(:coupon_plan, coupon:, plan: plan2)
+  end
+
+  around { |test| lago_premium!(&test) }
+
+  it 'Allows creation of partial credit note' do
+    # Creates two subscriptions
+    travel_to(DateTime.new(2022, 12, 19, 12)) do
+      create_subscription(
+        external_customer_id: customer.external_id,
+        external_id: "#{customer.external_id}_1",
+        plan_code: plan1.code,
+        billing_time: :anniversary,
+      )
+
+      create_subscription(
+        external_customer_id: customer.external_id,
+        external_id: "#{customer.external_id}_2",
+        plan_code: plan2.code,
+        billing_time: :anniversary,
+      )
+    end
+
+    # Apply a coupon to the customer
+    travel_to(DateTime.new(2023, 8, 29)) do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 250_00,
+      )
+    end
+
+    # Bill subscription on an anniversary date
+    travel_to(DateTime.new(2023, 10, 19)) do
+      Subscriptions::BillingService.call
+      perform_all_enqueued_jobs
+    end
+
+    invoice = customer.invoices.order(created_at: :desc).first
+    expect(invoice.fees_amount_cents).to eq(57_800)
+    expect(invoice.coupons_amount_cents).to eq(25_000)
+    expect(invoice.total_amount_cents).to eq(32_800)
+
+    fee1 = invoice.fees.find_by(amount_cents: 17_900)
+    expect(fee1.precise_coupons_amount_cents).to eq(0)
+
+    fee2 = invoice.fees.find_by(amount_cents: 39_900)
+    expect(fee2.precise_coupons_amount_cents).to eq(25_000)
+
+    # Emit a credit note on only one fee
+    travel_to(DateTime.new(2023, 10, 23)) do
+      update_invoice(invoice, payment_status: :succeeded)
+
+      create_credit_note(
+        invoice_id: invoice.id,
+        reason: :other,
+        credit_amount_cents: 0,
+        refund_amount_cents: 14_902,
+        items: [
+          {
+            fee_id: fee2.id,
+            amount_cents: 26_260,
+          },
+        ],
+      )
+    end
+
+    credit_note = invoice.credit_notes.first
+    expect(credit_note.refund_amount_cents).to eq(14_902)
+    expect(credit_note.total_amount_cents).to eq(14_902)
+    expect(credit_note.coupons_adjustment_amount_cents).to eq(11_358)
+  end
+end

--- a/spec/serializers/v1/credit_notes/estimate_serializer_spec.rb
+++ b/spec/serializers/v1/credit_notes/estimate_serializer_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe ::V1::CreditNotes::EstimateSerializer do
       expect(result[root_name]['sub_total_excluding_taxes_amount_cents'])
         .to eq(estimated_credit_note.sub_total_excluding_taxes_amount_cents)
       expect(result[root_name]['max_creditable_amount_cents']).to eq(estimated_credit_note.credit_amount_cents)
+      expect(result[root_name]['max_refundable_amount_cents']).to eq(estimated_credit_note.refund_amount_cents)
       expect(result[root_name]['coupons_adjustment_amount_cents'])
         .to eq(estimated_credit_note.coupons_adjustment_amount_cents)
       expect(result[root_name]['taxes_rate']).to eq(estimated_credit_note.taxes_rate)

--- a/spec/serializers/v1/credit_notes/estimate_serializer_spec.rb
+++ b/spec/serializers/v1/credit_notes/estimate_serializer_spec.rb
@@ -25,9 +25,11 @@ RSpec.describe ::V1::CreditNotes::EstimateSerializer do
       expect(result[root_name]['invoice_number']).to eq(estimated_credit_note.invoice.number)
       expect(result[root_name]['currency']).to eq(estimated_credit_note.currency)
       expect(result[root_name]['taxes_amount_cents']).to eq(estimated_credit_note.taxes_amount_cents)
-      expect(result[root_name]['sub_total_excluding_taxes_amount_cents']).to eq(estimated_credit_note.sub_total_excluding_taxes_amount_cents)
+      expect(result[root_name]['sub_total_excluding_taxes_amount_cents'])
+        .to eq(estimated_credit_note.sub_total_excluding_taxes_amount_cents)
       expect(result[root_name]['max_creditable_amount_cents']).to eq(estimated_credit_note.credit_amount_cents)
-      expect(result[root_name]['coupons_adjustment_amount_cents']).to eq(estimated_credit_note.coupons_adjustment_amount_cents)
+      expect(result[root_name]['coupons_adjustment_amount_cents'])
+        .to eq(estimated_credit_note.coupons_adjustment_amount_cents)
       expect(result[root_name]['taxes_rate']).to eq(estimated_credit_note.taxes_rate)
 
       expect(result[root_name]['items'].count).to eq(2)

--- a/spec/serializers/v1/credit_notes/estimate_serializer_spec.rb
+++ b/spec/serializers/v1/credit_notes/estimate_serializer_spec.rb
@@ -24,11 +24,9 @@ RSpec.describe ::V1::CreditNotes::EstimateSerializer do
       expect(result[root_name]['lago_invoice_id']).to eq(estimated_credit_note.invoice_id)
       expect(result[root_name]['invoice_number']).to eq(estimated_credit_note.invoice.number)
       expect(result[root_name]['currency']).to eq(estimated_credit_note.currency)
-      expect(result[root_name]['total_amount_cents']).to eq(estimated_credit_note.total_amount_cents)
       expect(result[root_name]['taxes_amount_cents']).to eq(estimated_credit_note.taxes_amount_cents)
       expect(result[root_name]['sub_total_excluding_taxes_amount_cents']).to eq(estimated_credit_note.sub_total_excluding_taxes_amount_cents)
       expect(result[root_name]['max_creditable_amount_cents']).to eq(estimated_credit_note.credit_amount_cents)
-      expect(result[root_name]['max_refundable_amount_cents']).to eq(estimated_credit_note.refund_amount_cents)
       expect(result[root_name]['coupons_adjustment_amount_cents']).to eq(estimated_credit_note.coupons_adjustment_amount_cents)
       expect(result[root_name]['taxes_rate']).to eq(estimated_credit_note.taxes_rate)
 

--- a/spec/serializers/v1/credit_notes/estimate_serializer_spec.rb
+++ b/spec/serializers/v1/credit_notes/estimate_serializer_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::CreditNotes::EstimateSerializer do
+  subject(:serializer) { described_class.new(estimated_credit_note, root_name:) }
+
+  let(:root_name) { 'estimated_credit_note' }
+
+  let(:estimated_credit_note) do
+    build(:credit_note).tap do |credit_note|
+      credit_note_items.each { |i| credit_note.items << i }
+      applied_taxes.each { |t| credit_note.applied_taxes << t }
+    end
+  end
+
+  let(:credit_note_items) { build_list(:credit_note_item, 2, amount_cents: 100) }
+  let(:applied_taxes) { build_list(:credit_note_applied_tax, 2) }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result[root_name]['lago_invoice_id']).to eq(estimated_credit_note.invoice_id)
+      expect(result[root_name]['invoice_number']).to eq(estimated_credit_note.invoice.number)
+      expect(result[root_name]['currency']).to eq(estimated_credit_note.currency)
+      expect(result[root_name]['total_amount_cents']).to eq(estimated_credit_note.total_amount_cents)
+      expect(result[root_name]['taxes_amount_cents']).to eq(estimated_credit_note.taxes_amount_cents)
+      expect(result[root_name]['sub_total_excluding_taxes_amount_cents']).to eq(estimated_credit_note.sub_total_excluding_taxes_amount_cents)
+      expect(result[root_name]['max_creditable_amount_cents']).to eq(estimated_credit_note.credit_amount_cents)
+      expect(result[root_name]['max_refundable_amount_cents']).to eq(estimated_credit_note.refund_amount_cents)
+      expect(result[root_name]['coupons_adjustment_amount_cents']).to eq(estimated_credit_note.coupons_adjustment_amount_cents)
+      expect(result[root_name]['taxes_rate']).to eq(estimated_credit_note.taxes_rate)
+
+      expect(result[root_name]['items'].count).to eq(2)
+      expect(result[root_name]['applied_taxes'].count).to eq(2)
+    end
+  end
+end

--- a/spec/services/credit_notes/estimate_service_spec.rb
+++ b/spec/services/credit_notes/estimate_service_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreditNotes::EstimateService, type: :service do
+  subject(:estimate_service) { described_class.new(invoice:, items:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:invoice) do
+    create(
+      :invoice,
+      organization:,
+      customer:,
+      currency: 'EUR',
+      fees_amount_cents: 20,
+      coupons_amount_cents: 10,
+      taxes_amount_cents: 2,
+      total_amount_cents: 12,
+      payment_status: :succeeded,
+      taxes_rate: 20,
+      version_number: 3,
+    )
+  end
+
+  let(:fee1) do
+    create(:fee, invoice:, amount_cents: 10, taxes_amount_cents: 1, taxes_rate: 20, precise_coupons_amount_cents: 5)
+  end
+
+  let(:fee2) do
+    create(:fee, invoice:, amount_cents: 10, taxes_amount_cents: 1, taxes_rate: 20, precise_coupons_amount_cents: 5)
+  end
+
+  let(:tax) { create(:tax, organization:, rate: 20) }
+
+  let(:items) do
+    [
+      {
+        fee_id: fee1.id,
+        amount_cents: 10,
+      },
+      {
+        fee_id: fee2.id,
+        amount_cents: 5,
+      },
+    ]
+  end
+
+  around { |test| lago_premium!(&test) }
+
+  before do
+    create(:fee_applied_tax, tax:, fee: fee1)
+    create(:fee_applied_tax, tax:, fee: fee2)
+  end
+
+  it 'estimates the credit and refund amount' do
+    result = estimate_service.call
+
+    aggregate_failures do
+      expect(result).to be_success
+
+      credit_note = result.credit_note
+      expect(credit_note).to have_attributes(
+        invoice:,
+        customer:,
+        currency: invoice.currency,
+        credit_amount_cents: 9,
+        coupons_adjustment_amount_cents: 8,
+        taxes_amount_cents: 2,
+        taxes_rate: 20,
+      )
+
+      expect(credit_note.applied_taxes.size).to eq(1)
+
+      expect(credit_note.items.size).to eq(2)
+
+      item1 = credit_note.items.first
+      expect(item1).to have_attributes(
+        fee: fee1,
+        amount_cents: 10,
+        amount_currency: invoice.currency,
+      )
+
+      item2 = credit_note.items.last
+      expect(item2).to have_attributes(
+        fee: fee2,
+        amount_cents: 5,
+        amount_currency: invoice.currency,
+      )
+    end
+  end
+
+  context 'with invalid items' do
+    let(:items) do
+      [
+        {
+          fee_id: fee1.id,
+          amount_cents: 10,
+        },
+        {
+          fee_id: fee2.id,
+          amount_cents: 15,
+        },
+      ]
+    end
+
+    it 'returns a failed result' do
+      result = estimate_service.call
+
+      aggregate_failures do
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages.keys).to include(:amount_cents)
+        expect(result.error.messages[:amount_cents]).to eq(
+          %w[
+            higher_than_remaining_fee_amount
+          ],
+        )
+      end
+    end
+  end
+
+  context 'when invoice is not found' do
+    let(:invoice) { nil }
+    let(:items) { [] }
+
+    it 'returns a failure' do
+      result = estimate_service.call
+
+      aggregate_failures do
+        expect(result).not_to be_success
+
+        expect(result.error).to be_a(BaseService::NotFoundFailure)
+        expect(result.error.message).to eq('invoice_not_found')
+      end
+    end
+  end
+
+  context 'when invoice is a prepaid credit invoice' do
+    let(:invoice) do
+      create(
+        :invoice,
+        :credit,
+        currency: 'EUR',
+        total_amount_cents: 24,
+        payment_status: :succeeded,
+        taxes_rate: 20,
+      )
+    end
+
+    it 'returns a failure' do
+      result = estimate_service.call
+
+      aggregate_failures do
+        expect(result).not_to be_success
+
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq('invalid_type_or_status')
+      end
+    end
+  end
+
+  context 'when invoice is legacy' do
+    let(:invoice) do
+      create(
+        :invoice,
+        currency: 'EUR',
+        sub_total_excluding_taxes_amount_cents: 20,
+        total_amount_cents: 24,
+        payment_status: :succeeded,
+        taxes_rate: 20,
+        version_number: 1,
+      )
+    end
+
+    it 'returns a failure' do
+      result = estimate_service.call
+
+      aggregate_failures do
+        expect(result).not_to be_success
+
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq('invalid_type_or_status')
+      end
+    end
+  end
+end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -61,6 +61,10 @@ module ScenariosHelper
     put_with_token(organization, "/api/v1/invoices/#{invoice.id}/finalize", {})
   end
 
+  def update_invoice(invoice, params)
+    put_with_token(organization, "/api/v1/invoices/#{invoice.id}", { invoice: params })
+  end
+
   ### Coupons
 
   def create_coupon(params)
@@ -89,6 +93,12 @@ module ScenariosHelper
     post_with_token(organization, '/api/v1/events', { event: params })
     perform_all_enqueued_jobs
     JSON.parse(response.body) unless response.body.empty?
+  end
+
+  ### Credit notes
+
+  def create_credit_note(params)
+    post_with_token(organization, '/api/v1/credit_notes', { credit_note: params })
   end
 
   # This performs any enqueued-jobs, and continues doing so until the queue is empty.

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -102,7 +102,7 @@ module ScenariosHelper
   end
 
   def estimate_credit_note(params)
-    get_with_token(organization, '/api/v1/credit_notes/estimate', { credit_note: params })
+    post_with_token(organization, '/api/v1/credit_notes/estimate', { credit_note: params })
   end
 
   # This performs any enqueued-jobs, and continues doing so until the queue is empty.

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -101,6 +101,10 @@ module ScenariosHelper
     post_with_token(organization, '/api/v1/credit_notes', { credit_note: params })
   end
 
+  def estimate_credit_note(params)
+    get_with_token(organization, '/api/v1/credit_notes/estimate', { credit_note: params })
+  end
+
   # This performs any enqueued-jobs, and continues doing so until the queue is empty.
   # Lots of the jobs enqueue other jobs as part of their work, and this ensures that
   # everything that's supposed to happen, happens.


### PR DESCRIPTION
## Context

Today it's hard to compute amounts for credit note creation when coupons or multiple tax rates are applied.
The front end and API users have to compute the tax and coupon pro-rata, credit and refund amounts by themselves hopping that the result will match the amounts computed on the backend when validating the validation.

## Description

In order to make it easier to create a credit note, this PR adds a new API end point and GraphQL resolver to retrieve creditable/refundable amounts based on items amount.

It exposes:
- A new `GET /api/v1/credit_notes` route
- A new `creditNoteEstimate` resolver