### PR TITLE
feat(events): Batch Event endpoint

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -94,14 +94,15 @@ module Api
 
       def batch_params
         params
-          .require(:event)
           .permit(
-            :transaction_id,
-            :external_customer_id,
-            :code,
-            :timestamp,
-            external_subscription_ids: [],
-            properties: {},
+            events: [
+              :transaction_id,
+              :external_customer_id,
+              :code,
+              :timestamp,
+              :external_subscription_id,
+              properties: {},
+            ],
           )
       end
 

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -104,7 +104,7 @@ module Api
               :code,
               :timestamp,
               :external_subscription_id,
-              properties: {},
+              properties: {}, # rubocop:disable Style/HashAsLastArrayItem
             ],
           ).to_h.deep_symbolize_keys
       end

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -53,12 +53,12 @@ module Events
 
     def post_validate_events
       ActiveRecord::Base.transaction do
-        result.events.each do |event|
-          event.save!
+        result.events.each.&:save!
+      end
 
-          produce_kafka_event(event)
-          Events::PostProcessJob.perform_later(event:)
-        end
+      result.events.each do |event|
+        produce_kafka_event(event)
+        Events::PostProcessJob.perform_later(event:)
       end
     end
 

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -47,7 +47,7 @@ module Events
         event.timestamp = Time.zone.at(event_params[:timestamp] ? event_params[:timestamp].to_f : timestamp)
 
         result.events.push(event)
-        result.errors.merge({ index => event.errors }) unless event.valid?
+        result.errors = result.errors.merge({ index => event.errors.messages }) unless event.valid?
       end
     end
 

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -6,7 +6,7 @@ module Events
 
     def initialize(organization:, events_params:, timestamp:, metadata:)
       @organization = organization
-      @events_params = events_params
+      @events_params = events_params[:events]
       @timestamp = timestamp
       @metadata = metadata
 

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -53,7 +53,7 @@ module Events
 
     def post_validate_events
       ActiveRecord::Base.transaction do
-        result.events.each.&:save!
+        result.events.each(&:save!)
       end
 
       result.events.each do |event|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -613,9 +613,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_15_130517) do
     t.string "tax_identification_number"
     t.integer "net_payment_term", default: 0, null: false
     t.string "default_currency", default: "USD", null: false
-    t.boolean "eu_tax_management", default: false
     t.integer "document_numbering", default: 0, null: false
     t.string "document_number_prefix"
+    t.boolean "eu_tax_management", default: false
     t.boolean "clickhouse_aggregation", default: false, null: false
     t.boolean "credits_auto_refreshed", default: false, null: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Events::CreateBatchService, type: :service do
       events << event
     end
 
-    events
+    { events: }
   end
 
   describe '.call' do
@@ -53,7 +53,7 @@ RSpec.describe Events::CreateBatchService, type: :service do
 
     context 'when events count is too big' do
       before do
