### PR TITLE
feat(grouped-by) Refact AdjustedFees for grouped by

### DIFF
--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -12,7 +12,7 @@ module Types
 
         field :billable_metric, Types::BillableMetrics::Object, null: false
         field :charge, Types::Charges::Object, null: false
-        field :grouped_by, [String], null: true
+        field :grouped_by, GraphQL::Types::JSON, null: true
         field :groups, [Types::Customers::Usage::ChargeGroup], null: true
 
         def units

--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -32,6 +32,7 @@ module AdjustedFees
         properties: fee.properties,
         units: params[:units].presence || 0,
         unit_amount_cents: params[:unit_amount_cents].presence || 0,
+        grouped_by: fee.grouped_by,
       )
 
       adjusted_fee.save!

--- a/app/services/charges/charge_model_factory.rb
+++ b/app/services/charges/charge_model_factory.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Charges
+  class ChargeModelFactory
+    def self.new_instance(charge:, aggregation_result:, properties:)
+      charge_model_class(charge:).new(charge:, aggregation_result:, properties:)
+    end
+
+    def self.charge_model_class(charge:)
+      case charge.charge_model.to_sym
+      when :standard
+        Charges::ChargeModels::StandardService
+      when :graduated
+        if charge.prorated?
+          Charges::ChargeModels::ProratedGraduatedService
+        else
+          Charges::ChargeModels::GraduatedService
+        end
+      when :graduated_percentage
+        Charges::ChargeModels::GraduatedPercentageService
+      when :package
+        Charges::ChargeModels::PackageService
+      when :percentage
+        Charges::ChargeModels::PercentageService
+      when :volume
+        Charges::ChargeModels::VolumeService
+      else
+        raise(NotImplementedError)
+      end
+    end
+  end
+end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -70,14 +70,15 @@ module Fees
     def init_fee(properties:, group: nil)
       # NOTE: Build fee for case when there is adjusted fee and units or amount has been adjusted.
       # Base fee creation flow handles case when only name has been adjusted
-      if invoice.draft? && adjusted_fee(group) && !adjusted_fee(group).adjusted_display_name?
-        amount_result = compute_amount_for_adjusted_fee(properties:, group:)
-        return result.fail_with_error!(amount_result.error) unless amount_result.success?
+      if invoice.draft? && (adjusted = adjusted_fee(group)) && !adjusted.adjusted_display_name?
+        adjustement_result = Fees::InitFromAdjustedChargeFeeService.call(
+          adjusted_fee: adjusted,
+          boundaries:,
+          properties:,
+        )
+        return result.fail_with_error!(adjustement_result.error) unless adjustement_result.success?
 
-        new_fee = init_adjusted_fee(amount_result, group)
-
-        result.fees << new_fee
-
+        result.fees << adjustement_result.fee
         return
       end
 
@@ -127,47 +128,6 @@ module Fees
       result.fees << new_fee
     end
 
-    def init_adjusted_fee(amount_result, group)
-      currency = invoice.total_amount.currency
-      adjusted_fee = adjusted_fee(group)
-
-      units = adjusted_fee.units
-      if adjusted_fee.adjusted_units?
-        rounded_amount = amount_result.amount.round(currency.exponent)
-        amount_cents = rounded_amount * currency.subunit_to_unit
-        unit_amount_cents = amount_result.unit_amount * currency.subunit_to_unit
-        precise_unit_amount = amount_result.unit_amount
-        amount_details = amount_result.amount_details
-      else
-        unit_amount_cents = adjusted_fee.unit_amount_cents.round
-        amount_cents = (units * unit_amount_cents).round
-        precise_unit_amount = amount_cents / (currency.subunit_to_unit * units)
-        amount_details = {}
-      end
-
-      Fee.new(
-        invoice:,
-        subscription:,
-        charge:,
-        amount_cents:,
-        amount_currency: currency,
-        fee_type: :charge,
-        invoiceable_type: 'Charge',
-        invoiceable: charge,
-        units:,
-        total_aggregated_units: units,
-        properties: boundaries.to_h,
-        events_count: 0,
-        group_id: group&.id,
-        payment_status: :pending,
-        taxes_amount_cents: 0,
-        unit_amount_cents:,
-        precise_unit_amount:,
-        amount_details:,
-        invoice_display_name: adjusted_fee.invoice_display_name,
-      )
-    end
-
     def adjusted_fee(group)
       @adjusted_fee ||= {}
 
