### PR TITLE
feat(unit-price): Set precise unit amount to standard charge model

### DIFF
--- a/app/services/charges/charge_models/base_service.rb
+++ b/app/services/charges/charge_models/base_service.rb
@@ -20,6 +20,7 @@ module Charges
         result.full_units_number = aggregation_result.full_units_number
         result.count = aggregation_result.count
         result.amount = compute_amount
+        result.unit_amount = unit_amount
 
         if aggregation_result.total_aggregated_units
           result.total_aggregated_units = aggregation_result.total_aggregated_units
@@ -36,6 +37,12 @@ module Charges
 
       def compute_amount
         raise NotImplementedError
+      end
+
+      def unit_amount
+        # TODO: Uncomment this.
+        # raise NotImplementedError
+        0
       end
     end
   end

--- a/app/services/charges/charge_models/standard_service.rb
+++ b/app/services/charges/charge_models/standard_service.rb
@@ -8,6 +8,13 @@ module Charges
       def compute_amount
         (units * BigDecimal(properties['amount']))
       end
+
+      def unit_amount
+        total_units = aggregation_result.full_units_number || units
+        return 0 if total_units.zero?
+
+        compute_amount / total_units
+      end
     end
   end
 end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -67,6 +67,7 @@ module Fees
       currency = invoice.total_amount.currency
       rounded_amount = amount_result.amount.round(currency.exponent)
       amount_cents = rounded_amount * currency.subunit_to_unit
+      unit_amount_cents = amount_result.unit_amount * currency.subunit_to_unit
 
       units = if is_current_usage && (charge.pay_in_advance? || charge.prorated?)
         amount_result.current_usage_units
@@ -92,6 +93,8 @@ module Fees
         group_id: group&.id,
         payment_status: :pending,
         taxes_amount_cents: 0,
+        unit_amount_cents:,
+        precise_unit_amount: amount_result.unit_amount,
       )
 
       result.fees << new_fee

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -21,6 +21,7 @@ module Fees
         f.events_count = 0
         f.group_id = nil
         f.true_up_parent_fee = fee
+        f.unit_amount_cents = f.amount_cents
       end
 
       result.true_up_fee = true_up_fee

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -22,6 +22,7 @@ module Fees
         f.group_id = nil
         f.true_up_parent_fee = fee
         f.unit_amount_cents = f.amount_cents
+        f.precise_unit_amount = f.unit_amount.to_f
       end
 
       result.true_up_fee = true_up_fee

--- a/db/migrate/20231102154537_change_precision_to_precise_unit_amount.rb
+++ b/db/migrate/20231102154537_change_precision_to_precise_unit_amount.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ChangePrecisionToPreciseUnitAmount < ActiveRecord::Migration[7.0]
+  def up
+    change_table :fees, bulk: true do |t|
+      t.change :precise_unit_amount, :decimal, precision: 30, scale: 15, null: false, default: '0.0'
+    end
+  end
+
+  def down
+    change_table :fees, bulk: true do |t|
+      t.change :precise_unit_amount, :decimal, precision: 30, scale: 5, null: false, default: '0.0'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_02_085146) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_02_154537) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -379,7 +379,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_02_085146) do
     t.decimal "precise_coupons_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "total_aggregated_units"
     t.string "invoice_display_name"
-    t.decimal "precise_unit_amount", precision: 30, scale: 5, default: "0.0", null: false
+    t.decimal "precise_unit_amount", precision: 30, scale: 15, default: "0.0", null: false
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"

--- a/spec/services/charges/charge_models/standard_service_spec.rb
+++ b/spec/services/charges/charge_models/standard_service_spec.rb
@@ -14,24 +14,27 @@ RSpec.describe Charges::ChargeModels::StandardService, type: :service do
   before do
     aggregation_result.aggregation = aggregation
     aggregation_result.total_aggregated_units = total_aggregated_units if total_aggregated_units
+    aggregation_result.full_units_number = full_units_number if full_units_number
   end
 
   let(:aggregation_result) { BaseService::Result.new }
   let(:aggregation) { 10 }
   let(:total_aggregated_units) { nil }
+  let(:full_units_number) { nil }
 
   let(:charge) do
     create(
       :standard_charge,
       charge_model: 'standard',
       properties: {
-        amount: '500',
+        amount: '5.12345',
       },
     )
   end
 
   it 'applies the charge model to the value' do
-    expect(apply_standard_service.amount).to eq(5000)
+    expect(apply_standard_service.amount).to eq(51.2345)
+    expect(apply_standard_service.unit_amount).to eq(5.12345)
   end
 
   context 'when aggregation result contains total_aggregated_units' do
