### PR TITLE
feat(filter): Handle billable metric filters in GraphQL and API

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -103,6 +103,7 @@ module Api
           :weighted_interval,
           :recurring,
           :field_name,
+          filters: [:key, { values: [] }],
           group: {},
         )
       end

--- a/app/graphql/types/billable_metric_filters/input.rb
+++ b/app/graphql/types/billable_metric_filters/input.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  module BillableMetricFilters
+    class Input < BaseInputObject
+      description 'Billable metric filters input arguments'
+
+      argument :key, String, required: true
+      argument :values, [String], required: true
+    end
+  end
+end

--- a/app/graphql/types/billable_metric_filters/object.rb
+++ b/app/graphql/types/billable_metric_filters/object.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module BillableMetricFilters
+    class Object < BaseObject
+      graphql_name 'BillableMetricFilter'
+      description 'Billable metric filters'
+
+      field :id, ID, null: false
+
+      field :key, String, null: false
+      field :values, [String], null: false
+    end
+  end
+end

--- a/app/graphql/types/billable_metrics/create_input.rb
+++ b/app/graphql/types/billable_metrics/create_input.rb
@@ -9,10 +9,12 @@ module Types
       argument :code, String, required: true
       argument :description, String
       argument :field_name, String, required: false
-      argument :group, GraphQL::Types::JSON, required: false
       argument :name, String, required: true
       argument :recurring, Boolean, required: false
       argument :weighted_interval, Types::BillableMetrics::WeightedIntervalEnum, required: false
+
+      argument :filters, [Types::BillableMetricFilters::Input], required: false
+      argument :group, GraphQL::Types::JSON, required: false
     end
   end
 end

--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -18,6 +18,7 @@ module Types
       field :field_name, String, null: true
       field :weighted_interval, Types::BillableMetrics::WeightedIntervalEnum, null: true
 
+      field :filters, [Types::BillableMetricFilters::Object], null: true
       field :flat_groups, [Types::Groups::Object], null: true, method: :selectable_groups
       field :group, GraphQL::Types::JSON, null: true, method: :active_groups_as_tree
 

--- a/app/graphql/types/billable_metrics/update_input.rb
+++ b/app/graphql/types/billable_metrics/update_input.rb
@@ -11,10 +11,12 @@ module Types
       argument :code, String, required: true
       argument :description, String
       argument :field_name, String, required: false
-      argument :group, GraphQL::Types::JSON, required: false
       argument :name, String, required: true
       argument :recurring, Boolean, required: false
       argument :weighted_interval, Types::BillableMetrics::WeightedIntervalEnum, required: false
+
+      argument :filters, [Types::BillableMetricFilters::Input], required: false
+      argument :group, GraphQL::Types::JSON, required: false
     end
   end
 end

--- a/app/serializers/v1/billable_metric_filter_serializer.rb
+++ b/app/serializers/v1/billable_metric_filter_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module V1
+  class BillableMetricFilterSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        key: model.key,
+        values: model.values,
+      }
+    end
+  end
+end

--- a/app/serializers/v1/billable_metric_serializer.rb
+++ b/app/serializers/v1/billable_metric_serializer.rb
@@ -3,7 +3,7 @@
 module V1
   class BillableMetricSerializer < ModelSerializer
     def serialize
