### PR TITLE
fix (customers): fix customer create flow when sync_with_provider is true

### DIFF
--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -156,7 +156,7 @@ module Customers
     end
 
     def create_billing_configuration(customer, billing_configuration = {})
-      return if billing_configuration.blank?
+      return if billing_configuration.blank? || (api_context? && billing_configuration[:payment_provider].nil?)
 
       create_provider_customer = billing_configuration[:sync_with_provider]
       create_provider_customer ||= billing_configuration[:provider_customer_id]

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -519,6 +519,36 @@ RSpec.describe Customers::CreateService, type: :service do
             end
           end
         end
+
+        context 'when payment_provider is not sent' do
+          let(:create_args) do
+            {
+              external_id: SecureRandom.uuid,
+              name: 'Foo Bar',
+              billing_configuration: {
+                vat_rate: 28,
+                sync_with_provider: true,
+              },
+            }
+          end
+
+          it 'updates the customer and reset payment_provider attribute' do
+            result = customers_service.create_from_api(
+              organization:,
+              params: create_args,
+            )
+
+            aggregate_failures do
+              expect(result).to be_success
+              expect(result.customer).to eq(customer)
+
+              # NOTE: It should not erase existing properties
+              expect(result.customer.vat_rate).to eq(28)
+              expect(result.customer.payment_provider).to eq(nil)
+              expect(result.customer.stripe_customer).not_to be_present
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
If `sync_with_provider` is true, there is no payment provider for customer but payload is missing payment_provider attribute the error is raised.

We need to add guard clause for that case