@@ -39,6 +42,14 @@ RSpec.describe Charges::ChargeModels::StandardService, type: :service do
 
     it 'assigns the total_aggregated_units to the result' do
       expect(apply_standard_service.total_aggregated_units).to eq(total_aggregated_units)
+    end
+  end
+
+  context 'when aggregation result contains full_units_number' do
+    let(:full_units_number) { 100 }
+
+    it 'applies the charge model to the value' do
+      expect(apply_standard_service.unit_amount).to eq(0.512345)
     end
   end
 end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -205,6 +205,8 @@ RSpec.describe Fees::ChargeService do
               expect(result).to be_success
               expect(result.fees.count).to eq(2)
               expect(result.fees.pluck(:amount_cents)).to contain_exactly(0, 548) # 548 is 1000 prorated for 17 days.
+              expect(result.fees.pluck(:unit_amount_cents)).to contain_exactly(0, 548)
+              expect(result.fees.pluck(:precise_unit_amount)).to contain_exactly(0, 5.48)
             end
           end
         end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -53,18 +53,18 @@ RSpec.describe Fees::ChargeService do
       it 'creates a fee' do
         result = charge_subscription_service.create
         expect(result).to be_success
-        created_fee = result.fees.first
-
-        aggregate_failures do
-          expect(created_fee.id).not_to be_nil
-          expect(created_fee.invoice_id).to eq(invoice.id)
-          expect(created_fee.charge_id).to eq(charge.id)
-          expect(created_fee.amount_cents).to eq(0)
-          expect(created_fee.amount_currency).to eq('EUR')
-          expect(created_fee.units).to eq(0)
-          expect(created_fee.events_count).to eq(0)
-          expect(created_fee.payment_status).to eq('pending')
-        end
+        expect(result.fees.first).to have_attributes(
+          id: String,
+          invoice_id: invoice.id,
+          charge_id: charge.id,
+          amount_cents: 0,
+          amount_currency: 'EUR',
+          units: 0,
+          unit_amount_cents: 0,
+          precise_unit_amount: 0,
+          events_count: 0,
+          payment_status: 'pending',
+        )
       end
 
       context 'with graduated charge model' do
@@ -102,16 +102,17 @@ RSpec.describe Fees::ChargeService do
         it 'creates a fee' do
           result = charge_subscription_service.create
           expect(result).to be_success
-          created_fee = result.fees.first
-
-          aggregate_failures do
-            expect(created_fee.id).not_to be_nil
-            expect(created_fee.invoice_id).to eq(invoice.id)
-            expect(created_fee.charge_id).to eq(charge.id)
-            expect(created_fee.amount_cents).to eq(5)
-            expect(created_fee.amount_currency).to eq('EUR')
-            expect(created_fee.units.to_s).to eq('4.0')
-          end
+          expect(result.fees.first).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            charge_id: charge.id,
+            amount_cents: 5,
+            amount_currency: 'EUR',
+            units: 4.0,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0.0,
+            events_count: 4,
+          )
         end
       end
 
@@ -160,16 +161,14 @@ RSpec.describe Fees::ChargeService do
         it 'creates a new fee for the complete period' do
           result = charge_subscription_service.create
           expect(result).to be_success
-          created_fee = result.fees.first
-
-          aggregate_failures do
-            expect(created_fee.id).not_to be_nil
-            expect(created_fee.invoice_id).to eq(invoice.id)
-            expect(created_fee.charge_id).to eq(charge.id)
-            expect(created_fee.amount_cents).to eq(2000)
-            expect(created_fee.amount_currency).to eq('EUR')
-            expect(created_fee.units).to eq(1)
-          end
+          expect(result.fees.first).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            charge_id: charge.id,
+            amount_cents: 2000,
+            amount_currency: 'EUR',
+            units: 1,
+          )
         end
       end
 
@@ -182,16 +181,16 @@ RSpec.describe Fees::ChargeService do
           it 'creates fees' do
             result = charge_subscription_service.create
             expect(result).to be_success
-            created_fee = result.fees.first
-
-            aggregate_failures do
-              expect(created_fee.id).not_to be_nil
-              expect(created_fee.invoice_id).to eq(invoice.id)
-              expect(created_fee.charge_id).to eq(charge.id)
-              expect(created_fee.amount_cents).to eq(0)
-              expect(created_fee.amount_currency).to eq('EUR')
-              expect(created_fee.units).to eq(0)
-            end
+            expect(result.fees.first).to have_attributes(
+              id: String,
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_cents: 0,
+              amount_currency: 'EUR',
+              units: 0,
+              unit_amount_cents: 0,
+              precise_unit_amount: 0,
+            )
           end
         end
       end
