### PR TITLE
feat(unit-price): Compute amount details for percentage charge model

### DIFF
--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -39,6 +39,7 @@ module V1
         succeeded_at: model.succeeded_at&.iso8601,
         failed_at: model.failed_at&.iso8601,
         refunded_at: model.refunded_at&.iso8601,
+        amount_details: model.amount_details,
       }.merge(legacy_values)
 
       payload.merge!(date_boundaries) if model.charge? || model.subscription?

--- a/app/services/charges/charge_models/base_service.rb
+++ b/app/services/charges/charge_models/base_service.rb
@@ -21,6 +21,7 @@ module Charges
         result.count = aggregation_result.count
         result.amount = compute_amount
         result.unit_amount = unit_amount
+        result.amount_details = amount_details
 
         if aggregation_result.total_aggregated_units
           result.total_aggregated_units = aggregation_result.total_aggregated_units
@@ -43,6 +44,12 @@ module Charges
         # TODO: Uncomment this.
         # raise NotImplementedError
         0
+      end
+
+      def amount_details
+        # TODO: Uncomment this.
+        # raise NotImplementedError
+        {}
       end
     end
   end

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -13,6 +13,33 @@ module Charges
         compute_percentage_amount + compute_fixed_amount
       end
 
+      def amount_details
+        percentage_units = units - free_units_count
+        percentage_units = 0 if percentage_units.negative?
+        percentage_unit_amount = percentage_units.zero? ? 0 : compute_percentage_amount.fdiv(percentage_units)
+
+        {
+          unit_amounts: {
+            free_units_count:,
+            free_units_value:,
+            percentage_units:,
+            percentage_amount: compute_percentage_amount,
+            percentage_unit_amount:,
+            fixed_amount: compute_fixed_amount,
+            #fixed_units:,
+            #fixed_unit_amount:,
+            units:
+          }
+        }
+      end
+
+      def unit_amount
+        total_units = aggregation_result.full_units_number || units
+        return 0 if total_units.zero?
+
+        compute_amount / total_units
+      end
+
       def compute_percentage_amount
         return 0 if free_units_value > units
 

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -95,6 +95,7 @@ module Fees
         taxes_amount_cents: 0,
         unit_amount_cents:,
         precise_unit_amount: amount_result.unit_amount,
+        amount_details: amount_result.amount_details,
       )
 
       result.fees << new_fee

--- a/db/migrate/20231114092154_add_amount_details_to_fees.rb
+++ b/db/migrate/20231114092154_add_amount_details_to_fees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAmountDetailsToFees < ActiveRecord::Migration[7.0]
+  def change
+    add_column :fees, :amount_details, :jsonb, null: false, default: '{}'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -403,6 +403,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_123744) do
     t.string "invoice_display_name"
     t.decimal "total_aggregated_units"
     t.decimal "precise_unit_amount", precision: 30, scale: 15, default: "0.0", null: false
+    t.jsonb "amount_details", default: "{}", null: false
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"

--- a/spec/requests/api/v1/fees_spec.rb
+++ b/spec/requests/api/v1/fees_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe Api::V1::FeesController, type: :request do
           succeeded_at: fee.succeeded_at&.iso8601,
           failed_at: fee.failed_at&.iso8601,
           refunded_at: fee.refunded_at&.iso8601,
