### PR TITLE
feat(group-by): Expose grouped_by for fees in GraphQL API

### DIFF
--- a/app/graphql/types/charges/properties.rb
+++ b/app/graphql/types/charges/properties.rb
@@ -4,17 +4,18 @@ module Types
   module Charges
     class Properties < Types::BaseObject
       # NOTE: Standard and Package charge model
-      field :amount, String, null: true, hash_key: :amount
+      field :amount, String, null: true
+      field :grouped_by, [String], null: true
 
       # NOTE: Graduated charge model
-      field :graduated_ranges, [Types::Charges::GraduatedRange], null: true, hash_key: :graduated_ranges
+      field :graduated_ranges, [Types::Charges::GraduatedRange], null: true
 
       # NOTE: Graduated percentage modle
       field :graduated_percentage_ranges, [Types::Charges::GraduatedPercentageRange], null: true
 
       # NOTE: Package charge model
-      field :free_units, GraphQL::Types::BigInt, null: true, hash_key: :free_units
-      field :package_size, GraphQL::Types::BigInt, null: true, hash_key: :package_size
+      field :free_units, GraphQL::Types::BigInt, null: true
+      field :package_size, GraphQL::Types::BigInt, null: true
 
       # NOTE: Percentage charge model
       field :fixed_amount, String, null: true
@@ -25,7 +26,7 @@ module Types
       field :rate, String, null: true
 
       # NOTE: Volume charge model
-      field :volume_ranges, [Types::Charges::VolumeRange], null: true, hash_key: :volume_ranges
+      field :volume_ranges, [Types::Charges::VolumeRange], null: true
     end
   end
 end

--- a/app/graphql/types/charges/properties_input.rb
+++ b/app/graphql/types/charges/properties_input.rb
@@ -5,6 +5,7 @@ module Types
     class PropertiesInput < Types::BaseInputObject
       # NOTE: Standard and Package charge model
       argument :amount, String, required: false
+      argument :grouped_by, [String], required: false
 
       # NOTE: Graduated charge model
       argument :graduated_ranges, [Types::Charges::GraduatedRangeInput], required: false

--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -12,6 +12,7 @@ module Types
 
         field :billable_metric, Types::BillableMetrics::Object, null: false
         field :charge, Types::Charges::Object, null: false
+        field :grouped_by, [String], null: true
         field :groups, [Types::Customers::Usage::ChargeGroup], null: true
 
         def units

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -10,6 +10,7 @@ module Types
       field :currency, Types::CurrencyEnum, null: false
       field :description, String, null: true
       field :group_name, String, null: true
+      field :grouped_by, [String], null: false
       field :invoice_display_name, String, null: true
       field :invoice_name, String, null: true
       field :subscription, Types::Subscriptions::Object, null: true

--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -24,6 +24,7 @@ module V1
               aggregation_type: fee.billable_metric.aggregation_type,
             },
             groups: groups(fees),
+            grouped_by: fee.grouped_by,
           }
         end
       end

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -21,6 +21,7 @@ module V1
           group_invoice_display_name: model.group_name,
           lago_item_id: model.item_id,
           item_type: model.item_type,
+          grouped_by: model.grouped_by,
         },
         pay_in_advance:,
         invoiceable:,

--- a/db/migrate/20240118140703_add_grouped_by_to_cached_aggregations.rb
+++ b/db/migrate/20240118140703_add_grouped_by_to_cached_aggregations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGroupedByToCachedAggregations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cached_aggregations, :grouped_by, :string, array: true, null: false, default: []
+  end
+end

--- a/db/migrate/20240118141022_add_grouped_by_to_fees.rb
+++ b/db/migrate/20240118141022_add_grouped_by_to_fees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGroupedByToFees < ActiveRecord::Migration[7.0]
+  def change
+    add_column :fees, :grouped_by, :string, array: true, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_15_130517) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_18_141022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -165,6 +165,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_15_130517) do
     t.decimal "max_aggregation_with_proration"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "grouped_by", default: [], null: false, array: true
     t.index ["charge_id"], name: "index_cached_aggregations_on_charge_id"
     t.index ["event_id"], name: "index_cached_aggregations_on_event_id"
     t.index ["external_subscription_id"], name: "index_cached_aggregations_on_external_subscription_id"
@@ -479,6 +480,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_15_130517) do
     t.decimal "precise_unit_amount", precision: 30, scale: 15, default: "0.0", null: false
     t.jsonb "amount_details", default: {}, null: false
     t.uuid "charge_filter_id"
