### PR TITLE
feat(invoice): Add new generating status to invoices

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -5,7 +5,7 @@ module Api
     class CreditNotesController < Api::BaseController
       def create
         service = CreditNotes::CreateService.new(
-          invoice: current_organization.invoices.find_by(id: input_params[:invoice_id]),
+          invoice: current_organization.invoices.not_generating.find_by(id: input_params[:invoice_id]),
           **input_params,
         )
         result = service.call
@@ -116,7 +116,7 @@ module Api
 
       def estimate
         result = CreditNotes::EstimateService.call(
-          invoice: current_organization.invoices.find_by(id: estimate_params[:invoice_id]),
+          invoice: current_organization.invoices.not_generating.find_by(id: estimate_params[:invoice_id]),
           items: estimate_params[:items],
         )
 

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -19,7 +19,7 @@ module Api
       end
 
       def update
-        invoice = current_organization.invoices.find_by(id: params[:id])
+        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
 
         result = Invoices::UpdateService.new(
           invoice:,
@@ -35,7 +35,7 @@ module Api
       end
 
       def show
-        invoice = current_organization.invoices.find_by(id: params[:id])
+        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
 
         return not_found_error(resource: 'invoice') unless invoice
 
@@ -43,7 +43,7 @@ module Api
       end
 
       def index
-        invoices = current_organization.invoices
+        invoices = current_organization.invoices.not_generating
         if params[:external_customer_id]
           invoices = invoices.joins(:customer).where(customers: { external_id: params[:external_customer_id] })
         end
@@ -90,7 +90,7 @@ module Api
       end
 
       def refresh
-        invoice = current_organization.invoices.find_by(id: params[:id])
+        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
         return not_found_error(resource: 'invoice') unless invoice
 
         result = Invoices::RefreshDraftService.call(invoice:)
@@ -114,7 +114,7 @@ module Api
       end
 
       def void
-        invoice = current_organization.invoices.find_by(id: params[:id])
+        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
 
         result = Invoices::VoidService.call(invoice:)
         if result.success?
@@ -125,7 +125,7 @@ module Api
       end
 
       def retry_payment
-        invoice = current_organization.invoices.find_by(id: params[:id])
+        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
         return not_found_error(resource: 'invoice') unless invoice
 
         result = Invoices::Payments::RetryService.new(invoice:).call

--- a/app/graphql/mutations/credit_notes/create.rb
+++ b/app/graphql/mutations/credit_notes/create.rb
@@ -26,7 +26,7 @@ module Mutations
 
         result = ::CreditNotes::CreateService
           .new(
-            invoice: current_organization.invoices.find_by(id: args[:invoice_id]),
+            invoice: current_organization.invoices.not_generating.find_by(id: args[:invoice_id]),
             **args,
           )
           .call

--- a/app/graphql/mutations/customer_portal/download_invoice.rb
+++ b/app/graphql/mutations/customer_portal/download_invoice.rb
@@ -13,7 +13,7 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(id:)
-        invoice = context[:customer_portal_user].invoices.find_by(id:)
+        invoice = context[:customer_portal_user].invoices.not_generating.find_by(id:)
         result = ::Invoices::GeneratePdfService.call(invoice:)
         result.success? ? result.invoice : result_error(result)
       end

--- a/app/graphql/mutations/invoices/download.rb
+++ b/app/graphql/mutations/invoices/download.rb
@@ -16,7 +16,7 @@ module Mutations
       def resolve(id:)
         validate_organization!
 
-        invoice = Invoice.find_by(id:, organization_id: current_organization.id)
+        invoice = Invoice.not_generating.find_by(id:, organization_id: current_organization.id)
         result = ::Invoices::GeneratePdfService.call(invoice:)
         result.success? ? result.invoice : result_error(result)
       end

--- a/app/graphql/mutations/invoices/refresh.rb
+++ b/app/graphql/mutations/invoices/refresh.rb
@@ -16,7 +16,7 @@ module Mutations
       def resolve(**args)
         validate_organization!
         result = ::Invoices::RefreshDraftService.call(
-          invoice: current_organization.invoices.find_by(id: args[:id]),
+          invoice: current_organization.invoices.not_generating.find_by(id: args[:id]),
         )
         result.success? ? result.invoice : result_error(result)
       end

--- a/app/graphql/mutations/invoices/retry_payment.rb
+++ b/app/graphql/mutations/invoices/retry_payment.rb
@@ -16,7 +16,7 @@ module Mutations
       def resolve(**args)
         validate_organization!
 
-        invoice = current_organization.invoices.find_by(id: args[:id])
+        invoice = current_organization.invoices.not_generating.find_by(id: args[:id])
         result = ::Invoices::Payments::RetryService.new(invoice:).call
 
         result.success? ? result.invoice : result_error(result)

--- a/app/graphql/mutations/invoices/update.rb
+++ b/app/graphql/mutations/invoices/update.rb
@@ -12,7 +12,7 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(**args)
-        invoice = context[:current_organization].invoices.find_by(id: args[:id])
+        invoice = context[:current_organization].invoices.not_generating.find_by(id: args[:id])
         result = ::Invoices::UpdateService.new(invoice:, params: args, webhook_notification: true).call
 
         result.success? ? result.invoice : result_error(result)

--- a/app/graphql/mutations/invoices/void.rb
+++ b/app/graphql/mutations/invoices/void.rb
@@ -16,7 +16,7 @@ module Mutations
       def resolve(**args)
         validate_organization!
         result = ::Invoices::VoidService.call(
-          invoice: current_organization.invoices.find_by(id: args[:id]),
+          invoice: current_organization.invoices.not_generating.find_by(id: args[:id]),
         )
         result.success? ? result.invoice : result_error(result)
       end

--- a/app/graphql/resolvers/credit_notes/estimate_resolver.rb
+++ b/app/graphql/resolvers/credit_notes/estimate_resolver.rb
@@ -17,7 +17,7 @@ module Resolvers
         validate_organization!
 
         result = ::CreditNotes::EstimateService.call(
-          invoice: current_organization.invoices.find_by(id: invoice_id),
+          invoice: current_organization.invoices.not_generating.find_by(id: invoice_id),
           items:,
         )
 

--- a/app/graphql/resolvers/invoice_resolver.rb
+++ b/app/graphql/resolvers/invoice_resolver.rb
@@ -14,7 +14,7 @@ module Resolvers
     def resolve(id:)
       validate_organization!
 
-      current_organization.invoices.find(id)
+      current_organization.invoices.not_generating.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'invoice')
     end

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -52,7 +52,10 @@ module Types
       field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
