### PR TITLE
misc(fee) expose description in type

### DIFF
--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -8,6 +8,7 @@ module Types
 
       field :charge, Types::Charges::Object, null: true
       field :currency, Types::CurrencyEnum, null: false
+      field :description, String, null: true
       field :group_name, String, null: true
       field :invoice_display_name, String, null: true
       field :invoice_name, String, null: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -2991,6 +2991,7 @@ type Fee implements InvoiceItem {
   charge: Charge
   creditableAmountCents: BigInt!
   currency: CurrencyEnum!
+  description: String
   eventsCount: BigInt
   feeType: FeeTypesEnum!
   group: Group

--- a/schema.json
+++ b/schema.json
@@ -11070,6 +11070,20 @@
               ]
             },
             {
+              "name": "description",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "eventsCount",
               "description": null,
               "type": {


### PR DESCRIPTION
## Context

We're refactoring invoices display in the UI.

Description attribute is not exposed on the fee type.

## Description

This PR exposed the fee description in the schema