### PR TITLE
fix(adyen-no-payment-methods): Fix adyen invoices payments create ser…

### DIFF
--- a/app/services/payment_provider_customers/adyen_service.rb
+++ b/app/services/payment_provider_customers/adyen_service.rb
@@ -2,6 +2,8 @@
 
 module PaymentProviderCustomers
   class AdyenService < BaseService
+    include Lago::Adyen::ErrorHandlable
+
     def initialize(adyen_customer = nil)
       @adyen_customer = adyen_customer
 
@@ -127,16 +129,6 @@ module PaymentProviderCustomers
           error_code: adyen_error.request&.dig('code') || adyen_error.code,
         },
       )
-    end
-
-    def handle_adyen_response(res)
-      return if res.status < 400
-
-      code = res.response['errorType']
-      message = res.response['message']
-
-      deliver_error_webhook(Adyen::AdyenError.new(nil, nil, message, code))
-      result.service_failure!(code:, message:)
     end
 
     def handle_missing_customer(shopper_reference)

--- a/lib/lago/adyen/error_handlable.rb
+++ b/lib/lago/adyen/error_handlable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Lago
+  module Adyen
+    module ErrorHandlable
+      def handle_adyen_response(res)
+        return if res.status < 400
+
+        code = res.response['errorType']
+        message = res.response['message']
+
+        deliver_error_webhook(::Adyen::AdyenError.new(nil, nil, message, code))
+        result.service_failure!(code:, message:)
+      end
+    end
+  end
+end

--- a/spec/factories/payment_responses.rb
+++ b/spec/factories/payment_responses.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   sequence :adyen_payments_response do
     OpenStruct.new(
+      status: 200,
       response: {
         'additionalData' => {
           'recurringProcessingModel' => 'UnscheduledCardOnFile',
@@ -10,6 +11,16 @@ FactoryBot.define do
         'pspReference' => SecureRandom.uuid,
         'resultCode' => 'Authorised',
         'merchantReference' => SecureRandom.uuid,
+      },
+    )
+  end
+
+  sequence :adyen_payments_error_response do
+    OpenStruct.new(
+      status: 422,
+      response: {
+        'errorType' => 'validation',
+        'message' => 'There are no payment methods available for the given parameters.',
       },
     )
   end
@@ -48,6 +59,7 @@ FactoryBot.define do
 
   sequence :adyen_payment_methods_response do
     OpenStruct.new(
+      status: 200,
       response: {
         'paymentMethods' => [
           {


### PR DESCRIPTION
## Context

When receiving an error from Adyen (422 Error), we do not log it and we do not return a webhook with the error. We should send a webhook with the error, so the user know about it.

## Description

This PR fixes Invoices::Payments::AdyenService#create method 