### PR TITLE
misc: generate organization sequential id only when this numbering type is selected

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -9,7 +9,7 @@ class Invoice < ApplicationRecord
   CREDIT_NOTES_MIN_VERSION = 2
   COUPON_BEFORE_VAT_VERSION = 3
 
-  before_save :ensure_organization_sequential_id
+  before_save :ensure_organization_sequential_id, if: -> { organization.per_organization? }
   before_save :ensure_number
 
   belongs_to :customer, -> { with_discarded }
@@ -286,11 +286,7 @@ class Invoice < ApplicationRecord
       transaction: true,
       timeout_seconds: 10.seconds,
     ) do
-      org_sequential_id = organization_sequence_scope
-        .where.not(organization_sequential_id: nil)
-        .order(organization_sequential_id: :desc)
-        .limit(1)
-        .pick(:organization_sequential_id)
+      org_sequential_id = organization_sequence_scope.count
       org_sequential_id ||= 0
 
       # NOTE: Start with the most recent sequential id and find first available sequential id that haven't occurred

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Invoice, type: :model do
       aggregate_failures do
         expect(invoice).to be_valid
         expect(invoice.sequential_id).to eq(1)
-        expect(invoice.organization_sequential_id).to eq(1)
+        expect(invoice.organization_sequential_id).to eq(0)
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe Invoice, type: :model do
         aggregate_failures do
           expect(invoice).to be_valid
           expect(invoice.sequential_id).to eq(6)
-          expect(invoice.organization_sequential_id).to eq(16)
+          expect(invoice.organization_sequential_id).to eq(0)
         end
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe Invoice, type: :model do
         aggregate_failures do
           expect(invoice).to be_valid
           expect(invoice.sequential_id).to eq(1)
-          expect(invoice.organization_sequential_id).to eq(1)
+          expect(invoice.organization_sequential_id).to eq(0)
         end
       end
     end

--- a/spec/scenarios/invoices/invoice_numbering_spec.rb
+++ b/spec/scenarios/invoices/invoice_numbering_spec.rb
@@ -71,7 +71,7 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       numbers = invoices.pluck(:number)
 
       expect(sequential_ids).to match_array([1, 1, 1])
-      expect(organization_sequential_ids).to match_array([1, 2, 3])
+      expect(organization_sequential_ids).to match_array([0, 0, 0])
       expect(numbers).to match_array(%w[ORG-1-001-001 ORG-1-002-001 ORG-1-003-001])
     end
 
@@ -86,7 +86,7 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       numbers = invoices.pluck(:number)
 
       expect(sequential_ids).to match_array([2, 2, 2])
-      expect(organization_sequential_ids).to match_array([1, 2, 3])
+      expect(organization_sequential_ids).to match_array([0, 0, 0])
       expect(numbers).to match_array(%w[ORG-1-001-002 ORG-1-002-002 ORG-1-003-002])
     end
 
@@ -101,7 +101,7 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       numbers = invoices.pluck(:number)
 
       expect(sequential_ids).to match_array([3, 3, 3])
-      expect(organization_sequential_ids).to match_array([1, 2, 3])
+      expect(organization_sequential_ids).to match_array([0, 0, 0])
       expect(numbers).to match_array(%w[ORG-1-001-003 ORG-1-002-003 ORG-1-003-003])
     end
 
@@ -135,7 +135,7 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       numbers = invoices.pluck(:number)
 
       expect(sequential_ids).to match_array([5, 5, 5])
-      expect(organization_sequential_ids).to match_array([1, 2, 3])
+      expect(organization_sequential_ids).to match_array([0, 0, 0])
       expect(numbers).to match_array(%w[ORG-11-001-005 ORG-11-002-005 ORG-11-003-005])
     end
 
@@ -155,7 +155,7 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       invoices = organization.reload.invoices.order(created_at: :desc)
 
       expect(invoices.first.sequential_id).to eq(6)
-      expect(invoices.first.organization_sequential_id).to eq(4)
+      expect(invoices.first.organization_sequential_id).to eq(0)
       expect(invoices.pluck(:number))
         .to match_array(
           %w[


### PR DESCRIPTION
## Context

Currently with each invoice we generate both `sequential_id` and `organization_sequential_id`. With this change we will generate `organization_sequential_id` only when `per_organization` numbering type is defined on the organization level.

## Description

This PR generates `organization_sequential_id` only when `per_organization` numbering type is selected.
