### PR TITLE
feat(unit-price): Compute amount details for volume charge model

### DIFF
--- a/app/services/charges/amount_details/range_graduated_service.rb
+++ b/app/services/charges/amount_details/range_graduated_service.rb
@@ -13,7 +13,7 @@ module Charges
         {
           from_value:,
           to_value:,
-          flat_amount:,
+          flat_unit_amount:,
           per_unit_amount:,
           units: BigDecimal(units).to_s,
           per_unit_total_amount:,
@@ -33,8 +33,8 @@ module Charges
         @to_value ||= range[:to_value]
       end
 
-      def flat_amount
-        @flat_amount ||= BigDecimal(range[:flat_amount])
+      def flat_unit_amount
+        @flat_unit_amount ||= BigDecimal(range[:flat_amount])
       end
 
       def per_unit_amount
@@ -46,7 +46,11 @@ module Charges
       end
 
       def total_with_flat_amount
-        @total_with_flat_amount ||= total_units.zero? ? per_unit_total_amount : per_unit_total_amount + flat_amount
+        @total_with_flat_amount ||= if total_units.zero?
+          per_unit_total_amount
+        else
+          per_unit_total_amount + flat_unit_amount
+        end
       end
 
       # NOTE: compute how many units to bill in the range

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -30,11 +30,11 @@ module Charges
           free_events:,
           paid_units:,
           rate_unit_amount:,
-          rate_amount: compute_percentage_amount,
+          rate_total_amount: compute_percentage_amount,
           paid_events:,
           fixed_fee_unit_amount: paid_events.positive? ? fixed_amount : 0,
-          fixed_fee_amount: compute_fixed_amount,
-          min_max_adjustment_amount:,
+          fixed_fee_total_amount: compute_fixed_amount,
+          min_max_adjustment_total_amount:,
         }
       end
 
@@ -175,7 +175,7 @@ module Charges
         amount
       end
 
-      def min_max_adjustment_amount
+      def min_max_adjustment_total_amount
         return 0 unless should_apply_min_max?
 
         compute_amount_with_transaction_min_max - compute_percentage_amount - compute_fixed_amount

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -16,7 +16,7 @@ module Charges
       def amount_details
         paid_units = units - free_units_value
         paid_units = 0 if paid_units.negative?
-        percentage_rate_unit_amount = paid_units.zero? ? 0 : compute_percentage_amount.fdiv(paid_units)
+        rate_unit_amount = paid_units.zero? ? 0 : compute_percentage_amount.fdiv(paid_units)
         free_events = if aggregation_result.count >= free_units_count
           free_units_count
         else
@@ -29,8 +29,8 @@ module Charges
           free_units: free_units_value,
           free_events:,
           paid_units:,
-          percentage_rate_unit_amount:,
-          percentage_rate_amount: compute_percentage_amount,
+          rate_unit_amount:,
+          rate_amount: compute_percentage_amount,
           paid_events:,
           fixed_fee_unit_amount: paid_events.positive? ? fixed_amount : 0,
           fixed_fee_amount: compute_fixed_amount,

--- a/app/services/charges/charge_models/volume_service.rb
+++ b/app/services/charges/charge_models/volume_service.rb
@@ -19,11 +19,19 @@ module Charges
       end
 
       def matching_range
-        number_of_units = (charge.prorated? && result.full_units_number) ? result.full_units_number : units
-
         @matching_range ||= ranges.find do |range|
           range[:from_value] <= number_of_units && (!range[:to_value] || number_of_units <= range[:to_value])
         end
+      end
+
+      def unit_amount
+        return 0 if number_of_units.zero?
+
+        compute_amount / number_of_units
+      end
+
+      def number_of_units
+        @number_of_units ||= (charge.prorated? && result.full_units_number) ? result.full_units_number : units
       end
     end
   end

--- a/app/services/charges/charge_models/volume_service.rb
+++ b/app/services/charges/charge_models/volume_service.rb
@@ -12,7 +12,7 @@ module Charges
       def compute_amount
         return 0 if units.zero?
 
-        per_unit_total_amount + flat_amount
+        per_unit_total_amount + flat_unit_amount
       end
 
       def unit_amount
@@ -22,17 +22,17 @@ module Charges
       end
 
       def amount_details
-        return { flat_amount: 0, per_unit_amount: 0, per_unit_total_amount: 0 } if number_of_units.zero?
+        return { flat_unit_amount: 0, per_unit_amount: 0, per_unit_total_amount: 0 } if number_of_units.zero?
 
         {
-          flat_amount:,
+          flat_unit_amount:,
           per_unit_amount:,
           per_unit_total_amount:,
         }
       end
 
