### PR TITLE
fix(checkout-url): Fix when the checkout url should be generated

### DIFF
--- a/app/services/payment_provider_customers/adyen_service.rb
+++ b/app/services/payment_provider_customers/adyen_service.rb
@@ -38,7 +38,7 @@ module PaymentProviderCustomers
           checkout_url: result.checkout_url,
         )
       end
- 
+
       result
     rescue Adyen::AdyenError => e
       deliver_error_webhook(e)

--- a/app/services/payment_provider_customers/create_service.rb
+++ b/app/services/payment_provider_customers/create_service.rb
@@ -89,7 +89,10 @@ module PaymentProviderCustomers
     end
 
     def should_generate_checkout_url?
-      result.provider_customer.provider_customer_id? && result.provider_customer.sync_with_provider.blank?
+      !result.provider_customer.id_previously_changed?(from: nil) && # it was not created but updated
+        result.provider_customer.provider_customer_id_previously_changed? &&
+        result.provider_customer.provider_customer_id? &&
+        result.provider_customer.sync_with_provider.blank?
     end
   end
 end

--- a/spec/services/payment_provider_customers/create_service_spec.rb
+++ b/spec/services/payment_provider_customers/create_service_spec.rb
@@ -117,33 +117,36 @@ RSpec.describe PaymentProviderCustomers::CreateService, type: :service do
       context 'when sync with provider is blank' do
         let(:sync_with_provider) { nil }
 
-        context 'when customer type is stripe' do
-          let(:customer_class) { PaymentProviderCustomers::StripeCustomer }
-          let(:provider) { create(:stripe_provider, organization: customer.organization) }
-
-          it 'generates checkout url' do
-            create_or_update
-            expect(create_service).to have_received(:generate_checkout_url)
-          end
-
-          it 'does not create customer' do
-            create_or_update
-            expect(create_service).not_to have_received(:create_customer_on_provider_service)
-          end
-        end
-
         context 'when customer type is adyen' do
           let(:customer_class) { PaymentProviderCustomers::AdyenCustomer }
           let(:provider) { create(:adyen_provider, organization: customer.organization) }
 
-          it 'generates checkout url' do
-            create_or_update
-            expect(create_service).to have_received(:generate_checkout_url)
+          context 'when provider customer exists' do
+            before do
+              create(:adyen_customer, customer:, payment_provider_id: provider.id)
+            end
+
+            it 'generates checkout url' do
+              create_or_update
+              expect(create_service).to have_received(:generate_checkout_url)
+            end
+
+            it 'does not create customer' do
+              create_or_update
+              expect(create_service).not_to have_received(:create_customer_on_provider_service)
+            end
           end
 
-          it 'does not create customer' do
-            create_or_update
-            expect(create_service).not_to have_received(:create_customer_on_provider_service)
+          context 'when provider customer does not exist' do
+            it 'does not generate checkout url' do
+              create_or_update
+              expect(create_service).not_to have_received(:generate_checkout_url)
+            end
+
+            it 'does not create customer' do
+              create_or_update
+              expect(create_service).not_to have_received(:create_customer_on_provider_service)
+            end
           end
         end
 
@@ -151,14 +154,65 @@ RSpec.describe PaymentProviderCustomers::CreateService, type: :service do
           let(:customer_class) { PaymentProviderCustomers::GocardlessCustomer }
           let(:provider) { create(:gocardless_provider, organization: customer.organization) }
 
-          it 'generates checkout url' do
-            create_or_update
-            expect(create_service).to have_received(:generate_checkout_url)
+          context 'when provider customer exists' do
+            before do
+              create(:gocardless_customer, customer:, payment_provider_id: provider.id)
+            end
+
+            it 'generates checkout url' do
+              create_or_update
+              expect(create_service).to have_received(:generate_checkout_url)
+            end
+
+            it 'does not create customer' do
+              create_or_update
+              expect(create_service).not_to have_received(:create_customer_on_provider_service)
+            end
           end
 
-          it 'does not create customer' do
-            create_or_update
-            expect(create_service).not_to have_received(:create_customer_on_provider_service)
+          context 'when provider customer does not exist' do
+            it 'does not generate checkout url' do
+              create_or_update
+              expect(create_service).not_to have_received(:generate_checkout_url)
+            end
+
+            it 'does not create customer' do
+              create_or_update
+              expect(create_service).not_to have_received(:create_customer_on_provider_service)
+            end
+          end
+        end
+
+        context 'when customer type is stripe' do
+          let(:customer_class) { PaymentProviderCustomers::StripeCustomer }
+          let(:provider) { create(:stripe_provider, organization: customer.organization) }
+
+          context 'when provider customer exists' do
+            before do
+              create(:stripe_customer, customer:, payment_provider_id: provider.id)
+            end
+
+            it 'generates checkout url' do
+              create_or_update
+              expect(create_service).to have_received(:generate_checkout_url)
+            end
+
+            it 'does not create customer' do
+              create_or_update
+              expect(create_service).not_to have_received(:create_customer_on_provider_service)
+            end
+          end
+
+          context 'when provider customer does not exist' do
+            it 'does not generate checkout url' do
+              create_or_update
+              expect(create_service).not_to have_received(:generate_checkout_url)
+            end
+
+            it 'does not create customer' do
+              create_or_update
+              expect(create_service).not_to have_received(:create_customer_on_provider_service)
+            end
           end
         end
       end


### PR DESCRIPTION
## Context

Cannot link customers to existing Adyen shoppers

## Description

This PR fixes a bug when the checkout url is generated and the customer is linked to a payment provider customer.