### PR TITLE
feat(unit-price): Add unit_amount to fees

### DIFF
--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -28,7 +28,6 @@ module Fees
             invoice_display_name: fee[:invoice_display_name].presence,
             description: fee[:description] || add_on.description,
             unit_amount_cents:,
-            precise_unit_amount: unit_amount_cents.fdiv(invoice.total_amount.currency.subunit_to_unit),
             amount_cents: (unit_amount_cents * units).round,
             amount_currency: invoice.currency,
             fee_type: :add_on,
@@ -38,6 +37,7 @@ module Fees
             payment_status: :pending,
             taxes_amount_cents: 0,
           )
+          fee.precise_unit_amount = fee.unit_amount.to_f
 
           taxes_result = tax_codes ? Fees::ApplyTaxesService.call(fee:, tax_codes:) : Fees::ApplyTaxesService.call(fee:)
           taxes_result.raise_if_error!

--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -28,6 +28,7 @@ module Fees
             invoice_display_name: fee[:invoice_display_name].presence,
             description: fee[:description] || add_on.description,
             unit_amount_cents:,
+            precise_unit_amount: unit_amount_cents.fdiv(invoice.total_amount.currency.subunit_to_unit),
             amount_cents: (unit_amount_cents * units).round,
             amount_currency: invoice.currency,
             fee_type: :add_on,

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -15,7 +15,7 @@ module Fees
 
       new_amount_cents = compute_amount.round
 
-      new_fee = Fee.create!(
+      new_fee = Fee.new(
         invoice:,
         subscription:,
         amount_cents: new_amount_cents,
@@ -29,6 +29,8 @@ module Fees
         taxes_amount_cents: 0,
         unit_amount_cents: new_amount_cents,
       )
+      new_fee.precise_unit_amount = new_fee.unit_amount.to_f
+      new_fee.save!
 
       result.fee = new_fee
       result

--- a/db/migrate/20231027144605_add_precise_unit_amount_to_fees.rb
+++ b/db/migrate/20231027144605_add_precise_unit_amount_to_fees.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddPreciseUnitAmountToFees < ActiveRecord::Migration[7.0]
+  class Fee < ApplicationRecord
+    monetize :amount_cents
+  end
+
+  def up
+    change_table :fees, bulk: true do |t|
+      t.change :unit_amount_cents, :bigint, null: false, default: 0
+    end
+    add_column :fees, :precise_unit_amount, :decimal, precision: 30, scale: 5, null: false, default: '0.0'
+
+    Fee.where.not(unit_amount_cents: 0).find_each do |f|
+      f.update!(precise_unit_amount: f.unit_amount_cents.fdiv(f.amount.currency.subunit_to_unit))
+    end
+  end
+
+  def down
+    change_table :fees, bulk: true do |t|
+      t.change :unit_amount_cents, :decimal, precision: 30, scale: 5, null: false
+    end
+    remove_column :fees, :precise_unit_amount, :decimal
+  end
+end

--- a/db/migrate/20231027144605_add_precise_unit_amount_to_fees.rb
+++ b/db/migrate/20231027144605_add_precise_unit_amount_to_fees.rb
@@ -2,7 +2,7 @@
 
 class AddPreciseUnitAmountToFees < ActiveRecord::Migration[7.0]
   class Fee < ApplicationRecord
-    monetize :amount_cents
+    monetize :unit_amount_cents, with_model_currency: :amount_currency
   end
 
   def up
@@ -12,7 +12,7 @@ class AddPreciseUnitAmountToFees < ActiveRecord::Migration[7.0]
     add_column :fees, :precise_unit_amount, :decimal, precision: 30, scale: 5, null: false, default: '0.0'
 
     Fee.where.not(unit_amount_cents: 0).find_each do |f|
-      f.update!(precise_unit_amount: f.unit_amount_cents.fdiv(f.amount.currency.subunit_to_unit))
+      f.update!(precise_unit_amount: f.unit_amount.to_f)
     end
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_20_091031) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_27_144605) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -374,11 +374,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_20_091031) do
     t.uuid "true_up_parent_fee_id"
     t.uuid "add_on_id"
     t.string "description"
-    t.decimal "unit_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
+    t.bigint "unit_amount_cents", default: 0, null: false
     t.boolean "pay_in_advance", default: false, null: false
     t.decimal "precise_coupons_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "total_aggregated_units"
     t.string "invoice_display_name"
+    t.decimal "precise_unit_amount", precision: 30, scale: 5, default: "0.0", null: false
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -43,28 +43,34 @@ RSpec.describe Fees::OneOffService do
       second_fee = result.fees[1]
 
       aggregate_failures do
