### PR TITLE
feat(grouped-by): Add grouped prorated sum logic

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -92,13 +92,6 @@ module BillableMetrics
         target_result.current_usage_units = 0 if target_result.current_usage_units.negative?
       end
 
-      def get_cached_aggregation_in_interval(from_datetime:, to_datetime:)
-        @from_datetime = from_datetime
-        @to_datetime = to_datetime
-
-        find_cached_aggregation
-      end
-
       def support_grouped_aggregation?
         false
       end

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -124,8 +124,6 @@ module BillableMetrics
         event_store.events_values(force_from: true)
       end
 
-      protected
-
       def support_grouped_aggregation?
         true
       end
@@ -133,13 +131,13 @@ module BillableMetrics
       # This method fetches the latest cached aggregation in current period. If such a record exists we know that
       # previous aggregation and previous maximum aggregation are stored there. Fetching these values
       # would help us in pay in advance value calculation without iterating through all events in current period
-      def find_cached_aggregation(grouped_by: nil)
+      def find_cached_aggregation(with_from_datetime: from_datetime, with_to_datetime: to_datetime, grouped_by: nil)
         query = CachedAggregation
           .where(organization_id: billable_metric.organization_id)
           .where(external_subscription_id: subscription.external_id)
           .where(charge_id: charge.id)
-          .from_datetime(from_datetime)
-          .to_datetime(to_datetime)
+          .from_datetime(with_from_datetime)
+          .to_datetime(with_to_datetime)
           .order(timestamp: :desc)
 
         if grouped_by.present?

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -73,20 +73,18 @@ module BillableMetrics
         (0...added_query.count).map { |_| 1 }
       end
 
-      protected
-
       # This method fetches the latest cached aggregation in current period. If such a record exists we know that
       # previous aggregation and previous maximum aggregation are stored there. Fetching these values
       # would help us in pay in advance value calculation without iterating through all events in current period
-      def find_cached_aggregation(*)
+      def find_cached_aggregation(with_from_datetime: from_datetime, with_to_datetime: to_datetime, **)
         return @cached_aggregation if @cached_aggregation
 
         query = CachedAggregation
           .where(organization_id: billable_metric.organization_id)
           .where(external_subscription_id: subscription.external_id)
           .where(charge_id: charge.id)
-          .from_datetime(from_datetime)
-          .to_datetime(to_datetime)
+          .from_datetime(with_from_datetime)
+          .to_datetime(with_to_datetime)
           .order(timestamp: :desc)
 
         query = query
@@ -116,6 +114,8 @@ module BillableMetrics
 
         @cached_aggregation = query.first
       end
+
+      protected
 
       def operation_type
         @operation_type ||= event.properties.fetch('operation_type', 'add')&.to_sym

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -8,7 +8,10 @@ module BillableMetrics
       end
 
       def cached_aggregation
-        @cached_aggregation ||= base_aggregator.get_cached_aggregation_in_interval(from_datetime:, to_datetime:)
+        @cached_aggregation ||= base_aggregator.find_cached_aggregation(
+          with_from_datetime: from_datetime,
+          with_to_datetime: to_datetime,
+        )
       end
 
       def compute_pay_in_advance_aggregation
@@ -58,30 +61,39 @@ module BillableMetrics
       # In current usage section two main values are presented, number of units in period and amount.
       # Proration affects only amount (calculated from aggregation) and number of units shows full number of units
       # (calculated from current_usage_units).
-      def handle_current_usage(result_with_proration, is_pay_in_advance)
+      def handle_current_usage(
+        result_with_proration, is_pay_in_advance, target_result: result,
+        aggregation_without_proration: nil
+      )
+        aggregation_without_proration ||= self.aggregation_without_proration
         value_without_proration = aggregation_without_proration.aggregation
+        cached_aggregation = base_aggregator.find_cached_aggregation(
+          with_from_datetime: from_datetime,
+          with_to_datetime: to_datetime,
+          grouped_by: target_result.grouped_by,
+        )
 
         if !is_pay_in_advance
