### PR TITLE
feat(unit-price): Add unit amount cents to subscription fee

### DIFF
--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -13,12 +13,12 @@ module Fees
     def create
       return result if already_billed?
 
-      new_amount_cents = compute_amount
+      new_amount_cents = compute_amount.round
 
       new_fee = Fee.create!(
         invoice:,
         subscription:,
-        amount_cents: new_amount_cents.round,
+        amount_cents: new_amount_cents,
         amount_currency: plan.amount_currency,
         fee_type: :subscription,
         invoiceable_type: 'Subscription',
@@ -27,6 +27,7 @@ module Fees
         properties: boundaries.to_h,
         payment_status: :pending,
         taxes_amount_cents: 0,
+        unit_amount_cents: new_amount_cents,
       )
 
       result.fee = new_fee

--- a/db/migrate/20231020091031_convert_unit_amount_cents_to_decimal.rb
+++ b/db/migrate/20231020091031_convert_unit_amount_cents_to_decimal.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ConvertUnitAmountCentsToDecimal < ActiveRecord::Migration[7.0]
+  def up
+    change_column :fees, :unit_amount_cents, :decimal, precision: 30, scale: 5, null: false
+  end
+
+  def down
+    change_column :fees, :unit_amount_cents, :bigint, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_10_090849) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_20_091031) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -374,11 +374,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_10_090849) do
     t.uuid "true_up_parent_fee_id"
     t.uuid "add_on_id"
     t.string "description"
-    t.bigint "unit_amount_cents", default: 0, null: false
+    t.decimal "unit_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
     t.boolean "pay_in_advance", default: false, null: false
     t.decimal "precise_coupons_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
-    t.string "invoice_display_name"
     t.decimal "total_aggregated_units"
+    t.string "invoice_display_name"
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Fees::SubscriptionService do
         units: 1,
         events_count: nil,
         payment_status: 'pending',
-        unit_amount_cents: plan.amount_cents
+        unit_amount_cents: plan.amount_cents,
       )
     end
 
@@ -80,7 +80,7 @@ RSpec.describe Fees::SubscriptionService do
           expect(result.fee).to have_attributes(
             id: String,
             amount_cents: 90,
-            unit_amount_cents: 90
+            unit_amount_cents: 90,
           )
         end
       end
@@ -131,7 +131,7 @@ RSpec.describe Fees::SubscriptionService do
             amount_cents: plan.amount_cents,
             amount_currency: plan.amount_currency,
             unit_amount_cents: plan.amount_cents,
-            units: 1
+            units: 1,
           )
         end
 
@@ -210,7 +210,7 @@ RSpec.describe Fees::SubscriptionService do
             invoice_id: invoice.id,
             amount_cents: 71,
             amount_currency: plan.amount_currency,
-            units: 1
+            units: 1,
           )
         end
 
@@ -324,7 +324,7 @@ RSpec.describe Fees::SubscriptionService do
             amount_cents: plan.amount_cents,
             amount_currency: plan.amount_currency,
             unit_amount_cents: plan.amount_cents,
-            units: 1
+            units: 1,
           )
         end
 
@@ -410,7 +410,7 @@ RSpec.describe Fees::SubscriptionService do
             invoice_id: invoice.id,
             amount_cents: 55,
             amount_currency: plan.amount_currency,
-            units: 1
+            units: 1,
           )
         end
 
@@ -554,7 +554,7 @@ RSpec.describe Fees::SubscriptionService do
             amount_cents: plan.amount_cents,
             amount_currency: plan.amount_currency,
             unit_amount_cents: plan.amount_cents,
-            units: 1
+            units: 1,
           )
         end
 
@@ -591,7 +591,7 @@ RSpec.describe Fees::SubscriptionService do
             invoice_id: invoice.id,
             amount_cents: 80,
             amount_currency: plan.amount_currency,
-            units: 1
+            units: 1,
           )
         end
 
@@ -796,7 +796,7 @@ RSpec.describe Fees::SubscriptionService do
         invoice_id: invoice.id,
         amount_cents: 65,
         amount_currency: plan.amount_currency,
