### PR TITLE
feat(recurring-transaction-rules): handle auto top up for threshold rule

### DIFF
--- a/app/services/wallets/balance/decrease_service.rb
+++ b/app/services/wallets/balance/decrease_service.rb
@@ -38,11 +38,11 @@ module Wallets
 
         return if threshold_rule.nil? || wallet.credits_balance > threshold_rule.threshold_credits
 
-        WalletTransactions::CreateJob.perform_later(
+        WalletTransactions::CreateJob.set(wait: 2.seconds).perform_later(
           organization_id: wallet.organization.id,
           wallet_id: wallet.id,
-          paid_credits: threshold_rule.paid_credits,
-          granted_credits: threshold_rule.granted_credits,
+          paid_credits: threshold_rule.paid_credits.to_s,
+          granted_credits: threshold_rule.granted_credits.to_s,
           source: :threshold,
         )
       end

--- a/app/services/wallets/balance/decrease_service.rb
+++ b/app/services/wallets/balance/decrease_service.rb
@@ -43,6 +43,7 @@ module Wallets
           wallet_id: wallet.id,
           paid_credits: threshold_rule.paid_credits,
           granted_credits: threshold_rule.granted_credits,
+          source: :threshold,
         )
       end
     end

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -9,8 +9,8 @@ module Wallets
         WalletTransactions::CreateJob.perform_later(
           organization_id: wallet.organization.id,
           wallet_id: wallet.id,
-          paid_credits: recurring_transaction_rule.paid_credits,
-          granted_credits: recurring_transaction_rule.granted_credits,
+          paid_credits: recurring_transaction_rule.paid_credits.to_s,
+          granted_credits: recurring_transaction_rule.granted_credits.to_s,
           source: :interval,
         )
       end

--- a/spec/services/wallets/balance/decrease_service_spec.rb
+++ b/spec/services/wallets/balance/decrease_service_spec.rb
@@ -22,5 +22,27 @@ RSpec.describe Wallets::Balance::DecreaseService, type: :service do
         .to change(wallet.reload, :consumed_credits).from(0).to(4.5)
         .and change(wallet, :consumed_amount_cents).from(0).to(450)
     end
+
+    context 'with recurring transaction threshold rule' do
+      let(:recurring_transaction_rule) do
+        create(:recurring_transaction_rule, wallet:, rule_type: 'threshold', threshold_credits: '6.0')
+      end
+
+      before { recurring_transaction_rule }
+
+      it 'calls wallet transaction create job when threshold border has been crossed' do
+        expect { create_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+      end
+
+      context 'when border has NOT been crossed' do
+        let(:recurring_transaction_rule) do
+          create(:recurring_transaction_rule, wallet:, rule_type: 'threshold', threshold_credits: '2.0')
+        end
+
+        it 'does not call wallet transaction create job' do
+          expect { create_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
+        end
+      end
+    end
   end
 end

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
             .with(
               organization_id: customer.organization_id,
               wallet_id: wallet.id,
-              paid_credits: recurring_transaction_rule.paid_credits,
-              granted_credits: recurring_transaction_rule.granted_credits,
+              paid_credits: recurring_transaction_rule.paid_credits.to_s,
+              granted_credits: recurring_transaction_rule.granted_credits.to_s,
               source: :interval,
             )
         end
@@ -63,8 +63,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
             .with(
               organization_id: customer.organization_id,
               wallet_id: wallet.id,
-              paid_credits: recurring_transaction_rule.paid_credits,
-              granted_credits: recurring_transaction_rule.granted_credits,
+              paid_credits: recurring_transaction_rule.paid_credits.to_s,
+              granted_credits: recurring_transaction_rule.granted_credits.to_s,
               source: :interval,
             )
         end
@@ -88,8 +88,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
               .with(
                 organization_id: customer.organization_id,
                 wallet_id: wallet.id,
-                paid_credits: recurring_transaction_rule.paid_credits,
-                granted_credits: recurring_transaction_rule.granted_credits,
+                paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
               )
           end
@@ -109,8 +109,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
             .with(
               organization_id: customer.organization_id,
               wallet_id: wallet.id,
-              paid_credits: recurring_transaction_rule.paid_credits,
-              granted_credits: recurring_transaction_rule.granted_credits,
+              paid_credits: recurring_transaction_rule.paid_credits.to_s,
+              granted_credits: recurring_transaction_rule.granted_credits.to_s,
               source: :interval,
             )
         end
@@ -134,8 +134,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
               .with(
                 organization_id: customer.organization_id,
                 wallet_id: wallet.id,
-                paid_credits: recurring_transaction_rule.paid_credits,
-                granted_credits: recurring_transaction_rule.granted_credits,
+                paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
               )
           end
@@ -154,8 +154,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
               .with(
                 organization_id: customer.organization_id,
                 wallet_id: wallet.id,
-                paid_credits: recurring_transaction_rule.paid_credits,
-                granted_credits: recurring_transaction_rule.granted_credits,
+                paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
               )
           end
@@ -175,8 +175,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
             .with(
               organization_id: customer.organization_id,
               wallet_id: wallet.id,
-              paid_credits: recurring_transaction_rule.paid_credits,
-              granted_credits: recurring_transaction_rule.granted_credits,
+              paid_credits: recurring_transaction_rule.paid_credits.to_s,
+              granted_credits: recurring_transaction_rule.granted_credits.to_s,
               source: :interval,
             )
         end
@@ -200,8 +200,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
               .with(
                 organization_id: customer.organization_id,
                 wallet_id: wallet.id,
-                paid_credits: recurring_transaction_rule.paid_credits,
-                granted_credits: recurring_transaction_rule.granted_credits,
+                paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
               )
           end


### PR DESCRIPTION
## Context

Currently Lago supports only manual wallet transactions. With Recurring transactions feature it will be possible to top-up wallet automatically with threshold or intervals rules.

## Description

This PR adds feature for automatic top-up based on threshold rule