### PR TITLE
feat(group-by): add grouped_by_value logic to event stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ db/events_schema.rb
 LAGO_VERSION
 
 **/.DS_Store
+.vscode

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -39,7 +39,6 @@ module BillableMetrics
           subscription:,
           boundaries:,
           group:,
-          event:,
         )
       end
 

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -38,7 +38,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries:,
-          group:,
+          filters: { group: },
         )
       end
 

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -172,7 +172,7 @@ module BillableMetrics
               from_datetime: subscription.started_at,
               to_datetime: subscription.terminated_at,
             },
-            group:,
+            filters: { group: },
           )
           store.aggregation_property = billable_metric.field_name
 

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -60,7 +60,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          group:,
+          filters: { group: },
         )
 
         event_store.use_from_boundary = false

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -61,7 +61,6 @@ module BillableMetrics
           subscription:,
           boundaries: { to_datetime: from_datetime },
           group:,
-          event:,
         )
 
         event_store.use_from_boundary = false

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -28,7 +28,6 @@ module BillableMetrics
           subscription:,
           boundaries: { to_datetime: from_datetime },
           group:,
-          event:,
         )
 
         event_store.use_from_boundary = false

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -27,7 +27,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          group:,
+          filters: { group: },
         )
 
         event_store.use_from_boundary = false

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -67,7 +67,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          group:,
+          filters: { group: },
         )
 
         event_store.use_from_boundary = false
@@ -92,7 +92,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          group:,
+          filters: { group: },
         )
 
         event_store.use_from_boundary = false

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -68,7 +68,6 @@ module BillableMetrics
           subscription:,
           boundaries: { to_datetime: from_datetime },
           group:,
-          event:,
         )
 
         event_store.use_from_boundary = false
@@ -94,7 +93,6 @@ module BillableMetrics
           subscription:,
           boundaries: { to_datetime: from_datetime },
           group:,
-          event:,
         )
 
         event_store.use_from_boundary = false

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -17,6 +17,10 @@ module Events
         @use_from_boundary = true
       end
 
+      def grouped_by_value?
+        grouped_by.present? && grouped_by_value.present?
+      end
+
       def events(force_from: false)
         raise NotImplementedError
       end

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -3,11 +3,14 @@
 module Events
   module Stores
     class BaseStore
-      def initialize(code:, subscription:, boundaries:, group: nil)
+      def initialize(code:, subscription:, boundaries:, filters: {})
         @code = code
         @subscription = subscription
         @boundaries = boundaries
-        @group = group
+
+        @group = filters[:group]
+        @grouped_by = filters[:grouped_by]
+        @grouped_by_value = filters[:grouped_by_value]
 
         @aggregation_property = nil
         @numeric_property = false
@@ -71,7 +74,7 @@ module Events
 
       protected
 
-      attr_accessor :code, :subscription, :group, :boundaries
+      attr_accessor :code, :subscription, :group, :boundaries, :grouped_by, :grouped_by_value
 
       delegate :customer, to: :subscription
 

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -3,12 +3,11 @@
 module Events
   module Stores
     class BaseStore
-      def initialize(code:, subscription:, boundaries:, group: nil, event: nil)
+      def initialize(code:, subscription:, boundaries:, group: nil)
         @code = code
         @subscription = subscription
         @boundaries = boundaries
         @group = group
-        @event = event
 
         @aggregation_property = nil
         @numeric_property = false
@@ -72,7 +71,7 @@ module Events
 
       protected
 
-      attr_accessor :code, :subscription, :group, :event, :boundaries
+      attr_accessor :code, :subscription, :group, :boundaries
 
       delegate :customer, to: :subscription
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -18,6 +18,8 @@ module Events
         scope = scope.where('events_raw.timestamp <= ?', to_datetime) if to_datetime
         scope = scope.where(numeric_condition) if numeric_property
 
+        scope = with_grouped_by_value(scope) if grouped_by_value?
+
         return scope unless group
 
         group_scope(scope)
@@ -174,6 +176,10 @@ module Events
         return scope unless group.parent
 
         scope.where('events_raw.properties[?] = ?', group.parent.key.to_s => group.parent.value.to_s)
