### PR TITLE
feat(grouped-by) Adapt sum aggregation to return grouped aggregation

### DIFF
--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -42,7 +42,7 @@ module Types
         end
 
         def grouped_usage
-          return [] unless object.first.grouped_by
+          return [] unless object.any? { |f| f.grouped_by.present? }
 
           object
         end

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -12,6 +12,7 @@ module BillableMetrics
         @filters = filters
         @group = filters[:group]
         @event = filters[:event]
+        @grouped_by = filters[:grouped_by]
 
         @boundaries = boundaries
 
@@ -19,7 +20,19 @@ module BillableMetrics
       end
 
       def aggregate(options: {})
-        raise(NotImplementedError)
+        if grouped_by.present? && support_grouped_aggregation?
+          compute_grouped_by_aggregation(options:)
+        else
+          compute_aggregation(options:)
+        end
+      end
+
+      def compute_aggregation(options: {})
+        raise NotImplementedError
+      end
+
+      def compute_grouped_by_aggregation(options: {})
+        raise NotImplementedError
       end
 
       def per_event_aggregation
@@ -30,7 +43,7 @@ module BillableMetrics
 
       protected
 
-      attr_accessor :event_store_class, :charge, :subscription, :filters, :group, :event, :boundaries
+      attr_accessor :event_store_class, :charge, :subscription, :filters, :group, :event, :boundaries, :grouped_by
 
       delegate :billable_metric, to: :charge
 
@@ -41,7 +54,7 @@ module BillableMetrics
           code: billable_metric.code,
           subscription:,
           boundaries:,
-          filters: { group: },
+          filters:,
         )
       end
 
@@ -82,6 +95,10 @@ module BillableMetrics
         @to_datetime = to_datetime
 
         cached_aggregation
+      end
+
+      def support_grouped_aggregation?
+        false
       end
     end
   end

--- a/app/services/charges/charge_model_factory.rb
+++ b/app/services/charges/charge_model_factory.rb
@@ -3,13 +3,17 @@
 module Charges
   class ChargeModelFactory
     def self.new_instance(charge:, aggregation_result:, properties:)
-      charge_model_class(charge:).new(charge:, aggregation_result:, properties:)
+      charge_model_class(charge:, aggregation_result:).new(charge:, aggregation_result:, properties:)
     end
 
-    def self.charge_model_class(charge:)
+    def self.charge_model_class(charge:, aggregation_result:)
       case charge.charge_model.to_sym
       when :standard
-        Charges::ChargeModels::StandardService
+        if charge.properties['grouped_by'].present? && aggregation_result.aggregations.present?
+          Charges::ChargeModels::GroupedStandardService
+        else
+          Charges::ChargeModels::StandardService
+        end
       when :graduated
         if charge.prorated?
           Charges::ChargeModels::ProratedGraduatedService

--- a/app/services/charges/charge_model_factory.rb
+++ b/app/services/charges/charge_model_factory.rb
@@ -9,7 +9,7 @@ module Charges
     def self.charge_model_class(charge:, aggregation_result:)
       case charge.charge_model.to_sym
       when :standard
-        if charge.properties['grouped_by'].present? && aggregation_result.aggregations.present?
+        if charge.properties['grouped_by'].present? && !aggregation_result.aggregations.nil?
           Charges::ChargeModels::GroupedStandardService
         else
           Charges::ChargeModels::StandardService

--- a/app/services/charges/charge_models/grouped_standard_service.rb
+++ b/app/services/charges/charge_models/grouped_standard_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Charges
+  module ChargeModels
+    class GroupedStandardService < BaseService
+      def self.apply(...)
+        new(...).apply
+      end
+
+      def initialize(charge:, aggregation_result:, properties:)
+        super
+
+        @charge = charge
+        @aggregation_result = aggregation_result
+        @properties = properties
+      end
+
+      def apply
+        result.model_results = aggregation_result.aggregations.map do |aggregation|
+          group_result = Charges::ChargeModels::StandardService.apply(
+            charge:,
+            aggregation_result: aggregation,
+            properties:,
+          )
+          group_result.grouped_by = aggregation.grouped_by
+          group_result
+        end
+
+        result
+      end
+
+      protected
+
+      attr_accessor :charge, :aggregation_result, :properties
+    end
+  end
+end

--- a/app/services/charges/charge_models/grouped_standard_service.rb
+++ b/app/services/charges/charge_models/grouped_standard_service.rb
@@ -16,7 +16,7 @@ module Charges
       end
 
       def apply
