### PR TITLE
feat(minimum-spending): Calculate minimum commitment amount cents

### DIFF
--- a/app/services/commitments/calculate_amount_service.rb
+++ b/app/services/commitments/calculate_amount_service.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Commitments
+  class CalculateAmountService < BaseService
+    attr_reader :commitment, :invoice_subscription
+
+    delegate :subscription, to: :invoice_subscription
+
+    def initialize(commitment:, invoice_subscription:)
+      @commitment = commitment
+      @invoice_subscription = invoice_subscription
+
+      super
+    end
+
+    def call
+      result.commitment_amount_cents = commitment_amount_cents
+      result
+    end
+
+    private
+
+    def commitment_amount_cents
+      return 0 if !commitment || !invoice_subscription || commitment.amount_cents.zero?
+
+      if subscription.anniversary?
+        # no proration when subscription is anniversary
+        commitment.amount_cents
+      else
+        # prorate the commitment fee amount in case of calendar subscriptions
+        Money.from_cents(commitment.amount_cents * proration_coefficient, commitment.plan.amount_currency).cents
+      end
+    end
+
+    def proration_coefficient
+      days = Utils::DatetimeService.date_diff_with_timezone(
+        invoice_subscription.from_datetime,
+        invoice_subscription.to_datetime,
+        invoice_subscription.from_datetime.time_zone,
+      )
+
+      days_total = Utils::DatetimeService.period_total_length_in_days(
+        invoice_subscription.from_datetime,
+        invoice_subscription.to_datetime,
+        commitment.plan.interval,
+      )
+
+      days / days_total.to_f
+    end
+  end
+end

--- a/app/services/commitments/calculate_amount_service.rb
+++ b/app/services/commitments/calculate_amount_service.rb
@@ -2,10 +2,6 @@
 
 module Commitments
   class CalculateAmountService < BaseService
-    attr_reader :commitment, :invoice_subscription
-
-    delegate :subscription, to: :invoice_subscription
-
     def initialize(commitment:, invoice_subscription:)
       @commitment = commitment
       @invoice_subscription = invoice_subscription
@@ -20,16 +16,18 @@ module Commitments
 
     private
 
+    attr_reader :commitment, :invoice_subscription
+
+    delegate :subscription, to: :invoice_subscription
+
     def commitment_amount_cents
       return 0 if !commitment || !invoice_subscription || commitment.amount_cents.zero?
 
-      if subscription.anniversary?
-        # no proration when subscription is anniversary
-        commitment.amount_cents
-      else
-        # prorate the commitment fee amount in case of calendar subscriptions
-        Money.from_cents(commitment.amount_cents * proration_coefficient, commitment.plan.amount_currency).cents
-      end
+      # No proration when subscription is anniversary
+      return commitment.amount_cents if subscription.anniversary?
+
+      # Prorate the commitment fee amount in case of calendar subscriptions
+      Money.from_cents(commitment.amount_cents * proration_coefficient, commitment.plan.amount_currency).cents
     end
 
     def proration_coefficient

--- a/app/services/utils/datetime_service.rb
+++ b/app/services/utils/datetime_service.rb
@@ -19,5 +19,32 @@ module Utils
 
       (to - from - offset).fdiv(1.day).ceil
     end
+
+    def self.period_total_length_in_days(from_datetime, to_datetime, interval)
+      timezone = from_datetime.time_zone
+
+      case interval.to_sym
+      when :weekly
+        7
+      when :monthly
+        Utils::DatetimeService.date_diff_with_timezone(
+          from_datetime.beginning_of_month.in_time_zone,
+          to_datetime.end_of_month.in_time_zone,
+          timezone,
+        )
+      when :quarterly
+        Utils::DatetimeService.date_diff_with_timezone(
+          from_datetime.beginning_of_quarter.in_time_zone,
+          to_datetime.end_of_quarter.in_time_zone,
+          timezone,
+        )
+      when :yearly
+        Utils::DatetimeService.date_diff_with_timezone(
+          from_datetime.beginning_of_year.in_time_zone,
+          to_datetime.end_of_year.in_time_zone,
+          timezone,
+        )
+      end
+    end
   end
 end

--- a/spec/services/commitments/calculate_amount_service_spec.rb
+++ b/spec/services/commitments/calculate_amount_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Commitments::CalculateAmountService, type: :service do
     create(:invoice_subscription, subscription:, from_datetime:, to_datetime:)
   end
 
