### PR TITLE
fix: Prevent from having NaN precise_coupons_amount_cents

### DIFF
--- a/app/services/credits/applied_coupon_service.rb
+++ b/app/services/credits/applied_coupon_service.rb
@@ -25,9 +25,11 @@ module Credits
       )
 
       fees.reload.each do |fee|
-        fee.precise_coupons_amount_cents += (
-          credit_amount * (fee.amount_cents - fee.precise_coupons_amount_cents)
-        ).fdiv(base_amount_cents)
+        unless base_amount_cents.zero?
+          fee.precise_coupons_amount_cents += (
+            credit_amount * (fee.amount_cents - fee.precise_coupons_amount_cents)
+          ).fdiv(base_amount_cents)
+        end
 
         fee.precise_coupons_amount_cents = fee.amount_cents if fee.amount_cents < fee.precise_coupons_amount_cents
         fee.save!

--- a/spec/services/credits/applied_coupon_service_spec.rb
+++ b/spec/services/credits/applied_coupon_service_spec.rb
@@ -56,6 +56,17 @@ RSpec.describe Credits::AppliedCouponService do
       expect(applied_coupon.reload).to be_terminated
     end
 
+    context 'when base_amount_cents is equal to 0' do
+      let(:base_amount_cents) { 0 }
+
+      it 'limits the credit amount to the invoice amount' do
+        result = credit_service.call
+
+        expect(result).to be_success
+        expect(result.credit.amount_cents).to eq(0)
+      end
+    end
+
     context 'when coupon amount is higher than invoice amount' do
       let(:base_amount_cents) { 6 }
 


### PR DESCRIPTION
Recently, an issue has been identified where finalizing an invoice wasn't possible due to a `FloatDomainError`.

That's because `precise_coupons_amount_cents` is trying to be created with a `NaN` value on `Fee` object.