### PR TITLE
feat(invoice-numbering): Invoice numbering db changes

### DIFF
--- a/db/migrate/20231123105540_add_fields_for_new_document_numbering.rb
+++ b/db/migrate/20231123105540_add_fields_for_new_document_numbering.rb
@@ -18,7 +18,7 @@ class AddFieldsForNewDocumentNumbering < ActiveRecord::Migration[7.0]
 					WITH ordered_organization_invoices AS (
 				    SELECT
               invoices.id AS invoice_id,
-              ROW_NUMBER() OVER (PARTITION BY invoices.organization_id, DATE_PART('month', invoices.issuing_date) ORDER BY invoices.issuing_date ASC, invoices.created_at ASC) AS rn
+              ROW_NUMBER() OVER (PARTITION BY invoices.organization_id, DATE_PART('month', invoices.created_at) ORDER BY invoices.created_at ASC) AS rn
 				    FROM invoices
 					)
 

--- a/db/migrate/20231123105540_add_fields_for_new_document_numbering.rb
+++ b/db/migrate/20231123105540_add_fields_for_new_document_numbering.rb
@@ -1,0 +1,36 @@
+class AddFieldsForNewDocumentNumbering < ActiveRecord::Migration[7.0]
+  def change
+    change_table :organizations, bulk: true do |t|
+      t.integer :document_numbering, default: 0, null: false
+      t.string :document_number_prefix, null: true
+    end
+    add_column :invoices, :organization_sequential_id, :integer, null: false, default: 0
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE organizations
+          SET document_number_prefix = UPPER(CAST(SUBSTRING(name, 1, 3) AS VARCHAR)) || '-' || UPPER(CAST(RIGHT(id::TEXT, 4) AS VARCHAR))
+          WHERE document_number_prefix IS NULL;
+        SQL
+
+        execute <<-SQL
+					WITH ordered_organization_invoices AS (
+				    SELECT
+              invoices.id AS invoice_id,
+              ROW_NUMBER() OVER (PARTITION BY invoices.organization_id, DATE_PART('month', invoices.issuing_date) ORDER BY invoices.issuing_date ASC, invoices.created_at ASC) AS rn
+				    FROM invoices
+					)
+
+					UPDATE invoices
+					SET organization_sequential_id = ordered_organization_invoices.rn
+					FROM ordered_organization_invoices
+					WHERE invoices.organization_sequential_id = 0
+            AND ordered_organization_invoices.invoice_id = invoices.id;
+        SQL
+      end
+    end
+
+    change_column_null :organizations, :document_number_prefix, null: false
+  end
+end

--- a/db/migrate/20231123105540_add_fields_for_new_document_numbering.rb
+++ b/db/migrate/20231123105540_add_fields_for_new_document_numbering.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddFieldsForNewDocumentNumbering < ActiveRecord::Migration[7.0]
   def change
     change_table :organizations, bulk: true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_23_095209) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_23_105540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -528,6 +528,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_23_095209) do
     t.date "payment_due_date"
     t.integer "net_payment_term", default: 0, null: false
     t.datetime "voided_at"
+    t.integer "organization_sequential_id", default: 0, null: false
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"
@@ -588,6 +589,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_23_095209) do
     t.string "tax_identification_number"
     t.integer "net_payment_term", default: 0, null: false
     t.string "default_currency", default: "USD", null: false
+    t.integer "document_numbering", default: 0, null: false
+    t.string "document_number_prefix"
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"


### PR DESCRIPTION
## Context

Currently Lago does not provide solution for updating document numbers. Also, `per_customer` is the only approach in creating incremental numbers. With this feature, it will be allowed to update one part of document number. Also, it will be possible to choose between `per_customer` and `per_organization` numbering 

## Description

This PR adds needed DB fields and migration.
