### PR TITLE
feat(recurring-transactions-wallet-rules): handle interval transaction rule

### DIFF
--- a/app/jobs/clock/create_interval_wallet_transactions_job.rb
+++ b/app/jobs/clock/create_interval_wallet_transactions_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Clock
+  class CreateIntervalWalletTransactionsJob < ApplicationJob
+    queue_as 'clock'
+
+    def perform
+      Wallets::CreateIntervalWalletTransactionsService.call
+    end
+  end
+end

--- a/app/jobs/wallet_transactions/create_job.rb
+++ b/app/jobs/wallet_transactions/create_job.rb
@@ -4,12 +4,13 @@ module WalletTransactions
   class CreateJob < ApplicationJob
     queue_as 'wallets'
 
-    def perform(organization_id:, wallet_id:, paid_credits:, granted_credits:)
+    def perform(organization_id:, wallet_id:, paid_credits:, granted_credits:, source:)
       WalletTransactions::CreateService.new.create(
         organization_id:,
         wallet_id:,
         paid_credits:,
         granted_credits:,
+        source:,
       )
     end
   end

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -6,6 +6,7 @@ module WalletTransactions
       return result unless valid?(**args)
 
       wallet_transactions = []
+      @source = args[:source] || :manual
 
       if args[:paid_credits]
         transaction = handle_paid_credits(wallet: result.current_wallet, paid_credits: args[:paid_credits])
@@ -27,6 +28,8 @@ module WalletTransactions
 
     private
 
+    attr_reader :source
+
     def handle_paid_credits(wallet:, paid_credits:)
       paid_credits_amount = BigDecimal(paid_credits)
 
@@ -38,6 +41,7 @@ module WalletTransactions
         amount: wallet.rate_amount * paid_credits_amount,
         credit_amount: paid_credits_amount,
         status: :pending,