-      def flat_amount
-        @flat_amount ||= BigDecimal(matching_range[:flat_amount])
+      def flat_unit_amount
+        @flat_unit_amount ||= BigDecimal(matching_range[:flat_amount])
       end
 
       def per_unit_amount

--- a/app/services/charges/charge_models/volume_service.rb
+++ b/app/services/charges/charge_models/volume_service.rb
@@ -36,11 +36,11 @@ module Charges
       end
 
       def per_unit_amount
-        @per_unit_amount ||= BigDecimal(matching_range[:per_unit_amount])
+        @per_unit_amount ||= per_unit_total_amount.fdiv(number_of_units)
       end
 
       def per_unit_total_amount
-        @per_unit_total_amount ||= units * per_unit_amount
+        @per_unit_total_amount ||= units * BigDecimal(matching_range[:per_unit_amount])
       end
 
       def matching_range

--- a/app/services/charges/charge_models/volume_service.rb
+++ b/app/services/charges/charge_models/volume_service.rb
@@ -12,22 +12,41 @@ module Charges
       def compute_amount
         return 0 if units.zero?
 
-        flat_amount = BigDecimal(matching_range[:flat_amount])
-        per_unit_amount = BigDecimal(matching_range[:per_unit_amount])
-
-        units * per_unit_amount + flat_amount
-      end
-
-      def matching_range
-        @matching_range ||= ranges.find do |range|
-          range[:from_value] <= number_of_units && (!range[:to_value] || number_of_units <= range[:to_value])
-        end
+        per_unit_total_amount + flat_amount
       end
 
       def unit_amount
         return 0 if number_of_units.zero?
 
         compute_amount / number_of_units
+      end
+
+      def amount_details
+        return { flat_amount: 0, per_unit_amount: 0, per_unit_total_amount: 0 } if number_of_units.zero?
+
+        {
+          flat_amount:,
+          per_unit_amount:,
+          per_unit_total_amount:,
+        }
+      end
+
+      def flat_amount
+        @flat_amount ||= BigDecimal(matching_range[:flat_amount])
+      end
+
+      def per_unit_amount
+        @per_unit_amount ||= BigDecimal(matching_range[:per_unit_amount])
+      end
+
+      def per_unit_total_amount
+        @per_unit_total_amount ||= units * per_unit_amount
+      end
+
+      def matching_range
+        @matching_range ||= ranges.find do |range|
+          range[:from_value] <= number_of_units && (!range[:to_value] || number_of_units <= range[:to_value])
+        end
       end
 
       def number_of_units

