### PR TITLE
feat(payment-url): handle incoming webhooks

### DIFF
--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -129,7 +129,7 @@ module PaymentProviders
 
     def update_payment_status(event, payment_type)
       provider_payment_id = event['pspReference']
-      status = event['success'] == 'true' ? 'succeeded' : 'failed'
+      status = (event['success'] == 'true') ? 'succeeded' : 'failed'
       metadata = { payment_type:, lago_invoice_id: event.dig('additionalData', 'metadata.lago_invoice_id') }
 
       Invoices::Payments::AdyenService.new.update_payment_status(provider_payment_id:, status:, metadata:)

--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -83,7 +83,15 @@ module PaymentProviders
 
       case event['eventCode']
       when 'AUTHORISATION'
-        return result if event.dig('amount', 'value') != 0
+        amount = event.dig('amount', 'value')
+        payment_type = event.dig('additionalData', 'metadata.payment_type')
+
+        if payment_type == 'one-time'
+          update_result = update_payment_status(event, payment_type)
+          return update_result.raise_if_error! || update_result
+        end
+
+        return result if amount != 0
 
         service = PaymentProviderCustomers::AdyenService.new
 
@@ -115,6 +123,16 @@ module PaymentProviders
         .where(payment_provider_id: nil, customers: { organization_id: }).each do |c|
           c.update(payment_provider_id: adyen_provider.id)
         end
+    end
+
+    private
+
+    def update_payment_status(event, payment_type)
+      provider_payment_id = event['pspReference']
+      status = event['success'] == 'true' ? 'succeeded' : 'failed'
+      metadata = { payment_type:, lago_invoice_id: event.dig('additionalData', 'metadata.lago_invoice_id') }
+
+      Invoices::Payments::AdyenService.new.update_payment_status(provider_payment_id:, status:, metadata:)
     end
   end
 end

--- a/spec/fixtures/adyen/webhook_authorisation_payment_response.json
+++ b/spec/fixtures/adyen/webhook_authorisation_payment_response.json
@@ -1,0 +1,40 @@
+{
+  "live": "false",
+  "notificationItems": [
+    {
+      "NotificationRequestItem": {
+        "additionalData": {
+          "authCode": "051793",
+          "paymentLinkId": "PLF11278A8985273C2",
+          "metadata.payment_type": "one-time",
+          "cardSummary": "1142",
+          "metadata.invoice_type": "subscription",
+          "checkout.cardAddedBrand": "visa",
+          "metadata.invoice_issuing_date": "2024-01-24",
+          "expiryDate": "03/2030",
+          "metadata.lago_customer_id": "a5488a6c-d2ed-44fd-8c97-7fcca4a6a84a",
+          "threeds2.cardEnrolled": "false",
+          "recurringProcessingModel": "CardOnFile",
+          "metadata.lago_invoice_id": "ec82efeb-88bb-44f8-ba30-0d55b3fd583a"
+        },
+        "amount": {
+          "currency": "EUR",
+          "value": 71
+        },
+        "eventCode": "AUTHORISATION",
+        "eventDate": "2024-01-26T14:06:02+01:00",
+        "merchantAccountCode": "LagoAccountECOM",
+        "merchantReference": "HOO-3588-202401-033",
+        "operations": [
+          "CANCEL",
+          "CAPTURE",
+          "REFUND"
+        ],
+        "paymentMethod": "visa",
+        "pspReference": "SGVWRSNQLDQ2WN82",
+        "reason": "051793:1142:03/2030",
+        "success": "true"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Context

Currently we are not able to generate one-time payment url

## Description

This PR handles incoming webhooks where invoice status is changed according to the checkout status