-  let(:subscription) { create(:active_subscription, customer:, plan:, billing_time:) }
+  let(:subscription) { create(:subscription, customer:, plan:, billing_time:) }
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }
   let(:plan) { create(:plan, organization:, interval:) }
@@ -226,7 +226,7 @@ RSpec.describe Commitments::CalculateAmountService, type: :service do
           it 'returns result' do
             result = apply_service.call
 
-            expect(result.commitment_amount_cents).to eq(192350)
+            expect(result.commitment_amount_cents).to eq(192_350)
           end
         end
       end

--- a/spec/services/commitments/calculate_amount_service_spec.rb
+++ b/spec/services/commitments/calculate_amount_service_spec.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Commitments::CalculateAmountService, type: :service do
+  subject(:apply_service) { described_class.new(commitment:, invoice_subscription:) }
+
+  let(:invoice_subscription) do
+    create(:invoice_subscription, subscription:, from_datetime:, to_datetime:)
+  end
+
+  let(:subscription) { create(:active_subscription, customer:, plan:, billing_time:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization:, interval:) }
+  let(:billing_time) { :calendar }
+
+  describe 'call' do
+    context 'when plan has weekly interval' do
+      let(:amount_cents) { 3_000 }
+      let(:interval) { :weekly }
+      let(:from_datetime) { DateTime.parse('2024-01-02T00:00:00') }
+      let(:to_datetime) { DateTime.parse('2024-01-07T23:59:59') }
+
+      context 'when subscription is calendar' do
+        let(:billing_time) { :calendar }
+
+        context 'when there is no commitment' do
+          let(:commitment) { nil }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(0)
+          end
+        end
+
+        context 'when a commitment exists for a plan' do
+          let(:commitment) { create(:commitment, plan:, amount_cents:) }
+
+          before { commitment }
+
+          it { is_expected.to delegate_method(:subscription).to(:invoice_subscription) }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(2_571)
+          end
+        end
+      end
+
+      context 'when subscription is anniversary' do
+        let(:billing_time) { :anniversary }
+
+        context 'when there is no commitment' do
+          let(:commitment) { nil }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(0)
+          end
+        end
+
+        context 'when a commitment exists for a plan' do
+          let(:commitment) { create(:commitment, plan:, amount_cents:) }
+
+          it { is_expected.to delegate_method(:subscription).to(:invoice_subscription) }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(commitment.amount_cents)
+          end
+        end
+      end
+    end
+
+    context 'when plan has monthly interval' do
+      let(:amount_cents) { 20_000 }
+      let(:interval) { :monthly }
+      let(:from_datetime) { DateTime.parse('2024-01-15T00:00:00') }
+      let(:to_datetime) { DateTime.parse('2024-01-31T23:59:59') }
+
+      context 'when subscription is calendar' do
+        let(:billing_time) { :calendar }
+
+        context 'when there is no commitment' do
+          let(:commitment) { nil }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(0)
+          end
+        end
+
+        context 'when a commitment exists for a plan' do
+          let(:commitment) { create(:commitment, plan:, amount_cents:) }
+
+          it { is_expected.to delegate_method(:subscription).to(:invoice_subscription) }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(10_968)
+          end
+        end
+      end
+
+      context 'when subscription is anniversary' do
+        let(:billing_time) { :anniversary }
+
+        context 'when there is no commitment' do
+          let(:commitment) { nil }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(0)
+          end
+        end
+
+        context 'when a commitment exists for a plan' do
+          let(:commitment) { create(:commitment, plan:, amount_cents:) }
+
+          it { is_expected.to delegate_method(:subscription).to(:invoice_subscription) }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(commitment.amount_cents)
+          end
+        end
+      end
+    end
+
+    context 'when plan has quarterly interval' do
+      let(:amount_cents) { 40_000 }
+      let(:interval) { :quarterly }
+      let(:from_datetime) { DateTime.parse('2024-01-15T00:00:00') }
+      let(:to_datetime) { DateTime.parse('2024-03-31T23:59:59') }
+
+      context 'when subscription is calendar' do
+        let(:billing_time) { :calendar }
+
+        context 'when there is no commitment' do
+          let(:commitment) { nil }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(0)
+          end
+        end
+
+        context 'when a commitment exists for a plan' do
+          let(:commitment) { create(:commitment, plan:, amount_cents:) }
+
+          before { commitment }
+
+          it { is_expected.to delegate_method(:subscription).to(:invoice_subscription) }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(33_846)
+          end
+        end
+      end
+
+      context 'when subscription is anniversary' do
+        let(:billing_time) { :anniversary }
+
+        context 'when there is no commitment' do
+          let(:commitment) { nil }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(0)
+          end
+        end
+
+        context 'when a commitment exists for a plan' do
+          let(:commitment) { create(:commitment, plan:, amount_cents:) }
+
+          it { is_expected.to delegate_method(:subscription).to(:invoice_subscription) }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(commitment.amount_cents)
+          end
+        end
+      end
+    end
+
+    context 'when plan has yearly interval' do
+      let(:amount_cents) { 200_000 }
+      let(:interval) { :yearly }
+      let(:from_datetime) { DateTime.parse('2024-01-15T00:00:00') }
+      let(:to_datetime) { DateTime.parse('2024-12-31T23:59:59') }
+
+      context 'when subscription is calendar' do
+        let(:billing_time) { :calendar }
+
+        context 'when there is no commitment' do
+          let(:commitment) { nil }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(0)
+          end
+        end
+
+        context 'when a commitment exists for a plan' do
+          let(:commitment) { create(:commitment, plan:, amount_cents:) }
+
+          before { commitment }
+
+          it { is_expected.to delegate_method(:subscription).to(:invoice_subscription) }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(192350)
+          end
+        end
+      end
+
+      context 'when subscription is anniversary' do
+        let(:billing_time) { :anniversary }
+
+        context 'when there is no commitment' do
+          let(:commitment) { nil }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(0)
+          end
+        end
+
+        context 'when a commitment exists for a plan' do
+          let(:commitment) { create(:commitment, plan:, amount_cents:) }
+
+          it { is_expected.to delegate_method(:subscription).to(:invoice_subscription) }
+
+          it 'returns result' do
+            result = apply_service.call
+
+            expect(result.commitment_amount_cents).to eq(commitment.amount_cents)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/services/utils/datetime_service_spec.rb
+++ b/spec/services/utils/datetime_service_spec.rb
@@ -60,4 +60,84 @@ RSpec.describe Utils::DatetimeService, type: :service do
       end
     end
   end
