### PR TITLE
feat(prepaid-credits): Add clock for refreshing wallets credits

### DIFF
--- a/app/jobs/clock/refresh_wallets_credits_job.rb
+++ b/app/jobs/clock/refresh_wallets_credits_job.rb
@@ -5,9 +5,13 @@ module Clock
     queue_as 'clock'
 
     def perform
-      Wallet.active.find_each do |wallet|
-        Wallets::RefreshCreditsJob.perform_later(wallet)
-      end
+      Wallet
+        .active
+        .joins(customer: :organization)
+        .merge(Organization.credits_auto_refreshed)
+        .find_each do |wallet|
+          Wallets::RefreshCreditsJob.perform_later(wallet)
+        end
     end
   end
 end

--- a/app/jobs/clock/refresh_wallets_credits_job.rb
+++ b/app/jobs/clock/refresh_wallets_credits_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Clock
+  class RefreshWalletsCreditsJob < ApplicationJob
+    queue_as 'clock'
+
+    def perform
+      Wallet.active.find_each do |wallet|
+        Wallets::RefreshCreditsJob.perform_later(wallet)
+      end
+    end
+  end
+end

--- a/app/jobs/wallets/refresh_credits_job.rb
+++ b/app/jobs/wallets/refresh_credits_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Wallets
+  class RefreshCreditsJob < ApplicationJob
+    queue_as 'wallets'
+
+    def perform(wallet)
+      Wallets::RefreshCreditsService.call(wallet:)
+    end
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -67,6 +67,8 @@ class Organization < ApplicationRecord
 
   after_create :generate_document_number_prefix
 
+  scope :credits_auto_refreshed, -> { where(credits_auto_refreshed: true) }
+
   def logo_url
     return if logo.blank?
 

--- a/app/services/wallets/refresh_credits_service.rb
+++ b/app/services/wallets/refresh_credits_service.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Wallets
+  class RefreshCreditsService < BaseService
+    def initialize(wallet:)
+      @wallet = wallet
+      super
+    end
+
+    def call
+      # TODO
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -26,6 +26,10 @@ module Clockwork
     Clock::RefreshDraftInvoicesJob.perform_later
   end
 
+  every(5.minutes, 'schedule:refresh_wallets_credits') do
+    Clock::RefreshWalletsCreditsJob.perform_later
+  end
+
   every(1.hour, 'schedule:terminate_ended_subscriptions', at: '*:05') do
     Clock::TerminateEndedSubscriptionsJob.perform_later
   end

--- a/db/migrate/20240115130517_add_credits_auto_refreshed_to_organizations.rb
+++ b/db/migrate/20240115130517_add_credits_auto_refreshed_to_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCreditsAutoRefreshedToOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :credits_auto_refreshed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_04_152816) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_15_130517) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -617,6 +617,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_04_152816) do
     t.integer "document_numbering", default: 0, null: false
     t.string "document_number_prefix"
     t.boolean "clickhouse_aggregation", default: false, null: false
+    t.boolean "credits_auto_refreshed", default: false, null: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"

--- a/spec/jobs/clock/refresh_wallets_credits_job_spec.rb
+++ b/spec/jobs/clock/refresh_wallets_credits_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Clock::RefreshWalletsCreditsJob, job: true do
+  subject { described_class }
+
+  describe '.perform' do
+    let(:wallet) { create(:wallet) }
+
+    before do
+      wallet
+      allow(Wallets::RefreshCreditsService).to receive(:call)
+    end
+
+    it 'calls the refresh service' do
+      described_class.perform_now
+      expect(Wallets::RefreshCreditsJob).to have_been_enqueued.with(wallet)
+    end
+
+    context 'when not active' do
+      let(:wallet) { create(:wallet, :terminated) }
+
+      it 'does not call the refresh service' do
+        described_class.perform_now
+        expect(Wallets::RefreshCreditsJob).not_to have_been_enqueued.with(wallet)
+      end
+    end
+  end
+end

--- a/spec/jobs/clock/refresh_wallets_credits_job_spec.rb
+++ b/spec/jobs/clock/refresh_wallets_credits_job_spec.rb
@@ -6,7 +6,9 @@ describe Clock::RefreshWalletsCreditsJob, job: true do
   subject { described_class }
 
   describe '.perform' do
-    let(:wallet) { create(:wallet) }
+    let(:organization) { create(:organization, credits_auto_refreshed: true) }
+    let(:customer) { create(:customer, organization:) }
+    let(:wallet) { create(:wallet, customer:) }
 
     before do
       wallet
@@ -20,6 +22,15 @@ describe Clock::RefreshWalletsCreditsJob, job: true do
 
     context 'when not active' do
       let(:wallet) { create(:wallet, :terminated) }
+
+      it 'does not call the refresh service' do
+        described_class.perform_now
+        expect(Wallets::RefreshCreditsJob).not_to have_been_enqueued.with(wallet)
+      end
+    end
+
+    context 'when not credits_auto_refreshed' do
+      let(:organization) { create(:organization, credits_auto_refreshed: false) }
 
       it 'does not call the refresh service' do
         described_class.perform_now

--- a/spec/jobs/wallets/refresh_credits_job_spec.rb
+++ b/spec/jobs/wallets/refresh_credits_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Wallets::RefreshCreditsJob, type: :job do
+  let(:wallet) { create(:wallet) }
+  let(:result) { BaseService::Result.new }
+
+  let(:refresh_service) do
+    instance_double(Wallets::RefreshCreditsService)
+  end
+
+  it 'delegates to the RefreshCredits service' do
+    allow(Wallets::RefreshCreditsService).to receive(:new).with(wallet:).and_return(refresh_service)
+    allow(refresh_service).to receive(:call).and_return(result)
+
+    described_class.perform_now(wallet)
+
+    expect(Wallets::RefreshCreditsService).to have_received(:new)
+    expect(refresh_service).to have_received(:call)
+  end
+end


### PR DESCRIPTION
## Feature

https://getlago.canny.io/feature-requests/p/real-time-prepaid-credit-consumption

## Context

The objective is to be able to consume credits in “real-time”, credit balance should be directly updated instead of waiting for the invoice creation (at the end of the period, or in some cases, when usage is marked as paid in advance).

## Description

The goal of this PR is to:
- Add `credits_auto_refreshed` to organizations
- Add `Clock::RefreshWalletsCreditsJob` job
- Add `Wallets::RefreshCreditsJob` job
- Add `Wallets::RefreshCreditsService` service
