### PR TITLE
fix(invoice): Monthly boundaries with aniversary on the 31st

### DIFF
--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -515,7 +515,7 @@ RSpec.describe Fees::SubscriptionService do
           {
             from_datetime: Time.zone.parse('2022-08-31 00:00:00'),
             to_datetime: Time.zone.parse('2022-09-30 23:59:59'),
-            timestamp: Time.zone.parse('2022-04-02 00:00').end_of_month.to_i,
+            timestamp: Time.zone.parse('2022-10-01 00:00').to_i,
           }
         end
 
@@ -528,7 +528,7 @@ RSpec.describe Fees::SubscriptionService do
             it 'creates a fee with prorated amount based on trial' do
               result = fees_subscription_service.create
 
-              expect(result.fee.amount_cents).to eq(1548)
+              expect(result.fee.amount_cents).to eq(1600)
             end
           end
         end

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -158,6 +158,15 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         it 'returns the day current billing day' do
           expect(result).to eq('2021-03-31 00:00:00 UTC')
         end
+
+        context 'when subscription month is shorter than billing one' do
+          let(:billing_at) { DateTime.parse('30 mar 2020') }
+          let(:subscription_at) { DateTime.parse('30 apr 2019') }
+
+          it 'returns the current billing day' do
+            expect(result).to eq('2020-02-29 00:00:00 UTC')
+          end
+        end
       end
     end
   end
@@ -231,10 +240,18 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       context 'when billing subscription day does not exist in the month' do
         let(:subscription_at) { DateTime.parse('31 Jan 2022') }
-        let(:billing_at) { DateTime.parse('01 Mar 2022') }
+        let(:billing_at) { DateTime.parse('28 Feb 2022') }
 
         it 'returns the last day of the month' do
-          expect(result).to eq('2022-02-28 23:59:59 UTC')
+          expect(result).to eq('2022-02-27 23:59:59 UTC')
+        end
+
+        context 'when subscription is not the last day of the month' do
+          let(:subscription_at) { DateTime.parse('30 Jan 2022') }
+
+          it 'returns the last day of the month' do
+            expect(result).to eq('2022-02-27 23:59:59 UTC')
+          end
         end
       end
 


### PR DESCRIPTION
## Context

An issue have been reported by a user on anniversary billing of monthly subscription. If the anniversary day of the subscription is on a 31, billing on month having less than 31 days result in wrong boundaries computation and possibly on invoice not generated due to the DB index preventing invoice duplication.

## Description

This PR fixes the issue by ensuring the boundaries are correct, matches the subscription identified by the billing job, does not overlap each other and covers every days.

For example, if the anniversary is on 31, when billing on 28 of February 2023, the period must go from 2023-01-31 to 2023-02-27, and the next period will cover 2023-02-28 to 2023-03-30

NOTE: the same issue might exists for quarterly subscriptions and for yearly with anniversary day on the 29 of February. Proper fixes will come in future PR.