### PR TITLE
fix(adyen): Fix shopper reference

### DIFF
--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -120,7 +120,7 @@ module Invoices
       def payment_method_params
         {
           merchantAccount: adyen_payment_provider.merchant_account,
-          shopperReference: customer.external_id,
+          shopperReference: customer.adyen_customer.provider_customer_id,
         }
       end
 
@@ -135,7 +135,7 @@ module Invoices
             type: 'scheme',
             storedPaymentMethodId: customer.adyen_customer.payment_method_id,
           },
-          shopperReference: customer.external_id,
+          shopperReference: customer.adyen_customer.provider_customer_id,
           merchantAccount: adyen_payment_provider.merchant_account,
           shopperInteraction: 'ContAuth',
           recurringProcessingModel: 'UnscheduledCardOnFile',

--- a/spec/services/invoices/payments/adyen_service_spec.rb
+++ b/spec/services/invoices/payments/adyen_service_spec.rb
@@ -243,6 +243,26 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
     end
   end
 
+  describe '#payment_method_params' do
+    subject(:payment_method_params) { adyen_service.__send__(:payment_method_params) }
+
+    let(:params) do
+      {
+        merchantAccount: adyen_payment_provider.merchant_account,
+        shopperReference: adyen_customer.provider_customer_id,
+      }
+    end
+
+    before do
+      adyen_payment_provider
+      adyen_customer
+    end
+
+    it 'returns payment method params' do
+      expect(payment_method_params).to eq(params)
+    end
+  end
+
   describe '.update_payment_status' do
     let(:payment) do
       create(


### PR DESCRIPTION
## Context

Cannot link customers to existing Adyen shoppers

## Description

This PR fixes a bug when the shopper reference was incorrectly set to an external id.