### PR TITLE
misc: Disable logs in test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,6 +10,9 @@ Rails.application.configure do
     'Cache-Control' => "public, max-age=#{1.hour.to_i}",
   }
 
+  config.logger = Logger.new(nil)
+  config.log_level = :fatal
+
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store


### PR DESCRIPTION
This PR uses a small trick to speed-up a bit the test suite. It redirects the logs to nowhere rather than to `logs/test.log` reducing the I/O, and keeps only the `fatal` logs