### PR TITLE
feat(unit-price): Compute amount details for graduated percentage charge model

### DIFF
--- a/app/services/charges/amount_details/range_graduated_percentage_service.rb
+++ b/app/services/charges/amount_details/range_graduated_percentage_service.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Charges
+  module AmountDetails
+    class RangeGraduatedPercentageService < ::BaseService
+      def initialize(range:, total_units:)
+        super
+        @range = range
+        @total_units = total_units
+      end
+
+      def call
+        {
+          from_value:,
+          to_value:,
+          flat_unit_amount:,
+          per_unit_amount:,
+          units: BigDecimal(units).to_s,
+          per_unit_total_amount:,
+          total_with_flat_amount:,
+        }
+      end
+
+      protected
+
+      attr_reader :range, :total_units
+
+      def from_value
+        @from_value ||= range[:from_value]
+      end
+
+      def to_value
+        @to_value ||= range[:to_value]
+      end
+
+      def flat_unit_amount
+        @flat_unit_amount ||= units.zero? ? 0 : BigDecimal(range[:flat_amount])
+      end
+
+      def rate
+        @rate ||= BigDecimal(range[:rate])
+      end
+
+      def per_unit_amount
+        @per_unit_amount ||= units.zero? ? 0 : per_unit_total_amount.fdiv(units)
+      end
+
+      def per_unit_total_amount
+        @per_unit_total_amount ||= (units * rate).fdiv(100)
+      end
+
+      def total_with_flat_amount
+        @total_with_flat_amount ||= if total_units.zero?
+          per_unit_total_amount
+        else
+          per_unit_total_amount + flat_unit_amount
+        end
+      end
+
+      # NOTE: compute how many units to bill in the range
+      def units
+        # NOTE: total_units is higher than the to_value of the range
+        if to_value && total_units >= to_value
+          return to_value - (from_value.zero? ? 1 : from_value) + 1
+        end
+
+        return to_value - from_value if to_value && total_units >= to_value
+        return total_units if from_value.zero?
+
+        # NOTE: total_units is in the range
+        total_units - from_value + 1
+      end
+    end
+  end
+end

--- a/app/services/charges/amount_details/range_graduated_service.rb
+++ b/app/services/charges/amount_details/range_graduated_service.rb
@@ -34,11 +34,11 @@ module Charges
       end
 
       def flat_unit_amount
-        @flat_unit_amount ||= BigDecimal(range[:flat_amount])
+        @flat_unit_amount ||= units.zero? ? 0 : BigDecimal(range[:flat_amount])
       end
 
       def per_unit_amount
-        @per_unit_amount ||= BigDecimal(range[:per_unit_amount])
+        @per_unit_amount ||= units.zero? ? 0 : BigDecimal(range[:per_unit_amount])
       end
 
       def per_unit_total_amount

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -16,7 +16,7 @@ module Charges
       def amount_details
         paid_units = units - free_units_value
         paid_units = 0 if paid_units.negative?
-        rate_unit_amount = paid_units.zero? ? 0 : compute_percentage_amount.fdiv(paid_units)
+        per_unit_amount = paid_units.zero? ? 0 : compute_percentage_amount.fdiv(paid_units)
         free_events = if aggregation_result.count >= free_units_count
           free_units_count
         else
@@ -29,8 +29,8 @@ module Charges
           free_units: free_units_value,
           free_events:,
           paid_units:,
-          rate_unit_amount:,
-          rate_total_amount: compute_percentage_amount,
+          per_unit_amount:,
+          per_unit_total_amount: compute_percentage_amount,
           paid_events:,
           fixed_fee_unit_amount: paid_events.positive? ? fixed_amount : 0,
           fixed_fee_total_amount: compute_fixed_amount,

