### PR TITLE
fix: date intervals in invoice template and fee payload

### DIFF
--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -52,6 +52,18 @@ module V1
     private
 
     def date_boundaries
+      if model.charge? && !model.pay_in_advance? && model.charge.pay_in_advance?
+        subscription = model.subscription
+        invoice = model.invoice
+        timestamp = invoice.invoice_subscription(subscription.id).timestamp
+        interval = invoice.charge_pay_in_advance_interval(timestamp, subscription)
+
+        return {
+          from_date: interval[:charges_from_date]&.to_datetime&.iso8601,
+          to_date: interval[:charges_to_date]&.to_datetime&.end_of_day&.iso8601,
+        }
+      end
+
       {
         from_date:,
         to_date:,

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -19,10 +19,34 @@
           td.body-2 == TaxHelper.applied_taxes(invoice_subscription(subscription.id).subscription_fee)
           td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).subscription_amount)
 
+        - if subscription? && subscription_fees(subscription.id).charge_kind.any?
+          / Charges payed in advance on payed in advance plan
+          - if subscription.plan.charges.where(pay_in_advance: true).any? && subscription.plan.pay_in_advance?
+            / Loop over all top level fees
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name} • #{f.group_name}" }.group_by(&:charge_id).each do |_charge_id, fees|
+              - fee = fees.first
+              - next unless fee.charge.pay_in_advance?
+
+              / Fees for groups
+              - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
+                - fees.select { |f| f.units.positive? }.each do |fee|
+                  - if fee.amount_details.blank?
+                    == SlimHelper.render('templates/invoices/v4/_default_fee', fees)
+                  - else
+                    == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
+
+                  / True up fees attached to the fee
+                  - if fee.true_up_fee.present?
+                    == SlimHelper.render('templates/invoices/v4/_true_up_fee', fee)
+
+              / Fees without group
+              - else
+                == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
+
     / Charge fees section for subscription invoice
     - if subscription? && subscription_fees(subscription.id).charge_kind.any?
       / Charges payed in arrears OR charges and plan payed in advance
-      - if (subscription.plan.charges.where(pay_in_advance: false).any? || (subscription.plan.charges.where(pay_in_advance: true).any? && subscription.plan.pay_in_advance?))
+      - if subscription.plan.charges.where(pay_in_advance: false).any?
         .invoice-resume.overflow-auto
           table.invoice-resume-table width="100%"
             - if different_boundaries_for_subscription_and_charges(subscription)
@@ -36,7 +60,7 @@
             / Loop over all top level fees
             - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name} • #{f.group_name}" }.group_by(&:charge_id).each do |_charge_id, fees|
               - fee = fees.first
-              - next if fee.charge.pay_in_advance? && !fee.charge.plan.pay_in_advance?
+              - next if fee.charge.pay_in_advance?
 
               / Fees for groups
               - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
@@ -71,21 +95,21 @@
               - fee = fees.first
               - next unless fee.charge.pay_in_advance?
 
-            / Fees for groups
-            - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
-              - fees.select { |f| f.units.positive? }.each do |fee|
-                - if fee.amount_details.blank?
-                  == SlimHelper.render('templates/invoices/v4/_default_fee', fees)
-                - else
-                  == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
+              / Fees for groups
+              - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
+                - fees.select { |f| f.units.positive? }.each do |fee|
+                  - if fee.amount_details.blank?
+                    == SlimHelper.render('templates/invoices/v4/_default_fee', fees)
+                  - else
+                    == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
 
-                / True up fees attached to the fee
-                - if fee.true_up_fee.present?
-                  == SlimHelper.render('templates/invoices/v4/_true_up_fee', fee)
+                  / True up fees attached to the fee
+                  - if fee.true_up_fee.present?
+                    == SlimHelper.render('templates/invoices/v4/_true_up_fee', fee)
 
-            / Fees without group
-            - else
-              == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
+              / Fees without group
+              - else
+                == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
 
     / Total section
     .invoice-resume.overflow-auto


### PR DESCRIPTION
## Context

In invoice template pay in advance charge fees haven't been grouped correctly and they were also incorrectly calculated in fee serializer

## Description

This PR fix both cases