### PR TITLE
misc: Add LAGO_SIDEKIQ_MAX_DEAD_JOBS env var

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -16,7 +16,7 @@ Sidekiq.configure_server do |config|
   config.redis = redis_config
   config.logger = Rails.logger
   config[:max_retries] = 0
-  config[:dead_max_jobs] = 100_000
+  config[:dead_max_jobs] = ENV.fetch('LAGO_SIDEKIQ_MAX_DEAD_JOBS', 100_000).to_i
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
Add ability to configure the length of the sidekiq dead job queue using `LAGO_SIDEKIQ_MAX_DEAD_JOBS` 
