### PR TITLE
feat(filter): Add new models and relations

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -8,11 +8,12 @@ class BillableMetric < ApplicationRecord
   belongs_to :organization
 
   has_many :charges, dependent: :destroy
-  has_many :groups, dependent: :delete_all
   has_many :plans, through: :charges
   has_many :quantified_events
   has_many :coupon_targets
   has_many :coupons, through: :coupon_targets
+  has_many :groups, dependent: :delete_all
+  has_many :filters, dependent: :delete_all, class_name: 'BillableMetricFilter'
 
   AGGREGATION_TYPES = {
     count_agg: 0,

--- a/app/models/billable_metric_filter.rb
+++ b/app/models/billable_metric_filter.rb
@@ -7,6 +7,10 @@ class BillableMetricFilter < ApplicationRecord
 
   belongs_to :billable_metric
 
+  has_many :filter_values, class_name: 'ChargeFilterValue', dependent: :destroy
+
   validates :key, presence: true
   validates :values, presence: true
+
+  default_scope -> { kept }
 end

--- a/app/models/billable_metric_filter.rb
+++ b/app/models/billable_metric_filter.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BillableMetricFilter < ApplicationRecord
+  include PaperTrailTraceable
+  include Discard::Model
+  self.discard_column = :deleted_at
+
+  belongs_to :billable_metric
+
+  validates :key, presence: true
+  validates :values, presence: true
+end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -11,6 +11,7 @@ class Charge < ApplicationRecord
 
   has_many :fees
   has_many :group_properties, dependent: :destroy
+  has_many :charge_filters, dependent: :destroy, class_name: 'ChargeFilter'
 
   has_many :applied_taxes, class_name: 'Charge::AppliedTax', dependent: :destroy
   has_many :taxes, through: :applied_taxes

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -11,7 +11,7 @@ class Charge < ApplicationRecord
 
   has_many :fees
   has_many :group_properties, dependent: :destroy
-  has_many :charge_filters, dependent: :destroy, class_name: 'ChargeFilter'
+  has_many :filters, dependent: :destroy, class_name: 'ChargeFilter'
 
   has_many :applied_taxes, class_name: 'Charge::AppliedTax', dependent: :destroy
   has_many :taxes, through: :applied_taxes

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -8,6 +8,7 @@ class ChargeFilter < ApplicationRecord
   belongs_to :charge
 
   has_many :values, class_name: 'ChargeFilterValue', dependent: :destroy
+  has_many :fees
 
   default_scope -> { kept }
 end

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ChargeFilter < ApplicationRecord
+  include PaperTrailTraceable
+  include Discard::Model
+  self.discard_column = :deleted_at
+
+  belongs_to :charge
+end

--- a/app/models/charge_filter_value.rb
+++ b/app/models/charge_filter_value.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-class ChargeFilter < ApplicationRecord
+class ChargeFilterValue < ApplicationRecord
   include PaperTrailTraceable
   include Discard::Model
   self.discard_column = :deleted_at
 
-  belongs_to :charge
+  belongs_to :charge_filter
+  belongs_to :billable_metric_filter
 
-  has_many :values, class_name: 'ChargeFilterValue', dependent: :destroy
+  validates :value, presence: true
 
   default_scope -> { kept }
 end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -8,6 +8,7 @@ class Fee < ApplicationRecord
   belongs_to :add_on, -> { with_discarded }, optional: true
   belongs_to :applied_add_on, optional: true
   belongs_to :subscription, optional: true
+  belongs_to :charge_filter, -> { with_discarded }, optional: true
   belongs_to :group, -> { with_discarded }, optional: true
   belongs_to :invoiceable, polymorphic: true, optional: true
   belongs_to :true_up_parent_fee, class_name: 'Fee', optional: true

--- a/db/migrate/20240111140424_create_billable_metric_filters.rb
+++ b/db/migrate/20240111140424_create_billable_metric_filters.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateBillableMetricFilters < ActiveRecord::Migration[7.0]
+  def change
+    create_table :billable_metric_filters, id: :uuid do |t|
+      t.references :billable_metric, null: false, foreign_key: true, type: :uuid
+      t.string :key, null: false
+      t.string :values, null: false, array: true, default: []
+
+      t.timestamps
+
+      t.datetime :deleted_at, index: true
+    end
+  end
+end

--- a/db/migrate/20240111140424_create_billable_metric_filters.rb
+++ b/db/migrate/20240111140424_create_billable_metric_filters.rb
@@ -3,7 +3,7 @@
 class CreateBillableMetricFilters < ActiveRecord::Migration[7.0]
   def change
     create_table :billable_metric_filters, id: :uuid do |t|
-      t.references :billable_metric, null: false, foreign_key: true, type: :uuid
+      t.references :billable_metric, null: false, foreign_key: true, type: :uuid, index: true
       t.string :key, null: false
       t.string :values, null: false, array: true, default: []
 

--- a/db/migrate/20240111151140_create_charge_filters.rb
+++ b/db/migrate/20240111151140_create_charge_filters.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateChargeFilters < ActiveRecord::Migration[7.0]
+  def change
+    create_table :charge_filters, id: :uuid do |t|
+      t.references :charge, null: false, foreign_key: true, type: :uuid, index: true
+      t.jsonb :properties, null: false, default: {}
+
+      t.timestamps
+
+      t.datetime :deleted_at, index: true
+    end
+  end
+end

--- a/db/migrate/20240111155133_create_charge_filter_values.rb
+++ b/db/migrate/20240111155133_create_charge_filter_values.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateChargeFilterValues < ActiveRecord::Migration[7.0]
+  def change
+    create_table :charge_filter_values, id: :uuid do |t|
+      t.references :charge_filter, null: false, foreign_key: true, type: :uuid, index: true
+      t.references :billable_metric_filter, null: false, foreign_key: true, type: :uuid, index: true
+
+      t.string :value, null: false
+
+      t.timestamps
+      t.datetime :deleted_at, index: true
+    end
+  end
+end

--- a/db/migrate/20240112091706_add_charge_filter_id_to_fees.rb
+++ b/db/migrate/20240112091706_add_charge_filter_id_to_fees.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddChargeFilterIdToFees < ActiveRecord::Migration[7.0]
+  def change
+    add_column :fees, :charge_filter_id, :uuid, null: true
+    add_index :fees, :charge_filter_id
+  end
+end

--- a/spec/factories/billable_metric_filters.rb
+++ b/spec/factories/billable_metric_filters.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :billable_metric_filter do
+    billable_metric
+    key { Faker::Name.name.underscore }
+    values { [Faker::Name.name, Faker::Name.name, Faker::Name.name] }
+  end
+end

--- a/spec/factories/charge_filter_values.rb
+++ b/spec/factories/charge_filter_values.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :charge_filter_value do
+    charge_filter
+    billable_metric_filter
+    value { Faker::Lorem.word }
+  end
+end

--- a/spec/factories/charge_filters.rb
+++ b/spec/factories/charge_filters.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :charge_filter do
+    transient do
+      charge { create(:standard_charge) }
+    end
+
+    charge_id { charge.id }
+    properties { charge.properties }
+  end
+end

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -51,6 +51,10 @@ FactoryBot.define do
     end
 
     total_aggregated_units { 0 }
+
+    trait :with_charge_filter do
+      charge_filter
+    end
   end
 
   factory :add_on_fee, class: 'Fee' do

--- a/spec/models/billable_metric_filter_spec.rb
+++ b/spec/models/billable_metric_filter_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe BillableMetricFilter, type: :model do
   it_behaves_like 'paper_trail traceable'
 
   it { is_expected.to belong_to(:billable_metric) }
+  it { is_expected.to have_many(:filter_values).dependent(:destroy) }
+
   it { is_expected.to validate_presence_of(:key) }
   it { is_expected.to validate_presence_of(:values) }
 end

--- a/spec/models/billable_metric_filter_spec.rb
+++ b/spec/models/billable_metric_filter_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetricFilter, type: :model do
+  subject(:billable_metric_filter) { build(:billable_metric_filter) }
+
+  it_behaves_like 'paper_trail traceable'
+
+  it { is_expected.to belong_to(:billable_metric) }
+  it { is_expected.to validate_presence_of(:key) }
+  it { is_expected.to validate_presence_of(:values) }
+end

--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe BillableMetric, type: :model do
 
   it_behaves_like 'paper_trail traceable'
 
+  it { is_expected.to have_many(:filters).dependent(:delete_all) }
+
   describe '#aggregation_type=' do
     let(:billable_metric) { described_class.new }
 

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -8,4 +8,5 @@ RSpec.describe ChargeFilter, type: :model do
   it_behaves_like 'paper_trail traceable'
 
   it { is_expected.to belong_to(:charge) }
+  it { is_expected.to have_many(:values).dependent(:destroy) }
 end

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChargeFilter, type: :model do
+  subject(:charge_filter) { build(:charge_filter) }
+
+  it_behaves_like 'paper_trail traceable'
+
+  it { is_expected.to belong_to(:charge) }
+end

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -9,4 +9,5 @@ RSpec.describe ChargeFilter, type: :model do
 
   it { is_expected.to belong_to(:charge) }
   it { is_expected.to have_many(:values).dependent(:destroy) }
+  it { is_expected.to have_many(:fees) }
 end

--- a/spec/models/charge_filter_value_spec.rb
+++ b/spec/models/charge_filter_value_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChargeFilterValue, type: :model do
+  subject { build(:charge_filter_value) }
+
+  it_behaves_like 'paper_trail traceable'
+
+  it { is_expected.to belong_to(:charge_filter) }
+  it { is_expected.to belong_to(:billable_metric_filter) }
+
+  it { is_expected.to validate_presence_of(:value) }
+end

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Charge, type: :model do
 
   it_behaves_like 'paper_trail traceable'
 
-  it { is_expected.to have_many(:charge_filters).dependent(:destroy) }
+  it { is_expected.to have_many(:filters).dependent(:destroy) }
 
   describe '#properties' do
     context 'with group properties' do

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Charge, type: :model do
 
   it_behaves_like 'paper_trail traceable'
 
+  it { is_expected.to have_many(:charge_filters).dependent(:destroy) }
+
   describe '#properties' do
     context 'with group properties' do
       it 'returns the group properties' do


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR is the first one of the epic. It adds the new `BillableMetricFilter`, `ChargeFilter`, `ChargeFilterValue` models as well as the relations with the `BillableMetric`, `Charge` and `Fee` models
