### PR TITLE
feat(filter): Discard filters with billable metrics

### DIFF
--- a/app/models/billable_metric_filter.rb
+++ b/app/models/billable_metric_filter.rb
@@ -8,6 +8,7 @@ class BillableMetricFilter < ApplicationRecord
   belongs_to :billable_metric
 
   has_many :filter_values, class_name: 'ChargeFilterValue', dependent: :destroy
+  has_many :charge_filters, through: :filter_values
 
   validates :key, presence: true
   validates :values, presence: true

--- a/app/services/billable_metrics/destroy_service.rb
+++ b/app/services/billable_metrics/destroy_service.rb
@@ -20,6 +20,9 @@ module BillableMetrics
           group.properties.discard_all
           group.discard!
         end
+
+        discard_filters
+
         Invoice.where(id: draft_invoice_ids).update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
       end
 
@@ -35,6 +38,14 @@ module BillableMetrics
     private
 
     attr_reader :metric
+
+    def discard_filters
+      metric.filters.each do |filter|
+        filter.filter_values.discard_all
+        filter.charge_filters.discard_all
+        filter.discard!
+      end
+    end
 
     def track_billable_metric_deleted
       SegmentTrackJob.perform_later(

--- a/spec/models/billable_metric_filter_spec.rb
+++ b/spec/models/billable_metric_filter_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe BillableMetricFilter, type: :model do
 
   it { is_expected.to belong_to(:billable_metric) }
   it { is_expected.to have_many(:filter_values).dependent(:destroy) }
+  it { is_expected.to have_many(:charge_filters).through(:filter_values) }
 
   it { is_expected.to validate_presence_of(:key) }
   it { is_expected.to validate_presence_of(:values) }

--- a/spec/services/billable_metrics/destroy_service_spec.rb
+++ b/spec/services/billable_metrics/destroy_service_spec.rb
@@ -13,9 +13,17 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
   let(:group) { create(:group, billable_metric:) }
   let(:group_property) { create(:group_property, group:, charge:) }
 
+  let(:filters) { create_list(:billable_metric_filter, 2, billable_metric:) }
+  let(:charge_filter) { create(:charge_filter, charge:) }
+  let(:filter_value) do
+    create(:charge_filter_value, charge_filter:, billable_metric_filter: filters.first)
+  end
+
   before do
     charge
     group_property
+
+    filter_value
 
     allow(SegmentTrackJob).to receive(:perform_later)
     allow(BillableMetrics::DeleteEventsJob).to receive(:perform_later).and_call_original
@@ -40,6 +48,13 @@ RSpec.describe BillableMetrics::DestroyService, type: :service do
       freeze_time do
         expect { destroy_service.call }.to change { group.reload.deleted_at }.from(nil).to(Time.current)
           .and change { group_property.reload.deleted_at }.from(nil).to(Time.current)
+      end
+    end
+
+    it 'soft deletes all related filters' do
+      freeze_time do
+        expect { destroy_service.call }.to change { billable_metric.filters.reload.kept.count }.from(2).to(0)
+          .and change { filter_value.reload.reload.deleted_at }.from(nil).to(Time.current)
       end
     end
 


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds the logic to discard all billable metric filters, charge filters and charge filter values when discarding a billable metric