### PR TITLE
feat(invoice-payment-url): Add setup for invoice payment url

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -144,7 +144,7 @@ module Api
           render(
             json: ::V1::PaymentProviders::InvoicePaymentSerializer.new(
               invoice,
-              root_name: 'invoice_payment_url',
+              root_name: 'invoice_payment_details',
               payment_url: result.payment_url,
             ),
           )

--- a/app/serializers/v1/payment_providers/invoice_payment_serializer.rb
+++ b/app/serializers/v1/payment_providers/invoice_payment_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module V1
+  module PaymentProviders
+    class InvoicePaymentSerializer < ModelSerializer
+      def serialize
+        {
+          lago_customer_id: model.customer&.id,
+          external_customer_id: model.customer&.external_id,
+          payment_provider: model.customer&.payment_provider,
+          lago_invoice_id: model.id,
+          payment_url: options[:payment_url],
+        }
+      end
+    end
+  end
+end

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -82,7 +82,8 @@ module Invoices
         result
       rescue Adyen::AdyenError => e
         deliver_error_webhook(e)
-        result
+
+        result.single_validation_failure!(error_code: 'payment_provider_error')
       end
 
       private

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -108,7 +108,7 @@ module Invoices
       end
 
       def success_redirect_url
-        adyen_payment_provider.success_redirect_url.presence || PaymentProviders::AdyenProvider::SUCCESS_REDIRECT_URL
+        adyen_payment_provider.success_redirect_url.presence || ::PaymentProviders::AdyenProvider::SUCCESS_REDIRECT_URL
       end
 
       def adyen_payment_provider

--- a/app/services/invoices/payments/generate_payment_url_service.rb
+++ b/app/services/invoices/payments/generate_payment_url_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    class GeneratePaymentUrlService < BaseService
+      def initialize(invoice:)
+        @invoice = invoice
+        @provider = invoice&.customer&.payment_provider&.to_s
+
+        super
+      end
+
+      def call
+        return result.not_found_failure!(resource: 'invoice') if invoice.blank?
+        return result.single_validation_failure!(error_code: 'no_linked_payment_provider') unless provider
+        return result.single_validation_failure!(error_code: 'invalid_payment_provider') if provider == 'gocardless'
+
+        if invoice.succeeded? || invoice.voided? || invoice.draft?
+          return result.single_validation_failure!(error_code: 'invalid_invoice_status_or_payment_status')
+        end
+
+        payment_url_result = Invoices::Payments::PaymentProviders::Factory.new_instance(invoice:).generate_payment_url
+
+        return payment_url_result unless payment_url_result.success?
+
+        if payment_url_result.payment_url.blank?
+          return result.single_validation_failure!(error_code: 'payment_provider_error')
+        end
+
+        payment_url_result
+      end
+
+      private
+
+      attr_reader :invoice, :provider
+    end
+  end
+end