-        events_params.push(
+        events_params[:events].push(
           {
             external_customer_id: SecureRandom.uuid,
             external_subscription_id: SecureRandom.uuid,
@@ -91,16 +91,18 @@ RSpec.describe Events::CreateBatchService, type: :service do
         end
 
         let(:events_params) do
-          [
-            {
-              external_customer_id: SecureRandom.uuid,
-              external_subscription_id: '123456',
-              code:,
-              transaction_id: '123456',
-              properties: { foo: 'bar' },
-              timestamp:,
-            },
-          ]
+          {
+            events: [
+              {
+                external_customer_id: SecureRandom.uuid,
+                external_subscription_id: '123456',
+                code:,
+                transaction_id: '123456',
+                properties: { foo: 'bar' },
+                timestamp:,
+              },
+            ],
+          }
         end
 
         before { existing_event }
@@ -124,16 +126,18 @@ RSpec.describe Events::CreateBatchService, type: :service do
       let(:timestamp) { nil }
 
       let(:events_params) do
-        [
-          {
-            external_customer_id: SecureRandom.uuid,
-            external_subscription_id: SecureRandom.uuid,
-            code:,
-            transaction_id: SecureRandom.uuid,
-            properties: { foo: 'bar' },
-            timestamp:,
-          },
-        ]
+        {
+          events: [
+            {
+              external_customer_id: SecureRandom.uuid,
+              external_subscription_id: SecureRandom.uuid,
+              code:,
+              transaction_id: SecureRandom.uuid,
+              properties: { foo: 'bar' },
+              timestamp:,
+            },
+          ],
+        }
       end
 
       it 'creates an event by setting the timestamp to the current datetime' do
@@ -148,16 +152,18 @@ RSpec.describe Events::CreateBatchService, type: :service do
       let(:timestamp) { Time.current.to_f.to_s }
 
       let(:events_params) do
-        [
-          {
-            external_customer_id: SecureRandom.uuid,
-            external_subscription_id: SecureRandom.uuid,
-            code:,
-            transaction_id: SecureRandom.uuid,
-            properties: { foo: 'bar' },
-            timestamp:,
-          },
-        ]
+        {
+          events: [
+            {
+              external_customer_id: SecureRandom.uuid,
+              external_subscription_id: SecureRandom.uuid,
+              code:,
+              transaction_id: SecureRandom.uuid,
+              properties: { foo: 'bar' },
+              timestamp:,
+            },
+          ],
+        }
       end
 
       it 'creates an event by setting timestamp' do
@@ -172,16 +178,18 @@ RSpec.describe Events::CreateBatchService, type: :service do
       let(:timestamp) { DateTime.parse('2023-09-04T15:45:12.344Z').to_f }
 
       let(:events_params) do
-        [
-          {
-            external_customer_id: SecureRandom.uuid,
-            external_subscription_id: SecureRandom.uuid,
-            code:,
-            transaction_id: SecureRandom.uuid,
-            properties: { foo: 'bar' },
-            timestamp:,
-          },
-        ]
+        {
+          events: [
+            {
+              external_customer_id: SecureRandom.uuid,
+              external_subscription_id: SecureRandom.uuid,
+              code:,
+              transaction_id: SecureRandom.uuid,
+              properties: { foo: 'bar' },
+              timestamp:,
+            },
+          ],
+        }
       end
 
       it 'creates an event by keeping the millisecond precision' do

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -78,5 +78,135 @@ RSpec.describe Events::CreateBatchService, type: :service do
         end
       end
     end
+
+    context 'with at least one invalid event' do
+      context 'with already existing event' do
+        let(:existing_event) do
+          create(
+            :event,
+            organization:,
+            transaction_id: '123456',
+            external_subscription_id: '123456',
+          )
+        end
+
+        let(:events_params) do
+          [
+            {
+              external_customer_id: SecureRandom.uuid,
+              external_subscription_id: '123456',
+              code:,
+              transaction_id: '123456',
+              properties: { foo: 'bar' },
+              timestamp:,
+            },
+          ]
+        end
+
+        before { existing_event }
+
+        it 'returns an error' do
+          result = nil
+
+          aggregate_failures do
+            expect { result = create_batch_service.call }.not_to change(Event, :count)
+
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[0].keys).to include(:transaction_id)
+            expect(result.error.messages[0][:transaction_id]).to include('value_already_exist')
+          end
+        end
+      end
+    end
+
+    context 'when timestamp is not present in the payload' do
+      let(:timestamp) { nil }
+
+      let(:events_params) do
+        [
+          {
+            external_customer_id: SecureRandom.uuid,
+            external_subscription_id: SecureRandom.uuid,
+            code:,
+            transaction_id: SecureRandom.uuid,
+            properties: { foo: 'bar' },
+            timestamp:,
+          },
+        ]
+      end
+
+      it 'creates an event by setting the timestamp to the current datetime' do
+        result = create_batch_service.call
+
+        expect(result).to be_success
+        expect(result.events.first.timestamp).to eq(Time.zone.at(creation_timestamp))
+      end
+    end
+
+    context 'when timestamp is given as string' do
+      let(:timestamp) { Time.current.to_f.to_s }
+
+      let(:events_params) do
+        [
+          {
+            external_customer_id: SecureRandom.uuid,
+            external_subscription_id: SecureRandom.uuid,
+            code:,
+            transaction_id: SecureRandom.uuid,
+            properties: { foo: 'bar' },
+            timestamp:,
+          },
+        ]
+      end
+
+      it 'creates an event by setting timestamp' do
+        result = create_batch_service.call
+
+        expect(result).to be_success
+        expect(result.events.first.timestamp).to eq(Time.zone.at(timestamp.to_f))
+      end
+    end
+
+    context 'when timestamp is sent with decimal precision' do
+      let(:timestamp) { DateTime.parse('2023-09-04T15:45:12.344Z').to_f }
+
+      let(:events_params) do
+        [
+          {
+            external_customer_id: SecureRandom.uuid,
+            external_subscription_id: SecureRandom.uuid,
+            code:,
+            transaction_id: SecureRandom.uuid,
+            properties: { foo: 'bar' },
+            timestamp:,
+          },
+        ]
+      end
+
+      it 'creates an event by keeping the millisecond precision' do
+        result = create_batch_service.call
+
+        expect(result).to be_success
+        expect(result.events.first.timestamp.iso8601(3)).to eq('2023-09-04T15:45:12.344Z')
+      end
+    end
+
+    context 'when kafka is configured' do
+      let(:karafka_producer) { instance_double(WaterDrop::Producer) }
+
+      before do
+        ENV['LAGO_KAFKA_BOOTSTRAP_SERVERS'] = 'kafka'
+      end
+
+      it 'produces the event on kafka' do
+        allow(Karafka).to receive(:producer).and_return(karafka_producer)
+        allow(karafka_producer).to receive(:produce_sync)
+
+        create_batch_service.call
+
+        expect(karafka_producer).to have_received(:produce_sync).exactly(100)
+      end
+    end
   end
 end

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -3,265 +3,79 @@
 require 'rails_helper'
 
 RSpec.describe Events::CreateBatchService, type: :service do
-  subject(:create_batch_service) { described_class.new }
+  subject(:create_batch_service) do
+    described_class.new(
+      organization:,
+      events_params:,
+      timestamp: creation_timestamp,
+      metadata:,
+    )
+  end
 
   let(:organization) { create(:organization) }
-  let(:billable_metric) { create(:billable_metric, organization:) }
-  let(:customer) { create(:customer, organization:) }
-  let(:subscription) { create(:active_subscription, customer:, organization:) }
-  let(:subscription2) { create(:active_subscription, customer:, organization:) }
+  let(:timestamp) { Time.current.to_f }
+  let(:code) { 'sum_agg' }
+  let(:metadata) { {} }
+  let(:creation_timestamp) { Time.current.to_f }
 
-  before do
-    subscription
-    subscription2
-  end
-
-  describe '#validate_params' do
-    let(:event_arguments) do
-      {
+  let(:events_params) do
+    events = []
+    100.times do
+      event = {
+        external_customer_id: SecureRandom.uuid,
+        external_subscription_id: SecureRandom.uuid,
+        code:,
         transaction_id: SecureRandom.uuid,
-        external_subscription_ids: [subscription.external_id, subscription2.external_id],
-        code: billable_metric.code,
+        properties: { foo: 'bar' },
+        timestamp:,
       }
+
+      events << event
     end
 
-    it 'successfully validates event arguments' do
-      result = create_batch_service.validate_params(organization:, params: event_arguments)
-
-      expect(result).to be_success
-    end
-
-    context 'with missing external_subscription_ids field' do
-      let(:event_arguments) do
-        {
-          transaction_id: SecureRandom.uuid,
-          code: billable_metric.code,
-        }
-      end
-
-      it 'returns an error' do
-        result = create_batch_service.validate_params(organization:, params: event_arguments)
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::NotFoundFailure)
-          expect(result.error.error_code).to eq('subscription_not_found')
-        end
-      end
-    end
-
-    context 'with invalid external_subscription_id value' do
-      let(:event_arguments) do
-        {
-          transaction_id: SecureRandom.uuid,
-          external_subscription_ids: [subscription.external_id, subscription2.external_id, 'invalid'],
-          code: billable_metric.code,
-        }
-      end
-
-      it 'returns an error' do
-        result = create_batch_service.validate_params(organization:, params: event_arguments)
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::NotFoundFailure)
-          expect(result.error.error_code).to eq('subscription_not_found')
-        end
-      end
-    end
-
-    context 'with invalid customer reference' do
-      let(:subscription3) { create(:active_subscription) }
-      let(:event_arguments) do
-        {
-          transaction_id: SecureRandom.uuid,
-          external_subscription_ids: [subscription3.external_id, subscription2.external_id],
-          code: billable_metric.code,
-        }
-      end
-
-      before { subscription3 }
-
-      it 'returns an error' do
-        result = create_batch_service.validate_params(organization:, params: event_arguments)
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::NotFoundFailure)
-          expect(result.error.error_code).to eq('customer_not_found')
-        end
-      end
-    end
-
-    context 'with invalid billable metric code' do
-      let(:event_arguments) do
-        {
-          transaction_id: SecureRandom.uuid,
-          external_subscription_ids: [subscription.external_id, subscription2.external_id],
-          code: 'foo',
-        }
-      end
-
-      it 'returns an error' do
-        result = create_batch_service.validate_params(organization:, params: event_arguments)
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::NotFoundFailure)
-          expect(result.error.error_code).to eq('billable_metric_not_found')
-        end
-      end
-    end
-
-    context 'with invalid properties' do
-      let(:billable_metric) { create(:sum_billable_metric, organization:) }
-      let(:event_arguments) do
-        {
-          transaction_id: SecureRandom.uuid,
-          external_subscription_ids: [subscription.external_id, subscription2.external_id],
-          code: billable_metric.code,
-          properties: {
-            item_id: 'test',
-          },
-        }
-      end
-
-      it 'returns an error' do
-        result = create_batch_service.validate_params(organization:, params: event_arguments)
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages.keys).to include(:properties)
-          expect(result.error.messages[:properties]).to include('value_is_not_valid_number')
-        end
-      end
-    end
+    events
   end
 