+
+  describe '.period_total_length_in_days' do
+    let(:result) do
+      datetime_service.period_total_length_in_days(from_datetime, to_datetime, interval)
+    end
+
+    context 'when non-leap year' do
+      let(:from_datetime) { Time.zone.parse('2022-01-01 00:00:00') }
+      let(:to_datetime) { Time.zone.parse('2022-01-31 23:59:59') }
+
+      context 'when interval is weekly' do
+        let(:interval) { :weekly }
+
+        it 'returns period length in days' do
+          expect(result).to eq(7)
+        end
+      end
+
+      context 'when interval is monthly' do
+        let(:interval) { :monthly }
+
+        it 'returns period length in days' do
+          expect(result).to eq(31)
+        end
+      end
+
+      context 'when interval is quarterly' do
+        let(:interval) { :quarterly }
+
+        it 'returns period length in days' do
+          expect(result).to eq(90)
+        end
+      end
+
+      context 'when interval is yearly' do
+        let(:interval) { :yearly }
+
+        it 'returns period length in days' do
+          expect(result).to eq(365)
+        end
+      end
+    end
+
+    context 'when leap year' do
+      let(:from_datetime) { Time.zone.parse('2020-01-01 00:00:00') }
+      let(:to_datetime) { Time.zone.parse('2020-01-31 23:59:59') }
+
+      context 'when interval is weekly' do
+        let(:interval) { :weekly }
+
+        it 'returns period length in days' do
+          expect(result).to eq(7)
+        end
+      end
+
+      context 'when interval is monthly' do
+        let(:interval) { :monthly }
+
+        it 'returns period length in days' do
+          expect(result).to eq(31)
+        end
+      end
+
+      context 'when interval is quarterly' do
+        let(:interval) { :quarterly }
+
+        it 'returns period length in days' do
+          expect(result).to eq(91)
+        end
+      end
+
+      context 'when interval is yearly' do
+        let(:interval) { :yearly }
+
+        it 'returns period length in days' do
+          expect(result).to eq(366)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/set-minimum-spend-for-subscriptions

## Context

As a user, I want to define the minimum spend that applies to the customer's plan. Consider the following monthly plan:

- Subscription fee = $50 per month (in arrears);
- Usage-based charge = $10 per unit per month (in arrears); and
- Monthly minimum spend = $100.

If at the end of the month, the customer has consumed 3 units, their total invoice will be: $50 + 3 * $10 = $80 + $20 (true-up fee) = $100.

## Description

This PR adds `Commitments::CalculateAmountService` that calculates the amount for a commitment.