--- a/spec/services/charges/amount_details/range_graduated_service_spec.rb
+++ b/spec/services/charges/amount_details/range_graduated_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Charges::AmountDetails::RangeGraduatedService, type: :service do
       {
         from_value: 0,
         to_value: 10,
-        flat_amount: 2,
+        flat_unit_amount: 2,
         per_unit_amount: 10,
         units: '10.0',
         per_unit_total_amount: 100,
@@ -44,7 +44,7 @@ RSpec.describe Charges::AmountDetails::RangeGraduatedService, type: :service do
         {
           from_value: 11,
           to_value: 20,
-          flat_amount: 1,
+          flat_unit_amount: 1,
           per_unit_amount: 8,
           units: '5.0',
           per_unit_total_amount: 40,

--- a/spec/services/charges/charge_models/graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/graduated_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
         {
           graduated_ranges: [
             {
-              flat_amount: 2,
+              flat_unit_amount: 2,
               from_value: 0,
               to_value: 10,
               per_unit_total_amount: 0,
@@ -79,7 +79,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
         {
           graduated_ranges: [
             {
-              flat_amount: 2,
+              flat_unit_amount: 2,
               from_value: 0,
               to_value: 10,
               per_unit_total_amount: 10,
@@ -103,7 +103,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
         {
           graduated_ranges: [
             {
-              flat_amount: 2,
+              flat_unit_amount: 2,
               from_value: 0,
               to_value: 10,
               per_unit_total_amount: 100,
@@ -127,7 +127,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
         {
           graduated_ranges: [
             {
-              flat_amount: 2,
+              flat_unit_amount: 2,
               from_value: 0,
               to_value: 10,
               per_unit_total_amount: 100,
@@ -136,7 +136,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
               units: '10.0',
             },
             {
-              flat_amount: 3,
+              flat_unit_amount: 3,
               from_value: 11,
               to_value: 20,
               per_unit_total_amount: 5,
@@ -160,7 +160,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
         {
           graduated_ranges: [
             {
-              flat_amount: 2,
+              flat_unit_amount: 2,
               from_value: 0,
               to_value: 10,
               per_unit_total_amount: 100,
@@ -169,7 +169,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
               units: '10.0',
             },
             {
-              flat_amount: 3,
+              flat_unit_amount: 3,
               from_value: 11,
               to_value: 20,
               per_unit_total_amount: 10,
@@ -193,7 +193,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
         {
           graduated_ranges: [
             {
-              flat_amount: 2,
+              flat_unit_amount: 2,
               from_value: 0,
               to_value: 10,
               per_unit_total_amount: 100,
@@ -202,7 +202,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
               units: '10.0',
             },
             {
-              flat_amount: 3,
+              flat_unit_amount: 3,
               from_value: 11,
               to_value: 20,
               per_unit_total_amount: 50,
@@ -211,7 +211,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
               units: '10.0',
             },
             {
-              flat_amount: 3,
+              flat_unit_amount: 3,
               from_value: 21,
               to_value: nil,
               per_unit_total_amount: 5,

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -54,11 +54,11 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           paid_units: 0,
           free_events: 2,
           rate_unit_amount: 0,
-          rate_amount: 0,
+          rate_total_amount: 0,
           paid_events: 2,
           fixed_fee_unit_amount: 2,
-          fixed_fee_amount: 0,
-          min_max_adjustment_amount: 0,
+          fixed_fee_total_amount: 0,
+          min_max_adjustment_total_amount: 0,
         },
       )
     end
@@ -75,11 +75,11 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           paid_units: 550,
           free_events: 2,
           rate_unit_amount: 0.013,
-          rate_amount: 7.15, # (800 - 250) * (1.3 / 100),
+          rate_total_amount: 7.15, # (800 - 250) * (1.3 / 100),
           paid_events: 2,
           fixed_fee_unit_amount: 2,
-          fixed_fee_amount: 4, # (4 - 2) * 2.0
-          min_max_adjustment_amount: 0,
+          fixed_fee_total_amount: 4, # (4 - 2) * 2.0
+          min_max_adjustment_total_amount: 0,
         },
       )
     end
@@ -102,11 +102,11 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           paid_units: 800,
           free_events: 0,
           rate_unit_amount: 0,
-          rate_amount: 0,
+          rate_total_amount: 0,
           paid_events: 4,
           fixed_fee_unit_amount: 2,
-          fixed_fee_amount: 8,
-          min_max_adjustment_amount: 0,
+          fixed_fee_total_amount: 8,
+          min_max_adjustment_total_amount: 0,
         },
       )
     end
@@ -125,11 +125,11 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           paid_units: 550,
           free_events: 2,
           rate_unit_amount: 0.013,
-          rate_amount: 7.15,
+          rate_total_amount: 7.15,
           paid_events: 2,
           fixed_fee_unit_amount: 2,
-          fixed_fee_amount: 4,
-          min_max_adjustment_amount: 0,
+          fixed_fee_total_amount: 4,
+          min_max_adjustment_total_amount: 0,
         },
       )
     end
@@ -148,11 +148,11 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           paid_units: 400,
           free_events: 3,
           rate_unit_amount: 0.013000000000000001,
-          rate_amount: 5.2, # (800 - 400) * (1.3 / 100)
+          rate_total_amount: 5.2, # (800 - 400) * (1.3 / 100)
           paid_events: 1,
           fixed_fee_unit_amount: 2,
-          fixed_fee_amount: 2, # (4 - 3) * 2.0
-          min_max_adjustment_amount: 0,
+          fixed_fee_total_amount: 2, # (4 - 3) * 2.0
+          min_max_adjustment_total_amount: 0,
         },
       )
     end
@@ -173,11 +173,11 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           paid_units: 800,
           free_events: 0,
           rate_unit_amount: 0.013000000000000001,
-          rate_amount: 10.4, # 800 * (1.3 / 100)
+          rate_total_amount: 10.4, # 800 * (1.3 / 100)
           paid_events: 4,
           fixed_fee_unit_amount: 2,
-          fixed_fee_amount: 8, # 4 * 2.0
-          min_max_adjustment_amount: 0,
+          fixed_fee_total_amount: 8, # 4 * 2.0
+          min_max_adjustment_total_amount: 0,
         },
       )
     end
@@ -198,11 +198,11 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           paid_units: 400,
           free_events: 3,
           rate_unit_amount: 0.013000000000000001,
-          rate_amount: 5.2, # (800 - 400) * (1.3 / 100)
+          rate_total_amount: 5.2, # (800 - 400) * (1.3 / 100)
           paid_events: 1,
           fixed_fee_unit_amount: 2,
-          fixed_fee_amount: 2, # (4 - 3) * 2.0
-          min_max_adjustment_amount: 0,
+          fixed_fee_total_amount: 2, # (4 - 3) * 2.0
+          min_max_adjustment_total_amount: 0,
         },
       )
     end

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 250,
           paid_units: 0,
           free_events: 2,
-          percentage_rate_unit_amount: 0,
-          percentage_rate_amount: 0,
+          rate_unit_amount: 0,
+          rate_amount: 0,
           paid_events: 2,
           fixed_fee_unit_amount: 2,
           fixed_fee_amount: 0,
@@ -74,8 +74,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 250,
           paid_units: 550,
           free_events: 2,
-          percentage_rate_unit_amount: 0.013,
-          percentage_rate_amount: 7.15, # (800 - 250) * (1.3 / 100),
+          rate_unit_amount: 0.013,
+          rate_amount: 7.15, # (800 - 250) * (1.3 / 100),
           paid_events: 2,
           fixed_fee_unit_amount: 2,
           fixed_fee_amount: 4, # (4 - 2) * 2.0
@@ -101,8 +101,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 0,
           paid_units: 800,
           free_events: 0,
-          percentage_rate_unit_amount: 0,
-          percentage_rate_amount: 0,
+          rate_unit_amount: 0,
+          rate_amount: 0,
           paid_events: 4,
           fixed_fee_unit_amount: 2,
           fixed_fee_amount: 8,
@@ -124,8 +124,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 250,
           paid_units: 550,
           free_events: 2,
-          percentage_rate_unit_amount: 0.013,
-          percentage_rate_amount: 7.15,
+          rate_unit_amount: 0.013,
+          rate_amount: 7.15,
           paid_events: 2,
           fixed_fee_unit_amount: 2,
           fixed_fee_amount: 4,
@@ -147,8 +147,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 400,
           paid_units: 400,
           free_events: 3,
-          percentage_rate_unit_amount: 0.013000000000000001,
-          percentage_rate_amount: 5.2, # (800 - 400) * (1.3 / 100)
+          rate_unit_amount: 0.013000000000000001,
+          rate_amount: 5.2, # (800 - 400) * (1.3 / 100)
           paid_events: 1,
           fixed_fee_unit_amount: 2,
           fixed_fee_amount: 2, # (4 - 3) * 2.0
@@ -172,8 +172,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 0,
           paid_units: 800,
           free_events: 0,
-          percentage_rate_unit_amount: 0.013000000000000001,
-          percentage_rate_amount: 10.4, # 800 * (1.3 / 100)
+          rate_unit_amount: 0.013000000000000001,
+          rate_amount: 10.4, # 800 * (1.3 / 100)
           paid_events: 4,
           fixed_fee_unit_amount: 2,
           fixed_fee_amount: 8, # 4 * 2.0
@@ -197,8 +197,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 400,
           paid_units: 400,
           free_events: 3,
-          percentage_rate_unit_amount: 0.013000000000000001,
-          percentage_rate_amount: 5.2, # (800 - 400) * (1.3 / 100)
+          rate_unit_amount: 0.013000000000000001,
+          rate_amount: 5.2, # (800 - 400) * (1.3 / 100)
           paid_events: 1,
           fixed_fee_unit_amount: 2,
           fixed_fee_amount: 2, # (4 - 3) * 2.0

--- a/spec/services/charges/charge_models/volume_service_spec.rb
+++ b/spec/services/charges/charge_models/volume_service_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
       expect(apply_volume_service.amount_details).to eq(
         {
           flat_amount: 50,
-          per_unit_amount: 0.5,
+          per_unit_amount: 0.331,
           per_unit_total_amount: 99.3,
         }
       )

--- a/spec/services/charges/charge_models/volume_service_spec.rb
+++ b/spec/services/charges/charge_models/volume_service_spec.rb
@@ -36,7 +36,13 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
     it 'does not apply the flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(0)
       expect(apply_volume_service.unit_amount).to eq(0)
-      expect(apply_volume_service.amount_details).to eq({})
+      expect(apply_volume_service.amount_details).to eq(
+        {
+          flat_amount: 0,
+          per_unit_amount: 0,
+          per_unit_total_amount: 0,
+        }
+      )
     end
   end
 
@@ -46,7 +52,13 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
     it 'applies a unit amount for 1 and the flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(12)
       expect(apply_volume_service.unit_amount).to eq(12)
-      expect(apply_volume_service.amount_details).to eq({})
+      expect(apply_volume_service.amount_details).to eq(
+        {
+          flat_amount: 10,
+          per_unit_amount: 2,
+          per_unit_total_amount: 2,
+        }
+      )
     end
   end
 
@@ -56,7 +68,13 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
     it 'applies unit amount for the first range and the flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(210)
       expect(apply_volume_service.unit_amount).to eq(2.1)
-      expect(apply_volume_service.amount_details).to eq({})
+      expect(apply_volume_service.amount_details).to eq(
+        {
+          flat_amount: 10,
+          per_unit_amount: 2,
+          per_unit_total_amount: 200,
+        }
+      )
     end
   end
 
@@ -66,7 +84,13 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
     it 'applies unit amount the second range and no flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(101)
       expect(apply_volume_service.unit_amount).to eq(1)
-      expect(apply_volume_service.amount_details).to eq({})
+      expect(apply_volume_service.amount_details).to eq(
+        {
+          flat_amount: 0,
+          per_unit_amount: 1,
+          per_unit_total_amount: 101,
+        }
+      )
     end
   end
 
@@ -76,7 +100,13 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
     it 'applies unit amount the second range and no flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(200)
       expect(apply_volume_service.unit_amount).to eq(1)
-      expect(apply_volume_service.amount_details).to eq({})
+      expect(apply_volume_service.amount_details).to eq(
+        {
+          flat_amount: 0,
+          per_unit_amount: 1,
+          per_unit_total_amount: 200,
+        }
+      )
     end
   end
 
@@ -86,7 +116,13 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
     it 'applies unit amount the second range and no flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(200)
       expect(apply_volume_service.unit_amount.round(2)).to eq(0.67)
-      expect(apply_volume_service.amount_details).to eq({})
+      expect(apply_volume_service.amount_details).to eq(
+        {
+          flat_amount: 50,
+          per_unit_amount: 0.5,
+          per_unit_total_amount: 150,
+        }
+      )
     end
   end
 
@@ -102,7 +138,13 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
     it 'applies unit amount the third range', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(149.3)
       expect(apply_volume_service.unit_amount.round(2)).to eq(0.50)
-      expect(apply_volume_service.amount_details).to eq({})
+      expect(apply_volume_service.amount_details).to eq(
+        {
+          flat_amount: 50,
+          per_unit_amount: 0.5,
+          per_unit_total_amount: 99.3,
+        }
+      )
     end
   end
 end

--- a/spec/services/charges/charge_models/volume_service_spec.rb
+++ b/spec/services/charges/charge_models/volume_service_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
       expect(apply_volume_service.unit_amount).to eq(0)
       expect(apply_volume_service.amount_details).to eq(
         {
-          flat_amount: 0,
+          flat_unit_amount: 0,
           per_unit_amount: 0,
           per_unit_total_amount: 0,
-        }
+        },
       )
     end
   end
@@ -54,10 +54,10 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
       expect(apply_volume_service.unit_amount).to eq(12)
       expect(apply_volume_service.amount_details).to eq(
         {
-          flat_amount: 10,
+          flat_unit_amount: 10,
           per_unit_amount: 2,
           per_unit_total_amount: 2,
-        }
+        },
       )
     end
   end
@@ -70,10 +70,10 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
       expect(apply_volume_service.unit_amount).to eq(2.1)
       expect(apply_volume_service.amount_details).to eq(
         {
-          flat_amount: 10,
+          flat_unit_amount: 10,
           per_unit_amount: 2,
           per_unit_total_amount: 200,
-        }
+        },
       )
     end
   end
@@ -86,10 +86,10 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
       expect(apply_volume_service.unit_amount).to eq(1)
       expect(apply_volume_service.amount_details).to eq(
         {
-          flat_amount: 0,
+          flat_unit_amount: 0,
           per_unit_amount: 1,
           per_unit_total_amount: 101,
-        }
+        },
       )
     end
   end
@@ -102,10 +102,10 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
       expect(apply_volume_service.unit_amount).to eq(1)
       expect(apply_volume_service.amount_details).to eq(
         {
-          flat_amount: 0,
+          flat_unit_amount: 0,
           per_unit_amount: 1,
           per_unit_total_amount: 200,
-        }
+        },
       )
     end
   end
@@ -118,10 +118,10 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
       expect(apply_volume_service.unit_amount.round(2)).to eq(0.67)
       expect(apply_volume_service.amount_details).to eq(
         {
-          flat_amount: 50,
+          flat_unit_amount: 50,
           per_unit_amount: 0.5,
           per_unit_total_amount: 150,
-        }
+        },
       )
     end
   end
