### PR TITLE
feat(event): clean-up event stores and add specs for clickhouse

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/getlago/clickhouse-activerecord.git
-  revision: d9198e9eacb50058d141a7f916995c872a2ead93
+  revision: b7154b26276f549c8893fc0ba9aa9848c59c32c7
   specs:
     clickhouse-activerecord (0.6.0)
       activerecord (>= 5.2)

--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -21,15 +21,11 @@ module BillableMetrics
 
       private
 
-      def compute_aggregation(latest_event)
-        result = if latest_event.present?
-          value = latest_event.properties.fetch(billable_metric.field_name, 0).to_s
-          BigDecimal(value).negative? ? 0 : value
-        else
-          0
-        end
+      def compute_aggregation(latest_value)
+        result = BigDecimal((latest_value || 0).to_s)
+        return BigDecimal(0) if result.negative?
 
-        BigDecimal(result)
+        result
       end
     end
   end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -32,7 +32,7 @@ module Events
       end
 
       def last
-        events.reorder(timestamp: :desc, created_at: :desc).first
+        events.reorder(timestamp: :desc, created_at: :desc).first&.properties&.[](aggregation_property)
       end
 
       private

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     )
   end
 
-  let(:billable_metric) { create(:billable_metric) }
+  let(:billable_metric) { create(:billable_metric, field_name: 'value') }
   let(:organization) { billable_metric.organization }
 
   let(:customer) { create(:customer, organization:) }
@@ -23,51 +23,89 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
   let(:boundaries) do
     {
-      charges_from_datetime: subscription.started_at.beginning_of_day,
-      charges_to_datetime: subscription.started_at.end_of_month.end_of_day,
+      from_datetime: subscription.started_at.beginning_of_day,
+      to_datetime: subscription.started_at.end_of_month.end_of_day,
     }
   end
 
   let(:group) { nil }
   let(:event) { nil }
 
-  before { skip if ENV['LAGO_CLICKHOUSE_ENABLED'].blank? }
+  let(:events) do
+    events = []
+
+    5.times do |i|
+      properties = { billable_metric.field_name => i + 1 }
+      properties[group.key.to_s] = group.value.to_s if group && i.even?
+
+      events << Clickhouse::EventsRaw.create!(
+        transaction_id: SecureRandom.uuid,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        external_customer_id: customer.external_id,
+        code:,
+        timestamp: boundaries[:from_datetime] + (i + 1).days,
+        properties:,
+      )
+    end
+
+    events
+  end
+
+  # NOTE: this does not include test with real values yet as we have to figure out
+  #       how to add factories of fixtures in spec env and to setup clickhouse on the CI
+  before do
+    if ENV['LAGO_CLICKHOUSE_ENABLED'].blank?
+      skip
+    else
+      events
+    end
+  end
 
   describe '.events' do
     it 'returns a list of events' do
-      expect(event_store.events).to eq([])
+      expect(event_store.events.count).to eq(5)
     end
 
     context 'with group' do
       let(:group) { create(:group, billable_metric:) }
 
       it 'returns a list of events' do
-        expect(event_store.events).to eq([])
+        expect(event_store.events.count).to eq(3)
       end
     end
   end
 
   describe '.count' do
     it 'returns the number of unique events' do
-      expect(event_store.count).to be_zero
+      expect(event_store.count).to eq(5)
     end
   end
 
   describe '.events_values' do
     it 'returns the value attached to each event' do
-      expect(event_store.events_values).to eq([])
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+
+      expect(event_store.events_values).to eq([1, 2, 3, 4, 5])
     end
   end
 
   describe '.max' do
     it 'returns the max value' do
-      expect(event_store.max).to be_nil
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+
+      expect(event_store.max).to eq(5)
     end
   end
 
   describe '.last' do
     it 'returns the last event' do
-      expect(event_store.last).to be_nil
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+
+      expect(event_store.last).to eq(5)
     end
   end
 end


### PR DESCRIPTION
# Context

This PR is part of the high usage event ingestion epic. It follows https://github.com/getlago/lago-api/pull/1476

# Description

The objective of the PR is to add specs to clickhouse aggregation and do some cleanup to prepare sum and weighted sum aggregation