### PR TITLE
 feat(group-by): Change grouped_by type for fees and cached_aggregation

### DIFF
--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -10,7 +10,7 @@ module Types
       field :currency, Types::CurrencyEnum, null: false
       field :description, String, null: true
       field :group_name, String, null: true
-      field :grouped_by, [String], null: false
+      field :grouped_by, GraphQL::Types::JSON, null: false
       field :invoice_display_name, String, null: true
       field :invoice_name, String, null: true
       field :subscription, Types::Subscriptions::Object, null: true

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -65,7 +65,7 @@ module Fees
           taxes_amount_cents: 0,
           unit_amount_cents:,
           precise_unit_amount: result.unit_amount,
-          grouped_by: (charge.properties['grouped_by'] || []).map { event.properties[_1] },
+          grouped_by: format_grouped_by,
         )
 
         taxes_result = Fees::ApplyTaxesService.call(fee:)
@@ -169,8 +169,14 @@ module Fees
         current_aggregation: aggregation_result.current_aggregation,
         max_aggregation: aggregation_result.max_aggregation,
         max_aggregation_with_proration: aggregation_result.max_aggregation_with_proration,
-        grouped_by: (charge.properties['grouped_by'] || []).map { event.properties[_1] },
+        grouped_by: format_grouped_by,
       )
+    end
+
+    def format_grouped_by
+      return {} if charge.properties['grouped_by'].blank?
+
+      charge.properties['grouped_by'].index_with { event.properties[_1] }
     end
   end
 end

--- a/db/migrate/20240123104811_change_fees_grouped_by_type.rb
+++ b/db/migrate/20240123104811_change_fees_grouped_by_type.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ChangeFeesGroupedByType < ActiveRecord::Migration[7.0]
+  def up
+    change_table :fees, bulk: true do |t|
+      t.remove :grouped_by
+      t.jsonb :grouped_by, null: false, default: {}
+    end
+
+    change_table :cached_aggregations, bulk: true do |t|
+      t.remove :grouped_by
+      t.jsonb :grouped_by, null: false, default: {}
+    end
+  end
+
+  def down
+    change_table :fees, bulk: true do |t|
+      t.remove :grouped_by
+      t.string :grouped_by, null: false, array: true, default: []
+    end
+
+    change_table :cached_aggregations, bulk: true do |t|
+      t.remove :grouped_by
+      t.string :grouped_by, null: false, array: true, default: []
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_18_141022) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_23_104811) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -165,7 +165,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_18_141022) do
     t.decimal "max_aggregation_with_proration"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "grouped_by", default: [], null: false, array: true
+    t.jsonb "grouped_by", default: {}, null: false
     t.index ["charge_id"], name: "index_cached_aggregations_on_charge_id"
     t.index ["event_id"], name: "index_cached_aggregations_on_event_id"
     t.index ["external_subscription_id"], name: "index_cached_aggregations_on_external_subscription_id"
@@ -480,7 +480,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_18_141022) do
     t.decimal "precise_unit_amount", precision: 30, scale: 15, default: "0.0", null: false
     t.jsonb "amount_details", default: {}, null: false
     t.uuid "charge_filter_id"
-    t.string "grouped_by", default: [], null: false, array: true
+    t.jsonb "grouped_by", default: {}, null: false
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_filter_id"], name: "index_fees_on_charge_filter_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -3061,7 +3061,7 @@ type Fee implements InvoiceItem {
   feeType: FeeTypesEnum!
   group: Group
   groupName: String
-  groupedBy: [String!]!
+  groupedBy: JSON!
   id: ID!
   invoiceDisplayName: String
   invoiceName: String

--- a/schema.json
+++ b/schema.json
@@ -11655,17 +11655,9 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  }
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
                 }
               },
               "isDeprecated": false,

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -20,5 +20,5 @@ RSpec.describe Types::Fees::Object do
   it { is_expected.to have_field(:applied_taxes).of_type('[FeeAppliedTax!]') }
   it { is_expected.to have_field(:adjusted_fee).of_type('Boolean!') }
   it { is_expected.to have_field(:adjusted_fee_type).of_type('AdjustedFeeTypeEnum') }
-  it { is_expected.to have_field(:grouped_by).of_type('[String!]!') }
+  it { is_expected.to have_field(:grouped_by).of_type('JSON!') }
 end

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
             pay_in_advance_event_id: event.id,
             unit_amount_cents: 1,
             precise_unit_amount: 0.01111111111,
-            grouped_by: ['foo'],
+            grouped_by: { 'operator' => 'foo' },
 
             taxes_rate: 20.0,
             taxes_amount_cents: 2,
@@ -387,7 +387,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
           expect(cached_aggregation.current_aggregation).to eq(9)
           expect(cached_aggregation.max_aggregation).to eq(9)
           expect(cached_aggregation.max_aggregation_with_proration).to be_nil
-          expect(cached_aggregation.grouped_by).to eq([])
+          expect(cached_aggregation.grouped_by).to eq({})
         end
       end
     end


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR changes the type of `fees#grouped_by` and `cached_aggregations#grouped_by` from an array of `string` to a `JSON`