--- a/app/services/invoices/payments/payment_providers/factory.rb
+++ b/app/services/invoices/payments/payment_providers/factory.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    module PaymentProviders
+      class Factory
+        def self.new_instance(invoice:)
+          self.service_class(invoice.customer&.payment_provider).new(invoice)
+        end
+
+        def self.service_class(payment_provider)
+          case payment_provider&.to_s
+          when 'stripe'
+            Invoices::Payments::StripeService
+          when 'adyen'
+            Invoices::Payments::AdyenService
+          when 'gocardless'
+            Invoices::Payments::GocardlessService
+          else
+            raise(NotImplementedError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/invoices/payments/payment_providers/factory.rb
+++ b/app/services/invoices/payments/payment_providers/factory.rb
@@ -5,7 +5,7 @@ module Invoices
     module PaymentProviders
       class Factory
         def self.new_instance(invoice:)
-          self.service_class(invoice.customer&.payment_provider).new(invoice)
+          service_class(invoice.customer&.payment_provider).new(invoice)
         end
 
         def self.service_class(payment_provider)

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -86,7 +86,8 @@ module Invoices
         result
       rescue Stripe::CardError, Stripe::InvalidRequestError, Stripe::AuthenticationError, Stripe::PermissionError => e
         deliver_error_webhook(e)
-        result
+
+        result.single_validation_failure!(error_code: 'payment_provider_error')
       end
 
       private

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -98,7 +98,7 @@ module Invoices
 
       def success_redirect_url
         stripe_payment_provider.success_redirect_url.presence ||
-          PaymentProviders::StripeProvider::SUCCESS_REDIRECT_URL
+          ::PaymentProviders::StripeProvider::SUCCESS_REDIRECT_URL
       end
 
       def should_process_payment?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
         post :download, on: :member
         post :void, on: :member
         post :retry_payment, on: :member
+        post :payment_url, on: :member
         put :refresh, on: :member
         put :finalize, on: :member
       end

--- a/spec/fixtures/adyen/webhook_authorisation_payment_response.json
+++ b/spec/fixtures/adyen/webhook_authorisation_payment_response.json
@@ -1,0 +1,40 @@
+{
+  "live": "false",
+  "notificationItems": [
+    {
+      "NotificationRequestItem": {
+        "additionalData": {
+          "authCode": "051793",
+          "paymentLinkId": "PLF11278A8985273C2",
+          "metadata.payment_type": "one-time",
+          "cardSummary": "1142",
+          "metadata.invoice_type": "subscription",
+          "checkout.cardAddedBrand": "visa",
+          "metadata.invoice_issuing_date": "2024-01-24",
+          "expiryDate": "03/2030",
+          "metadata.lago_customer_id": "a5488a6c-d2ed-44fd-8c97-7fcca4a6a84a",
+          "threeds2.cardEnrolled": "false",
+          "recurringProcessingModel": "CardOnFile",
+          "metadata.lago_invoice_id": "ec82efeb-88bb-44f8-ba30-0d55b3fd583a"
+        },
+        "amount": {
+          "currency": "EUR",
+          "value": 71
+        },
+        "eventCode": "AUTHORISATION",
+        "eventDate": "2024-01-26T14:06:02+01:00",
+        "merchantAccountCode": "LagoAccountECOM",
+        "merchantReference": "HOO-3588-202401-033",
+        "operations": [
+          "CANCEL",
+          "CAPTURE",
+          "REFUND"
+        ],
+        "paymentMethod": "visa",
+        "pspReference": "SGVWRSNQLDQ2WN82",
+        "reason": "051793:1142:03/2030",
+        "success": "true"
+      }
+    }
+  ]
+}

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -563,7 +563,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       aggregate_failures do
         expect(response).to have_http_status(:success)
 
-        expect(json[:invoice_payment_url][:payment_url]).to eq('https://example.com')
+        expect(json[:invoice_payment_details][:payment_url]).to eq('https://example.com')
       end
     end
   end

--- a/spec/requests/api/v1/invoices_spec.rb
+++ b/spec/requests/api/v1/invoices_spec.rb
@@ -563,7 +563,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
       aggregate_failures do
         expect(response).to have_http_status(:success)
 
-        expect(json[:invoice][:payment_url]).to eq('https://example.com')
+        expect(json[:invoice_payment_url][:payment_url]).to eq('https://example.com')
       end
     end
   end

--- a/spec/serializers/v1/payment_providers/invoice_payment_serializer_spec.rb
+++ b/spec/serializers/v1/payment_providers/invoice_payment_serializer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::PaymentProviders::InvoicePaymentSerializer do
+  subject(:serializer) { described_class.new(invoice, options) }
+
+  let(:invoice) { create(:invoice) }
+  let(:options) do
+    { 'payment_url' => 'https://example.com' }.with_indifferent_access
+  end
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['data']['lago_customer_id']).to eq(invoice.customer.id)
+      expect(result['data']['external_customer_id']).to eq(invoice.customer.external_id)
+      expect(result['data']['payment_provider']).to eq(invoice.customer.payment_provider)
+      expect(result['data']['lago_invoice_id']).to eq(invoice.id)
+      expect(result['data']['payment_url']).to eq('https://example.com')
+    end
+  end
+end