-  describe '#call' do
-    let(:transaction_id) { SecureRandom.uuid }
-    let(:subscription) { create(:active_subscription, customer:, organization:) }
-    let(:subscription2) { create(:active_subscription, customer:, organization:) }
+  describe '.call' do
+    it 'creates all events' do
+      result = nil
 
-    let(:create_args) do
-      {
-        external_subscription_ids: [subscription.external_id, subscription2.external_id],
-        code: billable_metric.code,
-        transaction_id:,
-        properties: { foo: 'bar' },
-        timestamp: Time.zone.now.to_i,
-      }
-    end
-    let(:timestamp) { Time.zone.now.to_i }
-
-    before do
-      subscription
-      subscription2
-    end
-
-    context 'when customer has two active subscription' do
-      it 'creates a new event for each subscription' do
-        result = create_batch_service.call(
-          organization:,
-          params: create_args,
-          timestamp:,
-          metadata: {},
-        )
+      aggregate_failures do
+        expect { result = create_batch_service.call }.to change(Event, :count).by(100)
 
         expect(result).to be_success
-
-        events = result.events
-
-        aggregate_failures do
-          expect(events.first.customer_id).to eq(customer.id)
-          expect(events.first.organization_id).to eq(organization.id)
-          expect(events.first.code).to eq(billable_metric.code)
-          expect(events.first.subscription_id).to eq(subscription.id)
-          expect(events.first.transaction_id).to eq("#{transaction_id}_0")
-          expect(events.last.customer_id).to eq(customer.id)
-          expect(events.last.organization_id).to eq(organization.id)
-          expect(events.last.code).to eq(billable_metric.code)
-          expect(events.last.subscription_id).to eq(subscription2.id)
-          expect(events.last.transaction_id).to eq("#{transaction_id}_1")
-        end
-      end
-
-      context 'when event matches a unique count billable metric' do
-        let(:billable_metric) do
-          create(
-            :billable_metric,
-            organization: customer.organization,
-            aggregation_type: 'unique_count_agg',
-            field_name: 'item_id',
-          )
-        end
-
-        let(:create_args) do
-          {
-            external_subscription_ids: [subscription.external_id, subscription2.external_id],
-            code: billable_metric.code,
-            transaction_id: SecureRandom.uuid,
-            properties: {
-              billable_metric.field_name => 'ext_12345',
-              'operation_type' => 'add',
-            },
-            timestamp: Time.zone.now.to_i,
-          }
-        end
-
-        it 'creates a quantified metric' do
-          expect do
-            create_batch_service.call(
-              organization:,
-              params: create_args,
-              timestamp:,
-              metadata: {},
-            )
-          end.to change(QuantifiedEvent, :count).by(2)
-        end
       end
     end
 
