### PR TITLE
feat(minimum-spending): Add models

### DIFF
--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Commitment < ApplicationRecord
+  belongs_to :plan
+  has_many :applied_taxes, class_name: 'Commitment::AppliedTax', dependent: :destroy
+  has_many :taxes, through: :applied_taxes
+
+  COMMITMENT_TYPES = {
+    minimum_commitment: 0,
+  }.freeze
+
+  enum commitment_type: COMMITMENT_TYPES
+
+  monetize :amount_cents, disable_validation: true, allow_nil: true
+
+  validates :amount_cents, numericality: { greater_than: 0 }, allow_nil: false
+  validates :commitment_type, uniqueness: { scope: :plan_id }
+end

--- a/app/models/commitment/applied_tax.rb
+++ b/app/models/commitment/applied_tax.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Commitment
+  class AppliedTax < ApplicationRecord
+    self.table_name = 'commitments_taxes'
+
+    belongs_to :commitment
+    belongs_to :tax
+  end
+end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -31,7 +31,7 @@ class Fee < ApplicationRecord
   monetize :unit_amount_cents, disable_validation: true, allow_nil: true, with_model_currency: :currency
 
   # TODO: Deprecate add_on type in the near future
-  FEE_TYPES = %i[charge add_on subscription credit].freeze
+  FEE_TYPES = %i[charge add_on subscription credit commitment].freeze
   PAYMENT_STATUS = %i[pending succeeded failed refunded].freeze
 
   enum fee_type: FEE_TYPES

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -9,6 +9,8 @@ class Plan < ApplicationRecord
   belongs_to :organization
   belongs_to :parent, class_name: 'Plan', optional: true
 
+  has_one :minimum_commitment, -> { where(commitment_type: :minimum_commitment) }, class_name: 'Commitment'
+
   has_many :charges, dependent: :destroy
   has_many :billable_metrics, through: :charges
   has_many :subscriptions

--- a/db/migrate/20240115094827_create_commitments.rb
+++ b/db/migrate/20240115094827_create_commitments.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateCommitments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :commitments, id: :uuid do |t|
+      t.references :plan, null: false, index: true, foreign_key: true, type: :uuid
+      t.integer :commitment_type, null: false
+      t.bigint :amount_cents, null: false
+      t.string :invoice_display_name
+
+      t.timestamps
+    end
+
+    add_index :commitments, [:commitment_type, :plan_id], unique: true
+  end
+end

--- a/db/migrate/20240115102012_create_commitment_applied_taxes.rb
+++ b/db/migrate/20240115102012_create_commitment_applied_taxes.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateCommitmentAppliedTaxes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :commitments_taxes, id: :uuid do |t|
+      t.references :commitment, type: :uuid, null: false, foreign_key: true, index: true
+      t.references :tax, type: :uuid, null: false, foreign_key: true, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -225,6 +225,26 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_15_130517) do
     t.index ["tax_id"], name: "index_charges_taxes_on_tax_id"
   end
 
+  create_table "commitments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "plan_id", null: false
+    t.integer "commitment_type", null: false
+    t.bigint "amount_cents", null: false
+    t.string "invoice_display_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["commitment_type", "plan_id"], name: "index_commitments_on_commitment_type_and_plan_id", unique: true
+    t.index ["plan_id"], name: "index_commitments_on_plan_id"
+  end
+
+  create_table "commitments_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "commitment_id", null: false
+    t.uuid "tax_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["commitment_id"], name: "index_commitments_taxes_on_commitment_id"
+    t.index ["tax_id"], name: "index_commitments_taxes_on_tax_id"
+  end
+
   create_table "coupon_targets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "coupon_id", null: false
     t.uuid "plan_id"
@@ -930,6 +950,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_15_130517) do
   add_foreign_key "charges", "plans"
   add_foreign_key "charges_taxes", "charges"
   add_foreign_key "charges_taxes", "taxes"
+  add_foreign_key "commitments", "plans"
+  add_foreign_key "commitments_taxes", "commitments"
+  add_foreign_key "commitments_taxes", "taxes"
   add_foreign_key "coupon_targets", "billable_metrics"
   add_foreign_key "coupon_targets", "coupons"
   add_foreign_key "coupon_targets", "plans"

--- a/schema.graphql
+++ b/schema.graphql
@@ -3126,6 +3126,7 @@ input FeeInput {
 enum FeeTypesEnum {
   add_on
   charge
+  commitment
   credit
   subscription
 }

--- a/schema.json
+++ b/schema.json
@@ -12497,6 +12497,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "commitment",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/factories/commitment_applied_taxes.rb
+++ b/spec/factories/commitment_applied_taxes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :commitment_applied_tax, class: 'Commitment::AppliedTax' do
+    commitment
+    tax
+  end
+end

--- a/spec/factories/commitments.rb
+++ b/spec/factories/commitments.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :commitment do
+    plan
+    commitment_type { 'minimum_commitment' }
+    amount_cents { 1_000 }
+    invoice_display_name { Faker::Subscription.plan }
+  end
+end

--- a/spec/models/commitment/applied_tax_spec.rb
+++ b/spec/models/commitment/applied_tax_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Commitment::AppliedTax, type: :model do
+  it { is_expected.to belong_to(:commitment) }
+  it { is_expected.to belong_to(:tax) }
+end

--- a/spec/models/commitment_spec.rb
+++ b/spec/models/commitment_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Commitment, type: :model do
+  it { is_expected.to belong_to(:plan) }
+  it { is_expected.to have_many(:applied_taxes).dependent(:destroy) }
+  it { is_expected.to have_many(:taxes) }
+
+  it { is_expected.to validate_numericality_of(:amount_cents) }
+
+  describe 'validations' do
+    subject(:commitment) { build(:commitment) }
+
+    describe 'of commitment type uniqueness' do
+      let(:errors) { commitment.errors }
+
+      context 'when it is unique in scope of plan' do
+        it 'does not add an error' do
+          expect(errors.where(:commitment_type, :taken)).not_to be_present
+        end
+      end
+
+      context 'when it not is unique in scope of plan' do
+        subject(:commitment) do
+          build(:commitment, plan:)
+        end
+
+        let(:plan) { create(:plan) }
+        let(:errors) { commitment.errors }
+
+        before do
+          create(:commitment, plan:)
+          commitment.valid?
+        end
+
+        it 'adds an error' do
+          expect(errors.where(:commitment_type, :taken)).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -5,6 +5,8 @@ require 'rails_helper'
 RSpec.describe Plan, type: :model do
   subject(:plan) { build(:plan, trial_period: 3) }
 
+  it { is_expected.to have_one(:minimum_commitment) }
+
   it_behaves_like 'paper_trail traceable'
 
   describe 'Validations' do


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/set-minimum-spend-for-subscriptions

## Context

As a user, I want to define the minimum spend that applies to the customer's plan. Consider the following monthly plan:

- Subscription fee = $50 per month (in arrears);
- Usage-based charge = $10 per unit per month (in arrears); and
- Monthly minimum spend = $100.

If at the end of the month, the customer has consumed 3 units, their total invoice will be: $50 + 3 * $10 = $80 + $20 (true-up fee) = $100.

## Description

In this PR we're adding migrations and models.