### PR TITLE
feat(group-by): add filters argument to aggregator classes

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -159,11 +159,11 @@ class Invoice < ApplicationRecord
       event_store_class: Events::Stores::PostgresStore,
       charge: fee.charge,
       subscription: fee.subscription,
-      group: fee.group,
       boundaries: {
         from_datetime: DateTime.parse(fee.properties['charges_from_datetime']),
         to_datetime: DateTime.parse(fee.properties['charges_to_datetime']),
       },
+      filters: { group: fee.group },
     ).breakdown.breakdown
   end
 

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -3,13 +3,16 @@
 module BillableMetrics
   module Aggregations
     class BaseService < ::BaseService
-      def initialize(event_store_class:, charge:, subscription:, boundaries:, group: nil, event: nil) # rubocop:disable Metrics/ParameterLists
+      def initialize(event_store_class:, charge:, subscription:, boundaries:, filters: {})
         super(nil)
         @event_store_class = event_store_class
         @charge = charge
         @subscription = subscription
-        @group = group
-        @event = event
+
+        @filters = filters
+        @group = filters[:group]
+        @event = filters[:event]
+
         @boundaries = boundaries
 
         result.aggregator = self
@@ -27,7 +30,7 @@ module BillableMetrics
 
       protected
 
-      attr_accessor :event_store_class, :charge, :subscription, :group, :event, :boundaries
+      attr_accessor :event_store_class, :charge, :subscription, :filters, :group, :event, :boundaries
 
       delegate :billable_metric, to: :charge
 

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -172,7 +172,7 @@ module BillableMetrics
               from_datetime: subscription.started_at,
               to_datetime: subscription.terminated_at,
             },
-            filters: { group: },
+            filters:,
           )
           store.aggregation_property = billable_metric.field_name
 

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -60,7 +60,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          filters: { group: },
+          filters:,
         )
 
         event_store.use_from_boundary = false

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -27,7 +27,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          filters: { group: },
+          filters:,
         )
 
         event_store.use_from_boundary = false

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -67,7 +67,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          filters: { group: },
+          filters:,
         )
 
         event_store.use_from_boundary = false
@@ -92,7 +92,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries: { to_datetime: from_datetime },
-          filters: { group: },
+          filters:,
         )
 
         event_store.use_from_boundary = false

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -16,11 +16,13 @@ module Charges
       aggregator = BillableMetrics::AggregationFactory.new_instance(
         charge:,
         subscription:,
-        group:,
-        event:,
         boundaries: {
           from_datetime: boundaries[:charges_from_datetime],
           to_datetime: boundaries[:charges_to_datetime],
+        },
+        filters: {
+          group:,
+          event:,
         },
       )
 

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -231,12 +231,12 @@ module Fees
         charge:,
         current_usage: is_current_usage,
         subscription:,
-        group:,
         boundaries: {
           from_datetime: boundaries.charges_from_datetime,
           to_datetime: boundaries.charges_to_datetime,
           charges_duration: boundaries.charges_duration,
         },
+        filters: { group: },
       )
     end
 

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       event_store_class:,
       charge:,
       subscription:,
-      group:,
-      event: pay_in_advance_event,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
+        event: pay_in_advance_event,
       },
     )
   end

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
       event_store_class:,
       charge:,
       subscription:,
-      group:,
       boundaries: {
         from_datetime:,
         to_datetime:,
       },
+      filters: { group: },
     )
   end
 

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       event_store_class:,
       charge:,
       subscription:,
-      group:,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
       },
     )
   end

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
       event_store_class:,
       charge:,
       subscription:,
-      group:,
-      event: pay_in_advance_event,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
+        event: pay_in_advance_event,
       },
     )
   end

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
       event_store_class:,
       charge:,
       subscription:,
-      group:,
-      event: pay_in_advance_event,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
+        event: pay_in_advance_event,
       },
     )
   end

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
       event_store_class:,
       charge:,
       subscription:,
-      group:,
       boundaries: {
         from_datetime:,
         to_datetime:,
         charges_duration:,
       },
+      filters: { group: },
     )
   end
 

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
       event_store_class:,
       charge:,
       subscription:,
-      group:,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
       },
     )
   end

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
       event_store_class:,
       charge:,
       subscription:,
-      group:,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
       },
     )
   end

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       event_store_class:,
       charge:,
       subscription:,
-      group:,
-      event: pay_in_advance_event,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
+        event: pay_in_advance_event,
       },
     )
   end

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
       event_store_class:,
       charge:,
       subscription:,
-      group:,
-      event: pay_in_advance_event,
       boundaries: {
         from_datetime:,
         to_datetime:,
+      },
+      filters: {
+        group:,
+        event: pay_in_advance_event,
       },
     )
   end

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -44,11 +44,13 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
             event_store_class: Events::Stores::PostgresStore,
             charge:,
             subscription:,
-            group:,
-            event:,
             boundaries: {
               from_datetime: boundaries[:charges_from_datetime],
               to_datetime: boundaries[:charges_to_datetime],
+            },
+            filters: {
+              group:,
+              event:,
             },
           )
 
@@ -75,11 +77,13 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
             event_store_class: Events::Stores::PostgresStore,
             charge:,
             subscription:,
-            group:,
-            event:,
             boundaries: {
               from_datetime: boundaries[:charges_from_datetime],
               to_datetime: boundaries[:charges_to_datetime],
+            },
+            filters: {
+              group:,
+              event:,
             },
           )
 
@@ -105,11 +109,13 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
             event_store_class: Events::Stores::PostgresStore,
             charge:,
             subscription:,
-            group:,
-            event:,
             boundaries: {
               from_datetime: boundaries[:charges_from_datetime],
               to_datetime: boundaries[:charges_to_datetime],
+            },
+            filters: {
+              group:,
+              event:,
             },
           )
 


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR adds a `filters` argument on the aggregation services to replace the `group` and `event` ones and will allow new filters for the next steps of the feature