### PR TITLE
misc: refactor money with precision helper method

### DIFF
--- a/app/services/utils/money_with_precision.rb
+++ b/app/services/utils/money_with_precision.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Utils
+  class MoneyWithPrecision < Money
+    self.default_infinite_precision = true
+  end
+end

--- a/app/views/helpers/money_helper.rb
+++ b/app/views/helpers/money_helper.rb
@@ -10,16 +10,10 @@ class MoneyHelper
   end
 
   def self.format_with_precision(amount_cents, currency)
-    Money.default_infinite_precision = true
-
-    formatted_amount = Money.from_amount(amount_cents, currency).format(
+    Utils::MoneyWithPrecision.from_amount(amount_cents, currency).format(
       format: I18n.t('money.format'),
       decimal_mark: I18n.t('money.decimal_mark'),
       thousands_separator: I18n.t('money.thousands_separator'),
     )
-
-    Money.default_infinite_precision = false
-
-    formatted_amount
   end
 end


### PR DESCRIPTION
## Context

Currently Money gem does not allow setting `default_infinite_precision` property per class instance. 

## Description

This PR cleans existing logic with the new class that extends Money. New class should be used only when `default_infinite_precision` is needed to be true. This approach is more safe and does not require setting and resetting property on each usage.
