### PR TITLE
fix(invoice): Add missing unique index on invoice organization_sequential ids

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -279,7 +279,10 @@ class Invoice < ApplicationRecord
   end
 
   def generate_organization_sequential_id
-    organization_sequence_scope = organization.invoices.where(created_at: Time.now.utc.all_month)
+    organization_sequence_scope = organization.invoices.where(
+      "date_trunc('month', created_at)::date = ?",
+      Time.now.utc.beginning_of_month.to_date,
+    )
 
     result = Invoice.with_advisory_lock(
       organization_id,

--- a/db/migrate/20231214133638_add_unique_index_on_invoice_organization_sequential_id.rb
+++ b/db/migrate/20231214133638_add_unique_index_on_invoice_organization_sequential_id.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnInvoiceOrganizationSequentialId < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :invoices,
+              "organization_id, organization_sequential_id, date_trunc('month'::text, created_at)",
+              name: 'unique_organization_sequential_id',
+              unique: true,
+              where: 'organization_sequential_id != 0'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_14_103653) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_14_133638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -527,6 +527,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_14_103653) do
     t.integer "net_payment_term", default: 0, null: false
     t.datetime "voided_at"
     t.integer "organization_sequential_id", default: 0, null: false
+    t.index "organization_id, organization_sequential_id, date_trunc('month'::text, created_at)", name: "unique_organization_sequential_id", unique: true, where: "(organization_sequential_id <> 0)"
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -10,6 +10,8 @@ FactoryBot.define do
     payment_status { 'pending' }
     currency { 'EUR' }
 
+    organization_sequential_id { rand(1_000_000) }
+
     trait :draft do
       status { :draft }
     end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Invoice, type: :model do
 
   describe 'sequential_id' do
     let(:customer) { create(:customer, organization:) }
-    let(:invoice) { build(:invoice, customer:, organization:) }
+    let(:invoice) { build(:invoice, customer:, organization:, organization_sequential_id: nil) }
 
     it 'assigns a sequential id and organization sequential id to a new invoice' do
       invoice.save
@@ -98,7 +98,7 @@ RSpec.describe Invoice, type: :model do
     let(:organization) { create(:organization, name: 'LAGO') }
     let(:customer) { create(:customer, organization:) }
     let(:subscription) { create(:subscription, organization:, customer:) }
-    let(:invoice) { build(:invoice, customer:, organization:) }
+    let(:invoice) { build(:invoice, customer:, organization:, organization_sequential_id: nil) }
 
     it 'generates the invoice number' do
       invoice.save


### PR DESCRIPTION
## Context

Invoice table is missing the index to ensure that `organization_sequential_id` is unique in the scope of the `organization_id`

## Description

This PR is adding the index