### PR TITLE
fix: Ensure email is sent after finalizing an invoice

### DIFF
--- a/app/services/customers/update_invoice_grace_period_service.rb
+++ b/app/services/customers/update_invoice_grace_period_service.rb
@@ -9,25 +9,24 @@ module Customers
     end
 
     def call
-      ActiveRecord::Base.transaction do
-        customer.update!(invoice_grace_period: grace_period)
+      customer.invoice_grace_period = grace_period
+      customer.save!
 
-        # NOTE: Finalize related draft invoices.
-        customer.invoices.ready_to_be_finalized.each do |invoice|
-          Invoices::FinalizeService.call(invoice:)
-        end
-
-        # NOTE: Update issuing_date on draft invoices.
-        customer.invoices.draft.each do |invoice|
-          invoice.update!(
-            issuing_date: grace_period_issuing_date(invoice),
-            payment_due_date: grace_period_payment_due_date(invoice),
-          )
-        end
-
-        result.customer = customer
-        result
+      # NOTE: Finalize related draft invoices.
+      customer.invoices.ready_to_be_finalized.each do |invoice|
+        Invoices::FinalizeService.call(invoice:)
       end
+
+      # NOTE: Update issuing_date on draft invoices.
+      customer.invoices.draft.each do |invoice|
+        invoice.update!(
+          issuing_date: grace_period_issuing_date(invoice),
+          payment_due_date: grace_period_payment_due_date(invoice),
+        )
+      end
+
+      result.customer = customer
+      result
     end
 
     private

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -13,13 +13,13 @@ module Customers
         )
       end
 
+      old_payment_provider = customer.payment_provider
       ActiveRecord::Base.transaction do
         billing_configuration = args[:billing_configuration]&.to_h || {}
         if args.key?(:currency)
           update_currency(customer:, currency: args[:currency], customer_update: true)
           return result unless result.success?
         end
-        old_payment_provider = customer.payment_provider
 
         customer.name = args[:name] if args.key?(:name)
         customer.tax_identification_number = args[:tax_identification_number] if args.key?(:tax_identification_number)
@@ -48,43 +48,43 @@ module Customers
         if billing_configuration.key?(:document_locale)
           customer.document_locale = billing_configuration[:document_locale]
         end
+      end
 
-        if License.premium? && args.key?(:invoice_grace_period)
-          Customers::UpdateInvoiceGracePeriodService.call(customer:, grace_period: args[:invoice_grace_period])
+      if License.premium? && args.key?(:invoice_grace_period)
+        Customers::UpdateInvoiceGracePeriodService.call(customer:, grace_period: args[:invoice_grace_period])
+      end
+
+      if args.key?(:billing_configuration)
+        billing = args[:billing_configuration]
+        customer.invoice_footer = billing[:invoice_footer] if billing.key?(:invoice_footer)
+        customer.vat_rate = billing[:vat_rate] if billing.key?(:vat_rate)
+
+        if License.premium? && billing.key?(:invoice_grace_period)
+          Customers::UpdateInvoiceGracePeriodService.call(customer:, grace_period: billing[:invoice_grace_period])
         end
+      end
 
-        if args.key?(:billing_configuration)
-          billing = args[:billing_configuration]
-          customer.invoice_footer = billing[:invoice_footer] if billing.key?(:invoice_footer)
-          customer.vat_rate = billing[:vat_rate] if billing.key?(:vat_rate)
+      if args.key?(:net_payment_term)
+        Customers::UpdateInvoicePaymentDueDateService.call(customer:, net_payment_term: args[:net_payment_term])
+      end
 
-          if License.premium? && billing.key?(:invoice_grace_period)
-            Customers::UpdateInvoiceGracePeriodService.call(customer:, grace_period: billing[:invoice_grace_period])
-          end
+      # NOTE: external_id is not editable if customer is attached to subscriptions
+      customer.external_id = args[:external_id] if customer.editable? && args.key?(:external_id)
+
+      ActiveRecord::Base.transaction do
+        customer.save!
+
+        if args[:tax_codes]
+          taxes_result = Customers::ApplyTaxesService.call(customer:, tax_codes: args[:tax_codes])
+          taxes_result.raise_if_error!
         end