@@ -180,20 +140,6 @@ module Fees
         .where("properties->>'charges_from_datetime' = ?", boundaries.charges_from_datetime&.iso8601(3))
         .where("properties->>'charges_to_datetime' = ?", boundaries.charges_to_datetime&.iso8601(3))
         .first
-    end
-
-    def compute_amount_for_adjusted_fee(properties:, group:)
-      adjusted_fee = adjusted_fee(group)
-      adjusted_fee_result = BaseService::Result.new
-
-      return adjusted_fee_result if adjusted_fee.adjusted_amount?
-
-      adjusted_fee_result.aggregation = adjusted_fee.units
-      adjusted_fee_result.current_usage_units = adjusted_fee.units
-      adjusted_fee_result.full_units_number = adjusted_fee.units
-      adjusted_fee_result.count = 0
-
-      apply_charge_model_service(adjusted_fee_result, properties)
     end
 
     def init_true_up_fee(fee:, amount_cents:)
@@ -241,28 +187,7 @@ module Fees
     end
 
     def apply_charge_model_service(aggregation_result, properties)
-      model_service = case charge.charge_model.to_sym
-                      when :standard
-                        Charges::ChargeModels::StandardService
-                      when :graduated
-                        if charge.prorated?
-                          Charges::ChargeModels::ProratedGraduatedService
-                        else
-                          Charges::ChargeModels::GraduatedService
-                        end
-                      when :graduated_percentage
-                        Charges::ChargeModels::GraduatedPercentageService
-                      when :package
-                        Charges::ChargeModels::PackageService
-                      when :percentage
-                        Charges::ChargeModels::PercentageService
-                      when :volume
-                        Charges::ChargeModels::VolumeService
-                      else
-                        raise(NotImplementedError)
-      end
-
-      model_service.apply(charge:, aggregation_result:, properties:)
+      Charges::ChargeModelFactory.new_instance(charge:, aggregation_result:, properties:).apply
     end
 
     def persist_recurring_value(aggregation_result, group)

--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module Fees
+  class InitFromAdjustedChargeFeeService < ::BaseService
+    def initialize(adjusted_fee:, boundaries:, properties:)
+      @adjusted_fee = adjusted_fee
+      @boundaries = boundaries
+      @properties = properties
+
+      super
+    end
+
+    def call
+      amount_result = compute_amount
+      return result.fail_with_error!(amount_result.error) unless amount_result.success?
+
+      result.fee = init_adjusted_fee(amount_result)
+      result
+    end
+
+    private
+
+    attr_reader :adjusted_fee, :boundaries, :properties
+
+    delegate :group, :charge, :invoice, :subscription, to: :adjusted_fee
+
+    def compute_amount
+      adjusted_fee_result = BaseService::Result.new
+      return adjusted_fee_result if adjusted_fee.adjusted_amount?
+
+      adjusted_fee_result.aggregation = adjusted_fee.units
+      adjusted_fee_result.current_usage_units = adjusted_fee.units
+      adjusted_fee_result.full_units_number = adjusted_fee.units
+      adjusted_fee_result.count = 0
+      adjusted_fee_result.grouped_by = adjusted_fee.grouped_by
+
+      apply_charge_model_service(adjusted_fee_result)
+    end
+
+    def apply_charge_model_service(aggregation_result)
+      Charges::ChargeModelFactory.new_instance(charge:, aggregation_result:, properties:).apply
+    end
+
+    def init_adjusted_fee(amount_result)
+      currency = invoice.total_amount.currency
+
+      units = adjusted_fee.units
+      if adjusted_fee.adjusted_units?
+        rounded_amount = amount_result.amount.round(currency.exponent)
+        amount_cents = rounded_amount * currency.subunit_to_unit
+        unit_amount_cents = amount_result.unit_amount * currency.subunit_to_unit
+        precise_unit_amount = amount_result.unit_amount
+        amount_details = amount_result.amount_details
+      else
+        unit_amount_cents = adjusted_fee.unit_amount_cents.round
+        amount_cents = (units * unit_amount_cents).round
+        precise_unit_amount = amount_cents / (currency.subunit_to_unit * units)
+        amount_details = {}
+      end
+
+      Fee.new(
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents:,
+        amount_currency: currency,
+        fee_type: :charge,
+        invoiceable_type: 'Charge',
+        invoiceable: charge,
+        units:,
+        total_aggregated_units: units,
+        properties: boundaries.to_h,
+        events_count: 0,
+        group_id: group&.id,
+        payment_status: :pending,
+        taxes_amount_cents: 0,
+        unit_amount_cents:,
+        precise_unit_amount:,
+        amount_details:,
+        invoice_display_name: adjusted_fee.invoice_display_name,
+        grouped_by: adjusted_fee.grouped_by,
+      )
+    end
+  end
+end

