### PR TITLE
fix(event): Add missing organization scope to event stores

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -10,6 +10,7 @@ module Events
       #       and should be deduplicated depending on the aggregation logic
       def events(force_from: false)
         scope = ::Clickhouse::EventsRaw.where(external_subscription_id: subscription.external_id)
+          .where(organization_id: subscription.organization.id)
           .where(code:)
           .order(timestamp: :asc)
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -5,6 +5,7 @@ module Events
     class PostgresStore < BaseStore
       def events(force_from: false)
         scope = Event.where(external_subscription_id: subscription.external_id)
+          .where(organization_id: subscription.organization.id)
           .where(code:)
           .order(timestamp: :asc)
 

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -428,8 +428,18 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 17 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 17)) do
-        create(:event, external_subscription_id: subscription.external_id, code: metric.code)
-        create(:event, external_subscription_id: subscription.external_id, code: metric.code)
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          code: metric.code,
+        )
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          code: metric.code,
+        )
 
         expect {
           refresh_invoice(subscription_invoice)
@@ -512,7 +522,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 17 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 17)) do
-        create(:event, external_subscription_id: subscription.external_id, code: metric.code)
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          code: metric.code,
+        )
 
         expect {
           refresh_invoice(subscription_invoice)
@@ -593,7 +608,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 16 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 16)) do
-        create(:event, external_subscription_id: subscription.external_id, code: metric.code)
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          code: metric.code,
+        )
 
         # Paid in advance invoice amount does not change.
         expect {
@@ -603,7 +623,12 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
       ### 17 Dec: Create event + refresh.
       travel_to(DateTime.new(2022, 12, 17)) do
-        create(:event, external_subscription_id: subscription.external_id, code: metric.code)
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          code: metric.code,
+        )
 
         # Paid in advance invoice amount does not change.
         expect {
@@ -622,6 +647,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         # Create event for Dec 18.
         create(
           :event,
+          organization_id: organization.id,
           external_subscription_id: subscription.external_id,
           timestamp: DateTime.new(2022, 12, 18),
           code: metric.code,

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
     create_list(
       :event,
       4,
+      organization_id: organization.id,
       code: billable_metric.code,
       subscription:,
       customer:,
@@ -95,6 +96,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -108,6 +110,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
 
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -121,6 +124,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
 
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -167,6 +171,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       agent_names.map do |agent_name|
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -178,6 +183,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
       end + [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
       create_list(
         :event,
         4,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -60,6 +61,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
 
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -109,6 +111,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
       [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -132,6 +135,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
       [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -155,6 +159,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
       [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -180,6 +185,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
       [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -192,6 +198,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
 
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -204,6 +211,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
 
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -232,6 +240,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
       agent_names.map do |agent_name|
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -244,6 +253,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
       end + [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       create_list(
         :event,
         4,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -60,6 +61,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
 
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -109,6 +111,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -132,6 +135,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -159,6 +163,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -185,6 +190,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -197,6 +203,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
 
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -233,6 +240,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       agent_names.map do |agent_name|
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -245,6 +253,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
       end + [
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
     create_list(
       :event,
       2,
+      organization_id: organization.id,
       code: billable_metric.code,
       customer:,
       subscription:,
@@ -65,6 +66,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
     create_list(
       :event,
       4,
+      organization_id: organization.id,
       code: billable_metric.code,
       customer:,
       subscription:,
@@ -149,6 +151,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
       create_list(
         :event,
         4,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -186,6 +189,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
     before do
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -207,6 +211,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
     before do
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -236,6 +241,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
     let(:latest_events) do
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -292,6 +298,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
     before do
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -304,6 +311,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
 
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -316,6 +324,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
 
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -355,6 +364,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
       billable_metric.update!(recurring: true)
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription: old_subscription,
@@ -378,6 +388,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
     let(:pay_in_advance_event) do
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -398,6 +409,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
       let(:latest_events) do
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -434,6 +446,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
       let(:latest_events) do
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -516,6 +529,7 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
       agent_names.map do |agent_name|
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
 
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         subscription:,
         customer:,
@@ -181,6 +182,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
 
           create(
             :event,
+            organization_id: organization.id,
             code: billable_metric.code,
             subscription: previous_subscription,
             customer:,

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
     create_list(
       :event,
       2,
+      organization_id: organization.id,
       code: billable_metric.code,
       customer:,
       subscription:,
@@ -71,6 +72,7 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
   let(:latest_events) do
     create(
       :event,
+      organization_id: organization.id,
       code: billable_metric.code,
       customer:,
       subscription:,

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     create_list(
       :event,
       2,
+      organization_id: organization.id,
       code: billable_metric.code,
       customer:,
       subscription:,
@@ -64,6 +65,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     create_list(
       :event,
       2,
+      organization_id: organization.id,
       code: billable_metric.code,
       customer:,
       subscription:,
@@ -141,6 +143,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     before do
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -162,6 +165,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     before do
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -204,6 +208,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     let(:latest_events) do
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -274,6 +279,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     let(:latest_events) do
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -316,6 +322,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     before do
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -328,6 +335,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
 
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -340,6 +348,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
 
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -377,6 +386,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       subscription.update!(previous_subscription: old_subscription)
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription: old_subscription,
@@ -400,6 +410,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     let(:pay_in_advance_event) do
       create(
         :event,
+        organization_id: organization.id,
         code: billable_metric.code,
         customer:,
         subscription:,
@@ -420,6 +431,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       let(:latest_events) do
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -458,6 +470,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
       let(:latest_events) do
         create(
           :event,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -543,6 +556,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
         create_list(
           :event,
           2,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -560,6 +574,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
         create_list(
           :event,
           2,
+          organization_id: organization.id,
           code: billable_metric.code,
           customer:,
           subscription:,
@@ -595,6 +610,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
           create_list(
             :event,
             2,
+            organization_id: organization.id,
             code: billable_metric.code,
             customer:,
             subscription:,
@@ -612,6 +628,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
           create_list(
             :event,
             2,
+            organization_id: organization.id,
             code: billable_metric.code,
             customer:,
             subscription:,
@@ -646,6 +663,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
           agent_names.map do |agent_name|
             create(
               :event,
+              organization_id: organization.id,
               code: billable_metric.code,
               customer:,
               subscription:,
@@ -731,6 +749,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
           agent_names.map do |agent_name|
             create(
               :event,
+              organization_id: organization.id,
               code: billable_metric.code,
               customer:,
               subscription:,


### PR DESCRIPTION
## Context

Both `Events::Stores::Clickhouse` and `Events::Stores::Postgres` are missing a filter to the `organization_id`, leading to a risk of aggregating events from other organizations if the same subscription_id and billable metric code exsits in multiple organizations.

## Description

This PR mitigate this risk by ensuring we always filter events on the organization_id