+        Customers::Metadata::UpdateService.call(customer:, params: args[:metadata]) if args[:metadata]
+      end
 
-        if args.key?(:net_payment_term)
-          Customers::UpdateInvoicePaymentDueDateService.call(customer:, net_payment_term: args[:net_payment_term])
-        end
-
-        # NOTE: external_id is not editable if customer is attached to subscriptions
-        customer.external_id = args[:external_id] if customer.editable? && args.key?(:external_id)
-
-        ActiveRecord::Base.transaction do
-          customer.save!
-
-          if args[:tax_codes]
-            taxes_result = Customers::ApplyTaxesService.call(customer:, tax_codes: args[:tax_codes])
-            taxes_result.raise_if_error!
-          end
-          Customers::Metadata::UpdateService.call(customer:, params: args[:metadata]) if args[:metadata]
-        end
-
-        # NOTE: if payment provider is updated, we need to create/update the provider customer
-        if args.key?(:provider_customer) || args.key?(:payment_provider)
-          payment_provider = old_payment_provider || customer.payment_provider
-          create_or_update_provider_customer(customer, payment_provider, args[:provider_customer])
-        end
+      # NOTE: if payment provider is updated, we need to create/update the provider customer
+      if args.key?(:provider_customer) || args.key?(:payment_provider)
+        payment_provider = old_payment_provider || customer.payment_provider
+        create_or_update_provider_customer(customer, payment_provider, args[:provider_customer])
       end
 
       result.customer = customer

--- a/app/services/organizations/update_invoice_grace_period_service.rb
+++ b/app/services/organizations/update_invoice_grace_period_service.rb
@@ -9,25 +9,24 @@ module Organizations
     end
 
     def call
-      ActiveRecord::Base.transaction do
-        organization.update!(invoice_grace_period: grace_period)
+      organization.invoice_grace_period = grace_period
+      organization.save!
 
-        # NOTE: Finalize related draft invoices.
-        organization.invoices.ready_to_be_finalized.each do |invoice|
-          Invoices::FinalizeService.call(invoice:)
-        end
-
-        # NOTE: Update issuing_date on draft invoices.
-        organization.invoices.draft.each do |invoice|
-          invoice.update!(
-            issuing_date: grace_period_issuing_date(invoice),
-            payment_due_date: grace_period_payment_due_date(invoice),
-          )
-        end
-
-        result.organization = organization
-        result
+      # NOTE: Finalize related draft invoices.
+      organization.invoices.ready_to_be_finalized.each do |invoice|
+        Invoices::FinalizeService.call(invoice:)
       end
+
+      # NOTE: Update issuing_date on draft invoices.
+      organization.invoices.draft.each do |invoice|
+        invoice.update!(
+          issuing_date: grace_period_issuing_date(invoice),
+          payment_due_date: grace_period_payment_due_date(invoice),
+        )
+      end
+
+      result.organization = organization
+      result
     end
 
     private

--- a/spec/scenarios/customers/update_invoice_grace_period_spec.rb
+++ b/spec/scenarios/customers/update_invoice_grace_period_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Update Customer Invoice Grace Period Scenarios', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
+  let(:plan) { create(:plan, pay_in_advance: true, organization:) }
+
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  around { |test| lago_premium!(&test) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+  end
+
+  it 'updates the grace period of the customer' do
+    ### 15 Dec: Create subscription + charge.
+    dec15 = DateTime.new(2022, 12, 15)
+
+    travel_to(dec15) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+        },
+      )
+    end
+
+    subscription = customer.subscriptions.find_by(external_id: customer.external_id)
+    dec_invoice = subscription.invoices.first
+    expect(dec_invoice).to be_draft
+
+    ### 1 Jan: Billing
+    jan1 = DateTime.new(2023, 1, 1)
+
+    travel_to(jan1) do
+      expect do
+        create_or_update_customer(
+          {
+            external_id: customer.external_id,
+            billing_configuration: { invoice_grace_period: 0 },
+          },
+        )
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(customer.reload.invoice_grace_period).to eq(0)
+      expect(dec_invoice.reload).to be_finalized
+    end
+  end
+end


### PR DESCRIPTION
We have some issues with not sent emails after updating the grace period to 0.
The goal of this is to fix them by removing a transaction.