@@ -230,7 +229,7 @@ RSpec.describe Fees::ChargeService do
           :standard_charge,
           plan: subscription.plan,
           billable_metric:,
-          properties: { amount: '10' },
+          properties: { amount: '10.12345' },
           group_properties: [
             build(
               :group_property,
@@ -312,18 +311,24 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 4000,
             units: 2,
+            unit_amount_cents: 2000,
+            precise_unit_amount: 20,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 5000,
             units: 1,
+            unit_amount_cents: 5000,
+            precise_unit_amount: 50,
           )
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 1000,
+            amount_cents: 1012,
             units: 1,
+            unit_amount_cents: 1012,
+            precise_unit_amount: 10.12345,
           )
         end
       end
@@ -347,18 +352,24 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 30_000,
             units: 15,
+            unit_amount_cents: 2000,
+            precise_unit_amount: 20,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 60_000,
             units: 12,
+            unit_amount_cents: 5000,
+            precise_unit_amount: 50,
           )
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 5000,
+            amount_cents: 5062,
             units: 5,
+            unit_amount_cents: 1012,
+            precise_unit_amount: 10.12345,
           )
         end
       end
@@ -382,18 +393,24 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 20_000,
             units: 10,
+            unit_amount_cents: 2000,
+            precise_unit_amount: 20,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 60_000,
             units: 12,
+            unit_amount_cents: 5000,
+            precise_unit_amount: 50,
           )
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 5000,
+            amount_cents: 5062,
             units: 5,
+            unit_amount_cents: 1012,
+            precise_unit_amount: 10.12345,
           )
         end
       end
@@ -504,8 +521,10 @@ RSpec.describe Fees::ChargeService do
 
             expect(created_fees.third).to have_attributes(
               group: france,
-              amount_cents: 1000,
+              amount_cents: 1012,
               units: 1,
+              unit_amount_cents: 1012,
+              precise_unit_amount: 10.12345,
             )
           end
         end
@@ -593,8 +612,10 @@ RSpec.describe Fees::ChargeService do
 
           expect(created_fees.third).to have_attributes(
             group: france,
-            amount_cents: 1000,
+            amount_cents: 1012,
             units: 1,
+            unit_amount_cents: 1012,
+            precise_unit_amount: 10.12345,
           )
         end
       end
@@ -707,18 +728,24 @@ RSpec.describe Fees::ChargeService do
           expect(created_fees.first).to have_attributes(
             group: europe,
             units: 2,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 5000,
             units: 1,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
 
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 0,
             units: 1,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
         end
       end
@@ -820,18 +847,24 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 200 + 2 * 2,
             units: 2,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 1 * 1,
             units: 1,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
 
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 100 + 5 * 1,
             units: 1,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
         end
       end
@@ -933,12 +966,16 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 3,
             units: 2,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 4,
             units: 1,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
         end
       end
@@ -1030,12 +1067,16 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 1400,
             units: 2,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 1100,
             units: 1,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
         end
       end
@@ -1137,12 +1178,16 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 5, # 2 × 0.02 + 0.01
             units: 2,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 4, # 1 × 0.03 + 0.01
             units: 1,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0,
           )
         end
       end

--- a/spec/services/fees/create_true_up_service_spec.rb
+++ b/spec/services/fees/create_true_up_service_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe Fees::CreateTrueUpService, type: :service do
             group: nil,
             amount_cents: 300,
             unit_amount_cents: 300,
+            precise_unit_amount: 3,
             true_up_parent_fee_id: fee.id,
           )
         end
@@ -129,6 +130,7 @@ RSpec.describe Fees::CreateTrueUpService, type: :service do
               group: nil,
               amount_cents: 300,
               unit_amount_cents: 300,
+              precise_unit_amount: 3,
               true_up_parent_fee_id: fee.id,
             )
           end

--- a/spec/services/fees/create_true_up_service_spec.rb
+++ b/spec/services/fees/create_true_up_service_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Fees::CreateTrueUpService, type: :service do
             events_count: 0,
             group: nil,
             amount_cents: 300,
+            unit_amount_cents: 300,
             true_up_parent_fee_id: fee.id,
           )
         end
@@ -127,6 +128,7 @@ RSpec.describe Fees::CreateTrueUpService, type: :service do
               events_count: 0,
               group: nil,
               amount_cents: 300,
+              unit_amount_cents: 300,
               true_up_parent_fee_id: fee.id,
             )
           end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown](https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown)

## Context

Invoices are not compliant as we’re not displaying unit prices of item on them.

The goal is to be compliant by adding unit price on invoice payload and pdf.
- Subscription invoices
- Charge (pay in advance) invoices

## Description

The goal of this PR is to compute `precise_unit_amount` for standard charge models.
