### PR TITLE
fix(webhook): Fix payment provider webhook.

### DIFF
--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -111,7 +111,7 @@ module PaymentProviderCustomers
     end
 
     def generate_checkout_url(send_webhook: true)
-      return result unless customer.organization.webhook_endpoints.any? || !send_webhook || !payment_provider
+      return result unless customer.organization.webhook_endpoints.any? || !send_webhook || !payment_provider(customer)
 
       res = Stripe::Checkout::Session.create(
         checkout_link_params,

--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -51,7 +51,12 @@ module PaymentProviders
       organization = Organization.find_by(id: organization_id)
       return result.service_failure!(code: 'webhook_error', message: 'Organization not found') unless organization
 
-      payment_provider_result = PaymentProviders::FindService.call(organization_id:, code:)
+      payment_provider_result = PaymentProviders::FindService.call(
+        organization_id:,
+        code:,
+        payment_provider_type: 'adyen',
+      )
+
       return payment_provider_result unless payment_provider_result.success?
 
       validator = ::Adyen::Utils::HmacValidator.new

--- a/app/services/payment_providers/gocardless_service.rb
+++ b/app/services/payment_providers/gocardless_service.rb
@@ -43,7 +43,12 @@ module PaymentProviders
     end
 
     def handle_incoming_webhook(organization_id:, body:, signature:, code: nil)
-      payment_provider_result = PaymentProviders::FindService.call(organization_id:, code:)
+      payment_provider_result = PaymentProviders::FindService.call(
+        organization_id:,
+        code:,
+        payment_provider_type: 'gocardless',
+      )
+
       return payment_provider_result unless payment_provider_result.success?
 
       events = GoCardlessPro::Webhook.parse(

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -90,7 +90,12 @@ module PaymentProviders
     def handle_incoming_webhook(organization_id:, params:, signature:, code: nil)
       organization = Organization.find_by(id: organization_id)
 
-      payment_provider_result = PaymentProviders::FindService.new(organization_id:, code:).call
+      payment_provider_result = PaymentProviders::FindService.call(
+        organization_id:,
+        code:,
+        payment_provider_type: 'stripe',
+      )
+
       return payment_provider_result unless payment_provider_result.success?
 
       event = ::Stripe::Webhook.construct_event(


### PR DESCRIPTION
## Context

Webhook handling was broken due to a missing argument for `PaymentProviders::FindService`.

## Description

Fix payment provider webhook.
Add missing `payment_provider_type` argument to `PaymentProviders::FindService`
