### PR TITLE
fix(credit-note): Fix credit note estimate taxe rate

### DIFF
--- a/app/graphql/types/credit_notes/estimate.rb
+++ b/app/graphql/types/credit_notes/estimate.rb
@@ -11,10 +11,12 @@ module Types
       field :coupons_adjustment_amount_cents, GraphQL::Types::BigInt, null: false
       field :max_creditable_amount_cents, GraphQL::Types::BigInt, method: :credit_amount_cents, null: false
       field :max_refundable_amount_cents, GraphQL::Types::BigInt, method: :refund_amount_cents, null: false
+      field :precise_coupons_adjustment_amount_cents, GraphQL::Types::Float, null: false
       field :sub_total_excluding_taxes_amount_cents, GraphQL::Types::BigInt, null: false
-      field :taxes_amount_cents, GraphQL::Types::BigInt, null: false
 
-      field :taxes_rate, Float, null: false
+      field :precise_taxes_amount_cents, GraphQL::Types::Float, null: false
+      field :taxes_amount_cents, GraphQL::Types::BigInt, null: false
+      field :taxes_rate, GraphQL::Types::Float, null: false
 
       field :items, [Types::CreditNoteItems::Estimate], null: false
 

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -118,7 +118,7 @@ class CreditNote < ApplicationRecord
   end
 
   def sub_total_excluding_taxes_amount_cents
-    total_amount_cents - taxes_amount_cents
+    (items.sum(&:precise_amount_cents) - precise_coupons_adjustment_amount_cents).round
   end
   alias sub_total_excluding_taxes_amount_currency currency
 

--- a/app/serializers/v1/credit_notes/estimate_serializer.rb
+++ b/app/serializers/v1/credit_notes/estimate_serializer.rb
@@ -9,10 +9,12 @@ module V1
           invoice_number: model.invoice.number,
           currency: model.currency,
           taxes_amount_cents: model.taxes_amount_cents,
+          precise_taxes_amount_cents: model.precise_taxes_amount_cents,
           sub_total_excluding_taxes_amount_cents: model.sub_total_excluding_taxes_amount_cents,
           max_creditable_amount_cents: model.credit_amount_cents,
           max_refundable_amount_cents: model.refund_amount_cents,
           coupons_adjustment_amount_cents: model.coupons_adjustment_amount_cents,
+          precise_coupons_adjustment_amount_cents: model.precise_coupons_adjustment_amount_cents,
           taxes_rate: model.taxes_rate,
         }
 

--- a/app/services/credit_notes/apply_taxes_service.rb
+++ b/app/services/credit_notes/apply_taxes_service.rb
@@ -95,9 +95,10 @@ module CreditNotes
     #       In order to compute the credit_note#taxes_rate, we have to apply
     #       a pro-rata of the items attached to the tax on the total items amount
     def pro_rated_taxes_rate(tax)
-      tax_items_amount_cents = indexed_items[tax.id].sum(&:precise_amount_cents)
+      tax_items_amount_cents = compute_base_amount_cents(tax)
+      total_items_amount_cents = items_amount_cents - result.coupons_adjustment_amount_cents
 
-      items_rate = tax_items_amount_cents.fdiv(items_amount_cents)
+      items_rate = tax_items_amount_cents.fdiv(total_items_amount_cents)
 
       items_rate * tax.rate
     end

--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -25,7 +25,10 @@ module Credits
       )
 
       fees.reload.each do |fee|
-        fee.precise_coupons_amount_cents += (credit_amount * fee.amount_cents).fdiv(base_amount_cents)
+        fee.precise_coupons_amount_cents += (
+          credit_amount * (fee.amount_cents - fee.precise_coupons_amount_cents)
+        ).fdiv(base_amount_cents)
+
         fee.precise_coupons_amount_cents = fee.amount_cents if fee.amount_cents < fee.precise_coupons_amount_cents
         fee.save!
       end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -120,26 +120,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_07_110809) do
     t.index ["organization_id"], name: "index_billable_metrics_on_organization_id"
   end
 
