### PR TITLE
fix(webhooks): Handle OpenSSL::SSL::SSLError error class for retry

### DIFF
--- a/app/services/webhooks/base_service.rb
+++ b/app/services/webhooks/base_service.rb
@@ -70,6 +70,7 @@ module Webhooks
            Net::ReadTimeout,
            Errno::ECONNRESET,
            Errno::ECONNREFUSED,
+           OpenSSL::SSL::SSLError,
            SocketError,
            EOFError => e
       fail_webhook(webhook, e)


### PR DESCRIPTION
## Description

This PR adds the `OpenSSL::SSL::SSLError` error to the list of webhook delivery errors that should be reprocessed automatically or marked as failed after 6 attempts