### PR TITLE
feat(stripe): do not mark invoice as failed when amount is too small

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -140,6 +140,10 @@ module Invoices
           },
         )
       rescue Stripe::CardError, Stripe::InvalidRequestError, Stripe::PermissionError => e
+        # NOTE: Do not mark the invoice as failed if the amount is too small for Stripe
+        #       For now we keep it as pending, the user can still update it manually
+        return if e.code == 'amount_too_small'
+
         deliver_error_webhook(e)
         update_invoice_payment_status(payment_status: :failed, deliver_webhook: false)
         nil


### PR DESCRIPTION
- Do not mark the invoice as failed when the amount is too small for Stripe