### PR TITLE
feat(event): Plug invoice create generating invoice for in advance aggregation

### DIFF
--- a/app/jobs/bill_subscription_job.rb
+++ b/app/jobs/bill_subscription_job.rb
@@ -5,13 +5,23 @@ class BillSubscriptionJob < ApplicationJob
 
   retry_on Sequenced::SequenceError, ActiveJob::DeserializationError
 
-  def perform(subscriptions, timestamp, recurring: false)
-    result = Invoices::SubscriptionService.new(
+  def perform(subscriptions, timestamp, recurring: false, invoice: nil)
+    result = Invoices::SubscriptionService.call(
       subscriptions:,
       timestamp:,
       recurring:,
-    ).create
+      invoice:,
+    )
+    return if result.success?
 
-    result.raise_if_error!
+    result.raise_if_error! if invoice || result.invoice.nil? || !result.invoice.generating?
+
+    # NOTE: retry the job with the already created invoice in a previous failed attempt
+    self.class.set(wait: 3.seconds).perform_later(
+      subscriptions,
+      timestamp,
+      recurring:,
+      invoice: result.invoice,
+    )
   end
 end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -142,8 +142,8 @@ class BaseService
     attr_accessor :failure
   end
 
-  def self.call(...)
-    new(...).call
+  def self.call(*, **, &block)
+    new(*, **).call(&block)
   end
 
   def initialize(current_user = nil)
@@ -152,7 +152,7 @@ class BaseService
     result.user = current_user
   end
 
-  def call
+  def call(**args, &block)
     raise NotImplementedError
   end
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -2,10 +2,9 @@
 
 module Invoices
   class CalculateFeesService < BaseService
-    def initialize(invoice:, subscriptions:, timestamp:, recurring: false, context: nil)
+    def initialize(invoice:, recurring: false, context: nil)
       @invoice = invoice
-      @subscriptions = subscriptions.uniq(&:id)
-      @timestamp = timestamp
+      @timestamp = invoice.invoice_subscriptions.first&.timestamp
 
       # NOTE: Billed automatically by the recurring billing process
       #       It is used to prevent double billing on billing day
@@ -17,28 +16,19 @@ module Invoices
     end
 
     def call
-      if duplicated_invoices?
-        return result.service_failure!(
-          code: 'duplicated_invoices',
-          message: 'Invoice subscription already exists with the boundaries',
-        )
-      end
-
       ActiveRecord::Base.transaction do
-        subscriptions.each do |subscription|
-          subscription_boundaries = subscriptions_boundaries[subscription.id]
-          boundaries = termination_boundaries(subscription, subscription_boundaries)
+        invoice.invoice_subscriptions.each do |invoice_subscription|
+          subscription = invoice_subscription.subscription
+          date_service = terminated_date_service(subscription, date_service(subscription))
 
-          InvoiceSubscription.create!(
-            invoice:,
-            subscription:,
-            timestamp: boundaries[:timestamp],
-            from_datetime: boundaries[:from_datetime],
-            to_datetime: boundaries[:to_datetime],
-            charges_from_datetime: boundaries[:charges_from_datetime],
-            charges_to_datetime: boundaries[:charges_to_datetime],
-            recurring:,
-          )
+          boundaries = {
+            from_datetime: invoice_subscription.from_datetime,
+            to_datetime: invoice_subscription.to_datetime,
+            charges_from_datetime: invoice_subscription.charges_from_datetime,
+            charges_to_datetime: invoice_subscription.charges_to_datetime,
+            timestamp: invoice_subscription.timestamp,
+            charges_duration: date_service.charges_duration_in_days,
+          }
 
           create_subscription_fee(subscription, boundaries) if should_create_subscription_fee?(subscription)
           create_charges_fees(subscription, boundaries) if should_create_charge_fees?(subscription)
@@ -72,31 +62,52 @@ module Invoices
     delegate :customer, :currency, to: :invoice
 
     def issuing_date
-      Time.zone.at(timestamp).in_time_zone(customer.applicable_timezone).to_date
+      timestamp.in_time_zone(customer.applicable_timezone).to_date
     end
 
     def date_service(subscription)
       Subscriptions::DatesService.new_instance(
         subscription,
-        Time.zone.at(timestamp),
+        timestamp,
         current_usage: subscription.terminated? && subscription.upgraded?,
       )
     end
 