-        units: 1
+        units: 1,
       )
     end
 
@@ -824,7 +824,7 @@ RSpec.describe Fees::SubscriptionService do
           invoice_id: invoice.id,
           amount_cents: 65,
           amount_currency: plan.amount_currency,
-          units: 1
+          units: 1,
         )
       end
     end
@@ -850,7 +850,7 @@ RSpec.describe Fees::SubscriptionService do
           invoice_id: invoice.id,
           amount_cents: 43,
           amount_currency: plan.amount_currency,
-          units: 1
+          units: 1,
         )
       end
     end
@@ -862,13 +862,13 @@ RSpec.describe Fees::SubscriptionService do
 
       it 'creates a fee' do
         result = fees_subscription_service.create
-       
+
         expect(result.fee).to have_attributes(
           id: String,
           invoice_id: invoice.id,
           amount_cents: 65,
           amount_currency: plan.amount_currency,
-          units: 1
+          units: 1,
         )
       end
     end
@@ -945,7 +945,7 @@ RSpec.describe Fees::SubscriptionService do
         invoice_id: invoice.id,
         amount_cents: 55,
         amount_currency: plan.amount_currency,
-        units: 1
+        units: 1,
       )
     end
 
@@ -973,7 +973,7 @@ RSpec.describe Fees::SubscriptionService do
           invoice_id: invoice.id,
           amount_cents: 55,
           amount_currency: plan.amount_currency,
-          units: 1
+          units: 1,
         )
       end
     end

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -52,17 +52,17 @@ RSpec.describe Fees::SubscriptionService do
   context 'when invoice is on a full period' do
     it 'creates a fee' do
       result = fees_subscription_service.create
-      created_fee = result.fee
 
-      aggregate_failures do
-        expect(created_fee.id).not_to be_nil
-        expect(created_fee.invoice_id).to eq(invoice.id)
-        expect(created_fee.amount_cents).to eq(plan.amount_cents)
-        expect(created_fee.amount_currency).to eq(plan.amount_currency)
-        expect(created_fee.units).to eq(1)
-        expect(created_fee.events_count).to be_nil
-        expect(created_fee.payment_status).to eq('pending')
-      end
+      expect(result.fee).to have_attributes(
+        id: String,
+        invoice_id: invoice.id,
+        amount_cents: plan.amount_cents,
+        amount_currency: plan.amount_currency,
+        units: 1,
+        events_count: nil,
+        payment_status: 'pending',
+        unit_amount_cents: plan.amount_cents
+      )
     end
 
     context 'when plan has a trial period' do
@@ -76,12 +76,12 @@ RSpec.describe Fees::SubscriptionService do
 
         it 'creates a fee with prorated amount based on trial' do
           result = fees_subscription_service.create
-          created_fee = result.fee
 
-          aggregate_failures do
-            expect(created_fee.id).not_to be_nil
-            expect(created_fee.amount_cents).to eq(90)
-          end
+          expect(result.fee).to have_attributes(
+            id: String,
+            amount_cents: 90,
+            unit_amount_cents: 90
+          )
         end
       end
 
@@ -124,15 +124,15 @@ RSpec.describe Fees::SubscriptionService do
 
         it 'creates a fee' do
           result = fees_subscription_service.create
-          created_fee = result.fee
 
-          aggregate_failures do
-            expect(created_fee.id).not_to be_nil
-            expect(created_fee.invoice_id).to eq(invoice.id)
-            expect(created_fee.amount_cents).to eq(plan.amount_cents)
-            expect(created_fee.amount_currency).to eq(plan.amount_currency)
-            expect(created_fee.units).to eq(1)
-          end
+          expect(result.fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            amount_cents: plan.amount_cents,
+            amount_currency: plan.amount_currency,
+            unit_amount_cents: plan.amount_cents,
+            units: 1
+          )
         end
 
         context 'when plan has a trial period' do
