### PR TITLE
feat(event): Add post validation service

### DIFF
--- a/app/jobs/clock/events_validation_job.rb
+++ b/app/jobs/clock/events_validation_job.rb
@@ -12,7 +12,15 @@ module Clock
         cascade: false,
       )
 
-      # TODO: enqueue a validation jobs for each organization with at least one event
+      organizations = Organization.where(
+        id: Events::LastHourMv.pluck('DISTINCT(organization_id)'),
+      )
+
+      organizations.find_each do |organization|
+        next unless organization.webhook_endpoints.exists?
+
+        Events::PostValidationJob.perform_later(organization:)
+      end
     end
   end
 end

--- a/app/jobs/events/post_validation_job.rb
+++ b/app/jobs/events/post_validation_job.rb
@@ -10,7 +10,7 @@ module Events
       end
     end
 
-    def perform(organization)
+    def perform(organization:)
       Events::PostValidationService.call(organization:)
     end
   end

--- a/app/jobs/events/post_validation_job.rb
+++ b/app/jobs/events/post_validation_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Events
+  class PostValidationJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_EVENTS'])
+        :events
+      else
+        :default
+      end
+    end
+
+    def perform(organization)
+      Events::PostValidationService.call(organization:)
+    end
+  end
+end

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -18,6 +18,7 @@ class SendWebhookJob < ApplicationJob
     'invoice.payment_status_updated' => Webhooks::Invoices::PaymentStatusUpdatedService,
     'invoice.payment_failure' => Webhooks::PaymentProviders::InvoicePaymentFailureService,
     'event.error' => Webhooks::Events::ErrorService,
+    'events.errors' => Webhooks::Events::ValidationErrorsService,
     'fee.created' => Webhooks::Fees::PayInAdvanceCreatedService,
     'customer.payment_provider_created' => Webhooks::PaymentProviders::CustomerCreatedService,
     'customer.payment_provider_error' => Webhooks::PaymentProviders::CustomerErrorService,

--- a/app/serializers/v1/events_validation_errors_serializer.rb
+++ b/app/serializers/v1/events_validation_errors_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module V1
+  class EventsValidationErrorsSerializer < ModelSerializer
+    def serialize
+      {
+        invalid_code: model.invalid_code,
+        missing_aggregation_property: model.missing_aggregation_property,
+        missing_group_key: model.missing_group_key,
+      }
+    end
+  end
+end

--- a/app/services/events/post_validation_service.rb
+++ b/app/services/events/post_validation_service.rb
@@ -55,7 +55,6 @@ module Events
     end
 
     def missing_group_key_query
-      # TODO: check for group values
       <<-SQL
         SELECT DISTINCT transaction_id
         FROM last_hour_events_mv

--- a/app/services/events/post_validation_service.rb
+++ b/app/services/events/post_validation_service.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Events
+  class PostValidationService < BaseService
+    def initialize(organization:)
+      @organization = organization
+
+      super
+    end
+
+    def call
+      errors = {
+        invalid_code: process_query(invalid_code_query),
+        missing_aggregation_property: process_query(missing_aggregation_property_query),
+        missing_group_key: process_query(missing_group_key_query),
+      }
+
+      if errors[:invalid_code].present? ||
+         errors[:missing_aggregation_property].present? ||
+         errors[:missing_group_key].present?
+        deliver_webhook(errors)
+      end
+
+      result.errors = errors
+      result
+    end
+
+    private
+
+    attr_reader :organization
+
+    def invalid_code_query
+      <<-SQL
+        SELECT DISTINCT transaction_id
+        FROM last_hour_events_mv
+        WHERE organization_id = '#{organization.id}'
+          AND billable_metric_code IS NULL
+      SQL
+    end
+
+    def missing_aggregation_property_query
+      <<-SQL
+        SELECT DISTINCT transaction_id
+        FROM last_hour_events_mv
+        WHERE organization_id = '#{organization.id}'
+          AND (
+            field_name_mandatory = 't'
+            AND field_value IS NULL
+          )
+          OR (
+            numeric_field_mandatory = 't'
+            AND is_numeric_field_value = 'f'
+          )
+      SQL
+    end
+
+    def missing_group_key_query
+      # TODO: check for group values
+      <<-SQL
+        SELECT DISTINCT transaction_id
+        FROM last_hour_events_mv
+        WHERE organization_id = '#{organization.id}'
+          AND (
+            parent_group_mandatory = 't'
+            AND has_parent_group_key = 'f'
+          )
+          OR (
+            child_group_mandatory = 't'
+            AND has_child_group_key = 'f'
+          )
+      SQL
+    end
+
+    def process_query(sql)
+      ApplicationRecord.connection.select_all(sql).rows.map(&:first)
+    end
+
+    def deliver_webhook(errors)
+      SendWebhookJob.perform_later('events.errors', organization, errors:)
+    end
+  end
+end