-    def subscriptions_boundaries
-      @subscriptions_boundaries ||= subscriptions.each_with_object({}) do |subscription, boundaries|
-        boundaries[subscription.id] = calculate_boundaries(subscription)
-      end
+    def terminated_date_service(subscription, date_service)
+      return date_service unless subscription.terminated? && subscription.next_subscription.nil?
+
+      # First we need to ensure that termination date is not started_at date. In that case boundaries are correct
+      # and we should bill only one day. If this is not the case we should proceed.
+      return date_service if (timestamp - 1.day) < subscription.started_at
+
+      # Date service has various checks for terminated subscriptions. We want to avoid it and fetch boundaries
+      # for current usage (current period) but when subscription was active (one day ago)
+      duplicate = subscription.dup.tap { |s| s.status = :active }
+      new_dates_service = Subscriptions::DatesService.new_instance(duplicate, timestamp - 1.day, current_usage: true)
+
+      return date_service if timestamp < new_dates_service.charges_to_datetime
+      return date_service unless (timestamp - new_dates_service.charges_to_datetime) < 1.day
+
+      # We should calculate boundaries as if subscription was not terminated
+      new_dates_service = Subscriptions::DatesService.new_instance(duplicate, timestamp, current_usage: false)
+
+      matching_invoice_subscription?(subscription, new_dates_service) ? date_service : new_dates_service
     end
 
-    def duplicated_invoices?
-      return false unless recurring
+    def matching_invoice_subscription?(subscription, date_service)
+      base_query = InvoiceSubscription
+        .where(subscription_id: subscription.id)
+        .recurring
+        .where(from_datetime: date_service.from_datetime)
+        .where(to_datetime: date_service.to_datetime)
 
-      subscriptions_boundaries.any? do |subscription_id, boundaries|
-        subscription = Subscription.includes(:plan).find(subscription_id)
-
-        matching_invoice_subscription?(subscription, boundaries)
+      if subscription.plan.yearly? && subscription.plan.bill_charges_monthly?
+        base_query = base_query
+          .where(charges_from_datetime: date_service.charges_from_datetime)
+          .where(charges_to_datetime: date_service.charges_to_datetime)
       end
+
+      base_query.exists?
     end
 
     def create_subscription_fee(subscription, boundaries)
@@ -249,75 +260,8 @@ module Invoices
       invoice.total_amount_cents -= credit_amount_cents
     end
 
-    def calculate_boundaries(subscription)
-      date_service = date_service(subscription)
-
-      {
-        from_datetime: date_service.from_datetime,
-        to_datetime: date_service.to_datetime,
-        charges_from_datetime: date_service.charges_from_datetime,
-        charges_to_datetime: date_service.charges_to_datetime,
-        timestamp: Time.zone.at(timestamp),
-        charges_duration: date_service.charges_duration_in_days,
-      }
-    end
-
     def not_in_finalizing_process?
       (invoice.draft? || invoice.voided?) && context != :finalize