@@ -140,10 +140,10 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
       expect(apply_volume_service.unit_amount.round(2)).to eq(0.50)
       expect(apply_volume_service.amount_details).to eq(
         {
-          flat_amount: 50,
+          flat_unit_amount: 50,
           per_unit_amount: 0.331,
           per_unit_total_amount: 99.3,
-        }
+        },
       )
     end
   end

--- a/spec/services/charges/charge_models/volume_service_spec.rb
+++ b/spec/services/charges/charge_models/volume_service_spec.rb
@@ -33,48 +33,60 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
   context 'when aggregation is 0' do
     let(:aggregation) { 0 }
 
-    it 'does not apply the flat amount' do
+    it 'does not apply the flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(0)
+      expect(apply_volume_service.unit_amount).to eq(0)
+      expect(apply_volume_service.amount_details).to eq({})
     end
   end
 
   context 'when aggregation is 1' do
     let(:aggregation) { 1 }
 
-    it 'applies a unit amount for 1 and the flat amount' do
+    it 'applies a unit amount for 1 and the flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(12)
+      expect(apply_volume_service.unit_amount).to eq(12)
+      expect(apply_volume_service.amount_details).to eq({})
     end
   end
 
   context 'when aggregation is the limit of the first range' do
     let(:aggregation) { 100 }
 