+          amount_details: fee.amount_details,
           applied_taxes: [],
         )
         expect(json[:fee][:item]).to include(

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe ::V1::FeeSerializer do
         'succeeded_at' => fee.succeeded_at&.iso8601,
         'failed_at' => fee.failed_at&.iso8601,
         'refunded_at' => fee.refunded_at&.iso8601,
+        'amount_details' => fee.amount_details,
       )
       expect(result['fee']['item']).to include(
         'type' => fee.fee_type,

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -49,15 +49,16 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
       expect(apply_percentage_service.unit_amount).to eq(0)
       expect(apply_percentage_service.amount_details).to eq(
         {
-          unit_amounts: {
-            free_units_count: 2,
-            free_units_value: 250,
-            percentage_units: 0,
-            percentage_amount: 0,
-            percentage_unit_amount: 0,
-            fixed_amount: 0,
-            units: 0,
-          },
+          units: 0,
+          free_units: 250,
+          paid_units: 0,
+          free_events: 2,
+          percentage_rate_unit_amount: 0,
+          percentage_rate_amount: 0,
+          paid_events: 2,
+          fixed_fee_unit_amount: 2,
+          fixed_fee_amount: 0,
+          min_max_adjustment_amount: 0,
         },
       )
     end
@@ -69,15 +70,16 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
       expect(apply_percentage_service.unit_amount).to eq(0.0139375) # 11.15 / 800
       expect(apply_percentage_service.amount_details).to eq(
         {
-          unit_amounts: {
-            free_units_count: 2,
-            free_units_value: 250,
-            percentage_units: 798,
-            percentage_amount: 7.15, # (800 - 250) * (1.3 / 100)
-            percentage_unit_amount: 0.008959899749373433,
-            fixed_amount: 4, # (4 - 2) * 2.0
-            units: 800,
-          },
+          units: 800,
+          free_units: 250,
+          paid_units: 550,
+          free_events: 2,
+          percentage_rate_unit_amount: 0.013,
+          percentage_rate_amount: 7.15, # (800 - 250) * (1.3 / 100),
+          paid_events: 2,
+          fixed_fee_unit_amount: 2,
+          fixed_fee_amount: 4, # (4 - 2) * 2.0
+          min_max_adjustment_amount: 0,
         },
       )
     end
@@ -95,17 +97,16 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
       expect(apply_percentage_service.unit_amount).to eq(0.01)
       expect(apply_percentage_service.amount_details).to eq(
         {
-          unit_amounts: {
-            free_units_count: 0,
-            free_units_value: 0,
-            percentage_units: 800,
-            percentage_amount: 0,
-            percentage_unit_amount: 0,
-            fixed_amount: 8,
-            #fixed_units: ,
-            #fixed_unit_amount: ,
-            units: 800,
-          },
+          units: 800,
+          free_units: 0,
+          paid_units: 800,
+          free_events: 0,
+          percentage_rate_unit_amount: 0,
+          percentage_rate_amount: 0,
+          paid_events: 4,
+          fixed_fee_unit_amount: 2,
+          fixed_fee_amount: 8,
+          min_max_adjustment_amount: 0,
         },
       )
     end
@@ -119,17 +120,16 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
       expect(apply_percentage_service.unit_amount).to eq(0.0139375)
       expect(apply_percentage_service.amount_details).to eq(
         {
-          unit_amounts: {
-            free_units_count: 2,
-            free_units_value: 250,
-            percentage_units: 798,
-            percentage_amount: 7.15,
-            percentage_unit_amount: 0.008959899749373433,
-            fixed_amount: 4,
-            #fixed_units: ,
-            #fixed_unit_amount: ,
-            units: 800,
-          },
+          units: 800,
+          free_units: 250,
+          paid_units: 550,
+          free_events: 2,
+          percentage_rate_unit_amount: 0.013,
+          percentage_rate_amount: 7.15,
+          paid_events: 2,
+          fixed_fee_unit_amount: 2,
+          fixed_fee_amount: 4,
+          min_max_adjustment_amount: 0,
         },
       )
     end
@@ -143,17 +143,16 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
       expect(apply_percentage_service.unit_amount).to eq(0.009)
       expect(apply_percentage_service.amount_details).to eq(
         {
-          unit_amounts: {
-            free_units_count: 3,
-            free_units_value: 400,
-            percentage_units: 797,
-            percentage_amount: 5.2, # (800 - 400) * (1.3 / 100)
-            percentage_unit_amount: 0.006524466750313676,
-            fixed_amount: 2, # (4 - 3) * 2.0
-            #fixed_units: ,
-            #fixed_unit_amount: ,
-            units: 800,
-          },
+          units: 800,
+          free_units: 400,
+          paid_units: 400,
+          free_events: 3,
+          percentage_rate_unit_amount: 0.013000000000000001,
+          percentage_rate_amount: 5.2, # (800 - 400) * (1.3 / 100)
+          paid_events: 1,
+          fixed_fee_unit_amount: 2,
+          fixed_fee_amount: 2, # (4 - 3) * 2.0
+          min_max_adjustment_amount: 0,
         },
       )
     end
@@ -169,17 +168,16 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
       expect(apply_percentage_service.unit_amount).to eq(0.023)
       expect(apply_percentage_service.amount_details).to eq(
         {
-          unit_amounts: {
-            free_units_count: 0,
-            free_units_value: 0,
-            percentage_units: 800,
-            percentage_amount: 10.4, # 800 * (1.3 / 100)
-            percentage_unit_amount: 0.013000000000000001,
-            fixed_amount: 8, # 4 * 2.0
-            #fixed_units: ,
-            #fixed_unit_amount: ,
-            units: 800,
-          },
+          units: 800,
+          free_units: 0,
+          paid_units: 800,
+          free_events: 0,
+          percentage_rate_unit_amount: 0.013000000000000001,
+          percentage_rate_amount: 10.4, # 800 * (1.3 / 100)
+          paid_events: 4,
+          fixed_fee_unit_amount: 2,
+          fixed_fee_amount: 8, # 4 * 2.0
+          min_max_adjustment_amount: 0,
         },
       )
     end
@@ -195,17 +193,16 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
       expect(apply_percentage_service.unit_amount).to eq(0.009)
       expect(apply_percentage_service.amount_details).to eq(
         {
-          unit_amounts: {
-            free_units_count: 3,
-            free_units_value: 400,
-            percentage_units: 797,
-            percentage_amount: 5.2, # (800 - 400) * (1.3 / 100)
-            percentage_unit_amount: 0.006524466750313676,
-            fixed_amount: 2, # (4 - 3) * 2.0
-            #fixed_units: ,
-            #fixed_unit_amount: ,
-            units: 800,
-          },
+          units: 800,
+          free_units: 400,
+          paid_units: 400,
+          free_events: 3,
+          percentage_rate_unit_amount: 0.013000000000000001,
+          percentage_rate_amount: 5.2, # (800 - 400) * (1.3 / 100)
+          paid_events: 1,
+          fixed_fee_unit_amount: 2,
+          fixed_fee_amount: 2, # (4 - 3) * 2.0
+          min_max_adjustment_amount: 0,
         },
       )
     end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe Fees::ChargeService do
             amount_cents: 5,
             amount_currency: 'EUR',
             units: 4.0,
-            unit_amount_cents: 1,
-            precise_unit_amount: 0.0125,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0.0,
             events_count: 4,
           )
         end
