### PR TITLE
feat(group-by): handle group for in pay in advance charges

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -159,11 +159,11 @@ class Invoice < ApplicationRecord
       event_store_class: Events::Stores::PostgresStore,
       charge: fee.charge,
       subscription: fee.subscription,
-      group: fee.group,
       boundaries: {
         from_datetime: DateTime.parse(fee.properties['charges_from_datetime']),
         to_datetime: DateTime.parse(fee.properties['charges_to_datetime']),
       },
+      filters: { group: fee.group },
     ).breakdown.breakdown
   end
 

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -3,13 +3,16 @@
 module BillableMetrics
   module Aggregations
     class BaseService < ::BaseService
-      def initialize(event_store_class:, charge:, subscription:, boundaries:, group: nil, event: nil) # rubocop:disable Metrics/ParameterLists
+      def initialize(event_store_class:, charge:, subscription:, boundaries:, filters: {})
         super(nil)
         @event_store_class = event_store_class
         @charge = charge
         @subscription = subscription
-        @group = group
-        @event = event
+
+        @filters = filters
+        @group = filters[:group]
+        @event = filters[:event]
+
         @boundaries = boundaries
 
         result.aggregator = self
@@ -27,7 +30,7 @@ module BillableMetrics
 
       protected
 
-      attr_accessor :event_store_class, :charge, :subscription, :group, :event, :boundaries
+      attr_accessor :event_store_class, :charge, :subscription, :filters, :group, :event, :boundaries
 
       delegate :billable_metric, to: :charge
 

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -172,7 +172,7 @@ module BillableMetrics
               from_datetime: subscription.started_at,
               to_datetime: subscription.terminated_at,
             },
-            filters: { group: },
+            filters:,
           )
           store.aggregation_property = billable_metric.field_name
 

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -60,7 +60,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          filters: { group: },
+          filters:,
         )
 
         event_store.use_from_boundary = false

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -27,7 +27,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          filters: { group: },
+          filters:,
         )
 
         event_store.use_from_boundary = false

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -67,7 +67,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          filters: { group: },
+          filters:,
         )
 
         event_store.use_from_boundary = false
@@ -92,7 +92,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          filters: { group: },
+          filters:,
         )
 
         event_store.use_from_boundary = false

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -16,11 +16,13 @@ module Charges
       aggregator = BillableMetrics::AggregationFactory.new_instance(
         charge:,
         subscription:,
-        group:,
-        event:,
         boundaries: {
           from_datetime: boundaries[:charges_from_datetime],
           to_datetime: boundaries[:charges_to_datetime],
+        },
+        filters: {
+          group:,
+          event:,
         },
       )
 

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -20,10 +20,7 @@ module Charges
           from_datetime: boundaries[:charges_from_datetime],
           to_datetime: boundaries[:charges_to_datetime],
         },
-        filters: {
-          group:,
-          event:,
-        },
+        filters: aggregation_filters,
       )
 
       aggregator.aggregate(options: aggregation_options)
@@ -41,6 +38,21 @@ module Charges
         free_units_per_events: properties['free_units_per_events'].to_i,
         free_units_per_total_aggregation: BigDecimal(properties['free_units_per_total_aggregation'] || 0),
       }
+    end
+
+    def aggregation_filters
+      filters = {
+        group:,
+        event:,
+      }
+
+      if charge.standard? && charge.properties['grouped_by'].present?
+        filters[:grouped_by_values] = charge.properties['grouped_by'].index_with do |grouped_by|
+          event.properties[grouped_by]
+        end
+      end
+
+      filters
     end
   end
 end

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -10,15 +10,15 @@ module Events
 
         @group = filters[:group]
         @grouped_by = filters[:grouped_by]
-        @grouped_by_value = filters[:grouped_by_value]
+        @grouped_by_values = filters[:grouped_by_values]
 
         @aggregation_property = nil
         @numeric_property = false
         @use_from_boundary = true
       end
 
-      def grouped_by_value?
-        grouped_by.present? && grouped_by_value.present?
+      def grouped_by_values?
+        grouped_by.present? && grouped_by_values.present?
       end
 
       def events(force_from: false)
@@ -78,7 +78,7 @@ module Events
 
       protected
 
-      attr_accessor :code, :subscription, :group, :boundaries, :grouped_by, :grouped_by_value
+      attr_accessor :code, :subscription, :group, :boundaries, :grouped_by, :grouped_by_values
 
       delegate :customer, to: :subscription
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -18,7 +18,7 @@ module Events
         scope = scope.where('events_raw.timestamp <= ?', to_datetime) if to_datetime
         scope = scope.where(numeric_condition) if numeric_property
 
