### PR TITLE
feat(payment-url): generate payment url for stripe and adyen

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -134,6 +134,25 @@ module Api
         head(:ok)
       end
 
+      def payment_url
+        invoice = current_organization.invoices.not_generating.includes(:customer).find_by(id: params[:id])
+        return not_found_error(resource: 'invoice') unless invoice
+
+        result = ::Invoices::Payments::GeneratePaymentUrlService.call(invoice:)
+
+        if result.success?
+          render(
+            json: ::V1::PaymentProviders::InvoicePaymentSerializer.new(
+              invoice,
+              root_name: 'invoice_payment_details',
+              payment_url: result.payment_url,
+            ),
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
       private
 
       def create_params

--- a/app/serializers/v1/payment_providers/invoice_payment_serializer.rb
+++ b/app/serializers/v1/payment_providers/invoice_payment_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module V1
+  module PaymentProviders
+    class InvoicePaymentSerializer < ModelSerializer
+      def serialize
+        {
+          lago_customer_id: model.customer&.id,
+          external_customer_id: model.customer&.external_id,
+          payment_provider: model.customer&.payment_provider,
+          lago_invoice_id: model.id,
+          payment_url: options[:payment_url],
+        }
+      end
+    end
+  end
+end

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -51,8 +51,12 @@ module Invoices
         result
       end
 
-      def update_payment_status(provider_payment_id:, status:)
-        payment = Payment.find_by(provider_payment_id:)
+      def update_payment_status(provider_payment_id:, status:, metadata: {})
+        payment = if metadata[:payment_type] == 'one-time'
+          create_payment(provider_payment_id:, metadata:)
+        else
+          Payment.find_by(provider_payment_id:)
+        end
         return result.not_found_failure!(resource: 'adyen_payment') unless payment
 
         result.payment = payment
@@ -82,7 +86,8 @@ module Invoices
         result
       rescue Adyen::AdyenError => e
         deliver_error_webhook(e)
-        result
+
+        result.single_validation_failure!(error_code: 'payment_provider_error')
       end
 
       private
@@ -90,6 +95,21 @@ module Invoices
       attr_accessor :invoice
 
       delegate :organization, :customer, to: :invoice
+
+      def create_payment(provider_payment_id:, metadata:)
+        @invoice = Invoice.find(metadata[:lago_invoice_id])
+
+        increment_payment_attempts
+
+        Payment.new(
+          invoice:,
+          payment_provider_id: adyen_payment_provider.id,
+          payment_provider_customer_id: customer.adyen_customer.id,
+          amount_cents: invoice.total_amount_cents,
+          amount_currency: invoice.currency.upcase,
+          provider_payment_id:,
+        )
+      end
 
       def should_process_payment?
         return false if invoice.succeeded? || invoice.voided?
@@ -107,7 +127,7 @@ module Invoices
       end
 
       def success_redirect_url
-        adyen_payment_provider.success_redirect_url.presence || PaymentProviders::AdyenProvider::SUCCESS_REDIRECT_URL
+        adyen_payment_provider.success_redirect_url.presence || ::PaymentProviders::AdyenProvider::SUCCESS_REDIRECT_URL
       end
 
       def adyen_payment_provider
@@ -167,7 +187,7 @@ module Invoices
 
       def payment_url_params
         prms = {
-          reference: invoice.id,
+          reference: invoice.number,
           amount: {
             value: invoice.total_amount_cents,
             currency: invoice.currency.upcase,
@@ -178,6 +198,13 @@ module Invoices
           storePaymentMethodMode: 'enabled',
           recurringProcessingModel: 'UnscheduledCardOnFile',
           expiresAt: Time.current + 1.day,
+          metadata: {
+            lago_customer_id: customer.id,
+            lago_invoice_id: invoice.id,
+            invoice_issuing_date: invoice.issuing_date.iso8601,
+            invoice_type: invoice.invoice_type,
+            payment_type: 'one-time',
+          },
         }
         prms[:shopperEmail] = customer.email if customer.email
         prms

--- a/app/services/invoices/payments/generate_payment_url_service.rb
+++ b/app/services/invoices/payments/generate_payment_url_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    class GeneratePaymentUrlService < BaseService
+      def initialize(invoice:)
+        @invoice = invoice
+        @provider = invoice&.customer&.payment_provider&.to_s
+
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: 'invoice') if invoice.blank?
+        return result.single_validation_failure!(error_code: 'no_linked_payment_provider') unless provider
+        return result.single_validation_failure!(error_code: 'invalid_payment_provider') if provider == 'gocardless'
+
+        if invoice.succeeded? || invoice.voided? || invoice.draft?
+          return result.single_validation_failure!(error_code: 'invalid_invoice_status_or_payment_status')
+        end
+
+        payment_url_result = Invoices::Payments::PaymentProviders::Factory.new_instance(invoice:).generate_payment_url
+
+        return payment_url_result unless payment_url_result.success?
+
+        if payment_url_result.payment_url.blank?
+          return result.single_validation_failure!(error_code: 'payment_provider_error')
+        end
+
+        payment_url_result
+      end
+
+      private
+
+      attr_reader :invoice, :provider
+    end
+  end
+end

--- a/app/services/invoices/payments/payment_providers/factory.rb
+++ b/app/services/invoices/payments/payment_providers/factory.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    module PaymentProviders
+      class Factory
+        def self.new_instance(invoice:)
+          service_class(invoice.customer&.payment_provider).new(invoice)
+        end
+
+        def self.service_class(payment_provider)
+          case payment_provider&.to_s
+          when 'stripe'
+            Invoices::Payments::StripeService
+          when 'adyen'
+            Invoices::Payments::AdyenService
+          when 'gocardless'
+            Invoices::Payments::GocardlessService
+          else
+            raise(NotImplementedError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -52,7 +52,11 @@ module Invoices
       end
 
       def update_payment_status(organization_id:, provider_payment_id:, status:, metadata: {})
-        payment = Payment.find_by(provider_payment_id:)
+        payment = if metadata[:payment_type] == 'one-time'
+          create_payment(provider_payment_id:, metadata:)
+        else
+          Payment.find_by(provider_payment_id:)
+        end
         return handle_missing_payment(organization_id, metadata) unless payment
 
         result.payment = payment
@@ -86,7 +90,8 @@ module Invoices
         result
       rescue Stripe::CardError, Stripe::InvalidRequestError, Stripe::AuthenticationError, Stripe::PermissionError => e
         deliver_error_webhook(e)
-        result
+
+        result.single_validation_failure!(error_code: 'payment_provider_error')
       end
 
       private
@@ -95,9 +100,24 @@ module Invoices
 
       delegate :organization, :customer, to: :invoice
 
+      def create_payment(provider_payment_id:, metadata:)
+        @invoice = Invoice.find(metadata[:lago_invoice_id])
+
+        increment_payment_attempts
+
+        Payment.new(
+          invoice:,
+          payment_provider_id: stripe_payment_provider.id,
+          payment_provider_customer_id: customer.stripe_customer.id,
+          amount_cents: invoice.total_amount_cents,
+          amount_currency: invoice.currency&.upcase,
+          provider_payment_id:,
+        )
+      end
+
       def success_redirect_url
         stripe_payment_provider.success_redirect_url.presence ||
-          PaymentProviders::StripeProvider::SUCCESS_REDIRECT_URL
+          ::PaymentProviders::StripeProvider::SUCCESS_REDIRECT_URL
       end
 
       def should_process_payment?
@@ -203,7 +223,7 @@ module Invoices
                 currency: invoice.currency.downcase,
                 unit_amount: invoice.total_amount_cents,
                 product_data: {
-                  name: invoice.id,
+                  name: invoice.number,
                 },
               },
             },
