### PR TITLE
fix(subscription): Target active subscription when updating

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -49,8 +49,21 @@ module Api
       end
 
       def update
+        query = current_organization.subscriptions
+          .where(external_id: params[:external_id])
+          .order(subscription_at: :desc)
+        subscription = if query.count > 1
+          if params[:status] == 'pending'
+            query.pending
+          else
+            query.active
+          end
+        else
+          query
+        end.first
+
         result = Subscriptions::UpdateService.call(
-          subscription: current_organization.subscriptions.find_by(external_id: params[:external_id]),
+          subscription:,
           params: SubscriptionLegacyInput.new(
             current_organization,
             update_params,


### PR DESCRIPTION
## Context

Subscription update via API is not always targeting the right subscription if multiple subscriptions share the same `external_id` (`active`, `terminated,` `pending`).

The root cause of this issue is that the query to find the subscription to update is taking the first `subscription`, no mater the status.

## Description

The current fix, changes the behavior:
- It takes the subscription if only one exists with the `external_id`
- Takes the active one by default is multiple exists
- Takes the pending one if the pending `params` is passed in argument.