### PR TITLE
feat (recurring-wallet-transactions): add db changes for recurring wallet transactions

### DIFF
--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class RecurringTransactionRule < ApplicationRecord
+  include PaperTrailTraceable
+
+  belongs_to :wallet
+
+  RULE_TYPES = [
+    :interval,
+    :threshold,
+  ].freeze
+
+  INTERVALS = [
+    :weekly,
+    :monthly,
+    :quarterly,
+    :yearly,
+  ].freeze
+
+  enum rule_type: RULE_TYPES
+  enum interval: INTERVALS
+end

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -8,6 +8,7 @@ class Wallet < ApplicationRecord
   has_one :organization, through: :customer
 
   has_many :wallet_transactions
+  has_many :recurring_transaction_rules
 
   monetize :balance_cents
   monetize :consumed_amount_cents

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -16,6 +16,13 @@ class WalletTransaction < ApplicationRecord
     :outbound,
   ].freeze
 
+  SOURCES = [
+    :manual,
+    :interval,
+    :threshold,
+  ].freeze
+
   enum status: STATUSES
   enum transaction_type: TRANSACTION_TYPES
+  enum source: SOURCES
 end

--- a/db/migrate/20231103144201_create_recurring_transaction_rules.rb
+++ b/db/migrate/20231103144201_create_recurring_transaction_rules.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateRecurringTransactionRules < ActiveRecord::Migration[7.0]
+  def change
+    create_table :recurring_transaction_rules, id: :uuid do |t|
+      t.references :wallet, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.integer :rule_type, default: 0, null: false
+      t.decimal :paid_credits, null: false, default: 0, precision: 30, scale: 5
+      t.decimal :granted_credits, null: false, default: 0, precision: 30, scale: 5
+      t.decimal :threshold_credits, null: true, default: 0, precision: 30, scale: 5
+      t.integer :interval, default: 0, null: true
+
+      t.timestamps
+    end
+
+    add_column :wallet_transactions, :source, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -690,6 +690,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_06_145424) do
     t.index ["group_id"], name: "index_quantified_events_on_group_id"
   end
 
+  create_table "recurring_transaction_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "wallet_id", null: false
+    t.integer "rule_type", default: 0, null: false
+    t.decimal "paid_credits", precision: 30, scale: 5, default: "0.0", null: false
+    t.decimal "granted_credits", precision: 30, scale: 5, default: "0.0", null: false
+    t.decimal "threshold_credits", precision: 30, scale: 5, default: "0.0"
+    t.integer "interval", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
+  end
+
   create_table "refunds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "payment_id", null: false
     t.uuid "credit_note_id", null: false
@@ -770,6 +782,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_06_145424) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "invoice_id"
+    t.integer "source", default: 0, null: false
     t.index ["invoice_id"], name: "index_wallet_transactions_on_invoice_id"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
   end
@@ -886,6 +899,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_06_145424) do
   add_foreign_key "plans_taxes", "taxes"
   add_foreign_key "quantified_events", "customers"
   add_foreign_key "quantified_events", "groups"
+  add_foreign_key "recurring_transaction_rules", "wallets"
   add_foreign_key "refunds", "credit_notes"
   add_foreign_key "refunds", "payment_provider_customers"
   add_foreign_key "refunds", "payment_providers"

--- a/spec/factories/recurring_transaction_rules.rb
+++ b/spec/factories/recurring_transaction_rules.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :recurring_transaction_rule do
+    wallet
+    rule_type { 'interval' }
+    paid_credits { '10.00' }
+    granted_credits { '10.00' }
+    interval { 'monthly' }
+  end
+end


### PR DESCRIPTION
## Context

Currently Lago supports only manual wallet transactions. With Recurring transactions feature it will be possible to top-up wallet automatically with threshold or intervals rules.

## Description

This PR adds needed DB changes
