### PR TITLE
fix(void-invoices-credit-notes): Do not create credit notes for voided invoice

### DIFF
--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -10,7 +10,8 @@ module CreditNotes
     end
 
     def call
-      return result if (last_subscription_fee&.amount_cents || 0).zero?
+
+      return result if (last_subscription_fee&.amount_cents || 0).zero? || last_subscription_fee.invoice.voided?
 
       amount = compute_amount
       return result unless amount.positive?

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -10,7 +10,6 @@ module CreditNotes
     end
 
     def call
-
       return result if (last_subscription_fee&.amount_cents || 0).zero? || last_subscription_fee.invoice.voided?
 
       amount = compute_amount

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
       end
     end
 
+    context 'when invoice is voided' do
+      before { invoice.void! }
+
+      it 'does not create a credit note' do
+        expect { create_service.call }.not_to change(CreditNote, :count)
+      end
+    end
+
     context 'when fee amount is zero' do
       let(:subscription_fee) do
         create(


### PR DESCRIPTION
## Context

Lago should not try to automatically generate credit notes for void invoices.

## Description

This PR fixes `CreditNotes::CreateFromTermination` service.