-  create_table "cached_aggregations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "organization_id", null: false
-    t.uuid "event_id", null: false
-    t.datetime "timestamp", null: false
-    t.string "external_subscription_id", null: false
-    t.uuid "billable_metric_id", null: false
-    t.uuid "group_id"
-    t.decimal "current_aggregation"
-    t.decimal "max_aggregation"
-    t.decimal "max_aggregation_with_proration"
-    t.datetime "created_at", null: false
-    t.index ["billable_metric_id"], name: "index_cached_aggregations_on_billable_metric_id"
-    t.index ["event_id"], name: "index_cached_aggregations_on_event_id"
-    t.index ["external_subscription_id"], name: "index_cached_aggregations_on_external_subscription_id"
-    t.index ["group_id"], name: "index_cached_aggregations_on_group_id"
-    t.index ["organization_id", "timestamp", "billable_metric_id", "group_id"], name: "index_timestamp_group_lookup"
-    t.index ["organization_id", "timestamp", "billable_metric_id"], name: "index_timestamp_lookup"
-    t.index ["organization_id"], name: "index_cached_aggregations_on_organization_id"
-  end
-
   create_table "charges", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "billable_metric_id"
     t.datetime "created_at", null: false
@@ -842,7 +822,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_07_110809) do
   add_foreign_key "applied_add_ons", "add_ons"
   add_foreign_key "applied_add_ons", "customers"
   add_foreign_key "billable_metrics", "organizations"