-    context 'when event for one subscription already exists' do
-      let(:existing_event) do
-        create(
-          :event,
-          organization:,
-          transaction_id: create_args[:transaction_id],
-          subscription_id: subscription.id,
+    it 'enqueues a post processing job' do
+      expect { create_batch_service.call }.to have_enqueued_job(Events::PostProcessJob).exactly(100)
+    end
+
+    context 'when events count is too big' do
+      before do
+        events_params.push(
+          {
+            external_customer_id: SecureRandom.uuid,
+            external_subscription_id: SecureRandom.uuid,
+            code:,
+            transaction_id: SecureRandom.uuid,
+            properties: { foo: 'bar' },
+            timestamp:,
+          },
         )
       end
 
-      before { existing_event }
+      it 'returns a too big error' do
+        result = nil
 
-      it 'does not duplicate existing event' do
-        expect do
-          create_batch_service.call(
-            organization:,
-            params: create_args,
-            timestamp:,
-            metadata: {},
-          )
-        end.to change(Event, :count).by(1)
-      end
-    end
+        aggregate_failures do
+          expect { result = create_batch_service.call }.not_to change(Event, :count)
 
-    context 'with timestamp sent with decimal precision' do
-      it 'creates event by keeping the millisecond precision' do
-        create_args[:timestamp] = DateTime.parse('2023-09-04 15:45:12.344').strftime('%s.%3N')
-
-        expect do
-          create_batch_service.call(
-            organization:,
-            params: create_args,
-            timestamp:,
-            metadata: {},
-          )
-        end.to change(Event, :count).by(2)
-
-        expect(Event.where(organization_id: organization.id).last.timestamp.iso8601(3))
-          .to eq('2023-09-04T15:45:12.344Z')
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to include(:events)
+          expect(result.error.messages[:events]).to include('too_many_events')
+        end
       end
     end
   end

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -207,6 +207,10 @@ RSpec.describe Events::CreateBatchService, type: :service do
         ENV['LAGO_KAFKA_BOOTSTRAP_SERVERS'] = 'kafka'
       end
 
+      after do
+        ENV['LAGO_KAFKA_BOOTSTRAP_SERVERS'] = nil
+      end
+
       it 'produces the event on kafka' do
         allow(Karafka).to receive(:producer).and_return(karafka_producer)
         allow(karafka_producer).to receive(:produce_sync)

--- a/spec/services/events/validate_creation_service_spec.rb
+++ b/spec/services/events/validate_creation_service_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Events::ValidateCreationService, type: :service do
       result:,
       customer:,
       subscriptions: [subscription],
-      batch:,
     )
   end
 
