### PR TITLE
feat(default-currency): Add organization default currency

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -40,6 +40,7 @@ module Api
       def input_params
         params.require(:organization).permit(
           :country,
+          :default_currency,
           :address_line1,
           :address_line2,
           :state,

--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -6,6 +6,7 @@ module Types
 
     field :id, ID, null: false
 
+    field :default_currency, Types::CurrencyEnum, null: false
     field :email, String
     field :legal_name, String
     field :legal_number, String

--- a/app/graphql/types/organizations/update_organization_input.rb
+++ b/app/graphql/types/organizations/update_organization_input.rb
@@ -5,7 +5,7 @@ module Types
     class UpdateOrganizationInput < BaseInputObject
       description 'Update Organization input arguments'
 
-      argument :default_currency, Types::CurrencyEnum, required: true
+      argument :default_currency, Types::CurrencyEnum, required: false
       argument :email, String, required: false
       argument :legal_name, String, required: false
       argument :legal_number, String, required: false

--- a/app/graphql/types/organizations/update_organization_input.rb
+++ b/app/graphql/types/organizations/update_organization_input.rb
@@ -5,6 +5,7 @@ module Types
     class UpdateOrganizationInput < BaseInputObject
       description 'Update Organization input arguments'
 
+      argument :default_currency, Types::CurrencyEnum, required: true
       argument :email, String, required: false
       argument :legal_name, String, required: false
       argument :legal_number, String, required: false

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -3,6 +3,7 @@
 class Organization < ApplicationRecord
   include PaperTrailTraceable
   include OrganizationTimezone
+  include Currencies
 
   EMAIL_SETTINGS = [
     'invoice.finalized',
@@ -39,6 +40,7 @@ class Organization < ApplicationRecord
   before_create :generate_api_key
 
   validates :country, country_code: true, unless: -> { country.nil? }
+  validates :default_currency, inclusion: { in: currency_list }
   validates :document_locale, language_code: true
   validates :email, email: true, if: :email?
   validates :invoice_footer, length: { maximum: 600 }

--- a/app/serializers/v1/organization_serializer.rb
+++ b/app/serializers/v1/organization_serializer.rb
@@ -6,6 +6,7 @@ module V1
       payload = {
         lago_id: model.id,
         name: model.name,
+        default_currency: model.default_currency,
         created_at: model.created_at.iso8601,
         webhook_url: webhook_urls.first.to_s,
         webhook_urls:,
@@ -51,8 +52,6 @@ module V1
         collection_name: 'taxes',
       ).serialize
     end
-
-    private
 
     def webhook_urls
       model.webhook_endpoints.map(&:webhook_url)

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -22,6 +22,7 @@ module Organizations
       organization.city = params[:city] if params.key?(:city)
       organization.state = params[:state] if params.key?(:state)
       organization.country = params[:country]&.upcase if params.key?(:country)
+      organization.default_currency = params[:default_currency]&.upcase if params.key?(:default_currency)
       organization.net_payment_term = params[:net_payment_term] if params.key?(:net_payment_term)
 
       billing = params[:billing_configuration]&.to_h || {}
@@ -33,7 +34,7 @@ module Organizations
 
       if params.key?(:webhook_url)
         webhook_endpoint = organization.webhook_endpoints.first_or_initialize
-        webhook_endpoint.update! webhook_url: params[:webhook_url]
+        webhook_endpoint.update!(webhook_url: params[:webhook_url])
       end
 
       if License.premium? && billing.key?(:invoice_grace_period)

--- a/db/migrate/20231101080314_add_default_currency_to_organizations.rb
+++ b/db/migrate/20231101080314_add_default_currency_to_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDefaultCurrencyToOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :default_currency, :string, null: false, default: 'USD'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -582,6 +582,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_02_085146) do
     t.string "email_settings", default: [], null: false, array: true
     t.string "tax_identification_number"
     t.integer "net_payment_term", default: 0, null: false
+    t.string "default_currency", default: "USD", null: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"

--- a/schema.graphql
+++ b/schema.graphql
@@ -3975,6 +3975,7 @@ type Organization {
   city: String
   country: CountryCode
   createdAt: ISO8601DateTime!
+  defaultCurrency: CurrencyEnum!
   email: String
   emailSettings: [EmailSettingsEnum!]
   gocardlessPaymentProvider: GocardlessProvider
@@ -5627,6 +5628,7 @@ input UpdateOrganizationInput {
   """
   clientMutationId: String
   country: CountryCode
+  defaultCurrency: CurrencyEnum
   email: String
   emailSettings: [EmailSettingsEnum!]
   legalName: String

--- a/schema.json
+++ b/schema.json
@@ -16571,6 +16571,24 @@
               ]
             },
             {
+              "name": "defaultCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "email",
               "description": null,
               "type": {
@@ -23880,6 +23898,18 @@
           "possibleTypes": null,
           "fields": null,
           "inputFields": [
+            {
+              "name": "defaultCurrency",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "CurrencyEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "email",
               "description": null,

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :organization do
     name { Faker::Company.name }
+    default_currency { 'USD' }
     vat_rate { 20 }
 
     email { Faker::Internet.email }

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           zipcode
           city
           country
+          defaultCurrency
           netPaymentTerm
           timezone
           emailSettings
@@ -46,6 +47,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           zipcode: 'FOO1234',
           city: 'Foobar',
           country: 'FR',
+          defaultCurrency: 'EUR',
           webhookUrl: 'https://app.test.dev',
           billingConfiguration: {
             invoiceFooter: 'invoice footer',
@@ -68,6 +70,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
       expect(result_data['zipcode']).to eq('FOO1234')
       expect(result_data['city']).to eq('Foobar')
       expect(result_data['country']).to eq('FR')
+      expect(result_data['defaultCurrency']).to eq('EUR')
       expect(result_data['netPaymentTerm']).to eq(10)
       expect(result_data['webhookUrl']).to eq('https://app.test.dev')
       expect(result_data['billingConfiguration']['invoiceFooter']).to eq('invoice footer')

--- a/spec/graphql/types/organization_type_spec.rb
+++ b/spec/graphql/types/organization_type_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::OrganizationType do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type('ID!') }
+
+  it { is_expected.to have_field(:default_currency).of_type('CurrencyEnum!') }
+  it { is_expected.to have_field(:email).of_type('String') }
+  it { is_expected.to have_field(:legal_name).of_type('String') }
+  it { is_expected.to have_field(:legal_number).of_type('String') }
+  it { is_expected.to have_field(:logo_url).of_type('String') }
+  it { is_expected.to have_field(:name).of_type('String!') }
+  it { is_expected.to have_field(:tax_identification_number).of_type('String') }
+
+  it { is_expected.to have_field(:address_line1).of_type('String') }
+  it { is_expected.to have_field(:address_line2).of_type('String') }
+  it { is_expected.to have_field(:city).of_type('String') }
+  it { is_expected.to have_field(:country).of_type('CountryCode') }
+  it { is_expected.to have_field(:net_payment_term).of_type('Int!') }
+  it { is_expected.to have_field(:state).of_type('String') }
+  it { is_expected.to have_field(:zipcode).of_type('String') }
+
+  it { is_expected.to have_field(:api_key).of_type('String!') }
+  it { is_expected.to have_field(:webhook_url).of_type('String') }
+
+  it { is_expected.to have_field(:timezone).of_type('TimezoneEnum') }
+
+  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+
+  it { is_expected.to have_field(:billing_configuration).of_type('OrganizationBillingConfiguration') }
+  it { is_expected.to have_field(:email_settings).of_type('[EmailSettingsEnum!]') }
+  it { is_expected.to have_field(:taxes).of_type('[Tax!]') }
+
+  it { is_expected.to have_field(:adyen_payment_provider).of_type('AdyenProvider') }
+  it { is_expected.to have_field(:gocardless_payment_provider).of_type('GocardlessProvider') }
+  it { is_expected.to have_field(:stripe_payment_provider).of_type('StripeProvider') }
+end

--- a/spec/graphql/types/organizations/update_organization_input_spec.rb
+++ b/spec/graphql/types/organizations/update_organization_input_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Organizations::UpdateOrganizationInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:default_currency).of_type('CurrencyEnum!') }
+  it { is_expected.to accept_argument(:email).of_type('String') }
+  it { is_expected.to accept_argument(:legal_name).of_type('String') }
+  it { is_expected.to accept_argument(:legal_number).of_type('String') }
+  it { is_expected.to accept_argument(:logo).of_type('String') }
+  it { is_expected.to accept_argument(:tax_identification_number).of_type('String') }
+
+  it { is_expected.to accept_argument(:address_line1).of_type('String') }
+  it { is_expected.to accept_argument(:address_line2).of_type('String') }
+  it { is_expected.to accept_argument(:city).of_type('String') }
+  it { is_expected.to accept_argument(:country).of_type('CountryCode') }
+  it { is_expected.to accept_argument(:net_payment_term).of_type('Int') }
+  it { is_expected.to accept_argument(:state).of_type('String') }
+  it { is_expected.to accept_argument(:zipcode).of_type('String') }
+
+  it { is_expected.to accept_argument(:webhook_url).of_type('String') }
+
+  it { is_expected.to accept_argument(:timezone).of_type('TimezoneEnum') }
+
+  it { is_expected.to accept_argument(:billing_configuration).of_type('OrganizationBillingConfigurationInput') }
+  it { is_expected.to accept_argument(:email_settings).of_type('[EmailSettingsEnum!]') }
+end

--- a/spec/graphql/types/organizations/update_organization_input_spec.rb
+++ b/spec/graphql/types/organizations/update_organization_input_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Types::Organizations::UpdateOrganizationInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:default_currency).of_type('CurrencyEnum!') }
+  it { is_expected.to accept_argument(:default_currency).of_type('CurrencyEnum') }
   it { is_expected.to accept_argument(:email).of_type('String') }
   it { is_expected.to accept_argument(:legal_name).of_type('String') }
   it { is_expected.to accept_argument(:legal_number).of_type('String') }

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Organization, type: :model do
   it { is_expected.to have_many(:webhook_endpoints) }
   it { is_expected.to have_many(:webhooks).through(:webhook_endpoints) }
 
+  it { is_expected.to validate_inclusion_of(:default_currency).in_array(described_class.currency_list) }
+
   it_behaves_like 'paper_trail traceable'
 
   describe 'Validations' do

--- a/spec/requests/api/v1/organizations_spec.rb
+++ b/spec/requests/api/v1/organizations_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
     let(:update_params) do
       {
         country: 'pl',
+        default_currency: 'EUR',
         address_line1: 'address1',
         address_line2: 'address2',
         state: 'state',
@@ -41,6 +42,7 @@ RSpec.describe Api::V1::OrganizationsController, type: :request do
 
       aggregate_failures do
         expect(json[:organization][:name]).to eq(organization.name)
+        expect(json[:organization][:default_currency]).to eq('EUR')
         expect(json[:organization][:webhook_url]).to eq(webhook_url)
         expect(json[:organization][:webhook_urls]).to eq([webhook_url])
         expect(json[:organization][:vat_rate]).to eq(update_params[:vat_rate])

--- a/spec/serializers/v1/organization_serializer_spec.rb
+++ b/spec/serializers/v1/organization_serializer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ::V1::OrganizationSerializer do
 
     aggregate_failures do
       expect(result['organization']['name']).to eq(org.name)
+      expect(result['organization']['default_currency']).to eq(org.default_currency)
       expect(result['organization']['created_at']).to eq(org.created_at.iso8601)
       expect(result['organization']['webhook_url']).to eq(webhook_urls.first)
       expect(result['organization']['webhook_urls']).to eq(webhook_urls)

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Organizations::UpdateService do
       state: 'Foobar',
       zipcode: 'FOO1234',
       city: 'Foobar',
+      default_currency: 'EUR',
       country:,
       timezone:,
       logo:,
@@ -51,6 +52,7 @@ RSpec.describe Organizations::UpdateService do
         expect(result.organization.zipcode).to eq('FOO1234')
         expect(result.organization.city).to eq('Foobar')
         expect(result.organization.country).to eq('FR')
+        expect(result.organization.default_currency).to eq('EUR')
         expect(result.organization.timezone).to eq('UTC')
 
         expect(result.organization.invoice_footer).to eq('invoice footer')


### PR DESCRIPTION
## Context

To display revenue graphs, we need to know what is the default currency of an organization. This default currency will be used as a filter when landing on this dashboard section.

## Description

This PR adds `default_currency` column to `organizations` table.

It also adds the field to organization graphql type and update input, serializer and the organization update service.