-  add_foreign_key "cached_aggregations", "groups"
   add_foreign_key "charges", "billable_metrics"
   add_foreign_key "charges", "plans"
   add_foreign_key "charges_taxes", "charges"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1869,6 +1869,8 @@ type CreditNoteEstimate {
   items: [CreditNoteItemEstimate!]!
   maxCreditableAmountCents: BigInt!
   maxRefundableAmountCents: BigInt!
+  preciseCouponsAdjustmentAmountCents: Float!
+  preciseTaxesAmountCents: Float!
   subTotalExcludingTaxesAmountCents: BigInt!
   taxesAmountCents: BigInt!
   taxesRate: Float!

--- a/schema.json
+++ b/schema.json
@@ -7246,6 +7246,42 @@
               ]
             },
             {
+              "name": "preciseCouponsAdjustmentAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "preciseTaxesAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "subTotalExcludingTaxesAmountCents",
               "description": null,
               "type": {

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe CreditNote, type: :model do
   describe ' #sub_total_excluding_taxes_amount_cents' do
     it 'returs the total amount without the taxes' do
       expect(credit_note.sub_total_excluding_taxes_amount_cents)
-        .to eq(credit_note.total_amount_cents - credit_note.taxes_amount_cents)
+        .to eq(credit_note.items.sum(&:precise_amount_cents) - credit_note.precise_coupons_adjustment_amount_cents)
     end
   end
 end

--- a/spec/scenarios/credit_note_spec.rb
+++ b/spec/scenarios/credit_note_spec.rb
@@ -6,6 +6,8 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
   let(:customer) { create(:customer, organization:) }
 
+  let(:tax) { create(:tax, organization:, rate: 10) }
+
   let(:plan1) do
     create(
       :plan,
@@ -42,7 +44,17 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
     create(:coupon_plan, coupon:, plan: plan2)
   end
 
+  let(:plan_tax) { create(:tax, organization:, name: 'Plan Tax', rate: 10, applied_to_organization: false) }
+  let(:plan_applied_tax) { create(:plan_applied_tax, plan: plan2, tax: plan_tax) }
+  let(:plan_applied_tax2) { create(:plan_applied_tax, plan: plan2, tax:) }
+
   around { |test| lago_premium!(&test) }
+
+  before do
+    tax
+    plan_applied_tax
+    plan_applied_tax2
+  end
 
   it 'Allows creation of partial credit note' do
     # Creates two subscriptions
@@ -80,7 +92,9 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
     invoice = customer.invoices.order(created_at: :desc).first
     expect(invoice.fees_amount_cents).to eq(57_800)
     expect(invoice.coupons_amount_cents).to eq(25_000)
-    expect(invoice.total_amount_cents).to eq(32_800)
+    expect(invoice.taxes_rate).to eq(14.54268)
+    expect(invoice.taxes_amount_cents).to eq(4_770)
+    expect(invoice.total_amount_cents).to eq(37_570)
 
     fee1 = invoice.fees.find_by(amount_cents: 17_900)
     expect(fee1.precise_coupons_amount_cents).to eq(0)
@@ -107,12 +121,12 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
       )
 
       estimate = json[:estimated_credit_note]
-      expect(estimate[:taxes_amount_cents]).to eq(0)
+      expect(estimate[:taxes_amount_cents]).to eq(4_770)
       expect(estimate[:sub_total_excluding_taxes_amount_cents]).to eq(32_800)
-      expect(estimate[:max_creditable_amount_cents]).to eq(32_800)
-      expect(estimate[:max_refundable_amount_cents]).to eq(32_800)
+      expect(estimate[:max_creditable_amount_cents]).to eq(37_570)
+      expect(estimate[:max_refundable_amount_cents]).to eq(37_570)
       expect(estimate[:coupons_adjustment_amount_cents]).to eq(250_00)
-      expect(estimate[:taxes_rate]).to eq(0)
+      expect(estimate[:taxes_rate]).to eq(14.54268)
 
       estimate_credit_note(
         invoice_id: invoice.id,
@@ -126,19 +140,19 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
 
       # Estimate the credit notes amount on one partial fee
       estimate = json[:estimated_credit_note]
-      expect(estimate[:taxes_amount_cents]).to eq(0)
+      expect(estimate[:taxes_amount_cents]).to eq(1961)
       expect(estimate[:sub_total_excluding_taxes_amount_cents]).to eq(9_806)
-      expect(estimate[:max_creditable_amount_cents]).to eq(9_806)
-      expect(estimate[:max_refundable_amount_cents]).to eq(9_806)
+      expect(estimate[:max_creditable_amount_cents]).to eq(11_768)
+      expect(estimate[:max_refundable_amount_cents]).to eq(11_768)
       expect(estimate[:coupons_adjustment_amount_cents]).to eq(16_454)
-      expect(estimate[:taxes_rate]).to eq(0)
+      expect(estimate[:taxes_rate]).to eq(20)
 
       # Emit a credit note on only one fee
       create_credit_note(
         invoice_id: invoice.id,
         reason: :other,
         credit_amount_cents: 0,
-        refund_amount_cents: 9_806,
+        refund_amount_cents: 11_768,
         items: [
           {
             fee_id: fee2.id,
@@ -149,8 +163,177 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
     end
 
     credit_note = invoice.credit_notes.first
-    expect(credit_note.refund_amount_cents).to eq(9_806)
-    expect(credit_note.total_amount_cents).to eq(9_806)
+    expect(credit_note.refund_amount_cents).to eq(11_768)
+    expect(credit_note.total_amount_cents).to eq(11_768)
     expect(credit_note.coupons_adjustment_amount_cents).to eq(16_454)
+  end
+
+  context 'when applying multiple time the same coupon' do
+    let(:plan) do
+      create(
+        :plan,
+        organization:,
+        interval: :monthly,
+        amount_cents: 1_999,
+        pay_in_advance: false,
+      )
+    end
+
+    let(:charge1) do
+      create(
+        :standard_charge,
+        plan:,
+        min_amount_cents: 99_290,
+      )
+    end
+
+    let(:charge2) do
+      create(
+        :standard_charge,
+        plan:,
+        min_amount_cents: 299_770,
+      )
+    end
+
+    let(:charge3) do
+      create(
+        :standard_charge,
+        plan:,
+        min_amount_cents: 3_130,
+      )
+    end
+
+    let(:charge4) do
+      create(
+        :standard_charge,
+        plan:,
+        min_amount_cents: 6_460,
+      )
+    end
+
+    let(:charge5) do
+      create(
+        :standard_charge,
+        plan:,
+        min_amount_cents: 3_130,
+      )
+    end
+
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 10_00,
+        expiration: :no_expiration,
+        coupon_type: :fixed_amount,
+        frequency: :forever,
+        limited_plans: false,
+        reusable: true,
+      )
+    end
+
+    before do
+      charge1
+      charge2
+      charge3
+      charge4
+      charge5
+    end
+
+    it 'Allows creation of partial credit note' do
+      # Creates two subscriptions
+      travel_to(DateTime.new(2022, 12, 19, 12)) do
+        create_subscription(
+          external_customer_id: customer.external_id,
+          external_id: "#{customer.external_id}_1",
+          plan_code: plan.code,
+          billing_time: :anniversary,
+        )
+      end
+
+      # Apply a coupon twice to the customer
+      travel_to(DateTime.new(2023, 8, 29)) do
+        apply_coupon(
+          external_customer_id: customer.external_id,
+          coupon_code: coupon.code,
+          amount_cents: 1_000,
+        )
+
+        apply_coupon(
+          external_customer_id: customer.external_id,
+          coupon_code: coupon.code,
+          amount_cents: 1_000,
+        )
+      end
+
+      # Bill subscription on an anniversary date
+      travel_to(DateTime.new(2023, 10, 19)) do
+        Subscriptions::BillingService.call
+        perform_all_enqueued_jobs
+      end
+
+      invoice = customer.invoices.order(created_at: :desc).first
+      expect(invoice.fees_amount_cents).to eq(413_779)
+      expect(invoice.coupons_amount_cents).to eq(2_000)
+      expect(invoice.taxes_rate).to eq(10)
+      expect(invoice.taxes_amount_cents).to eq(41_178)
+      expect(invoice.total_amount_cents).to eq(452_957)
+
+      fee1 = invoice.fees.find_by(amount_cents: charge1.min_amount_cents)
+      expect(fee1.precise_coupons_amount_cents).to eq(479.91802)
+
+      fee2 = invoice.fees.find_by(amount_cents: charge2.min_amount_cents)
+      expect(fee2.precise_coupons_amount_cents).to eq(1_448.93772)
+
+      fee3 = invoice.fees.find_by(amount_cents: charge3.min_amount_cents)
+      expect(fee3.precise_coupons_amount_cents).to eq(15.12884)
+
+      fee4 = invoice.fees.find_by(amount_cents: charge4.min_amount_cents)
+      expect(fee4.precise_coupons_amount_cents).to eq(31.2244)
+
+      fee5 = invoice.fees.find_by(amount_cents: charge5.min_amount_cents)
+      expect(fee5.precise_coupons_amount_cents).to eq(15.12884)
+
+      fee6 = invoice.fees.find_by(amount_cents: plan.amount_cents)
+      expect(fee6.precise_coupons_amount_cents).to eq(9.66216)
+
+      travel_to(DateTime.new(2023, 10, 23)) do
+        update_invoice(invoice, payment_status: :succeeded)
+
+        estimate_credit_note(
+          invoice_id: invoice.id,
+          items: [
+            {
+              fee_id: fee6.id,
+              amount_cents: 100,
+            },
+            {
+              fee_id: fee2.id,
+              amount_cents: 100,
+            },
+            {
+              fee_id: fee3.id,
+              amount_cents: 100,
+            },
+            {
+              fee_id: fee4.id,
+              amount_cents: 100,
+            },
+            {
+              fee_id: fee5.id,
+              amount_cents: 100,
+            },
+          ],
+        )
+
+        estimate = json[:estimated_credit_note]
+        expect(estimate[:coupons_adjustment_amount_cents]).to eq(2)
+        expect(estimate[:sub_total_excluding_taxes_amount_cents]).to eq(498)
+        expect(estimate[:taxes_amount_cents]).to eq(50)
+        expect(estimate[:max_creditable_amount_cents]).to eq(547)
+        expect(estimate[:max_refundable_amount_cents]).to eq(547)
+        expect(estimate[:taxes_rate]).to eq(10)
+      end
+    end
   end
 end

--- a/spec/services/credit_notes/validate_service_spec.rb
+++ b/spec/services/credit_notes/validate_service_spec.rb
@@ -42,7 +42,10 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
     )
   end
 
-  before { item }
+  before do
+    item
+    credit_note.reload
+  end
 
   describe '.call' do
     it 'validates the credit_note' do


### PR DESCRIPTION
## Context

Since it's a complicated task to create a credit note with coupons, multiple tax rates and other complex computation, we recently introduce a `CreditNotes::EstimateService` and the corresponding API/GraphQL endpoint to interact with it.

However, it appears that the computation is not always correct when different taxes are applied to an invoice.

## Description

This PR tries the fix this situation by fixing the computed tax rate on the credit note and by exposing the `precise_taxes_amount_cents` into the GraphQL query.