### PR TITLE
feat(event): Use only event external_ids in aggregations

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -52,7 +52,7 @@ module BillableMetrics
       end
 
       def events_scope(from_datetime:, to_datetime:)
-        events = Event.where(subscription_id: subscription.id)
+        events = Event.where(external_subscription_id: subscription.external_id)
           .from_datetime(from_datetime)
           .to_datetime(to_datetime)
           .where(code: billable_metric.code)
@@ -63,13 +63,7 @@ module BillableMetrics
       end
 
       def recurring_events_scope(to_datetime:, from_datetime: nil)
-        subscription_ids = customer.subscriptions
-          .where(external_id: subscription.external_id)
-          .pluck(:id)
-
-        events = Event
-          .where(customer_id: customer.id)
-          .where(subscription_id: subscription_ids)
+        events = Event.where(external_subscription_id: subscription.external_id)
           .where(code: billable_metric.code)
           .to_datetime(to_datetime)
         events = events.from_datetime(from_datetime) unless from_datetime.nil?

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -150,9 +150,13 @@ module BillableMetrics
         quantified_events = if billable_metric.recurring?
           quantified_events.where(external_subscription_id: subscription.external_id)
         else
-          quantified_event_ids = Event.where(subscription_id: subscription.id)
+          scope = Event.where(external_subscription_id: subscription.external_id)
             .where('quantified_event_id IS NOT NULL')
-            .pluck('DISTINCT(quantified_event_id)')
+            .where(timestamp: subscription.started_at..)
+
+          scope = scope.where(timestamp: ...subscription.terminated_at) if subscription.terminated?
+
+          quantified_event_ids = scope.pluck('DISTINCT(quantified_event_id)')
 
           quantified_events.where(id: quantified_event_ids)
         end

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -151,16 +151,10 @@ module BillableMetrics
       # NOTE: In case of upgrade/downgrade, if latest value is not persisted yet,
       #       we need to fetch latest value from previous events attached to the same external subscription ID
       def latest_value_from_events
-        subscription_ids = customer.subscriptions
-          .where(external_id: subscription.external_id)
-          .pluck(:id)
-
-        scope = Event.where(customer_id: customer.id)
-          .where(subscription_id: subscription_ids)
+        scope = Event.where(external_subscription_id: subscription.external_id)
           .where(code: billable_metric.code)
           .where(created_at: billable_metric.created_at...)
           .where(timestamp: ..from_datetime)
-          .where.not(subscription_id: subscription.id)
           .where(field_presence_condition)
           .where(field_numeric_condition)
 

--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -9,15 +9,12 @@ module Events
     end
 
     def call
-      event.customer_id = customer&.id
       event.external_customer_id ||= customer&.external_id
 
       # NOTE: prevent subscription if more than 1 subscription is active
       #       if multiple terminated matches the timestamp, takes the most recent
-      if subscriptions.count(&:active?) <= 1
-        subscription = subscriptions.first
-        event.subscription_id = subscription&.id
-        event.external_subscription_id ||= subscription&.external_id
+      if !event.external_subscription_id && subscriptions.count(&:active?) <= 1
+        event.external_subscription_id ||= subscriptions.first&.external_id
       end
 
       event.save!

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -4,8 +4,7 @@ module Events
   module Stores
     class PostgresStore < BaseStore
       def events
-        # TODO: switch to external_subscription_id to allow events sent before subscription creation
-        scope = Event.where(subscription_id: subscription.id)
+        scope = Event.where(external_subscription_id: subscription.external_id)
           .from_datetime(from_datetime)
           .to_datetime(to_datetime)
           .where(code:)