@@ -25,310 +24,230 @@ RSpec.describe Events::ValidateCreationService, type: :service do
   end
 
   describe '.call' do
-    context 'when batch is false' do
-      let(:batch) { false }
+    context 'when customer has only one active subscription and external_subscription_id is not given' do
+      it 'does not return any validation errors' do
+        expect(validate_event).to be_nil
+        expect(result).to be_success
+      end
+    end
 
-      context 'when customer has only one active subscription and external_subscription_id is not given' do
-        it 'does not return any validation errors' do
-          expect(validate_event).to be_nil
-          expect(result).to be_success
-        end
+    context 'when customer has only one active subscription and customer is not given' do
+      let(:params) do
+        { code: billable_metric.code, external_subscription_id: subscription.external_id, transaction_id: }
       end
 
-      context 'when customer has only one active subscription and customer is not given' do
-        let(:params) do
-          { code: billable_metric.code, external_subscription_id: subscription.external_id, transaction_id: }
-        end
+      it 'does not return any validation errors' do
+        expect(validate_event).to be_nil
+        expect(result).to be_success
+      end
+    end
 
-        it 'does not return any validation errors' do
-          expect(validate_event).to be_nil
-          expect(result).to be_success
-        end
+    context 'when customer has two active subscriptions' do
+      before { create(:active_subscription, customer:, organization:) }
+
+      let(:params) do
+        { code: billable_metric.code, external_subscription_id: subscription.external_id, transaction_id: }
       end
 
-      context 'when customer has two active subscriptions' do
-        before { create(:active_subscription, customer:, organization:) }
+      it 'does not return any validation errors' do
+        expect(validate_event).to be_nil
+        expect(result).to be_success
+      end
+    end
 
-        let(:params) do
-          { code: billable_metric.code, external_subscription_id: subscription.external_id, transaction_id: }
-        end
-
-        it 'does not return any validation errors' do
-          expect(validate_event).to be_nil
-          expect(result).to be_success
-        end
+    context 'when customer is not given but subscription is present' do
+      let(:params) do
+        { code: billable_metric.code, transaction_id: }
       end
 
-      context 'when customer is not given but subscription is present' do
-        let(:params) do
-          { code: billable_metric.code, transaction_id: }
-        end
-
-        let(:validate_event) do
-          described_class.call(
-            organization:,
-            params:,
-            result:,
-            customer: nil,
-            subscriptions: [subscription],
-          )
-        end
-
-        it 'does not return any validation errors' do
-          expect(validate_event).to be_nil
-          expect(result).to be_success
-        end
+      let(:validate_event) do
+        described_class.call(
+          organization:,
+          params:,
+          result:,
+          customer: nil,
+          subscriptions: [subscription],
+        )
       end
 
-      context 'when there are two active subscriptions but external_subscription_id is not given' do
-        let(:subscription2) { create(:active_subscription, customer:, organization:) }
+      it 'does not return any validation errors' do
+        expect(validate_event).to be_nil
+        expect(result).to be_success
+      end
+    end
 
-        let(:validate_event) do
-          described_class.call(
-            organization:,
-            params:,
-            result:,
-            customer:,
-            subscriptions: [subscription, subscription2],
-          )
-        end
+    context 'when there are two active subscriptions but external_subscription_id is not given' do
+      let(:subscription2) { create(:active_subscription, customer:, organization:) }
 
-        it 'returns a subscription_not_found error' do
-          validate_event
-
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq('subscription_not_found')
-          end
-        end
+      let(:validate_event) do
+        described_class.call(
+          organization:,
+          params:,
+          result:,
+          customer:,
+          subscriptions: [subscription, subscription2],
+        )
       end
 
