### PR TITLE
feat(billable-metric): Use Factory pattern to initialize aggregators

### DIFF
--- a/app/services/billable_metrics/aggregation_factory.rb
+++ b/app/services/billable_metrics/aggregation_factory.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module BillableMetrics
+  class AggregationFactory
+    def self.new_instance(charge:, current_usage: false, **attributes)
+      aggregator_class(charge, current_usage).new(
+        billable_metric: charge.billable_metric,
+        **attributes,
+      )
+    end
+
+    def self.aggregator_class(charge, current_usage)
+      case charge.billable_metric.aggregation_type.to_sym
+      when :count_agg
+        BillableMetrics::Aggregations::CountService
+
+      when :latest_agg
+        raise(NotImplementedError) if charge.pay_in_advance? && !current_usage
+
+        BillableMetrics::Aggregations::LatestService
+
+      when :max_agg
+        raise(NotImplementedError) if charge.pay_in_advance? && !current_usage
+
+        BillableMetrics::Aggregations::MaxService
+
+      when :sum_agg
+        if charge.prorated?
+          BillableMetrics::ProratedAggregations::SumService
+        else
+          BillableMetrics::Aggregations::SumService
+        end
+
+      when :unique_count_agg
+        if charge.prorated?
+          BillableMetrics::ProratedAggregations::UniqueCountService
+        else
+          BillableMetrics::Aggregations::UniqueCountService
+        end
+
+      when :recurring_count_agg
+        raise(NotImplementedError) if charge.pay_in_advance? && !current_usage
+
+        BillableMetrics::Aggregations::RecurringCountService
+
+      when :weighted_sum_agg
+        raise(NotImplementedError) if charge.pay_in_advance? && !current_usage
+
+        BillableMetrics::Aggregations::WeightedSumService
+
+      else
+        raise(NotImplementedError)
+      end
+    end
+  end
+end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -128,37 +128,9 @@ module Fees
     end
 
     def aggregator(group:)
