### PR TITLE
feat (edit-draft-invoice): add adjusted fee bool field in fee graphql object

### DIFF
--- a/app/graphql/types/adjusted_fees/adjusted_fee_type_enum.rb
+++ b/app/graphql/types/adjusted_fees/adjusted_fee_type_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module AdjustedFees
+    class AdjustedFeeTypeEnum < Types::BaseEnum
+      graphql_name 'AdjustedFeeTypeEnum'
+
+      AdjustedFee::ADJUSTED_FEE_TYPES.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/adjusted_fees/adjusted_fee_type_enum.rb
+++ b/app/graphql/types/adjusted_fees/adjusted_fee_type_enum.rb
@@ -3,8 +3,6 @@
 module Types
   module AdjustedFees
     class AdjustedFeeTypeEnum < Types::BaseEnum
-      graphql_name 'AdjustedFeeTypeEnum'
-
       AdjustedFee::ADJUSTED_FEE_TYPES.each do |type|
         value type
       end

--- a/app/graphql/types/adjusted_fees/create_input.rb
+++ b/app/graphql/types/adjusted_fees/create_input.rb
@@ -8,7 +8,7 @@ module Types
       argument :fee_id, ID, required: true
       argument :invoice_display_name, String, required: false
       argument :unit_amount_cents, GraphQL::Types::BigInt, required: false
-      argument :units, GraphQL::Types::Float, required: true
+      argument :units, GraphQL::Types::Float, required: false
     end
   end
 end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -47,7 +47,7 @@ module Types
       end
 
       def adjusted_fee_type
-        return nil unless object.adjusted_fee.present?
+        return nil if object.adjusted_fee.blank?
 
         object.adjusted_fee.adjusted_units? ? 'adjusted_units' : 'adjusted_amount'
       end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -47,11 +47,9 @@ module Types
       end
 
       def adjusted_fee_type
-        if object.adjusted_fee.present?
-          object.adjusted_fee.adjusted_units? ? 'adjusted_units' : 'adjusted_amount'
-        else
-          nil
-        end
+        return nil unless object.adjusted_fee.present?
+
+        object.adjusted_fee.adjusted_units? ? 'adjusted_units' : 'adjusted_amount'
       end
     end
   end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -29,6 +29,7 @@ module Types
       field :amount_details, Types::Fees::AmountDetails::Object, null: true
 
       field :adjusted_fee, Boolean, null: false
+      field :adjusted_fee_type, String, null: true
 
       delegate :group_name, to: :object
       delegate :invoice_name, to: :object
@@ -43,6 +44,14 @@ module Types
 
       def adjusted_fee
         object.adjusted_fee.present?
+      end
+
+      def adjusted_fee_type
+        if object.adjusted_fee.present?
+          object.adjusted_fee.adjusted_units? ? 'adjusted_units' : 'adjusted_amount'
+        else
+          nil
+        end
       end
     end
   end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -28,6 +28,8 @@ module Types
 
       field :amount_details, Types::Fees::AmountDetails::Object, null: true
 
+      field :adjusted_fee, Boolean, null: false
+
       delegate :group_name, to: :object
       delegate :invoice_name, to: :object
 
@@ -37,6 +39,10 @@ module Types
 
       def applied_taxes
         object.applied_taxes.order(tax_rate: :desc)
+      end
+
+      def adjusted_fee
+        object.adjusted_fee.present?
       end
     end
   end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -48,6 +48,7 @@ module Types
 
       def adjusted_fee_type
         return nil if object.adjusted_fee.blank?
+        return nil if object.adjusted_fee.adjusted_display_name?
 
         object.adjusted_fee.adjusted_units? ? 'adjusted_units' : 'adjusted_amount'
       end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -29,7 +29,7 @@ module Types
       field :amount_details, Types::Fees::AmountDetails::Object, null: true
 
       field :adjusted_fee, Boolean, null: false
-      field :adjusted_fee_type, String, null: true
+      field :adjusted_fee_type, Types::AdjustedFees::AdjustedFeeTypeEnum, null: true
 
       delegate :group_name, to: :object
       delegate :invoice_name, to: :object

--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -7,5 +7,10 @@ class AdjustedFee < ApplicationRecord
   belongs_to :charge, optional: true
   belongs_to :group, optional: true
 