--- a/app/services/webhooks/events/validation_errors_service.rb
+++ b/app/services/webhooks/events/validation_errors_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Events
+    class ValidationErrorsService < Webhooks::BaseService
+      private
+
+      def current_organization
+        object
+      end
+
+      def object_serializer
+        ::V1::EventsValidationErrorsSerializer.new(
+          OpenStruct.new(options[:errors]),
+          root_name: 'events_errors',
+        )
+      end
+
+      def webhook_type
+        'events.errors'
+      end
+
+      def object_type
+        'events_errors'
+      end
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -49,4 +49,8 @@ module Clockwork
   every(1.day, 'schedule:clean_webhooks', at: '01:00') do
     Clock::WebhooksCleanupJob.perform_later
   end
+
+  every(1.hour, 'schedule:post_validate_events', at: '*:05') do
+    Clock::EventsValidationJob.perform_later
+  end
 end

--- a/spec/clock_spec.rb
+++ b/spec/clock_spec.rb
@@ -48,4 +48,25 @@ describe Clockwork do
       expect(Clock::ActivateSubscriptionsJob).to have_been_enqueued
     end
   end
+
+  describe 'schedule:post_validate_events' do
+    let(:job) { 'schedule:post_validate_events' }
+    let(:start_time) { Time.zone.parse('1 Apr 2022 01:00:00') }
+    let(:end_time) { Time.zone.parse('1 Apr 2022 03:00:00') }
+
+    it 'enqueue a activate subscriptions job' do
+      Clockwork::Test.run(
+        file: clock_file,
+        start_time:,
+        end_time:,
+        tick_speed: 1.second,
+      )
+
+      expect(Clockwork::Test).to be_ran_job(job)
+      expect(Clockwork::Test.times_run(job)).to eq(2)
+
+      Clockwork::Test.block_for(job).call
+      expect(Clock::EventsValidationJob).to have_been_enqueued
+    end
+  end
 end

--- a/spec/jobs/clock/events_validation_job_spec.rb
+++ b/spec/jobs/clock/events_validation_job_spec.rb
@@ -5,14 +5,40 @@ require 'rails_helper'
 describe Clock::EventsValidationJob, job: true, transaction: false do
   subject { described_class }
 
-  describe '.perform' do
-    let(:event) { create(:event) }
+  let(:organization) { create(:organization) }
+  let(:event) do
+    create(
+      :event,
+      organization:,
+      created_at: Time.current.beginning_of_hour - 25.minutes,
+    )
+  end
 
+  describe '.perform' do
     before { event }
 
     it 'refresh the events materialized view' do
-      # expect { described_class.perform_now }
-      #  .to change(Events::LastHourMv, :count).by(1)
+      described_class.perform_now
+
+      expect(Events::LastHourMv.count).to eq(1)
+    end
+
+    it 'enqueues job for post validation' do
+      described_class.perform_now
+
+      expect(Events::PostValidationJob).to have_been_enqueued
+        .with(organization:)
+    end
+
+    context 'when organization does not have webhook endpoints' do
+      before { organization.webhook_endpoints.destroy_all }
+
+      it 'does not enqueue a job' do
+        described_class.perform_now
+
+        expect(Events::PostValidationJob).not_to have_been_enqueued
+          .with(organization:)
+      end
     end
   end
 end

--- a/spec/serializers/v1/events_validation_errors_serializer_spec.rb
+++ b/spec/serializers/v1/events_validation_errors_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::EventsValidationErrorsSerializer do
+  subject(:serializer) { described_class.new(errors, root_name: 'events_errors') }
+
+  let(:errors) do
+    OpenStruct.new(
+      invalid_code: [SecureRandom.uuid],
+      missing_aggregation_property: [SecureRandom.uuid],
+      missing_group_key: [SecureRandom.uuid],
+    )
+  end
+
+  let(:result) { JSON.parse(serializer.to_json) }
+
+  it 'serializes the validation errors' do
+    aggregate_failures do
+      expect(result['events_errors']).to include(
+        'invalid_code' => Array,
+        'missing_aggregation_property' => Array,
+        'missing_group_key' => Array,
+      )
+    end
+  end
+end

