### PR TITLE
Add unique key of webhook message to header

### DIFF
--- a/app/services/webhooks/base_service.rb
+++ b/app/services/webhooks/base_service.rb
@@ -61,7 +61,7 @@ module Webhooks
 
     def send_webhook(webhook, webhook_endpoint, payload)
       http_client = LagoHttpClient::Client.new(webhook_endpoint.webhook_url)
-      headers = generate_headers(webhook_endpoint, payload)
+      headers = generate_headers(webhook.id, webhook_endpoint, payload)
       response = http_client.post_with_response(payload, headers)
 
       succeed_webhook(webhook, response)
@@ -75,7 +75,7 @@ module Webhooks
         .perform_later(webhook_type, object, options, webhook.id)
     end
 
-    def generate_headers(webhook_endpoint, payload)
+    def generate_headers(webhook_id, webhook_endpoint, payload)
       signature = case webhook_endpoint.signature_algo&.to_sym
                   when :jwt
                     jwt_signature(payload)
@@ -86,6 +86,7 @@ module Webhooks
       {
         'X-Lago-Signature' => signature,
         'X-Lago-Signature-Algorithm' => webhook_endpoint.signature_algo.to_s,
+        'X-Lago-Unique-Key' => webhook_id,
       }
     end
 

--- a/app/services/webhooks/base_service.rb
+++ b/app/services/webhooks/base_service.rb
@@ -119,6 +119,7 @@ module Webhooks
       webhook.payload = payload.to_json
       webhook.retries += 1 if webhook.failed?
       webhook.last_retried_at = Time.zone.now if webhook.retries.positive?
+      webhook.pending!
       webhook
     end
 

--- a/spec/services/webhooks/base_service_spec.rb
+++ b/spec/services/webhooks/base_service_spec.rb
@@ -209,11 +209,14 @@ RSpec.describe Webhooks::BaseService, type: :service do
     end
 
     it 'generates the query headers' do
-      headers = webhook_service.__send__(:generate_headers, webhook_endpoint, payload)
+      dummy_webhook_id = '895b41d0-474f-4a1f-a911-2df2d74dbe67'
+      headers = webhook_service.__send__(:generate_headers, dummy_webhook_id, webhook_endpoint, payload)
 
       expect(headers).to have_key('X-Lago-Signature')
       expect(headers).to have_key('X-Lago-Signature-Algorithm')
+      expect(headers).to have_key('X-Lago-Unique-Key')
       expect(headers['X-Lago-Signature-Algorithm']).to eq('jwt')
+      expect(headers['X-Lago-Unique-Key']).to eq(dummy_webhook_id)
     end
   end
 


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/developer-experience/p/add-unique-id-of-webhook-message-to-header

## Context

For diagnostic reasons, it useful to have the unique key of the webhook be included in the request as a header.

## Description

Added the header to the request.