-    end
-
-    def matching_invoice_subscription?(subscription, boundaries)
-      base_query = InvoiceSubscription
-        .where(subscription_id: subscription.id)
-        .recurring
-        .where(from_datetime: boundaries[:from_datetime])
-        .where(to_datetime: boundaries[:to_datetime])
-
-      if subscription.plan.yearly? && subscription.plan.bill_charges_monthly?
-        base_query = base_query
-          .where(charges_from_datetime: boundaries[:charges_from_datetime])
-          .where(charges_to_datetime: boundaries[:charges_to_datetime])
-      end
-
-      base_query.exists?
-    end
-
-    # This method calculates boundaries for terminated subscription. If termination is happening on billing date
-    # new boundaries will be calculated only if there is no invoice subscription object for previous period.
-    # Basically, we will bill regular subscription amount for previous period.
-    # If subscription is happening on any other day, method is returning boundaries only for the used dates in
-    # current period
-    def termination_boundaries(subscription, boundaries)
-      return boundaries unless subscription.terminated? && subscription.next_subscription.nil?
-
-      current_time = Time.zone.at(timestamp)
-
-      # First we need to ensure that termination date is not started_at date. In that case boundaries are correct
-      # and we should bill only one day. If this is not the case we should proceed.
-      return boundaries if (current_time - 1.day) < subscription.started_at
-
-      # Date service has various checks for terminated subscriptions. We want to avoid it and fetch boundaries
-      # for current usage (current period) but when subscription was active (one day ago)
-      duplicate = subscription.dup.tap { |s| s.status = :active }
-
-      dates_service = Subscriptions::DatesService.new_instance(duplicate, current_time - 1.day, current_usage: true)
-
-      return boundaries if current_time < dates_service.charges_to_datetime
-      return boundaries unless (current_time - dates_service.charges_to_datetime) < 1.day
-
-      # We should calculate boundaries as if subscription was not terminated
-      dates_service = Subscriptions::DatesService.new_instance(duplicate, current_time, current_usage: false)
-
-      previous_period_boundaries = {
-        from_datetime: dates_service.from_datetime,
-        to_datetime: dates_service.to_datetime,
-        charges_from_datetime: dates_service.charges_from_datetime,
-        charges_to_datetime: dates_service.charges_to_datetime,
-        timestamp: current_time,
-        charges_duration: dates_service.charges_duration_in_days,
-      }
-
-      matching_invoice_subscription?(subscription, previous_period_boundaries) ? boundaries : previous_period_boundaries
     end
   end
 end