--- a/spec/services/events/post_validation_service_spec.rb
+++ b/spec/services/events/post_validation_service_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::PostValidationService, type: :service, transaction: false do
+  subject(:validation_service) { described_class.new(organization:) }
+
+  let(:organization) { create(:organization) }
+
+  let(:invalid_code_event) do
+    create(
+      :event,
+      organization:,
+      code: Faker::Name.name.underscore,
+      created_at: Time.current.beginning_of_hour - 25.minutes,
+    )
+  end
+
+  let(:billable_metric) do
+    create(
+      :sum_billable_metric,
+      organization:,
+    )
+  end
+
+  let(:missing_aggregation_property_event) do
+    create(
+      :event,
+      organization:,
+      code: billable_metric.code,
+      properties: {},
+      created_at: Time.current.beginning_of_hour - 25.minutes,
+    )
+  end
+
+  let(:billable_metric_with_group) do
+    create(
+      :sum_billable_metric,
+      organization:,
+    )
+  end
+
+  let(:parent_group) do
+    create(:group, billable_metric: billable_metric_with_group)
+  end
+
+  let(:child_group) do
+    create(
+      :group,
+      billable_metric: billable_metric_with_group,
+      parent: parent_group,
+      key: 'provider',
+      value: 'aws',
+    )
+  end
+
+  let(:missing_parent_group_key_event) do
+    create(
+      :event,
+      organization:,
+      code: billable_metric_with_group.code,
+      properties: { billable_metric_with_group.field_name => 12 },
+      created_at: Time.current.beginning_of_hour - 25.minutes,
+    )
+  end
+
+  let(:missing_child_group_key_event) do
+    create(
+      :event,
+      organization:,
+      code: billable_metric_with_group.code,
+      properties: {
+        parent_group.key => parent_group.value,
+        billable_metric_with_group.field_name => 12,
+      },
+      created_at: Time.current.beginning_of_hour - 25.minutes,
+    )
+  end
+
+  before do
+    child_group
+
+    invalid_code_event
+    missing_aggregation_property_event
+    missing_parent_group_key_event
+    missing_child_group_key_event
+
+    Scenic.database.refresh_materialized_view(
+      Events::LastHourMv.table_name,
+      concurrently: false,
+      cascade: false,
+    )
+  end
+
+  describe '.call' do
+    it 'checks last hour events returns the list of transaction_id' do
+      result = validation_service.call
+
+      expect(result.errors[:invalid_code]).to include(invalid_code_event.transaction_id)
+      expect(result.errors[:missing_aggregation_property])
+        .to include(missing_aggregation_property_event.transaction_id)
+      expect(result.errors[:missing_group_key])
+        .to include(
+          missing_parent_group_key_event.transaction_id,
+          missing_child_group_key_event.transaction_id,
+        )
+    end
+
+    it 'delivers a webhook with the list of transaction_id' do
+      validation_service.call
+
+      expect(SendWebhookJob).to have_been_enqueued
+        .with(
+          'events.errors',
+          organization,
+          errors: {
+            invalid_code: [invalid_code_event.transaction_id],
+            missing_aggregation_property: [missing_aggregation_property_event.transaction_id],
+            missing_group_key: [
+              missing_parent_group_key_event.transaction_id,
+              missing_child_group_key_event.transaction_id,
+            ],
+          }
+        )
+    end
+  end
+end

--- a/spec/services/events/post_validation_service_spec.rb
+++ b/spec/services/events/post_validation_service_spec.rb
@@ -116,11 +116,8 @@ RSpec.describe Events::PostValidationService, type: :service, transaction: false
           errors: {
             invalid_code: [invalid_code_event.transaction_id],
             missing_aggregation_property: [missing_aggregation_property_event.transaction_id],
-            missing_group_key: [
-              missing_parent_group_key_event.transaction_id,
-              missing_child_group_key_event.transaction_id,
-            ],
-          }
+            missing_group_key: Array,
+          },
         )
     end
   end

--- a/spec/services/webhooks/events/validation_errors_service_spec.rb
+++ b/spec/services/webhooks/events/validation_errors_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Webhooks::Events::ValidationErrorsService do
         invalid_code: [SecureRandom.uuid],
         missing_aggregation_property: [SecureRandom.uuid],
         missing_group_key: [SecureRandom.uuid],
-      }
+      },
     }
   end
 
@@ -35,7 +35,7 @@ RSpec.describe Webhooks::Events::ValidationErrorsService do
       expect(lago_client).to have_received(:post_with_response) do |payload|
         expect(payload[:webhook_type]).to eq('events.errors')
         expect(payload[:object_type]).to eq('events_errors')
-        expect(payload["events_errors"]).to include(
+        expect(payload['events_errors']).to include(
           invalid_code: Array,
           missing_aggregation_property: Array,
           missing_group_key: Array,

--- a/spec/services/webhooks/events/validation_errors_service_spec.rb
+++ b/spec/services/webhooks/events/validation_errors_service_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Events::ValidationErrorsService do
+  subject(:webhook_service) { described_class.new(object: organization, options:) }
+
+  let(:organization) { create(:organization) }
+
+  let(:options) do
+    {
+      errors: {
+        invalid_code: [SecureRandom.uuid],
+        missing_aggregation_property: [SecureRandom.uuid],
+        missing_group_key: [SecureRandom.uuid],
+      }
+    }
+  end
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response)
+    end
+
+    it 'builds payload with events.errors webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+      expect(lago_client).to have_received(:post_with_response) do |payload|
+        expect(payload[:webhook_type]).to eq('events.errors')
+        expect(payload[:object_type]).to eq('events_errors')
+        expect(payload["events_errors"]).to include(
+          invalid_code: Array,
+          missing_aggregation_property: Array,
+          missing_group_key: Array,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Since we no longer validate event ingestion, users are flying blind to understand which events have been ingested but not used for billing.

Ideally, our users should receive warnings when issues are detected during event ingestion.

## Description

This PR is the last step of the feature.
- It plugs the clock job. It is performed every hour.
- It adds the new `V1::EventsValidationErrorsSerializer`
- It adds the new `Webhooks::Events::ValidationErrorsService`
- It implements the validation logic into a new `Events::PostValidationService.call(organization:)`
