### PR TITLE
Add ability to set Google Cloud Storage credentials file path by environment variable

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -25,6 +25,6 @@ amazon_compatible_endpoint:
 
 google:
   service: GCS
-  credentials: <%= ENV.fetch('GCS_KEYFILE_JSON_PATH', Rails.root.join('gcs_keyfile.json')) %>
+  credentials: <%= ENV.fetch('LAGO_GCS_KEYFILE_JSON_PATH', Rails.root.join('gcs_keyfile.json')) %>
   project: <%= ENV['LAGO_GCS_PROJECT'] %>
   bucket: <%= ENV['LAGO_GCS_BUCKET'] %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -25,6 +25,6 @@ amazon_compatible_endpoint:
 
 google:
   service: GCS
-  credentials: <%= Rails.root.join('gcs_keyfile.json') %>
+  credentials: <%= ENV.fetch('GCS_KEYFILE_JSON_PATH', Rails.root.join('gcs_keyfile.json')) %>
   project: <%= ENV['LAGO_GCS_PROJECT'] %>
   bucket: <%= ENV['LAGO_GCS_BUCKET'] %>


### PR DESCRIPTION
## Context

Lago by default looks at a file on disk to load Google Cloud credentials, which is not a convenient option for us right now since our platform only allows putting secret files at a certain path, and Lago hardcodes it as located in the Rails root.

This PR adds a env var to allow overriding this configuration.

## Description

Uses the value of the env var `GCS_KEYFILE_JSON_PATH` or falls back if the env var isn't set, falls back to pre-existing behavior.