--- a/db/migrate/20240125080718_add_grouped_by_to_adjusted_fees.rb
+++ b/db/migrate/20240125080718_add_grouped_by_to_adjusted_fees.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGroupedByToAdjustedFees < ActiveRecord::Migration[7.0]
+  def change
+    add_column :adjusted_fees, :grouped_by, :jsonb, null: false, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_23_104811) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_25_080718) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_23_104811) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "group_id"
+    t.jsonb "grouped_by", default: {}, null: false
     t.index ["charge_id"], name: "index_adjusted_fees_on_charge_id"
     t.index ["fee_id"], name: "index_adjusted_fees_on_fee_id"
     t.index ["group_id"], name: "index_adjusted_fees_on_group_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -253,7 +253,7 @@ type ChargeUsage {
   billableMetric: BillableMetric!
   charge: Charge!
   eventsCount: Int!
-  groupedBy: [String!]
+  groupedBy: JSON
   groups: [GroupUsage!]
   units: Float!
 }

--- a/schema.json
+++ b/schema.json
@@ -2570,17 +2570,9 @@
               "name": "groupedBy",
               "description": null,
               "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/types/customers/usage/charge_spec.rb
+++ b/spec/graphql/types/customers/usage/charge_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe Types::Customers::Usage::Charge do
   it { is_expected.to have_field(:units).of_type('Float!') }
   it { is_expected.to have_field(:billable_metric).of_type('BillableMetric!') }
   it { is_expected.to have_field(:charge).of_type('Charge!') }
-  it { is_expected.to have_field(:grouped_by).of_type('[String!]') }
+  it { is_expected.to have_field(:grouped_by).of_type('JSON') }
   it { is_expected.to have_field(:groups).of_type('[GroupUsage!]') }
 end

--- a/spec/services/charges/charge_model_factory_spec.rb
+++ b/spec/services/charges/charge_model_factory_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::ChargeModelFactory, type: :service do
+  subject(:factory) { described_class }
+
+  let(:charge) { build(:standard_charge) }
+  let(:aggregation_result) { BaseService::Result.new }
+  let(:properties) { charge.properties }
+
+  let(:result) { factory.new_instance(charge:, aggregation_result:, properties:) }
+
+  describe '#new_instance' do
+    context 'with standard charge model' do
+      it { expect(result).to be_a(Charges::ChargeModels::StandardService) }
+    end
+
+    context 'with graduated charge model' do
+      let(:charge) { build(:graduated_charge) }
+
+      it { expect(result).to be_a(Charges::ChargeModels::GraduatedService) }
+
+      context 'when charge is prorated' do
+        let(:charge) { build(:graduated_charge, prorated: true) }
+
+        it { expect(result).to be_a(Charges::ChargeModels::ProratedGraduatedService) }
+      end
+    end
+
+    context 'with graduated_percentage charge model' do
+      let(:charge) { build(:graduated_percentage_charge) }
+
+      it { expect(result).to be_a(Charges::ChargeModels::GraduatedPercentageService) }
+    end
+
+    context 'with package charge model' do
+      let(:charge) { build(:package_charge) }
+
+      it { expect(result).to be_a(Charges::ChargeModels::PackageService) }
+    end
+
+    context 'with percentage charge model' do
+      let(:charge) { build(:percentage_charge) }
+
+      it { expect(result).to be_a(Charges::ChargeModels::PercentageService) }
+    end
+
+    context 'with volume charge model' do
+      let(:charge) { build(:volume_charge) }
+
+      it { expect(result).to be_a(Charges::ChargeModels::VolumeService) }
+    end
+  end
+end