-      context 'when there are two active subscriptions but external_subscription_id is invalid' do
-        let(:params) do
-          {
-            code: billable_metric.code,
-            external_subscription_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
-            transaction_id:,
-          }
-        end
+      it 'returns a subscription_not_found error' do
+        validate_event
 
-        let(:subscription2) { create(:active_subscription, customer:, organization:) }
-
-        let(:validate_event) do
-          described_class.call(
-            organization:,
-            params:,
-            result:,
-            customer:,
-            subscriptions: [subscription, subscription2],
-          )
-        end
-
-        it 'returns a not found error' do
-          validate_event
-
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq('subscription_not_found')
-          end
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('subscription_not_found')
         end
       end
+    end
 
-      context 'when there is one active subscription with the same external_id' do
-        let(:subscription) do
-          create(:subscription, customer:, organization:, external_id:, status: :terminated)
-        end
-        let(:external_id) { SecureRandom.uuid }
-        let(:params) do
-          {
-            code: billable_metric.code,
-            external_subscription_id: external_id,
-            external_customer_id: customer.external_id,
-            transaction_id:,
-          }
-        end
-
-        before do
-          subscription
-          create(:active_subscription, customer:, organization:, external_id:)
-        end
-
-        it 'does not return any validation errors' do
-          expect(validate_event).to be_nil
-          expect(result).to be_success
-        end
+    context 'when there are two active subscriptions but external_subscription_id is invalid' do
+      let(:params) do
+        {
+          code: billable_metric.code,
+          external_subscription_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          transaction_id:,
+        }
       end
 
-      context 'when transaction_id is already used' do
-        before do
-          create(
-            :event,
-            transaction_id:,
-            external_subscription_id: subscription.external_id,
-            subscription_id: subscription.id,
-            organization_id: organization.id,
-          )
+      let(:subscription2) { create(:active_subscription, customer:, organization:) }
+
+      let(:validate_event) do
+        described_class.call(
+          organization:,
+          params:,
+          result:,
+          customer:,
+          subscriptions: [subscription, subscription2],
+        )
+      end
+
+      it 'returns a not found error' do
+        validate_event
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('subscription_not_found')
         end
+      end
+    end
 
-        it 'returns a validation error' do
-          validate_event
+    context 'when there is one active subscription with the same external_id' do
+      let(:subscription) do
+        create(:subscription, customer:, organization:, external_id:, status: :terminated)
+      end
+      let(:external_id) { SecureRandom.uuid }
+      let(:params) do
+        {
+          code: billable_metric.code,
+          external_subscription_id: external_id,
+          external_customer_id: customer.external_id,
+          transaction_id:,
+        }
+      end
 
+      before do
+        subscription
+        create(:active_subscription, customer:, organization:, external_id:)
+      end
+
+      it 'does not return any validation errors' do
+        expect(validate_event).to be_nil
+        expect(result).to be_success
+      end
+    end
+
+    context 'when transaction_id is already used' do
+      before do
+        create(
+          :event,
+          transaction_id:,
+          external_subscription_id: subscription.external_id,
+          subscription_id: subscription.id,
+          organization_id: organization.id,
+        )
+      end
+
+      it 'returns a validation error' do
+        validate_event
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages.keys).to include(:transaction_id)
+        expect(result.error.messages[:transaction_id]).to include('value_is_missing_or_already_exists')
+      end
+    end
+
+    context 'when code does not exist' do
+      let(:params) do
+        { external_customer_id: customer.external_id, code: 'event_code', transaction_id: }
+      end
+
+      it 'returns an event_not_found error' do
+        validate_event
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('billable_metric_not_found')
+        end
+      end
+    end
+
+    context 'when field_name value is not a number' do
+      let(:billable_metric) { create(:sum_billable_metric, organization:) }
+      let(:params) do
+        {
+          code: billable_metric.code,
+          external_customer_id: customer.external_id,
+          properties: {
+            item_id: 'test',
+          },
+          transaction_id:,
+        }
+      end
+
+      it 'returns an value_is_not_valid_number error' do
+        validate_event
+
+        aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
-          expect(result.error.messages.keys).to include(:transaction_id)
-          expect(result.error.messages[:transaction_id]).to include('value_is_missing_or_already_exists')
+          expect(result.error.messages.keys).to include(:properties)
+          expect(result.error.messages[:properties]).to include('value_is_not_valid_number')
         end
       end
 
