### PR TITLE
fix: API Invoice payment retry when not found

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -126,7 +126,7 @@ module Api
 
       def retry_payment
         invoice = current_organization.invoices.find_by(id: params[:id])
-        return not_found_error(resource:) unless invoice
+        return not_found_error(resource: 'invoice') unless invoice
 
         result = Invoices::Payments::RetryService.new(invoice:).call
         return render_error_response(result) unless result.success?


### PR DESCRIPTION
## Context

This PR fixes `undefined local variable or method `resource' for #<Api::V1::InvoicesController` when trying to retry a payment for an invoice, when the invoice is not found.

