### PR TITLE
fix(usage): Use charges boundaries for past usage

### DIFF
--- a/app/queries/past_usage_query.rb
+++ b/app/queries/past_usage_query.rb
@@ -27,10 +27,10 @@ class PastUsageQuery < BaseQuery
 
   def query
     base_query = InvoiceSubscription.joins(subscription: :customer)
-      .where.not(from_datetime: nil)
+      .where.not(charges_from_datetime: nil)
       .where(customers: { external_id: filters.external_customer_id, organization_id: organization.id })
       .where(subscriptions: { external_id: filters.external_subscription_id })
-      .order(from_datetime: :desc)
+      .order(charges_from_datetime: :desc)
       .includes(:invoice)
 
     base_query = paginate(base_query)

--- a/app/serializers/v1/customers/past_usage_serializer.rb
+++ b/app/serializers/v1/customers/past_usage_serializer.rb
@@ -5,8 +5,8 @@ module V1
     class PastUsageSerializer < ModelSerializer
       def serialize
         payload = {
-          from_datetime: invoice_subscription.from_datetime.iso8601,
-          to_datetime: invoice_subscription.to_datetime.iso8601,
+          from_datetime: invoice_subscription.charges_from_datetime.iso8601,
+          to_datetime: invoice_subscription.charges_to_datetime.iso8601,
           issuing_date: invoice.issuing_date.iso8601,
           currency: invoice.currency,
           amount_cents: invoice.fees_amount_cents,

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+Rake::Task['db:migrate'].enhance do
+  Rake::Task['db:clickhouse:filter'].invoke
+end
+
 if Rake::Task.task_defined?('db:schema:dump:clickhouse')
   Rake::Task['db:schema:dump:clickhouse'].enhance do
     Rake::Task['db:clickhouse:filter'].invoke

--- a/spec/queries/past_usage_query_spec.rb
+++ b/spec/queries/past_usage_query_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe PastUsageQuery, type: :query do
   let(:invoice_subscription1) do
     create(
       :invoice_subscription,
-      from_datetime: DateTime.parse('2023-08-17T00:00:00'),
-      to_datetime: DateTime.parse('2023-09-16T23:59:59'),
+      charges_from_datetime: DateTime.parse('2023-08-17T00:00:00'),
+      charges_to_datetime: DateTime.parse('2023-09-16T23:59:59'),
       subscription:,
     )
   end
@@ -32,8 +32,8 @@ RSpec.describe PastUsageQuery, type: :query do
   let(:invoice_subscription2) do
     create(
       :invoice_subscription,
-      from_datetime: DateTime.parse('2023-07-17T00:00:00'),
-      to_datetime: DateTime.parse('2023-08-16T23:59:59'),
+      charges_from_datetime: DateTime.parse('2023-07-17T00:00:00'),
+      charges_to_datetime: DateTime.parse('2023-08-16T23:59:59'),
       subscription:,
     )
   end

--- a/spec/requests/api/v1/customers/usage_spec.rb
+++ b/spec/requests/api/v1/customers/usage_spec.rb
@@ -273,8 +273,8 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do # rubocop:
     let(:invoice_subscription) do
       create(
         :invoice_subscription,
-        from_datetime: DateTime.parse('2023-08-17T00:00:00'),
-        to_datetime: DateTime.parse('2023-09-16T23:59:59'),
+        charges_from_datetime: DateTime.parse('2023-08-17T00:00:00'),
+        charges_to_datetime: DateTime.parse('2023-09-16T23:59:59'),
         subscription:,
       )
     end
@@ -312,8 +312,8 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do # rubocop:
         expect(json[:usage_periods].count).to eq(1)
 
         usage = json[:usage_periods].first
-        expect(usage[:from_datetime]).to eq(invoice_subscription.from_datetime.iso8601)
-        expect(usage[:to_datetime]).to eq(invoice_subscription.to_datetime.iso8601)
+        expect(usage[:from_datetime]).to eq(invoice_subscription.charges_from_datetime.iso8601)
+        expect(usage[:to_datetime]).to eq(invoice_subscription.charges_to_datetime.iso8601)
         expect(usage[:issuing_date]).to eq(invoice.issuing_date.iso8601)
         expect(usage[:currency]).to eq(invoice.currency)
         expect(usage[:amount_cents]).to eq(invoice.fees_amount_cents)

--- a/spec/serializers/v1/customers/past_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/past_usage_serializer_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe ::V1::Customers::PastUsageSerializer do
   let(:invoice_subscription) do
     create(
       :invoice_subscription,
-      from_datetime: DateTime.parse('2023-08-17T00:00:00'),
-      to_datetime: DateTime.parse('2023-09-16T23:59:59'),
+      charges_from_datetime: DateTime.parse('2023-08-17T00:00:00'),
+      charges_to_datetime: DateTime.parse('2023-09-16T23:59:59'),
       subscription:,
     )
   end


### PR DESCRIPTION
## Context

When we query the `/past_usage` endpoint, the API returns `usage_periods.from_datetime` and `usage_periods.to_datetime`.

However, these are based on the subscription fee and not on the fees for usage-based charges.

## Description

This PR moves the past usage logic from `invoice_subscriptions#from_date` and `invoice_subscriptions#to_date` to `invoice_subscriptions#charges_from_date` and `invoice_subscriptions#charges_to_date`