--- a/spec/services/charges/amount_details/range_graduated_percentage_service_spec.rb
+++ b/spec/services/charges/amount_details/range_graduated_percentage_service_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::AmountDetails::RangeGraduatedPercentageService, type: :service do
+  subject(:service) { described_class.new(range:, total_units:) }
+
+  let(:total_units) { 15 }
+  let(:range) do
+    {
+      from_value: 0,
+      to_value: 10,
+      rate: '2',
+      flat_amount: '2',
+    }
+  end
+
+  it 'returns expected amount details' do
+    expect(service.call).to eq(
+      {
+        from_value: 0,
+        to_value: 10,
+        flat_unit_amount: 2,
+        per_unit_amount: 0.02,
+        units: '10.0',
+        per_unit_total_amount: 0.2,
+        total_with_flat_amount: 2.2,
+      },
+    )
+  end
+
+  context 'when total units <= range to_value' do
+    let(:range) do
+      {
+        from_value: 11,
+        to_value: 20,
+        rate: '1',
+        flat_amount: '1',
+      }
+    end
+
+    it 'returns expected amount details' do
+      expect(service.call).to eq(
+        {
+          from_value: 11,
+          to_value: 20,
+          flat_unit_amount: 1,
+          per_unit_amount: 0.01,
+          units: '5.0',
+          per_unit_total_amount: 0.05,
+          total_with_flat_amount: 1.05,
+        },
+      )
+    end
+  end
+end

--- a/spec/services/charges/charge_models/graduated_percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/graduated_percentage_service_spec.rb
@@ -50,8 +50,24 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
     let(:aggregation) { 0 }
     let(:aggregation_count) { 0 }
 
-    it 'does not apply the flat amount' do
+    it 'does not apply the flat amount', :aggregate_failures do
       expect(apply_graduated_percentage_service.amount).to eq(0)
+      expect(apply_graduated_percentage_service.unit_amount).to eq(0)
+      expect(apply_graduated_percentage_service.amount_details).to eq(
+        {
+          graduated_percentage_ranges: [
+            {
+              flat_unit_amount: 0,
+              from_value: 0,
+              to_value: 10,
+              per_unit_total_amount: 0,
+              total_with_flat_amount: 0,
+              per_unit_amount: 0,
+              units: '0.0',
+            },
+          ],
+        },
+      )
     end
   end
 
@@ -59,9 +75,25 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
     let(:aggregation) { 1 }
     let(:aggregation_count) { 1 }
 
-    it 'applies a unit amount for 1 and the flat rate for 1' do
+    it 'applies a unit amount for 1 and the flat rate for 1', :aggregate_failures do
       # NOTE: 200 + 1 * 0.01
       expect(apply_graduated_percentage_service.amount).to eq(200.01)
+      expect(apply_graduated_percentage_service.unit_amount).to eq(200.01)
+      expect(apply_graduated_percentage_service.amount_details).to eq(
+        {
+          graduated_percentage_ranges: [
+            {
+              flat_unit_amount: 200,
+              from_value: 0,
+              to_value: 10,
+              per_unit_total_amount: 0.01,
+              total_with_flat_amount: 200.01,
+              per_unit_amount: 0.01,
+              units: '1.0',
+            },
+          ],
+        },
+      )
     end
   end
 
@@ -69,9 +101,25 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
     let(:aggregation) { 10 }
     let(:aggregation_count) { 1 }
 
-    it 'applies all unit amount up to the top bound' do
+    it 'applies all unit amount up to the top bound', :aggregate_failures do
       # NOTE: 200 + 10 * 0.01
       expect(apply_graduated_percentage_service.amount).to eq(200.1)
+      expect(apply_graduated_percentage_service.unit_amount).to eq(20.01)
+      expect(apply_graduated_percentage_service.amount_details).to eq(
+        {
+          graduated_percentage_ranges: [
+            {
+              flat_unit_amount: 200,
+              from_value: 0,
+              to_value: 10,
+              per_unit_total_amount: 0.1,
+              total_with_flat_amount: 200.1,
+              per_unit_amount: 0.01,
+              units: '10.0',
+            },
+          ],
+        },
+      )
     end
   end
 
@@ -79,9 +127,34 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
     let(:aggregation) { 11 }
     let(:aggregation_count) { 1 }
 
-    it 'applies next ranges flat amount' do
+    it 'applies next ranges flat amount', :aggregate_failures do
       # NOTE: 200 + 300 + 10 * 0.01 + 1 * 0.02
       expect(apply_graduated_percentage_service.amount).to eq(500.12)
