### PR TITLE
feat(minimum-spending): Add graphql commitment type

### DIFF
--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -22,6 +22,7 @@ module Mutations
       argument :trial_period, Float, required: false
 
       argument :charges, [Types::Charges::Input]
+      argument :minimum_commitment, Types::Commitments::Input, required: false
 
       type Types::Plans::Object
 

--- a/app/graphql/mutations/plans/update.rb
+++ b/app/graphql/mutations/plans/update.rb
@@ -22,6 +22,7 @@ module Mutations
       argument :trial_period, Float, required: false
 
       argument :charges, [Types::Charges::Input]
+      argument :minimum_commitment, Types::Commitments::Input, required: false
 
       type Types::Plans::Object
 

--- a/app/graphql/types/commitments/commitment_type_enum.rb
+++ b/app/graphql/types/commitments/commitment_type_enum.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module Commitments
+    class CommitmentTypeEnum < Types::BaseEnum
+      Commitment::COMMITMENT_TYPES.keys.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/commitments/input.rb
+++ b/app/graphql/types/commitments/input.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module Commitments
+    class Input < Types::BaseInputObject
+      graphql_name 'CommitmentInput'
+
+      argument :amount_cents, GraphQL::Types::BigInt, required: false
+      argument :commitment_type, Types::Commitments::CommitmentTypeEnum, required: false
+      argument :id, ID, required: false
+      argument :invoice_display_name, String, required: false
+      argument :tax_codes, [String], required: false
+    end
+  end
+end

--- a/app/graphql/types/commitments/object.rb
+++ b/app/graphql/types/commitments/object.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  module Commitments
+    class Object < Types::BaseObject
+      graphql_name 'Commitment'
+
+      field :id, ID, null: false
+
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :commitment_type, Types::Commitments::CommitmentTypeEnum, null: false
+      field :invoice_display_name, String, null: true
+      field :plan, Types::Plans::Object, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      field :taxes, [Types::Taxes::Object], null: true
+    end
+  end
+end

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -15,6 +15,7 @@ module Types
       field :description, String
       field :interval, Types::Plans::IntervalEnum, null: false
       field :invoice_display_name, String
+      field :minimum_commitment, Types::Commitments::Object, null: true
       field :name, String, null: false
       field :parent, Types::Plans::Object, null: true
       field :pay_in_advance, Boolean, null: false

--- a/app/graphql/types/subscriptions/plan_overrides_input.rb
+++ b/app/graphql/types/subscriptions/plan_overrides_input.rb
@@ -8,6 +8,7 @@ module Types
       argument :charges, [Types::Subscriptions::ChargeOverridesInput], required: false
       argument :description, String, required: false
       argument :invoice_display_name, String, required: false
+      argument :minimum_commitment, Types::Commitments::Input, required: false
       argument :name, String, required: false
       argument :tax_codes, [String], required: false
       argument :trial_period, Float, required: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -265,6 +265,29 @@ type CollectionMetadata {
   totalPages: Int!
 }
 