@@ -212,6 +232,15 @@ module Invoices
           success_url: success_redirect_url,
           customer: customer.stripe_customer.provider_customer_id,
           payment_method_types: customer.stripe_customer.provider_payment_methods,
+          payment_intent_data: {
+            metadata: {
+              lago_customer_id: customer.id,
+              lago_invoice_id: invoice.id,
+              invoice_issuing_date: invoice.issuing_date.iso8601,
+              invoice_type: invoice.invoice_type,
+              payment_type: 'one-time',
+            },
+          },
         }
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
         post :download, on: :member
         post :void, on: :member
         post :retry_payment, on: :member
+        post :payment_url, on: :member
         put :refresh, on: :member
         put :finalize, on: :member
       end

--- a/spec/fixtures/adyen/webhook_authorisation_payment_response.json
+++ b/spec/fixtures/adyen/webhook_authorisation_payment_response.json
@@ -1,0 +1,40 @@
+{
+  "live": "false",
+  "notificationItems": [
+    {
+      "NotificationRequestItem": {
+        "additionalData": {
+          "authCode": "051793",
+          "paymentLinkId": "PLF11278A8985273C2",
+          "metadata.payment_type": "one-time",
+          "cardSummary": "1142",
+          "metadata.invoice_type": "subscription",
+          "checkout.cardAddedBrand": "visa",
+          "metadata.invoice_issuing_date": "2024-01-24",
+          "expiryDate": "03/2030",
+          "metadata.lago_customer_id": "a5488a6c-d2ed-44fd-8c97-7fcca4a6a84a",
+          "threeds2.cardEnrolled": "false",
+          "recurringProcessingModel": "CardOnFile",
+          "metadata.lago_invoice_id": "ec82efeb-88bb-44f8-ba30-0d55b3fd583a"
+        },
+        "amount": {
+          "currency": "EUR",
+          "value": 71
+        },
+        "eventCode": "AUTHORISATION",
+        "eventDate": "2024-01-26T14:06:02+01:00",
+        "merchantAccountCode": "LagoAccountECOM",
+        "merchantReference": "HOO-3588-202401-033",
+        "operations": [
+          "CANCEL",
+          "CAPTURE",
+          "REFUND"
+        ],
+        "paymentMethod": "visa",
+        "pspReference": "SGVWRSNQLDQ2WN82",
+        "reason": "051793:1142:03/2030",
+        "success": "true"
+      }
+    }
+  ]
+}

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -537,4 +537,34 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       end
     end
   end
