### PR TITLE
misc(docker): Use now ruby-slim instead of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,29 @@
-FROM ruby:3.2.2-alpine as build
+FROM ruby:3.2.2-slim as build
 
 WORKDIR /app
 
 COPY ./Gemfile /app/Gemfile
 COPY ./Gemfile.lock /app/Gemfile.lock
 
-RUN apk add --no-cache \
-  git \
-  bash \
-  build-base \
-  libxml2-dev \
-  libxslt-dev \
-  nodejs \
-  tzdata \
-  openssl \
-  postgresql-dev \
-  libc6-compat
+RUN apt update -qq && apt install nodejs build-essential git pkg-config libpq-dev -y
 
-ENV BUNDLER_VERSION='2.3.26'
-RUN gem install bundler --no-document -v '2.3.26'
+ENV BUNDLER_VERSION='2.4.21'
+RUN gem install bundler --no-document -v '2.4.21'
 
 RUN bundle config build.nokogiri --use-system-libraries &&\
   bundle install --jobs=3 --retry=3 --without development test
 
-FROM ruby:3.2.2-alpine
+FROM ruby:3.2.2-slim
 
 WORKDIR /app
 
 COPY . /app
 
-RUN apk add --no-cache \
-  bash \
-  postgresql-dev \
-  tzdata \
-  libc6-compat
-
 ARG SEGMENT_WRITE_KEY
 ARG GOCARDLESS_CLIENT_ID
 ARG GOCARDLESS_CLIENT_SECRET
+
+RUN apt update -qq && apt install git libpq-dev -y
 
 ENV SEGMENT_WRITE_KEY $SEGMENT_WRITE_KEY
 ENV GOCARDLESS_CLIENT_ID $GOCARDLESS_CLIENT_ID

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,24 +1,14 @@
-FROM ruby:3.2.2-alpine
+FROM ruby:3.2.2-slim
 
 WORKDIR /app
 
 COPY ./Gemfile /app/Gemfile
 COPY ./Gemfile.lock /app/Gemfile.lock
 
-RUN apk add --no-cache \
-  git \
-  bash \
-  build-base \
-  libxml2-dev \
-  libxslt-dev \
-  nodejs \
-  tzdata \
-  postgresql-dev \
-  openssl \
-  gcompat
+RUN apt update -qq && apt install nodejs build-essential git pkg-config libpq-dev -y
 
-ENV BUNDLER_VERSION='2.3.26'
-RUN gem install bundler --no-document -v '2.3.26'
+ENV BUNDLER_VERSION='2.4.21'
+RUN gem install bundler --no-document -v '2.4.21'
 
 RUN bundle config build.nokogiri --use-system-libraries &&\
  bundle install


### PR DESCRIPTION
- `alpine` for ruby is not recommended in term of performances, a classic `slim` image based on debian is better.