### PR TITLE
fix(invoice): Prevent duplication of invoice subscriptions

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -4,7 +4,7 @@ module Invoices
   class CalculateFeesService < BaseService
     def initialize(invoice:, subscriptions:, timestamp:, recurring: false, context: nil)
       @invoice = invoice
-      @subscriptions = subscriptions
+      @subscriptions = subscriptions.uniq(&:id)
       @timestamp = timestamp
 
       # NOTE: Billed automatically by the recurring billing process
@@ -114,11 +114,11 @@ module Invoices
         .where
         .not(pay_in_advance: true, billable_metric: { recurring: false })
         .each do |charge|
-        next if should_not_create_charge_fee?(charge, subscription)
+          next if should_not_create_charge_fee?(charge, subscription)
 
-        fee_result = Fees::ChargeService.new(invoice:, charge:, subscription:, boundaries:).create
-        fee_result.raise_if_error!
-      end
+          fee_result = Fees::ChargeService.new(invoice:, charge:, subscription:, boundaries:).create
+          fee_result.raise_if_error!
+        end
     end
 
     def should_not_create_charge_fee?(charge, subscription)

--- a/db/migrate/20231123095209_add_unique_index_on_invoice_subscriptions.rb
+++ b/db/migrate/20231123095209_add_unique_index_on_invoice_subscriptions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnInvoiceSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    add_index :invoice_subscriptions, %i[invoice_id subscription_id], unique: true, where: "created_at >= '2023-11-23'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_17_123744) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_23_095209) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -400,8 +400,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_123744) do
     t.bigint "unit_amount_cents", default: 0, null: false
     t.boolean "pay_in_advance", default: false, null: false
     t.decimal "precise_coupons_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
-    t.string "invoice_display_name"
     t.decimal "total_aggregated_units"
+    t.string "invoice_display_name"
     t.decimal "precise_unit_amount", precision: 30, scale: 15, default: "0.0", null: false
     t.jsonb "amount_details", default: "{}", null: false
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
@@ -493,6 +493,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_17_123744) do
     t.datetime "to_datetime"
     t.datetime "charges_from_datetime"
     t.datetime "charges_to_datetime"
+    t.index ["invoice_id", "subscription_id"], name: "index_invoice_subscriptions_on_invoice_id_and_subscription_id", unique: true, where: "(created_at >= '2023-11-23 00:00:00'::timestamp without time zone)"
     t.index ["invoice_id"], name: "index_invoice_subscriptions_on_invoice_id"
     t.index ["subscription_id", "charges_from_datetime", "charges_to_datetime"], name: "index_invoice_subscriptions_on_charges_from_and_to_datetime", unique: true, where: "((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE))"
     t.index ["subscription_id"], name: "index_invoice_subscriptions_on_subscription_id"


### PR DESCRIPTION
## Context

We recently end-up with the following bug:

```
The invoice subscription is duplicated, so the same information appears twice on the draft invoice, but the total amount is correct.

If we refresh the invoice, the duplicate invoice subscription disappears (tried with another invoice that had the same issue).
```

## Description

To prevent such a situation, we have to enforce:
- The database to make sure a subscription can only be attached once to an invoice (unity at invoice subscription level)
- That the `Invoices::CalculateFeesService` makes sure that each subscription is taken into account only one time
