### PR TITLE
feat(filter): Add grouped_by logic on events aggregation

### DIFF
--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -39,6 +39,10 @@ module Events
 
       delegate :count, to: :events
 
+      def grouped_count
+        raise NotImplementedError
+      end
+
       def max
         raise NotImplementedError
       end

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -59,6 +59,10 @@ module Events
         raise NotImplementedError
       end
 
+      def grouped_sum
+        raise NotImplementedError
+      end
+
       def prorated_sum(period_duration:, persisted_duration: nil)
         raise NotImplementedError
       end

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -18,7 +18,7 @@ module Events
       end
 
       def grouped_by_values?
-        grouped_by.present? && grouped_by_values.present?
+        grouped_by_values.present?
       end
 
       def events(force_from: false)
@@ -52,6 +52,10 @@ module Events
       end
 
       def last
+        raise NotImplementedError
+      end
+
+      def grouped_last
         raise NotImplementedError
       end
 

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -47,6 +47,10 @@ module Events
         raise NotImplementedError
       end
 
+      def grouped_max
+        raise NotImplementedError
+      end
+
       def last
         raise NotImplementedError
       end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -92,6 +92,14 @@ module Events
         events.maximum(Arel.sql(sanitized_numeric_property))
       end
 
+      def grouped_max
+        events
+          .reorder(nil)
+          .group(grouped_by.map { |group| sanitized_propery_name(group) })
+          .maximum(Arel.sql(sanitized_numeric_property))
+          .map { |group, value| { group: [group].flatten.map(&:presence), value: } }
+      end
+
       def last
         value = events.last&.properties&.[](aggregation_property)
         return value unless value

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -54,7 +54,7 @@ module Events
           with events as (#{cte_sql})
 
           select
-            COUNT(events.transaction_count)::numeric AS events_count
+            COUNT(events.transaction_count) AS events_count
           from events
         SQL
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -71,6 +71,14 @@ module Events
         events.sum("(#{sanitized_propery_name})::numeric")
       end
 
+      def grouped_sum
+        events
+          .reorder(nil)
+          .group(grouped_by.map { |group| sanitized_propery_name(group) })
+          .sum("(#{sanitized_propery_name})::numeric")
+          .map { |group, value| { group: [group].flatten, value: } }
+      end
+
       def prorated_sum(period_duration:, persisted_duration: nil)
         ratio = if persisted_duration
           persisted_duration.fdiv(period_duration)

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -43,6 +43,14 @@ module Events
         events.pluck(Arel.sql("(#{sanitized_propery_name})::numeric * (#{ratio_sql})::numeric"))
       end
 
+      def grouped_count
+        events
+          .reorder(nil)
+          .group(grouped_by.map { |group| sanitized_propery_name(group) })
+          .count
+          .map { |group, value| { group: [group].flatten, value: } }
+      end
+
       def max
         events.maximum("(#{sanitized_propery_name})::numeric")
       end
@@ -136,9 +144,9 @@ module Events
         scope
       end
 
-      def sanitized_propery_name
+      def sanitized_propery_name(property = aggregation_property)
         ActiveRecord::Base.sanitize_sql_for_conditions(
-          ['events.properties->>?', aggregation_property],
+          ['events.properties->>?', property],
         )
       end
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -55,6 +55,14 @@ module Events
         events.maximum("(#{sanitized_propery_name})::numeric")
       end
 
+      def grouped_max
+        events
+          .reorder(nil)
+          .group(grouped_by.map { |group| sanitized_propery_name(group) })
+          .maximum("(#{sanitized_propery_name})::numeric")
+          .map { |group, value| { group: [group].flatten, value: } }
+      end
+
       def last
         events.reorder(timestamp: :desc, created_at: :desc).first&.properties&.[](aggregation_property)
       end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -117,13 +117,13 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
       expect(result.count).to eq(4)
 
-      null_group = result.find { |v| v[:group].first.nil? }
+      null_group = result.find { |v| v[:groups]['cloud'].nil? }
       expect(null_group[:value]).to eq(2)
 
       result.each do |row|
-        next if row[:group].first.nil?
+        next if row[:groups]['cloud'].nil?
 
-        expect(row[:group].count).to eq(1)
+        expect(row[:groups]['cloud']).not_to be_nil
         expect(row[:value]).to eq(1)
       end
     end
@@ -136,14 +136,15 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
         expect(result.count).to eq(4)
 
-        null_group = result.find { |v| v[:group].first.nil? }
-        expect(null_group[:group]).to eq([nil, nil])
+        null_group = result.find { |v| v[:groups]['cloud'].nil? }
+        expect(null_group[:groups]['region']).to be_nil
         expect(null_group[:value]).to eq(2)
 
         result[...-1].each do |row|
-          next if row[:group].first.nil?
+          next if row[:groups]['cloud'].nil?
 
-          expect(row[:group].count).to eq(2)
+          expect(row[:groups]['cloud']).not_to be_nil
+          expect(row[:groups]['region']).not_to be_nil
           expect(row[:value]).to eq(1)
         end
       end
@@ -201,14 +202,14 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
       expect(result.count).to eq(4)
 
-      null_group = result.find { |v| v[:group].first.nil? }
-      expect(null_group[:group]).to eq([nil])
+      null_group = result.find { |v| v[:groups]['cloud'].nil? }
       expect(null_group[:value]).to eq(4)
 
       result[...-1].each do |row|
-        next if row[:group].first.nil?
+        next if row[:groups]['cloud'].nil?
 
-        expect(row[:group].count).to eq(1)
+        expect(row[:groups]['cloud']).not_to be_nil
+        expect(row[:value]).not_to be_nil
       end
     end
 
@@ -220,14 +221,16 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
         expect(result.count).to eq(4)
 
-        null_group = result.find { |v| v[:group].first.nil? }
-        expect(null_group[:group]).to eq([nil, nil])
+        null_group = result.find { |v| v[:groups]['cloud'].nil? }
+        expect(null_group[:groups]['region']).to be_nil
         expect(null_group[:value]).to eq(4)
 
         result[...-1].each do |row|
-          next if row[:group].first.nil?
+          next if row[:groups]['cloud'].nil?
 
-          expect(row[:group].count).to eq(2)
+          expect(row[:groups]['cloud']).not_to be_nil
+          expect(row[:groups]['region']).not_to be_nil
+          expect(row[:value]).not_to be_nil
         end
       end
     end
@@ -255,14 +258,13 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
       expect(result.count).to eq(4)
 
-      null_group = result.find { |v| v[:group].first.nil? }
-      expect(null_group[:group]).to eq([nil])
+      null_group = result.find { |v| v[:groups]['cloud'].nil? }
       expect(null_group[:value]).to eq(4)
 
       result[...-1].each do |row|
-        next if row[:group].first.nil?
+        next if row[:groups]['cloud'].nil?
 
-        expect(row[:group].count).to eq(1)
+        expect(row[:groups]['cloud']).not_to be_nil
         expect(row[:value]).not_to be_nil
       end
     end
@@ -275,14 +277,15 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
         expect(result.count).to eq(4)
 
-        null_group = result.find { |v| v[:group].first.nil? }
-        expect(null_group[:group]).to eq([nil, nil])
+        null_group = result.find { |v| v[:groups]['cloud'].nil? }
+        expect(null_group[:groups]['region']).to be_nil
         expect(null_group[:value]).to eq(4)
 
         result[...-1].each do |row|
-          next if row[:group].first.nil?
+          next if row[:groups]['cloud'].nil?
 
-          expect(row[:group].count).to eq(2)
+          expect(row[:groups]['cloud']).not_to be_nil
+          expect(row[:groups]['region']).not_to be_nil
           expect(row[:value]).not_to be_nil
         end
       end
@@ -311,14 +314,13 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
       expect(result.count).to eq(4)
 
-      null_group = result.find { |v| v[:group].first.nil? }
-      expect(null_group[:group]).to eq([nil])
+      null_group = result.find { |v| v[:groups]['cloud'].nil? }
       expect(null_group[:value]).to eq(6)
 
       result[...-1].each do |row|
-        next if row[:group].first.nil?
+        next if row[:groups]['cloud'].nil?
 
-        expect(row[:group].count).to eq(1)
+        expect(row[:groups]['cloud']).not_to be_nil
         expect(row[:value]).not_to be_nil
       end
     end
@@ -331,14 +333,15 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
         expect(result.count).to eq(4)
 
-        null_group = result.find { |v| v[:group].first.nil? }
-        expect(null_group[:group]).to eq([nil, nil])
+        null_group = result.find { |v| v[:groups]['cloud'].nil? }
+        expect(null_group[:groups]['region']).to be_nil
         expect(null_group[:value]).to eq(6)
 
         result[...-1].each do |row|
-          next if row[:group].first.nil?
+          next if row[:groups]['cloud'].nil?
 
-          expect(row[:group].count).to eq(2)
+          expect(row[:groups]['cloud']).not_to be_nil
+          expect(row[:groups]['region']).not_to be_nil
           expect(row[:value]).not_to be_nil
         end
       end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -242,6 +242,53 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     end
   end
 
+  describe '.grouped_last' do
+    let(:grouped_by) { %w[cloud] }
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it 'returns the value attached to each event prorated on the provided duration' do
+      result = event_store.grouped_last
+
+      expect(result.count).to eq(4)
+
+      null_group = result.find { |v| v[:group].first.nil? }
+      expect(null_group[:group]).to eq([nil])
+      expect(null_group[:value]).to eq(4)
+
+      result[...-1].each do |row|
+        next if row[:group].first.nil?
+
+        expect(row[:group].count).to eq(1)
+        expect(row[:value]).not_to be_nil
+      end
+    end
+
+    context 'with multiple groups' do
+      let(:grouped_by) { %w[cloud region] }
+
+      it 'returns the last value for each provided groups' do
+        result = event_store.grouped_last
+
+        expect(result.count).to eq(4)
+
+        null_group = result.find { |v| v[:group].first.nil? }
+        expect(null_group[:group]).to eq([nil, nil])
+        expect(null_group[:value]).to eq(4)
+
+        result[...-1].each do |row|
+          next if row[:group].first.nil?
+
+          expect(row[:group].count).to eq(2)
+          expect(row[:value]).not_to be_nil
+        end
+      end
+    end
+  end
+
   describe '.sum' do
     it 'returns the sum of event properties' do
       event_store.aggregation_property = billable_metric.field_name

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -251,6 +251,53 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     end
   end
 
+  describe '.grouped_sum' do
+    let(:grouped_by) { %w[cloud] }
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it 'returns the sum of values grouped by the provided group' do
+      result = event_store.grouped_sum
+
+      expect(result.count).to eq(4)
+
+      null_group = result.find { |v| v[:group].first.nil? }
+      expect(null_group[:group]).to eq([nil])
+      expect(null_group[:value]).to eq(6)
+
+      result[...-1].each do |row|
+        next if row[:group].first.nil?
+
+        expect(row[:group].count).to eq(1)
+        expect(row[:value]).not_to be_nil
+      end
+    end
+
+    context 'with multiple groups' do
+      let(:grouped_by) { %w[cloud region] }
+
+      it 'returns the sum of values grouped by the provided groups' do
+        result = event_store.grouped_sum
+
+        expect(result.count).to eq(4)
+
+        null_group = result.find { |v| v[:group].first.nil? }
+        expect(null_group[:group]).to eq([nil, nil])
+        expect(null_group[:value]).to eq(6)
+
+        result[...-1].each do |row|
+          next if row[:group].first.nil?
+
+          expect(row[:group].count).to eq(2)
+          expect(row[:value]).not_to be_nil
+        end
+      end
+    end
+  end
+
   describe '.prorated_sum' do
     it 'returns the prorated sum of event properties' do
       event_store.aggregation_property = billable_metric.field_name

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
           grouped_by_values.each { |grouped_by, value| properties[grouped_by] = value }
         elsif grouped_by.present?
           grouped_by.each do |group|
-            properties[group] = Faker::Lorem.word
+            properties[group] = "#{Faker::Fantasy::Tolkien.character}_#{i}"
           end
         end
       end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -41,9 +41,10 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
       if i.even?
         properties[group.key.to_s] = group.value.to_s if group
-        properties[grouped_by] = grouped_by_values[grouped_by] if grouped_by_values
 
-        if grouped_by.present? && grouped_by_values.blank?
+        if grouped_by_values.present?
+          grouped_by_values.each { |grouped_by, value| properties[grouped_by] = value }
+        elsif grouped_by.present?
           grouped_by.each do |group|
             properties[group] = Faker::Lorem.word
           end
@@ -94,7 +95,6 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     end
 
     context 'with grouped_by_values' do
-      let(:grouped_by) { 'region' }
       let(:grouped_by_values) { { 'region' => 'europe' } }
 
       it 'returns a list of events' do

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -108,11 +108,11 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       expect(result.count).to eq(4)
 
       null_group = result.last
-      expect(null_group[:group]).to eq([nil])
+      expect(null_group[:groups]['cloud']).to be_nil
       expect(null_group[:value]).to eq(2)
 
       result[...-1].each do |row|
-        expect(row[:group].count).to eq(1)
+        expect(row[:groups]['cloud']).not_to be_nil
         expect(row[:value]).to eq(1)
       end
     end
@@ -126,11 +126,13 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
         expect(result.count).to eq(4)
 
         null_group = result.last
-        expect(null_group[:group]).to eq([nil, nil])
+        expect(null_group[:groups]['cloud']).to be_nil
+        expect(null_group[:groups]['region']).to be_nil
         expect(null_group[:value]).to eq(2)
 
         result[...-1].each do |row|
-          expect(row[:group].count).to eq(2)
+          expect(row[:groups]['cloud']).not_to be_nil
+          expect(row[:groups]['region']).not_to be_nil
           expect(row[:value]).to eq(1)
         end
       end
@@ -189,11 +191,12 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       expect(result.count).to eq(4)
 
       null_group = result.last
-      expect(null_group[:group]).to eq([nil])
+      expect(null_group[:groups]['cloud']).to be_nil
       expect(null_group[:value]).to eq(4)
 
       result[...-1].each do |row|
-        expect(row[:group].count).to eq(1)
+        expect(row[:groups]['cloud']).not_to be_nil
+        expect(row[:value]).not_to be_nil
       end
     end
 
@@ -206,11 +209,14 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
         expect(result.count).to eq(4)
 
         null_group = result.last
-        expect(null_group[:group]).to eq([nil, nil])
+        expect(null_group[:groups]['cloud']).to be_nil
+        expect(null_group[:groups]['region']).to be_nil
         expect(null_group[:value]).to eq(4)
 
         result[...-1].each do |row|
-          expect(row[:group].count).to eq(2)
+          expect(row[:groups]['cloud']).not_to be_nil
+          expect(row[:groups]['region']).not_to be_nil
+          expect(row[:value]).not_to be_nil
         end
       end
     end
@@ -239,11 +245,11 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       expect(result.count).to eq(4)
 
       null_group = result.last
-      expect(null_group[:group]).to eq([nil])
+      expect(null_group[:groups]['cloud']).to be_nil
       expect(null_group[:value]).to eq(4)
 
       result[...-1].each do |row|
-        expect(row[:group].count).to eq(1)
+        expect(row[:groups]['cloud']).not_to be_nil
         expect(row[:value]).not_to be_nil
       end
     end
@@ -257,11 +263,13 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
         expect(result.count).to eq(4)
 
         null_group = result.last
-        expect(null_group[:group]).to eq([nil, nil])
+        expect(null_group[:groups]['cloud']).to be_nil
+        expect(null_group[:groups]['region']).to be_nil
         expect(null_group[:value]).to eq(4)
 
         result[...-1].each do |row|
-          expect(row[:group].count).to eq(2)
+          expect(row[:groups]['cloud']).not_to be_nil
+          expect(row[:groups]['region']).not_to be_nil
           expect(row[:value]).not_to be_nil
         end
       end
@@ -291,11 +299,11 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       expect(result.count).to eq(4)
 
       null_group = result.last
-      expect(null_group[:group]).to eq([nil])
+      expect(null_group[:groups]['cloud']).to be_nil
       expect(null_group[:value]).to eq(6)
 
       result[...-1].each do |row|
-        expect(row[:group].count).to eq(1)
+        expect(row[:groups]['cloud']).not_to be_nil
         expect(row[:value]).not_to be_nil
       end
     end
@@ -309,11 +317,13 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
         expect(result.count).to eq(4)
 
         null_group = result.last
-        expect(null_group[:group]).to eq([nil, nil])
+        expect(null_group[:groups]['cloud']).to be_nil
+        expect(null_group[:groups]['region']).to be_nil
         expect(null_group[:value]).to eq(6)
 
         result[...-1].each do |row|
-          expect(row[:group].count).to eq(2)
+          expect(row[:groups]['cloud']).not_to be_nil
+          expect(row[:groups]['region']).not_to be_nil
           expect(row[:value]).not_to be_nil
         end
       end

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
           grouped_by_values.each { |grouped_by, value| event.properties[grouped_by] = value }
         elsif grouped_by.present?
           grouped_by.each do |group|
-            event.properties[group] = Faker::Lorem.word
+            event.properties[group] = "#{Faker::Fantasy::Tolkien.character}_#{i}"
           end
         end
       end

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -175,6 +175,47 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
+  describe '.grouped_max' do
+    let(:grouped_by) { %w[cloud] }
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it 'returns the max values grouped by the provided group' do
+      result = event_store.grouped_max
+
+      expect(result.count).to eq(4)
+
+      null_group = result.last
+      expect(null_group[:group]).to eq([nil])
+      expect(null_group[:value]).to eq(4)
+
+      result[...-1].each do |row|
+        expect(row[:group].count).to eq(1)
+      end
+    end
+
+    context 'with multiple groups' do
+      let(:grouped_by) { %w[cloud region] }
+
+      it 'returns the max values grouped by the provided groups' do
+        result = event_store.grouped_max
+
+        expect(result.count).to eq(4)
+
+        null_group = result.last
+        expect(null_group[:group]).to eq([nil, nil])
+        expect(null_group[:value]).to eq(4)
+
+        result[...-1].each do |row|
+          expect(row[:group].count).to eq(2)
+        end
+      end
+    end
+  end
+
   describe '.last' do
     it 'returns the last event' do
       event_store.aggregation_property = billable_metric.field_name

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -234,6 +234,49 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
+  describe '.grouped_sum' do
+    let(:grouped_by) { %w[cloud] }
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it 'returns the sum of values grouped by the provided group' do
+      result = event_store.grouped_sum
+
+      expect(result.count).to eq(4)
+
+      null_group = result.last
+      expect(null_group[:group]).to eq([nil])
+      expect(null_group[:value]).to eq(6)
+
+      result[...-1].each do |row|
+        expect(row[:group].count).to eq(1)
+        expect(row[:value]).not_to be_nil
+      end
+    end
+
+    context 'with multiple groups' do
+      let(:grouped_by) { %w[cloud region] }
+
+      it 'returns the sum of values grouped by the provided groups' do
+        result = event_store.grouped_sum
+
+        expect(result.count).to eq(4)
+
+        null_group = result.last
+        expect(null_group[:group]).to eq([nil, nil])
+        expect(null_group[:value]).to eq(6)
+
+        result[...-1].each do |row|
+          expect(row[:group].count).to eq(2)
+          expect(row[:value]).not_to be_nil
+        end
+      end
+    end
+  end
+
   describe '.prorated_sum' do
     it 'returns the prorated sum of event properties' do
       event_store.aggregation_property = billable_metric.field_name

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -51,9 +51,10 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
 
       if i.even?
         event.properties[group.key] = group.value if group
-        event.properties[grouped_by] = grouped_by_values[grouped_by] if grouped_by_values
 
-        if grouped_by.present? && grouped_by_values.blank?
+        if grouped_by_values.present?
+          grouped_by_values.each { |grouped_by, value| event.properties[grouped_by] = value }
+        elsif grouped_by.present?
           grouped_by.each do |group|
             event.properties[group] = Faker::Lorem.word
           end
@@ -84,7 +85,6 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
 
     context 'with grouped_by_values' do
-      let(:grouped_by) { 'region' }
       let(:grouped_by_values) { { 'region' => 'europe' } }
 
       it 'returns a list of events' do


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR updates the event stores to add support for grouped aggregation on:
- `count`
- `max`
- `sum`
- `last`