+      expect(apply_graduated_percentage_service.unit_amount.round(2)).to eq(45.47)
+      expect(apply_graduated_percentage_service.amount_details).to eq(
+        {
+          graduated_percentage_ranges: [
+            {
+              flat_unit_amount: 200,
+              from_value: 0,
+              to_value: 10,
+              per_unit_total_amount: 0.1,
+              total_with_flat_amount: 200.1,
+              per_unit_amount: 0.01,
+              units: '10.0',
+            },
+            {
+              flat_unit_amount: 300,
+              from_value: 11,
+              to_value: 20,
+              per_unit_total_amount: 0.02,
+              total_with_flat_amount: 300.02,
+              per_unit_amount: 0.02,
+              units: '1.0',
+            },
+          ],
+        },
+      )
     end
   end
 
@@ -89,9 +162,34 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
     let(:aggregation) { 12 }
     let(:aggregation_count) { 1 }
 
-    it 'applies next ranges flat amount and range units amount' do
+    it 'applies next ranges flat amount and range units amount', :aggregate_failures do
       # NOTE: 200 + 300 + 10 * 0.01 + 2 * 0.02
       expect(apply_graduated_percentage_service.amount).to eq(500.14)
+      expect(apply_graduated_percentage_service.unit_amount.round(2)).to eq(41.68)
+      expect(apply_graduated_percentage_service.amount_details).to eq(
+        {
+          graduated_percentage_ranges: [
+            {
+              flat_unit_amount: 200,
+              from_value: 0,
+              to_value: 10,
+              per_unit_total_amount: 0.1,
+              total_with_flat_amount: 200.1,
+              per_unit_amount: 0.01,
+              units: '10.0',
+            },
+            {
+              flat_unit_amount: 300,
+              from_value: 11,
+              to_value: 20,
+              per_unit_total_amount: 0.04,
+              total_with_flat_amount: 300.04,
+              per_unit_amount: 0.02,
+              units: '2.0',
+            },
+          ],
+        },
+      )
     end
   end
 
@@ -99,9 +197,43 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
     let(:aggregation) { 21 }
     let(:aggregation_count) { 1 }
 
-    it 'applies last unit amount for more unit in last step' do
+    it 'applies last unit amount for more unit in last step', :aggregate_failures do
       # NOTE: 200 + 300 + 400 + 10 * 0.01 + 10 * 0.02 + 1 * 0.03
       expect(apply_graduated_percentage_service.amount).to eq(900.33)
+      expect(apply_graduated_percentage_service.unit_amount.round(2)).to eq(42.87)
+      expect(apply_graduated_percentage_service.amount_details).to eq(
+        {
+          graduated_percentage_ranges: [
+            {
+              flat_unit_amount: 200,
+              from_value: 0,
+              to_value: 10,
+              per_unit_total_amount: 0.1,
+              total_with_flat_amount: 200.1,
+              per_unit_amount: 0.01,
+              units: '10.0',
+            },
+            {
+              flat_unit_amount: 300,
+              from_value: 11,
+              to_value: 20,
+              per_unit_total_amount: 0.2,
+              total_with_flat_amount: 300.2,
+              per_unit_amount: 0.02,
+              units: '10.0',
+            },
+            {
+              flat_unit_amount: 400,
+              from_value: 21,
+              to_value: nil,
+              per_unit_total_amount: 0.03,
+              total_with_flat_amount: 400.03,
+              per_unit_amount: 0.03,
+              units: '1.0',
+            },
+          ],
+        },
+      )
     end
   end
 end

