### PR TITLE
feat(filter): Create or update service for billable metric filters

### DIFF
--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -23,6 +23,13 @@ module BillableMetrics
           return group_result if group_result.error
         end
 
+        if args[:filters].present?
+          BillableMetricFilters::CreateOrUpdateBatchService.call(
+            billable_metric: metric,
+            filters_params: args[:filters].map(&:with_indifferent_access),
+          ).raise_if_error!
+        end
+
         result.billable_metric = metric
         track_billable_metric_created(metric)
       end

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
-  subject(:service) { described_class.call(billable_metric:, filter_params:) }
+  subject(:service) { described_class.call(billable_metric:, filters_params:) }
 
   let(:billable_metric) { create(:billable_metric) }
 
   context 'when filter params is empty' do
-    let(:filter_params) { {} }
+    let(:filters_params) { {} }
 
     it 'does not create any filters' do
       expect { service }.not_to change(BillableMetricFilter, :count)
@@ -39,7 +39,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
   end
 
   context 'with new filters' do
-    let(:filter_params) do
+    let(:filters_params) do
       [
         {
           key: 'region',
@@ -70,7 +70,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
   end
 
   context 'with existing filters' do
-    let(:filter_params) do
+    let(:filters_params) do
       [
         {
           key: 'region',
@@ -93,7 +93,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
     end
 
     context 'when a value is removed' do
-      let(:filter_params) do
+      let(:filters_params) do
         [
           {
             key: 'region',

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -16,9 +16,13 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       description: 'New metric description',
       aggregation_type: 'sum_agg',
       field_name: 'field_value',
-    }.tap { |p| p[:group] = group unless group.nil? }
+    }.tap do |p|
+      p[:group] = group unless group.nil?
+      p[:filters] = filters unless filters.nil?
+    end
   end
   let(:group) { nil }
+  let(:filters) { nil }
 
   describe '#call' do
     it 'updates the billable metric' do
@@ -72,6 +76,21 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
             expect(result.error.messages[:group]).to eq(['value_is_invalid'])
           end
         end
+      end
+    end
+
+    context 'with filters arguments' do
+      let(:filters) do
+        [
+          {
+            key: 'cloud',
+            values: %w[aws google],
+          },
+        ]
+      end
+
+      it 'updates billable metric\'s filters' do
+        expect { update_service.call }.to change { billable_metric.filters.reload.count }.from(0).to(1)
       end
     end
 


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds a new `BillableMetricFilters::CreateOrUpdateBatchService` to manage billable metric filters