### PR TITLE
fix(invoice): Do not update payment status of draft invoices

### DIFF
--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -31,6 +31,10 @@ module Invoices
       old_payment_status = invoice.payment_status
       invoice.payment_status = params[:payment_status] if params.key?(:payment_status)
 
+      if invoice.draft? && (old_payment_status != invoice.payment_status)
+        return result.not_allowed_failure!(code: 'payment_status_update_on_draft_invoice')
+      end
+
       if params.key?(:ready_for_payment_processing) && !invoice.voided?
         invoice.ready_for_payment_processing = params[:ready_for_payment_processing]
       end

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -47,6 +47,30 @@ RSpec.describe Invoices::UpdateService do
       )
     end
 
+    context 'when updating payment status' do
+      context 'when invoice is in draft status' do
+        let(:invoice) { create(:invoice, :draft) }
+
+        it 'does not update the invoice' do
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+            expect(result.error.code).to eq('payment_status_update_on_draft_invoice')
+          end
+        end
+      end
+
+      context 'when invoice is not in draft status' do
+        it 'updates the invoice' do
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.invoice).to eq(invoice)
+            expect(result.invoice.payment_status).to eq(update_args[:payment_status])
+          end
+        end
+      end
+    end
+
     context 'with attached fees' do
       it 'euqueus a job to update the payment_status of the fees' do
         result


### PR DESCRIPTION
## Context

It should not be possible to update the payment status of a draft invoice

## Description

This PR fixes the issue by adding a check to the invoice update service.