### PR TITLE
fix(charge-usage): Fix sorting by group name

### DIFF
--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -31,7 +31,7 @@ module V1
       private
 
       def groups(fees)
-        fees.sort_by { |f| f.group&.name }.map do |f|
+        fees.sort_by { |f| f.group&.name.to_s }.map do |f|
           next unless f.group
 
           {

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::Customers::ChargeUsageSerializer do
+  subject(:serializer) { described_class.new(nil) }
+
+  describe '#groups' do
+    subject(:serializer_groups) { serializer.__send__(:groups, fees) }
+
+    let(:fees) { [fee1, fee2] }
+    let(:group) { create(:group) }
+
+    context 'when all fees have groups' do
+      let(:fee1) { create(:fee, group:) }
+      let(:fee2) { create(:fee, group:) }
+
+      let(:groups) do
+        [
+          {
+            lago_id: fee2.group.id,
+            key: fee2.group.key,
+            value: fee2.group.value,
+            units: fee2.units,
+            amount_cents: fee2.amount_cents,
+            events_count: fee2.events_count,
+          },
+          {
+            lago_id: fee1.group.id,
+            key: fee1.group.key,
+            value: fee1.group.value,
+            units: fee1.units,
+            amount_cents: fee1.amount_cents,
+            events_count: fee1.events_count,
+          },
+        ]
+      end
+
+      it 'returns groups array' do
+        expect(serializer_groups).to eq(groups)
+      end
+    end
+
+    context 'when one fee does not have a group' do
+      let(:fee1) { create(:fee) }
+      let(:fee2) { create(:fee, group:) }
+
+      let(:groups) do
+        [
+          {
+            lago_id: fee2.group.id,
+            key: fee2.group.key,
+            value: fee2.group.value,
+            units: fee2.units,
+            amount_cents: fee2.amount_cents,
+            events_count: fee2.events_count,
+          },
+        ]
+      end
+
+      it 'returns groups array' do
+        expect(serializer_groups).to eq(groups)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Sorting fee by group name raises an error when fee belongs to no group.

## Description

This PR fixes the sorting in `ChargeUsageSerializer`