### PR TITLE
feat(events): Add Materialized view for post validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'kaminari-activerecord'
 gem 'paper_trail'
 gem 'pg'
 gem 'ransack', '~> 4.0.0'
+gem 'scenic'
 gem 'with_advisory_lock'
 
 # Currencies, Countries, Timezones...

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,6 +443,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    scenic (1.7.0)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     sentry-rails (5.12.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.12.0)
@@ -573,6 +576,7 @@ DEPENDENCIES
   rspec-graphql_matchers
   rspec-rails
   sass-rails
+  scenic
   sentry-rails (~> 5.12.0)
   sentry-ruby (~> 5.12.0)
   sentry-sidekiq (~> 5.12.0)
@@ -592,4 +596,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.3.26
+   2.4.21

--- a/app/jobs/clock/events_validation_job.rb
+++ b/app/jobs/clock/events_validation_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Clock
+  class EventsValidationJob < ApplicationJob
+    queue_as 'clock'
+
+    def perform
+      # NOTE: refresh the last hour events materialized view
+      Scenic.database.refresh_materialized_view(
+        Events::LastHourMv.table_name,
+        concurrently: false,
+        cascade: false,
+      )
+
+      # TODO: enqueue a validation jobs for each organization with at least one event
+    end
+  end
+end

--- a/app/models/events/last_hour_mv.rb
+++ b/app/models/events/last_hour_mv.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Events
+  class LastHourMv < ApplicationRecord
+    self.table_name = 'last_hour_events_mv'
+
+    def readonly?
+      true
+    end
+  end
+end

--- a/db/clickhouse_migrate/20231030163703_create_events_raw_mv.rb
+++ b/db/clickhouse_migrate/20231030163703_create_events_raw_mv.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 class CreateEventsRawMv < ActiveRecord::Migration[7.0]
   def change

--- a/db/migrate/20231109141829_create_last_hour_events_mv.rb
+++ b/db/migrate/20231109141829_create_last_hour_events_mv.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CreateLastHourEventsMv < ActiveRecord::Migration[7.0]
+  def change
+    create_view :last_hour_events_mv, materialized: true
+  end
+end

--- a/db/migrate/20231109154934_add_events_validation_index.rb
+++ b/db/migrate/20231109154934_add_events_validation_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddEventsValidationIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :events, %i[organization_id code created_at], where: 'deleted_at IS NULL'
+  end
+end

--- a/db/views/last_hour_events_mv_v01.sql
+++ b/db/views/last_hour_events_mv_v01.sql
@@ -1,0 +1,43 @@
+WITH billable_metric_groups AS (
+  SELECT
+		billable_metrics.id AS bm_id,
+		billable_metrics.code bm_code,
+		COUNT(parent_groups.id) AS parent_group_count,
+		array_agg(parent_groups.key) AS parent_group_keys,
+		COUNT(child_groups.id) AS child_group_count,
+		array_agg(child_groups.key) AS child_group_keys
+	FROM billable_metrics
+		LEFT JOIN groups AS parent_groups
+			ON parent_groups.billable_metric_id = billable_metrics.id
+			AND parent_groups.parent_group_id IS NULL
+		LEFT JOIN groups AS child_groups
+			ON child_groups.billable_metric_id = billable_metrics.id
+			AND child_groups.parent_group_id IS NOT NULL
+	WHERE billable_metrics.deleted_at IS NULL
+	GROUP BY billable_metrics.id, billable_metrics.code
+)
+
+SELECT
+  events.organization_id,
+  events.transaction_id,
+  events.timestamp,
+  events.properties,
+  billable_metrics.code AS billable_metric_code,
+  billable_metrics.aggregation_type != 0 AS field_name_mandatory,
+  billable_metrics.aggregation_type IN (1,2,5,6) AS numeric_field_mandatory,
+  events.properties ->> billable_metrics.field_name::text AS field_value,
+  events.properties ->> billable_metrics.field_name::text ~ '^\d+(\.\d+)?$' AS is_numeric_field_value,
+  COALESCE(billable_metric_groups.parent_group_count, 0) > 0 AS parent_group_mandatory,
+  events.properties ?| billable_metric_groups.parent_group_keys AS has_parent_group_key,
+  COALESCE(billable_metric_groups.child_group_count, 0) > 0 AS child_group_mandatory,
+  events.properties ?| billable_metric_groups.child_group_keys AS has_child_group_key
+FROM
+  events
+    LEFT JOIN billable_metrics ON billable_metrics.code = events.code
+      AND events.organization_id = billable_metrics.organization_id
+    LEFT JOIN billable_metric_groups ON billable_metrics.id = billable_metric_groups.bm_id
+WHERE
+  events.deleted_at IS NULL
+  AND events.created_at >= date_trunc('hour', NOW()) - INTERVAL '1 hour'
+  AND events.created_at < date_trunc('hour', NOW())
+  AND billable_metrics.deleted_at IS NULL

--- a/spec/jobs/clock/events_validation_job_spec.rb
+++ b/spec/jobs/clock/events_validation_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Clock::EventsValidationJob, job: true, transaction: false do
+  subject { described_class }
+
+  describe '.perform' do
+    let(:event) { create(:event) }
+
+    before { event }
+
+    it 'refresh the events materialized view' do
+      # expect { described_class.perform_now }
+      #  .to change(Events::LastHourMv, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Since we no longer validate event ingestion, users are flying blind to understand which events have been ingested but not used for billing.

Ideally, our users should receive warnings when issues are detected during event ingestion.

## Description

This PR is the first step of the feature.
It adds a new Clock job (not activated yet) that will be executed every hour to:
- Refresh a materialized view with the events from the last terminated hour
- (later) enqueue a validation job for each organization that have received at least one event
