### PR TITLE
fix(fee): expose charges boundaries in serializer when charge fee

### DIFF
--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -22,8 +22,8 @@ module V1
           lago_item_id: model.item_id,
           item_type: model.item_type,
         },
-        pay_in_advance: pay_in_advance,
-        invoiceable: invoiceable,
+        pay_in_advance:,
+        invoiceable:,
         amount_cents: model.amount_cents,
         amount_currency: model.amount_currency,
         taxes_amount_cents: model.taxes_amount_cents,
@@ -59,11 +59,13 @@ module V1
     end
 
     def from_date
-      model.properties['from_datetime']&.to_datetime&.iso8601
+      property = model.charge? ? 'charges_from_datetime' : 'from_datetime'
+      model.properties[property]&.to_datetime&.iso8601
     end
 
     def to_date
-      model.properties['to_datetime']&.to_datetime&.iso8601
+      property = model.charge? ? 'charges_to_datetime' : 'to_datetime'
+      model.properties[property]&.to_datetime&.iso8601
     end
 
     def pay_in_advance_charge_attributes

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe ::V1::FeeSerializer do
         :charge_fee,
         charge:,
         properties: {
-          from_datetime: Time.current,
-          to_datetime: Time.current,
+          charges_from_datetime: Time.current,
+          charges_to_datetime: Time.current,
         },
       )
     end


### PR DESCRIPTION
## Context

The `V1::FeeSerializer` exposes `from_date` and `to_date` attributes.
Today this attribute uses the `from|to_datetime` property store in the `fee#properties` field.
This behavior is okay if the fee is a subscription fee as these attributes are the subscription boundaries, but does not always work for charge fees if the charge and subscription period are not in sync.

## Description

This PR fixes the behavior by exposing the `charges_from|to_datetime` when the fee is a charge fee
