### PR TITLE
feat(event): Inject event store in aggregators

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -152,6 +152,7 @@ class Invoice < ApplicationRecord
               end
 
     service.new(
+      event_store_class: Events::Stores::PostgresStore,
       billable_metric: fee.charge.billable_metric,
       subscription: fee.subscription,
       group: fee.group,

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -3,8 +3,9 @@
 module BillableMetrics
   module Aggregations
     class BaseService < ::BaseService
-      def initialize(billable_metric:, subscription:, boundaries:, group: nil, event: nil)
+      def initialize(event_store_class:, billable_metric:, subscription:, boundaries:, group: nil, event: nil) # rubocop:disable Metrics/ParameterLists
         super(nil)
+        @event_store_class = event_store_class
         @billable_metric = billable_metric
         @subscription = subscription
         @group = group
@@ -26,9 +27,19 @@ module BillableMetrics
 
       protected
 
-      attr_accessor :billable_metric, :subscription, :group, :event, :boundaries
+      attr_accessor :event_store_class, :billable_metric, :subscription, :group, :event, :boundaries
 
       delegate :customer, to: :subscription
+
+      def event_store
+        @event_store ||= event_store_class.new(
+          code: billable_metric.code,
+          subscription:,
+          boundaries:,
+          group:,
+          event:,
+        )
+      end
 
       def from_datetime
         boundaries[:from_datetime]

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -4,7 +4,7 @@ module BillableMetrics
   module Aggregations
     class CountService < BillableMetrics::Aggregations::BaseService
       def aggregate(options: {})
-        result.aggregation = events_scope(from_datetime:, to_datetime:).count
+        result.aggregation = event_store.count
         result.current_usage_units = result.aggregation
         result.count = result.aggregation
         result.pay_in_advance_aggregation = BigDecimal(1)
@@ -24,7 +24,7 @@ module BillableMetrics
       end
 
       def compute_per_event_aggregation
-        (0...events_scope(from_datetime:, to_datetime:).count).map { |_| 1 }
+        (0...event_store.count).map { |_| 1 }
       end
     end
   end

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    class BaseStore
+      def initialize(code:, subscription:, boundaries:, group: nil, event: nil)
+        @code = code
+        @subscription = subscription
+        @boundaries = boundaries
+        @group = group
+        @event = event
+      end
+
+      def events
+        raise NotImplementedError
+      end
+
+      def count
+        events.count # rubocop:disable Rails/Delegate
+      end
+
+      protected
+
+      attr_accessor :code, :subscription, :group, :event, :boundaries
+
+      def from_datetime
+        boundaries[:from_datetime]
+      end
+
+      def to_datetime
+        boundaries[:to_datetime]
+      end
+    end
+  end
+end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    class ClickhouseStore < BaseStore
+      # NOTE: keeps in mind that events could contains duplicated transaction_id
+      #       and should be deduplicated depending on the aggregation logic
+      def events
+        scope = Clickhouse::EventsRaw.where(external_subscription_id: subscription.external_id)
+          .where('events_raw.timestamp >= ?', from_datetime)
+          .where('events_raw.timestamp <= ?', to_datetime)
+          .where(code:)
+          .order(timestamp: :asc)
+
+        return scope unless group
+
+        scope
+      end
+
+      def count
+        sql = events.select('COUNT(DISTINCT(events_raw.transaction_id)) AS events_count').to_sql
+        Clickhouse::EventsRaw.connection.select_value(sql).to_i
+      end
+
+      private
+
+      def group_scope(scope)
+        scope.where('events_raw.properties[?] = ?', group.key.to_s, group.value.to_s)
+        return scope unless group.parent
+
+        scope.where('events_raw.properties[?] = ?', group.parent.key.to_s => group.parent.value.to_s)
+      end
+    end
+  end
+end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    class PostgresStore < BaseStore
+      def events
+        # TODO: switch to external_subscription_id to allow events sent before subscription creation
+        scope = Event.where(subscription_id: subscription.id)
+          .from_datetime(from_datetime)
+          .to_datetime(to_datetime)
+          .where(code:)
+          .order(timestamp: :asc)
+        return scope unless group
+
+        group_scope(scope)
+      end
+
+      private
+
+      def group_scope(scope)
+        scope = scope.where('events.properties @> ?', { group.key.to_s => group.value }.to_json)
+        return scope unless group.parent
+
+        scope.where('events.properties @> ?', { group.parent.key.to_s => group.parent.value }.to_json)
+      end
+    end
+  end
+end

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
   subject(:count_service) do
     described_class.new(
+      event_store_class:,
       billable_metric:,
       subscription:,
       group:,
@@ -15,6 +16,8 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       },
     )
   end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
   subject(:latest_service) do
     described_class.new(
+      event_store_class:,
       billable_metric:,
       subscription:,
       group:,
@@ -14,6 +15,8 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
       },
     )
   end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
   subject(:max_service) do
     described_class.new(
+      event_store_class:,
       billable_metric:,
       subscription:,
       group:,
@@ -14,6 +15,8 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       },
     )
   end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :service do
   subject(:recurring_service) do
     described_class.new(
+      event_store_class:,
       billable_metric:,
       subscription:,
       group:,
@@ -14,6 +15,8 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       },
     )
   end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
 
   let(:subscription) do
     create(

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transaction: false do
   subject(:sum_service) do
     described_class.new(
+      event_store_class:,
       billable_metric:,
       subscription:,
       group:,
@@ -15,6 +16,8 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
       },
     )
   end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
 
   let(:subscription) { create(:subscription, started_at: Time.current.beginning_of_month - 6.months) }
   let(:organization) { subscription.organization }

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service, transaction: false do
   subject(:count_service) do
     described_class.new(
+      event_store_class:,
       billable_metric:,
       subscription:,
       group:,
@@ -15,6 +16,8 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       },
     )
   end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
 
   let(:subscription) do
     create(

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service, transaction: false do
   subject(:aggregator) do
     described_class.new(
+      event_store_class:,
       billable_metric:,
       subscription:,
       group:,
@@ -15,6 +16,8 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
       },
     )
   end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
 
   let(:subscription) { create(:subscription, started_at: DateTime.parse('2023-04-01 22:22:22')) }
   let(:organization) { subscription.organization }

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transaction: false do
   subject(:service) do
     described_class.new(
+      event_store_class:,
       billable_metric:,
       subscription:,
       group:,
@@ -14,6 +15,8 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
       },
     )
   end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
 
   let(:subscription) do
     create(

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
   subject(:service) do
     described_class.new(
+      event_store_class:,
       billable_metric:,
       subscription:,
       group:,
@@ -14,6 +15,8 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
       },
     )
   end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
 
   let(:subscription) do
     create(

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service, transaction: false do
   subject(:sum_service) do
     described_class.new(
+      event_store_class:,
       billable_metric:,
       subscription:,
       group:,
@@ -15,6 +16,8 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       },
     )
   end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
 
   let(:subscription) { create(:subscription, started_at: DateTime.parse('2022-12-01 00:00:00')) }
   let(:organization) { subscription.organization }

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: :service, transaction: false do
   subject(:unique_count_service) do
     described_class.new(
+      event_store_class:,
       billable_metric:,
       subscription:,
       group:,
@@ -15,6 +16,8 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
       },
     )
   end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
 
   let(:subscription) do
     create(

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService, type: :service do
 
   let(:aggregator) do
     BillableMetrics::Aggregations::CountService.new(
+      event_store_class: Events::Stores::PostgresStore,
       billable_metric: charge.billable_metric,
       subscription: nil,
       boundaries: nil,

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -138,8 +138,15 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
     let(:per_transaction_min_amount) { '1.75' }
 
     let(:aggregator) do
-      BillableMetrics::Aggregations::SumService.new(billable_metric: nil, subscription: nil, boundaries: nil)
+      BillableMetrics::Aggregations::SumService.new(
+        event_store_class:,
+        billable_metric: nil,
+        subscription: nil,
+        boundaries: nil,
+      )
     end
+
+    let(:event_store_class) { Events::Stores::PostgresStore }
 
     let(:aggregation) { 11_100 }
 

--- a/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
@@ -15,8 +15,14 @@ RSpec.describe Charges::ChargeModels::ProratedGraduatedService, type: :service d
   let(:billable_metric) { create(:sum_billable_metric, recurring: true) }
   let(:aggregation) { 5.96667 }
   let(:aggregator) do
-    BillableMetrics::ProratedAggregations::SumService.new(billable_metric:, subscription: nil, boundaries: nil)
+    BillableMetrics::ProratedAggregations::SumService.new(
+      event_store_class:,
+      billable_metric:,
+      subscription: nil,
+      boundaries: nil,
+    )
   end
+  let(:event_store_class) { Events::Stores::PostgresStore }
   let(:per_event_aggregation) do
     BaseService::Result.new.tap do |r|
       r.event_aggregation = [5, 5, 10, -6]

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
 
         expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
           .with(
+            event_store_class: Events::Stores::PostgresStore,
             billable_metric:,
             subscription:,
             group:,
@@ -68,6 +69,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
 
         expect(BillableMetrics::Aggregations::SumService).to have_received(:new)
           .with(
+            event_store_class: Events::Stores::PostgresStore,
             billable_metric:,
             subscription:,
             group:,
@@ -97,6 +99,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
 
         expect(BillableMetrics::Aggregations::UniqueCountService).to have_received(:new)
           .with(
+            event_store_class: Events::Stores::PostgresStore,
             billable_metric:,
             subscription:,
             group:,


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/1404, https://github.com/getlago/lago-api/pull/1419 and https://github.com/getlago/lago-api/pull/1422 and uses dependency injection to pass the event data store to the aggregator services.

## Description

The PR adds to event store:
- `Events::Stores::PostrgresStore`
- `Events::Stores::ClickhouseStore`

These store all extends `Events::Stores::BaseStore` and could be passed to the aggregation initializers

NOTE: Only count aggregation is implemented using this logic, more will come later