### PR TITLE
fix(invoice): Add missing unique index on invoice sequential ids

### DIFF
--- a/db/migrate/20231214103653_add_unique_index_on_invoice_sequential_id.rb
+++ b/db/migrate/20231214103653_add_unique_index_on_invoice_sequential_id.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnInvoiceSequentialId < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index(:invoices, %i[customer_id sequential_id], unique: true, algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_07_095229) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_14_103653) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -527,6 +527,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_07_095229) do
     t.integer "net_payment_term", default: 0, null: false
     t.datetime "voided_at"
     t.integer "organization_sequential_id", default: 0, null: false
+    t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"
@@ -587,9 +588,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_07_095229) do
     t.string "tax_identification_number"
     t.integer "net_payment_term", default: 0, null: false
     t.string "default_currency", default: "USD", null: false
-    t.boolean "eu_tax_management", default: false
     t.integer "document_numbering", default: 0, null: false
     t.string "document_number_prefix"
+    t.boolean "eu_tax_management", default: false
     t.boolean "clickhouse_aggregation", default: false, null: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"


### PR DESCRIPTION
## Context

Invoice table is missing the two indexes to ensure that `sequential_id` and `organization_sequential_id` are unique in their scope (`customer_id` or `organization_id`)

## Description

This PR is adding those indexes