### PR TITLE
feat(event): Enable clickhouse per organization

### DIFF
--- a/db/migrate/20231207095229_add_clickhouse_flag_to_organizations.rb
+++ b/db/migrate/20231207095229_add_clickhouse_flag_to_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddClickhouseFlagToOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :clickhouse_aggregation, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_04_151512) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_07_095229) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -592,6 +592,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_04_151512) do
     t.boolean "eu_tax_management", default: false
     t.integer "document_numbering", default: 0, null: false
     t.string "document_number_prefix"
+    t.boolean "clickhouse_aggregation", default: false, null: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     end
   end
 
+  after do
+    next if ENV['LAGO_CLICKHOUSE_ENABLED'].blank?
+
+    Clickhouse::EventsRaw.connection.execute('TRUNCATE TABLE events_raw')
+  end
+
   describe '.events' do
     it 'returns a list of events' do
       expect(event_store.events.count).to eq(5)


### PR DESCRIPTION
## Context

This PR is part of the high usage ingestion epic. It follows the refactoring of the aggregation classes to allow clickhouse usage.

## Description

This PR add logic to turn on clickhouse usage when:
- Clickhouse is globaly enabled on the application
- Organization has `clickhouse_aggregation` flag turn to `true`
- The aggregation allows clickhouse
- The charge is not payed in advance