### PR TITLE
fix(event): Pay in advance with missing or invalid group

### DIFF
--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -15,7 +15,7 @@ module Fees
       fees = []
 
       ActiveRecord::Base.transaction do
-        if charge.group_properties.blank?
+        if charge.billable_metric.selectable_groups.blank?
           fees << create_fee(properties: charge.properties)
         else
           fees += create_group_properties_fees

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -508,14 +508,76 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
       end
     end
 
-    context 'when there is no group properties' do
+    context 'when there is an invalid group' do
       let(:transaction_id) { "#{SecureRandom.uuid}test" }
       let(:parent_group_id) { create(:group, billable_metric:, key: 'cloud', value: 'AWS').id }
       let(:group) do
         create(:group, billable_metric:, key: 'region', value: 'europe', parent_group_id:)
       end
 
+      it 'does not create a pay_in_advance fee' do
+        ### 24 january: Create subscription.
+        jan24 = DateTime.new(2023, 1, 24)
+
+        travel_to(jan24) do
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code,
+            },
+          )
+        end
+
+        create(
+          :standard_charge,
+          :pay_in_advance,
+          invoiceable: true,
+          plan:,
+          billable_metric:,
+          properties: {
+            amount: '10',
+          },
+          group_properties: [
+            build(
+              :group_property,
+              group:,
+              values: {
+                amount: '20',
+                amount_currency: 'EUR',
+              },
+            ),
+          ],
+        )
+
+        subscription = customer.subscriptions.first
+
+        ### 15 february: Send an event.
+        feb15 = DateTime.new(2023, 2, 15)
+
+        travel_to(feb15) do
+          create_event(
+            {
+              code: billable_metric.code,
+              transaction_id:,
+              external_customer_id: customer.external_id,
+              properties: { amount: '10', bad: 'fake', cloud: 'AWS' },
+            },
+          )
+
+          expect(Event.find_by(transaction_id:).metadata['current_aggregation']).to be_nil
+          expect(subscription.reload.fees.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when there is no group properties' do
+      let(:transaction_id) { "#{SecureRandom.uuid}test" }
+      let(:parent_group_id) { create(:group, billable_metric:, key: 'cloud', value: 'AWS').id }
+
       it 'creates a pay_in_advance fee' do
+        create(:group, billable_metric:, key: 'region', value: 'europe', parent_group_id:)
+
         ### 24 january: Create subscription.
         jan24 = DateTime.new(2023, 1, 24)
 
@@ -550,7 +612,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
               code: billable_metric.code,
               transaction_id:,
               external_customer_id: customer.external_id,
-              properties: { amount: '2', region: 'europe' },
+              properties: { amount: '2', region: 'europe', cloud: 'AWS' },
             },
           )
 
@@ -559,7 +621,6 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
           expect(subscription.reload.fees.count).to eq(1)
 
           fee = subscription.fees.first
-
           expect(fee.invoice_id).not_to be_nil
           expect(fee.charge_id).to eq(charge.id)
           expect(fee.pay_in_advance).to eq(true)
@@ -572,10 +633,10 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
 
     context 'when there is no matching group but default group properties' do
       let(:transaction_id) { "#{SecureRandom.uuid}test" }
-      let(:group2) { create(:group, billable_metric:, key: 'country', value: 'italy') }
 
       it 'creates a pay_in_advance fee' do
         create(:group, billable_metric:, key: 'country', value: 'france')
+        create(:group, billable_metric:, key: 'country', value: 'italy')
 
         ### 24 january: Create subscription.
         jan24 = DateTime.new(2023, 1, 24)
@@ -596,17 +657,8 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
           invoiceable: true,
           plan:,
           billable_metric:,
-          properties: { amount: '10' },
-          group_properties: [
-            build(
-              :group_property,
-              group: group2,
-              values: {
-                amount: '20',
-                amount_currency: 'EUR',
-              },
-            ),
-          ],
+          properties: { amount: '20' },
+          group_properties: [],
         )
 
         subscription = customer.subscriptions.first


### PR DESCRIPTION
## Context

An issue has recently been identified with the pay in advance aggregation and group:

```
Steps to reproduce:

1. Create a billable metric with groups;
2. Create a plan with a charge paid in advance linked to the billable metric;
3. Create a subscription;
4. Send events that don’t include the expected group properties → Lago generates a fee even if the group value is invalid or the expected group key is missing.
```

It is a side effect of the default properties at charge level recently introduced.

## Description

This PR changes the check for group on billable metrics by checking the selectable groups rather than the group properties at charge level.