### PR TITLE
feat(event): Link quantified events to organization

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -20,6 +20,7 @@ class Organization < ApplicationRecord
   has_many :credit_notes, through: :invoices
   has_many :fees, through: :subscriptions
   has_many :events
+  has_many :quantified_events
   has_many :coupons
   has_many :applied_coupons, through: :coupons
   has_many :add_ons

--- a/app/models/quantified_event.rb
+++ b/app/models/quantified_event.rb
@@ -7,7 +7,7 @@ class QuantifiedEvent < ApplicationRecord
 
   RECURRING_TOTAL_UNITS = 'total_aggregated_units'
 
-  belongs_to :customer
+  belongs_to :organization
   belongs_to :billable_metric
   belongs_to :group, optional: true
 

--- a/app/services/billable_metrics/aggregations/recurring_count_service.rb
+++ b/app/services/billable_metrics/aggregations/recurring_count_service.rb
@@ -60,9 +60,8 @@ module BillableMetrics
 
       def base_scope
         quantified_events = QuantifiedEvent
-          .joins(customer: :organization)
+          .where(organization_id: billable_metric.organization_id)
           .where(billable_metric_id: billable_metric.id)
-          .where(customer_id: subscription.customer_id)
           .where(external_subscription_id: subscription.external_id)
 
         return quantified_events unless group

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -144,9 +144,8 @@ module BillableMetrics
 
       def base_scope
         quantified_events = QuantifiedEvent
-          .joins(customer: :organization)
+          .where(organization_id: billable_metric.organization_id)
           .where(billable_metric_id: billable_metric.id)
-          .where(customer_id: subscription.customer_id)
 
         quantified_events = if billable_metric.recurring?
           quantified_events.where(external_subscription_id: subscription.external_id)

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -132,7 +132,7 @@ module BillableMetrics
 
         quantified_events = QuantifiedEvent
           .where(billable_metric_id: billable_metric.id)
-          .where(customer_id: subscription.customer_id)
+          .where(organization_id: billable_metric.organization_id)
           .where(external_subscription_id: subscription.external_id)
           .where(added_at: ...from_datetime)
           .order(added_at: :desc)

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -104,9 +104,8 @@ module BillableMetrics
 
       def base_scope
         quantified_events = QuantifiedEvent
-          .joins(customer: :organization)
           .where(billable_metric_id: billable_metric.id)
-          .where(customer_id: subscription.customer_id)
+          .where(organization_id: billable_metric.organization_id)
           .where(external_subscription_id: subscription.external_id)
 
         return quantified_events unless group

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -177,7 +177,7 @@ module Fees
 
       # NOTE: persist current recurring value for next period
       result.quantified_events << QuantifiedEvent.find_or_initialize_by(
-        customer_id: customer.id,
+        organization_id: billable_metric.organization_id,
         external_subscription_id: subscription.external_id,
         group_id: group&.id,
         billable_metric_id: billable_metric.id,

--- a/app/services/quantified_events/create_or_update_service.rb
+++ b/app/services/quantified_events/create_or_update_service.rb
@@ -32,7 +32,7 @@ module QuantifiedEvents
         organization_id: organization.id,
         billable_metric_id: matching_billable_metric.id,
         external_id: event.properties[matching_billable_metric.field_name],
-        external_subscription_id: subscription.external_id,
+        external_subscription_id: event.external_subscription_id,
       ).where(removed_at: nil).none?
     end
 
