### PR TITLE
feat(minimum-spending): Add serializers

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -11,6 +11,7 @@ class Plan < ApplicationRecord
 
   has_one :minimum_commitment, -> { where(commitment_type: :minimum_commitment) }, class_name: 'Commitment'
 
+  has_many :commitments
   has_many :charges, dependent: :destroy
   has_many :billable_metrics, through: :charges
   has_many :subscriptions

--- a/app/models/tax.rb
+++ b/app/models/tax.rb
@@ -20,6 +20,8 @@ class Tax < ApplicationRecord
   has_many :plans, through: :plans_taxes
   has_many :charges_taxes, class_name: 'Charge::AppliedTax', dependent: :destroy
   has_many :charges, through: :charges_taxes
+  has_many :commitments_taxes, class_name: 'Commitment::AppliedTax', dependent: :destroy
+  has_many :commitments, through: :commitments_taxes
 
   belongs_to :organization
 

--- a/app/serializers/v1/commitment_serializer.rb
+++ b/app/serializers/v1/commitment_serializer.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module V1
+  class CommitmentSerializer < ModelSerializer
+    def serialize
+      payload = {
+        lago_id: model.id,
+        plan_code: model.plan.code,
+        invoice_display_name: model.invoice_display_name,
+        commitment_type: model.commitment_type,
+        amount_cents: model.amount_cents,
+        interval: model.plan.interval,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601,
+      }
+
+      payload.merge!(taxes) if include?(:taxes)
+
+      payload
+    end
+
+    private
+
+    def taxes
+      ::CollectionSerializer.new(
+        model.taxes,
+        ::V1::TaxSerializer,
+        collection_name: 'taxes',
+      ).serialize
+    end
+  end
+end

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -24,6 +24,7 @@ module V1
 
       payload.merge!(charges) if include?(:charges)
       payload.merge!(taxes) if include?(:taxes)
+      payload.merge!(commitments) if include?(:commitments)
 
       payload
     end
@@ -35,6 +36,15 @@ module V1
         model.charges,
         ::V1::ChargeSerializer,
         collection_name: 'charges',
+        includes: include?(:taxes) ? %i[taxes] : [],
+      ).serialize
+    end
+
+    def commitments
+      ::CollectionSerializer.new(
+        model.commitments,
+        ::V1::CommitmentSerializer,
+        collection_name: 'commitments',
         includes: include?(:taxes) ? %i[taxes] : [],
       ).serialize
     end

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -24,7 +24,7 @@ module V1
 
       payload.merge!(charges) if include?(:charges)
       payload.merge!(taxes) if include?(:taxes)
-      payload.merge!(commitments) if include?(:commitments)
+      payload.merge!(minimum_commitment) if include?(:minimum_commitment) && model.minimum_commitment
 
       payload
     end
@@ -40,13 +40,13 @@ module V1
       ).serialize
     end
 
-    def commitments
-      ::CollectionSerializer.new(
-        model.commitments,
-        ::V1::CommitmentSerializer,
-        collection_name: 'commitments',
-        includes: include?(:taxes) ? %i[taxes] : [],
-      ).serialize
+    def minimum_commitment
+      {
+        minimum_commitment: V1::CommitmentSerializer.new(
+          model.minimum_commitment,
+          includes: include?(:taxes) ? %i[taxes] : [],
+        ).serialize,
+      }
     end
 
     def taxes

--- a/app/serializers/v1/tax_serializer.rb
+++ b/app/serializers/v1/tax_serializer.rb
@@ -14,6 +14,7 @@ module V1
         customers_count: model.customers_count,
         plans_count: model.plans.count,
         charges_count: model.charges.count,
+        commitments_count: model.commitments.count,
         created_at: model.created_at.iso8601,
       }
     end

--- a/spec/serializers/v1/commitment_serializer_spec.rb
+++ b/spec/serializers/v1/commitment_serializer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::CommitmentSerializer do
+  subject(:serializer) do
+    described_class.new(commitment, root_name: 'commitment', includes: %i[taxes])
+  end
+
+  let(:commitment) { create(:commitment) }
+  let(:tax) { create(:tax, organization: commitment.plan.organization) }
+  let(:commitment_applied_tax) { create(:commitment_applied_tax, commitment:, tax:) }
+
+  before { commitment_applied_tax }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['commitment']['lago_id']).to eq(commitment.id)
+      expect(result['commitment']['plan_code']).to eq(commitment.plan.code)
+      expect(result['commitment']['invoice_display_name']).to eq(commitment.invoice_display_name)
+      expect(result['commitment']['commitment_type']).to eq(commitment.commitment_type)
+      expect(result['commitment']['amount_cents']).to eq(commitment.amount_cents)
+      expect(result['commitment']['interval']).to eq(commitment.plan.interval)
+      expect(result['commitment']['created_at']).to eq(commitment.created_at.iso8601)
+      expect(result['commitment']['updated_at']).to eq(commitment.updated_at.iso8601)
+
+      expect(result['commitment']['taxes'].count).to eq(1)
+      expect(result['commitment']['taxes'].first['commitments_count']).to eq(1)
+    end
+  end
+end