--- a/spec/services/invoices/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/invoices/payments/generate_payment_url_service_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::Payments::GeneratePaymentUrlService, type: :service do
+  subject(:generate_payment_url_service) { described_class.new(invoice:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:, payment_provider:, payment_provider_code: code) }
+  let(:invoice) { create(:invoice, customer:) }
+  let(:payment_provider) { 'stripe' }
+  let(:code) { 'stripe_1' }
+
+  describe '.call' do
+    let(:stripe_provider) { create(:stripe_provider, organization:, code:) }
+
+    context 'when payment provider is linked' do
+      before do
+        create(
+          :stripe_customer,
+          customer_id: customer.id,
+          payment_provider: stripe_provider,
+        )
+
+        customer.update(payment_provider: 'stripe')
+
+        allow(Stripe::Checkout::Session).to receive(:create)
+          .and_return({ 'url' => 'https://example55.com' })
+      end
+
+      it 'returns the generated payment url' do
+        result = generate_payment_url_service.call
+
+        expect(result.payment_url).to eq('https://example55.com')
+      end
+    end
+
+    context 'when invoice is blank' do
+      it 'returns an error' do
+        result = described_class.new(invoice: nil).call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.message).to eq('invoice_not_found')
+        end
+      end
+    end
+
+    context 'when payment provider is blank' do
+      let(:payment_provider) { nil }
+
+      it 'returns an error' do
+        result = generate_payment_url_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(['no_linked_payment_provider'])
+        end
+      end
+    end
+
+    context 'when payment provider is gocardless' do
+      let(:payment_provider) { 'gocardless' }
+
+      it 'returns an error' do
+        result = generate_payment_url_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(['invalid_payment_provider'])
+        end
+      end
+    end
+
+    context 'when invoice payment status is invalid' do
+      before { invoice.succeeded! }
+
+      it 'returns an error' do
+        result = generate_payment_url_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:base]).to eq(['invalid_invoice_status_or_payment_status'])
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/payments/payment_providers/factory_spec.rb
+++ b/spec/services/invoices/payments/payment_providers/factory_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::Payments::PaymentProviders::Factory, type: :service do
+  subject(:factory_service) { described_class.new_instance(invoice:) }
+
+  let(:payment_provider) { 'stripe' }
+  let(:invoice) { create(:invoice, customer:) }
+  let(:customer) { create(:customer, payment_provider:) }
+
+  describe '#self.new_instance' do
+    context 'when stripe' do
+      it  'returns correct class' do
+        expect(factory_service.class.to_s).to eq('Invoices::Payments::StripeService')
+      end
+    end
+
+    context 'when adyen' do
+      let(:payment_provider) { 'adyen' }
+
+      it  'returns correct class' do
+        expect(factory_service.class.to_s).to eq('Invoices::Payments::AdyenService')
+      end
+    end
+
+    context 'when gocardless' do
+      let(:payment_provider) { 'gocardless' }
+
+      it  'returns correct class' do
+        expect(factory_service.class.to_s).to eq('Invoices::Payments::GocardlessService')
+      end
+    end
+  end
+end

--- a/spec/services/invoices/payments/payment_providers/factory_spec.rb
+++ b/spec/services/invoices/payments/payment_providers/factory_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Invoices::Payments::PaymentProviders::Factory, type: :service do
 
   describe '#self.new_instance' do
     context 'when stripe' do
-      it  'returns correct class' do
+      it 'returns correct class' do
         expect(factory_service.class.to_s).to eq('Invoices::Payments::StripeService')
       end
     end
@@ -19,7 +19,7 @@ RSpec.describe Invoices::Payments::PaymentProviders::Factory, type: :service do
     context 'when adyen' do
       let(:payment_provider) { 'adyen' }
 
-      it  'returns correct class' do
+      it 'returns correct class' do
         expect(factory_service.class.to_s).to eq('Invoices::Payments::AdyenService')
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Invoices::Payments::PaymentProviders::Factory, type: :service do
     context 'when gocardless' do
       let(:payment_provider) { 'gocardless' }
 
-      it  'returns correct class' do
+      it 'returns correct class' do
         expect(factory_service.class.to_s).to eq('Invoices::Payments::GocardlessService')
       end
     end


### PR DESCRIPTION
## Context

Some customers don’t have payment methods that accept recurring payments (ie: card payments in India) and currently it is not possible to fetch one-time payment link when invoice payment status is failed.

## Description

This PR adds base setup for creating one-time payment link. Actual integration logic was already implemented in another PR.