### PR TITLE
feat(grouped-by): Add grouped count aggregation

### DIFF
--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -3,12 +3,35 @@
 module BillableMetrics
   module Aggregations
     class CountService < BillableMetrics::Aggregations::BaseService
-      def aggregate(options: {})
+      def compute_aggregation(options: {})
         result.aggregation = event_store.count
         result.current_usage_units = result.aggregation
         result.count = result.aggregation
         result.pay_in_advance_aggregation = BigDecimal(1)
         result.options = { running_total: running_total(options) }
+        result
+      end
+
+      # NOTE: Apply the grouped_by filter to the aggregation
+      #       Result will have an aggregations attribute
+      #       containing the aggregation result of each group.
+      #
+      #       This logic is only applicable for in arrears aggregation
+      #       (exept for the current_usage update)
+      #       as pay in advance aggregation will be computed on a single group
+      #       with the grouped_by_values filter
+      def compute_grouped_by_aggregation(*)
+        aggregations = event_store.grouped_count
+
+        result.aggregations = aggregations.map do |aggregation|
+          group_result = BaseService::Result.new
+          group_result.grouped_by = aggregation[:groups]
+          group_result.aggregation = aggregation[:value]
+          group_result.count = aggregation[:value]
+          group_result.current_usage_units = aggregation[:value]
+          group_result
+        end
+
         result
       end
 
@@ -25,6 +48,12 @@ module BillableMetrics
 
       def compute_per_event_aggregation
         (0...event_store.count).map { |_| 1 }
+      end
+
+      protected
+
+      def support_grouped_aggregation?
+        true
       end
     end
   end


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR adapt the grouped logic to the count aggregation