--- a/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
+++ b/spec/services/fees/init_from_adjusted_charge_fee_service_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fees::InitFromAdjustedChargeFeeService, type: :service do
+  subject(:init_service) { described_class.new(adjusted_fee:, boundaries:, properties:) }
+
+  let(:subscription) do
+    create(
+      :subscription,
+      status: :active,
+      started_at: DateTime.parse('2022-03-15'),
+    )
+  end
+
+  let(:invoice) { create(:invoice, status: :draft) }
+  let(:invoice_subscription) { create(:invoice_subscription, invoice:, subscription:) }
+
+  let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
+  let(:charge) do
+    create(
+      :standard_charge,
+      plan: subscription.plan,
+      billable_metric:,
+      properties: {
+        amount: '20',
+        amount_currency: 'EUR',
+      },
+    )
+  end
+  let(:properties) { charge.properties }
+
+  let(:boundaries) do
+    {
+      charges_from_datetime: subscription.started_at.beginning_of_day,
+      charges_to_datetime: subscription.started_at.end_of_month.end_of_day,
+    }
+  end
+
+  let(:adjusted_fee) do
+    create(
+      :adjusted_fee,
+      invoice:,
+      subscription:,
+      charge:,
+      properties: {},
+      fee_type: :charge,
+      adjusted_units: true,
+      adjusted_amount: false,
+      units: 3,
+    )
+  end
+
+  before do
+    invoice_subscription
+  end
+
+  context 'with adjusted units' do
+    it 'initializes a fee' do
+      result = init_service.call
+
+      expect(result).to be_success
+      expect(result.fee).to be_a(Fee)
+      expect(result.fee).to have_attributes(
+        id: nil,
+        invoice:,
+        subscription:,
+        charge:,
+        amount_cents: 6_000,
+        amount_currency: invoice.currency,
+        units: 3,
+        unit_amount_cents: 2_000,
+        precise_unit_amount: 20,
+        events_count: 0,
+        payment_status: 'pending',
+      )
+    end
+  end
+
+  context 'with adjusted amount' do
+    let(:adjusted_fee) do
+      create(
+        :adjusted_fee,
+        invoice:,
+        subscription:,
+        charge:,
+        properties:,
+        fee_type: :charge,
+        adjusted_units: false,
+        adjusted_amount: true,
+        units: 4,
+        unit_amount_cents: 200,
+      )
+    end
+
+    it 'initializes a fee' do
+      result = init_service.call
+
+      expect(result).to be_success
+      expect(result.fee).to be_a(Fee)
+      expect(result.fee).to have_attributes(
+        id: nil,
+        invoice:,
+        charge:,
+        amount_cents: 800,
+        amount_currency: invoice.currency,
+        units: 4,
+        unit_amount_cents: 200,
+        precise_unit_amount: 2,
+        events_count: 0,
+        payment_status: 'pending',
+      )
+    end
+  end
+
+  context 'with charge model error' do
+    let(:error_result) do
+      BaseService::Result.new.tap do |result|
+        result.service_failure!(code: 'error', message: 'message')
+      end
+    end
+
+    let(:charge_model_instance) { instance_double(Charges::ChargeModels::StandardService) }
+
+    it 'returns an error' do
+      allow(Charges::ChargeModels::StandardService).to receive(:new).and_return(charge_model_instance)
+      allow(charge_model_instance).to receive(:apply).and_return(error_result)
+
+      result = init_service.call
+      expect(result).not_to be_success
+      expect(result.error).to be_a(BaseService::ServiceFailure)
+      expect(result.error.code).to eq('error')
+      expect(result.error.error_message).to eq('message')
+    end
+  end
+end


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR changes adds a new `grouped_by` json field to the `AdjustedFee` model and moves the creation of fees from an adjusted fee into a proper service to ease the next steps of the feature and make it easier to tests and maintain.
