### PR TITLE
feat (invoices): add db changes for edit draft invoice feature

### DIFF
--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AdjustedFee < ApplicationRecord
+  belongs_to :invoice
+  belongs_to :fee, optional: true
+
+  enum fee_type: Fee::FEE_TYPES
+end

--- a/db/migrate/20231220140936_create_adjusted_fees.rb
+++ b/db/migrate/20231220140936_create_adjusted_fees.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateAdjustedFees < ActiveRecord::Migration[7.0]
+  def change
+    create_table :adjusted_fees, id: :uuid do |t|
+      t.references :fee, type: :uuid, null: true, index: true, foreign_key: true
+      t.references :invoice, type: :uuid, null: false, index: true, foreign_key: true
+      t.references :subscription, type: :uuid, null: true, foreign_key: true, index: true
+      t.references :charge, type: :uuid, null: true, foreign_key: true, index: true
+
+      t.string :invoice_display_name
+      t.integer :fee_type
+      t.boolean :adjusted_units, default: false, null: false
+      t.boolean :adjusted_amount, default: false, null: false
+      t.decimal :units, default: '0.0', null: false
+      t.bigint :unit_amount_cents, null: false, default: 0
+      t.jsonb :properties, null: false, default: {}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_19_121735) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_20_140936) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -71,6 +71,26 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_19_121735) do
     t.index ["add_on_id", "tax_id"], name: "index_add_ons_taxes_on_add_on_id_and_tax_id", unique: true
     t.index ["add_on_id"], name: "index_add_ons_taxes_on_add_on_id"
     t.index ["tax_id"], name: "index_add_ons_taxes_on_tax_id"
+  end
+
+  create_table "adjusted_fees", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "fee_id"
+    t.uuid "invoice_id", null: false
+    t.uuid "subscription_id"
+    t.uuid "charge_id"
+    t.string "invoice_display_name"
+    t.integer "fee_type"
+    t.boolean "adjusted_units", default: false, null: false
+    t.boolean "adjusted_amount", default: false, null: false
+    t.decimal "units", default: "0.0", null: false
+    t.bigint "unit_amount_cents", default: 0, null: false
+    t.jsonb "properties", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["charge_id"], name: "index_adjusted_fees_on_charge_id"
+    t.index ["fee_id"], name: "index_adjusted_fees_on_fee_id"
+    t.index ["invoice_id"], name: "index_adjusted_fees_on_invoice_id"
+    t.index ["subscription_id"], name: "index_adjusted_fees_on_subscription_id"
   end
 
   create_table "applied_add_ons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -850,6 +870,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_19_121735) do
   add_foreign_key "add_ons", "organizations"
   add_foreign_key "add_ons_taxes", "add_ons"
   add_foreign_key "add_ons_taxes", "taxes"
+  add_foreign_key "adjusted_fees", "charges"
+  add_foreign_key "adjusted_fees", "fees"
+  add_foreign_key "adjusted_fees", "invoices"
+  add_foreign_key "adjusted_fees", "subscriptions"
   add_foreign_key "applied_add_ons", "add_ons"
   add_foreign_key "applied_add_ons", "customers"
   add_foreign_key "billable_metrics", "organizations"

--- a/spec/factories/adjusted_fees.rb
+++ b/spec/factories/adjusted_fees.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :adjusted_fee do
+    invoice
+    fee
+    charge { nil }
+    subscription
+
+    fee_type { 'subscription' }
+
+    unit_amount_cents { 200 }
+    units { 2 }
+    adjusted_amount { true }
+
+    invoice_display_name { Faker::Fantasy::Tolkien.character }
+  end
+end


### PR DESCRIPTION
## Context

Currently it is not possible to edit units and amounts on draft invoice fees.

## Description

This feature adds DB changes need for edit draft invoice feature