+        source:,
       )
 
       BillPaidCreditJob.perform_later(
@@ -61,6 +65,7 @@ module WalletTransactions
           credit_amount: granted_credits_amount,
           status: :settled,
           settled_at: Time.current,
+          source:,
         )
 
         Wallets::Balance::IncreaseService.new(

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+module Wallets
+  class CreateIntervalWalletTransactionsService < BaseService
+    def call
+      recurring_transaction_rules.each do |recurring_transaction_rule|
+        wallet = recurring_transaction_rule.wallet
+
+        WalletTransactions::CreateJob.perform_later(
+          organization_id: wallet.organization.id,
+          wallet_id: wallet.id,
+          paid_credits: recurring_transaction_rule.paid_credits,
+          granted_credits: recurring_transaction_rule.granted_credits,
+          source: :interval,
+        )
+      end
+    end
+
+    private
+
+    def today
+      @today ||= Time.current
+    end
+
+    # NOTE: Retrieve list of recurring_transaction_rules that should create wallet transactions today
+    def recurring_transaction_rules
+      sql = <<-SQL
+        WITH
+          pending_recurring_rules AS (
+            -- Anniversary rules
+            (#{weekly_anniversary})
+            UNION
+            (#{monthly_anniversary})
+            UNION
+            (#{quarterly_anniversary})
+            UNION
+            (#{yearly_anniversary})
+          ),
+          -- Filter wallets which rules are already applied today (in customer's applicable timezone)
+          already_applied_today AS (#{already_applied_today})
+
+        SELECT DISTINCT(recurring_transaction_rules.*)
+        FROM recurring_transaction_rules
+          INNER JOIN pending_recurring_rules ON pending_recurring_rules.rule_id = recurring_transaction_rules.id
+          INNER JOIN wallets ON wallets.id = recurring_transaction_rules.wallet_id
+          INNER JOIN customers ON customers.id = wallets.customer_id
+          INNER JOIN organizations ON organizations.id = customers.organization_id
+          LEFT JOIN already_applied_today ON already_applied_today.wallet_id = wallets.id
+        WHERE
+          -- Exclude top-ups already applied today
+          already_applied_today.top_up_count IS NULL
+          -- Do not take into account wallets that are created today
+          AND DATE(wallets.created_at#{at_time_zone}) != DATE(:today#{at_time_zone})
+        GROUP BY recurring_transaction_rules.id
+      SQL
+
+      RecurringTransactionRule.find_by_sql([sql, { today: }])
+    end
+
+    def base_recurring_transaction_rule_scope(interval: nil, conditions: nil)
+      <<-SQL
+        SELECT recurring_transaction_rules.id AS rule_id
+        FROM recurring_transaction_rules
+          INNER JOIN wallets ON wallets.id = recurring_transaction_rules.wallet_id
+          INNER JOIN customers ON customers.id = wallets.customer_id
+          INNER JOIN organizations ON organizations.id = customers.organization_id
+        WHERE wallets.status = #{Wallet.statuses[:active]}
+          AND recurring_transaction_rules.rule_type = #{RecurringTransactionRule.rule_types[:interval]}
+          AND recurring_transaction_rules.interval = #{RecurringTransactionRule.intervals[interval]}
+          AND #{conditions.join(' AND ')}
+        GROUP BY recurring_transaction_rules.id
+      SQL
+    end
+
+    def weekly_anniversary
+      base_recurring_transaction_rule_scope(
+        interval: :weekly,
+        conditions: [
+          "EXTRACT(ISODOW FROM (wallets.created_at#{at_time_zone})) =
+          EXTRACT(ISODOW FROM (:today#{at_time_zone}))",
+        ],
+      )
+    end
+
+    def monthly_anniversary
+      base_recurring_transaction_rule_scope(
+        interval: :monthly,
+        conditions: [<<-SQL],
+          DATE_PART('day', (wallets.created_at#{at_time_zone})) = ANY (
+            -- Check if today is the last day of the month
+            CASE WHEN DATE_PART('day', (#{end_of_month})) = DATE_PART('day', :today#{at_time_zone})
+            THEN
+              -- If so and if it counts less than 31 days, we need to take all days up to 31 into account
+              (SELECT ARRAY(SELECT generate_series(DATE_PART('day', :today#{at_time_zone})::integer, 31)))
+            ELSE
+              -- Otherwise, we just need the current day
+              (SELECT ARRAY[DATE_PART('day', :today#{at_time_zone})])
+            END
+          )
+        SQL
+      )
+    end
+
+    # NOTE: Billed quarterly on anniversary date
+    # rubocop:disable Layout/LineLength
+    def quarterly_anniversary
+      billing_day = <<-SQL
+        DATE_PART('day', (wallets.created_at#{at_time_zone})) = ANY (
+          -- Check if today is the last day of the month
+          CASE WHEN DATE_PART('day', (#{end_of_month})) = DATE_PART('day', :today#{at_time_zone})
+          THEN
+            -- If so and if it counts less than 31 days, we need to take all days up to 31 into account
+            (SELECT ARRAY(SELECT generate_series(DATE_PART('day', :today#{at_time_zone})::integer, 31)))
+          ELSE
+            -- Otherwise, we just need the current day
+            (SELECT ARRAY[DATE_PART('day', :today#{at_time_zone})])
+          END
+        )
+      SQL
+
+      billing_month = <<-SQL
+        (
+          -- We need to avoid zero and instead of it use 12. E.g.: (3 + 9) % 12 = 0 -> 12
+          CASE WHEN MOD(CAST(DATE_PART('month', (wallets.created_at#{at_time_zone})) AS INTEGER), 3) = 0
+          THEN
+            (DATE_PART('month', :today#{at_time_zone}) IN (3, 6, 9, 12))
+          ELSE (
+            DATE_PART('month', (wallets.created_at#{at_time_zone})) = DATE_PART('month', :today#{at_time_zone})
+              OR MOD(CAST(DATE_PART('month', (wallets.created_at#{at_time_zone})) + 3 AS INTEGER), 12) = DATE_PART('month', :today#{at_time_zone})
+              OR MOD(CAST(DATE_PART('month', (wallets.created_at#{at_time_zone})) + 6 AS INTEGER), 12) = DATE_PART('month', :today#{at_time_zone})
+              OR MOD(CAST(DATE_PART('month', (wallets.created_at#{at_time_zone})) + 9 AS INTEGER), 12) = DATE_PART('month', :today#{at_time_zone})
+          )
+          END
+        )
+      SQL
+
+      base_recurring_transaction_rule_scope(
+        interval: :quarterly,
+        conditions: [billing_month, billing_day],
+      )
+    end
+    # rubocop:enable Layout/LineLength
+
+    def yearly_anniversary
+      billing_month = <<-SQL
+        -- Ensure we are on the billing month
+        DATE_PART('month', (wallets.created_at#{at_time_zone})) = DATE_PART('month', :today#{at_time_zone})
+      SQL
+
+      billing_day = <<-SQL
+        -- Check if we are not in a leap year when today is february the 28th
+        DATE_PART('day', (wallets.created_at#{at_time_zone})) = ANY (
+          CASE WHEN (
+            DATE_PART('month', :today#{at_time_zone}) = 2
+            AND DATE_PART('day', :today#{at_time_zone}) = 28
+            AND DATE_PART('day', (#{end_of_month})) = 28
+          )
+          THEN
+            -- If not a leap year, we have to tale february the 29th into account
+            ARRAY[28, 29]
+          ELSE
+            -- Otherwise, we just need the current day
+            ARRAY[DATE_PART('day', :today#{at_time_zone})]
+          END
+        )
+      SQL
+
+      base_recurring_transaction_rule_scope(
+        interval: :yearly,
+        conditions: [billing_month, billing_day],
+      )
+    end
+
+    def at_time_zone(customer: 'customers', organization: 'organizations')
+      <<-SQL
+      ::timestamptz AT TIME ZONE COALESCE(#{customer}.timezone, #{organization}.timezone, 'UTC')
+      SQL
+    end
+
+    def end_of_month
+      <<-SQL
+        (DATE_TRUNC('month', :today#{at_time_zone}) + INTERVAL '1 month - 1 day')::date
+      SQL
+    end
+
+    def already_applied_today
+      <<-SQL
+        SELECT
+          wallet_transactions.wallet_id,
+          COUNT(wallet_transactions.id) AS top_up_count
+        FROM wallet_transactions
+          INNER JOIN wallets AS wal ON wallet_transactions.wallet_id = wal.id
+          INNER JOIN customers AS cus ON wal.customer_id = cus.id
+          INNER JOIN organizations AS org ON cus.organization_id = org.id
+        WHERE wallet_transactions.source = #{WalletTransaction.sources[:interval]}
+          AND wallet_transactions.transaction_type = #{WalletTransaction.transaction_types[:inbound]}
+          AND DATE(
+            (wallet_transactions.created_at)#{at_time_zone(customer: 'cus', organization: 'org')}
+          ) = DATE(:today#{at_time_zone(customer: 'cus', organization: 'org')})
+        GROUP BY wallet_transactions.wallet_id
+      SQL
+    end
+  end
+end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -31,6 +31,7 @@ module Wallets
         wallet_id: wallet.id,
         paid_credits: args[:paid_credits],
         granted_credits: args[:granted_credits],
+        source: :manual,
       )
 
       result

--- a/spec/jobs/clock/create_interval_wallet_transactions_job_spec.rb
+++ b/spec/jobs/clock/create_interval_wallet_transactions_job_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Clock::CreateIntervalWalletTransactionsJob, job: true do
+  subject(:interval_wallet_transactions_job) { described_class }
+
+  describe '.perform' do
+    before { allow(Wallets::CreateIntervalWalletTransactionsService).to receive(:call) }
+    it 'removes all old webhooks' do
+      interval_wallet_transactions_job.perform_now
+
+      expect(Wallets::CreateIntervalWalletTransactionsService).to have_received(:call)
+    end
+  end
+end

--- a/spec/jobs/clock/create_interval_wallet_transactions_job_spec.rb
+++ b/spec/jobs/clock/create_interval_wallet_transactions_job_spec.rb
@@ -7,6 +7,7 @@ describe Clock::CreateIntervalWalletTransactionsJob, job: true do
 
   describe '.perform' do
     before { allow(Wallets::CreateIntervalWalletTransactionsService).to receive(:call) }
+
     it 'removes all old webhooks' do
       interval_wallet_transactions_job.perform_now
 

--- a/spec/jobs/wallet_transactions/create_job_spec.rb
+++ b/spec/jobs/wallet_transactions/create_job_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe WalletTransactions::CreateJob, type: :job do
       wallet_id: '123456',
       paid_credits: '1.00',
       granted_credits: '1.00',
+      source: 'manual',
     )
 
     expect(wallet_transaction_create_service).to have_received(:create).with(
@@ -24,6 +25,7 @@ RSpec.describe WalletTransactions::CreateJob, type: :job do
       wallet_id: '123456',
       paid_credits: '1.00',
       granted_credits: '1.00',
+      source: 'manual',
     )
   end
 end

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -24,12 +24,24 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
         organization_id: organization.id,
         paid_credits:,
         granted_credits:,
+        source: :manual,
       }
     end
 
     it 'creates a wallet transactions' do
       expect { create_service.create(**create_args) }
         .to change(WalletTransaction, :count).by(2)
+    end
+
+    it 'sets correct source' do
+      create_service.create(**create_args)
+
+      wallet_transactions = WalletTransaction.where(wallet_id: wallet.id).order(created_at: :desc)
+
+      aggregate_failures do
+        expect(wallet_transactions[0].source.to_s).to eq('manual')
+        expect(wallet_transactions[1].source.to_s).to eq('manual')
+      end
     end
 
     it 'enqueues the BillPaidCreditJob' do

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -1,0 +1,268 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service do
+  subject(:create_interval_transactions_service) { described_class.new }
+
+  describe '.call' do
+    let(:wallet) { create(:wallet, customer:, created_at:) }
+    let(:created_at) { DateTime.parse('20 Feb 2021') }
+    let(:customer) { create(:customer) }
+
+    let(:recurring_transaction_rule) do
+      create(
+        :recurring_transaction_rule,
+        rule_type: :interval,
+        wallet:,
+        interval:,
+        created_at: created_at + 1.second,
+      )
+    end
+
+    before { recurring_transaction_rule }
+
+    context 'when recurring transactions should be created weekly' do
+      let(:interval) { :weekly }
+
+      let(:current_date) do
+        DateTime.parse('20 Jun 2022').prev_occurring(created_at.strftime('%A').downcase.to_sym)
+      end
+
+      it 'enqueues a job on correct day' do
+        travel_to(current_date) do
+          create_interval_transactions_service.call
+
+          expect(WalletTransactions::CreateJob).to have_been_enqueued
+            .with(
+              organization_id: customer.organization_id,
+              wallet_id: wallet.id,
+              paid_credits: recurring_transaction_rule.paid_credits,
+              granted_credits: recurring_transaction_rule.granted_credits,
+              source: :interval,
+            )
+        end
+      end
+
+      it 'does not enqueue a job on other day' do
+        travel_to(current_date + 1.day) do
+          expect { create_interval_transactions_service.call }.not_to have_enqueued_job
+        end
+      end
+    end
+
+    context 'when recurring transactions should be created monthly' do
+      let(:interval) { :monthly }
+      let(:current_date) { created_at.next_month }
+
+      it 'enqueues a job on correct day' do
+        travel_to(current_date) do
+          create_interval_transactions_service.call
+
+          expect(WalletTransactions::CreateJob).to have_been_enqueued
+            .with(
+              organization_id: customer.organization_id,
+              wallet_id: wallet.id,
+              paid_credits: recurring_transaction_rule.paid_credits,
+              granted_credits: recurring_transaction_rule.granted_credits,
+              source: :interval,
+            )
+        end
+      end
+
+      it 'does not enqueue a job on other day' do
+        travel_to(current_date + 1.day) do
+          expect { create_interval_transactions_service.call }.not_to have_enqueued_job
+        end
+      end
+
+      context 'when wallet is created on a 31st' do
+        let(:created_at) { DateTime.parse('31 Mar 2021') }
+        let(:current_date) { DateTime.parse('30 Apr 2021') }
+
+        it 'enqueues a job if the month count less than 31 days' do
+          travel_to(current_date) do
+            create_interval_transactions_service.call
+
+            expect(WalletTransactions::CreateJob).to have_been_enqueued
+              .with(
+                organization_id: customer.organization_id,
+                wallet_id: wallet.id,
+                paid_credits: recurring_transaction_rule.paid_credits,
+                granted_credits: recurring_transaction_rule.granted_credits,
+                source: :interval,
+              )
+          end
+        end
+      end
+    end
+
+    context 'when recurring transactions should be created quarterly' do
+      let(:interval) { :quarterly }
+      let(:current_date) { created_at + 3.months }
+
+      it 'enqueues a job on correct day' do
+        travel_to(current_date) do
+          create_interval_transactions_service.call
+
+          expect(WalletTransactions::CreateJob).to have_been_enqueued
+          .with(
+            organization_id: customer.organization_id,
+            wallet_id: wallet.id,
+            paid_credits: recurring_transaction_rule.paid_credits,
+            granted_credits: recurring_transaction_rule.granted_credits,
+            source: :interval,
+          )
+        end
+      end
+
+      it 'does not enqueue a job on other day' do
+        travel_to(current_date + 1.day) do
+          expect { create_interval_transactions_service.call }.not_to have_enqueued_job
+        end
+      end
+
+      context 'when it is March' do
+        let(:created_at) { DateTime.parse('15 Mar 2021') }
+        let(:current_date) { DateTime.parse('15 Sep 2022') }
+
+        it 'enqueues a job' do
+          travel_to(current_date) do
+            create_interval_transactions_service.call
+
+            expect(WalletTransactions::CreateJob).to have_been_enqueued
+              .with(
+                organization_id: customer.organization_id,
+                wallet_id: wallet.id,
+                paid_credits: recurring_transaction_rule.paid_credits,
+                granted_credits: recurring_transaction_rule.granted_credits,
+                source: :interval,
+              )
+          end
+        end
+      end
+
+      context 'when wallet is created on a 31st' do
+        let(:created_at) { DateTime.parse('31 Mar 2021') }
+        let(:current_date) { DateTime.parse('30 Jun 2022') }
+
+        it 'enqueues a job if the month count less than 31 days' do
+          travel_to(current_date) do
+            create_interval_transactions_service.call
+
+            expect(WalletTransactions::CreateJob).to have_been_enqueued
+              .with(
+                organization_id: customer.organization_id,
+                wallet_id: wallet.id,
+                paid_credits: recurring_transaction_rule.paid_credits,
+                granted_credits: recurring_transaction_rule.granted_credits,
+                source: :interval,
+              )
+          end
+        end
+      end
+    end
+
+    context 'when recurring transactions should be created yearly' do
+      let(:interval) { :yearly }
+      let(:current_date) { created_at.next_year }
+
+      it 'enqueues a job on correct day' do
+        travel_to(current_date) do
+          create_interval_transactions_service.call
+
+          expect(WalletTransactions::CreateJob).to have_been_enqueued
+            .with(
+              organization_id: customer.organization_id,
+              wallet_id: wallet.id,
+              paid_credits: recurring_transaction_rule.paid_credits,
+              granted_credits: recurring_transaction_rule.granted_credits,
+              source: :interval,
+            )
+        end
+      end
+
+      it 'does not enqueue a job on other day' do
+        travel_to(current_date + 1.day) do
+          expect { create_interval_transactions_service.call }.not_to have_enqueued_job
+        end
+      end
+
+      context 'when wallet is created on 29th of february' do
+        let(:created_at) { DateTime.parse('29 Feb 2020') }
+        let(:current_date) { DateTime.parse('28 Feb 2022') }
+
+        it 'enqueues a job on 28th of february when year is not a leap year' do
+          travel_to(current_date) do
+            create_interval_transactions_service.call
+
+            expect(WalletTransactions::CreateJob).to have_been_enqueued
+              .with(
+                organization_id: customer.organization_id,
+                wallet_id: wallet.id,
+                paid_credits: recurring_transaction_rule.paid_credits,
+                granted_credits: recurring_transaction_rule.granted_credits,
+                source: :interval,
+              )
+          end
+        end
+      end
+    end
+
+    context 'when on wallet creation day' do
+      let(:interval) { :monthly }
+      let(:customer) { create(:customer, timezone:) }
+      let(:timezone) { nil }
+
+      it 'does not enqueue a job' do
+        travel_to(created_at) do
+          expect { create_interval_transactions_service.call }.not_to have_enqueued_job
+        end
+      end
+
+      context 'with customer timezone' do
+        let(:timezone) { 'Pacific/Noumea' }
+
+        it 'does not enqueue a job' do
+          travel_to(created_at + 10.hours) do
+            expect { create_interval_transactions_service.call }.not_to have_enqueued_job
+          end
+        end
+      end
+    end
+
+    context 'when wallet transactions had already been created that day' do
+      let(:interval) { :monthly }
+      let(:current_date) { DateTime.parse('20 Mar 2021T12:00:00') }
+
+      let(:wallet_transaction) do
+        create(
+          :wallet_transaction,
+          wallet:,
+          transaction_type: :inbound,
+          source: :interval,
+          created_at: current_date - 1.hour,
+        )
+      end
+
+      before { wallet_transaction }
+
+      it 'does not enqueue a job' do
+        travel_to(current_date) do
+          expect { create_interval_transactions_service.call }.not_to have_enqueued_job
+        end
+      end
+
+      context 'with customer timezone' do
+        let(:customer) { create(:customer, timezone:) }
+        let(:timezone) { 'Pacific/Noumea' }
+
+        it 'does not enqueue a job' do
+          travel_to(current_date + 10.hours) do
+            expect { create_interval_transactions_service.call }.not_to have_enqueued_job
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -106,13 +106,13 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
           create_interval_transactions_service.call
 
           expect(WalletTransactions::CreateJob).to have_been_enqueued
-          .with(
-            organization_id: customer.organization_id,
-            wallet_id: wallet.id,
-            paid_credits: recurring_transaction_rule.paid_credits,
-            granted_credits: recurring_transaction_rule.granted_credits,
-            source: :interval,
-          )
+            .with(
+              organization_id: customer.organization_id,
+              wallet_id: wallet.id,
+              paid_credits: recurring_transaction_rule.paid_credits,
+              granted_credits: recurring_transaction_rule.granted_credits,
+              source: :interval,
+            )
         end
       end
 


### PR DESCRIPTION
## Context

Currently, wallet transactions (top-up) can be added in a manual way. With this feature we will enable automatic top-up based on interval or threshold rules

## Description

This PR adds support for automatic top-up based on wallet interval recurring rules