### PR TITLE
fix(graduated-prorated-charge-model): Fix graduated prorated initial state

### DIFF
--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -140,6 +140,9 @@ module BillableMetrics
 
         return previous_charge_fee_units if previous_charge_fee_units
 
+        # NOTE: aggregation_without_proration returns lifetime aggregation of total full units.
+        # full_per_event_aggregation variable includes all full units in certain period.
+        # Difference between those two values gives us recurring amount.
         recurring_value_before_first_fee = aggregation_without_proration.aggregation - full_per_event_aggregation.sum
 
         recurring_value_before_first_fee.zero? ? nil : recurring_value_before_first_fee

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -106,6 +106,10 @@ module BillableMetrics
         ).fdiv(period_duration)
       end
 
+      def options=(options)
+        @options = options
+      end
+
       private
 
       attr_reader :base_aggregator

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -106,9 +106,7 @@ module BillableMetrics
         ).fdiv(period_duration)
       end
 
-      def options=(options)
-        @options = options
-      end
+      attr_accessor :options
 
       private
 

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -100,16 +100,13 @@ module BillableMetrics
 
       def recurring_value
         previous_charge_fee_units = previous_charge_fee&.units
-
         return previous_charge_fee_units if previous_charge_fee_units
 
         query = persisted_query
-          .select("SUM((CAST(#{sanitized_field_name} AS FLOAT)) * (#{persisted_pro_rata}))::numeric").to_sql
-        recurring_value_before_first_fee = ActiveRecord::Base.connection.execute(query).first['sum']
+          .select("SUM(((#{sanitized_field_name})::numeric) * (#{persisted_pro_rata}))::numeric").to_sql
+        recurring_value_before_first_fee = ActiveRecord::Base.connection.select_one(query)['sum']
 
-        return nil unless recurring_value_before_first_fee
-
-        (recurring_value_before_first_fee <= 0) ? nil : recurring_value_before_first_fee
+        ((recurring_value_before_first_fee || 0) <= 0) ? nil : recurring_value_before_first_fee
       end
     end
   end

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -54,8 +54,6 @@ module BillableMetrics
 
       protected
 
-      attr_reader :options
-
       def compute_aggregation
         ActiveRecord::Base.connection.execute(aggregation_query).first['aggregation_result']
       end

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -109,7 +109,7 @@ module BillableMetrics
 
         return nil unless recurring_value_before_first_fee
 
-        recurring_value_before_first_fee <= 0 ? nil : recurring_value_before_first_fee
+        (recurring_value_before_first_fee <= 0) ? nil : recurring_value_before_first_fee
       end
     end
   end

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -43,8 +43,6 @@ module BillableMetrics
 
       protected
 
-      attr_reader :options
-
       def compute_prorated_aggregation
         ActiveRecord::Base.connection.execute(prorated_aggregation_query).first['aggregation_result']
       end

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -199,7 +199,6 @@ module BillableMetrics
 
       def recurring_value
         previous_charge_fee_units = previous_charge_fee&.units
-
         return previous_charge_fee_units if previous_charge_fee_units
 
         recurring_value_before_first_fee = prorated_persisted_query.sum("(#{persisted_pro_rata})::numeric")

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -203,7 +203,8 @@ module BillableMetrics
         return previous_charge_fee_units if previous_charge_fee_units
 
         recurring_value_before_first_fee = prorated_persisted_query.sum("(#{persisted_pro_rata})::numeric")
-        recurring_value_before_first_fee <= 0 ? nil : recurring_value_before_first_fee
+
+        (recurring_value_before_first_fee <= 0) ? nil : recurring_value_before_first_fee
       end
     end
   end

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -31,8 +31,8 @@ module BillableMetrics
       end
 
       def per_event_aggregation
-        recurring_value = previous_charge_fee&.units
-        recurring_aggregation = recurring_value ? [BigDecimal(recurring_value) * persisted_pro_rata] : []
+        recurring_result = recurring_value
+        recurring_aggregation = recurring_result ? [BigDecimal(recurring_result) * persisted_pro_rata] : []
         period_agg = compute_per_event_prorated_aggregation
 
         Result.new.tap do |result|
@@ -195,6 +195,15 @@ module BillableMetrics
             value: element.first,
           )
         end