@@ -204,15 +204,14 @@ RSpec.describe Fees::SubscriptionService do
 
         it 'creates a fee' do
           result = fees_subscription_service.create
-          created_fee = result.fee
 
-          aggregate_failures do
-            expect(created_fee.id).not_to be_nil
-            expect(created_fee.invoice_id).to eq(invoice.id)
-            expect(created_fee.amount_cents).to eq(71)
-            expect(created_fee.amount_currency).to eq(plan.amount_currency)
-            expect(created_fee.units).to eq(1)
-          end
+          expect(result.fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            amount_cents: 71,
+            amount_currency: plan.amount_currency,
+            units: 1
+          )
         end
 
         context 'when plan has a trial period' do
@@ -318,15 +317,15 @@ RSpec.describe Fees::SubscriptionService do
 
         it 'creates a fee' do
           result = fees_subscription_service.create
-          created_fee = result.fee
 
-          aggregate_failures do
-            expect(created_fee.id).not_to be_nil
-            expect(created_fee.invoice_id).to eq(invoice.id)
-            expect(created_fee.amount_cents).to eq(plan.amount_cents)
-            expect(created_fee.amount_currency).to eq(plan.amount_currency)
-            expect(created_fee.units).to eq(1)
-          end
+          expect(result.fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            amount_cents: plan.amount_cents,
+            amount_currency: plan.amount_currency,
+            unit_amount_cents: plan.amount_cents,
+            units: 1
+          )
         end
 
         context 'when plan has a trial period' do
@@ -405,15 +404,14 @@ RSpec.describe Fees::SubscriptionService do
 
         it 'creates a fee' do
           result = fees_subscription_service.create
-          created_fee = result.fee
 
-          aggregate_failures do
-            expect(created_fee.id).not_to be_nil
-            expect(created_fee.invoice_id).to eq(invoice.id)
-            expect(created_fee.amount_cents).to eq(55)
-            expect(created_fee.amount_currency).to eq(plan.amount_currency)
-            expect(created_fee.units).to eq(1)
-          end
+          expect(result.fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            amount_cents: 55,
+            amount_currency: plan.amount_currency,
+            units: 1
+          )
         end
 
         context 'when plan has a trial period' do
@@ -549,14 +547,15 @@ RSpec.describe Fees::SubscriptionService do
 
         it 'creates a fee' do
           result = fees_subscription_service.create
-          created_fee = result.fee
 
-          aggregate_failures do
-            expect(created_fee.id).not_to be_nil
-            expect(created_fee.invoice_id).to eq(invoice.id)
-            expect(created_fee.amount_cents).to eq(plan.amount_cents)
-            expect(created_fee.amount_currency).to eq(plan.amount_currency)
-          end
+          expect(result.fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            amount_cents: plan.amount_cents,
+            amount_currency: plan.amount_currency,
+            unit_amount_cents: plan.amount_cents,
+            units: 1
+          )
         end
 
         context 'when plan is pay in advance' do
@@ -586,14 +585,14 @@ RSpec.describe Fees::SubscriptionService do
 
         it 'creates a fee' do
           result = fees_subscription_service.create
-          created_fee = result.fee
 
-          aggregate_failures do
-            expect(created_fee.id).not_to be_nil
-            expect(created_fee.invoice_id).to eq(invoice.id)
-            expect(created_fee.amount_cents).to eq(80)
-            expect(created_fee.amount_currency).to eq(plan.amount_currency)
-          end
+          expect(result.fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            amount_cents: 80,
+            amount_currency: plan.amount_currency,
+            units: 1
+          )
         end
 
         context 'when plan is pay in advance' do
@@ -791,14 +790,14 @@ RSpec.describe Fees::SubscriptionService do
 
     it 'creates a fee' do
       result = fees_subscription_service.create
-      created_fee = result.fee
 