--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module Invoices
+  class CreateInvoiceSubscriptionService < BaseService
+    def initialize(invoice:, subscriptions:, timestamp:, recurring:, refresh: false)
+      @invoice = invoice
+      @subscriptions = subscriptions
+      @timestamp = timestamp
+      @recurring = recurring
+      @refresh = refresh
+
+      super
+    end
+
+    def call
+      if duplicated_invoices?
+        return result.service_failure!(
+          code: 'duplicated_invoices',
+          message: 'Invoice subscription already exists with the boundaries',
+        )
+      end
+
+      result.invoice_subscriptions = []
+
+      impacted_subscriptions.each do |subscription|
+        subscription_boundaries = subscriptions_boundaries[subscription.id]
+        boundaries = termination_boundaries(subscription, subscription_boundaries)
+
+        result.invoice_subscriptions << InvoiceSubscription.create!(
+          invoice:,
+          subscription:,
+          timestamp: boundaries[:timestamp],
+          from_datetime: boundaries[:from_datetime],
+          to_datetime: boundaries[:to_datetime],
+          charges_from_datetime: boundaries[:charges_from_datetime],
+          charges_to_datetime: boundaries[:charges_to_datetime],
+          recurring:,
+        )
+      end
+
+      result
+    end
+
+    private
+
+    attr_accessor :invoice, :subscriptions, :timestamp, :recurring, :refresh
+
+    def datetime
+      @datetime ||= Time.zone.at(timestamp)
+    end
+
+    def impacted_subscriptions
+      @impacted_subscriptions ||= if refresh
+        subscriptions
+      else
+        (recurring ? subscriptions.select(&:active?) : subscriptions).uniq(&:id)
+      end
+    end
+
+    def duplicated_invoices?
+      return false unless recurring
+
+      subscriptions_boundaries.any? do |subscription_id, boundaries|
+        subscription = Subscription.includes(:plan).find(subscription_id)
+
+        matching_invoice_subscription?(subscription, boundaries)
+      end
+    end
+
+    def subscriptions_boundaries
+      @subscriptions_boundaries ||= impacted_subscriptions.each_with_object({}) do |subscription, boundaries|
+        boundaries[subscription.id] = calculate_boundaries(subscription)
+      end
+    end
+
+    def calculate_boundaries(subscription)
+      date_service = date_service(subscription)
+
+      {
+        from_datetime: date_service.from_datetime,
+        to_datetime: date_service.to_datetime,
+        charges_from_datetime: date_service.charges_from_datetime,
+        charges_to_datetime: date_service.charges_to_datetime,
+        timestamp: datetime,
+      }
+    end
+
+    def date_service(subscription)
+      Subscriptions::DatesService.new_instance(
+        subscription,
+        datetime,
+        current_usage: subscription.terminated? && subscription.upgraded?,
+      )
+    end
+
+    # This method calculates boundaries for terminated subscription. If termination is happening on billing date
+    # new boundaries will be calculated only if there is no invoice subscription object for previous period.
+    # Basically, we will bill regular subscription amount for previous period.
+    # If subscription is happening on any other day, method is returning boundaries only for the used dates in
+    # current period
+    def termination_boundaries(subscription, boundaries)
+      return boundaries unless subscription.terminated? && subscription.next_subscription.nil?
+
+      # First we need to ensure that termination date is not started_at date. In that case boundaries are correct
+      # and we should bill only one day. If this is not the case we should proceed.
+      return boundaries if (datetime - 1.day) < subscription.started_at
+
+      # Date service has various checks for terminated subscriptions. We want to avoid it and fetch boundaries
+      # for current usage (current period) but when subscription was active (one day ago)
+      duplicate = subscription.dup.tap { |s| s.status = :active }
+
+      dates_service = Subscriptions::DatesService.new_instance(duplicate, datetime - 1.day, current_usage: true)
+      return boundaries if datetime < dates_service.charges_to_datetime
+      return boundaries unless (datetime - dates_service.charges_to_datetime) < 1.day
+
+      # We should calculate boundaries as if subscription was not terminated
+      dates_service = Subscriptions::DatesService.new_instance(duplicate, datetime, current_usage: false)
+
+      previous_period_boundaries = {
+        from_datetime: dates_service.from_datetime,
+        to_datetime: dates_service.to_datetime,
+        charges_from_datetime: dates_service.charges_from_datetime,
+        charges_to_datetime: dates_service.charges_to_datetime,
+        timestamp: datetime,
+        charges_duration: dates_service.charges_duration_in_days,
+      }
+
+      matching_invoice_subscription?(subscription, previous_period_boundaries) ? boundaries : previous_period_boundaries
+    end
+
+    def matching_invoice_subscription?(subscription, boundaries)
+      base_query = InvoiceSubscription
+        .where(subscription_id: subscription.id)
+        .recurring
+        .where(from_datetime: boundaries[:from_datetime])
+        .where(to_datetime: boundaries[:to_datetime])
+
+      if subscription.plan.yearly? && subscription.plan.bill_charges_monthly?
+        base_query = base_query
+          .where(charges_from_datetime: boundaries[:charges_from_datetime])
+          .where(charges_to_datetime: boundaries[:charges_to_datetime])
+      end
+
+      base_query.exists?
+    end
+  end
+end

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -64,8 +64,11 @@ module Invoices
         invoice_type: :subscription,
         currency: customer.currency,
         datetime: Time.zone.at(timestamp),
-        subscriptions_details: [Invoices::CreateGeneratingService::SubscriptionDetails.new(subscription, {}, false)],
-      )
+      ) do |invoice|
+        Invoices::CreateInvoiceSubscriptionService
+          .call(invoice:, subscriptions: [subscription], timestamp:, recurring: false)
+          .raise_if_error!
+      end
       invoice_result.raise_if_error!
 
       @invoice = invoice_result.invoice

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -27,13 +27,20 @@ module Invoices
         timestamp = fetch_timestamp
 
         invoice.fees.destroy_all
+
         invoice.invoice_subscriptions.destroy_all
         invoice.applied_taxes.destroy_all
 
