### PR TITLE
fix(subscription): Add missing validation rule for billing time

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -14,7 +14,7 @@ class Subscription < ApplicationRecord
   has_many :invoices, through: :invoice_subscriptions
   has_many :fees
 
-  validates :external_id, presence: true
+  validates :external_id, :billing_time, presence: true
   validate :validate_external_id, on: :create
 
   STATUSES = [

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -123,6 +123,20 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           expect(result.subscription).to be_calendar
         end
       end
+
+      context 'when billing time is empty' do
+        let(:billing_time) { '' }
+
+        it 'creates a calendar subscription' do
+          result = create_service.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:billing_time]).to eq(['value_is_mandatory'])
+          end
+        end
+      end
     end
 
     context 'when License is free and plan_overrides is passed' do


### PR DESCRIPTION
## Context

A validation rule is missing for the `billing_time` field on the `Subscription` model, leading to an HTTP `500` error rather than to a `422` when a blank string is provided.

## Description

This PR adds the missing presence validation
