### PR TITLE
feat(minimum-spending): Add controllers for plan commitments

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -60,7 +60,7 @@ module Api
             ::V1::PlanSerializer,
             collection_name: 'plans',
             meta: pagination_metadata(plans),
-            includes: %i[charges taxes],
+            includes: %i[charges taxes minimum_commitment],
           ),
         )
       end
@@ -80,6 +80,12 @@ module Api
           :pay_in_advance,
           :bill_charges_monthly,
           tax_codes: [],
+          minimum_commitment: [
+            :id,
+            :invoice_display_name,
+            :amount_cents,
+            { tax_codes: [] },
+          ],
           charges: [
             :id,
             :invoice_display_name,
@@ -109,7 +115,7 @@ module Api
           json: ::V1::PlanSerializer.new(
             plan,
             root_name: 'plan',
-            includes: %i[charges taxes],
+            includes: %i[charges taxes minimum_commitment],
           ),
         )
       end

--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -45,7 +45,7 @@ module V1
         minimum_commitment: V1::CommitmentSerializer.new(
           model.minimum_commitment,
           includes: include?(:taxes) ? %i[taxes] : [],
-        ).serialize,
+        ).serialize.except(:commitment_type),
       }
     end
 

--- a/app/services/commitments/apply_taxes_service.rb
+++ b/app/services/commitments/apply_taxes_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Commitments
+  class ApplyTaxesService < BaseService
+    def initialize(commitment:, tax_codes:)
+      @commitment = commitment
+      @tax_codes = tax_codes
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'commitment') unless commitment
+      return result.not_found_failure!(resource: 'tax') if (tax_codes - taxes.pluck(:code)).present?
+
+      commitment.applied_taxes.where(
+        tax_id: commitment.taxes.where.not(code: tax_codes).pluck(:id),
+      ).destroy_all
+
+      result.applied_taxes = tax_codes.map do |tax_code|
+        commitment.applied_taxes.find_or_create_by!(tax: taxes.find_by(code: tax_code))
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :commitment, :tax_codes
+
+    def taxes
+      @taxes ||= commitment.plan.organization.taxes.where(code: tax_codes)
+    end
+  end
+end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -101,8 +101,8 @@ module Plans
     def process_minimum_commitment(plan, params)
       minimum_commitment = plan.minimum_commitment || Commitment.new(plan:, commitment_type: 'minimum_commitment')
 
-      minimum_commitment.amount_cents = params[:amount_cents]
-      minimum_commitment.invoice_display_name = params[:invoice_display_name]
+      minimum_commitment.amount_cents = params[:amount_cents] if params.key?(:amount_cents)
+      minimum_commitment.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
       minimum_commitment.save!
 
       if params[:tax_codes]

--- a/spec/factories/commitments.rb
+++ b/spec/factories/commitments.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     commitment_type { 'minimum_commitment' }
     amount_cents { 1_000 }
     invoice_display_name { Faker::Subscription.plan }
+
+    trait :minimum_commitment do
+      commitment_type { 'minimum_commitment' }
+    end
   end
 end

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -59,6 +59,9 @@ RSpec.describe ::V1::PlanSerializer do
         'updated_at' => commitment.updated_at.iso8601,
         'taxes' => [],
       )
+      expect(result['plan']['minimum_commitment']).not_to include(
+        'commitment_type' => 'minimum_commitment',
+      )
     end
   end
 

--- a/spec/services/commitments/apply_taxes_service_spec.rb
+++ b/spec/services/commitments/apply_taxes_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Commitments::ApplyTaxesService, type: :service do
+  subject(:apply_service) { described_class.new(commitment:, tax_codes:) }
+
+  let(:commitment) { create(:commitment, plan:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:organization) { create(:organization) }
+  let(:tax1) { create(:tax, organization:, code: 'tax1') }
+  let(:tax2) { create(:tax, organization:, code: 'tax2') }
+  let(:tax_codes) { [tax1.code, tax2.code] }
+
+  describe 'call' do
+    it 'applies taxes to the commitment' do
+      expect { apply_service.call }.to change { commitment.applied_taxes.count }.from(0).to(2)
+    end
+
+    it 'returns applied taxes' do
+      result = apply_service.call
+      expect(result.applied_taxes.count).to eq(2)
+    end
+
+    context 'when commitment is not found' do
+      let(:commitment) { nil }
+
+      it 'returns an error' do
+        result = apply_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('commitment_not_found')
+        end
+      end
+    end
+
+    context 'when tax is not found' do
+      let(:tax_codes) { ['unknown'] }
+
+      it 'returns an error' do
+        result = apply_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('tax_not_found')
+        end
+      end
+    end
+
+    context 'when applied tax is already present' do
+      it 'does not create a new applied tax' do
+        create(:commitment_applied_tax, commitment:, tax: tax1)
+        expect { apply_service.call }.to change { commitment.applied_taxes.count }.from(1).to(2)
+      end
+    end
+
+    context 'when trying to apply twice the same tax' do
+      let(:tax_codes) { [tax1.code, tax1.code] }
+
+      it 'assigns it only once' do
+        expect { apply_service.call }.to change { commitment.applied_taxes.count }.from(0).to(1)
+      end
+    end
+  end
+end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -299,6 +299,36 @@ RSpec.describe Plans::UpdateService, type: :service do
         end
       end
 
+      context 'when only some minimum commitment arguments are present' do
+        let(:minimum_commitment_args) do
+          { invoice_display_name: minimum_commitment_invoice_display_name }
+        end
+
+        before { update_args.merge!({ minimum_commitment: minimum_commitment_args }) }
+
+        context 'when license is premium' do
+          around { |test| lago_premium!(&test) }
+
+          it 'does not update minimum commitment args that are not present' do
+            result = plans_service.call
+
+            aggregate_failures do
+              expect(result.plan.minimum_commitment.invoice_display_name).to eq(minimum_commitment_invoice_display_name)
+              expect(result.plan.minimum_commitment.amount_cents).to eq(minimum_commitment.amount_cents)
+            end
+          end
+        end
+
+        context 'when license is not premium' do
+          it 'does not update minimum commitment' do
+            result = plans_service.call
+
+            expect(result.plan.minimum_commitment.invoice_display_name).to eq(minimum_commitment.invoice_display_name)
+            expect(result.plan.minimum_commitment.amount_cents).to eq(minimum_commitment.amount_cents)
+          end
+        end
+      end
+
       context 'when minimum commitment arguments are not present' do
         context 'when license is premium' do
           around { |test| lago_premium!(&test) }


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/set-minimum-spend-for-subscriptions

## Context

As a user, I want to define the minimum spend that applies to the customer's plan. Consider the following monthly plan:

- Subscription fee = $50 per month (in arrears);
- Usage-based charge = $10 per unit per month (in arrears); and
- Monthly minimum spend = $100.

If at the end of the month, the customer has consumed 3 units, their total invoice will be: $50 + 3 * $10 = $80 + $20 (true-up fee) = $100.

## Description

In this PR we're updating plan create/update services for creating and updating plan's minimum commitment. Also the controllers are updated to support it.