### PR TITLE
fix customer slug upon updating org prefix

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -250,9 +250,10 @@ class Invoice < ApplicationRecord
     return if number.present?
 
     if organization.document_numbering.to_s == 'per_customer'
+      customer_slug = "#{organization.document_number_prefix}-#{format('%03d', customer.sequential_id)}"
       formatted_sequential_id = format('%03d', sequential_id)
 
-      self.number = "#{customer.slug}-#{formatted_sequential_id}"
+      self.number = "#{customer_slug}-#{formatted_sequential_id}"
     else
       org_formatted_sequential_id = format('%03d', organization_sequential_id)
 

--- a/spec/scenarios/invoices/invoice_numbering_spec.rb
+++ b/spec/scenarios/invoices/invoice_numbering_spec.rb
@@ -107,7 +107,7 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
 
     # NOTE: October 19th: Switching to per_organization numbering and Bill subscription
     travel_to(DateTime.new(2023, 10, 19, 12, 12)) do
-      organization.update!(document_numbering: 'per_organization')
+      organization.update!(document_numbering: 'per_organization', document_number_prefix: 'ORG-11')
 
       Subscriptions::BillingService.call
       perform_all_enqueued_jobs
@@ -119,7 +119,7 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
 
       expect(sequential_ids).to match_array([4, 4, 4])
       expect(organization_sequential_ids).to match_array([1, 2, 3])
-      expect(numbers).to match_array(%w[ORG-1-202310-001 ORG-1-202310-002 ORG-1-202310-003])
+      expect(numbers).to match_array(%w[ORG-11-202310-001 ORG-11-202310-002 ORG-11-202310-003])
     end
 
     # NOTE: November 19th: Switching to per_customer numbering and Bill subscription
@@ -136,7 +136,7 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
 
       expect(sequential_ids).to match_array([5, 5, 5])
       expect(organization_sequential_ids).to match_array([1, 2, 3])
-      expect(numbers).to match_array(%w[ORG-1-001-005 ORG-1-002-005 ORG-1-003-005])
+      expect(numbers).to match_array(%w[ORG-11-001-005 ORG-11-002-005 ORG-11-003-005])
     end
 
     # NOTE: November 22: New subscription for second customer
@@ -168,13 +168,13 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
             ORG-1-001-003
             ORG-1-002-003
             ORG-1-003-003
-            ORG-1-202310-001
-            ORG-1-202310-002
-            ORG-1-202310-003
-            ORG-1-001-005
-            ORG-1-002-005
-            ORG-1-003-005
-            ORG-1-002-006
+            ORG-11-202310-001
+            ORG-11-202310-002
+            ORG-11-202310-003
+            ORG-11-001-005
+            ORG-11-002-005
+            ORG-11-003-005
+            ORG-11-002-006
           ],
         )
     end


### PR DESCRIPTION
## Context

Before, it was not possible to adapt document number. With this feature it will be enabled to switch between `per_customer` and `per_organization` document numbering logic. Also, it will be possible to edit number prefix.

## Description

This PR fixes customer slug in `per_customer` numbering