-        scope = with_grouped_by_value(scope) if grouped_by_value?
+        scope = with_grouped_by_values(scope) if grouped_by_values?
 
         return scope unless group
 
@@ -178,8 +178,12 @@ module Events
         scope.where('events_raw.properties[?] = ?', group.parent.key.to_s => group.parent.value.to_s)
       end
 
-      def with_grouped_by_value(scope)
-        scope.where('events_raw.properties[?] = ?', grouped_by.to_s, grouped_by_value.to_s)
+      def with_grouped_by_values(scope)
+        grouped_by_values.each do |grouped_by, grouped_by_value|
+          scope = scope.where('events_raw.properties[?] = ?', grouped_by, grouped_by_value)
+        end
+
+        scope
       end
 
       def numeric_condition

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -16,7 +16,7 @@ module Events
             .where(numeric_condition)
         end
 
-        scope = with_grouped_by_value(scope) if grouped_by_value?
+        scope = with_grouped_by_values(scope) if grouped_by_values?
 
         return scope unless group
 
@@ -128,8 +128,12 @@ module Events
         scope.where('events.properties @> ?', { group.parent.key.to_s => group.parent.value }.to_json)
       end
 
-      def with_grouped_by_value(scope)
-        scope.where('events.properties @> ?', { grouped_by.to_s => grouped_by_value.to_s }.to_json)
+      def with_grouped_by_values(scope)
+        grouped_by_values.each do |grouped_by, grouped_by_value|
+          scope = scope.where('events.properties @> ?', { grouped_by.to_s => grouped_by_value.to_s }.to_json)
+        end
+
+        scope
       end
 
       def sanitized_propery_name

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -231,12 +231,12 @@ module Fees
         charge:,
         current_usage: is_current_usage,
         subscription:,
-        group:,
         boundaries: {
           from_datetime: boundaries.charges_from_datetime,
           to_datetime: boundaries.charges_to_datetime,
           charges_duration: boundaries.charges_duration,
         },
+        filters: { group: },
       )
     end
 

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -65,6 +65,7 @@ module Fees
           taxes_amount_cents: 0,
           unit_amount_cents:,
           precise_unit_amount: result.unit_amount,
+          grouped_by: (charge.properties['grouped_by'] || []).map { event.properties[_1] },
         )
 
         taxes_result = Fees::ApplyTaxesService.call(fee:)
@@ -168,6 +169,7 @@ module Fees
         current_aggregation: aggregation_result.current_aggregation,
         max_aggregation: aggregation_result.max_aggregation,
         max_aggregation_with_proration: aggregation_result.max_aggregation_with_proration,
+        grouped_by: (charge.properties['grouped_by'] || []).map { event.properties[_1] },
       )
     end
   end

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       event_store_class:,
       charge:,
       subscription:,
-      group:,
-      event: pay_in_advance_event,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
+        event: pay_in_advance_event,
       },
     )
   end

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
       event_store_class:,
       charge:,
       subscription:,
-      group:,
       boundaries: {
         from_datetime:,
         to_datetime:,
       },
+      filters: { group: },
     )
   end
 

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       event_store_class:,
       charge:,
       subscription:,
-      group:,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
       },
     )
   end

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
       event_store_class:,
       charge:,
       subscription:,
-      group:,
-      event: pay_in_advance_event,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
+        event: pay_in_advance_event,
       },
     )
   end

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       event_store_class:,
       charge:,
       subscription:,
-      group:,
-      event: pay_in_advance_event,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
+        event: pay_in_advance_event,
       },
     )
   end

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
       event_store_class:,
       charge:,
       subscription:,
-      group:,
       boundaries: {
         from_datetime:,
         to_datetime:,
         charges_duration:,
       },
+      filters: { group: },
     )
   end
 

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
       event_store_class:,
       charge:,
       subscription:,
-      group:,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
       },
     )
   end

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
       event_store_class:,
       charge:,
       subscription:,
-      group:,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
       },
     )
   end

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       event_store_class:,
       charge:,
       subscription:,
-      group:,
-      event: pay_in_advance_event,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
+        event: pay_in_advance_event,
       },
     )
   end

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
       event_store_class:,
       charge:,
       subscription:,
-      group:,
-      event: pay_in_advance_event,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
+        event: pay_in_advance_event,
       },
     )
   end

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -44,11 +44,13 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
             event_store_class: Events::Stores::PostgresStore,
             charge:,
             subscription:,
-            group:,
-            event:,
             boundaries: {
               from_datetime: boundaries[:charges_from_datetime],
               to_datetime: boundaries[:charges_to_datetime],
+            },
+            filters: {
+              group:,
+              event:,
             },
           )
 