+  ADJUSTED_FEE_TYPES = [
+    :adjusted_units,
+    :adjusted_amount,
+  ].freeze
+
   enum fee_type: Fee::FEE_TYPES
 end

--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -13,4 +13,8 @@ class AdjustedFee < ApplicationRecord
   ].freeze
 
   enum fee_type: Fee::FEE_TYPES
+
+  def adjusted_display_name?
+    adjusted_units.blank? && adjusted_amount.blank?
+  end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1587,7 +1587,7 @@ input CreateAdjustedFeeInput {
   feeId: ID!
   invoiceDisplayName: String
   unitAmountCents: BigInt
-  units: Float!
+  units: Float
 }
 
 """

--- a/schema.graphql
+++ b/schema.graphql
@@ -3030,6 +3030,7 @@ type EventCollection {
 }
 
 type Fee implements InvoiceItem {
+  adjustedFee: Boolean!
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   amountDetails: FeeAmountDetails

--- a/schema.graphql
+++ b/schema.graphql
@@ -88,6 +88,11 @@ input AddStripePaymentProviderInput {
   successRedirectUrl: String
 }
 
+enum AdjustedFeeTypeEnum {
+  adjusted_amount
+  adjusted_units
+}
+
 type AdyenProvider {
   apiKey: String
   code: String!
@@ -3031,7 +3036,7 @@ type EventCollection {
 
 type Fee implements InvoiceItem {
   adjustedFee: Boolean!
-  adjustedFeeType: String
+  adjustedFeeType: AdjustedFeeTypeEnum
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   amountDetails: FeeAmountDetails

--- a/schema.graphql
+++ b/schema.graphql
@@ -3031,6 +3031,7 @@ type EventCollection {
 
 type Fee implements InvoiceItem {
   adjustedFee: Boolean!
+  adjustedFeeType: String
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   amountDetails: FeeAmountDetails

--- a/schema.json
+++ b/schema.json
@@ -11263,6 +11263,24 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "adjustedFee",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "amountCents",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -672,6 +672,29 @@
           "enumValues": null
         },
         {
+          "kind": "ENUM",
+          "name": "AdjustedFeeTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "adjusted_units",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "adjusted_amount",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
           "kind": "OBJECT",
           "name": "AdyenProvider",
           "description": null,
@@ -11284,8 +11307,8 @@
               "name": "adjustedFeeType",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "AdjustedFeeTypeEnum",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -4858,13 +4858,9 @@
               "name": "units",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Float",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -11281,6 +11281,20 @@
               ]
             },
             {
+              "name": "adjustedFeeType",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "amountCents",
               "description": null,
               "type": {

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -19,4 +19,5 @@ RSpec.describe Types::Fees::Object do
   it { is_expected.to have_field(:units).of_type('Float!') }
   it { is_expected.to have_field(:applied_taxes).of_type('[FeeAppliedTax!]') }
   it { is_expected.to have_field(:adjusted_fee).of_type('Boolean!') }
+  it { is_expected.to have_field(:adjusted_fee_type).of_type('String') }
 end

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -19,5 +19,5 @@ RSpec.describe Types::Fees::Object do
   it { is_expected.to have_field(:units).of_type('Float!') }
   it { is_expected.to have_field(:applied_taxes).of_type('[FeeAppliedTax!]') }
   it { is_expected.to have_field(:adjusted_fee).of_type('Boolean!') }
-  it { is_expected.to have_field(:adjusted_fee_type).of_type('String') }
+  it { is_expected.to have_field(:adjusted_fee_type).of_type('AdjustedFeeTypeEnum') }
 end

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -18,4 +18,5 @@ RSpec.describe Types::Fees::Object do
   it { is_expected.to have_field(:taxes_rate).of_type('Float') }
   it { is_expected.to have_field(:units).of_type('Float!') }
   it { is_expected.to have_field(:applied_taxes).of_type('[FeeAppliedTax!]') }
+  it { is_expected.to have_field(:adjusted_fee).of_type('Boolean!') }
 end


### PR DESCRIPTION
## Context

Currently it is not possible to manually edit the draft invoice through the UI. With this feature it will be possible to adjust fee, remove adjusted values and recalculate draft invoice based on those values.

## Description

This PR adds `adjusted_fee` bool attribute to the `fee` graphql object. It will allow FE to recognise if adjusted fee is attached and if `reset` option should be available