+      end
+
+      def with_grouped_by_value(scope)
+        scope.where('events_raw.properties[?] = ?', grouped_by.to_s, grouped_by_value.to_s)
       end
 
       def numeric_condition

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -16,6 +16,8 @@ module Events
             .where(numeric_condition)
         end
 
+        scope = with_grouped_by_value(scope) if grouped_by_value?
+
         return scope unless group
 
         group_scope(scope)
@@ -124,6 +126,10 @@ module Events
         return scope unless group.parent
 
         scope.where('events.properties @> ?', { group.parent.key.to_s => group.parent.value }.to_json)
+      end
+
+      def with_grouped_by_value(scope)
+        scope.where('events.properties @> ?', { grouped_by.to_s => grouped_by_value.to_s }.to_json)
       end
 
       def sanitized_propery_name

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
       code:,
       subscription:,
       boundaries:,
-      filters: { group: },
+      filters: { group:, grouped_by:, grouped_by_value: },
     )
   end
 
@@ -30,13 +30,19 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
   end
 
   let(:group) { nil }
+  let(:grouped_by) { nil }
+  let(:grouped_by_value) { nil }
 
   let(:events) do
     events = []
 
     5.times do |i|
       properties = { billable_metric.field_name => i + 1 }
-      properties[group.key.to_s] = group.value.to_s if group && i.even?
+
+      if i.even?
+        properties[group.key.to_s] = group.value.to_s if group
+        properties[grouped_by] = grouped_by_value if grouped_by_value
+      end
 
       events << Clickhouse::EventsRaw.create!(
         transaction_id: SecureRandom.uuid,
@@ -75,6 +81,15 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
     context 'with group' do
       let(:group) { create(:group, billable_metric:) }
+
+      it 'returns a list of events' do
+        expect(event_store.events.count).to eq(3)
+      end
+    end
+
+    context 'with grouped_by_value' do
+      let(:grouped_by) { 'region' }
+      let(:grouped_by_value) { 'europe' }
 
       it 'returns a list of events' do
         expect(event_store.events.count).to eq(3)

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
       subscription:,
       boundaries:,
       group:,
-      event:,
     )
   end
 
@@ -31,7 +30,6 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
   end
 
   let(:group) { nil }
-  let(:event) { nil }
 
   let(:events) do
     events = []

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
       code:,
       subscription:,
       boundaries:,
-      group:,
+      filters: { group: },
     )
   end
 

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       code:,
       subscription:,
       boundaries:,
-      filters: { group: },
+      filters: { group:, grouped_by:, grouped_by_value: },
     )
   end
 
@@ -30,12 +30,14 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
   end
 
   let(:group) { nil }
+  let(:grouped_by) { nil }
+  let(:grouped_by_value) { nil }
 
   let(:events) do
     events = []
 
     5.times do |i|
-      event = create(
+      event = build(
         :event,
         organization_id: organization.id,
         external_subscription_id: subscription.external_id,
@@ -47,10 +49,12 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
         },
       )
 
-      if group && i.even?
-        event.properties[group.key] = group.value
-        event.save!
+      if i.even?
+        event.properties[group.key] = group.value if group
+        event.properties[grouped_by] = grouped_by_value if grouped_by_value
       end
+
+      event.save!
 
       events << event
     end
@@ -67,6 +71,15 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
 
     context 'with group' do
       let(:group) { create(:group, billable_metric:) }
+
+      it 'returns a list of events' do
+        expect(event_store.events.count).to eq(3)
+      end
+    end
+
+    context 'with grouped_by_value' do
+      let(:grouped_by) { 'region' }
+      let(:grouped_by_value) { 'europe' }
 
       it 'returns a list of events' do
         expect(event_store.events.count).to eq(3)

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       subscription:,
       boundaries:,
       group:,
-      event:,
     )
   end
 
@@ -31,7 +30,6 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
   end
 
   let(:group) { nil }
-  let(:event) { nil }
 
   let(:events) do
     events = []

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       code:,
       subscription:,
       boundaries:,
-      group:,
+      filters: { group: },
     )
   end
 


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR refactors the filtering arguments in the events store services:
- Remove the unused `event` argument
- Move the `group` argument as a sub value of a new `filters` one
- Add `grouped_by` and `grouped_by_value` argument in the `filters`
- Add logic to handle `grouped_by_value` when present