### PR TITLE
fix: Ability to update charge from subscription

### DIFF
--- a/app/graphql/types/subscriptions/charge_overrides_input.rb
+++ b/app/graphql/types/subscriptions/charge_overrides_input.rb
@@ -3,6 +3,7 @@
 module Types
   module Subscriptions
     class ChargeOverridesInput < Types::BaseInputObject
+      argument :billable_metric_id, ID, required: true
       argument :id, ID, required: true
 
       argument :group_properties, [Types::Charges::GroupPropertiesInput], required: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -218,6 +218,7 @@ enum ChargeModelEnum {
 }
 
 input ChargeOverridesInput {
+  billableMetricId: ID!
   groupProperties: [GroupPropertiesInput!]
   id: ID!
   invoiceDisplayName: String

--- a/schema.json
+++ b/schema.json
@@ -2145,6 +2145,22 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "billableMetricId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
             amountCents: 100,
             charges: [
               id: charge.id,
+              billableMetricId: charge.billable_metric_id,
               invoiceDisplayName: 'invoice display name',
             ],
           },


### PR DESCRIPTION
Currently, updating a charge from a subscription is not working because `billable_metric_id` is missing.
The goal of this PR is to fix it by accepting `billableMetricId`.