-      context 'when code does not exist' do
-        let(:params) do
-          { external_customer_id: customer.external_id, code: 'event_code', transaction_id: }
-        end
-
-        it 'returns an event_not_found error' do
-          validate_event
-
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq('billable_metric_not_found')
-          end
-        end
-      end
-
-      context 'when field_name value is not a number' do
-        let(:billable_metric) { create(:sum_billable_metric, organization:) }
+      context 'when field_name cannot be found' do
         let(:params) do
           {
             code: billable_metric.code,
             external_customer_id: customer.external_id,
             properties: {
-              item_id: 'test',
+              invalid_key: 'test',
             },
             transaction_id:,
           }
         end
 
-        it 'returns an value_is_not_valid_number error' do
-          validate_event
-
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages.keys).to include(:properties)
-            expect(result.error.messages[:properties]).to include('value_is_not_valid_number')
-          end
-        end
-
-        context 'when field_name cannot be found' do
-          let(:params) do
-            {
-              code: billable_metric.code,
-              external_customer_id: customer.external_id,
-              properties: {
-                invalid_key: 'test',
-              },
-              transaction_id:,
-            }
-          end
-
-          it 'does not raise error' do
-            validate_event
-
-            expect(result).to be_success
-          end
-        end
-
-        context 'when properties are missing' do
-          let(:params) do
-            {
-              code: billable_metric.code,
-              external_customer_id: customer.external_id,
-              transaction_id:,
-            }
-          end
-
-          it 'does not raise error' do
-            validate_event
-
-            expect(result).to be_success
-          end
-        end
-      end
-
-      context 'when event belongs to a unique count persisted event' do
-        let(:billable_metric) do
-          create(
-            :billable_metric,
-            organization:,
-            aggregation_type: 'unique_count_agg',
-            field_name: 'item_id',
-          )
-        end
-
-        let(:params) do
-          {
-            customer_id: customer.external_id,
-            code: billable_metric.code,
-            properties: {
-              billable_metric.field_name => 'ext_1234',
-              'operation_type' => operation_type,
-            },
-            transaction_id:,
-          }
-        end
-
-        let(:operation_type) { 'add' }
-
-        it 'returns no error' do
+        it 'does not raise error' do
           validate_event
 
           expect(result).to be_success
         end
-
-        context 'when params are invalid' do
-          let(:operation_type) { 'invalid' }
-
-          it 'returns invalid recurring resource error' do
-            validate_event
-
-            aggregate_failures do
-              expect(result).not_to be_success
-              expect(result.error).to be_a(BaseService::ValidationFailure)
-              expect(result.error.messages.keys).to include(:operation_type)
-              expect(result.error.messages[:operation_type]).to eq(['invalid_operation_type'])
-            end
-          end
-        end
       end
 
-      context 'when event belongs to a unique count persisted event and subscription is terminated' do
-        let(:billable_metric) do
-          create(
-            :billable_metric,
-            organization:,
-            aggregation_type: 'unique_count_agg',
-            field_name: 'item_id',
-          )
-        end
-
-        let(:subscription) { create(:subscription, customer:, organization:, status: :terminated) }
+      context 'when properties are missing' do
         let(:params) do
           {
-            external_subscription_id: subscription.external_id,
             code: billable_metric.code,
-            properties: {
-              billable_metric.field_name => 'ext_1234',
-              'operation_type' => 'add',
-            },
+            external_customer_id: customer.external_id,
             transaction_id:,
           }
         end
 
-        it 'returns no error' do
+        it 'does not raise error' do
           validate_event
 
           expect(result).to be_success
@@ -336,177 +255,79 @@ RSpec.describe Events::ValidateCreationService, type: :service do
       end
     end
 
-    context 'when batch is true' do
-      let(:batch) { true }
-
-      context 'when everything is passing' do
-        let(:params) do
-          { external_subscription_ids: [subscription.external_id], code: billable_metric.code }
-        end
-
-        it 'does not return any validation errors' do
-          expect(validate_event).to be_nil
-          expect(result).to be_success
-        end
+    context 'when event belongs to a unique count persisted event' do
+      let(:billable_metric) do
+        create(
+          :billable_metric,
+          organization:,
+          aggregation_type: 'unique_count_agg',
+          field_name: 'item_id',
+        )
       end
 
-      context 'when external_subscription_ids is blank' do
-        let(:params) do
-          { external_subscription_ids: [] }
-        end
-
-        it 'returns a subscription_not_found error' do
-          validate_event
-
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq('subscription_not_found')
-          end
-        end
+      let(:params) do
+        {
+          customer_id: customer.external_id,
+          code: billable_metric.code,
+          properties: {
+            billable_metric.field_name => 'ext_1234',
+            'operation_type' => operation_type,
+          },
+          transaction_id:,
+        }
       end
 