-          result.aggregation = result_with_proration.negative? ? 0 : result_with_proration
-          result.current_usage_units = value_without_proration.negative? ? 0 : value_without_proration
+          target_result.aggregation = result_with_proration.negative? ? 0 : result_with_proration
+          target_result.current_usage_units = value_without_proration.negative? ? 0 : value_without_proration
         elsif cached_aggregation && persisted_pro_rata < 1
-          result.current_usage_units = aggregation_without_proration.current_usage_units
+          target_result.current_usage_units = aggregation_without_proration.current_usage_units
 
           persisted_units_without_proration = aggregation_without_proration.current_usage_units -
                                               BigDecimal(cached_aggregation.current_aggregation)
-          result.aggregation = (persisted_units_without_proration * persisted_pro_rata).ceil(5) +
-                               BigDecimal(cached_aggregation.max_aggregation_with_proration)
+          target_result.aggregation = (persisted_units_without_proration * persisted_pro_rata).ceil(5) +
+                                      BigDecimal(cached_aggregation.max_aggregation_with_proration)
         elsif cached_aggregation
-          result.current_usage_units = aggregation_without_proration.current_usage_units
-          result.aggregation = aggregation_without_proration.current_usage_units -
-                               BigDecimal(cached_aggregation.current_aggregation) +
-                               BigDecimal(cached_aggregation.max_aggregation_with_proration)
+          target_result.current_usage_units = aggregation_without_proration.current_usage_units
+          target_result.aggregation = aggregation_without_proration.current_usage_units -
+                                      BigDecimal(cached_aggregation.current_aggregation) +
+                                      BigDecimal(cached_aggregation.max_aggregation_with_proration)
         elsif persisted_pro_rata < 1
-          result.aggregation = result_with_proration.negative? ? 0 : result_with_proration
-          result.current_usage_units = aggregation_without_proration.current_usage_units
+          target_result.aggregation = result_with_proration.negative? ? 0 : result_with_proration
+          target_result.current_usage_units = aggregation_without_proration.current_usage_units
         else
-          result.aggregation = value_without_proration
-          result.current_usage_units = aggregation_without_proration.current_usage_units
+          target_result.aggregation = value_without_proration
+          target_result.current_usage_units = aggregation_without_proration.current_usage_units
         end
       end
 

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -12,13 +12,13 @@ module BillableMetrics
         event_store.aggregation_property = billable_metric.field_name
       end
 
-      def aggregate(options: {})
+      def compute_aggregation(options: {})
         @options = options
 
         # For charges that are pay in advance on billing date we always bill full amount
         return aggregation_without_proration if event.nil? && options[:is_pay_in_advance] && !options[:is_current_usage]
 
-        aggregation = compute_aggregation.ceil(5)
+        aggregation = compute_event_aggregation.ceil(5)
         result.full_units_number = aggregation_without_proration.aggregation if event.nil?
 
         if options[:is_current_usage]
@@ -30,6 +30,44 @@ module BillableMetrics
         result.pay_in_advance_aggregation = compute_pay_in_advance_aggregation
         result.count = aggregation_without_proration.count
         result.options = options
+        result
+      rescue ActiveRecord::StatementInvalid => e
+        result.service_failure!(code: 'aggregation_failure', message: e.message)
+      end
+
+      # NOTE: Apply the grouped_by filter to the aggregation
+      #       Result will have an aggregations attribute
+      #       containing the aggregation result of each group.
+      #
+      #       This logic is only applicable for in arrears aggregation
+      #       (exept for the current_usage update)
+      #       as pay in advance aggregation will be computed on a single group
+      #       with the grouped_by_values filter
+      def compute_grouped_by_aggregation(options: {})
+        @options = options
+
+        # For charges that are pay in advance on billing date we always bill full amount
+        return aggregation_without_proration if event.nil? && options[:is_pay_in_advance] && !options[:is_current_usage]
+
+        aggregations = compute_grouped_event_aggregation
+
+        result.aggregations = aggregations.map do |aggregation|
+          # TODO: in_advance and current_usage
+
+          group_result = BaseService::Result.new
+          group_result.grouped_by = aggregation[:groups]
+          group_result.aggregation = aggregation[:value].ceil(5)
+
+          group_result_without_proration = aggregation_without_proration.aggregations.find do |agg|
+            agg.grouped_by == aggregation[:groups]
+          end
+          group_result.full_units_number = group_result_without_proration&.aggregation || 0
+          group_result.count = group_result_without_proration&.count || 0
+          group_result.options = options
+
+          group_result
+        end
+
         result
       rescue ActiveRecord::StatementInvalid => e
         result.service_failure!(code: 'aggregation_failure', message: e.message)
