### PR TITLE
fix: Initial migration is broken with missing task

### DIFF
--- a/db/migrate/20221114102649_fill_sync_with_provider_field.rb
+++ b/db/migrate/20221114102649_fill_sync_with_provider_field.rb
@@ -2,7 +2,6 @@
 
 class FillSyncWithProviderField < ActiveRecord::Migration[7.0]
   def change
-    LagoApi::Application.load_tasks
-    Rake::Task['customers:populate_sync_with_provider'].invoke
+    # NOTE: kept for backward compatibility
   end
 end


### PR DESCRIPTION
## Context

The initial migration process is failing because of a removed task

## Description

This PR fixes the process by removing the task invocation