### PR TITLE
feat(event): Add cached aggregation model

### DIFF
--- a/app/models/cached_aggregation.rb
+++ b/app/models/cached_aggregation.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CachedAggregation < ApplicationRecord
+  belongs_to :organization
+  belongs_to :charge
+  belongs_to :group, optional: true
+
+  validates :event_id, presence: true
+  validates :external_subscription_id, presence: true
+  validates :timestamp, presence: true
+
+  scope :from_datetime, ->(from_datetime) { where('cached_aggregations.timestamp::timestamp(0) >= ?', from_datetime) }
+  scope :to_datetime, ->(to_datetime) { where('cached_aggregations.timestamp::timestamp(0) <= ?', to_datetime) }
+end

--- a/db/migrate/20231016115055_create_cached_aggregations.rb
+++ b/db/migrate/20231016115055_create_cached_aggregations.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class CreateCachedAggregations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :cached_aggregations, id: :uuid do |t|
+      t.references :organization, type: :uuid, null: false, index: true
+
+      t.uuid :event_id, null: false, index: true
+      t.datetime :timestamp, null: false
+      t.string :external_subscription_id, null: false, index: true
+      t.references :charge, type: :uuid, null: false, index: true
+      t.references :group, type: :uuid, foreign_key: true, null: true, index: true
+
+      t.decimal :current_aggregation
+      t.decimal :max_aggregation
+      t.decimal :max_aggregation_with_proration
+
+      t.timestamps
+
+      t.index %i[organization_id timestamp charge_id], name: 'index_timestamp_lookup'
+      t.index %i[organization_id timestamp charge_id group_id], name: 'index_timestamp_group_lookup'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -120,6 +120,27 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_09_154934) do
     t.index ["organization_id"], name: "index_billable_metrics_on_organization_id"
   end
 
+  create_table "cached_aggregations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "organization_id", null: false
+    t.uuid "event_id", null: false
+    t.datetime "timestamp", null: false
+    t.string "external_subscription_id", null: false
+    t.uuid "charge_id", null: false
+    t.uuid "group_id"
+    t.decimal "current_aggregation"
+    t.decimal "max_aggregation"
+    t.decimal "max_aggregation_with_proration"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["charge_id"], name: "index_cached_aggregations_on_charge_id"
+    t.index ["event_id"], name: "index_cached_aggregations_on_event_id"
+    t.index ["external_subscription_id"], name: "index_cached_aggregations_on_external_subscription_id"
+    t.index ["group_id"], name: "index_cached_aggregations_on_group_id"
+    t.index ["organization_id", "timestamp", "charge_id", "group_id"], name: "index_timestamp_group_lookup"
+    t.index ["organization_id", "timestamp", "charge_id"], name: "index_timestamp_lookup"
+    t.index ["organization_id"], name: "index_cached_aggregations_on_organization_id"
+  end
+
   create_table "charges", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "billable_metric_id"
     t.datetime "created_at", null: false
@@ -824,6 +845,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_09_154934) do
   add_foreign_key "applied_add_ons", "add_ons"
   add_foreign_key "applied_add_ons", "customers"
   add_foreign_key "billable_metrics", "organizations"
+  add_foreign_key "cached_aggregations", "groups"
   add_foreign_key "charges", "billable_metrics"
   add_foreign_key "charges", "plans"
   add_foreign_key "charges_taxes", "charges"

--- a/spec/factories/cached_aggregations.rb
+++ b/spec/factories/cached_aggregations.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :cached_aggregation do
+    organization
+    charge
+    association :charge, factory: :standard_charge
+    event_id { SecureRandom.uuid }
+    external_subscription_id { SecureRandom.uuid }
+    timestamp { Time.current }
+  end
+end


### PR DESCRIPTION
## Context

## Context

On the path for high volume improvements, we need to adapt the structure of the events table for better performance.

## Description

This PR is the first step for https://github.com/getlago/lago-api/pull/1400
It creates the `CachedAggregation` model that will be used to move events cached metadata outside of the event table.