-      context 'when customer is not given' do
-        let(:params) do
-          { code: billable_metric.code, external_subscription_ids: [SecureRandom.uuid] }
-        end
+      let(:operation_type) { 'add' }
 
-        let(:validate_event) do
-          described_class.call(
-            organization:,
-            params:,
-            result:,
-            customer: nil,
-            subscriptions: [subscription],
-            batch:,
-          )
-        end
+      it 'returns no error' do
+        validate_event
 
-        it 'returns a customer_not_found error' do
-          validate_event
-
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq('customer_not_found')
-          end
-        end
+        expect(result).to be_success
       end
 
-      context 'when there are two active subscriptions but subscription_ids is invalid' do
-        let(:params) do
-          {
-            code: billable_metric.code,
-            external_subscription_ids: [SecureRandom.uuid],
-            external_customer_id: customer.external_id,
-          }
-        end
+      context 'when params are invalid' do
+        let(:operation_type) { 'invalid' }
 
-        before do
-          create(:active_subscription, customer:, organization:)
-        end
-
-        it 'returns subscription is invalid error' do
-          validate_event
-
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq('subscription_not_found')
-          end
-        end
-      end
-
-      context 'when code does not exist' do
-        let(:params) do
-          {
-            code: 'event_code',
-            external_subscription_ids: [subscription.external_id],
-            external_customer_id: customer.external_id,
-          }
-        end
-
-        it 'returns an event_not_found error' do
-          validate_event
-
-          aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::NotFoundFailure)
-            expect(result.error.message).to eq('billable_metric_not_found')
-          end
-        end
-      end
-
-      context 'when properties field_name value is not a number' do
-        let(:billable_metric) { create(:sum_billable_metric, organization:) }
-        let(:params) do
-          {
-            code: billable_metric.code,
-            external_customer_id: customer.external_id,
-            external_subscription_ids: [subscription.external_id],
-            properties: {
-              item_id: 'test',
-            },
-          }
-        end
-
-        it 'returns an value_is_not_valid_number error' do
+        it 'returns invalid recurring resource error' do
           validate_event
 
           aggregate_failures do
             expect(result).not_to be_success
             expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages.keys).to include(:properties)
-            expect(result.error.messages[:properties]).to include('value_is_not_valid_number')
+            expect(result.error.messages.keys).to include(:operation_type)
+            expect(result.error.messages[:operation_type]).to eq(['invalid_operation_type'])
           end
         end
       end
+    end
 
-      context 'when event belongs to a unique count persisted metric' do
-        let(:billable_metric) do
-          create(
-            :billable_metric,
-            organization:,
-            aggregation_type: 'unique_count_agg',
-            field_name: 'item_id',
-          )
-        end
+    context 'when event belongs to a unique count persisted event and subscription is terminated' do
+      let(:billable_metric) do
+        create(
+          :billable_metric,
+          organization:,
+          aggregation_type: 'unique_count_agg',
+          field_name: 'item_id',
+        )
+      end
 
-        let(:params) do
-          {
-            external_subscription_ids: [subscription.external_id],
-            code: billable_metric.code,
-            properties: {
-              billable_metric.field_name => 'ext_1234',
-              'operation_type' => operation_type,
-            },
-          }
-        end
+      let(:subscription) { create(:subscription, customer:, organization:, status: :terminated) }
+      let(:params) do
+        {
+          external_subscription_id: subscription.external_id,
+          code: billable_metric.code,
+          properties: {
+            billable_metric.field_name => 'ext_1234',
+            'operation_type' => 'add',
+          },
+          transaction_id:,
+        }
+      end
 
-        let(:operation_type) { 'add' }
+      it 'returns no error' do
+        validate_event
 
-        it 'returns no error' do
-          validate_event
-
-          expect(result).to be_success
-        end
-
-        context 'when params are invalid' do
-          let(:operation_type) { 'invalid' }
-
-          it 'returns invalid recurring resource error' do
-            validate_event
-
-            aggregate_failures do
-              expect(result).not_to be_success
-              expect(result.error).to be_a(BaseService::ValidationFailure)
-
-              subscription_field = "subscription[#{subscription.external_id}]_operation_type".to_sym
-              expect(result.error.messages.keys).to include(subscription_field)
-              expect(result.error.messages[subscription_field]).to eq(['invalid_operation_type'])
-            end
-          end
-        end
+        expect(result).to be_success
       end
     end
   end


### PR DESCRIPTION
## Context

- We want to support multiple events ingestion with one API call.

## Description

- Update the `/events/batch` endpoint that was deprecated
- Add the support of 100 event at a time
- Add a simple validation
- It follows the same process as the single event ingestion