@@ -60,7 +60,7 @@ module QuantifiedEvents
         QuantifiedEvent.create!(
           organization_id: organization.id,
           billable_metric: matching_billable_metric,
-          external_subscription_id: subscription.external_id,
+          external_subscription_id: event.external_subscription_id,
           external_id: event.properties[matching_billable_metric.field_name],
           properties: event.properties,
           added_at: event.timestamp,
@@ -72,7 +72,7 @@ module QuantifiedEvents
       metric = QuantifiedEvent.find_by(
         organization_id: organization.id,
         billable_metric_id: matching_billable_metric.id,
-        external_subscription_id: subscription.external_id,
+        external_subscription_id: event.external_subscription_id,
         external_id: event.properties[matching_billable_metric.field_name],
         removed_at: nil,
       )
@@ -95,7 +95,7 @@ module QuantifiedEvents
         .find_by(
           organization_id: organization.id,
           billable_metric_id: matching_billable_metric.id,
-          external_subscription_id: subscription.external_id,
+          external_subscription_id: event.external_subscription_id,
           external_id: event.properties[matching_billable_metric.field_name],
         )
     end

--- a/app/services/quantified_events/create_or_update_service.rb
+++ b/app/services/quantified_events/create_or_update_service.rb
@@ -10,10 +10,10 @@ module QuantifiedEvents
 
     def call
       result.quantified_event = case event_operation_type
-                               when :add
-                                 add_metric
-                               when :remove
-                                 remove_metric
+                                when :add
+                                  add_metric
+                                when :remove
+                                  remove_metric
       end
 
       result
@@ -29,7 +29,7 @@ module QuantifiedEvents
 
       # NOTE: Ensure no active quantified metric exists with the same external id
       QuantifiedEvent.where(
-        customer_id: customer.id,
+        organization_id: organization.id,
         billable_metric_id: matching_billable_metric.id,
         external_id: event.properties[matching_billable_metric.field_name],
         external_subscription_id: subscription.external_id,
@@ -40,7 +40,7 @@ module QuantifiedEvents
 
     attr_accessor :event
 
-    delegate :customer, :subscription, :organization, to: :event
+    delegate :subscription, :organization, to: :event
 
     def event_operation_type
       operation_type = event.properties['operation_type']&.to_sym
@@ -58,7 +58,7 @@ module QuantifiedEvents
         quantified_removed_on_event_day
       else
         QuantifiedEvent.create!(
-          customer:,
+          organization_id: organization.id,
           billable_metric: matching_billable_metric,
           external_subscription_id: subscription.external_id,
           external_id: event.properties[matching_billable_metric.field_name],
@@ -70,7 +70,7 @@ module QuantifiedEvents
 
     def remove_metric
       metric = QuantifiedEvent.find_by(
-        customer_id: customer.id,
+        organization_id: organization.id,
         billable_metric_id: matching_billable_metric.id,
         external_subscription_id: subscription.external_id,
         external_id: event.properties[matching_billable_metric.field_name],
@@ -93,7 +93,7 @@ module QuantifiedEvents
       @quantified_removed_on_event_day ||= QuantifiedEvent
         .where('DATE(removed_at) = ?', event.timestamp.to_date)
         .find_by(
-          customer_id: customer.id,
+          organization_id: organization.id,
           billable_metric_id: matching_billable_metric.id,
           external_subscription_id: subscription.external_id,
           external_id: event.properties[matching_billable_metric.field_name],

--- a/app/services/quantified_events/validate_creation_service.rb
+++ b/app/services/quantified_events/validate_creation_service.rb
@@ -22,7 +22,7 @@ module QuantifiedEvents
 
     attr_accessor :subscription, :billable_metric
 
-    delegate :customer, to: :subscription
+    delegate :organization, to: :subscription
 
     def operation_type
       @operation_type ||= begin
@@ -45,7 +45,7 @@ module QuantifiedEvents
       return unless operation_type == :remove
 
       return if QuantifiedEvent.where(
-        customer_id: customer.id,
+        organization_id: organization.id,
         external_id:,
         external_subscription_id: subscription.external_id,
       ).where(removed_at: nil).exists?

--- a/db/migrate/20231117123744_add_organization_id_to_quantified_events.rb
+++ b/db/migrate/20231117123744_add_organization_id_to_quantified_events.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToQuantifiedEvents < ActiveRecord::Migration[7.0]
+  def up
+    add_reference :quantified_events, :organization, type: :uuid, null: true, index: true, foreign_key: true
+
+    execute <<-SQL
+      UPDATE quantified_events
+      SET organization_id = customers.organization_id
+      FROM customers
+      WHERE quantified_events.customer_id = customers.id
+    SQL
+
+    change_column_null :quantified_events, :organization_id, false
+    remove_column :quantified_events, :customer_id
+    add_index :quantified_events,
+              %i[organization_id external_subscription_id billable_metric_id],
+              name: 'index_search_quantified_events'
+  end
+
+  def down
+    add_reference :quantified_events, :customer, type: :uuid, null: true, index: true, foreign_key: true
+
+    execute <<-SQL
+      UPDATE quantified_events
+      SET customer_id = subscriptions.customer_id
+      FROM subscriptions
+        INNER JOIN customers ON customers.id = subscriptions.customer_id
+      WHERE quantified_events.external_subscription_id = subscriptions.external_id
+        AND customers.organization_id = quantified_events.organization_id
+    SQL
+
+    change_column_null :quantified_events, :customer_id, false
+    remove_column :quantified_events, :organization_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_09_154934) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_17_123744) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -674,7 +674,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_09_154934) do
   end
 
   create_table "quantified_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "customer_id", null: false
     t.string "external_subscription_id", null: false
     t.string "external_id"
     t.datetime "added_at", null: false
@@ -685,12 +684,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_09_154934) do
     t.jsonb "properties", default: {}, null: false
     t.datetime "deleted_at"
     t.uuid "group_id"
+    t.uuid "organization_id", null: false
     t.index ["billable_metric_id"], name: "index_quantified_events_on_billable_metric_id"
-    t.index ["customer_id", "external_subscription_id", "billable_metric_id"], name: "index_search_quantified_events"
-    t.index ["customer_id"], name: "index_quantified_events_on_customer_id"
     t.index ["deleted_at"], name: "index_quantified_events_on_deleted_at"
     t.index ["external_id"], name: "index_quantified_events_on_external_id"
     t.index ["group_id"], name: "index_quantified_events_on_group_id"
+    t.index ["organization_id", "external_subscription_id", "billable_metric_id"], name: "index_search_quantified_events"
+    t.index ["organization_id"], name: "index_quantified_events_on_organization_id"
   end
 
   create_table "recurring_transaction_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -900,8 +900,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_09_154934) do
   add_foreign_key "plans", "plans", column: "parent_id"
   add_foreign_key "plans_taxes", "plans"
   add_foreign_key "plans_taxes", "taxes"
-  add_foreign_key "quantified_events", "customers"
   add_foreign_key "quantified_events", "groups"
+  add_foreign_key "quantified_events", "organizations"
   add_foreign_key "recurring_transaction_rules", "wallets"
   add_foreign_key "refunds", "credit_notes"
   add_foreign_key "refunds", "payment_provider_customers"

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -22,19 +22,4 @@ namespace :events do
       event.update!(subscription_id: subscription.id)
     end
   end
-
-  desc 'Fill missing properties on persisted_events'
-  task fill_persisted_properties: :environment do
-    QuantifiedEvent.unscoped.find_each do |persisted_event|
-      event = Event.unscoped.where(
-        organization_id: persisted_event.billable_metric.organization_id,
-        customer_id: persisted_event.customer_id,
-      ).where(
-        "properties -> '#{persisted_event.billable_metric.field_name}' = ?",
-        persisted_event.external_id,
-      ).first
-
-      persisted_event.update!(properties: event.properties)
-    end
-  end
 end

--- a/spec/factories/quantified_events.rb
+++ b/spec/factories/quantified_events.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :quantified_event do
-    customer
+    organization { billable_metric.organization }
     billable_metric
 
     external_id { SecureRandom.uuid }

--- a/spec/scenarios/billable_metrics/weighted_sum_spec.rb
+++ b/spec/scenarios/billable_metrics/weighted_sum_spec.rb
@@ -45,7 +45,7 @@ describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request, tra
         Subscriptions::BillingService.new.call
         perform_all_enqueued_jobs
       end.to change { subscription.reload.invoices.count }.from(0).to(1)
-        .and change { customer.reload.quantified_events.count }.from(0).to(1)
+        .and change { organization.reload.quantified_events.count }.from(0).to(1)
     end
 
     invoice = subscription.invoices.first
@@ -90,7 +90,7 @@ describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request, tra
         Subscriptions::BillingService.new.call
         perform_all_enqueued_jobs
       end.to change { subscription.reload.invoices.count }.from(1).to(2)
-        .and change { customer.reload.quantified_events.count }.from(1).to(2)
+        .and change { organization.reload.quantified_events.count }.from(1).to(2)
     end
 
     invoice = subscription.invoices.order(:created_at).last

--- a/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/recurring_count_service_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
   let(:quantified_event) do
     create(
       :quantified_event,
-      customer:,
       added_at:,
       removed_at:,
       external_subscription_id: subscription.external_id,
@@ -432,7 +431,6 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
       before do
         create(
           :quantified_event,
-          customer:,
           added_at:,
           removed_at:,
           external_subscription_id: subscription.external_id,
@@ -445,7 +443,6 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
 
         create(
           :quantified_event,
-          customer:,
           added_at:,
           removed_at:,
           external_subscription_id: subscription.external_id,
@@ -458,7 +455,6 @@ RSpec.describe BillableMetrics::Aggregations::RecurringCountService, type: :serv
 
         create(
           :quantified_event,
-          customer:,
           added_at:,
           removed_at:,
           external_subscription_id: subscription.external_id,

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -70,7 +70,6 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
   let(:quantified_event) do
     create(
       :quantified_event,
-      customer:,
       added_at:,
       removed_at:,
       external_subscription_id: subscription.external_id,
@@ -87,7 +86,6 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       let(:new_quantified_event) do
         create(
           :quantified_event,
-          customer:,
           added_at: from_datetime + 10.days,
           removed_at:,
           external_subscription_id: subscription.external_id,
@@ -135,7 +133,6 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       let(:new_quantified_event) do
         create(
           :quantified_event,
-          customer:,
           added_at: from_datetime + 10.days,
           removed_at:,
           external_subscription_id: subscription.external_id,
@@ -295,7 +292,6 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       let(:previous_quantified_event) do
         create(
           :quantified_event,
-          customer:,
           added_at: from_datetime + 5.days,
           removed_at:,
           external_id: '000',
@@ -341,7 +337,6 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       let(:new_quantified_event) do
         create(
           :quantified_event,
-          customer:,
           added_at: from_datetime + 10.days,
           removed_at:,
           external_subscription_id: subscription.external_id,
@@ -402,7 +397,6 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         let(:previous_quantified_event) do
           create(
             :quantified_event,
-            customer:,
             added_at: from_datetime + 5.days,
             removed_at:,
             external_id: '000',
@@ -441,7 +435,6 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         let(:previous_quantified_event) do
           create(
             :quantified_event,
-            customer:,
             added_at: from_datetime + 5.days,
             removed_at:,
             external_id: '000',

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -123,7 +123,6 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
       create(
         :quantified_event,
         billable_metric:,
-        customer:,
         external_subscription_id: subscription.external_id,
         added_at: from_datetime - 1.day,
         properties: { QuantifiedEvent::RECURRING_TOTAL_UNITS => 1000 },

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
   let(:quantified_event) do
     create(
       :quantified_event,
-      customer:,
       added_at:,
       removed_at:,
       external_subscription_id: subscription.external_id,

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
   let(:quantified_event) do
     create(
       :quantified_event,
-      customer:,
       added_at:,
       removed_at:,
       external_subscription_id: subscription.external_id,
@@ -83,7 +82,6 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
         let(:new_quantified_event) do
           create(
             :quantified_event,
-            customer:,
             added_at: from_datetime + 10.days,
             removed_at:,
             external_subscription_id: subscription.external_id,
@@ -157,7 +155,6 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
         let(:quantified_event) do
           create(
             :quantified_event,
-            customer:,
             added_at:,
             removed_at:,
             external_subscription_id: subscription.external_id,
@@ -243,7 +240,6 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
       let(:new_quantified_event) do
         create(
           :quantified_event,
-          customer:,
           added_at: from_datetime + 10.days,
           removed_at:,
           external_subscription_id: subscription.external_id,
@@ -284,7 +280,6 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
       let(:previous_quantified_event) do
         create(
           :quantified_event,
-          customer:,
           added_at: from_datetime + 5.days,
           removed_at:,
           external_id: '000',
@@ -326,7 +321,6 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
       let(:new_quantified_event) do
         create(
           :quantified_event,
-          customer:,
           added_at: from_datetime + 10.days,
           removed_at:,
           external_subscription_id: subscription.external_id,
@@ -370,7 +364,6 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
         let(:previous_quantified_event) do
           create(
             :quantified_event,
-            customer:,
             added_at: from_datetime + 5.days,
             removed_at:,
             external_id: '000',
@@ -408,7 +401,6 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
         let(:previous_quantified_event) do
           create(
             :quantified_event,
-            customer:,
             added_at: from_datetime + 5.days,
             removed_at:,
             external_id: '000',
@@ -490,7 +482,6 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
       let(:quantified_event2) do
         create(
           :quantified_event,
-          customer:,
           added_at: from_datetime + 10.days,
           removed_at: nil,
           external_subscription_id: subscription.external_id,
@@ -500,7 +491,6 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
       let(:quantified_event3) do
         create(
           :quantified_event,
-          customer:,
           added_at: from_datetime + 20.days,
           removed_at: from_datetime + 20.days,
           external_subscription_id: subscription.external_id,

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -432,7 +432,6 @@ RSpec.describe Fees::ChargeService do
         let(:quantified_event1) do
           create(
             :quantified_event,
-            customer: subscription.customer,
             added_at: DateTime.parse('2022-03-16'),
             removed_at: nil,
             external_id: '12',
@@ -455,7 +454,6 @@ RSpec.describe Fees::ChargeService do
         let(:quantified_event2) do
           create(
             :quantified_event,
-            customer: subscription.customer,
             added_at: DateTime.parse('2022-03-16'),
             removed_at: nil,
             external_id: '10',
@@ -478,7 +476,6 @@ RSpec.describe Fees::ChargeService do
         let(:quantified_event3) do
           create(
             :quantified_event,
-            customer: subscription.customer,
             added_at: DateTime.parse('2022-03-16'),
             removed_at: nil,
             external_id: '5',
@@ -545,7 +542,6 @@ RSpec.describe Fees::ChargeService do
 
         create(
           :quantified_event,
-          customer: subscription.customer,
           billable_metric:,
           external_subscription_id: subscription.external_id,
           external_id: 'ext_11',
@@ -559,7 +555,6 @@ RSpec.describe Fees::ChargeService do
         )
         create(
           :quantified_event,
-          customer: subscription.customer,
           billable_metric:,
           external_subscription_id: subscription.external_id,
           external_id: 'ext_12',
@@ -573,7 +568,6 @@ RSpec.describe Fees::ChargeService do
         )
         create(
           :quantified_event,
-          customer: subscription.customer,
           billable_metric:,
           external_subscription_id: subscription.external_id,
           external_id: 'ext_13',
@@ -1265,7 +1259,7 @@ RSpec.describe Fees::ChargeService do
           expect(created_fee.payment_status).to eq('pending')
 
           expect(quantified_event.id).not_to be_nil
-          expect(quantified_event.customer_id).to eq(customer.id)
+          expect(quantified_event.organization).to eq(organization)
           expect(quantified_event.external_subscription_id).to eq(subscription.external_id)
           expect(quantified_event.external_id).to be_nil
           expect(quantified_event.group_id).to be_nil

--- a/spec/services/quantified_events/create_or_update_service_spec.rb
+++ b/spec/services/quantified_events/create_or_update_service_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
           expect(service_result).to be_success
 
           quantified_event = service_result.quantified_event
-          expect(quantified_event.customer).to eq(event.customer)
+          expect(quantified_event.organization).to eq(event.organization)
           expect(quantified_event.external_subscription_id).to eq(event.subscription.external_id)
           expect(quantified_event.external_id).to eq('ext_12345')
           expect(quantified_event.properties).to eq(event.properties)
@@ -59,7 +59,6 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
         let(:quantified_event) do
           create(
             :quantified_event,
-            customer: event.customer,
             billable_metric:,
             external_subscription_id: event.subscription.external_id,
             external_id: 'ext_12345',
@@ -97,7 +96,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
           expect(service_result).to be_success
 
           quantified_event = service_result.quantified_event
-          expect(quantified_event.customer).to eq(event.customer)
+          expect(quantified_event.organization).to eq(event.organization)
           expect(quantified_event.external_subscription_id).to eq(event.subscription.external_id)
           expect(quantified_event.external_id).to eq('ext_12345')
           expect(quantified_event.properties).to eq(event.properties)
@@ -110,7 +109,6 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
       let(:quantified_event) do
         create(
           :quantified_event,
-          customer: event.customer,
           billable_metric:,
           external_subscription_id: event.subscription.external_id,
           external_id: 'ext_12345',
@@ -136,7 +134,6 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
         before do
           create(
             :quantified_event,
-            customer: event.customer,
             billable_metric:,
             external_subscription_id: event.subscription.external_id,
             external_id: 'ext_12345',
@@ -183,7 +180,6 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
       before do
         create(
           :quantified_event,
-          customer: event.customer,
           billable_metric:,
           external_subscription_id: event.subscription.external_id,
           external_id: 'ext_12345',

--- a/spec/services/quantified_events/validate_creation_service_spec.rb
+++ b/spec/services/quantified_events/validate_creation_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe QuantifiedEvents::ValidateCreationService, type: :service do
   let(:result) { BaseService::Result.new }
   let(:subscription) { create(:subscription) }
   let(:customer) { subscription.customer }
+  let(:organization) { customer.organization }
 
   let(:billable_metric) do
     create(
@@ -93,7 +94,7 @@ RSpec.describe QuantifiedEvents::ValidateCreationService, type: :service do
       before do
         create(
           :quantified_event,
-          customer:,
+          organization:,
           external_id:,
           external_subscription_id: subscription.external_id,
         )
@@ -106,7 +107,7 @@ RSpec.describe QuantifiedEvents::ValidateCreationService, type: :service do
       before do
         create(
           :quantified_event,
-          customer:,
+          organization:,
           external_id:,
           external_subscription_id: subscription.external_id,
           removed_at: Time.current - 3.days,


### PR DESCRIPTION
## Context

Related to https://github.com/getlago/lago-api/pull/1436

On the path for high volume improvements, we need to remove the need for event post-processing and align aggregation logic between Clickhouse and Postgres event stores.

## Description

In order to use `subscriptions#external_id` only for events aggregation, we have to fix the relation on the `quantified_events` table as we cannot rely to `customer_id` anymore.

To fix the logic, this PR:
- Adds `quantified_events#organization_id` relation
- Drops `quantified_events#customer_id` relation
- Adapt the logic to stop relying on customer