### PR TITLE
feat(edit-draft-invoice): add group_id to adjusted fees table

### DIFF
--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -5,6 +5,7 @@ class AdjustedFee < ApplicationRecord
   belongs_to :subscription
   belongs_to :fee, optional: true
   belongs_to :charge, optional: true
+  belongs_to :group, optional: true
 
   enum fee_type: Fee::FEE_TYPES
 end

--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -23,6 +23,7 @@ module AdjustedFees
         invoice: fee.invoice,
         subscription: fee.subscription,
         charge: fee.charge,
+        group: fee.group,
         adjusted_units: params[:unit_amount_cents]&.blank?,
         adjusted_amount: params[:unit_amount_cents]&.present?,
         invoice_display_name: params[:invoice_display_name],

--- a/db/migrate/20240103125624_add_group_id_to_adjusted_fees.rb
+++ b/db/migrate/20240103125624_add_group_id_to_adjusted_fees.rb
@@ -1,0 +1,5 @@
+class AddGroupIdToAdjustedFees < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :adjusted_fees, :group, type: :uuid, null: true, index: true, foreign_key: true
+  end
+end

--- a/db/migrate/20240103125624_add_group_id_to_adjusted_fees.rb
+++ b/db/migrate/20240103125624_add_group_id_to_adjusted_fees.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGroupIdToAdjustedFees < ActiveRecord::Migration[7.0]
   def change
     add_reference :adjusted_fees, :group, type: :uuid, null: true, index: true, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_20_140936) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_03_125624) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -87,8 +87,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_20_140936) do
     t.jsonb "properties", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "group_id"
     t.index ["charge_id"], name: "index_adjusted_fees_on_charge_id"
     t.index ["fee_id"], name: "index_adjusted_fees_on_fee_id"
+    t.index ["group_id"], name: "index_adjusted_fees_on_group_id"
     t.index ["invoice_id"], name: "index_adjusted_fees_on_invoice_id"
     t.index ["subscription_id"], name: "index_adjusted_fees_on_subscription_id"
   end
@@ -872,6 +874,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_20_140936) do
   add_foreign_key "add_ons_taxes", "taxes"
   add_foreign_key "adjusted_fees", "charges"
   add_foreign_key "adjusted_fees", "fees"
+  add_foreign_key "adjusted_fees", "groups"
   add_foreign_key "adjusted_fees", "invoices"
   add_foreign_key "adjusted_fees", "subscriptions"
   add_foreign_key "applied_add_ons", "add_ons"


### PR DESCRIPTION
## Context

Currently it is not possible to manually edit draft invoice.

## Description

This id DB-only change where group_id is added to the adjusted fees table, collection needed to persist manual adjustments.