@@ -962,16 +962,16 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 3,
             units: 2,
-            unit_amount_cents: 1,
-            precise_unit_amount: 0.015,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0.0,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 4,
             units: 1,
-            unit_amount_cents: 4,
-            precise_unit_amount: 0.04,
+            unit_amount_cents: 0,
+            precise_unit_amount: 0.0,
           )
         end
       end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe Fees::ChargeService do
             amount_cents: 5,
             amount_currency: 'EUR',
             units: 4.0,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0.0,
+            unit_amount_cents: 1,
+            precise_unit_amount: 0.0125,
             events_count: 4,
           )
         end
@@ -843,24 +843,24 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 200 + 2 * 2,
             units: 2,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0,
+            unit_amount_cents: 102,
+            precise_unit_amount: 1.02,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 1 * 1,
             units: 1,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0,
+            unit_amount_cents: 1,
+            precise_unit_amount: 0.01,
           )
 
           expect(created_fees.third).to have_attributes(
             group: france,
             amount_cents: 100 + 5 * 1,
             units: 1,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0,
+            unit_amount_cents: 105,
+            precise_unit_amount: 1.05,
           )
         end
       end
@@ -962,16 +962,16 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 3,
             units: 2,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0,
+            unit_amount_cents: 1,
+            precise_unit_amount: 0.015,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 4,
             units: 1,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0,
+            unit_amount_cents: 4,
+            precise_unit_amount: 0.04,
           )
         end
       end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown](https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown)

## Context

Invoices are not compliant as we’re not displaying unit prices of item on them.

The goal is to be compliant by adding unit price on invoice payload and pdf.
- Subscription invoices
- Charge (pay in advance) invoices

## Description

The goal of this PR is to compute amount details for the percentage charge model.

Here is how it will be presented on the invoice:
<img width="648" alt="Screenshot 2023-11-16 at 09 54 30" src="https://github.com/getlago/lago-api/assets/226046/0177c34d-cc8a-453f-8b1b-7b7c5d7fc19a">