+
+  describe 'POST /invoices/:id/payment_url' do
+    let(:organization) { create(:organization) }
+    let(:stripe_provider) { create(:stripe_provider, organization:, code:) }
+    let(:customer) { create(:customer, organization:, payment_provider_code: code) }
+    let(:code) { 'stripe_1' }
+
+    before do
+      create(
+        :stripe_customer,
+        customer_id: customer.id,
+        payment_provider: stripe_provider,
+      )
+
+      customer.update(payment_provider: 'stripe')
+
+      allow(Stripe::Checkout::Session).to receive(:create)
+        .and_return({ 'url' => 'https://example.com' })
+    end
+
+    it 'returns the generated payment url' do
+      post_with_token(organization, "/api/v1/invoices/#{invoice.id}/payment_url")
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+
+        expect(json[:invoice_payment_details][:payment_url]).to eq('https://example.com')
+      end
+    end
+  end
 end

--- a/spec/serializers/v1/payment_providers/invoice_payment_serializer_spec.rb
+++ b/spec/serializers/v1/payment_providers/invoice_payment_serializer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::PaymentProviders::InvoicePaymentSerializer do
+  subject(:serializer) { described_class.new(invoice, options) }
+
+  let(:invoice) { create(:invoice) }
+  let(:options) do
+    { 'payment_url' => 'https://example.com' }.with_indifferent_access
+  end
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['data']['lago_customer_id']).to eq(invoice.customer.id)
+      expect(result['data']['external_customer_id']).to eq(invoice.customer.external_id)
+      expect(result['data']['payment_provider']).to eq(invoice.customer.payment_provider)
+      expect(result['data']['lago_invoice_id']).to eq(invoice.id)
+      expect(result['data']['payment_url']).to eq('https://example.com')
+    end
+  end
+end

--- a/spec/services/invoices/payments/adyen_service_spec.rb
+++ b/spec/services/invoices/payments/adyen_service_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
   let(:adyen_customer) { create(:adyen_customer, customer:) }
   let(:adyen_client) { instance_double(Adyen::Client) }
   let(:payments_api) { Adyen::PaymentsApi.new(adyen_client, 70) }
+  let(:payment_links_api) { Adyen::PaymentLinksApi.new(adyen_client, 70) }
+  let(:payment_links_response) { generate(:adyen_payment_links_response) }
   let(:checkout) { Adyen::Checkout.new(adyen_client, 70) }
   let(:payments_response) { generate(:adyen_payments_response) }
   let(:payment_methods_response) { generate(:adyen_payment_methods_response) }
@@ -336,6 +338,48 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
           expect(result.error.messages.keys).to include(:payment_status)
           expect(result.error.messages[:payment_status]).to include('value_is_invalid')
         end