-      aggregate_failures do
-        expect(created_fee.id).not_to be_nil
-        expect(created_fee.invoice_id).to eq(invoice.id)
-        expect(created_fee.amount_cents).to eq(65)
-        expect(created_fee.amount_currency).to eq(plan.amount_currency)
-      end
+      expect(result.fee).to have_attributes(
+        id: String,
+        invoice_id: invoice.id,
+        amount_cents: 65,
+        amount_currency: plan.amount_currency,
+        units: 1
+      )
     end
 
     context 'with customer timezone' do
@@ -819,14 +818,14 @@ RSpec.describe Fees::SubscriptionService do
 
       it 'creates a fee' do
         result = fees_subscription_service.create
-        created_fee = result.fee
 
-        aggregate_failures do
-          expect(created_fee.id).not_to be_nil
-          expect(created_fee.invoice_id).to eq(invoice.id)
-          expect(created_fee.amount_cents).to eq(65)
-          expect(created_fee.amount_currency).to eq(plan.amount_currency)
-        end
+        expect(result.fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          amount_cents: 65,
+          amount_currency: plan.amount_currency,
+          units: 1
+        )
       end
     end
 
@@ -845,14 +844,14 @@ RSpec.describe Fees::SubscriptionService do
 
       it 'creates a fee' do
         result = fees_subscription_service.create
-        created_fee = result.fee
 
-        aggregate_failures do
-          expect(created_fee.id).not_to be_nil
-          expect(created_fee.invoice_id).to eq(invoice.id)
-          expect(created_fee.amount_cents).to eq(43)
-          expect(created_fee.amount_currency).to eq(plan.amount_currency)
-        end
+        expect(result.fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          amount_cents: 43,
+          amount_currency: plan.amount_currency,
+          units: 1
+        )
       end
     end
 
@@ -863,14 +862,14 @@ RSpec.describe Fees::SubscriptionService do
 
       it 'creates a fee' do
         result = fees_subscription_service.create
-        created_fee = result.fee
-
-        aggregate_failures do
-          expect(created_fee.id).not_to be_nil
-          expect(created_fee.invoice_id).to eq(invoice.id)
-          expect(created_fee.amount_cents).to eq(65)
-          expect(created_fee.amount_currency).to eq(plan.amount_currency)
-        end
+       
+        expect(result.fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          amount_cents: 65,
+          amount_currency: plan.amount_currency,
+          units: 1
+        )
       end
     end
 
@@ -940,14 +939,14 @@ RSpec.describe Fees::SubscriptionService do
 
     it 'creates a subscription fee' do
       result = fees_subscription_service.create
-      created_fee = result.fee
 
-      aggregate_failures do
-        expect(created_fee.id).not_to be_nil
-        expect(created_fee.invoice_id).to eq(invoice.id)
-        expect(created_fee.amount_cents).to eq(55)
-        expect(created_fee.amount_currency).to eq(plan.amount_currency)
-      end
+      expect(result.fee).to have_attributes(
+        id: String,
+        invoice_id: invoice.id,
+        amount_cents: 55,
+        amount_currency: plan.amount_currency,
+        units: 1
+      )
     end
 
     context 'with customer timezone' do
@@ -968,14 +967,14 @@ RSpec.describe Fees::SubscriptionService do
 
       it 'creates a subscription fee' do
         result = fees_subscription_service.create
-        created_fee = result.fee
 
-        aggregate_failures do
-          expect(created_fee.id).not_to be_nil
-          expect(created_fee.invoice_id).to eq(invoice.id)
-          expect(created_fee.amount_cents).to eq(55)
-          expect(created_fee.amount_currency).to eq(plan.amount_currency)
-        end
+        expect(result.fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          amount_cents: 55,
+          amount_currency: plan.amount_currency,
+          units: 1
+        )
       end
     end
 


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/{{FEATURE_SLUG}}](https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown)

## Context

Invoices are not compliant as we’re not displaying unit prices of item on them.

The goal is to be compliant by adding unit price on invoice payload and pdf.
- Subscription invoices
- Charge (pay in advance) invoices

## Description

The goal of this PR is to:
- convert unit amount cents to decimal
- compute unit amount cents to subscription's fee