--- a/app/services/fees/estimate_pay_in_advance_service.rb
+++ b/app/services/fees/estimate_pay_in_advance_service.rb
@@ -46,8 +46,8 @@ module Fees
       @event = Event.new(
         organization_id: organization.id,
         code: params[:code],
-        customer:,
-        subscription: subscriptions.first,
+        external_customer_id: customer&.external_id,
+        external_subscription_id: subscriptions.first&.external_id,
         properties: params[:properties] || {},
         transaction_id: SecureRandom.uuid,
         timestamp: Time.current,
@@ -78,11 +78,11 @@ module Fees
       @subscriptions = subscriptions
         .where("date_trunc('second', started_at::timestamp) <= ?", timestamp)
         .where("terminated_at IS NULL OR date_trunc('second', terminated_at::timestamp) >= ?", timestamp)
-        .order(started_at: :desc)
+        .order('terminated_at DESC NULLS FIRST, started_at DESC')
     end
 
     def charges
-      @charges ||= event.subscription
+      @charges ||= subscriptions.first
         .plan
         .charges
         .pay_in_advance

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -71,9 +71,7 @@ module Subscriptions
         datetime = new_datetime if ((datetime.in_time_zone - new_datetime.in_time_zone) / 1.hour).abs < 26
       end
 
-      if datetime < subscription.started_at
-        datetime = subscription.started_at.in_time_zone(customer.applicable_timezone).beginning_of_day.utc
-      end
+      datetime = subscription.started_at if datetime < subscription.started_at
 
       datetime
     end

--- a/db/seeds/base.rb
+++ b/db/seeds/base.rb
@@ -103,8 +103,8 @@ Charge.create_with(
       time = Time.current - offset.month - rand(1..20).days
 
       Event.create!(
-        customer_id: customer.id,
-        subscription_id: sub.id,
+        external_customer_id: customer.external_id,
+        external_subscription_id: sub.external_id,
         organization_id: organization.id,
         transaction_id: SecureRandom.uuid,
         timestamp: time - rand(0..12).seconds,
@@ -124,8 +124,8 @@ Charge.create_with(
       time = Time.current - offset.month - rand(1..20).days
 
       Event.create!(
-        customer_id: customer.id,
-        subscription_id: sub.id,
+        external_customer_id: customer.external_id,
+        external_subscription_id: sub.external_id,
         organization_id: organization.id,
         transaction_id: SecureRandom.uuid,
         timestamp: time - rand(0..12).seconds,
@@ -144,8 +144,8 @@ Charge.create_with(
     time = Time.zone.now - rand(1..20).days
 
     Event.create!(
-      customer_id: customer.id,
-      subscription_id: sub.id,
+      external_customer_id: customer.external_id,
+      external_subscription_id: sub.external_id,
       organization_id: organization.id,
       transaction_id: SecureRandom.uuid,
       timestamp: time - 120.seconds,
@@ -164,8 +164,8 @@ Charge.create_with(
     time = Time.zone.now - rand(1..20).days
 
     Event.create!(
-      customer_id: customer.id,
-      subscription_id: sub.id,
+      external_customer_id: customer.external_id,
+      external_subscription_id: sub.external_id,
       organization_id: organization.id,
       transaction_id: SecureRandom.uuid,
       timestamp: time - 120.seconds,
@@ -221,8 +221,8 @@ organization.customers.find_each do |customer|
     time = Time.zone.now
 
     Event.create!(
-      customer_id: customer.id,
-      subscription_id: customer.active_subscriptions&.first&.id,
+      external_customer_id: customer.external_id,
+      external_subscription_id: customer.active_subscriptions&.first&.external_id,
       organization_id: organization.id,
       transaction_id: SecureRandom.uuid,
       timestamp: time - rand(0..24).hours,

--- a/db/seeds/groups.rb
+++ b/db/seeds/groups.rb
@@ -79,8 +79,8 @@ unless customer.events.exists?
   time = Time.current
   2.times do
     Event.create!(
-      customer:,
-      subscription:,
+      external_customer_id: customer.external_id,
+      external_subscription_id: subscription.external_id,
       organization:,
       transaction_id: SecureRandom.uuid,
       timestamp: time - rand(0..12).seconds,
@@ -95,8 +95,8 @@ unless customer.events.exists?
   end
 
   Event.create!(
-    customer:,
-    subscription:,
+    external_customer_id: customer.external_id,
+    external_subscription_id: subscription.external_id,
     organization:,
     transaction_id: SecureRandom.uuid,
     timestamp: time - rand(0..12).seconds,
@@ -163,8 +163,8 @@ Charge.create_with(
 2.times do
   time = Time.current
   Event.create!(
-    customer:,
-    subscription:,
+    external_customer_id: customer.external_id,
+    external_subscription_id: subscription.external_id,
     organization:,
     transaction_id: SecureRandom.uuid,
     timestamp: time - rand(0..12).seconds,
@@ -182,8 +182,8 @@ Charge.create_with(
 end
 
 Event.create!(
-  customer:,
-  subscription:,
+  external_customer_id: customer.external_id,
+  external_subscription_id: subscription.external_id,
   organization:,
   transaction_id: SecureRandom.uuid,
   timestamp: time - rand(0..12).seconds,
@@ -200,8 +200,8 @@ Event.create!(
 )
 
 Event.create!(
-  customer:,
-  subscription:,
+  external_customer_id: customer.external_id,
+  external_subscription_id: subscription.external_id,
   organization:,
   transaction_id: SecureRandom.uuid,
   timestamp: time - rand(0..12).seconds,
@@ -218,8 +218,8 @@ Event.create!(
 )
 
 Event.create!(
-  customer:,
-  subscription:,
+  external_customer_id: customer.external_id,
+  external_subscription_id: subscription.external_id,
   organization:,
   transaction_id: SecureRandom.uuid,
   timestamp: time - rand(0..12).seconds,

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -8,8 +8,6 @@ FactoryBot.define do
     end
 
     organization_id { create(:organization).id }
-    customer_id { customer.id }
-    subscription_id { subscription.id }
 
     transaction_id { SecureRandom.uuid }
     code { Faker::Name.name.underscore }

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,3 +1,135 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+
+RSpec.describe Event, type: :model do
+  describe '#customer' do
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, organization:, customer:) }
+    let(:external_customer_id) { customer.external_id }
+    let(:external_subscription_id) { subscription.external_id }
+
+    let(:timestamp) { Time.current - 1.second }
+
+    let(:event) do
+      create(
+        :event,
+        organization:,
+        external_customer_id:,
+        external_subscription_id:,
+        timestamp:,
+      )
+    end
+
+    it 'returns the customer' do
+      expect(event.customer).to eq(customer)
+    end
+
+    context 'when a customer with the same external id was deleted' do
+      let(:deleted_at) { timestamp - 2.days }
+      let(:deleted_customer) do
+        create(:customer, organization:, external_id: external_customer_id, deleted_at:)
+      end
+
+      before { deleted_customer }
+
+      it 'returns the customer' do
+        expect(event.customer).to eq(customer)
+      end
+
+      context 'when the timestamp is before the deleted date' do
+        let(:deleted_at) { timestamp + 2.days }
+
+        it 'returns the deleted customer' do
+          expect(event.customer).to eq(deleted_customer)
+        end
+      end
+    end
+  end
+
+  describe '#subscription' do
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+    let(:plan) { create(:plan, organization:) }
+    let(:subscription) { create(:subscription, organization:, customer:, plan:, started_at:) }
+
+    let(:started_at) { Time.current - 3.days }
+    let(:external_customer_id) { customer.external_id }
+    let(:external_subscription_id) { subscription.external_id }
+    let(:timestamp) { Time.current - 1.second }
+
+    let(:event) do
+      create(
+        :event,
+        organization:,
+        external_customer_id:,
+        external_subscription_id:,
+        timestamp:,
+      )
+    end
+
+    it 'returns the subscription' do
+      expect(event.subscription).to eq(subscription)
+    end
+
+    context 'without external_customer_id' do
+      let(:external_customer_id) { nil }
+
+      it 'returns the subscription' do
+        expect(event.subscription).to eq(subscription)
+      end
+    end
+
+    context 'when subscription is terminated' do
+      let(:subscription) { create(:subscription, :terminated, organization:, customer:, started_at:) }
+
+      it 'returns the subscription' do
+        expect(event.subscription).to eq(subscription)
+      end
+
+      context 'when a new active subscription exists' do
+        let(:started_at) { 1.month.ago }
+        let(:timestamp) { 1.week.ago }
+
+        let(:active_subscription) do
+          create(
+            :subscription,
+            customer:,
+            organization:,
+            started_at: 1.day.ago,
+            external_id: subscription.external_id,
+          )
+        end
+
+        before { active_subscription }
+
+        it 'returns the active subscription' do
+          expect(event.subscription).to eq(subscription)
+        end
+      end
+
+      context 'when subscription is an upgrade/downgrade' do
+        let(:started_at) { 1.week.ago }
+
+        let(:terminated_subscription) do
+          create(
+            :subscription,
+            :terminated,
+            organization:,
+            customer:,
+            external_id: external_subscription_id,
+            started_at: 1.month.ago,
+            terminated_at: timestamp - 1.day,
+          )
+        end
+
+        before { terminated_subscription }
+
+        it 'returns the subscription' do
+          expect(event.subscription).to eq(subscription)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/create_event_spec.rb
+++ b/spec/scenarios/create_event_spec.rb
@@ -94,9 +94,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
       event = organization.events.order(created_at: :asc).last
       expect(event).to have_attributes(
         code: billable_metric.code,
-        customer_id: subscription.customer.id,
         external_customer_id: 'unknown',
-        subscription_id: subscription.id,
         external_subscription_id: subscription.external_id,
       )
     end
@@ -116,9 +114,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
       event = organization.events.order(created_at: :asc).last
       expect(event).to have_attributes(
         code: billable_metric.code,
-        customer_id: nil,
         external_customer_id: 'unknown',
-        subscription_id: nil,
         external_subscription_id: 'unknown',
       )
     end
@@ -141,9 +137,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
       event = organization.events.order(created_at: :asc).last
       expect(event).to have_attributes(
         code: billable_metric.code,
-        customer_id: nil,
         external_customer_id: nil,
-        subscription_id: nil,
         external_subscription_id: subscription2.external_id,
       )
     end
@@ -160,9 +154,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
       event = organization.events.order(created_at: :asc).last
       expect(event).to have_attributes(
         code: billable_metric.code,
-        customer_id: subscription.customer_id,
         external_customer_id: subscription.customer.external_id,
-        subscription_id: subscription.id,
         external_subscription_id: subscription.external_id,
       )
     end
@@ -182,9 +174,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
       event = organization.events.order(created_at: :asc).last
       expect(event).to have_attributes(
         code: billable_metric.code,
-        customer_id: subscription.customer_id,
         external_customer_id: subscription.customer.external_id,
-        subscription_id: nil,
         external_subscription_id: subscription.external_id,
       )
     end
@@ -203,9 +193,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
       event = organization.events.order(created_at: :asc).last
       expect(event).to have_attributes(
         code: billable_metric.code,
-        customer_id: subscription.customer_id,
         external_customer_id: subscription.customer.external_id,
-        subscription_id: subscription.id,
         external_subscription_id: subscription.external_id,
       )
     end
@@ -225,9 +213,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
       event = organization.events.order(created_at: :asc).last
       expect(event).to have_attributes(
         code: billable_metric.code,
-        customer_id: subscription.customer_id,
         external_customer_id: subscription.customer.external_id,
-        subscription_id: nil,
         external_subscription_id: subscription.external_id,
       )
     end
@@ -246,9 +232,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
       event = organization.events.order(created_at: :asc).last
       expect(event).to have_attributes(
         code: billable_metric.code,
-        customer_id: subscription.customer_id,
         external_customer_id: subscription.customer.external_id,
-        subscription_id: nil,
         external_subscription_id: subscription.external_id,
       )
     end
@@ -272,9 +256,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
       event = organization.events.order(created_at: :asc).last
       expect(event).to have_attributes(
         code: billable_metric.code,
-        customer_id: subscription.customer_id,
         external_customer_id: subscription.customer.external_id,
-        subscription_id: subscription.id,
         external_subscription_id: subscription.external_id,
       )
     end
@@ -296,9 +278,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
       event = organization.events.order(created_at: :asc).last
       expect(event).to have_attributes(
         code: billable_metric.code,
-        customer_id: customer.id,
         external_customer_id: customer.external_id,
-        subscription_id: nil,
         external_subscription_id: nil,
       )
     end
@@ -317,9 +297,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
             external_subscription_id: subscription2.external_id,
           ),
         )
-      end.to change { Event.where(subscription_id: subscription2.id).count }
-
-      expect(Event.where(subscription_id: subscription.id).count).to eq(0)
+      end.to change { Event.where(external_subscription_id: subscription2.external_id).count }
     end
   end
 
@@ -334,12 +312,10 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
 
     before { subscription2 }
 
-    it 'creates the event on the active subscription' do
+    it 'creates the event' do
       expect do
         create_event(params.merge(external_subscription_id: subscription.external_id))
-      end.to change { Event.where(subscription_id: subscription.id).count }
-
-      expect(Event.where(subscription_id: subscription2.id).count).to eq(0)
+      end.to change { Event.where(external_subscription_id: subscription.external_id).count }
     end
   end
 end

--- a/spec/scenarios/customer_usage_spec.rb
+++ b/spec/scenarios/customer_usage_spec.rb
@@ -25,7 +25,7 @@ describe 'Customer usage Scenario', :scenarios, type: :request do
         subscription = customer.subscriptions.first
         fetch_current_usage(customer:, subscription:)
 
-        expect(json[:customer_usage][:from_datetime]).to eq('2023-01-01T00:00:00Z')
+        expect(json[:customer_usage][:from_datetime]).to eq('2023-01-01T09:30:00Z')
         expect(json[:customer_usage][:to_datetime]).to eq('2023-12-31T23:59:59Z')
       end
     end
@@ -47,7 +47,7 @@ describe 'Customer usage Scenario', :scenarios, type: :request do
           subscription = customer.subscriptions.first
           fetch_current_usage(customer:, subscription:)
 
-          expect(json[:customer_usage][:from_datetime]).to eq('2022-12-31T23:00:00Z')
+          expect(json[:customer_usage][:from_datetime]).to eq('2023-01-01T09:30:00Z')
           expect(json[:customer_usage][:to_datetime]).to eq('2023-12-31T22:59:59Z')
         end
       end
@@ -70,7 +70,7 @@ describe 'Customer usage Scenario', :scenarios, type: :request do
           subscription = customer.subscriptions.first
           fetch_current_usage(customer:, subscription:)
 
-          expect(json[:customer_usage][:from_datetime]).to eq('2023-01-01T08:00:00Z')
+          expect(json[:customer_usage][:from_datetime]).to eq('2023-01-01T09:30:00Z')
           expect(json[:customer_usage][:to_datetime]).to eq('2024-01-01T07:59:59Z')
         end
       end

--- a/spec/scenarios/invoices_spec.rb
+++ b/spec/scenarios/invoices_spec.rb
@@ -428,8 +428,8 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 17 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 17)) do
-        create(:event, subscription_id: subscription.id, code: metric.code)
-        create(:event, subscription_id: subscription.id, code: metric.code)
+        create(:event, external_subscription_id: subscription.external_id, code: metric.code)
+        create(:event, external_subscription_id: subscription.external_id, code: metric.code)
 
         expect {
           refresh_invoice(subscription_invoice)
@@ -512,7 +512,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 17 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 17)) do
-        create(:event, subscription_id: subscription.id, code: metric.code)
+        create(:event, external_subscription_id: subscription.external_id, code: metric.code)
 
         expect {
           refresh_invoice(subscription_invoice)
@@ -593,7 +593,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 16 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 16)) do
-        create(:event, subscription_id: subscription.id, code: metric.code)
+        create(:event, external_subscription_id: subscription.external_id, code: metric.code)
 
         # Paid in advance invoice amount does not change.
         expect {
@@ -603,7 +603,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 17 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 17)) do
-        create(:event, subscription_id: subscription.id, code: metric.code)
+        create(:event, external_subscription_id: subscription.external_id, code: metric.code)
 
         # Paid in advance invoice amount does not change.
         expect {
@@ -620,7 +620,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         expect(new_invoice.total_amount_cents).to eq(1440) # (1000 + 200) * 1.2
 
         # Create event for Dec 18.
-        create(:event, subscription_id: subscription.id, timestamp: DateTime.new(2022, 12, 18), code: metric.code)
+        create(
+          :event,
+          external_subscription_id: subscription.external_id,
+          timestamp: DateTime.new(2022, 12, 18),
+          code: metric.code,
+        )
 
         # Paid in advance invoice amount does not change.
         expect {

--- a/spec/scenarios/subscriptions/upgrade_spec.rb
+++ b/spec/scenarios/subscriptions/upgrade_spec.rb
@@ -65,7 +65,7 @@ describe 'Subscription Upgrade Scenario', :scenarios, type: :request, transactio
       expect(invoice.fees_amount_cents).to eq(monthly_plan.amount_cents)
       expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq('2023-07-29T00:00:00Z')
       expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq('2023-08-28T23:59:59Z')
-      expect(invoice.invoice_subscriptions.first.charges_from_datetime.iso8601).to eq('2023-06-29T00:00:00Z')
+      expect(invoice.invoice_subscriptions.first.charges_from_datetime.iso8601).to eq('2023-06-29T12:12:00Z')
       expect(invoice.invoice_subscriptions.first.charges_to_datetime.iso8601).to eq('2023-07-28T23:59:59Z')
     end
 

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
     create(
       :event,
       code: billable_metric.code,
-      customer:,
-      subscription:,
+      external_customer_id: customer.external_id,
+      external_subscription_id: subscription.external_id,
       timestamp: added_at,
       quantified_event:,
     )
@@ -96,8 +96,8 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         create(
           :event,
           code: billable_metric.code,
-          customer:,
-          subscription:,
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
           timestamp: from_datetime + 10.days,
           quantified_event: new_quantified_event,
         )
@@ -124,8 +124,8 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         create(
           :event,
           code: billable_metric.code,
-          customer:,
-          subscription:,
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
           timestamp: from_datetime + 10.days,
           quantified_event: new_quantified_event,
         )
@@ -276,8 +276,8 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         create(
           :event,
           code: billable_metric.code,
-          customer:,
-          subscription:,
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
           timestamp: from_datetime + 5.days,
           quantified_event: previous_quantified_event,
           properties: {
@@ -327,8 +327,8 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         create(
           :event,
           code: billable_metric.code,
-          customer:,
-          subscription:,
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
           timestamp: from_datetime + 10.days,
           properties:,
           quantified_event: new_quantified_event,
@@ -381,8 +381,8 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
           create(
             :event,
             code: billable_metric.code,
-            customer:,
-            subscription:,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
             timestamp: from_datetime + 5.days,
             quantified_event: previous_quantified_event,
             properties: {
@@ -419,8 +419,8 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
           create(
             :event,
             code: billable_metric.code,
-            customer:,
-            subscription:,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
             timestamp: from_datetime + 5.days,
             quantified_event: previous_quantified_event,
             properties: {

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -7,15 +7,18 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
     described_class.new(charge:, boundaries:, group:, properties:, event:)
   end
 
-  let(:billable_metric) { create(:billable_metric, aggregation_type:, field_name: 'item_id') }
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:, aggregation_type:, field_name: 'item_id') }
   let(:charge) { create(:standard_charge, billable_metric:, pay_in_advance: true) }
   let(:group) { create(:group) }
   let(:aggregation_type) { 'count_agg' }
-  let(:event) { create(:event, subscription_id: subscription.id) }
+  let(:event) { create(:event, organization:, external_subscription_id: subscription.external_id) }
   let(:properties) { {} }
 
+  let(:customer) { create(:customer, organization:) }
+
   let(:subscription) do
-    create(:subscription, started_at: DateTime.parse('2023-03-15'))
+    create(:subscription, customer:, started_at: DateTime.parse('2023-03-15'))
   end
 
   let(:boundaries) do

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:active_subscription, organization:, customer:, plan:) }
+  let(:subscription) { create(:active_subscription, customer:, plan:) }
   let(:tax) { create(:tax, organization:, rate: 20) }
 
   let(:group) { nil }
@@ -20,8 +20,8 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
   let(:event) do
     create(
       :event,
-      subscription_id: subscription.id,
-      customer_id: customer.id,
+      external_subscription_id: subscription.external_id,
+      external_customer_id: customer.external_id,
       organization_id: organization.id,
     )
   end
@@ -153,8 +153,9 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
       let(:event) do
         create(
           :event,
-          subscription:,
-          customer:,
+          organization:,
+          external_subscription_id: subscription.external_id,
+          external_customer_id: customer.external_id,
           properties: {
             region: 'europe',
           },
@@ -197,8 +198,9 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
         let(:event) do
           create(
             :event,
-            subscription:,
-            customer:,
+            organization:,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
             properties: {
               cloud: 'AWS',
               region: 'europe',
@@ -239,8 +241,9 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
         let(:event) do
           create(
             :event,
-            subscription:,
-            customer:,
+            organization:,
+            external_subscription_id: subscription.external_id,
+            external_customer_id: customer.external_id,
             properties: {
               region: 'usa',
             },

--- a/spec/services/quantified_events/create_or_update_service_spec.rb
+++ b/spec/services/quantified_events/create_or_update_service_spec.rb
@@ -7,9 +7,14 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
     described_class.new(event)
   end
 
+  let(:customer) { create(:customer) }
+  let(:subscription) { create(:active_subscription, started_at: event_timestamp - 3.days, customer:) }
+  let(:organization) { customer.organization }
+
   let(:billable_metric) do
     create(
       :billable_metric,
+      organization:,
       aggregation_type: 'unique_count_agg',
       field_name: 'item_id',
     )
@@ -19,9 +24,11 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
     create(
       :event,
       properties:,
-      organization: billable_metric.organization,
+      organization:,
       code: billable_metric.code,
       timestamp: event_timestamp,
+      external_customer_id: customer.external_id,
+      external_subscription_id: subscription.external_id,
     )
   end
 
@@ -48,7 +55,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
 
           quantified_event = service_result.quantified_event
           expect(quantified_event.organization).to eq(event.organization)
-          expect(quantified_event.external_subscription_id).to eq(event.subscription.external_id)
+          expect(quantified_event.external_subscription_id).to eq(subscription.external_id)
           expect(quantified_event.external_id).to eq('ext_12345')
           expect(quantified_event.properties).to eq(event.properties)
           expect(quantified_event.added_at.to_s).to eq(event.timestamp.to_s)
@@ -60,7 +67,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
           create(
             :quantified_event,
             billable_metric:,
-            external_subscription_id: event.subscription.external_id,
+            external_subscription_id: subscription.external_id,
             external_id: 'ext_12345',
             removed_at: Time.zone.parse('31 Oct 2022 09:25:00'),
           )
@@ -84,6 +91,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
       let(:billable_metric) do
         create(
           :billable_metric,
+          organization:,
           aggregation_type: 'unique_count_agg',
           field_name: 'item_id',
         )
@@ -97,7 +105,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
 
           quantified_event = service_result.quantified_event
           expect(quantified_event.organization).to eq(event.organization)
-          expect(quantified_event.external_subscription_id).to eq(event.subscription.external_id)
+          expect(quantified_event.external_subscription_id).to eq(subscription.external_id)
           expect(quantified_event.external_id).to eq('ext_12345')
           expect(quantified_event.properties).to eq(event.properties)
           expect(quantified_event.added_at.to_s).to eq(event.timestamp.to_s)
@@ -110,7 +118,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
         create(
           :quantified_event,
           billable_metric:,
-          external_subscription_id: event.subscription.external_id,
+          external_subscription_id: subscription.external_id,
           external_id: 'ext_12345',
         )
       end
@@ -135,7 +143,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
           create(
             :quantified_event,
             billable_metric:,
-            external_subscription_id: event.subscription.external_id,
+            external_subscription_id: subscription.external_id,
             external_id: 'ext_12345',
             removed_at: (Time.current - 1.hour).to_i,
           )
@@ -181,7 +189,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
         create(
           :quantified_event,
           billable_metric:,
-          external_subscription_id: event.subscription.external_id,
+          external_subscription_id: subscription.external_id,
           external_id: 'ext_12345',
         )
       end

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -246,7 +246,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
     context 'when billing_time is calendar' do
       let(:billing_time) { :calendar }
-      let(:billing_at) { DateTime.parse('01 Jan 2022') }
+      let(:billing_at) { DateTime.parse('01 Jan 2023') }
       let(:subscription_at) { DateTime.parse('02 Feb 2020') }
 
       it 'returns from_date' do
@@ -295,7 +295,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         let(:subscription_at) { DateTime.parse('02 Feb 2020') }
 
         it 'returns the start of the previous period' do
-          expect(result).to eq('2021-01-01 00:00:00 UTC')
+          expect(result).to eq('2022-01-01 00:00:00 UTC')
         end
       end
 
@@ -303,10 +303,11 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         before { plan.update!(bill_charges_monthly: true) }
 
         it 'returns the begining of the previous month' do
-          expect(result).to eq('2021-12-01 00:00:00 UTC')
+          expect(result).to eq('2022-12-01 00:00:00 UTC')
         end
 
         context 'when subscription started in the middle of a period' do
+          let(:billing_at) { DateTime.parse('01 Jan 2022') }
           let(:started_at) { DateTime.parse('03 Mar 2022') }
 
           it 'returns the start date' do


### PR DESCRIPTION
## Context

On the path for high volume improvements, we need to remove the need for event post-processing and align aggregation logic between Clickhouse and Postgres event stores.

## Description

Clickhouse aggregation is (will be) built around on `events#external_subscription_id`, this PRs ensures that all events related logic does not use `events#customer_id` and `events#subscription_id` anymore