-        expect(first_fee.id).not_to be_nil
-        expect(first_fee.invoice_id).to eq(invoice.id)
-        expect(first_fee.add_on_id).to eq(add_on_first.id)
-        expect(first_fee.description).to eq('desc-123')
-        expect(first_fee.unit_amount_cents).to eq(1200)
-        expect(first_fee.units).to eq(2)
-        expect(first_fee.amount_cents).to eq(2400)
-        expect(first_fee.amount_currency).to eq('EUR')
-        expect(first_fee.fee_type).to eq('add_on')
-        expect(first_fee.payment_status).to eq('pending')
+        expect(first_fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          add_on_id: add_on_first.id,
+          description: 'desc-123',
+          unit_amount_cents: 1200,
+          precise_unit_amount: 12,
+          units: 2,
+          amount_cents: 2400,
+          amount_currency: 'EUR',
+          fee_type: 'add_on',
+          payment_status: 'pending',
+        )
         expect(first_fee.taxes.map(&:code)).to contain_exactly(tax2.code)
 
-        expect(second_fee.id).not_to be_nil
-        expect(second_fee.invoice_id).to eq(invoice.id)
-        expect(second_fee.add_on_id).to eq(add_on_second.id)
-        expect(second_fee.description).to eq(add_on_second.description)
-        expect(second_fee.unit_amount_cents).to eq(400)
-        expect(second_fee.units).to eq(1)
-        expect(second_fee.amount_cents).to eq(400)
-        expect(second_fee.amount_currency).to eq('EUR')
-        expect(second_fee.fee_type).to eq('add_on')
-        expect(second_fee.payment_status).to eq('pending')
+        expect(second_fee).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          add_on_id: add_on_second.id,
+          description: add_on_second.description,
+          unit_amount_cents: 400,
+          precise_unit_amount: 4,
+          units: 1,
+          amount_cents: 400,
+          amount_currency: 'EUR',
+          fee_type: 'add_on',
+          payment_status: 'pending',
+        )
         expect(second_fee.taxes.map(&:code)).to contain_exactly(tax.code)
       end
     end
@@ -84,7 +90,7 @@ RSpec.describe Fees::OneOffService do
         ]
       end
 
-      it 'does not create a invalid fee' do
+      it 'does not create an invalid fee' do
         one_off_service.create
 
         expect(Fee.find_by(description: add_on_second.description)).to be_nil

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -56,12 +56,13 @@ RSpec.describe Fees::SubscriptionService do
       expect(result.fee).to have_attributes(
         id: String,
         invoice_id: invoice.id,
-        amount_cents: plan.amount_cents,
-        amount_currency: plan.amount_currency,
+        amount_cents: 100,
+        amount_currency: 'EUR',
         units: 1,
         events_count: nil,
         payment_status: 'pending',
-        unit_amount_cents: plan.amount_cents,
+        unit_amount_cents: 100,
+        precise_unit_amount: 1,
       )
     end
 
@@ -81,6 +82,7 @@ RSpec.describe Fees::SubscriptionService do
             id: String,
             amount_cents: 90,
             unit_amount_cents: 90,
+            precise_unit_amount: 0.9,
           )
         end
       end
@@ -128,9 +130,10 @@ RSpec.describe Fees::SubscriptionService do
           expect(result.fee).to have_attributes(
             id: String,
             invoice_id: invoice.id,
-            amount_cents: plan.amount_cents,
-            amount_currency: plan.amount_currency,
-            unit_amount_cents: plan.amount_cents,
+            amount_cents: 100,
+            amount_currency: 'EUR',
+            unit_amount_cents: 100,
+            precise_unit_amount: 1,
             units: 1,
           )
         end
@@ -321,9 +324,10 @@ RSpec.describe Fees::SubscriptionService do
           expect(result.fee).to have_attributes(
             id: String,
             invoice_id: invoice.id,
-            amount_cents: plan.amount_cents,
-            amount_currency: plan.amount_currency,
-            unit_amount_cents: plan.amount_cents,
+            amount_cents: 100,
+            amount_currency: 'EUR',
+            unit_amount_cents: 100,
+            precise_unit_amount: 1,
             units: 1,
           )
         end
@@ -551,9 +555,10 @@ RSpec.describe Fees::SubscriptionService do
           expect(result.fee).to have_attributes(
             id: String,
             invoice_id: invoice.id,
-            amount_cents: plan.amount_cents,
-            amount_currency: plan.amount_currency,
-            unit_amount_cents: plan.amount_cents,
+            amount_cents: 100,
+            amount_currency: 'EUR',
+            unit_amount_cents: 100,
+            precise_unit_amount: 1,
             units: 1,
           )
         end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown](https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown)

## Context

Invoices are not compliant as we’re not displaying unit prices of item on them.

The goal is to be compliant by adding unit price on invoice payload and pdf.
- Subscription invoices
- Charge (pay in advance) invoices

## Description

The goal of this PR is to:
- revert unit amount cents to bigint
- create new decimal column `unit_amount` to store precise fee's unit amount

We'll deprecate `unit_amount_cents` in the future.