+type Commitment {
+  amountCents: BigInt!
+  commitmentType: CommitmentTypeEnum!
+  createdAt: ISO8601DateTime!
+  id: ID!
+  invoiceDisplayName: String
+  plan: Plan!
+  taxes: [Tax!]
+  updatedAt: ISO8601DateTime!
+}
+
+input CommitmentInput {
+  amountCents: BigInt
+  commitmentType: CommitmentTypeEnum
+  id: ID
+  invoiceDisplayName: String
+  taxCodes: [String!]
+}
+
+enum CommitmentTypeEnum {
+  minimum_commitment
+}
+
 enum CountryCode {
   """
   Andorra
@@ -1810,6 +1833,7 @@ input CreatePlanInput {
   description: String
   interval: PlanInterval!
   invoiceDisplayName: String
+  minimumCommitment: CommitmentInput
   name: String!
   payInAdvance: Boolean!
   taxCodes: [String!]
@@ -4272,6 +4296,7 @@ type Plan {
   id: ID!
   interval: PlanInterval!
   invoiceDisplayName: String
+  minimumCommitment: Commitment
   name: String!
   organization: Organization
   parent: Plan
@@ -4300,6 +4325,7 @@ input PlanOverridesInput {
   charges: [ChargeOverridesInput!]
   description: String
   invoiceDisplayName: String
+  minimumCommitment: CommitmentInput
   name: String
   taxCodes: [String!]
   trialPeriod: Float
@@ -5986,6 +6012,7 @@ input UpdatePlanInput {
   id: String!
   interval: PlanInterval!
   invoiceDisplayName: String
+  minimumCommitment: CommitmentInput
   name: String!
   payInAdvance: Boolean!
   taxCodes: [String!]

--- a/schema.json
+++ b/schema.json
@@ -2722,6 +2722,259 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Commitment",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "commitmentType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CommitmentTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "plan",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Plan",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "taxes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Tax",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CommitmentInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "commitmentType",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "CommitmentTypeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxCodes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "CommitmentTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "minimum_commitment",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
           "kind": "ENUM",
           "name": "CountryCode",
           "description": null,
@@ -6562,6 +6815,18 @@
                     }
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minimumCommitment",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "CommitmentInput",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -19448,6 +19713,20 @@
               ]
             },
             {
+              "name": "minimumCommitment",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Commitment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "name",
               "description": null,
               "type": {
@@ -19749,6 +20028,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minimumCommitment",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "CommitmentInput",
                 "ofType": null
               },
               "defaultValue": null,
@@ -27242,6 +27533,18 @@
                     }
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minimumCommitment",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "CommitmentInput",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization:) }
+  let(:minimum_commitment_invoice_display_name) { 'Minimum spending' }
+  let(:minimum_commitment_amount_cents) { 100 }
+  let(:commitment_tax) { create(:tax, organization:) }
   let(:mutation) do
     <<~GQL
       mutation($input: UpdatePlanInput!) {
@@ -18,6 +21,12 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
           payInAdvance,
           amountCents,
           amountCurrency,
+          minimumCommitment {
+            id,
+            amountCents,
+            invoiceDisplayName,
+            taxes { id code rate }
+          },
           charges {
             id,
             chargeModel,
@@ -57,11 +66,12 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
     create_list(:billable_metric, 5, organization:)
   end
 
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:) }
   let(:first_group) { create(:group, billable_metric: billable_metrics[1]) }
   let(:second_group) { create(:group, billable_metric: billable_metrics[2]) }
 
-  it 'updates a plan' do
-    result = execute_graphql(
+  let(:graphql) do
+    {
       current_user: membership.user,
       query: mutation,
       variables: {
@@ -74,6 +84,11 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
           payInAdvance: false,
           amountCents: '200',
           amountCurrency: 'EUR',
+          minimumCommitment: {
+            amountCents: minimum_commitment_amount_cents,
+            invoiceDisplayName: minimum_commitment_invoice_display_name,
+            taxCodes: [commitment_tax.code],
+          },
           charges: [
             {
               billableMetricId: billable_metrics[0].id,
@@ -152,47 +167,137 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
           ],
         },
       },
-    )
+    }
+  end
 
-    result_data = result['data']['updatePlan']
+  before { minimum_commitment }
 
-    aggregate_failures do
-      expect(result_data['id']).to be_present
-      expect(result_data['name']).to eq('Updated plan')
-      expect(result_data['invoiceDisplayName']).to eq('Updated plan invoice name')
-      expect(result_data['code']).to eq('new_plan')
-      expect(result_data['interval']).to eq('monthly')
-      expect(result_data['payInAdvance']).to eq(false)
-      expect(result_data['amountCents']).to eq('200')
-      expect(result_data['amountCurrency']).to eq('EUR')
-      expect(result_data['charges'].count).to eq(5)
+  context 'with premium license' do
+    around { |test| lago_premium!(&test) }
 
-      standard_charge = result_data['charges'][0]
-      expect(standard_charge['properties']['amount']).to eq('100.00')
-      expect(standard_charge['chargeModel']).to eq('standard')
+    it 'updates a plan' do
+      result = execute_graphql(**graphql)
 
-      package_charge = result_data['charges'][1]
-      expect(package_charge['chargeModel']).to eq('package')
-      group_properties = package_charge['groupProperties'][0]['values']
-      expect(group_properties['amount']).to eq('300.00')
-      expect(group_properties['freeUnits']).to eq('10')
-      expect(group_properties['packageSize']).to eq('10')
+      result_data = result['data']['updatePlan']
 
-      percentage_charge = result_data['charges'][2]
-      expect(percentage_charge['chargeModel']).to eq('percentage')
-      group_properties = percentage_charge['groupProperties'][0]['values']
-      expect(group_properties['rate']).to eq('0.25')
-      expect(group_properties['fixedAmount']).to eq('2')
-      expect(group_properties['freeUnitsPerEvents']).to eq('5')
-      expect(group_properties['freeUnitsPerTotalAggregation']).to eq('50')
+      aggregate_failures do
+        expect(result_data['id']).to be_present
+        expect(result_data['name']).to eq('Updated plan')
+        expect(result_data['invoiceDisplayName']).to eq('Updated plan invoice name')
+        expect(result_data['code']).to eq('new_plan')
+        expect(result_data['interval']).to eq('monthly')
+        expect(result_data['payInAdvance']).to eq(false)
+        expect(result_data['amountCents']).to eq('200')
+        expect(result_data['amountCurrency']).to eq('EUR')
+        expect(result_data['charges'].count).to eq(5)
 
-      graduated_charge = result_data['charges'][3]
-      expect(graduated_charge['chargeModel']).to eq('graduated')
-      expect(graduated_charge['properties']['graduatedRanges'].count).to eq(2)
+        standard_charge = result_data['charges'][0]
+        expect(standard_charge['properties']['amount']).to eq('100.00')
+        expect(standard_charge['chargeModel']).to eq('standard')
 
-      volume_charge = result_data['charges'][4]
-      expect(volume_charge['chargeModel']).to eq('volume')
-      expect(volume_charge['properties']['volumeRanges'].count).to eq(2)
+        package_charge = result_data['charges'][1]
+        expect(package_charge['chargeModel']).to eq('package')
+        group_properties = package_charge['groupProperties'][0]['values']
+        expect(group_properties['amount']).to eq('300.00')
+        expect(group_properties['freeUnits']).to eq('10')
+        expect(group_properties['packageSize']).to eq('10')
+
+        percentage_charge = result_data['charges'][2]
+        expect(percentage_charge['chargeModel']).to eq('percentage')
+        group_properties = percentage_charge['groupProperties'][0]['values']
+        expect(group_properties['rate']).to eq('0.25')
+        expect(group_properties['fixedAmount']).to eq('2')
+        expect(group_properties['freeUnitsPerEvents']).to eq('5')
+        expect(group_properties['freeUnitsPerTotalAggregation']).to eq('50')
+
+        graduated_charge = result_data['charges'][3]
+        expect(graduated_charge['chargeModel']).to eq('graduated')
+        expect(graduated_charge['properties']['graduatedRanges'].count).to eq(2)
+
+        volume_charge = result_data['charges'][4]
+        expect(volume_charge['chargeModel']).to eq('volume')
+        expect(volume_charge['properties']['volumeRanges'].count).to eq(2)
+
+        expect(result_data['minimumCommitment']).to include(
+          'invoiceDisplayName' => minimum_commitment_invoice_display_name,
+          'amountCents' => minimum_commitment_amount_cents.to_s,
+        )
+        expect(result_data['minimumCommitment']['taxes'].count).to eq(1)
+      end
+    end
+
+    it 'updates minimum commitment' do
+      result = execute_graphql(**graphql)
+
+      result_data = result['data']['updatePlan']
+
+      aggregate_failures do
+        expect(result_data['minimumCommitment']).to include(
+          'invoiceDisplayName' => minimum_commitment_invoice_display_name,
+          'amountCents' => minimum_commitment_amount_cents.to_s,
+        )
+        expect(result_data['minimumCommitment']['taxes'].count).to eq(1)
+      end
+    end
+  end
+
+  context 'without premium license' do
+    it 'updates a plan' do
+      result = execute_graphql(**graphql)
+
+      result_data = result['data']['updatePlan']
+
+      aggregate_failures do
+        expect(result_data['id']).to be_present
+        expect(result_data['name']).to eq('Updated plan')
+        expect(result_data['invoiceDisplayName']).to eq('Updated plan invoice name')
+        expect(result_data['code']).to eq('new_plan')
+        expect(result_data['interval']).to eq('monthly')
+        expect(result_data['payInAdvance']).to eq(false)
+        expect(result_data['amountCents']).to eq('200')
+        expect(result_data['amountCurrency']).to eq('EUR')
+        expect(result_data['charges'].count).to eq(5)
+
+        standard_charge = result_data['charges'][0]
+        expect(standard_charge['properties']['amount']).to eq('100.00')
+        expect(standard_charge['chargeModel']).to eq('standard')
+
+        package_charge = result_data['charges'][1]
+        expect(package_charge['chargeModel']).to eq('package')
+        group_properties = package_charge['groupProperties'][0]['values']
+        expect(group_properties['amount']).to eq('300.00')
+        expect(group_properties['freeUnits']).to eq('10')
+        expect(group_properties['packageSize']).to eq('10')
+
+        percentage_charge = result_data['charges'][2]
+        expect(percentage_charge['chargeModel']).to eq('percentage')
+        group_properties = percentage_charge['groupProperties'][0]['values']
+        expect(group_properties['rate']).to eq('0.25')
+        expect(group_properties['fixedAmount']).to eq('2')
+        expect(group_properties['freeUnitsPerEvents']).to eq('5')
+        expect(group_properties['freeUnitsPerTotalAggregation']).to eq('50')
+
+        graduated_charge = result_data['charges'][3]
+        expect(graduated_charge['chargeModel']).to eq('graduated')
+        expect(graduated_charge['properties']['graduatedRanges'].count).to eq(2)
+
+        volume_charge = result_data['charges'][4]
+        expect(volume_charge['chargeModel']).to eq('volume')
+        expect(volume_charge['properties']['volumeRanges'].count).to eq(2)
+      end
+    end
+
+    it 'does not update minimum commitment' do
+      result = execute_graphql(**graphql)
+
+      result_data = result['data']['updatePlan']
+
+      aggregate_failures do
+        expect(result_data['minimumCommitment']).to include(
+          'invoiceDisplayName' => minimum_commitment.invoice_display_name,
+          'amountCents' => minimum_commitment.amount_cents.to_s,
+        )
+      end
     end
   end
 

--- a/spec/graphql/resolvers/plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_resolver_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
               deletedAt
             }
           }
+          minimumCommitment {
+            id
+            amountCents
+            invoiceDisplayName
+            taxes { id rate }
+          }
         }
       }
     GQL
@@ -61,11 +67,13 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
 
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, billable_metric:, plan:) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:) }
 
   before do
     customer
     group_property
     create_list(:subscription, 2, customer:, plan:)
+    minimum_commitment
   end
 
   it 'returns a single plan' do
@@ -82,6 +90,12 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
       expect(plan_response['id']).to eq(plan.id)
       expect(plan_response['subscriptionsCount']).to eq(2)
       expect(plan_response['customersCount']).to eq(1)
+      expect(plan_response['minimumCommitment']).to include(
+        'id' => minimum_commitment.id,
+        'amountCents' => minimum_commitment.amount_cents.to_s,
+        'invoiceDisplayName' => minimum_commitment.invoice_display_name,
+        'taxes' => [],
+      )
     end
   end
 

--- a/spec/graphql/types/commitments/input_spec.rb
+++ b/spec/graphql/types/commitments/input_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Commitments::Input do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:id).of_type('ID') }
+  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
+  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt') }
+  it { is_expected.to accept_argument(:commitment_type).of_type('CommitmentTypeEnum') }
+  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
+end

--- a/spec/graphql/types/commitments/object_spec.rb
+++ b/spec/graphql/types/commitments/object_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Commitments::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type('ID!') }
+  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:commitment_type).of_type('CommitmentTypeEnum!') }
+  it { is_expected.to have_field(:invoice_display_name).of_type('String') }
+  it { is_expected.to have_field(:plan).of_type('Plan!') }
+  it { is_expected.to have_field(:taxes).of_type('[Tax!]') }
+  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+end

--- a/spec/graphql/types/plans/object_spec.rb
+++ b/spec/graphql/types/plans/object_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Types::Plans::Object do
   it { is_expected.to have_field(:description).of_type('String') }
   it { is_expected.to have_field(:interval).of_type('PlanInterval!') }
   it { is_expected.to have_field(:invoice_display_name).of_type('String') }
+  it { is_expected.to have_field(:minimum_commitment).of_type('Commitment') }
   it { is_expected.to have_field(:name).of_type('String!') }
   it { is_expected.to have_field(:parent).of_type('Plan') }
   it { is_expected.to have_field(:pay_in_advance).of_type('Boolean!') }

--- a/spec/graphql/types/subscriptions/plan_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/plan_overrides_input_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Subscriptions::PlanOverridesInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt') }
+  it { is_expected.to accept_argument(:amount_currency).of_type('CurrencyEnum') }
+  it { is_expected.to accept_argument(:charges).of_type('[ChargeOverridesInput!]') }
+  it { is_expected.to accept_argument(:description).of_type('String') }
+  it { is_expected.to accept_argument(:minimum_commitment).of_type('CommitmentInput') }
+  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
+  it { is_expected.to accept_argument(:name).of_type('String') }
+  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
+  it { is_expected.to accept_argument(:trial_period).of_type('Float') }
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/set-minimum-spend-for-subscriptions

## Context

As a user, I want to define the minimum spend that applies to the customer's plan. Consider the following monthly plan:

- Subscription fee = $50 per month (in arrears);
- Usage-based charge = $10 per unit per month (in arrears); and
- Monthly minimum spend = $100.

If at the end of the month, the customer has consumed 3 units, their total invoice will be: $50 + 3 * $10 = $80 + $20 (true-up fee) = $100.

## Description

In this PR we're adding GraphQL resources for minimum commitment.