### PR TITLE
Fix in advance group events

### DIFF
--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -504,6 +504,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
 
           expect(Event.find_by(transaction_id:).metadata['current_aggregation']).to be_nil
           expect(subscription.reload.fees.count).to eq(0)
+          expect(subscription.invoices.count).to eq(0)
         end
       end
     end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/1536

## Description

It improves the preivous PR by ensuring that no in advance invoice is created when no fees is created after reception of an event with invalid groups.