### PR TITLE
fix(adyen-no-payment-methods): Send an error webhook when no payment methods are active

### DIFF
--- a/spec/factories/payment_responses.rb
+++ b/spec/factories/payment_responses.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
 
   sequence :adyen_payment_links_response do
     OpenStruct.new(
+      status: 200,
       response: {
         'amount' => {
           'currency' => 'EUR',
@@ -31,6 +32,16 @@ FactoryBot.define do
         'id' => SecureRandom.uuid,
         'status' => 'active',
         'url' => 'https://test.adyen.link/test',
+      },
+    )
+  end
+
+  sequence :adyen_payment_links_error_response do
+    OpenStruct.new(
+      status: 422,
+      response: {
+        'errorType' => 'validation',
+        'message' => 'There are no payment methods available for the given parameters.',
       },
     )
   end


### PR DESCRIPTION
## Context

When receiving an error from Adyen (422 Error), we do not log it and we do not return a webhook with the error. We should send a webhook with the error, so the user know about it.