### PR TITLE
feat(unit-price): Compute amount details for package charge model

### DIFF
--- a/app/services/charges/charge_models/package_service.rb
+++ b/app/services/charges/charge_models/package_service.rb
@@ -6,23 +6,46 @@ module Charges
       protected
 
       def compute_amount
-        # NOTE: exclude free units from the count
-        billed_units = units - free_units
-        return 0 if billed_units.negative?
+        return 0 if paid_units.negative?
 
         # NOTE: Check how many packages (groups of units) are consumed
         #       It's rounded up, because a group counts from its first unit
-        package_count = billed_units.fdiv(package_size).ceil
+        package_count = paid_units.fdiv(per_package_size).ceil
+        package_count * per_package_unit_amount
+      end
 
-        package_count * BigDecimal(properties['amount'])
+      def unit_amount
+        return 0 if paid_units <= 0
+
+        compute_amount / paid_units
+      end
+
+      def amount_details
+        return { free_units: 0, paid_units: 0, per_package_size: 0, per_package_unit_amount: 0 } if units.zero?
+        return { free_units:, paid_units: 0, per_package_size:, per_package_unit_amount: } if paid_units.negative?
+
+        {
+          free_units:,
+          paid_units:,
+          per_package_size:,
+          per_package_unit_amount:,
+        }
+      end
+
+      def paid_units
+        @paid_units ||= units - free_units
       end
 
       def free_units
-        properties['free_units'] || 0
+        @free_units ||= properties['free_units'] || 0
       end
 
-      def package_size
-        properties['package_size']
+      def per_package_size
+        @per_package_size ||= properties['package_size']
+      end
+
+      def per_package_unit_amount
+        @per_package_unit_amount ||= BigDecimal(properties['amount'])
       end
     end
   end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -724,16 +724,17 @@ RSpec.describe Fees::ChargeService do
           expect(created_fees.first).to have_attributes(
             group: europe,
             units: 2,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0,
+            amount_cents: 10_000,
+            unit_amount_cents: 10_000,
+            precise_unit_amount: 100,
           )
 
           expect(created_fees.second).to have_attributes(
             group: usa,
             amount_cents: 5000,
             units: 1,
-            unit_amount_cents: 0,
-            precise_unit_amount: 0,
+            unit_amount_cents: 5000,
+            precise_unit_amount: 50,
           )
 
           expect(created_fees.third).to have_attributes(


### PR DESCRIPTION
## Roadmap Task

👉  [https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown](https://getlago.canny.io/feature-requests/p/display-unit-price-fee-breakdown)

## Context

Invoices are not compliant as we’re not displaying unit prices of item on them.

The goal is to be compliant by adding unit price on invoice payload and pdf.
- Subscription invoices
- Charge (pay in advance) invoices

## Description

The goal of this PR is to compute amount details for the package charge model.

Here is how it will be presented on the invoice:
<img width="649" alt="Screenshot 2023-11-24 at 13 49 37" src="https://github.com/getlago/lago-api/assets/226046/84fa26af-b109-499b-8a2c-f5dee5c2cd1b">


