### PR TITLE
fix(one-off-invoice): Fix custom display names on one off invoices

### DIFF
--- a/app/views/templates/invoices/one_off.slim
+++ b/app/views/templates/invoices/one_off.slim
@@ -428,7 +428,7 @@ html
             - fees.each do |fee|
               tr
                 td
-                  .body-1 = fee.add_on.invoice_name
+                  .body-1 = fee.invoice_name
                   .body-3 = fee.description
                 td.body-2 = fee.units
                 td.body-2 = MoneyHelper.format(fee.unit_amount)


### PR DESCRIPTION
## Context

By adding a display names in a one-off invoice, the document does not show the display name but the actual name of the add-on.