--- a/spec/serializers/v1/commitment_serializer_spec.rb
+++ b/spec/serializers/v1/commitment_serializer_spec.rb
@@ -11,23 +11,42 @@ RSpec.describe ::V1::CommitmentSerializer do
   let(:tax) { create(:tax, organization: commitment.plan.organization) }
   let(:commitment_applied_tax) { create(:commitment_applied_tax, commitment:, tax:) }
 
+  let(:commitment_hash) do
+    {
+      'lago_id' => commitment.id,
+      'plan_code' => commitment.plan.code,
+      'invoice_display_name' => commitment.invoice_display_name,
+      'commitment_type' => commitment.commitment_type,
+      'amount_cents' => commitment.amount_cents,
+      'interval' => commitment.plan.interval,
+      'created_at' => commitment.created_at.iso8601,
+      'updated_at' => commitment.updated_at.iso8601,
+    }
+  end
+
+  let(:commitment_tax_hash) do
+    {
+      'lago_id' => tax.id,
+      'name' => tax.name,
+      'code' => tax.code,
+      'rate' => tax.rate,
+      'description' => tax.description,
+      'applied_to_organization' => tax.applied_to_organization,
+      'commitments_count' => 1,
+    }
+  end
+
   before { commitment_applied_tax }
 
   it 'serializes the object' do
     result = JSON.parse(serializer.to_json)
 
-    aggregate_failures do
-      expect(result['commitment']['lago_id']).to eq(commitment.id)
-      expect(result['commitment']['plan_code']).to eq(commitment.plan.code)
-      expect(result['commitment']['invoice_display_name']).to eq(commitment.invoice_display_name)
-      expect(result['commitment']['commitment_type']).to eq(commitment.commitment_type)
-      expect(result['commitment']['amount_cents']).to eq(commitment.amount_cents)
-      expect(result['commitment']['interval']).to eq(commitment.plan.interval)
-      expect(result['commitment']['created_at']).to eq(commitment.created_at.iso8601)
-      expect(result['commitment']['updated_at']).to eq(commitment.updated_at.iso8601)
+    expect(result['commitment']).to include(commitment_hash)
+  end
 
-      expect(result['commitment']['taxes'].count).to eq(1)
-      expect(result['commitment']['taxes'].first['commitments_count']).to eq(1)
-    end
+  it 'serializes taxes' do
+    result = JSON.parse(serializer.to_json)
+
+    expect(result['commitment']['taxes'].first).to include(commitment_tax_hash)
   end
 end

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -3,57 +3,99 @@
 require 'rails_helper'
 
 RSpec.describe ::V1::PlanSerializer do
-  subject(:serializer) { described_class.new(plan, root_name: 'plan', includes: %i[charges taxes commitments]) }
+  subject(:serializer) { described_class.new(plan, root_name: 'plan', includes: %i[charges taxes minimum_commitment]) }
 
   let(:plan) { create(:plan) }
   let(:customer) { create(:customer, organization: plan.organization) }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:charge) { create(:standard_charge, plan:) }
-  let(:commitment) { create(:commitment, plan:) }
 
-  before { subscription && charge && commitment }
+  before { subscription && charge }
 
-  it 'serializes the object', :aggregate_failures do
-    overridden_plan = create(:plan, parent_id: plan.id)
-    customer2 = create(:customer, organization: plan.organization)
-    create(:subscription, customer: customer2, plan: overridden_plan)
+  context 'when plan has one minimium commitment' do
+    let(:commitment) { create(:commitment, plan:) }
 
-    result = JSON.parse(serializer.to_json)
+    before { commitment }
 