@@ -75,11 +77,13 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
             event_store_class: Events::Stores::PostgresStore,
             charge:,
             subscription:,
-            group:,
-            event:,
             boundaries: {
               from_datetime: boundaries[:charges_from_datetime],
               to_datetime: boundaries[:charges_to_datetime],
+            },
+            filters: {
+              group:,
+              event:,
             },
           )
 
@@ -105,11 +109,13 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
             event_store_class: Events::Stores::PostgresStore,
             charge:,
             subscription:,
-            group:,
-            event:,
             boundaries: {
               from_datetime: boundaries[:charges_from_datetime],
               to_datetime: boundaries[:charges_to_datetime],
+            },
+            filters: {
+              group:,
+              event:,
             },
           )
 

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -58,6 +58,52 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
           options: { free_units_per_events: 0, free_units_per_total_aggregation: 0 },
         )
       end
+
+      describe 'when charge model has grouped_by property' do
+        let(:charge) do
+          create(
+            :standard_charge,
+            billable_metric:,
+            pay_in_advance: true,
+            properties: { 'grouped_by' => ['operator'], 'amount' => '100' },
+          )
+        end
+
+        let(:event) do
+          create(
+            :event,
+            organization:,
+            external_subscription_id: subscription.external_id,
+            properties: { 'operator' => 'foo' },
+          )
+        end
+
+        it 'delegates to the count aggregation service' do
+          allow(BillableMetrics::Aggregations::CountService).to receive(:new).and_return(count_service)
+
+          agg_service.call
+
+          expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
+            .with(
+              event_store_class: Events::Stores::PostgresStore,
+              charge:,
+              subscription:,
+              boundaries: {
+                from_datetime: boundaries[:charges_from_datetime],
+                to_datetime: boundaries[:charges_to_datetime],
+              },
+              filters: {
+                group:,
+                event:,
+                grouped_by_values: { 'operator' => 'foo' },
+              },
+            )
+
+          expect(count_service).to have_received(:aggregate).with(
+            options: { free_units_per_events: 0, free_units_per_total_aggregation: 0 },
+          )
+        end
+      end
     end
 
     describe 'when sum aggregation' do

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
       code:,
       subscription:,
       boundaries:,
-      filters: { group:, grouped_by:, grouped_by_value: },
+      filters: { group:, grouped_by:, grouped_by_values: },
     )
   end
 
@@ -31,7 +31,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
   let(:group) { nil }
   let(:grouped_by) { nil }
-  let(:grouped_by_value) { nil }
+  let(:grouped_by_values) { nil }
 
   let(:events) do
     events = []
@@ -41,7 +41,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
       if i.even?
         properties[group.key.to_s] = group.value.to_s if group
-        properties[grouped_by] = grouped_by_value if grouped_by_value
+        properties[grouped_by] = grouped_by_values[grouped_by] if grouped_by_values
       end
 
       events << Clickhouse::EventsRaw.create!(
@@ -87,9 +87,9 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
       end
     end
 
-    context 'with grouped_by_value' do
+    context 'with grouped_by_values' do
       let(:grouped_by) { 'region' }
-      let(:grouped_by_value) { 'europe' }
+      let(:grouped_by_values) { { 'region' => 'europe' } }
 
       it 'returns a list of events' do
         expect(event_store.events.count).to eq(3)

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       code:,
       subscription:,
       boundaries:,
-      filters: { group:, grouped_by:, grouped_by_value: },
+      filters: { group:, grouped_by:, grouped_by_values: },
     )
   end
 
@@ -31,7 +31,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
 
   let(:group) { nil }
   let(:grouped_by) { nil }
-  let(:grouped_by_value) { nil }
+  let(:grouped_by_values) { nil }
 
   let(:events) do
     events = []
@@ -51,7 +51,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
 
       if i.even?
         event.properties[group.key] = group.value if group
-        event.properties[grouped_by] = grouped_by_value if grouped_by_value
+        event.properties[grouped_by] = grouped_by_values[grouped_by] if grouped_by_values
       end
 
       event.save!
@@ -77,9 +77,9 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       end
     end
 
-    context 'with grouped_by_value' do
+    context 'with grouped_by_values' do
       let(:grouped_by) { 'region' }
-      let(:grouped_by_value) { 'europe' }
+      let(:grouped_by_values) { { 'region' => 'europe' } }
 
       it 'returns a list of events' do
         expect(event_store.events.count).to eq(3)


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR refactors the filtering arguments in the aggregation services:
- Move the `group` argument as a sub value of a new `filters` one
- Add `grouped_by` and `grouped_by_value` argument in the `filters`
- Adapt logic for pay in advance charges 