### PR TITLE
fix(invoice): Finalize each invoice in a single job

### DIFF
--- a/app/jobs/clock/finalize_invoices_job.rb
+++ b/app/jobs/clock/finalize_invoices_job.rb
@@ -6,7 +6,7 @@ module Clock
 
     def perform
       Invoice.ready_to_be_finalized.each do |invoice|
-        Invoices::FinalizeService.call(invoice:)
+        Invoices::FinalizeJob.perform_later(invoice)
       end
     end
   end

--- a/app/jobs/invoices/finalize_job.rb
+++ b/app/jobs/invoices/finalize_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Invoices
+  class FinalizeJob < ApplicationJob
+    queue_as 'invoices'
+
+    def perform(invoice)
+      Invoices::FinalizeService.call(invoice:)
+    end
+  end
+end

--- a/spec/jobs/clock/finalize_invoices_job_spec.rb
+++ b/spec/jobs/clock/finalize_invoices_job_spec.rb
@@ -38,8 +38,8 @@ describe Clock::FinalizeInvoicesJob, job: true do
 
         travel_to(current_date) do
           described_class.perform_now
-          expect(Invoices::FinalizeService).not_to have_received(:call).with(invoice: draft_invoice)
-          expect(Invoices::FinalizeService).not_to have_received(:call).with(invoice: finalized_invoice)
+          expect(Invoices::FinalizeJob).not_to have_been_enqueued.with(draft_invoice)
+          expect(Invoices::FinalizeJob).not_to have_been_enqueued.with(finalized_invoice)
         end
       end
     end
@@ -50,7 +50,7 @@ describe Clock::FinalizeInvoicesJob, job: true do
 
         travel_to(current_date) do
           described_class.perform_now
-          expect(Invoices::FinalizeService).to have_received(:call).with(invoice: draft_invoice)
+          expect(Invoices::FinalizeJob).to have_been_enqueued.with(draft_invoice)
         end
       end
     end

--- a/spec/jobs/invoices/finalize_job_spec.rb
+++ b/spec/jobs/invoices/finalize_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::FinalizeJob, type: :job do
+  let(:invoice) { create(:invoice) }
+
+  let(:result) { BaseService::Result.new }
+
+  let(:finalize_service) do
+    instance_double(Invoices::FinalizeService)
+  end
+
+  it 'delegates to the Generate service' do
+    allow(Invoices::FinalizeService).to receive(:new)
+      .with(invoice:)
+      .and_return(finalize_service)
+    allow(finalize_service).to receive(:call)
+      .and_return(result)
+
+    described_class.perform_now(invoice)
+
+    expect(Invoices::FinalizeService).to have_received(:new)
+    expect(finalize_service).to have_received(:call)
+  end
+end


### PR DESCRIPTION
## Context

Some `Clock::FinalizeInvoicesJob` are failling with a `BaseService::ValidationFailure: Validation errors: {:amount_cents=>["value_is_out_of_range"]}` error.

Since all invoices are processed in a single jobs, it's preventing all invoices from being finalized automatically.

## Description

This PR does not fix the root cause of the failed job (we first have to identify with invoice is impacted) but it processing each invoice in its own job, to make sure that a failure on an invoice does not impact the other invoices