--- a/spec/services/charges/charge_models/graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/graduated_service_spec.rb
@@ -55,12 +55,12 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
         {
           graduated_ranges: [
             {
-              flat_unit_amount: 2,
+              flat_unit_amount: 0,
               from_value: 0,
               to_value: 10,
               per_unit_total_amount: 0,
               total_with_flat_amount: 0,
-              per_unit_amount: 10,
+              per_unit_amount: 0,
               units: '0.0',
             },
           ],

--- a/spec/services/charges/charge_models/percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/percentage_service_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 250,
           paid_units: 0,
           free_events: 2,
-          rate_unit_amount: 0,
-          rate_total_amount: 0,
+          per_unit_amount: 0,
+          per_unit_total_amount: 0,
           paid_events: 2,
           fixed_fee_unit_amount: 2,
           fixed_fee_total_amount: 0,
@@ -74,8 +74,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 250,
           paid_units: 550,
           free_events: 2,
-          rate_unit_amount: 0.013,
-          rate_total_amount: 7.15, # (800 - 250) * (1.3 / 100),
+          per_unit_amount: 0.013,
+          per_unit_total_amount: 7.15, # (800 - 250) * (1.3 / 100),
           paid_events: 2,
           fixed_fee_unit_amount: 2,
           fixed_fee_total_amount: 4, # (4 - 2) * 2.0
@@ -101,8 +101,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 0,
           paid_units: 800,
           free_events: 0,
-          rate_unit_amount: 0,
-          rate_total_amount: 0,
+          per_unit_amount: 0,
+          per_unit_total_amount: 0,
           paid_events: 4,
           fixed_fee_unit_amount: 2,
           fixed_fee_total_amount: 8,
@@ -124,8 +124,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 250,
           paid_units: 550,
           free_events: 2,
-          rate_unit_amount: 0.013,
-          rate_total_amount: 7.15,
+          per_unit_amount: 0.013,
+          per_unit_total_amount: 7.15,
           paid_events: 2,
           fixed_fee_unit_amount: 2,
           fixed_fee_total_amount: 4,
@@ -147,8 +147,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 400,
           paid_units: 400,
           free_events: 3,
-          rate_unit_amount: 0.013000000000000001,
-          rate_total_amount: 5.2, # (800 - 400) * (1.3 / 100)
+          per_unit_amount: 0.013000000000000001,
+          per_unit_total_amount: 5.2, # (800 - 400) * (1.3 / 100)
           paid_events: 1,
           fixed_fee_unit_amount: 2,
           fixed_fee_total_amount: 2, # (4 - 3) * 2.0
@@ -172,8 +172,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 0,
           paid_units: 800,
           free_events: 0,
-          rate_unit_amount: 0.013000000000000001,
-          rate_total_amount: 10.4, # 800 * (1.3 / 100)
+          per_unit_amount: 0.013000000000000001,
+          per_unit_total_amount: 10.4, # 800 * (1.3 / 100)
           paid_events: 4,
           fixed_fee_unit_amount: 2,
           fixed_fee_total_amount: 8, # 4 * 2.0
@@ -197,8 +197,8 @@ RSpec.describe Charges::ChargeModels::PercentageService, type: :service do
           free_units: 400,
           paid_units: 400,
           free_events: 3,
-          rate_unit_amount: 0.013000000000000001,
-          rate_total_amount: 5.2, # (800 - 400) * (1.3 / 100)
+          per_unit_amount: 0.013000000000000001,
+          per_unit_total_amount: 5.2, # (800 - 400) * (1.3 / 100)
           paid_events: 1,
           fixed_fee_unit_amount: 2,
           fixed_fee_total_amount: 2, # (4 - 3) * 2.0

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -1174,16 +1174,16 @@ RSpec.describe Fees::ChargeService do
             group: europe,
             amount_cents: 5, # 2 × 0.02 + 0.01
             units: 2,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0,
+            unit_amount_cents: 2,
+            precise_unit_amount: 0.025,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 4, # 1 × 0.03 + 0.01
             units: 1,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0,
+            unit_amount_cents: 4,
+            precise_unit_amount: 0.04,
           )
         end
       end


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown](https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown)

## Context

Invoices are not compliant as we’re not displaying unit prices of item on them.

The goal is to be compliant by adding unit price on invoice payload and pdf.
- Subscription invoices
- Charge (pay in advance) invoices

## Description

The goal of this PR is to compute amount details for the graduated percentage charge model.

Here is how it will be presented on the invoice:
<img width="746" alt="Screenshot 2023-11-24 at 10 13 27" src="https://github.com/getlago/lago-api/assets/226046/0884da35-df7d-477d-8a24-0b553082dfb9">

