### PR TITLE
fix(fees): handle subscription fee for downgrade case with anniversary interval

### DIFF
--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -84,7 +84,11 @@ module Fees
     # NOTE: Subscription has already been billed once and is not terminated
     #        or when it is payed in advance on an anniversary base
     def should_use_full_amount?
-      return true if plan.pay_in_advance? && subscription.anniversary?
+      # First condition covers case when plan is pay in advance and on anniversary base.
+      # This case is used for the first subscription invoice since following cases will cover recurring invoices.
+      # However, we should not bill full amount if subscription is downgraded since in that case, first invoice
+      # should be prorated (this part is covered with first_subscription_amount method).
+      return true if plan.pay_in_advance? && subscription.anniversary? && !subscription.previous_subscription_id
       return true if subscription.fees.subscription_kind.where('created_at < ?', invoice.created_at).exists?
       return true if subscription.started_in_past? && plan.pay_in_advance?
 

--- a/spec/scenarios/subscriptions/downgrade_spec.rb
+++ b/spec/scenarios/subscriptions/downgrade_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Subscription Downgrade Scenario', :scenarios, type: :request, transaction: false do
+  let(:organization) { create(:organization, webhook_url: false) }
+
+  let(:customer) { create(:customer, organization:) }
+
+  let(:monthly_plan) do
+    create(
+      :plan,
+      organization:,
+      interval: 'monthly',
+      amount_cents: 12_900,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:yearly_plan) do
+    create(
+      :plan,
+      organization:,
+      interval: 'yearly',
+      amount_cents: 118_800,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:subscription_at) { DateTime.new(2023, 7, 19, 12, 12) }
+
+  it 'downgrades and bill subscriptions' do
+    subscription = nil
+
+    # NOTE: Jul 19th: create the subscription
+    travel_to(subscription_at) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: monthly_plan.code,
+          billing_time: 'anniversary',
+          subscription_at: subscription_at.iso8601,
+        },
+      )
+
+      subscription = customer.subscriptions.first
+      expect(subscription).to be_active
+      expect(subscription.invoices.count).to eq(1)
+
+      invoice = subscription.invoices.last
+      expect(invoice.fees_amount_cents).to eq(monthly_plan.amount_cents)
+      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq('2023-07-19T00:00:00Z')
+      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq('2023-08-18T23:59:59Z')
+    end
+
+    # NOTE: August 19th: Bill subscription
+    travel_to(DateTime.new(2023, 8, 19, 12, 12)) do
+      Subscriptions::BillingService.call
+      expect { perform_all_enqueued_jobs }.to change { subscription.reload.invoices.count }
+
+      expect(subscription.invoices.count).to eq(2)
+
+      invoice = subscription.invoices.order(created_at: :asc).last
+      expect(invoice.fees_amount_cents).to eq(monthly_plan.amount_cents)
+      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq('2023-08-19T00:00:00Z')
+      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq('2023-09-18T23:59:59Z')
+      expect(invoice.invoice_subscriptions.first.charges_from_datetime.iso8601).to eq('2023-07-19T12:12:00Z')
+      expect(invoice.invoice_subscriptions.first.charges_to_datetime.iso8601).to eq('2023-08-18T23:59:59Z')
+    end
+
+    # NOTE: September 19th: Bill subscription
+    travel_to(DateTime.new(2023, 9, 19, 12, 12)) do
+      Subscriptions::BillingService.call
+      expect { perform_all_enqueued_jobs }.to change { subscription.reload.invoices.count }
+
+      expect(subscription.invoices.count).to eq(3)
+
+      invoice = subscription.invoices.order(created_at: :asc).last
+      expect(invoice.fees_amount_cents).to eq(monthly_plan.amount_cents)
+      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq('2023-09-19T00:00:00Z')
+      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq('2023-10-18T23:59:59Z')
+      expect(invoice.invoice_subscriptions.first.charges_from_datetime.iso8601).to eq('2023-08-19T00:00:00Z')
+      expect(invoice.invoice_subscriptions.first.charges_to_datetime.iso8601).to eq('2023-09-18T23:59:59Z')
+    end
+
+    # NOTE: October 19th: Bill subscription
+    travel_to(DateTime.new(2023, 10, 19, 12, 12)) do
+      Subscriptions::BillingService.call
+      expect { perform_all_enqueued_jobs }.to change { subscription.reload.invoices.count }
+
+      expect(subscription.invoices.count).to eq(4)
+
+      invoice = subscription.invoices.order(created_at: :asc).last
+      expect(invoice.fees_amount_cents).to eq(monthly_plan.amount_cents)
+      expect(invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq('2023-10-19T00:00:00Z')
+      expect(invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq('2023-11-18T23:59:59Z')
+      expect(invoice.invoice_subscriptions.first.charges_from_datetime.iso8601).to eq('2023-09-19T00:00:00Z')
+      expect(invoice.invoice_subscriptions.first.charges_to_datetime.iso8601).to eq('2023-10-18T23:59:59Z')
+    end
+
+    # NOTE: On November 9th: Downgrade to the yearly plan
+    travel_to(DateTime.new(2023, 11, 9, 0, 0)) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: yearly_plan.code,
+          billing_time: 'anniversary',
+        },
+      )
+
+      expect(subscription.reload).to be_active
+      expect(subscription.invoices.count).to eq(4)
+    end
+
+    # NOTE: November 19th: Bill subscription. Old subscription is terminated and pending one is activated
+    travel_to(DateTime.new(2023, 11, 19, 12, 12)) do
+      Subscriptions::BillingService.call
+      expect { perform_all_enqueued_jobs }.to change { subscription.reload.invoices.count }
+      expect(subscription.reload).to be_terminated
+      expect(subscription.invoices.count).to eq(5)
+
+      # Termination invoice. For in advance subscription without charges it should be equal to zero
+      invoice = subscription.invoices.order(created_at: :asc).last
+      expect(invoice.fees_amount_cents).to eq(0)
+
+      new_subscription = subscription.reload.next_subscription
+
+      expect(new_subscription.reload).to be_active
+      expect(new_subscription.invoices.count).to eq(1)
+
+      new_sub_invoice = new_subscription.invoices.order(created_at: :asc).last
+      # There are 243 days from new sub started_at until old subscription subscription_at. Also, 2024 is a leap year
+      expect(new_sub_invoice.fees_amount_cents).to eq((yearly_plan.amount_cents.fdiv(366) * 243).round)
+      expect(new_sub_invoice.invoice_subscriptions.first.from_datetime.iso8601).to eq('2023-11-19T00:00:00Z')
+      expect(new_sub_invoice.invoice_subscriptions.first.to_datetime.iso8601).to eq('2024-07-18T23:59:59Z')
+    end
+  end
+end


### PR DESCRIPTION
## Description

For the first `pay in advance` invoice for `downgraded` subscription we bill full value instead of prorated value. This is not noticed if plan is switched from monthly to monthly or weekly, but if we switch from monthly to yearly; invoice end_date would be equal to next year subscription_at and the number of days is less than one year, so we should not bill full period amount
