### PR TITLE
feat(unit-price) add amount_details attribute to Fee object

### DIFF
--- a/app/graphql/types/fees/amount_details/graduated_percentage_range.rb
+++ b/app/graphql/types/fees/amount_details/graduated_percentage_range.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Types
+  module Fees
+    module AmountDetails
+      class GraduatedPercentageRange < Types::BaseObject
+        graphql_name 'FeeAmountDetailsGraduatedPercentageRange'
+
+        field :flat_unit_amount, String, null: true
+        field :from_value, Integer, null: true
+        field :per_unit_total_amount, String, null: true
+        field :rate, String, null: true
+        field :to_value, Integer, null: true
+        field :total_with_flat_amount, String, null: true
+        field :units, String, null: true
+      end
+    end
+  end
+end

--- a/app/graphql/types/fees/amount_details/graduated_range.rb
+++ b/app/graphql/types/fees/amount_details/graduated_range.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Types
+  module Fees
+    module AmountDetails
+      class GraduatedRange < Types::BaseObject
+        graphql_name 'FeeAmountDetailsGraduatedRange'
+
+        field :flat_unit_amount, String, null: true
+        field :from_value, Integer, null: true
+        field :per_unit_amount, String, null: true
+        field :per_unit_total_amount, String, null: true
+        field :to_value, Integer, null: true
+        field :total_with_flat_amount, String, null: true
+        field :units, String, null: true
+      end
+    end
+  end
+end

--- a/app/graphql/types/fees/amount_details/object.rb
+++ b/app/graphql/types/fees/amount_details/object.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Types
+  module Fees
+    module AmountDetails
+      class Object < Types::BaseObject
+        graphql_name 'FeeAmountDetails'
+
+        # NOTE: Graduated charge model
+        field :graduated_ranges, [Types::Fees::AmountDetails::GraduatedRange], null: true
+
+        # NOTE: Graduated percentage modle
+        field :graduated_percentage_ranges, [Types::Fees::AmountDetails::GraduatedPercentageRange], null: true
+
+        # NOTE: Package charge model
+        field :per_package_size, Integer, null: true
+        field :per_package_unit_amount, String, null: true
+
+        # NOTE: Percentage charge model
+        field :fixed_fee_total_amount, String, null: true
+        field :fixed_fee_unit_amount, String, null: true
+        field :free_events, Integer, null: true
+        field :min_max_adjustment_total_amount, String, null: true
+        field :paid_events, Integer, null: true
+        field :rate, String, null: true
+        field :units, String, null: true
+
+        # NOTE: Volume charge model
+        field :flat_unit_amount, String, null: true
+        field :per_unit_amount, String, null: true
+
+        # NOTE: Percentage & Volume charge model
+        field :per_unit_total_amount, String, null: true
+
+        # NOTE: Package & Percentage charge model
+        field :free_units, String, null: true
+        field :paid_units, String, null: true
+      end
+    end
+  end
+end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -26,6 +26,8 @@ module Types
 
       field :applied_taxes, [Types::Fees::AppliedTaxes::Object]
 
+      field :amount_details, Types::Fees::AmountDetails::Object, null: true
+
       delegate :group_name, to: :object
       delegate :invoice_name, to: :object
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -3023,6 +3023,7 @@ type EventCollection {
 type Fee implements InvoiceItem {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
+  amountDetails: FeeAmountDetails
   appliedTaxes: [FeeAppliedTax!]
   charge: Charge
   creditableAmountCents: BigInt!
@@ -3045,6 +3046,45 @@ type Fee implements InvoiceItem {
   trueUpFee: Fee
   trueUpParentFee: Fee
   units: Float!
+}
+
+type FeeAmountDetails {
+  fixedFeeTotalAmount: String
+  fixedFeeUnitAmount: String
+  flatUnitAmount: String
+  freeEvents: Int
+  freeUnits: String
+  graduatedPercentageRanges: [FeeAmountDetailsGraduatedPercentageRange!]
+  graduatedRanges: [FeeAmountDetailsGraduatedRange!]
+  minMaxAdjustmentTotalAmount: String
+  paidEvents: Int
+  paidUnits: String
+  perPackageSize: Int
+  perPackageUnitAmount: String
+  perUnitAmount: String
+  perUnitTotalAmount: String
+  rate: String
+  units: String
+}
+
+type FeeAmountDetailsGraduatedPercentageRange {
+  flatUnitAmount: String
+  fromValue: Int
+  perUnitTotalAmount: String
+  rate: String
+  toValue: Int
+  totalWithFlatAmount: String
+  units: String
+}
+
+type FeeAmountDetailsGraduatedRange {
+  flatUnitAmount: String
+  fromValue: Int
+  perUnitAmount: String
+  perUnitTotalAmount: String
+  toValue: Int
+  totalWithFlatAmount: String
+  units: String
 }
 
 type FeeAppliedTax implements AppliedTax {

--- a/schema.json
+++ b/schema.json
@@ -11157,6 +11157,20 @@
               ]
             },
             {
+              "name": "amountDetails",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "FeeAmountDetails",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "appliedTaxes",
               "description": null,
               "type": {
@@ -11505,6 +11519,481 @@
                   "name": "Float",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FeeAmountDetails",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "fixedFeeTotalAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fixedFeeUnitAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "flatUnitAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "freeEvents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "freeUnits",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "graduatedPercentageRanges",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "FeeAmountDetailsGraduatedPercentageRange",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "graduatedRanges",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "FeeAmountDetailsGraduatedRange",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "minMaxAdjustmentTotalAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "paidEvents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "paidUnits",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "perPackageSize",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "perPackageUnitAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "perUnitAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "perUnitTotalAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "rate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "units",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FeeAmountDetailsGraduatedPercentageRange",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "flatUnitAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fromValue",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "perUnitTotalAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "rate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "toValue",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "totalWithFlatAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "units",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FeeAmountDetailsGraduatedRange",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "flatUnitAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "fromValue",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "perUnitAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "perUnitTotalAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "toValue",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "totalWithFlatAmount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "units",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,


### PR DESCRIPTION
## Context

We're adding more context to the invoices. PDF have already been updated using the new `amount_details` attribute's values

## Description

This PR maps the new attributes and expose them to GraphQL to have them available for FE