+      end
+    end
+  end
+
+  describe '#generate_payment_url' do
+    before do
+      adyen_payment_provider
+      adyen_customer
+
+      allow(Adyen::Client).to receive(:new)
+        .and_return(adyen_client)
+      allow(adyen_client).to receive(:checkout)
+        .and_return(checkout)
+      allow(checkout).to receive(:payment_links_api)
+        .and_return(payment_links_api)
+      allow(payment_links_api).to receive(:payment_links)
+        .and_return(payment_links_response)
+    end
+
+    it 'generates payment url' do
+      adyen_service.generate_payment_url
+
+      expect(payment_links_api).to have_received(:payment_links)
+    end
+
+    context 'when invoice is succeeded' do
+      before { invoice.succeeded! }
+
+      it 'does not generate payment url' do
+        adyen_service.generate_payment_url
+
+        expect(payment_links_api).not_to have_received(:payment_links)
+      end
+    end
+
+    context 'when invoice is voided' do
+      before { invoice.voided! }
+
+      it 'does not generate payment url' do
+        adyen_service.generate_payment_url
+
+        expect(payment_links_api).not_to have_received(:payment_links)
       end
     end
   end

--- a/spec/services/invoices/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/invoices/payments/generate_payment_url_service_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::Payments::GeneratePaymentUrlService, type: :service do
+  subject(:generate_payment_url_service) { described_class.new(invoice:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:, payment_provider:, payment_provider_code: code) }
+  let(:invoice) { create(:invoice, customer:) }
+  let(:payment_provider) { 'stripe' }
+  let(:code) { 'stripe_1' }
+
+  describe '.call' do
+    let(:stripe_provider) { create(:stripe_provider, organization:, code:) }
+
+    context 'when payment provider is linked' do
+      before do
+        create(
+          :stripe_customer,
+          customer_id: customer.id,
+          payment_provider: stripe_provider,
+        )
+
+        customer.update(payment_provider: 'stripe')
+
+        allow(Stripe::Checkout::Session).to receive(:create)
+          .and_return({ 'url' => 'https://example55.com' })
+      end
+
+      it 'returns the generated payment url' do
+        result = generate_payment_url_service.call
+
+        expect(result.payment_url).to eq('https://example55.com')
+      end
+    end
+
+    context 'when invoice is blank' do
+      it 'returns an error' do
+        result = described_class.new(invoice: nil).call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.message).to eq('invoice_not_found')
+        end
+      end
+    end
+
+    context 'when payment provider is blank' do
+      let(:payment_provider) { nil }
+
+      it 'returns an error' do
+        result = generate_payment_url_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(['no_linked_payment_provider'])
+        end
+      end
+    end
+
+    context 'when payment provider is gocardless' do
+      let(:payment_provider) { 'gocardless' }
+
+      it 'returns an error' do
+        result = generate_payment_url_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(['invalid_payment_provider'])
+        end
+      end
+    end
+
+    context 'when invoice payment status is invalid' do
+      before { invoice.succeeded! }
+
+      it 'returns an error' do
+        result = generate_payment_url_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(['invalid_invoice_status_or_payment_status'])
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/payments/payment_providers/factory_spec.rb
+++ b/spec/services/invoices/payments/payment_providers/factory_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::Payments::PaymentProviders::Factory, type: :service do
+  subject(:factory_service) { described_class.new_instance(invoice:) }
+
+  let(:payment_provider) { 'stripe' }
+  let(:invoice) { create(:invoice, customer:) }
+  let(:customer) { create(:customer, payment_provider:) }
+
+  describe '#self.new_instance' do
+    context 'when stripe' do
+      it 'returns correct class' do
+        expect(factory_service.class.to_s).to eq('Invoices::Payments::StripeService')
+      end
+    end
+
+    context 'when adyen' do
+      let(:payment_provider) { 'adyen' }
+
+      it 'returns correct class' do
+        expect(factory_service.class.to_s).to eq('Invoices::Payments::AdyenService')
+      end
+    end
+
+    context 'when gocardless' do
+      let(:payment_provider) { 'gocardless' }
+
+      it 'returns correct class' do
+        expect(factory_service.class.to_s).to eq('Invoices::Payments::GocardlessService')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Some customers don’t have payment methods that accept recurring payments (ie: card payments in India) and currently it is not possible to fetch one-time payment link when invoice payment status is failed.

## Description

This PR adds a logic for stripe and adyen in order to generate one time payment link