-        result.model_results = aggregation_result.aggregations.map do |aggregation|
+        result.grouped_results = aggregation_result.aggregations.map do |aggregation|
           group_result = Charges::ChargeModels::StandardService.apply(
             charge:,
             aggregation_result: aggregation,

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -192,6 +192,8 @@ module Fees
 
     def persist_recurring_value(aggregation_result, group)
       return if is_current_usage
+
+      # NOTE: Only weighted sum aggregation is setting this value
       return unless aggregation_result.recurring_updated_at
 
       result.quantified_events ||= []

--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -32,7 +32,6 @@ module Fees
       adjusted_fee_result.current_usage_units = adjusted_fee.units
       adjusted_fee_result.full_units_number = adjusted_fee.units
       adjusted_fee_result.count = 0
-      adjusted_fee_result.grouped_by = adjusted_fee.grouped_by
 
       apply_charge_model_service(adjusted_fee_result)
     end

--- a/spec/services/charges/charge_model_factory_spec.rb
+++ b/spec/services/charges/charge_model_factory_spec.rb
@@ -14,6 +14,13 @@ RSpec.describe Charges::ChargeModelFactory, type: :service do
   describe '#new_instance' do
     context 'with standard charge model' do
       it { expect(result).to be_a(Charges::ChargeModels::StandardService) }
+
+      context 'when charge is grouped' do
+        let(:charge) { build(:standard_charge, properties: { grouped_by: ['cloud'] }) }
+        let(:aggregation_result) { BaseService::Result.new.tap { |r| r.aggregations = [BaseService::Result.new] } }
+
+        it { expect(result).to be_a(Charges::ChargeModels::GroupedStandardService) }
+      end
     end
 
     context 'with graduated charge model' do

--- a/spec/services/charges/charge_models/grouped_standard_service_spec.rb
+++ b/spec/services/charges/charge_models/grouped_standard_service_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Charges::ChargeModels::GroupedStandardService do
+  subject(:apply_grouped_standard_service) do
+    described_class.apply(
+      charge:, aggregation_result:, properties: charge.properties,
+    )
+  end
+
+  let(:aggregation_result) do
+    BaseService::Result.new.tap do |result|
+      result.aggregations = group_results.map do |group_result|
+        BaseService::Result.new.tap do |aggregation|
+          aggregation.aggregation = group_result[:aggregation]
+          aggregation.count = group_result[:count]
+          aggregation.grouped_by = group_result[:grouped_by]
+        end
+      end
+    end
+  end
+
+  let(:group_results) do
+    [
+      {
+        grouped_by: { 'cloud' => 'aws' },
+        aggregation: 10,
+        count: 2,
+      },
+      {
+        grouped_by: { 'cloud' => 'gcp' },
+        aggregation: 20,
+        count: 7,
+      },
+    ]
+  end
+
+  let(:charge) do
+    create(
+      :standard_charge,
+      charge_model: 'standard',
+      properties: {
+        amount: '5.12345',
+      },
+    )
+  end
+
+  it 'applies the charge model to the values' do
+    expect(apply_grouped_standard_service.model_results.count).to eq(group_results.count)
+
+    group_results.each_with_index do |group_result, index|
+      result = apply_grouped_standard_service.model_results[index]
+
+      expect(result.units).to eq(group_result[:aggregation])
+      expect(result.current_usage_units).to eq(nil)
+      expect(result.full_units_number).to eq(nil)
+      expect(result.count).to eq(group_result[:count])
+      expect(result.amount).to eq(group_result[:aggregation] * BigDecimal('5.12345'))
+      expect(result.unit_amount).to eq(5.12345)
+      expect(result.amount_details).to eq({})
+      expect(result.grouped_by).to eq(group_result[:grouped_by])
+    end
+  end
+end

--- a/spec/services/charges/charge_models/grouped_standard_service_spec.rb
+++ b/spec/services/charges/charge_models/grouped_standard_service_spec.rb
@@ -47,10 +47,10 @@ RSpec.describe Charges::ChargeModels::GroupedStandardService do
   end
 
   it 'applies the charge model to the values' do
-    expect(apply_grouped_standard_service.model_results.count).to eq(group_results.count)
+    expect(apply_grouped_standard_service.grouped_results.count).to eq(group_results.count)
 
     group_results.each_with_index do |group_result, index|
-      result = apply_grouped_standard_service.model_results[index]
+      result = apply_grouped_standard_service.grouped_results[index]
 
       expect(result.units).to eq(group_result[:aggregation])
       expect(result.current_usage_units).to eq(nil)


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR applies the grouped_by logic to in arrears charges with sum aggregation. It creates a fee per aggregated group.