-    it 'applies unit amount for the first range and the flat amount' do
+    it 'applies unit amount for the first range and the flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(210)
+      expect(apply_volume_service.unit_amount).to eq(2.1)
+      expect(apply_volume_service.amount_details).to eq({})
     end
   end
 
   context 'when aggregation is the lower limit of the second range' do
     let(:aggregation) { 101 }
 
-    it 'applies unit amount the second range and no flat amount' do
+    it 'applies unit amount the second range and no flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(101)
+      expect(apply_volume_service.unit_amount).to eq(1)
+      expect(apply_volume_service.amount_details).to eq({})
     end
   end
 
   context 'when aggregation is the uper limit of the second range' do
     let(:aggregation) { 200 }
 
-    it 'applies unit amount the second range and no flat amount' do
+    it 'applies unit amount the second range and no flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(200)
+      expect(apply_volume_service.unit_amount).to eq(1)
+      expect(apply_volume_service.amount_details).to eq({})
     end
   end
 
   context 'when aggregation is the above the lower limit of the last range' do
     let(:aggregation) { 300 }
 
-    it 'applies unit amount the second range and no flat amount' do
+    it 'applies unit amount the second range and no flat amount', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(200)
+      expect(apply_volume_service.unit_amount.round(2)).to eq(0.67)
+      expect(apply_volume_service.amount_details).to eq({})
     end
   end
 
@@ -87,8 +99,10 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
       aggregation_result.full_units_number = 300
     end
 
-    it 'applies unit amount the third range' do
+    it 'applies unit amount the third range', :aggregate_failures do
       expect(apply_volume_service.amount).to eq(149.3)
+      expect(apply_volume_service.unit_amount.round(2)).to eq(0.50)
+      expect(apply_volume_service.amount_details).to eq({})
     end
   end
 end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -1063,16 +1063,16 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 1400,
             units: 2,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0,
+            unit_amount_cents: 700,
+            precise_unit_amount: 7,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 1100,
             units: 1,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0,
+            unit_amount_cents: 1100,
+            precise_unit_amount: 11,
           )
         end
       end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown](https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown)

## Context

Invoices are not compliant as we’re not displaying unit prices of item on them.

The goal is to be compliant by adding unit price on invoice payload and pdf.
- Subscription invoices
- Charge (pay in advance) invoices

## Description

The goal of this PR is to compute amount details for the volume charge model.

Here is how it will be presented on the invoice:
<img width="647" alt="Screenshot 2023-11-20 at 22 27 48" src="https://github.com/getlago/lago-api/assets/226046/d27604ea-53ed-46e6-a451-c5ef6d017479">