-      {
+      payload = {
         lago_id: model.id,
         name: model.name,
         code: model.code,
@@ -18,6 +18,10 @@ module V1
         draft_invoices_count:,
         plans_count:,
       }
+
+      payload.merge!(filters)
+
+      payload
     end
 
     private
@@ -37,6 +41,14 @@ module V1
 
     def plans_count
       model.plans.distinct.count
+    end
+
+    def filters
+      ::CollectionSerializer.new(
+        model.filters,
+        ::V1::BillableMetricFilterSerializer,
+        collection_name: 'filters',
+      ).serialize
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -161,6 +161,7 @@ type BillableMetric {
   description: String
   draftInvoicesCount: Int!
   fieldName: String
+  filters: [BillableMetricFilter!]
   flatGroups: [Group!]
   group: JSON
   id: ID!
@@ -176,6 +177,15 @@ type BillableMetric {
 type BillableMetricCollection {
   collection: [BillableMetric!]!
   metadata: CollectionMetadata!
+}
+
+"""
+Billable metric filters
+"""
+type BillableMetricFilter {
+  id: ID!
+  key: String!
+  values: [String!]!
 }
 
 enum BillingTimeEnum {
@@ -1616,6 +1626,7 @@ input CreateBillableMetricInput {
   code: String!
   description: String!
   fieldName: String
+  filters: [Input!]
   group: JSON
   name: String!
   recurring: Boolean
@@ -3263,6 +3274,14 @@ scalar ISO8601Date
 An ISO 8601-encoded datetime
 """
 scalar ISO8601DateTime
+
+"""
+Billable metric filters input arguments
+"""
+input Input {
+  key: String!
+  values: [String!]!
+}
 
 type Invite {
   acceptedAt: ISO8601DateTime!
@@ -5747,6 +5766,7 @@ input UpdateBillableMetricInput {
   code: String!
   description: String!
   fieldName: String
+  filters: [Input!]
   group: JSON
   id: String!
   name: String!

--- a/schema.json
+++ b/schema.json
@@ -1506,6 +1506,28 @@
               ]
             },
             {
+              "name": "filters",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "BillableMetricFilter",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "flatGroups",
               "description": null,
               "type": {
@@ -1726,6 +1748,81 @@
                   "kind": "OBJECT",
                   "name": "CollectionMetadata",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "BillableMetricFilter",
+          "description": "Billable metric filters",
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "key",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "values",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
                 }
               },
               "isDeprecated": false,
@@ -5046,18 +5143,6 @@
               "deprecationReason": null
             },
             {
-              "name": "group",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "JSON",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "name",
               "description": null,
               "type": {
@@ -5091,6 +5176,38 @@
               "type": {
                 "kind": "ENUM",
                 "name": "WeightedIntervalEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filters",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Input",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "group",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
                 "ofType": null
               },
               "defaultValue": null,
@@ -13686,6 +13803,57 @@
           "possibleTypes": null,
           "fields": null,
           "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "Input",
+          "description": "Billable metric filters input arguments",
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "key",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "values",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "enumValues": null
         },
         {
@@ -25248,18 +25416,6 @@
               "deprecationReason": null
             },
             {
-              "name": "group",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "JSON",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "name",
               "description": null,
               "type": {
@@ -25293,6 +25449,38 @@
               "type": {
                 "kind": "ENUM",
                 "name": "WeightedIntervalEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filters",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "Input",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "group",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/types/billable_metric_filters/input_spec.rb
+++ b/spec/graphql/types/billable_metric_filters/input_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::BillableMetricFilters::Input do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:key).of_type('String!') }
+  it { is_expected.to accept_argument(:values).of_type('[String!]!') }
+end

--- a/spec/graphql/types/billable_metric_filters/object_spec.rb
+++ b/spec/graphql/types/billable_metric_filters/object_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::BillableMetricFilters::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type('ID!') }
+  it { is_expected.to have_field(:key).of_type('String!') }
+  it { is_expected.to have_field(:values).of_type('[String!]!') }
+end

--- a/spec/graphql/types/billable_metrics/create_input_spec.rb
+++ b/spec/graphql/types/billable_metrics/create_input_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::BillableMetrics::CreateInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:aggregation_type).of_type('AggregationTypeEnum!') }
+  it { is_expected.to accept_argument(:code).of_type('String!') }
+  it { is_expected.to accept_argument(:description).of_type('String!') }
+  it { is_expected.to accept_argument(:field_name).of_type('String') }
+  it { is_expected.to accept_argument(:name).of_type('String!') }
+  it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
+  it { is_expected.to accept_argument(:weighted_interval).of_type('WeightedIntervalEnum') }
+  it { is_expected.to accept_argument(:filters).of_type('[Input!]') }
+  it { is_expected.to accept_argument(:group).of_type('JSON') }
+end

--- a/spec/graphql/types/billable_metrics/object_spec.rb
+++ b/spec/graphql/types/billable_metrics/object_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::BillableMetrics::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type('ID!') }
+  it { is_expected.to have_field(:organization).of_type('Organization') }
+  it { is_expected.to have_field(:code).of_type('String!') }
+  it { is_expected.to have_field(:name).of_type('String!') }
+  it { is_expected.to have_field(:description).of_type('String') }
+  it { is_expected.to have_field(:aggregation_type).of_type('AggregationTypeEnum!') }
+  it { is_expected.to have_field(:field_name).of_type('String') }
+  it { is_expected.to have_field(:weighted_interval).of_type('WeightedIntervalEnum') }
+  it { is_expected.to have_field(:filters).of_type('[BillableMetricFilter!]') }
+  it { is_expected.to have_field(:flat_groups).of_type('[Group!]') }
+  it { is_expected.to have_field(:group).of_type('JSON') }
+  it { is_expected.to have_field(:active_subscriptions_count).of_type('Int!') }
+  it { is_expected.to have_field(:draft_invoices_count).of_type('Int!') }
+  it { is_expected.to have_field(:plans_count).of_type('Int!') }
+  it { is_expected.to have_field(:recurring).of_type('Boolean!') }
+  it { is_expected.to have_field(:subscriptions_count).of_type('Int!') }
+  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:deleted_at).of_type('ISO8601DateTime') }
+  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+end

--- a/spec/graphql/types/billable_metrics/update_input_spec.rb
+++ b/spec/graphql/types/billable_metrics/update_input_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::BillableMetrics::UpdateInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:id).of_type('String!') }
+  it { is_expected.to accept_argument(:aggregation_type).of_type('AggregationTypeEnum!') }
+  it { is_expected.to accept_argument(:code).of_type('String!') }
+  it { is_expected.to accept_argument(:description).of_type('String!') }
+  it { is_expected.to accept_argument(:field_name).of_type('String') }
+  it { is_expected.to accept_argument(:name).of_type('String!') }
+  it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
+  it { is_expected.to accept_argument(:weighted_interval).of_type('WeightedIntervalEnum') }
+  it { is_expected.to accept_argument(:filters).of_type('[Input!]') }
+  it { is_expected.to accept_argument(:group).of_type('JSON') }
+end

--- a/spec/requests/api/v1/billable_metrics_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
       expect(json[:billable_metric][:created_at]).to be_present
       expect(json[:billable_metric][:recurring]).to eq(create_params[:recurring])
       expect(json[:billable_metric][:group]).to eq({})
+      expect(json[:billable_metric][:filters]).to eq([])
     end
 
     context 'with group parameter' do
@@ -84,8 +85,10 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
 
         expect(response).to have_http_status(:success)
         expect(json[:billable_metric][:lago_id]).to be_present
-        expect(json[:billable_metric][:recurring]).to eq(create_params[:recurring
-          ])
+        expect(json[:billable_metric][:recurring]).to eq(
+          create_params[:recurring
+                    ],
+        )
         expect(json[:billable_metric][:aggregation_type]).to eq('weighted_sum_agg')
         expect(json[:billable_metric][:weighted_interval]).to eq('seconds')
       end
@@ -115,6 +118,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
       expect(response).to have_http_status(:success)
       expect(json[:billable_metric][:lago_id]).to eq(billable_metric.id)
       expect(json[:billable_metric][:code]).to eq(update_params[:code])
+      expect(json[:billable_metric][:filters]).to eq([])
     end
 
     context 'with group parameter' do

--- a/spec/serializers/v1/billable_metric_filter_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_filter_serializer_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::BillableMetricFilterSerializer do
+  subject(:serializer) { described_class.new(billable_metric_filter, root_name: 'billable_metric_filter') }
+
+  let(:billable_metric_filter) { create(:billable_metric_filter) }
+  let(:result) { JSON.parse(serializer.to_json) }
+
+  it 'serializes the object' do
+    aggregate_failures do
+      expect(result['billable_metric_filter']).to include(
+        'lago_id' => billable_metric_filter.id,
+        'key' => billable_metric_filter.key,
+        'values' => billable_metric_filter.values,
+      )
+    end
+  end
+end

--- a/spec/serializers/v1/billable_metric_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_serializer_spec.rb
@@ -18,10 +18,12 @@ RSpec.describe ::V1::BillableMetricSerializer do
       expect(result['billable_metric']['field_name']).to eq(billable_metric.field_name)
       expect(result['billable_metric']['created_at']).to eq(billable_metric.created_at.iso8601)
       expect(result['billable_metric']['weighted_interval']).to eq(billable_metric.weighted_interval)
-      expect(result['billable_metric']['group']).to eq({})
       expect(result['billable_metric']['active_subscriptions_count']).to eq(0)
       expect(result['billable_metric']['draft_invoices_count']).to eq(0)
       expect(result['billable_metric']['plans_count']).to eq(0)
+
+      expect(result['billable_metric']['filters']).to eq([])
+      expect(result['billable_metric']['group']).to eq({})
     end
   end
 

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
+  subject(:service) { described_class.call(billable_metric:, filter_params:) }
+
+  let(:billable_metric) { create(:billable_metric) }
+
+  context 'when filter params is empty' do
+    let(:filter_params) { {} }
+
+    it 'does not create any filters' do
+      expect { service }.not_to change(BillableMetricFilter, :count)
+    end
+
+    context 'when there are existing filters' do
+      let(:filter) { create(:billable_metric_filter, billable_metric:) }
+
+      let(:charge) { create(:standard_charge, billable_metric:) }
+      let(:charge_filter) { create(:charge_filter, charge:) }
+      let(:filter_value) do
+        create(
+          :charge_filter_value,
+          charge_filter:,
+          billable_metric_filter: filter,
+          value: filter.values.first,
+        )
+      end
+
+      before { filter_value }
+
+      it 'discards all filters and the related values' do
+        expect { service }.to change { filter.reload.discarded? }.to(true)
+          .and change { filter_value.reload.discarded? }.to(true)
+          .and change { charge_filter.reload.discarded? }.to(true)
+      end
+    end
+  end
+
+  context 'with new filters' do
+    let(:filter_params) do
+      [
+        {
+          key: 'region',
+          values: %w[Europe US],
+        },
+        {
+          key: 'cloud',
+          values: %w[aws gcp],
+        },
+      ]
+    end
+
+    it 'creates the filters' do
+      expect { service }.to change(BillableMetricFilter, :count).by(2)
+
+      filter1 = billable_metric.filters.find_by(key: 'region')
+      expect(filter1).to have_attributes(
+        key: 'region',
+        values: %w[Europe US],
+      )
+
+      filter2 = billable_metric.filters.find_by(key: 'cloud')
+      expect(filter2).to have_attributes(
+        key: 'cloud',
+        values: %w[aws gcp],
+      )
+    end
+  end
+
+  context 'with existing filters' do
+    let(:filter_params) do
+      [
+        {
+          key: 'region',
+          values: %w[Europe US Africa],
+        },
+      ]
+    end
+
+    let(:filter) { create(:billable_metric_filter, billable_metric:, key: 'region', values: %w[Europe US]) }
+
+    before { filter }
+
+    it 'updates the filters' do
+      expect { service }.not_to change(BillableMetricFilter, :count)
+
+      expect(filter.reload).to have_attributes(
+        key: 'region',
+        values: %w[Europe US Africa],
+      )
+    end
+
+    context 'when a value is removed' do
+      let(:filter_params) do
+        [
+          {
+            key: 'region',
+            values: %w[Europe],
+          },
+        ]
+      end
+
+      let!(:filter_value) do
+        create(
+          :charge_filter_value,
+          billable_metric_filter: filter,
+          value: 'US',
+        )
+      end
+
+      it 'discards the removed value' do
+        expect { service }.not_to change(BillableMetricFilter, :count)
+
+        expect(filter.reload).to have_attributes(
+          key: 'region',
+          values: %w[Europe],
+        )
+
+        expect(filter_value.reload).to be_discarded
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR exposes billable metric filters in both API and GraphQL API