### PR TITLE
feat(taxes): Add EU VAT Taxe management field on Organizations

### DIFF
--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -45,6 +45,7 @@ module Types
         invoice_footer: object&.invoice_footer,
         invoice_grace_period: object&.invoice_grace_period,
         document_locale: object&.document_locale,
+        eu_tax_management: object&.eu_tax_management,
       }
     end
 

--- a/app/graphql/types/organizations/billing_configuration.rb
+++ b/app/graphql/types/organizations/billing_configuration.rb
@@ -6,6 +6,7 @@ module Types
       graphql_name 'OrganizationBillingConfiguration'
 
       field :document_locale, String
+      field :eu_tax_management, Boolean
       field :id, ID, null: false
       field :invoice_footer, String
       field :invoice_grace_period, Integer, null: false

--- a/app/graphql/types/organizations/billing_configuration_input.rb
+++ b/app/graphql/types/organizations/billing_configuration_input.rb
@@ -6,6 +6,7 @@ module Types
       graphql_name 'OrganizationBillingConfigurationInput'
 
       argument :document_locale, String, required: false
+      argument :eu_tax_management, Boolean, required: false
       argument :invoice_footer, String, required: false
       argument :invoice_grace_period, Integer, required: false
     end

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -32,6 +32,9 @@ module Organizations
       # NOTE(legacy): keep accepting vat_rate field temporary by converting it into tax rate
       handle_legacy_vat_rate(billing[:vat_rate]) if billing.key?(:vat_rate)
 
+      # NOTE: handle eu tax management for organization
+      handle_eu_tax_management(billing[:eu_tax_management]) if billing.key?(:eu_tax_management)
+
       if params.key?(:webhook_url)
         webhook_endpoint = organization.webhook_endpoints.first_or_initialize
         webhook_endpoint.update!(webhook_url: params[:webhook_url])
@@ -112,6 +115,10 @@ module Organizations
         name: "Tax (#{vat_rate}%)",
         applied_to_organization: true,
       ).find_or_create_by!(code: "tax_#{vat_rate}")
+    end
+
+    def handle_eu_tax_management(eu_tax_management)
+      organization.eu_tax_management = eu_tax_management
     end
   end
 end

--- a/db/migrate/20231129145100_add_eu_tax_management_to_organizations.rb
+++ b/db/migrate/20231129145100_add_eu_tax_management_to_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEuTaxManagementToOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :eu_tax_management, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_28_092231) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_29_145100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -588,6 +588,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_28_092231) do
     t.string "tax_identification_number"
     t.integer "net_payment_term", default: 0, null: false
     t.string "default_currency", default: "USD", null: false
+    t.boolean "eu_tax_management", default: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"
@@ -817,7 +818,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_28_092231) do
     t.string "webhook_url", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "signature_algo", default: 0, null: false
+    t.integer "signature", default: 0
     t.index ["organization_id"], name: "index_webhook_endpoints_on_organization_id"
     t.index ["webhook_url", "organization_id"], name: "index_webhook_endpoints_on_webhook_url_and_organization_id", unique: true
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4061,6 +4061,7 @@ type Organization {
 
 type OrganizationBillingConfiguration {
   documentLocale: String
+  euTaxManagement: Boolean
   id: ID!
   invoiceFooter: String
   invoiceGracePeriod: Int!
@@ -4069,6 +4070,7 @@ type OrganizationBillingConfiguration {
 
 input OrganizationBillingConfigurationInput {
   documentLocale: String
+  euTaxManagement: Boolean
   invoiceFooter: String
   invoiceGracePeriod: Int
 }

--- a/schema.json
+++ b/schema.json
@@ -17527,6 +17527,20 @@
               ]
             },
             {
+              "name": "euTaxManagement",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -17612,6 +17626,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "euTaxManagement",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -23,7 +23,12 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           timezone
           emailSettings
           webhookUrl
-          billingConfiguration { invoiceFooter, invoiceGracePeriod, documentLocale }
+          billingConfiguration {
+            invoiceFooter,
+            invoiceGracePeriod,
+            documentLocale,
+            euTaxManagement,
+          }
         }
       }
     GQL
@@ -52,6 +57,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           billingConfiguration: {
             invoiceFooter: 'invoice footer',
             documentLocale: 'fr',
+            euTaxManagement: true,
           },
         },
       },
@@ -76,6 +82,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
       expect(result_data['billingConfiguration']['invoiceFooter']).to eq('invoice footer')
       expect(result_data['billingConfiguration']['invoiceGracePeriod']).to eq(0)
       expect(result_data['billingConfiguration']['documentLocale']).to eq('fr')
+      expect(result_data['billingConfiguration']['euTaxManagement']).to be_truthy
       expect(result_data['timezone']).to eq('TZ_UTC')
     end
   end

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Organizations::UpdateService do
         invoice_footer: 'invoice footer',
         document_locale: 'fr',
         invoice_grace_period:,
+        eu_tax_management: true,
       },
     }
   end
@@ -57,6 +58,7 @@ RSpec.describe Organizations::UpdateService do
 
         expect(result.organization.invoice_footer).to eq('invoice footer')
         expect(result.organization.document_locale).to eq('fr')
+        expect(result.organization.eu_tax_management).to be_truthy
       end
     end
 


### PR DESCRIPTION
## Context

- Part 1 of the EU VAT auto management
- We want to support VAT autodetection for european organizations.

## Description

- Add the `eu_tax_management` field on `organizations`
