### PR TITLE
fix(events): Negative event values should not be flagged as invalid

### DIFF
--- a/db/migrate/20231219121735_update_last_hour_events_mv_to_version2.rb
+++ b/db/migrate/20231219121735_update_last_hour_events_mv_to_version2.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UpdateLastHourEventsMvToVersion2 < ActiveRecord::Migration[7.0]
+  def change
+    drop_view :last_hour_events_mv, materialized: true
+    create_view :last_hour_events_mv, materialized: true, version: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_14_133638) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_19_121735) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -946,7 +946,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_14_133638) do
       (billable_metrics.aggregation_type <> 0) AS field_name_mandatory,
       (billable_metrics.aggregation_type = ANY (ARRAY[1, 2, 5, 6])) AS numeric_field_mandatory,
       (events.properties ->> (billable_metrics.field_name)::text) AS field_value,
-      ((events.properties ->> (billable_metrics.field_name)::text) ~ '^\\d+(\\.\\d+)?$'::text) AS is_numeric_field_value,
+      ((events.properties ->> (billable_metrics.field_name)::text) ~ '^-?\\d+(\\.\\d+)?$'::text) AS is_numeric_field_value,
       (COALESCE(billable_metric_groups.parent_group_count, (0)::bigint) > 0) AS parent_group_mandatory,
       (events.properties ?| (billable_metric_groups.parent_group_keys)::text[]) AS has_parent_group_key,
       (COALESCE(billable_metric_groups.child_group_count, (0)::bigint) > 0) AS child_group_mandatory,

--- a/db/views/last_hour_events_mv_v02.sql
+++ b/db/views/last_hour_events_mv_v02.sql
@@ -1,0 +1,43 @@
+WITH billable_metric_groups AS (
+  SELECT
+		billable_metrics.id AS bm_id,
+		billable_metrics.code bm_code,
+		COUNT(parent_groups.id) AS parent_group_count,
+		array_agg(parent_groups.key) AS parent_group_keys,
+		COUNT(child_groups.id) AS child_group_count,
+		array_agg(child_groups.key) AS child_group_keys
+	FROM billable_metrics
+		LEFT JOIN groups AS parent_groups
+			ON parent_groups.billable_metric_id = billable_metrics.id
+			AND parent_groups.parent_group_id IS NULL
+		LEFT JOIN groups AS child_groups
+			ON child_groups.billable_metric_id = billable_metrics.id
+			AND child_groups.parent_group_id IS NOT NULL
+	WHERE billable_metrics.deleted_at IS NULL
+	GROUP BY billable_metrics.id, billable_metrics.code
+)
+
+SELECT
+  events.organization_id,
+  events.transaction_id,
+  events.timestamp,
+  events.properties,
+  billable_metrics.code AS billable_metric_code,
+  billable_metrics.aggregation_type != 0 AS field_name_mandatory,
+  billable_metrics.aggregation_type IN (1,2,5,6) AS numeric_field_mandatory,
+  events.properties ->> billable_metrics.field_name::text AS field_value,
+  events.properties ->> billable_metrics.field_name::text ~ '^-?\d+(\.\d+)?$' AS is_numeric_field_value,
+  COALESCE(billable_metric_groups.parent_group_count, 0) > 0 AS parent_group_mandatory,
+  events.properties ?| billable_metric_groups.parent_group_keys AS has_parent_group_key,
+  COALESCE(billable_metric_groups.child_group_count, 0) > 0 AS child_group_mandatory,
+  events.properties ?| billable_metric_groups.child_group_keys AS has_child_group_key
+FROM
+  events
+    LEFT JOIN billable_metrics ON billable_metrics.code = events.code
+      AND events.organization_id = billable_metrics.organization_id
+    LEFT JOIN billable_metric_groups ON billable_metrics.id = billable_metric_groups.bm_id
+WHERE
+  events.deleted_at IS NULL
+  AND events.created_at >= date_trunc('hour', NOW()) - INTERVAL '1 hour'
+  AND events.created_at < date_trunc('hour', NOW())
+  AND billable_metrics.deleted_at IS NULL

--- a/spec/services/events/post_validation_service_spec.rb
+++ b/spec/services/events/post_validation_service_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Events::PostValidationService, type: :service, transaction: false
     )
   end
 
+  let(:negative_aggregation_property_event) do
+    create(
+      :event,
+      organization:,
+      code: billable_metric.code,
+      properties: { billable_metric.field_name => -12 },
+      created_at: Time.current.beginning_of_hour - 25.minutes,
+    )
+  end
+
   let(:billable_metric_with_group) do
     create(
       :sum_billable_metric,
@@ -82,6 +92,7 @@ RSpec.describe Events::PostValidationService, type: :service, transaction: false
 
     invalid_code_event
     missing_aggregation_property_event
+    negative_aggregation_property_event
     missing_parent_group_key_event
     missing_child_group_key_event
 
@@ -110,6 +121,8 @@ RSpec.describe Events::PostValidationService, type: :service, transaction: false
       expect(result.errors[:invalid_code]).to include(invalid_code_event.transaction_id)
       expect(result.errors[:missing_aggregation_property])
         .to include(missing_aggregation_property_event.transaction_id)
+      expect(result.errors[:missing_aggregation_property])
+        .not_to include(negative_aggregation_property_event.transaction_id)
       expect(result.errors[:missing_group_key])
         .to include(
           missing_parent_group_key_event.transaction_id,


### PR DESCRIPTION
## Context

The following issue was reported for the post event validation process:

```
events.errors webhook includes valid events

Steps to reproduce:

1. Create a billable metric based on `sum_agg` with groups;
2. Create a plan with a charge for this metric (standard pricing);
3. Start a subscription;
4. Send events with the correct aggregation properties, but negative values;
5. Wait for the `events.errors` webhook → events with negative values are included in the payload (`missing_aggregation_property`).
```

## Description

This PR fix the behavior by making sure that events with negative values are not flagged as invalid
