### PR TITLE
feat(event): Refact aggregator to scope on charge

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -153,7 +153,7 @@ class Invoice < ApplicationRecord
 
     service.new(
       event_store_class: Events::Stores::PostgresStore,
-      billable_metric: fee.charge.billable_metric,
+      charge: fee.charge,
       subscription: fee.subscription,
       group: fee.group,
       boundaries: {

--- a/app/services/billable_metrics/aggregation_factory.rb
+++ b/app/services/billable_metrics/aggregation_factory.rb
@@ -21,7 +21,7 @@ module BillableMetrics
 
       aggregator_class(charge, current_usage).new(
         event_store_class: event_store,
-        billable_metric: charge.billable_metric,
+        charge:,
         **attributes,
       )
     end

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -3,10 +3,10 @@
 module BillableMetrics
   module Aggregations
     class BaseService < ::BaseService
-      def initialize(event_store_class:, billable_metric:, subscription:, boundaries:, group: nil, event: nil) # rubocop:disable Metrics/ParameterLists
+      def initialize(event_store_class:, charge:, subscription:, boundaries:, group: nil, event: nil) # rubocop:disable Metrics/ParameterLists
         super(nil)
         @event_store_class = event_store_class
-        @billable_metric = billable_metric
+        @charge = charge
         @subscription = subscription
         @group = group
         @event = event
@@ -27,7 +27,9 @@ module BillableMetrics
 
       protected
 
-      attr_accessor :event_store_class, :billable_metric, :subscription, :group, :event, :boundaries
+      attr_accessor :event_store_class, :charge, :subscription, :group, :event, :boundaries
+
+      delegate :billable_metric, to: :charge
 
       delegate :customer, to: :subscription
 

--- a/spec/factories/cached_aggregations.rb
+++ b/spec/factories/cached_aggregations.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :cached_aggregation do
     organization
-    charge
     association :charge, factory: :standard_charge
     event_id { SecureRandom.uuid }
     external_subscription_id { SecureRandom.uuid }

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
   subject(:count_service) do
     described_class.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       event: pay_in_advance_event,
@@ -29,6 +29,13 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       :billable_metric,
       organization:,
       aggregation_type: 'count_agg',
+    )
+  end
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
     )
   end
 

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
   subject(:latest_service) do
     described_class.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       boundaries: {
@@ -29,6 +29,13 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
       organization:,
       aggregation_type: 'latest_agg',
       field_name: 'total_count',
+    )
+  end
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
     )
   end
 

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
   subject(:max_service) do
     described_class.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       boundaries: {
@@ -29,6 +29,13 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       organization:,
       aggregation_type: 'max_agg',
       field_name: 'total_count',
+    )
+  end
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
     )
   end
 

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
   subject(:recurring_service) do
     described_class.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       boundaries: {
@@ -39,6 +39,13 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       organization:,
       aggregation_type: 'recurring_count_agg',
       field_name: 'unique_id',
+    )
+  end
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
     )
   end
 

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
   subject(:sum_service) do
     described_class.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       event: pay_in_advance_event,
@@ -30,6 +30,13 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
       organization:,
       aggregation_type: 'sum_agg',
       field_name: 'total_count',
+    )
+  end
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
     )
   end
 

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
   subject(:count_service) do
     described_class.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       event: pay_in_advance_event,
@@ -42,6 +42,13 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       aggregation_type: 'unique_count_agg',
       field_name: 'unique_id',
       recurring: true,
+    )
+  end
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
     )
   end
 

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
   subject(:aggregator) do
     described_class.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       boundaries: {
@@ -25,6 +25,13 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
   let(:group) { nil }
 
   let(:billable_metric) { create(:weighted_sum_billable_metric, organization:) }
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
+    )
+  end
 
   let(:from_datetime) { Time.zone.parse('2023-08-01 00:00:00.000') }
   let(:to_datetime) { Time.zone.parse('2023-08-31 23:59:59.999') }

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
   subject(:service) do
     described_class.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       boundaries: {
@@ -40,6 +40,13 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
       aggregation_type: 'sum_agg',
       field_name: 'total_count',
       recurring: true,
+    )
+  end
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
     )
   end
 

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
   subject(:service) do
     described_class.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       boundaries: {
@@ -39,6 +39,13 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
       organization:,
       aggregation_type: 'unique_count_agg',
       field_name: 'unique_id',
+    )
+  end
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
     )
   end
 

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
   subject(:sum_service) do
     described_class.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       event: pay_in_advance_event,
@@ -31,6 +31,13 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       aggregation_type: 'sum_agg',
       field_name: 'total_count',
       recurring: true,
+    )
+  end
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
     )
   end
 

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
   subject(:unique_count_service) do
     described_class.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription:,
       group:,
       event: pay_in_advance_event,
@@ -43,6 +43,13 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
       aggregation_type: 'unique_count_agg',
       field_name: 'unique_id',
       recurring: true,
+    )
+  end
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
     )
   end
 

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService, type: :service do
   let(:aggregator) do
     BillableMetrics::Aggregations::CountService.new(
       event_store_class: Events::Stores::PostgresStore,
-      billable_metric: charge.billable_metric,
+      charge:,
       subscription: nil,
       boundaries: nil,
     )

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
     let(:aggregator) do
       BillableMetrics::Aggregations::SumService.new(
         event_store_class:,
-        billable_metric: nil,
+        charge: nil,
         subscription: nil,
         boundaries: nil,
       )

--- a/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Charges::ChargeModels::ProratedGraduatedService, type: :service d
   let(:aggregator) do
     BillableMetrics::ProratedAggregations::SumService.new(
       event_store_class:,
-      billable_metric:,
+      charge:,
       subscription: nil,
       boundaries: nil,
     )

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
         expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
           .with(
             event_store_class: Events::Stores::PostgresStore,
-            billable_metric:,
+            charge:,
             subscription:,
             group:,
             event:,
@@ -70,7 +70,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
         expect(BillableMetrics::Aggregations::SumService).to have_received(:new)
           .with(
             event_store_class: Events::Stores::PostgresStore,
-            billable_metric:,
+            charge:,
             subscription:,
             group:,
             event:,
@@ -100,7 +100,7 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
         expect(BillableMetrics::Aggregations::UniqueCountService).to have_received(:new)
           .with(
             event_store_class: Events::Stores::PostgresStore,
-            billable_metric:,
+            charge:,
             subscription:,
             group:,
             event:,


### PR DESCRIPTION
## Context

On the path for high volume improvements, we need to adapt the structure of the events table for better performance.

This PR follows https://github.com/getlago/lago-api/pull/1465 and is a preparation for https://github.com/getlago/lago-api/pull/1400

## Description

This PR changes the signature of aggregator, to use charge instead of billable_metric as argument. This charge will be used later to deal with cached aggregation.

The aggregation logic will keep relying on billable metric. It's done easily by using delegation: `delegate :billable_metric, to: :charge`