-      field :active_subscriptions_count, Integer, null: false, description: 'Number of active subscriptions per customer'
+      field :active_subscriptions_count,
+            Integer,
+            null: false,
+            description: 'Number of active subscriptions per customer'
       field :credit_notes_balance_amount_cents,
             GraphQL::Types::BigInt,
             null: false,
@@ -69,7 +72,7 @@ module Types
       end
 
       def invoices
-        object.invoices.order(created_at: :desc)
+        object.invoices.not_generating.order(created_at: :desc)
       end
 
       def applied_coupons

--- a/app/graphql/types/invoices/status_type_enum.rb
+++ b/app/graphql/types/invoices/status_type_enum.rb
@@ -5,7 +5,7 @@ module Types
     class StatusTypeEnum < Types::BaseEnum
       graphql_name 'InvoiceStatusTypeEnum'
 
-      Invoice::STATUS.each do |type|
+      Invoice::STATUS.reject { |k| k == :generating }.each do |type|
         value type
       end
     end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -49,7 +49,7 @@ class Invoice < ApplicationRecord
 
   INVOICE_TYPES = %i[subscription add_on credit one_off].freeze
   PAYMENT_STATUS = %i[pending succeeded failed].freeze
-  STATUS = %i[draft finalized voided].freeze
+  STATUS = %i[draft finalized voided generating].freeze
 
   enum invoice_type: INVOICE_TYPES
   enum payment_status: PAYMENT_STATUS

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -21,7 +21,7 @@ class InvoicesQuery < BaseQuery
   attr_reader :search_term
 
   def base_scope
-    organization.invoices.ransack(search_params)
+    organization.invoices.not_generating.ransack(search_params)
   end
 
   def search_params


### PR DESCRIPTION
## Context

With the increasing number of invoice generated by the cloud instance of lago, a scalability issue have been identified in the process assigning the `sequential_id` and `organization_sequential_id` to new invoices.

The process uses an database `advisory lock` ensuring that the sequential id is unique and contiguous within the system.
Today, this lock is used in the invoice creation transaction and since this transaction could take time, the lock could be kept for a long time, leading to a lot of `SequenceError`.

## Description

The new process will first create the invoice to "reserve" the sequential ID in a short db transaction, to reduce the window of locking and will perform the rest of the computation logic in an other process.

This PR is the first step of this new process, it adds the new invoice `generating` status, and make sure that generating invoices are not exposed to the end-users
