### PR TITLE
fix(stripe): Fix stripe update without payment provider

### DIFF
--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -27,6 +27,8 @@ module PaymentProviderCustomers
     end
 
     def update
+      return result unless organization.stripe_payment_provider
+
       Stripe::Customer.update(stripe_customer.provider_customer_id, stripe_update_payload, { api_key: })
       result
     rescue Stripe::InvalidRequestError, Stripe::PermissionError => e


### PR DESCRIPTION
## Context

Fix a bug when no PSP is connected to a customer.

## Description

Return a successful result when no PSP is connected to a stripe customer, so the stripe API call does not fail with nil api_key.