### PR TITLE
Make it possible to configure when subscription termination alert is sent by setting env var

### DIFF
--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -25,11 +25,11 @@ module Clock
     private
 
     def sent_at_dates
-      # The alert will be sent 15 and 45 days before the subscription is terminated by default.
-      # You can override the default by setting below env var.
-      # E.g. LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS=1,15,45 will cause it
-      # to be sent at 1, 15, 45 days before subscription terminates, respectively.
-      sent_at_days_config = ENV.fetch("LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS", "15,45")
+      # NOTE: The alert will be sent 15 and 45 days before the subscription is terminated by default.
+      #       You can override the default by setting below env var.
+      #       E.g. LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS=1,15,45 will cause it
+      #       to be sent at 1, 15, 45 days before subscription terminates, respectively.
+      sent_at_days_config = ENV.fetch('LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS', '15,45')
       sent_at_days_config.split(',').map { |day_string| Time.current + day_string.to_i.days }.map(&:to_date)
     end
   end

--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -12,7 +12,7 @@ module Clock
         .active
         .where(
           'DATE(subscriptions.ending_at::timestamptz) IN (?)',
-          [(Time.current + 45.days).to_date, (Time.current + 15.days).to_date],
+          sent_at_dates,
         )
         .where('webhooks.id IS NULL OR webhooks.created_at::date != ?', Time.current.to_date)
         .find_each do |subscription|
@@ -20,6 +20,17 @@ module Clock
             SendWebhookJob.perform_later('subscription.termination_alert', subscription)
           end
         end
+    end
+
+    private
+
+    def sent_at_dates
+      # The alert will be sent 15 and 45 days before the subscription is terminated by default.
+      # You can override the default by setting below env var.
+      # E.g. LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS=1,15,45 will cause it
+      # to be sent at 1, 15, 45 days before subscription terminates, respectively.
+      sent_at_days_config = ENV.fetch("LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS", "15,45")
+      sent_at_days_config.split(',').map { |day_string| Time.current + day_string.to_i.days }.map(&:to_date)
     end
   end
 end

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -67,9 +67,7 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
 
           # Now validate that with custom config, it is actually sent
           stub_const('ENV', 'LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS' => '1,15,45')
-          expect do
-            described_class.perform_now
-          end
+          expect { described_class.perform_now}
             .to have_enqueued_job(SendWebhookJob)
             .with('subscription.termination_alert', Subscription)
             .exactly(:once)

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -37,8 +37,8 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
           described_class.perform_now
         end
           .to have_enqueued_job(SendWebhookJob)
-                .with('subscription.termination_alert', Subscription)
-                .exactly(:once)
+          .with('subscription.termination_alert', Subscription)
+          .exactly(:once)
       end
     end
 
@@ -101,8 +101,8 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
             described_class.perform_now
           end
             .to have_enqueued_job(SendWebhookJob)
-                  .with('subscription.termination_alert', Subscription)
-                  .exactly(0).times
+            .with('subscription.termination_alert', Subscription)
+            .exactly(0).times
         end
       end
     end
@@ -128,8 +128,8 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
             described_class.perform_now
           end
             .to have_enqueued_job(SendWebhookJob)
-                  .with('subscription.termination_alert', Subscription)
-                  .exactly(:once)
+            .with('subscription.termination_alert', Subscription)
+            .exactly(:once)
         end
       end
     end

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -51,8 +51,8 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
             described_class.perform_now
           end
             .to have_enqueued_job(SendWebhookJob)
-                  .with('subscription.termination_alert', Subscription)
-                  .exactly(:once)
+            .with('subscription.termination_alert', Subscription)
+            .exactly(:once)
         end
       end
     end
@@ -74,8 +74,8 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
             described_class.perform_now
           end
             .to have_enqueued_job(SendWebhookJob)
-                  .with('subscription.termination_alert', Subscription)
-                  .exactly(:once)
+            .with('subscription.termination_alert', Subscription)
+            .exactly(:once)
         end
       end
     end

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -37,8 +37,8 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
           described_class.perform_now
         end
           .to have_enqueued_job(SendWebhookJob)
-          .with('subscription.termination_alert', Subscription)
-          .exactly(:once)
+                .with('subscription.termination_alert', Subscription)
+                .exactly(:once)
       end
     end
 
@@ -51,8 +51,31 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
             described_class.perform_now
           end
             .to have_enqueued_job(SendWebhookJob)
-            .with('subscription.termination_alert', Subscription)
-            .exactly(:once)
+                  .with('subscription.termination_alert', Subscription)
+                  .exactly(:once)
+        end
+      end
+    end
+
+    context 'when current date is 1 day before subscription ending_at' do
+      it 'sends webhook that subscription is going to be terminated but only if config is overridden' do
+        current_date = ending_at - 1.days
+
+        travel_to(current_date) do
+          # First validate that with default config nothing is sent
+          expect do
+            described_class.perform_now
+          end
+            .not_to have_enqueued_job(SendWebhookJob)
+
+          # Now validate that with custom config, it is actually sent
+          stub_const('ENV', 'LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS' => '1,15,45')
+          expect do
+            described_class.perform_now
+          end
+            .to have_enqueued_job(SendWebhookJob)
+                  .with('subscription.termination_alert', Subscription)
+                  .exactly(:once)
         end
       end
     end
@@ -78,8 +101,8 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
             described_class.perform_now
           end
             .to have_enqueued_job(SendWebhookJob)
-            .with('subscription.termination_alert', Subscription)
-            .exactly(0).times
+                  .with('subscription.termination_alert', Subscription)
+                  .exactly(0).times
         end
       end
     end
@@ -105,8 +128,8 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
             described_class.perform_now
           end
             .to have_enqueued_job(SendWebhookJob)
-            .with('subscription.termination_alert', Subscription)
-            .exactly(:once)
+                  .with('subscription.termination_alert', Subscription)
+                  .exactly(:once)
         end
       end
     end

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -63,10 +63,7 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
 
         travel_to(current_date) do
           # First validate that with default config nothing is sent
-          expect do
-            described_class.perform_now
-          end
-            .not_to have_enqueued_job(SendWebhookJob)
+          expect { described_class.perform_now }.not_to have_enqueued_job(SendWebhookJob)
 
           # Now validate that with custom config, it is actually sent
           stub_const('ENV', 'LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS' => '1,15,45')


### PR DESCRIPTION
## Context

It's nice to make this configurable. e.g. in my case I want it sent 1 day before ending as well.

## Description

By setting env var `LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS` it can be overridden from the defaults.

E.g. `LAGO_SUBSCRIPTION_TERMINATION_ALERT_SENT_AT_DAYS` to `1,30` will cause it be sent 1 and 30 days in advance.