+    t.string "grouped_by", default: [], null: false, array: true
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_filter_id"], name: "index_fees_on_charge_filter_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -4272,6 +4272,7 @@ type Properties {
   freeUnitsPerTotalAggregation: String
   graduatedPercentageRanges: [GraduatedPercentageRange!]
   graduatedRanges: [GraduatedRange!]
+  groupedBy: [String!]
   packageSize: BigInt
   perTransactionMaxAmount: String
   perTransactionMinAmount: String
@@ -4287,6 +4288,7 @@ input PropertiesInput {
   freeUnitsPerTotalAggregation: String
   graduatedPercentageRanges: [GraduatedPercentageRangeInput!]
   graduatedRanges: [GraduatedRangeInput!]
+  groupedBy: [String!]
   packageSize: BigInt
   perTransactionMaxAmount: String
   perTransactionMinAmount: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -238,6 +238,7 @@ type ChargeUsage {
   billableMetric: BillableMetric!
   charge: Charge!
   eventsCount: Int!
+  groupedBy: [String!]
   groups: [GroupUsage!]
   units: Float!
 }
@@ -3042,6 +3043,7 @@ type Fee implements InvoiceItem {
   feeType: FeeTypesEnum!
   group: Group
   groupName: String
+  groupedBy: [String!]!
   id: ID!
   invoiceDisplayName: String
   invoiceName: String

--- a/schema.json
+++ b/schema.json
@@ -19554,6 +19554,28 @@
               ]
             },
             {
+              "name": "groupedBy",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "packageSize",
               "description": null,
               "type": {
@@ -19650,6 +19672,26 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "groupedBy",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -2447,6 +2447,28 @@
               ]
             },
             {
+              "name": "groupedBy",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "groups",
               "description": null,
               "type": {
@@ -11451,6 +11473,32 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "groupedBy",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/types/charges/properties_input_spec.rb
+++ b/spec/graphql/types/charges/properties_input_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Charges::PropertiesInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:amount).of_type('String') }
+  it { is_expected.to accept_argument(:grouped_by).of_type('[String!]') }
+
+  it { is_expected.to accept_argument(:graduated_ranges).of_type('[GraduatedRangeInput!]') }
+
+  it { is_expected.to accept_argument(:graduated_percentage_ranges).of_type('[GraduatedPercentageRangeInput!]') }
+
+  it { is_expected.to accept_argument(:free_units).of_type('BigInt') }
+  it { is_expected.to accept_argument(:package_size).of_type('BigInt') }
+
+  it { is_expected.to accept_argument(:fixed_amount).of_type('String') }
+  it { is_expected.to accept_argument(:free_units_per_events).of_type('BigInt') }
+  it { is_expected.to accept_argument(:free_units_per_total_aggregation).of_type('String') }
+  it { is_expected.to accept_argument(:per_transaction_max_amount).of_type('String') }
+  it { is_expected.to accept_argument(:per_transaction_min_amount).of_type('String') }
+  it { is_expected.to accept_argument(:rate).of_type('String') }
+
+  it { is_expected.to accept_argument(:volume_ranges).of_type('[VolumeRangeInput!]') }
+end

--- a/spec/graphql/types/charges/properties_spec.rb
+++ b/spec/graphql/types/charges/properties_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Charges::Properties do
+  subject { described_class }
+
+  it { is_expected.to have_field(:amount).of_type('String') }
+  it { is_expected.to have_field(:grouped_by).of_type('[String!]') }
+
+  it { is_expected.to have_field(:graduated_ranges).of_type('[GraduatedRange!]') }
+
+  it { is_expected.to have_field(:graduated_percentage_ranges).of_type('[GraduatedPercentageRange!]') }
+
+  it { is_expected.to have_field(:free_units).of_type('BigInt') }
+  it { is_expected.to have_field(:package_size).of_type('BigInt') }
+
+  it { is_expected.to have_field(:fixed_amount).of_type('String') }
+  it { is_expected.to have_field(:free_units_per_events).of_type('BigInt') }
+  it { is_expected.to have_field(:free_units_per_total_aggregation).of_type('String') }
+  it { is_expected.to have_field(:per_transaction_max_amount).of_type('String') }
+  it { is_expected.to have_field(:per_transaction_min_amount).of_type('String') }
+  it { is_expected.to have_field(:rate).of_type('String') }
+
+  it { is_expected.to have_field(:volume_ranges).of_type('[VolumeRange!]') }
+end

--- a/spec/graphql/types/customers/usage/charge_spec.rb
+++ b/spec/graphql/types/customers/usage/charge_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Customers::Usage::Charge do
+  subject { described_class }
+
+  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:events_count).of_type('Int!') }
+  it { is_expected.to have_field(:units).of_type('Float!') }
+  it { is_expected.to have_field(:billable_metric).of_type('BillableMetric!') }
+  it { is_expected.to have_field(:charge).of_type('Charge!') }
+  it { is_expected.to have_field(:grouped_by).of_type('[String!]') }
+  it { is_expected.to have_field(:groups).of_type('[GroupUsage!]') }
+end

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -18,4 +18,5 @@ RSpec.describe Types::Fees::Object do
   it { is_expected.to have_field(:taxes_rate).of_type('Float') }
   it { is_expected.to have_field(:units).of_type('Float!') }
   it { is_expected.to have_field(:applied_taxes).of_type('[FeeAppliedTax!]') }
+  it { is_expected.to have_field(:grouped_by).of_type('[String!]!') }
 end

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe ::V1::FeeSerializer do
         'invoice_display_name' => fee.invoice_name,
         'lago_item_id' => fee.item_id,
         'item_type' => fee.item_type,
+        'grouped_by' => fee.grouped_by,
       )
 
       expect(result['fee']['from_date']).not_to be_nil


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR adds:
- A `grouped_by` attribute to the fees table
- A `grouped_by` attribute to the cached_aggregation
- Exposes this attributes in API and GraphQL
- Allow and expose the same attribute to the standard charge model properties in GraphQL