### PR TITLE
fix: reduce lock scope for sequence_id generation

### DIFF
--- a/app/models/concerns/sequenced.rb
+++ b/app/models/concerns/sequenced.rb
@@ -18,7 +18,7 @@ module Sequenced
 
     def generate_sequential_id
       result = self.class.with_advisory_lock(
-        "#{self.class.name.underscore}_lock",
+        lock_key_value,
         transaction: true,
         timeout_seconds: 10.seconds,
       ) do
@@ -41,11 +41,16 @@ module Sequenced
     def sequence_scope
       self.class.class_exec(self, &self.class.sequenced_options[:scope])
     end
+
+    def lock_key_value
+      "#{self.class.class_exec(self, &self.class.sequenced_lock_key) || self.class.name.underscore}_lock"
+    end
   end
 
   class_methods do
-    def sequenced(scope:)
+    def sequenced(scope:, lock_key: nil)
       self.sequenced_options = { scope: }
+      self.sequenced_lock_key = lock_key
     end
 
     def sequenced_options=(options)
@@ -54,6 +59,14 @@ module Sequenced
 
     def sequenced_options
       @sequenced_options
+    end
+
+    def sequenced_lock_key=(lock_key)
+      @sequenced_lock_key = lock_key
+    end
+
+    def sequenced_lock_key
+      @sequenced_lock_key
     end
   end
 

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -51,7 +51,8 @@ class CreditNote < ApplicationRecord
   enum reason: REASON
   enum status: STATUS
 
-  sequenced scope: ->(credit_note) { CreditNote.where(invoice_id: credit_note.invoice_id) }
+  sequenced scope: ->(credit_note) { CreditNote.where(invoice_id: credit_note.invoice_id) },
+            lock_key: ->(credit_note) { credit_note.invoice_id }
 
   validates :total_amount_cents, numericality: { greater_than_or_equal_to: 0 }
   validates :credit_amount_cents, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -39,7 +39,8 @@ class Customer < ApplicationRecord
   PAYMENT_PROVIDERS = %w[stripe gocardless adyen].freeze
 
   default_scope -> { kept }
-  sequenced scope: ->(customer) { customer.organization.customers.with_discarded }
+  sequenced scope: ->(customer) { customer.organization.customers.with_discarded },
+            lock_key: ->(customer) { customer.organization_id }
 
   validates :country, country_code: true, unless: -> { country.nil? }
   validates :document_locale, language_code: true, unless: -> { document_locale.nil? }

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -68,7 +68,8 @@ class Invoice < ApplicationRecord
     end
   end
 
-  sequenced scope: ->(invoice) { invoice.customer.invoices }
+  sequenced scope: ->(invoice) { invoice.customer.invoices },
+            lock_key: ->(invoice) { invoice.customer_id }
 
   scope :ready_to_be_finalized,
         lambda {
@@ -149,7 +150,7 @@ class Invoice < ApplicationRecord
                 BillableMetrics::Breakdown::UniqueCountService
               else
                 raise(NotImplementedError)
-              end
+    end
 
     service.new(
       event_store_class: Events::Stores::PostgresStore,


### PR DESCRIPTION
## Context

On billing day, a lot of `BillSubscriptionJob` are failing with `Sequenced::SequenceError: Unable to aquire lock on the database`

It appears this issue is related to a lock created for ensuring the uniqueness of the `sequential_id`. The lock uses `invoices_lock` as name and so is shared between all invoices, locking the entire table...

## Description

Since the `lock` logic is scoped at customer level, it would make more sense to use the `customer_id` in the lock key, to lock only invoices attached to the customer