-      return @aggregator if @aggregator && !group
-
-      aggregator_service = case billable_metric.aggregation_type.to_sym
-                           when :count_agg
-                             BillableMetrics::Aggregations::CountService
-                           when :latest_agg
-                             BillableMetrics::Aggregations::LatestService
-                           when :max_agg
-                             BillableMetrics::Aggregations::MaxService
-                           when :sum_agg
-                             if charge.prorated?
-                               BillableMetrics::ProratedAggregations::SumService
-                             else
-                               BillableMetrics::Aggregations::SumService
-                             end
-                           when :unique_count_agg
-                             if charge.prorated?
-                               BillableMetrics::ProratedAggregations::UniqueCountService
-                             else
-                               BillableMetrics::Aggregations::UniqueCountService
-                             end
-                           when :recurring_count_agg
-                             BillableMetrics::Aggregations::RecurringCountService
-                           when :weighted_sum_agg
-                             BillableMetrics::Aggregations::WeightedSumService
-                           else
-                             raise(NotImplementedError)
-      end
-
-      @aggregator = aggregator_service.new(
-        billable_metric:,
+      BillableMetrics::AggregationFactory.new_instance(
+        charge:,
+        current_usage: is_current_usage,
         subscription:,
         group:,
         boundaries: {

--- a/spec/factories/billable_metrics.rb
+++ b/spec/factories/billable_metrics.rb
@@ -40,4 +40,9 @@ FactoryBot.define do
     weighted_interval { 'seconds' }
     field_name { 'value' }
   end
+
+  factory :unique_count_billable_metric, parent: :billable_metric do
+    aggregation_type { 'unique_count_agg' }
+    field_name { 'item_id' }
+  end
 end

--- a/spec/services/billable_metrics/aggregation_factory_spec.rb
+++ b/spec/services/billable_metrics/aggregation_factory_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetrics::AggregationFactory, type: :service do
+  subject(:factory) { described_class }
+
+  let(:billable_metric) { create(billable_aggregation, recurring:) }
+  let(:billable_aggregation) { :billable_metric }
+  let(:recurring) { false }
+
+  let(:charge) { build(:standard_charge, billable_metric:, pay_in_advance:, prorated:) }
+  let(:pay_in_advance) { false }
+  let(:prorated) { false }
+
+  let(:subscription) { create(:subscription, started_at: DateTime.parse('2023-03-15')) }
+  let(:boundaries) do
+    {
+      charges_from_datetime: subscription.started_at.beginning_of_day,
+      charges_to_datetime: subscription.started_at.end_of_month.end_of_day,
+    }
+  end
+
+  let(:current_usage) { false }
+
+  let(:result) { factory.new_instance(charge:, current_usage:, subscription:, boundaries:) }
+
+  describe '#new_instance' do
+    context 'with count_agg aggregation' do
+      let(:billable_aggregation) { :billable_metric }
+
+      it { expect(result).to be_a(BillableMetrics::Aggregations::CountService) }
+    end
+
+    context 'with latest_agg aggregation' do
+      let(:billable_aggregation) { :latest_billable_metric }
+
+      it { expect(result).to be_a(BillableMetrics::Aggregations::LatestService) }
+
+      context 'when pay_in_advance' do
+        let(:pay_in_advance) { true }
+
+        it { expect { result }.to raise_error(NotImplementedError) }
+
+        context 'when current usage' do
+          let(:current_usage) { true }
+
+          it { expect(result).to be_a(BillableMetrics::Aggregations::LatestService) }
+        end
+      end
+    end
+
+    context 'with max_agg aggregation' do
+      let(:billable_aggregation) { :max_billable_metric }
+
+      it { expect(result).to be_a(BillableMetrics::Aggregations::MaxService) }
+
+      context 'when pay_in_advance' do
+        let(:pay_in_advance) { true }
+
+        it { expect { result }.to raise_error(NotImplementedError) }
+
+        context 'when current usage' do
+          let(:current_usage) { true }
+
+          it { expect(result).to be_a(BillableMetrics::Aggregations::MaxService) }
+        end
+      end
+    end
+
+    context 'with sum_agg aggregation' do
+      let(:billable_aggregation) { :sum_billable_metric }
+
+      it { expect(result).to be_a(BillableMetrics::Aggregations::SumService) }
+
+      context 'when prorated' do
+        let(:prorated) { true }
+        let(:recurring) { true }
+
+        it { expect(result).to be_a(BillableMetrics::ProratedAggregations::SumService) }
+      end
+    end
+
+    context 'with unique_count_agg aggregation' do
+      let(:billable_aggregation) { :unique_count_billable_metric }
+
+      it { expect(result).to be_a(BillableMetrics::Aggregations::UniqueCountService) }
+
+      context 'when prorated' do
+        let(:prorated) { true }
+        let(:recurring) { true }
+
+        it { expect(result).to be_a(BillableMetrics::ProratedAggregations::UniqueCountService) }
+      end
+    end
+
+    context 'with recurring_count_agg aggregation' do
+      let(:billable_aggregation) { :recurring_billable_metric }
+
+      it { expect(result).to be_a(BillableMetrics::Aggregations::RecurringCountService) }
+
+      context 'when pay_in_advance' do
+        let(:pay_in_advance) { true }
+
+        it { expect { result }.to raise_error(NotImplementedError) }
+
+        context 'when current usage' do
+          let(:current_usage) { true }
+
+          it { expect(result).to be_a(BillableMetrics::Aggregations::RecurringCountService) }
+        end
+      end
+    end
+
+    context 'with weighted_sum_agg aggregation' do
+      let(:billable_aggregation) { :weighted_sum_billable_metric }
+
+      it { expect(result).to be_a(BillableMetrics::Aggregations::WeightedSumService) }
+
+      context 'when pay_in_advance' do
+        let(:pay_in_advance) { true }
+
+        it { expect { result }.to raise_error(NotImplementedError) }
+
+        context 'when current usage' do
+          let(:current_usage) { true }
+
+          it { expect(result).to be_a(BillableMetrics::Aggregations::WeightedSumService) }
+        end
+      end
+    end
+  end
+end

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
   end
 
   let(:billable_metric) { create(:billable_metric, aggregation_type:, field_name: 'item_id') }
-  let(:charge) { create(:standard_charge, billable_metric:) }
+  let(:charge) { create(:standard_charge, billable_metric:, pay_in_advance: true) }
   let(:group) { create(:group) }
   let(:aggregation_type) { 'count_agg' }
   let(:event) { create(:event, subscription_id: subscription.id) }
@@ -110,14 +110,6 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
         expect(unique_count_service).to have_received(:aggregate).with(
           options: { free_units_per_events: 0, free_units_per_total_aggregation: 0 },
         )
-      end
-    end
-
-    describe 'when unknown aggregation' do
-      let(:aggregation_type) { 'max_agg' }
-
-      it 'raises a NotImplementedError' do
-        expect { agg_service.call }.to raise_error(NotImplementedError)
       end
     end
   end


### PR DESCRIPTION
## Context

With the coming high usage event ingestion, aggregator classes will have to be adapted to target the right event store (PG or Clickhouse) depending on the context.

To make it easier, and since current Aggregator initialization is quite complex, a small cleanup has to be performed in order to simplify the logic.

## Description

This PR takes advantage of the factory pattern to initialize the right aggregator for a charge.

It will also soon be responsible for passing the right Event store
