### PR TITLE
fix(stripe): Return result when no PSP is connected

### DIFF
--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -10,7 +10,7 @@ module PaymentProviderCustomers
 
     def create
       result.stripe_customer = stripe_customer
-      return result if stripe_customer.provider_customer_id?
+      return result if stripe_customer.provider_customer_id? || !organization.stripe_payment_provider
 
       stripe_result = create_stripe_customer
       return result if !stripe_result || !result.success?

--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -51,6 +51,30 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
       end
     end
 
+    context 'when no payment provider is connected' do
+      let(:stripe_customer) do
+        create(:stripe_customer, customer:, provider_customer_id: nil)
+      end
+
+      before { stripe_provider.destroy! }
+
+      it 'does not call stripe API' do
+        allow(Stripe::Customer).to receive(:create)
+
+        stripe_service.create
+
+        expect(Stripe::Customer).not_to have_received(:create)
+      end
+
+      it 'returns success' do
+        allow(Stripe::Customer).to receive(:create)
+
+        result = stripe_service.create
+
+        expect(result).to be_success
+      end
+    end
+
     context 'when payment provider has incorrect API key' do
       before do
         allow(Stripe::Customer).to receive(:create)


### PR DESCRIPTION
## Context

Fix a bug when no PSP is connected to a customer.

## Description

Return a successful result when no PSP is connected to a stripe customer, so the worker does not fail.