### PR TITLE
feat(event): Plug invoice create generating invoice for in advance aggregation

### DIFF
--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -6,10 +6,19 @@ module Invoices
 
     retry_on Sequenced::SequenceError
 
-    def perform(charge:, event:, timestamp:)
-      result = Invoices::CreatePayInAdvanceChargeService.call(charge:, event:, timestamp:)
+    def perform(charge:, event:, timestamp:, invoice: nil)
+      result = Invoices::CreatePayInAdvanceChargeService.call(charge:, event:, timestamp:, invoice:)
+      return if result.success?
 
-      result.raise_if_error!
+      result.raise_if_error! if invoice || result.invoice.nil? || !result.invoice.generating?
+
+      # NOTE: retry the job with the already created invoice in a previous failed attempt
+      self.class.set(wait: 3.seconds).perform_later(
+        charge:,
+        event:,
+        timestamp:,
+        invoice: result.invoice,
+      )
     end
   end
 end

--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -41,6 +41,7 @@ module Invoices
 
     delegate :organization, to: :customer
 
+    # NOTE: accounting date must be in customer timezone
     def issuing_date
       date = datetime.in_time_zone(customer.applicable_timezone).to_date
       return date unless grace_period?

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -98,15 +98,6 @@ module Invoices
       )
     end
 
-    # NOTE: accounting date must be in customer timezone
-    def issuing_date
-      Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone).to_date
-    end
-
-    def payment_due_date
-      (issuing_date + customer.applicable_net_payment_term.days).to_date
-    end
-
     def should_deliver_email?
       License.premium? && customer.organization.email_settings.include?('invoice.finalized')
     end

--- a/spec/jobs/invoices/create_pay_in_advance_charge_job_spec.rb
+++ b/spec/jobs/invoices/create_pay_in_advance_charge_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeJob, type: :job do
 
   before do
     allow(Invoices::CreatePayInAdvanceChargeService).to receive(:new)
-      .with(charge:, event:, timestamp:)
+      .with(charge:, event:, timestamp:, invoice: nil)
       .and_return(invoice_service)
     allow(invoice_service).to receive(:call)
       .and_return(result)
@@ -37,6 +37,50 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeJob, type: :job do
 
       expect(Invoices::CreatePayInAdvanceChargeService).to have_received(:new)
       expect(invoice_service).to have_received(:call)
+    end
+
+    context 'with a previously created invoice' do
+      let(:invoice) { create(:invoice, :generating) }
+
+      it 'raises an error' do
+        expect do
+          described_class.perform_now(charge:, event:, timestamp:)
+        end.to raise_error(BaseService::FailedResult)
+
+        expect(Invoices::CreatePayInAdvanceChargeService).to have_received(:new)
+        expect(invoice_service).to have_received(:call)
+      end
+    end
+
+    context 'when a generating invoice is attached to the result' do
+      let(:invoice) { create(:invoice, :generating) }
+
+      before { result.invoice = invoice }
+
+      it 'retries the job with the invoice' do
+        described_class.perform_now(charge:, event:, timestamp:)
+
+        expect(Invoices::CreatePayInAdvanceChargeService).to have_received(:new)
+        expect(invoice_service).to have_received(:call)
+
+        expect(described_class).to have_been_enqueued
+          .with(charge:, event:, timestamp:, invoice:)
+      end
+    end
+
+    context 'when a not generating invoice is attached to the result' do
+      let(:invoice) { create(:invoice, :draft) }
+
+      before { result.invoice = invoice }
+
+      it 'raises an error' do
+        expect do
+          described_class.perform_now(charge:, event:, timestamp:)
+        end.to raise_error(BaseService::FailedResult)
+
+        expect(Invoices::CreatePayInAdvanceChargeService).to have_received(:new)
+        expect(invoice_service).to have_received(:call)
+      end
     end
   end
 end

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -301,49 +301,6 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
       end
     end
 
-    context 'when in invoice mode' do
-      subject(:fee_service) { described_class.new(charge:, event:, estimate:, invoice:) }
-
-      let(:invoice) { create(:invoice, customer:, organization:) }
-
-      it 'creates a fee with invoice attached' do
-        result = fee_service.call
-
-        aggregate_failures do
-          expect(result).to be_success
-
-          expect(result.fees.count).to eq(1)
-          expect(result.fees.first).to have_attributes(
-            invoice:,
-            subscription:,
-            charge:,
-            amount_cents: 10,
-            amount_currency: 'EUR',
-            fee_type: 'charge',
-            pay_in_advance: true,
-            invoiceable: charge,
-            units: 9,
-            properties: Hash,
-            events_count: 1,
-            group: nil,
-            pay_in_advance_event_id: event.id,
-            payment_status: 'pending',
-
-            taxes_rate: 0,
-            taxes_amount_cents: 0,
-          )
-          expect(result.fees.first.applied_taxes.count).to eq(0)
-        end
-      end
-
-      it 'delivers a webhook' do
-        fee_service.call
-
-        expect(SendWebhookJob).to have_been_enqueued
-          .with('fee.created', Fee)
-      end
-    end
-
     context 'when in current and max aggregation result' do
       let(:aggregation_result) do
         BaseService::Result.new.tap do |result|

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -134,10 +134,16 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
       expect(payment_create_service).to have_received(:call)
     end
 
-    it 'enqueues a SendWebhookJob' do
+    it 'enqueues a SendWebhookJob for the invoice' do
       expect do
         invoice_service.call
       end.to have_enqueued_job(SendWebhookJob).with('invoice.created', Invoice)
+    end
+
+    it 'enqueues a SendWebhookJob for the fees' do
+      expect do
+        invoice_service.call
+      end.to have_enqueued_job(SendWebhookJob).with('fee.created', Fee)
     end
 
     it 'does not enqueue an ActionMailer::MailDeliveryJob' do


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/1546

## Description

It makes use of the new `Invoices::CreateGeneratingService` service in the `Invoices::CreatePayInAdvanceChargeService`, to reduce the risk of database locking when generating the `organization_sequential_id`

A logic to prevent duplication of `generating` invoice was also added to the `Invoices::CreatePayInAdvanceChargeJob`