-        calculate_result = Invoices::CalculateFeesService.call(
-          invoice: invoice.reload,
+        Invoices::CreateInvoiceSubscriptionService.call(
+          invoice:,
           subscriptions: Subscription.find(subscription_ids),
           timestamp:,
+          recurring:,
+          refresh: true,
+        ).raise_if_error!
+
+        calculate_result = Invoices::CalculateFeesService.call(
+          invoice: invoice.reload,
           recurring:,
           context:,
         )

--- a/db/seeds/invoices.rb
+++ b/db/seeds/invoices.rb
@@ -5,11 +5,11 @@ Subscription.all.find_each do |subscription|
   invoice_count = (Time.current - subscription.subscription_at).fdiv(1.month).round
 
   (0..invoice_count).each do |offset|
-    Invoices::SubscriptionService.new(
+    Invoices::SubscriptionService.call(
       subscriptions: [subscription],
       timestamp: Time.current - offset.months + 1.day,
       recurring: true,
-    ).create
+    )
   end
 end
 

--- a/lib/tasks/subscriptions.rake
+++ b/lib/tasks/subscriptions.rake
@@ -21,11 +21,11 @@ namespace :subscriptions do
     abort "External subscription ids not found\n\n" if subscriptions.blank?
     abort "Subscriptions don't belong to the same customer\n\n" if subscriptions.pluck(:customer_id).uniq.count > 1
 
-    result = Invoices::SubscriptionService.new(
+    result = Invoices::SubscriptionService.call(
       subscriptions:,
       timestamp: args[:timestamp].to_i,
       recurring: false,
-    ).create
+    )
     invoice = result.invoice
 
     invoice.update!(created_at: Time.zone.at(args[:timestamp].to_i))

--- a/spec/jobs/bill_subscription_job_spec.rb
+++ b/spec/jobs/bill_subscription_job_spec.rb
@@ -3,23 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe BillSubscriptionJob, type: :job do
-  let(:subscription) { create(:subscription) }
+  let(:subscriptions) { [create(:subscription)] }
   let(:timestamp) { Time.zone.now.to_i }
 
-  let(:invoice_service) { instance_double(Invoices::SubscriptionService) }
+  let(:invoice) { nil }
+  let(:recurring) { false }
   let(:result) { BaseService::Result.new }
 
-  it 'calls the invoices create service' do
-    allow(Invoices::SubscriptionService).to receive(:new)
-      .with(subscriptions: [subscription], timestamp:, recurring: false)
-      .and_return(invoice_service)
-    allow(invoice_service).to receive(:create)
+  before do
+    allow(Invoices::SubscriptionService).to receive(:call)
+      .with(subscriptions:, timestamp:, recurring:, invoice:)
       .and_return(result)
+  end
 
-    described_class.perform_now([subscription], timestamp)
+  it 'calls the invoices create service' do
+    described_class.perform_now(subscriptions, timestamp)
 
-    expect(Invoices::SubscriptionService).to have_received(:new)
-    expect(invoice_service).to have_received(:create)
+    expect(Invoices::SubscriptionService).to have_received(:call)
   end
 
   context 'when result is a failure' do
@@ -28,18 +28,52 @@ RSpec.describe BillSubscriptionJob, type: :job do
     end
 
     it 'raises an error' do
-      allow(Invoices::SubscriptionService).to receive(:new)
-        .with(subscriptions: [subscription], timestamp:, recurring: false)
-        .and_return(invoice_service)
-      allow(invoice_service).to receive(:create)
-        .and_return(result)
-
       expect do
-        described_class.perform_now([subscription], timestamp)
+        described_class.perform_now(subscriptions, timestamp)
       end.to raise_error(BaseService::FailedResult)
 
-      expect(Invoices::SubscriptionService).to have_received(:new)
-      expect(invoice_service).to have_received(:create)
+      expect(Invoices::SubscriptionService).to have_received(:call)
+    end
+
+    context 'with a previously created invoice' do
+      let(:invoice) { create(:invoice, :generating) }
+
+      it 'raises an error' do
+        expect do
+          described_class.perform_now(subscriptions, timestamp, invoice:)
+        end.to raise_error(BaseService::FailedResult)
+
+        expect(Invoices::SubscriptionService).to have_received(:call)
+      end
+    end
+
+    context 'when a generating invoice is attached to the result' do
+      let(:result_invoice) { create(:invoice, :generating) }
+
+      before { result.invoice = result_invoice }
+
+      it 'retries the job with the invoice' do
+        described_class.perform_now(subscriptions, timestamp)
+
+        expect(Invoices::SubscriptionService).to have_received(:call)
+
+        expect(described_class).to have_been_enqueued
+          .with(subscriptions, timestamp, recurring: false, invoice: result_invoice)
+      end
+    end
+
+    context 'when a not generating invoice is attached to the result' do
+      let(:result_invoice) { create(:invoice, :draft) }
+
+      before { result.invoice = result_invoice }
+
+      it 'raises an error' do
+        expect do
+          described_class.perform_now(subscriptions, timestamp)
+        end.to raise_error(BaseService::FailedResult)
+
+        expect(Invoices::SubscriptionService).to have_received(:call)
+      end
     end
   end
 end

--- a/spec/services/invoices/create_invoice_subscription_service_spec.rb
+++ b/spec/services/invoices/create_invoice_subscription_service_spec.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::CreateInvoiceSubscriptionService do
+  subject(:create_service) { described_class.new(invoice:, subscriptions:, timestamp:, recurring:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:invoice) { create(:invoice, organization:, customer:, status: :generating) }
+  let(:subscriptions) { [subscription] }
+  let(:timestamp) { Time.zone.parse('2022-03-07T00:00:00') }
+  let(:recurring) { false }
+
+  let(:subscription) do
+    create(
+      :subscription,
+      plan:,
+      customer:,
+      billing_time:,
+      subscription_at:,
+      started_at:,
+      created_at:,
+      status:,
+      terminated_at:,
+    )
+  end
+
+  let(:started_at) { Time.zone.parse('2021-06-06T00:00:00') }
+  let(:created_at) { started_at }
+  let(:subscription_at) { started_at }
+  let(:terminated_at) { nil }
+  let(:status) { :active }
+  let(:plan) { create(:plan, organization:, interval:, pay_in_advance:) }
+  let(:pay_in_advance) { false }
+  let(:billing_time) { :anniversary }
+  let(:interval) { 'monthly' }
+
+  describe '#call' do
+    it 'creates invoice subscriptions' do
+      result = create_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.invoice_subscriptions.count).to eq(1)
+
+        invoice_subscription = result.invoice_subscriptions.first
+        expect(invoice_subscription).to have_attributes(
+          invoice:,
+          subscription:,
+          timestamp: match_datetime(timestamp),
+          from_datetime: match_datetime(Time.zone.parse('2022-02-06 00:00:00')),
+          to_datetime: match_datetime(Time.zone.parse('2022-03-05 23:59:59')),
+          charges_from_datetime: match_datetime(Time.zone.parse('2022-02-06 00:00:00')),
+          charges_to_datetime: match_datetime(Time.zone.parse('2022-03-05 23:59:59')),
+          recurring:,
+        )
+      end
+    end
+
+    context 'when the plan is pay in advance' do
+      let(:billing_time) { :calendar }
+      let(:timestamp) { Time.zone.parse('2023-10-01T00:15:00') }
+      let(:started_at) { Time.zone.parse('2023-08-01T08:00:01') }
+      let(:pay_in_advance) { false }
+      let(:status) { :terminated }
+      let(:terminated_at) { Time.zone.parse('2023-10-01T00:00:00') }
+
+      it 'creates invoice subscriptions with termination boundaries' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice_subscriptions.count).to eq(1)
+
+          invoice_subscription = result.invoice_subscriptions.first
+          expect(invoice_subscription).to have_attributes(
+            invoice:,
+            subscription:,
+            timestamp: match_datetime(timestamp),
+            from_datetime: match_datetime(Time.zone.parse('2023-09-01T00:00:00')),
+            to_datetime: match_datetime(Time.zone.parse('2023-09-30T23:59:59')),
+            charges_from_datetime: match_datetime(Time.zone.parse('2023-09-01T00:00:00')),
+            charges_to_datetime: match_datetime(Time.zone.parse('2023-09-30T23:59:59')),
+            recurring:,
+          )
+        end
+      end
+
+      context 'when an existing invoice with the same boundaries' do
+        let(:invoice_subscription) do
+          create(
+            :invoice_subscription,
+            invoice: old_invoice,
+            subscription:,
+            from_datetime: Time.zone.parse('2023-09-01T00:00:00.000Z'),
+            to_datetime: Time.zone.parse('2023-09-30T23:59:59.999Z').end_of_day,
+            charges_from_datetime: Time.zone.parse('2023-09-01T00:00:00.000Z'),
+            charges_to_datetime: Time.zone.parse('2023-09-30T23:59:59.999Z').end_of_day,
+            recurring: true,
+          )
+        end
+
+        let(:old_invoice) do
+          create(
+            :invoice,
+            created_at: started_at - 3.months,
+            customer: subscription.customer,
+            organization: plan.organization,
+          )
+        end
+
+        before { invoice_subscription }
+
+        it 'creates an invoice subscriptions' do
+          result = create_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.invoice_subscriptions.count).to eq(1)
+
+            invoice_subscription = result.invoice_subscriptions.first
+            expect(invoice_subscription).to have_attributes(
+              invoice:,
+              subscription:,
+              from_datetime: match_datetime(Time.zone.parse('2023-10-01T00:00:00')),
+              to_datetime: match_datetime(Time.zone.parse('2023-10-01T00:00:00')),
+              charges_from_datetime: match_datetime(Time.zone.parse('2023-10-01T00:00:00')),
+              charges_to_datetime: match_datetime(Time.zone.parse('2023-10-01T00:00:00')),
+              recurring:,
+            )
+          end
+        end
+      end
+    end
+
+    context 'when two subscriptions are given' do
+      let(:subscription2) do
+        create(
+          :subscription,
+          plan:,
+          customer: subscription.customer,
+          subscription_at: (Time.zone.now - 2.years).to_date,
+          started_at: Time.zone.now - 2.years,
+        )
+      end
+
+      let(:subscriptions) { [subscription, subscription2] }
+
+      it 'creates subscription and charges fees for both' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice_subscriptions.count).to eq(2)
+        end
+      end
+
+      context 'when subscriptions are duplicated' do
+        let(:subscriptions) { [subscription, subscription] }
+
+        it 'ensures charges are not duplicated' do
+          result = create_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.invoice_subscriptions.count).to eq(1)
+          end
+        end
+      end
+    end
+
+    context 'when recurring and subscription is not active' do
+      let(:recurring) { true }
+      let(:status) { :terminated }
+
+      it 'does not create an invoice subscription' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice_subscriptions).to be_empty
+        end
+      end
+    end
+
+    context 'when invoice_subscription already exists' do
+      let(:recurring) { true }
+
+      let(:date_service) do
+        Subscriptions::DatesService.new_instance(
+          subscription,
+          Time.zone.at(timestamp),
+          current_usage: false,
+        )
+      end
+
+      before do
+        create(
+          :invoice_subscription,
+          subscription:,
+          recurring:,
+          timestamp: timestamp.to_i,
+          from_datetime: date_service.from_datetime,
+          to_datetime: date_service.to_datetime,
+          charges_from_datetime: date_service.charges_from_datetime,
+          charges_to_datetime: date_service.charges_to_datetime,
+        )
+      end
+
+      it 'returns a service failure' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ServiceFailure)
+          expect(result.error.code).to eq('duplicated_invoices')
+          expect(result.error.error_message).to be_present
+        end
+      end
+
+      context 'when plan interval is yearly and charges are not paid on monthly basis' do
+        let(:plan) do
+          create(:plan, organization:, interval: 'yearly', pay_in_advance: false, bill_charges_monthly: false)
+        end
+
+        it 'returns a service failure' do
+          result = create_service.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ServiceFailure)
+            expect(result.error.code).to eq('duplicated_invoices')
+            expect(result.error.error_message).to be_present
+          end
+        end
+      end
+
+      context 'when plan interval is yearly and charges are paid on monthly basis' do
+        let(:plan) do
+          create(:plan, organization:, interval: 'yearly', pay_in_advance: false, bill_charges_monthly: true)
+        end
+
+        it 'returns a service failure' do
+          result = create_service.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ServiceFailure)
+            expect(result.error.code).to eq('duplicated_invoices')
+            expect(result.error.error_message).to be_present
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/1546

## Description

It makes use of the new `Invoices::CreateGeneratingService` service in the `Invoices::SubscriptionService`, to reduce the risk of database locking when generating the `organization_sequential_id`

A logic to prevent duplication of `generating` invoice was also added to the `Invoices::SubscriptionService`