-    expect(result['plan']).to include(
-      'lago_id' => plan.id,
-      'name' => plan.name,
-      'invoice_display_name' => plan.invoice_display_name,
-      'created_at' => plan.created_at.iso8601,
-      'code' => plan.code,
-      'interval' => plan.interval,
-      'description' => plan.description,
-      'amount_cents' => plan.amount_cents,
-      'amount_currency' => plan.amount_currency,
-      'trial_period' => plan.trial_period,
-      'pay_in_advance' => plan.pay_in_advance,
-      'bill_charges_monthly' => plan.bill_charges_monthly,
-      'customers_count' => 2,
-      'active_subscriptions_count' => 2,
-      'draft_invoices_count' => 0,
-      'parent_id' => nil,
-      'taxes' => [],
-    )
+    it 'serializes the object', :aggregate_failures do
+      overridden_plan = create(:plan, parent_id: plan.id)
+      customer2 = create(:customer, organization: plan.organization)
+      create(:subscription, customer: customer2, plan: overridden_plan)
 
-    expect(result['plan']['charges'].first).to include(
-      'lago_id' => charge.id,
-      'group_properties' => [],
-    )
+      result = JSON.parse(serializer.to_json)
 
-    expect(result['plan']['commitments'].first).to include(
-      'lago_id' => commitment.id,
-      'plan_code' => commitment.plan.code,
-      'invoice_display_name' => commitment.invoice_display_name,
-      'amount_cents' => commitment.amount_cents,
-      'interval' => commitment.plan.interval,
-      'created_at' => commitment.created_at.iso8601,
-      'updated_at' => commitment.updated_at.iso8601,
-      'taxes' => [],
-    )
+      expect(result['plan']).to include(
+        'lago_id' => plan.id,
+        'name' => plan.name,
+        'invoice_display_name' => plan.invoice_display_name,
+        'created_at' => plan.created_at.iso8601,
+        'code' => plan.code,
+        'interval' => plan.interval,
+        'description' => plan.description,
+        'amount_cents' => plan.amount_cents,
+        'amount_currency' => plan.amount_currency,
+        'trial_period' => plan.trial_period,
+        'pay_in_advance' => plan.pay_in_advance,
+        'bill_charges_monthly' => plan.bill_charges_monthly,
+        'customers_count' => 2,
+        'active_subscriptions_count' => 2,
+        'draft_invoices_count' => 0,
+        'parent_id' => nil,
+        'taxes' => [],
+      )
+
+      expect(result['plan']['charges'].first).to include(
+        'lago_id' => charge.id,
+        'group_properties' => [],
+      )
+
+      expect(result['plan']['minimum_commitment']).to include(
+        'lago_id' => commitment.id,
+        'plan_code' => commitment.plan.code,
+        'invoice_display_name' => commitment.invoice_display_name,
+        'amount_cents' => commitment.amount_cents,
+        'interval' => commitment.plan.interval,
+        'created_at' => commitment.created_at.iso8601,
+        'updated_at' => commitment.updated_at.iso8601,
+        'taxes' => [],
+      )
+    end
+  end
+
+  context 'when plan has no minimium commitment' do
+    it 'serializes the object', :aggregate_failures do
+      overridden_plan = create(:plan, parent_id: plan.id)
+      customer2 = create(:customer, organization: plan.organization)
+      create(:subscription, customer: customer2, plan: overridden_plan)
+
+      result = JSON.parse(serializer.to_json)
+
+      expect(result['plan']).to include(
+        'lago_id' => plan.id,
+        'name' => plan.name,
+        'invoice_display_name' => plan.invoice_display_name,
+        'created_at' => plan.created_at.iso8601,
+        'code' => plan.code,
+        'interval' => plan.interval,
+        'description' => plan.description,
+        'amount_cents' => plan.amount_cents,
+        'amount_currency' => plan.amount_currency,
+        'trial_period' => plan.trial_period,
+        'pay_in_advance' => plan.pay_in_advance,
+        'bill_charges_monthly' => plan.bill_charges_monthly,
+        'customers_count' => 2,
+        'active_subscriptions_count' => 2,
+        'draft_invoices_count' => 0,
+        'parent_id' => nil,
+        'taxes' => [],
+      )
+
+      expect(result['plan']['charges'].first).to include(
+        'lago_id' => charge.id,
+        'group_properties' => [],
+      )
+
+      expect(result['plan']['minimum_commitment']).to be_nil
+    end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/set-minimum-spend-for-subscriptions

## Context

As a user, I want to define the minimum spend that applies to the customer's plan. Consider the following monthly plan:

- Subscription fee = $50 per month (in arrears);
- Usage-based charge = $10 per unit per month (in arrears); and
- Monthly minimum spend = $100.

If at the end of the month, the customer has consumed 3 units, their total invoice will be: $50 + 3 * $10 = $80 + $20 (true-up fee) = $100.

## Description

In this PR we're adding serializers.