+      end
+
+      def recurring_value
+        previous_charge_fee_units = previous_charge_fee&.units
+
+        return previous_charge_fee_units if previous_charge_fee_units
+
+        recurring_value_before_first_fee = prorated_persisted_query.sum("(#{persisted_pro_rata})::numeric")
+        recurring_value_before_first_fee <= 0 ? nil : recurring_value_before_first_fee
       end
     end
   end

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -60,6 +60,11 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
           },
         )
 
+        fetch_current_usage(customer:)
+        expect(json[:customer_usage][:amount_cents].round(2)).to eq(0)
+        expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(0)
+        expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.0')
+
         travel_to(DateTime.new(2023, 9, 10)) do
           create_event(
             {

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -239,7 +239,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                timestamp: 1699336493, ## November 2023
+                timestamp: 1_699_336_493, ## November 2023
                 external_subscription_id: subscription.external_id,
                 properties: { amount: '5' },
               },
@@ -249,7 +249,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                timestamp: 1699336493, ## November 2023
+                timestamp: 1_699_336_493, ## November 2023
                 external_subscription_id: subscription.external_id,
                 properties: { amount: '5' },
               },

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -524,7 +524,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
 
   describe '.per_event_aggregation' do
     it 'aggregates per events' do
-      sum_service.instance_variable_set(:@options, {})
+      sum_service.options = {}
       result = sum_service.per_event_aggregation
 
       expect(result.event_aggregation).to eq([5, 12, 12])

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -524,10 +524,11 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
 
   describe '.per_event_aggregation' do
     it 'aggregates per events' do
+      sum_service.instance_variable_set(:@options, {})
       result = sum_service.per_event_aggregation
 
-      expect(result.event_aggregation).to eq([12, 12])
-      expect(result.event_prorated_aggregation.map { |el| el.round(5) }).to eq([2.32258, 2.32258])
+      expect(result.event_aggregation).to eq([5, 12, 12])
+      expect(result.event_prorated_aggregation.map { |el| el.round(5) }).to eq([5, 2.32258, 2.32258])
     end
   end
 end

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -538,7 +538,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
       end
     end
 
-    context 'with multiple events added in the period and with one added and removed during period' do
+    context 'with multiple events added and removed in the period and with one persisted' do
       let(:quantified_event2) do
         create(
           :quantified_event,

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -442,6 +442,8 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
   end
 
   describe '.per_event_aggregation' do
+    before { unique_count_service.instance_variable_set(:@options, {}) }
+
     context 'with event added in the period' do
       let(:added_at) { from_datetime + 10.days }
 
@@ -533,6 +535,42 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
 
         expect(result.event_aggregation).to eq([1, 1, 1])
         expect(result.event_prorated_aggregation.map { |el| el.ceil(5) }).to eq([first, first, second])
+      end
+    end
+
+    context 'with multiple events added in the period and with one added and removed during period' do
+      let(:quantified_event2) do
+        create(
+          :quantified_event,
+          added_at: from_datetime + 10.days,
+          removed_at: nil,
+          external_subscription_id: subscription.external_id,
+          billable_metric:,
+        )
+      end
+      let(:quantified_event3) do
+        create(
+          :quantified_event,
+          added_at: from_datetime + 20.days,
+          removed_at: from_datetime + 20.days,
+          external_subscription_id: subscription.external_id,
+          billable_metric:,
+        )
+      end
+
+      before do
+        quantified_event2
+        quantified_event3
+      end
+
+      it 'aggregates per events' do
+        result = unique_count_service.per_event_aggregation
+
+        second = 21.fdiv(31).ceil(5)
+        third = 1.fdiv(31).ceil(5)
+
+        expect(result.event_aggregation).to eq([1, 1, 1])
+        expect(result.event_prorated_aggregation.map { |el| el.ceil(5) }).to eq([1, second, third])
       end
     end
   end

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -442,7 +442,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
   end
 
   describe '.per_event_aggregation' do
-    before { unique_count_service.instance_variable_set(:@options, {}) }
+    before { unique_count_service.options = {} }
 
     context 'with event added in the period' do
       let(:added_at) { from_datetime + 10.days }


### PR DESCRIPTION
## Context

Usually, for graduated prorated charge model, in order to fetch recurring value for each billing period, we take it from the last invoice's fee that belongs to certain charge. Mentioned logic also ignores all events contained in recurring value that are ingested after generation of previous invoice.

## Description

If there are not generated invoices yet, we still want to include past events, even if they got ingested after subscription creation with the past timestamp. This PR fixes this case.