### PR TITLE
fix(subscriptions): fix termination boundaries

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -296,6 +296,8 @@ module Invoices
       current_time = Time.zone.at(timestamp)
       current_time_in_timezone = Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone)
 
+      return boundaries if (current_time_in_timezone - 1.day) < subscription.started_at
+
       dates_service = Subscriptions::DatesService.new_instance(duplicate, current_time - 1.day, current_usage: true)
 
       return boundaries if current_time_in_timezone < dates_service.charges_to_datetime

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -284,8 +284,9 @@ module Invoices
 
     # This method calculates boundaries for terminated subscription. If termination is happening on billing date
     # new boundaries will be calculated only if there is no invoice subscription object for previous period.
-    # If subscription is happening on any other day method is returning nil and boundaries are calculated with existing
-    # algorithm
+    # Basically, we will bill regular subscription amount for previous period.
+    # If subscription is happening on any other day, method is returning boundaries only for the used dates in
+    # current period
     def termination_boundaries(subscription, boundaries)
       return boundaries unless subscription.terminated? && subscription.next_subscription.nil?
 
@@ -296,6 +297,8 @@ module Invoices
       current_time = Time.zone.at(timestamp)
       current_time_in_timezone = Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone)
 
+      # First we need to ensure that termination date is not started_at date. In that case boundaries are correct
+      # and we should bill only one day. If this is not the case we should proceed.
       return boundaries if (current_time_in_timezone - 1.day) < subscription.started_at
 
       dates_service = Subscriptions::DatesService.new_instance(duplicate, current_time - 1.day, current_usage: true)

--- a/spec/scenarios/subscriptions/terminate_ended_spec.rb
+++ b/spec/scenarios/subscriptions/terminate_ended_spec.rb
@@ -198,7 +198,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
           expect(subscription).to be_active
         end
 
-        Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidationss
+        Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
         WebhookEndpoint.destroy_all
 
         travel_to(creation_time + 5.hours) do
@@ -407,7 +407,7 @@ describe 'Subscriptions Termination Scenario', :scenarios, type: :request do
             expect(subscription).to be_active
           end
 
-          Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidationss
+          Organization.update_all(webhook_url: nil) # rubocop:disable Rails/SkipsModelValidations
           WebhookEndpoint.destroy_all
 
           travel_to(ending_at + 5.minutes) do


### PR DESCRIPTION
## Description

When anniversery period and when `terminated_at` is the same as `started_at`, termination boundaries haven't been calculated correctly.

This PR fixes this issue and adds scenario test for this case.
