### PR TITLE
fix(plan-override): Ensure to override parent plans

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -137,6 +137,7 @@ module Api
           {
             charges: [
               :id,
+              :billable_metric_id,
               :min_amount_cents,
               :invoice_display_name,
               { properties: {} },

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -9,7 +9,7 @@ module Api
           organization_id: current_organization.id,
         )
 
-        plan = Plan.find_by(
+        plan = Plan.parents.find_by(
           code: create_params[:plan_code],
           organization_id: current_organization.id,
         )

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -23,7 +23,13 @@ module Subscriptions
       subscription.name = params[:name] if params.key?(:name)
       subscription.ending_at = params[:ending_at] if params.key?(:ending_at)
 
-      subscription.plan = override_plan(subscription.plan) if params.key?(:plan_overrides)
+      if params.key?(:plan_overrides)
+        plan_result = Plans::UpdateService.call(
+          plan: subscription.plan,
+          params: params[:plan_overrides].to_h.with_indifferent_access,
+        )
+        return plan_result unless plan_result.success?
+      end
 
       if subscription.starting_in_the_future? && params.key?(:subscription_at)
         subscription.subscription_at = params[:subscription_at]

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Api::V1::SubscriptionsController, type: :request do
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
-  let(:plan) { create(:plan, organization:, amount_cents: 500) }
+  let(:plan) { create(:plan, organization:, amount_cents: 500, description: 'desc') }
 
   around { |test| lago_premium!(&test) }
 
@@ -31,6 +31,8 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
     end
 
     it 'returns a success', :aggregate_failures do
+      create(:plan, code: plan.code, parent_id: plan.id, organization:, description: 'foo')
+
       post_with_token(organization, '/api/v1/subscriptions', { subscription: params })
 
       expect(response).to have_http_status(:ok)
@@ -54,6 +56,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       expect(json[:subscription][:plan]).to include(
         amount_cents: 100,
         name: 'overridden name',
+        description: 'desc',
       )
     end
 

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -33,31 +33,31 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
     it 'returns a success', :aggregate_failures do
       create(:plan, code: plan.code, parent_id: plan.id, organization:, description: 'foo')
 
-      post_with_token(organization, '/api/v1/subscriptions', { subscription: params })
-
-      expect(response).to have_http_status(:ok)
-
-      expect(json[:subscription]).to include(
-        lago_id: String,
-        external_id: String,
-        external_customer_id: customer.external_id,
-        lago_customer_id: customer.id,
-        plan_code: plan.code,
-        status: 'active',
-        name: 'subscription name',
-        started_at: String,
-        billing_time: 'anniversary',
-        subscription_at: Time.current.iso8601,
-        ending_at: (Time.current + 1.year).iso8601,
-        previous_plan_code: nil,
-        next_plan_code: nil,
-        downgrade_plan_date: nil,
-      )
-      expect(json[:subscription][:plan]).to include(
-        amount_cents: 100,
-        name: 'overridden name',
-        description: 'desc',
-      )
+      freeze_time do
+        post_with_token(organization, '/api/v1/subscriptions', { subscription: params })
+        expect(response).to have_http_status(:ok)
+        expect(json[:subscription]).to include(
+          lago_id: String,
+          external_id: String,
+          external_customer_id: customer.external_id,
+          lago_customer_id: customer.id,
+          plan_code: plan.code,
+          status: 'active',
+          name: 'subscription name',
+          started_at: String,
+          billing_time: 'anniversary',
+          subscription_at: Time.current.iso8601,
+          ending_at: (Time.current + 1.year).iso8601,
+          previous_plan_code: nil,
+          next_plan_code: nil,
+          downgrade_plan_date: nil,
+        )
+        expect(json[:subscription][:plan]).to include(
+          amount_cents: 100,
+          name: 'overridden name',
+          description: 'desc',
+        )
+      end
     end
 
     context 'with external_customer_id, external_id and name as integer' do
@@ -168,7 +168,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
         name: 'subscription name new',
         subscription_at: '2022-09-05T12:23:12Z',
         plan_overrides: {
-          amount_cents: 100,
+          name: 'plan new name',
         },
       }
     end
@@ -184,7 +184,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       expect(json[:subscription][:subscription_at].to_s).to eq('2022-09-05T12:23:12Z')
 
       expect(json[:subscription][:plan]).to include(
-        amount_cents: 100,
+        name: 'plan new name',
       )
     end
 

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -108,6 +108,22 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
       end
     end
 
+    context 'when plan_overrides' do
+      let(:params) do
+        {
+          plan_overrides: {
+            name: 'new name',
+          },
+        }
+      end
+
+      around { |test| lago_premium!(&test) }
+
+      it 'updates the plan accordingly' do
+        expect { update_service.call }.to change { subscription.plan.reload.name }.to('new name')
+      end
+    end
+
     context 'when License is free and plan_overrides is passed' do
       let(:params) do
         {


### PR DESCRIPTION
The goal of this PR is to:
- Ensure to not override a children plan
- Update the plan when updating a subscription with plan overrides