### PR TITLE
fix(credit-note-email): adapt mail delivery for credit note created

### DIFF
--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -161,7 +161,7 @@ module CreditNotes
       return unless credit_note.organization.email_settings.include?('credit_note.created')
 
       CreditNoteMailer.with(credit_note:)
-        .created.deliver_later
+        .created.deliver_later(wait: 3.seconds)
     end
 
     def should_handle_refund?


### PR DESCRIPTION
## Context

There are some failed mail deliveries when creating credit note upon subscription termination.

## Description

When terminating `pay_in_advance = true` subscription, credit note is created automatically and the email should be delivered to the customer. However, if Mailer job is scheduled before parent transaction has ended, credit note cannot be fetched within the mailer job.