### PR TITLE
feat(event): Use generating invoice service for prepaid credit invoices

### DIFF
--- a/spec/jobs/bill_paid_credit_job_spec.rb
+++ b/spec/jobs/bill_paid_credit_job_spec.rb
@@ -9,19 +9,18 @@ RSpec.describe BillPaidCreditJob, type: :job do
   let(:invoice_service) { instance_double(Invoices::PaidCreditService) }
   let(:result) { BaseService::Result.new }
 
+  let(:invoice) { nil }
+
   before do
-    allow(Invoices::PaidCreditService).to receive(:new)
-      .with(wallet_transaction:, timestamp:)
-      .and_return(invoice_service)
-    allow(invoice_service).to receive(:create)
+    allow(Invoices::PaidCreditService).to receive(:call)
+      .with(wallet_transaction:, timestamp:, invoice:)
       .and_return(result)
   end
 
-  it 'calls the paid credit service create method' do
+  it 'calls the paid credit service call method' do
     described_class.perform_now(wallet_transaction, timestamp)
 
-    expect(Invoices::PaidCreditService).to have_received(:new)
-    expect(invoice_service).to have_received(:create)
+    expect(Invoices::PaidCreditService).to have_received(:call)
   end
 
   context 'when result is a failure' do
@@ -34,8 +33,49 @@ RSpec.describe BillPaidCreditJob, type: :job do
         described_class.perform_now(wallet_transaction, timestamp)
       end.to raise_error(BaseService::FailedResult)
 
-      expect(Invoices::PaidCreditService).to have_received(:new)
-      expect(invoice_service).to have_received(:create)
+      expect(Invoices::PaidCreditService).to have_received(:call)
+    end
+
+    context 'with a previously created invoice' do
+      let(:previous_invoice) { create(:invoice, :generating) }
+      let(:invoice) { previous_invoice }
+
+      it 'raises an error' do
+        expect do
+          described_class.perform_now(wallet_transaction, timestamp, invoice: previous_invoice)
+        end.to raise_error(BaseService::FailedResult)
+
+        expect(Invoices::PaidCreditService).to have_received(:call)
+      end
+    end
+
+    context 'when a generating invoice is attached to the result' do
+      let(:previous_invoice) { create(:invoice, :generating) }
+
+      before { result.invoice = previous_invoice }
+
+      it 'retries the job with the invoice' do
+        described_class.perform_now(wallet_transaction, timestamp)
+
+        expect(Invoices::PaidCreditService).to have_received(:call)
+
+        expect(described_class).to have_been_enqueued
+          .with(wallet_transaction, timestamp, invoice: previous_invoice)
+      end
+    end
+
+    context 'when a not generating invoice is attached to the result' do
+      let(:previous_invoice) { create(:invoice, :draft) }
+
+      before { result.invoice = previous_invoice }
+
+      it 'raises an error' do
+        expect do
+          described_class.perform_now(wallet_transaction, timestamp)
+        end.to raise_error(BaseService::FailedResult)
+
+        expect(Invoices::PaidCreditService).to have_received(:call)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/1546

## Description

It makes use of the new `Invoices::CreateGeneratingService` service in the `Invoices::PaidCreditService`, to reduce the risk of database locking when generating the `organization_sequential_id`

A logic to prevent duplication of `generating` invoice was also added to the `BillPaidCreditJob`