### PR TITLE
fix(plan-override): render forbidden error for plan override without premium license

### DIFF
--- a/app/services/plans/override_service.rb
+++ b/app/services/plans/override_service.rb
@@ -10,7 +10,7 @@ module Plans
     end
 
     def call
-      return result unless License.premium?
+      return result.forbidden_failure! unless License.premium?
 
       ActiveRecord::Base.transaction do
         new_plan = plan.dup.tap do |p|

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -26,6 +26,7 @@ module Subscriptions
 
     def call
       return result unless valid?(customer:, plan:, subscription_at:, ending_at: params[:ending_at])
+      return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides)
 
       plan.amount_currency = plan_overrides[:amount_currency] if plan_overrides[:amount_currency]
       plan.amount_cents = plan_overrides[:amount_cents] if plan_overrides[:amount_cents]

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -18,6 +18,7 @@ module Subscriptions
       )
         return result
       end
+      return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides)
 
       subscription.name = params[:name] if params.key?(:name)
       subscription.ending_at = params[:ending_at] if params.key?(:ending_at)

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -125,6 +125,30 @@ RSpec.describe Subscriptions::CreateService, type: :service do
       end
     end
 
+    context 'when License is free and plan_overrides is passed' do
+      let(:params) do
+        {
+          external_customer_id:,
+          plan_code:,
+          name:,
+          external_id:,
+          billing_time:,
+          subscription_at:,
+          subscription_id:,
+          plan_overrides: {
+            amount_cents: 0,
+          },
+        }
+      end
+
+      it 'returns an error' do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(result.error.code).to eq('feature_unavailable')
+      end
+    end
+
     context 'when customer does not exists in API context' do
       let(:customer) { Customer.new(organization:, external_id: SecureRandom.uuid) }
 

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -107,5 +107,23 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
         expect(result.error.error_code).to eq('subscription_not_found')
       end
     end
+
+    context 'when License is free and plan_overrides is passed' do
+      let(:params) do
+        {
+          name: 'new name',
+          plan_overrides: {
+            amount_cents: 0,
+          },
+        }
+      end
+
+      it 'returns an error' do
+        result = update_service.call
+
+        expect(result).not_to be_success
+        expect(result.error.code).to eq('feature_unavailable')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

When license is not valid and user wants to perform plan override, we should render forbidden error and not unprocessable entity error (validation failure)