@@ -52,17 +90,11 @@ module BillableMetrics
 
       protected
 
-      def compute_aggregation
-        result = 0.0
-
-        # NOTE: Billed on the full period
-        result += persisted_sum || 0
-
-        # NOTE: Added during the period
-        result + (event_store.prorated_sum(period_duration:) || 0)
+      def support_grouped_aggregation?
+        true
       end
 
-      def persisted_sum
+      def persisted_event_store_instante
         event_store = event_store_class.new(
           code: billable_metric.code,
           subscription:,
@@ -73,8 +105,21 @@ module BillableMetrics
         event_store.use_from_boundary = false
         event_store.aggregation_property = billable_metric.field_name
         event_store.numeric_property = true
+        event_store
+      end
 
-        event_store.prorated_sum(
+      def compute_event_aggregation
+        result = 0.0
+
+        # NOTE: Billed on the full period
+        result += persisted_sum || 0
+
+        # NOTE: Added during the period
+        result + (event_store.prorated_sum(period_duration:) || 0)
+      end
+
+      def persisted_sum
+        persisted_event_store_instante.prorated_sum(
           period_duration:,
           persisted_duration: Utils::DatetimeService.date_diff_with_timezone(
             from_datetime,
@@ -88,20 +133,41 @@ module BillableMetrics
         previous_charge_fee_units = previous_charge_fee&.units
         return previous_charge_fee_units if previous_charge_fee_units
 
-        event_store = event_store_class.new(
-          code: billable_metric.code,
-          subscription:,
-          boundaries: { to_datetime: from_datetime },
-          filters:,
-        )
-
-        event_store.use_from_boundary = false
-        event_store.aggregation_property = billable_metric.field_name
-        event_store.numeric_property = true
-
-        recurring_value_before_first_fee = event_store.sum
+        recurring_value_before_first_fee = persisted_event_store_instante.sum
 
         ((recurring_value_before_first_fee || 0) <= 0) ? nil : recurring_value_before_first_fee
+      end
+
+      def compute_grouped_event_aggregation
+        result = grouped_persisted_sums
+        current_results = event_store.grouped_prorated_sum(period_duration:)
+
+        current_results.each do |group_result|
+          group = group_result[:groups]
+
+          if (persisted_group = result.find { |r| r[:groups] == group })
+            # NOTE: A persisted value already exists for this group
+            #       We just append the value to the persisted one
+            persisted_group[:value] += group_result[:value]
+            next
+          end
+
+          # NOTE: Add the new group to the result
+          result << group_result
+        end
+
+        result
+      end
+
+      def grouped_persisted_sums
+        persisted_event_store_instante.grouped_prorated_sum(
+          period_duration:,
+          persisted_duration: Utils::DatetimeService.date_diff_with_timezone(
+            from_datetime,
+            to_datetime,
+            subscription.customer.applicable_timezone,
+          ),
+        )
       end
     end
   end

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -583,5 +583,195 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
         expect(aggregation.grouped_by['agent_name']).to eq(agent_names[index])
       end
     end
+
+    context 'when current usage' do
+      let(:options) { { is_pay_in_advance:, is_current_usage: true } }
+      let(:is_pay_in_advance) { false }
+      let(:grouped_by) { ['agent_name'] }
+      let(:agent_names) { %w[aragorn] }
+
+      let(:old_events) do
+        agent_names.map do |agent_name|
+          create_list(
+            :event,
+            2,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: subscription.started_at + 3.months,
+            properties: {
+              total_count: 2.5,
+              agent_name:,
+            },
+          )
+        end.flatten
+      end
+
+      let(:latest_events) do
+        agent_names.map do |agent_name|
+          create_list(
+            :event,
+            2,
+            code: billable_metric.code,
+            customer:,
+            subscription:,
+            timestamp: from_datetime + 25.days,
+            properties: {
+              total_count: 12,
+              agent_name:,
+            },
+          )
+        end.flatten
+      end
+
+      context 'when charge is pay in arrear' do
+        it 'returns period maximum as aggregation' do
+          result = sum_service.aggregate(options:)
+
+          expect(result.aggregations.count).to eq(1)
+
+          result.aggregations.sort_by { |a| a.grouped_by['agent_name'] }.each_with_index do |aggregation, index|
+            expect(aggregation.aggregation).to eq(9.64517) # 5 + (12*6/31) + (12*6/31)
+            expect(aggregation.count).to eq(4)
+            expect(aggregation.current_usage_units).to eq(29)
+            expect(aggregation.grouped_by['agent_name']).to eq(agent_names[index])
+          end
+        end
+      end
+
+      context 'when charge is pay in advance' do
+        let(:is_pay_in_advance) { true }
+
+        let(:latest_events) do
+          agent_names.map do |agent_name|
+            create(
+              :event,
+              code: billable_metric.code,
+              customer:,
+              subscription:,
+              timestamp: to_datetime - 3.days,
+              properties: {
+                total_count: 4,
+                agent_name:,
+              },
+            )
+          end.flatten
+        end
+
+        let(:cached_aggregation) do
+          create(
+            :cached_aggregation,
+            organization: billable_metric.organization,
+            charge:,
+            external_subscription_id: subscription.external_id,
+            event_id: latest_events.first.id,
+            timestamp: latest_events.first.timestamp,
+            current_aggregation: '4',
+            max_aggregation: '6',
+            max_aggregation_with_proration: '3.8',
+            grouped_by: { 'agent_name' => agent_names.first },
+          )
+        end
+
+        before { cached_aggregation }
+
+        it 'returns period maximum as aggregation' do
+          result = sum_service.aggregate(options:)
+
+          expect(result.aggregations.count).to eq(1)
+
+          result.aggregations.sort_by { |a| a.grouped_by['agent_name'] }.each_with_index do |aggregation, index|
+            expect(aggregation.aggregation).to eq(8.8)
+            expect(aggregation.current_usage_units).to eq(9)
+            expect(aggregation.grouped_by['agent_name']).to eq(agent_names[index])
+          end
+        end
+
+        context 'when cached aggregation does not exist' do
+          let(:latest_events) { nil }
+          let(:cached_aggregation) { nil }
+
+          it 'returns zero as aggregation' do
+            result = sum_service.aggregate(options:)
+
+            expect(result.aggregations.count).to eq(1)
+
+            result.aggregations.sort_by { |a| a.grouped_by['agent_name'] }.each_with_index do |aggregation, index|
+              expect(aggregation.aggregation).to eq(5)
+              expect(aggregation.current_usage_units).to eq(5)
+              expect(aggregation.grouped_by['agent_name']).to eq(agent_names[index])
+            end
+          end
+        end
+      end
+
+      context 'when  charge is pay in advance and just upgraded' do
+        let(:from_datetime) { Time.zone.parse('2023-05-15 00:00:00') }
+        let(:is_pay_in_advance) { true }
+        let(:latest_events) { nil }
+
+        it 'returns correct values' do
+          result = sum_service.aggregate(options:)
+
+          expect(result.aggregations.count).to eq(1)
+
+          result.aggregations.sort_by { |a| a.grouped_by['agent_name'] }.each_with_index do |aggregation, index|
+            expect(aggregation.aggregation).to eq((5 * 17.fdiv(31)).ceil(5))
+            expect(aggregation.current_usage_units).to eq(5)
+            expect(aggregation.grouped_by['agent_name']).to eq(agent_names[index])
+          end
+        end
+      end
+
+      context 'when charge is pay in advance and just upgraded and new event in period' do
+        let(:from_datetime) { Time.zone.parse('2023-05-15 00:00:00') }
+        let(:is_pay_in_advance) { true }
+
+        let(:latest_events) do
+          agent_names.map do |agent_name|
+            create(
+              :event,
+              code: billable_metric.code,
+              customer:,
+              subscription:,
+              timestamp: to_datetime - 10.days,
+              properties: {
+                total_count: 4,
+                agent_name:,
+              },
+            )
+          end.flatten
+        end
+
+        let(:cached_aggregation) do
+          create(
+            :cached_aggregation,
+            organization: billable_metric.organization,
+            charge:,
+            external_subscription_id: subscription.external_id,
+            event_id: latest_events.first.id,
+            timestamp: latest_events.first.timestamp,
+            current_aggregation: '4',
+            max_aggregation: '6',
+            max_aggregation_with_proration: '3.8',
+            grouped_by: { 'agent_name' => agent_names.first },
+          )
+        end
+
+        before { cached_aggregation }
+
+        it 'returns correct values' do
+          result = sum_service.aggregate(options:)
+
+          expect(result.aggregations.count).to eq(1)
+
+          result.aggregations.sort_by { |a| a.grouped_by['agent_name'] }.each_with_index do |aggregation, index|
+            expect(aggregation.aggregation).to eq((5 * 17.fdiv(31)).ceil(5) + 3.8)
+            expect(aggregation.current_usage_units).to eq(9)
+            expect(aggregation.grouped_by['agent_name']).to eq(agent_names[index])
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -366,6 +366,72 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     end
   end
 
+  describe '.grouped_prorated_sum' do
+    let(:grouped_by) { %w[cloud] }
+
+    it 'returns the prorated sum of event properties' do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+
+      result = event_store.grouped_prorated_sum(period_duration: 31)
+
+      expect(result.count).to eq(4)
+
+      null_group = result.find { |v| v[:groups]['cloud'].nil? }
+      expect(null_group[:groups]['cloud']).to be_nil
+      expect(null_group[:value].round(5)).to eq(2.64516)
+
+      (result - [null_group]).each do |row|
+        expect(row[:groups]['cloud']).not_to be_nil
+        expect(row[:value]).not_to be_nil
+      end
+    end
+
+    context 'with persisted_duration' do
+      it 'returns the prorated sum of event properties' do
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
+
+        result = event_store.grouped_prorated_sum(period_duration: 31, persisted_duration: 10)
+
+        expect(result.count).to eq(4)
+
+        null_group = result.find { |v| v[:groups]['cloud'].nil? }
+        expect(null_group[:groups]['cloud']).to be_nil
+        expect(null_group[:value].round(5)).to eq(1.93548)
+
+        (result - [null_group]).each do |row|
+          expect(row[:groups]['cloud']).not_to be_nil
+          expect(row[:value]).not_to be_nil
+        end
+      end
+    end
+
+    context 'with multiple groups' do
+      let(:grouped_by) { %w[cloud region] }
+
+      it 'returns the sum of values grouped by the provided groups' do
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
+
+        result = event_store.grouped_prorated_sum(period_duration: 31)
+
+        expect(result.count).to eq(4)
+
+        null_group = result.find { |v| v[:groups]['cloud'].nil? }
+        expect(null_group[:groups]['cloud']).to be_nil
+        expect(null_group[:groups]['region']).to be_nil
+        expect(null_group[:value].round(5)).to eq(2.64516)
+
+        (result - [null_group]).each do |row|
+          expect(row[:groups]['cloud']).not_to be_nil
+          expect(row[:groups]['region']).not_to be_nil
+          expect(row[:value]).not_to be_nil
+        end
+      end
+    end
+  end
+
   describe '.sum_date_breakdown' do
     it 'returns the sum grouped by day' do
       event_store.aggregation_property = billable_metric.field_name


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR adds the prorated grouped sum computation logic in the event stores
