### PR TITLE
fix(plan): cancel pending subscription on destroy

### DIFF
--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -15,6 +15,9 @@ module Plans
         Subscriptions::TerminateService.call(subscription:, async: false)
       end
 
+      # NOTE: Cancel pending subscription to make sure they won't be activated.
+      plan.subscriptions.pending.find_each(&:mark_as_canceled!)
+
       # NOTE: Finalize all draft invoices.
       invoices = Invoice.draft.joins(:plans).where(plans: { id: plan.id }).distinct
       invoices.each { |invoice| Invoices::FinalizeService.call(invoice:) }

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -80,6 +80,24 @@ RSpec.describe Plans::DestroyService, type: :service do
       end
     end
 
+    context 'with pending subscriptions' do
+      let(:subscriptions) { create_list(:pending_subscription, 2, plan:) }
+
+      before { subscriptions }
+
+      it 'cancels the subscriptions' do
+        result = destroy_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          subscriptions.each do |subscription|
+            expect(subscription.reload).to be_canceled
+          end
+        end
+      end
+    end
+
     context 'with draft invoices' do
       let(:subscription) { create(:active_subscription, plan:) }
       let(:invoices) { create_list(:invoice, 2, :draft) }


### PR DESCRIPTION
## Context

The following issue was reported for the post event validation process:

```
Pending subscriptions not automatically cancelled when deleting plans

Steps to reproduce:

1. Create plan;
2. Assign the plan to a customer to create an active subscription;
3. Assign the same plan to the customer to create a pending subscription (i.e. start date in the future);
4. Delete the plan → only the active subscription is automatically terminated.

Expected behaviour: pending subscriptions should be cancelled when the associated plan is deleted.
```

## Description

This PR ensures that all pending subscriptions attached to a deleting plan are being canceled
