### PR TITLE
feat(grouped-by): Add full logic on weighted sum aggregation

### DIFF
--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -10,7 +10,7 @@ module BillableMetrics
         event_store.aggregation_property = billable_metric.field_name
       end
 
-      def aggregate(*)
+      def compute_aggregation(*)
         result.aggregation = event_store.weighted_sum(initial_value:).ceil(20)
         result.count = event_store.count
         result.variation = event_store.sum || 0
@@ -24,7 +24,52 @@ module BillableMetrics
         result
       end
 
+      # NOTE: Apply the grouped_by filter to the aggregation
+      #       Result will have an aggregations attribute
+      #       containing the aggregation result of each group.
+      def compute_grouped_by_aggregation(*)
+        aggregations = event_store.grouped_weighted_sum(initial_values: grouped_latest_values)
+        return empty_results if aggregations.blank?
+
+        counts = event_store.grouped_count
+        sums = event_store.grouped_sum
+
+        latest_values = []
+        last_events = []
+        if billable_metric.recurring?
+          latest_values = grouped_latest_values
+          last_events = event_store.grouped_last_event
+        end
+
+        result.aggregations = aggregations.map do |aggregation|
+          group_result = BaseService::Result.new
+          group_result.grouped_by = aggregation[:groups]
+
+          aggregation_value = aggregation[:value]
+          group_result.aggregation = aggregation_value
+          group_result.count = counts.find { |c| c[:groups] == aggregation[:groups] }&.[](:value) || 0
+          group_result.variation = sums.find { |c| c[:groups] == aggregation[:groups] }&.[](:value) || 0
+          group_result.total_aggregated_units = group_result.variation
+
+          if billable_metric.recurring?
+            latest_value = latest_values.find { |c| c[:groups] == aggregation[:groups] }&.[](:value) || 0
+            last_event = last_events.find { |c| c[:groups] == aggregation[:groups] }
+
+            group_result.total_aggregated_units = latest_value + group_result.variation
+            group_result.recurring_updated_at = last_event&.[](:timestamp) || from_datetime
+          end
+
+          group_result
+        end
+
+        result
+      end
+
       private
+
+      def support_grouped_aggregation?
+        true
+      end
 
       def initial_value
         return 0 unless billable_metric.recurring?
@@ -40,6 +85,7 @@ module BillableMetrics
           .where(organization_id: billable_metric.organization_id)
           .where(external_subscription_id: subscription.external_id)
           .where(added_at: ...from_datetime)
+          .where(grouped_by: {})
           .order(added_at: :desc)
 
         quantified_events = quantified_events.where(group_id: group.id) if group
@@ -68,6 +114,50 @@ module BillableMetrics
         event_store.numeric_property = true
 
         event_store.sum
+      end
+
+      def grouped_latest_values
+        return @grouped_latest_values if @grouped_latest_values
+
+        quantified_events = QuantifiedEvent
+          .where(billable_metric_id: billable_metric.id)
+          .where(organization_id: billable_metric.organization_id)
+          .where(external_subscription_id: subscription.external_id)
+          .where(added_at: ...from_datetime)
+          .order(added_at: :desc)
+
+        grouped_by.each do |key|
+          quantified_events = quantified_events.where('grouped_by?:key', key:)
+        end
+
+        quantified_events = quantified_events.where(group_id: group.id) if group
+
+        if quantified_events.all.any?
+          return @grouped_latest_values = quantified_events.map do |quantified_event|
+            {
+              groups: quantified_event.grouped_by,
+              value: quantified_event.properties.[](QuantifiedEvent::RECURRING_TOTAL_UNITS),
+            }
+          end
+        end
+        return @grouped_latest_values = grouped_latest_values_from_events if subscription.previous_subscription_id?
+
+        @grouped_latest_values = {}
+      end
+
+      def grouped_latest_values_from_events
+        event_store = event_store_class.new(
+          code: billable_metric.code,
+          subscription:,
+          boundaries: { to_datetime: from_datetime },
+          filters:,
+        )
+
+        event_store.use_from_boundary = false
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
+
+        event_store.grouped_sum
       end
     end
   end

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -90,11 +90,11 @@ module Events
         boundaries[:charges_duration]
       end
 
-      attr_accessor :numeric_property, :aggregation_property, :use_from_boundary
+      attr_accessor :numeric_property, :aggregation_property, :use_from_boundary, :grouped_by
 
       protected
 
-      attr_accessor :code, :subscription, :group, :boundaries, :grouped_by, :grouped_by_values
+      attr_accessor :code, :subscription, :group, :boundaries, :grouped_by_values
 
       delegate :customer, to: :subscription
 

--- a/app/services/events/stores/clickhouse/weighted_sum_query.rb
+++ b/app/services/events/stores/clickhouse/weighted_sum_query.rb
@@ -20,6 +20,23 @@ module Events
           SQL
         end
 
+        def grouped_query(initial_values:)
+          <<-SQL
+            #{grouped_events_cte_sql(initial_values)}
+
+            SELECT
+              #{group_names},
+              SUM(period_ratio) as aggregation
+            FROM (
+              SELECT
+                #{group_names},
+                (#{grouped_period_ratio_sql}) AS period_ratio
+              FROM events_data
+            ) cumulated_ratios
+            GROUP BY #{group_names}
+          SQL
+        end
+
         # NOTE: not used in production, only for debug purpose to check the computed values before aggregation
         def breakdown_query
           <<-SQL
@@ -40,7 +57,7 @@ module Events
 
         attr_reader :store
 
-        delegate :events, :charges_duration, :sanitized_numeric_property, to: :store
+        delegate :events, :charges_duration, :sanitized_propery_name, :sanitized_numeric_property, to: :store
 
         def events_cte_sql
           <<-SQL
@@ -95,6 +112,97 @@ module Events
               toDecimal128(0, :decimal_scale)
             )
           SQL
+        end
+
+        def grouped_events_cte_sql(initial_values)
+          groups = store.grouped_by.map.with_index do |group, index|
+            "#{sanitized_propery_name(group)} AS g_#{index}"
+          end
+
+          <<-SQL
+            WITH events_data AS (
+              (#{grouped_initial_value_sql(initial_values)})
+              UNION ALL
+              (#{
+                events
+                  .select("#{groups.join(', ')}, timestamp, #{sanitized_numeric_property} AS difference")
+                  .group(Events::Stores::ClickhouseStore::DEDUPLICATION_GROUP)
+                  .to_sql
+              })
+              UNION ALL
+              (#{grouped_end_of_period_value_sql(initial_values)})
+            )
+          SQL
+        end
+
+        def grouped_initial_value_sql(initial_values)
+          values = initial_values.map do |initial_value|
+            groups = store.grouped_by.map do |g|
+              "'#{ActiveRecord::Base.sanitize_sql_for_conditions(initial_value[:groups][g])}'"
+            end
+
+            [
+              groups,
+              'toDateTime64(:from_datetime, 5, \'UTC\') AS timestamp',
+              "toDecimal128(#{initial_value[:value]}, :decimal_scale) AS difference",
+            ].flatten.join(', ')
+          end
+
+          <<-SQL
+            SELECT
+              #{store.grouped_by.map.with_index { |_, index| "tuple.#{index + 1} AS g_#{index}" }.join(', ')},
+              tuple.#{store.grouped_by.count + 1} AS timestamp,
+              tuple.#{store.grouped_by.count + 2} AS difference
+            FROM ( SELECT arrayJoin([#{values.map { "tuple(#{_1})" }.join(', ')}]) AS tuple )
+          SQL
+        end
+
+        def grouped_end_of_period_value_sql(initial_values)
+          values = initial_values.map do |initial_value|
+            groups = store.grouped_by.map do |g|
+              "'#{ActiveRecord::Base.sanitize_sql_for_conditions(initial_value[:groups][g])}'"
+            end
+
+            [
+              groups,
+              "toDateTime64(:to_datetime, 5, 'UTC') AS timestamp",
+              'toDecimal128(0, :decimal_scale) AS difference',
+            ].flatten.join(', ')
+          end
+
+          <<-SQL
+            SELECT
+              #{store.grouped_by.map.with_index { |_, index| "tuple.#{index + 1} AS g_#{index}" }.join(', ')},
+              tuple.#{store.grouped_by.count + 1} AS timestamp,
+              tuple.#{store.grouped_by.count + 2} AS difference
+            FROM ( SELECT arrayJoin([#{values.map { "tuple(#{_1})" }.join(', ')}]) AS tuple )
+          SQL
+        end
+
+        def grouped_period_ratio_sql
+          <<-SQL
+            if(
+              -- NOTE: duration in seconds between current event and next one
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (PARTITION BY #{group_names} ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) > 0,
+
+              -- NOTE: cumulative sum from previous events in the period
+              (SUM(difference) OVER (PARTITION BY #{group_names} ORDER BY timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW))
+              *
+              -- NOTE: duration in seconds between current event and next one - using end of period as final boundaries
+              date_diff('seconds', timestamp, leadInFrame(timestamp, 1, toDateTime64(:to_datetime, 5, 'UTC')) OVER (PARTITION BY #{group_names} ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING))
+              /
+              -- NOTE: full duration of the period
+              #{charges_duration.days.to_i}
+              ,
+
+              -- NOTE: duration was null so usage is null
+              toDecimal128(0, :decimal_scale)
+            )
+          SQL
+        end
+
+        def group_names
+          @group_names ||= store.grouped_by.map.with_index { |_, index| "g_#{index}" }.join(', ')
         end
       end
     end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -60,7 +60,7 @@ module Events
           ORDER BY #{group_names}, events.timestamp DESC
         SQL
 
-        prepare_grouped_result(::Clickhouse::EventsRaw.connection.select_all(sql).rows)
+        prepare_grouped_result(::Clickhouse::EventsRaw.connection.select_all(sql).rows, timestamp: true)
       end
 
       def prorated_events_values(total_duration)
@@ -425,7 +425,7 @@ module Events
             value: row.last,
           }
 
-          result[:timestamp] = row[-2] if last_group
+          result[:timestamp] = row[-2] if timestamp
 
           result
         end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -276,6 +276,40 @@ module Events
         result['aggregation']
       end
 
+      def grouped_weighted_sum(initial_values: [])
+        query = Clickhouse::WeightedSumQuery.new(store: self)
+
+        # NOTE: build the list of initial values for each groups
+        #       from the events in the period
+        formated_initial_values = grouped_count.map do |group|
+          value = 0
+          previous_group = initial_values.find { |g| g[:groups] == group[:groups] }
+          value = previous_group[:value] if previous_group
+          { groups: group[:groups], value: }
+        end
+
+        # NOTE: add the initial values for groups that are not in the events
+        initial_values.each do |intial_value|
+          next if formated_initial_values.find { |g| g[:groups] == intial_value[:groups] }
+
+          formated_initial_values << intial_value
+        end
+        return [] if formated_initial_values.empty?
+
+        sql = ActiveRecord::Base.sanitize_sql_for_conditions(
+          [
+            query.grouped_query(initial_values: formated_initial_values),
+            {
+              from_datetime:,
+              to_datetime: to_datetime.ceil,
+              decimal_scale: DECIMAL_SCALE,
+            },
+          ],
+        )
+
+        prepare_grouped_result(::Clickhouse::EventsRaw.connection.select_all(sql).rows)
+      end
+
       # NOTE: not used in production, only for debug purpose to check the computed values before aggregation
       def weighted_sum_breakdown(initial_value: 0)
         query = Events::Stores::Clickhouse::WeightedSumQuery.new(store: self)

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -38,6 +38,31 @@ module Events
         events.last
       end
 
+      def grouped_last_event
+        groups = grouped_by.map { |group| sanitized_propery_name(group) }
+        group_names = groups.map.with_index { |_, index| "g_#{index}" }.join(', ')
+
+        cte_sql = events.group(DEDUPLICATION_GROUP)
+          .select(Arel.sql(
+            (groups.map.with_index { |group, index| "#{group} AS g_#{index}" } +
+            ["#{sanitized_numeric_property} AS property", 'events_raw.timestamp']).join(', '),
+          ))
+          .to_sql
+
+        sql = <<-SQL
+          with events as (#{cte_sql})
+
+          select
+            DISTINCT ON (#{group_names}) #{group_names},
+            events.timestamp,
+            property
+          from events
+          ORDER BY #{group_names}, events.timestamp DESC
+        SQL
+
+        prepare_grouped_result(::Clickhouse::EventsRaw.connection.select_all(sql).rows)
+      end
+
       def prorated_events_values(total_duration)
         ratio_sql = duration_ratio_sql('events_raw.timestamp', to_datetime, total_duration)
 
@@ -390,14 +415,19 @@ module Events
       # NOTE: returns the values for each groups
       #       The result format will be an array of hash with the format:
       #       [{ groups: { 'cloud' => 'aws', 'region' => 'us_east_1' }, value: 12.9 }, ...]
-      def prepare_grouped_result(rows)
+      def prepare_grouped_result(rows, timestamp: false)
         rows.map do |row|
-          groups = row.flatten[...-1].map(&:presence)
+          last_group = timestamp ? -2 : -1
+          groups = row.flatten[...last_group].map(&:presence)
 
-          {
+          result = {
             groups: grouped_by.each_with_object({}).with_index { |(g, r), i| r.merge!(g => groups[i]) },
             value: row.last,
           }
+
+          result[:timestamp] = row[-2] if last_group
+
+          result
         end
       end
     end

--- a/app/services/events/stores/postgres/weighted_sum_query.rb
+++ b/app/services/events/stores/postgres/weighted_sum_query.rb
@@ -142,13 +142,18 @@ module Events
               end
             end
 
-            "(#{groups.join(', ')}, timestamp without time zone :from_datetime, #{initial_value[:value]}, timestamp without time zone :from_datetime)"
+            [
+              groups,
+              'timestamp without time zone :from_datetime',
+              initial_value[:value],
+              'timestamp without time zone :from_datetime',
+            ].flatten.join(', ')
           end
 
           <<-SQL
             SELECT *
             FROM (
-                VALUES #{values.join(', ')}
+                VALUES #{values.map { "(#{_1})" }.join(', ')}
             ) AS t(#{group_names}, timestamp, difference, created_at)
           SQL
         end
@@ -163,13 +168,18 @@ module Events
               end
             end
 
-            "(#{groups.join(', ')}, timestamp without time zone :from_datetime, 0, timestamp without time zone :from_datetime)"
+            [
+              groups,
+              'timestamp without time zone :from_datetime',
+              0,
+              'timestamp without time zone :from_datetime',
+            ].flatten.join(', ')
           end
 
           <<-SQL
             SELECT *
             FROM (
-              VALUES #{values.join(', ')}
+              VALUES #{values.map { "(#{_1})" }.join(', ')}
             ) AS t(#{group_names}, timestamp, difference, created_at)
           SQL
         end

--- a/db/migrate/20240129155938_add_grouped_by_to_quantified_events.rb
+++ b/db/migrate/20240129155938_add_grouped_by_to_quantified_events.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddGroupedByToQuantifiedEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :quantified_events, :grouped_by, :jsonb, null: false, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_25_080718) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_29_155938) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -778,6 +778,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_25_080718) do
     t.datetime "deleted_at"
     t.uuid "group_id"
     t.uuid "organization_id", null: false
+    t.jsonb "grouped_by", default: {}, null: false
     t.index ["billable_metric_id"], name: "index_quantified_events_on_billable_metric_id"
     t.index ["deleted_at"], name: "index_quantified_events_on_deleted_at"
     t.index ["external_id"], name: "index_quantified_events_on_external_id"

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -13,16 +13,18 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
         to_datetime:,
         charges_duration:,
       },
-      filters: { group: },
+      filters:,
     )
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:filters) { { group:, grouped_by: } }
 
   let(:subscription) { create(:subscription, started_at: DateTime.parse('2023-04-01 22:22:22')) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:group) { nil }
+  let(:grouped_by) { nil }
 
   let(:billable_metric) { create(:weighted_sum_billable_metric, organization:) }
 
@@ -53,6 +55,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
     events_values.each do |values|
       properties = { value: values[:value] }
       properties[:region] = values[:region] if values[:region]
+      properties[:agent_name] = values[:agent_name] if values[:agent_name]
 
       create(
         :event,
@@ -246,6 +249,274 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
 
       expect(result.aggregation.to_s).to eq('1000.0')
       expect(result.count).to eq(1)
+    end
+  end
+
+  describe '.grouped_by aggregation' do
+    let(:grouped_by) { ['agent_name'] }
+    let(:agent_names) { %w[aragorn frodo] }
+
+    let(:events_values) do
+      [
+        { timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 2, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-08-01 01:00:00'), value: 3, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-08-01 01:30:00'), value: 1, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-08-01 02:00:00'), value: -4, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-08-01 04:00:00'), value: -2, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-08-01 05:00:00'), value: 10, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-08-01 05:30:00'), value: -10, agent_name: 'aragorn' },
+
+        { timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 2, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-08-01 01:00:00'), value: 3, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-08-01 01:30:00'), value: 1, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-08-01 02:00:00'), value: -4, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-08-01 04:00:00'), value: -2, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-08-01 05:00:00'), value: 10, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-08-01 05:30:00'), value: -10, agent_name: 'frodo' },
+      ]
+    end
+
+    it 'returns a grouped aggregations' do
+      result = aggregator.aggregate
+
+      expect(result.aggregations.count).to eq(2)
+
+      result.aggregations.sort_by { |a| a.grouped_by['agent_name'] }.each_with_index do |aggregation, index|
+        expect(aggregation.aggregation.round(5).to_s).to eq('0.02218')
+        expect(aggregation.count).to eq(7)
+        expect(aggregation.grouped_by['agent_name']).to eq(agent_names[index])
+      end
+    end
+
+    context 'with no events' do
+      let(:events_values) { [] }
+
+      it 'returns an empty result' do
+        result = aggregator.aggregate
+
+        expect(result.aggregations.count).to eq(1)
+
+        aggregation = result.aggregations.first
+        expect(aggregation.aggregation).to eq(0)
+        expect(aggregation.count).to eq(0)
+        expect(aggregation.grouped_by).to eq({ 'agent_name' => nil })
+      end
+    end
+
+    context 'with events with the same timestamp' do
+      let(:events_values) do
+        [
+          { timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 3, agent_name: 'aragorn' },
+          { timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 3, agent_name: 'aragorn' },
+
+          { timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 3, agent_name: 'frodo' },
+          { timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 3, agent_name: 'frodo' },
+        ]
+      end
+
+      it 'aggregates the events' do
+        result = aggregator.aggregate
+
+        expect(result.aggregations.count).to eq(2)
+
+        result.aggregations.sort_by { |a| a.grouped_by['agent_name'] }.each_with_index do |aggregation, index|
+          expect(aggregation.aggregation.round(5)).to eq(6)
+          expect(aggregation.count).to eq(2)
+          expect(aggregation.grouped_by['agent_name']).to eq(agent_names[index])
+        end
+      end
+    end
+
+    context 'when billable metric is recurring' do
+      let(:billable_metric) { create(:weighted_sum_billable_metric, :recurring, organization:) }
+
+      let(:events_values) { [] }
+
+      let(:quantified_events) do
+        [
+          create(
+            :quantified_event,
+            billable_metric:,
+            external_subscription_id: subscription.external_id,
+            added_at: from_datetime - 1.day,
+            properties: { QuantifiedEvent::RECURRING_TOTAL_UNITS => 1000 },
+            grouped_by: { 'agent_name' => 'aragorn' },
+          ),
+
+          create(
+            :quantified_event,
+            billable_metric:,
+            external_subscription_id: subscription.external_id,
+            added_at: from_datetime - 1.day,
+            properties: { QuantifiedEvent::RECURRING_TOTAL_UNITS => 1000 },
+            grouped_by: { 'agent_name' => 'frodo' },
+          ),
+        ]
+      end
+
+      before { quantified_events }
+
+      it 'uses the persisted recurring value as initial value' do
+        result = aggregator.aggregate
+
+        expect(result.aggregations.count).to eq(2)
+
+        result.aggregations.sort_by { |a| a.grouped_by['agent_name'] }.each_with_index do |aggregation, index|
+          expect(aggregation.aggregation.to_s).to eq('1000.0')
+          expect(aggregation.count).to eq(0)
+          expect(aggregation.variation).to eq(0)
+          expect(aggregation.total_aggregated_units).to eq(1000)
+          expect(aggregation.grouped_by['agent_name']).to eq(agent_names[index])
+          expect(aggregation.recurring_updated_at).to eq(from_datetime)
+        end
+      end
+
+      context 'without quantified events' do
+        let(:quantified_events) {}
+
+        it 'returns an empty result' do
+          result = aggregator.aggregate
+
+          expect(result.aggregations.count).to eq(1)
+
+          aggregation = result.aggregations.first
+          expect(aggregation.aggregation).to eq(0)
+          expect(aggregation.count).to eq(0)
+          expect(aggregation.grouped_by).to eq({ 'agent_name' => nil })
+        end
+
+        context 'with events attached to a previous subcription' do
+          let(:previous_subscription) do
+            create(
+              :subscription,
+              :terminated,
+              started_at: DateTime.parse('2022-01-01 22:22:22'),
+              terminated_at: DateTime.parse('2023-04-01 22:22:21'),
+            )
+          end
+
+          let(:customer) { previous_subscription.customer }
+
+          let(:subscription) do
+            create(
+              :subscription,
+              started_at: DateTime.parse('2023-04-01 22:22:22'),
+              previous_subscription:,
+              customer:,
+              external_id: previous_subscription.external_id,
+            )
+          end
+
+          before do
+            subscription
+
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              subscription: previous_subscription,
+              customer:,
+              timestamp: Time.zone.parse('2023-03-01 22:22:22'),
+              properties: { value: 10, agent_name: 'aragorn' },
+            )
+
+            create(
+              :event,
+              organization_id: organization.id,
+              code: billable_metric.code,
+              subscription: previous_subscription,
+              customer:,
+              timestamp: Time.zone.parse('2023-03-01 22:22:22'),
+              properties: { value: 10, agent_name: 'frodo' },
+            )
+          end
+
+          it 'uses previous events as latest value' do
+            result = aggregator.aggregate
+
+            aggregate_failures do
+              expect(result.aggregations.count).to eq(2)
+
+              result.aggregations.sort_by { |a| a.grouped_by['agent_name'] }.each_with_index do |aggregation, index|
+                expect(aggregation.aggregation.to_s).to eq('10.0')
+                expect(aggregation.count).to eq(0)
+                expect(aggregation.variation).to eq(0)
+                expect(aggregation.total_aggregated_units).to eq(10)
+                expect(aggregation.grouped_by['agent_name']).to eq(agent_names[index])
+                expect(aggregation.recurring_updated_at).to eq(from_datetime)
+              end
+            end
+          end
+        end
+      end
+
+      context 'with events' do
+        let(:events_values) do
+          [
+            { timestamp: DateTime.parse('2023-08-01 00:00:00.000'), value: 2, agent_name: 'aragorn' },
+            { timestamp: DateTime.parse('2023-08-01 01:00:00'), value: 3, agent_name: 'aragorn' },
+            { timestamp: DateTime.parse('2023-08-01 01:30:00'), value: 1, agent_name: 'aragorn' },
+            { timestamp: DateTime.parse('2023-08-01 02:00:00'), value: -4, agent_name: 'aragorn' },
+            { timestamp: DateTime.parse('2023-08-01 04:00:00'), value: -2, agent_name: 'aragorn' },
+            { timestamp: DateTime.parse('2023-08-01 05:00:00'), value: 10, agent_name: 'aragorn' },
+            { timestamp: DateTime.parse('2023-08-01 05:30:00'), value: -10, agent_name: 'aragorn' },
+
+            { timestamp: DateTime.parse('2023-08-01 00:00:00.000'), value: 2, agent_name: 'frodo' },
+            { timestamp: DateTime.parse('2023-08-01 01:00:00'), value: 3, agent_name: 'frodo' },
+            { timestamp: DateTime.parse('2023-08-01 01:30:00'), value: 1, agent_name: 'frodo' },
+            { timestamp: DateTime.parse('2023-08-01 02:00:00'), value: -4, agent_name: 'frodo' },
+            { timestamp: DateTime.parse('2023-08-01 04:00:00'), value: -2, agent_name: 'frodo' },
+            { timestamp: DateTime.parse('2023-08-01 05:00:00'), value: 10, agent_name: 'frodo' },
+            { timestamp: DateTime.parse('2023-08-01 05:30:00'), value: -10, agent_name: 'frodo' },
+          ]
+        end
+
+        it 'aggregates the events' do
+          result = aggregator.aggregate
+
+          aggregate_failures do
+            expect(result.aggregations.count).to eq(2)
+
+            result.aggregations.sort_by { |a| a.grouped_by['agent_name'] }.each_with_index do |aggregation, index|
+              expect(aggregation.aggregation.round(5).to_s).to eq('1000.02218')
+              expect(aggregation.count).to eq(7)
+              expect(aggregation.variation).to eq(0)
+              expect(aggregation.total_aggregated_units).to eq(1000)
+              expect(aggregation.grouped_by['agent_name']).to eq(agent_names[index])
+              expect(aggregation.recurring_updated_at).to eq('2023-08-01 05:30:00')
+            end
+          end
+        end
+      end
+    end
+
+    context 'with group' do
+      let(:group) { create(:group, billable_metric:, key: 'region', value: 'europe') }
+
+      let(:events_values) do
+        [
+          {
+            timestamp: DateTime.parse('2023-08-01 00:00:00.000'),
+            value: 1000,
+            region: 'europe',
+            agent_name: 'aragorn',
+          },
+          { timestamp: DateTime.parse('2023-08-01 00:00:00.000'), value: 1000, region: 'europe', agent_name: 'frodo' },
+        ]
+      end
+
+      it 'aggregates the events' do
+        result = aggregator.aggregate
+
+        aggregate_failures do
+          expect(result.aggregations.count).to eq(2)
+
+          result.aggregations.sort_by { |a| a.grouped_by['agent_name'] }.each_with_index do |aggregation, _index|
+            expect(aggregation.aggregation.round(5).to_s).to eq('1000.0')
+            expect(aggregation.count).to eq(1)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -169,6 +169,55 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     end
   end
 
+  describe '.grouped_last_event' do
+    let(:grouped_by) { %w[cloud] }
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it 'returns the last events grouped by the provided group' do
+      result = event_store.grouped_last_event
+
+      expect(result.count).to eq(4)
+
+      null_group = result.find { |v| v[:groups]['cloud'].nil? }
+      expect(null_group[:groups]['cloud']).to be_nil
+      expect(null_group[:value]).to eq(4)
+      expect(null_group[:timestamp]).not_to be_nil
+
+      (result - [null_group]).each do |row|
+        expect(row[:groups]['cloud']).not_to be_nil
+        expect(row[:value]).not_to be_nil
+        expect(row[:timestamp]).not_to be_nil
+      end
+    end
+
+    context 'with multiple groups' do
+      let(:grouped_by) { %w[cloud region] }
+
+      it 'returns the last events grouped by the provided groups' do
+        result = event_store.grouped_last_event
+
+        expect(result.count).to eq(4)
+
+        null_group = result.find { |v| v[:groups]['cloud'].nil? }
+        expect(null_group[:groups]['cloud']).to be_nil
+        expect(null_group[:groups]['region']).to be_nil
+        expect(null_group[:value]).to eq(4)
+        expect(null_group[:timestamp]).not_to be_nil
+
+        (result - [null_group]).each do |row|
+          expect(row[:groups]['cloud']).not_to be_nil
+          expect(row[:groups]['region']).not_to be_nil
+          expect(row[:value]).not_to be_nil
+          expect(row[:timestamp]).not_to be_nil
+        end
+      end
+    end
+  end
+
   describe '.prorated_events_values' do
     it 'returns the values attached to each event with prorata on period duration' do
       event_store.aggregation_property = billable_metric.field_name

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -540,4 +540,142 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       end
     end
   end
+
+  describe '.grouped_weighted_sum' do
+    let(:grouped_by) { %w[agent_name other] }
+
+    let(:started_at) { Time.zone.parse('2023-03-01') }
+
+    let(:events_values) do
+      [
+        { timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 2, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-03-01 01:00:00'), value: 3, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-03-01 01:30:00'), value: 1, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-03-01 02:00:00'), value: -4, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-03-01 04:00:00'), value: -2, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-03-01 05:00:00'), value: 10, agent_name: 'frodo' },
+        { timestamp: Time.zone.parse('2023-03-01 05:30:00'), value: -10, agent_name: 'frodo' },
+
+        { timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 2, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-03-01 01:00:00'), value: 3, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-03-01 01:30:00'), value: 1, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-03-01 02:00:00'), value: -4, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-03-01 04:00:00'), value: -2, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-03-01 05:00:00'), value: 10, agent_name: 'aragorn' },
+        { timestamp: Time.zone.parse('2023-03-01 05:30:00'), value: -10, agent_name: 'aragorn' },
+
+        { timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 2 },
+        { timestamp: Time.zone.parse('2023-03-01 01:00:00'), value: 3 },
+        { timestamp: Time.zone.parse('2023-03-01 01:30:00'), value: 1 },
+        { timestamp: Time.zone.parse('2023-03-01 02:00:00'), value: -4 },
+        { timestamp: Time.zone.parse('2023-03-01 04:00:00'), value: -2 },
+        { timestamp: Time.zone.parse('2023-03-01 05:00:00'), value: 10 },
+        { timestamp: Time.zone.parse('2023-03-01 05:30:00'), value: -10 },
+      ]
+    end
+
+    let(:events) do
+      events = []
+
+      events_values.each do |values|
+        properties = { value: values[:value] }
+        properties[:region] = values[:region] if values[:region]
+        properties[:agent_name] = values[:agent_name] if values[:agent_name]
+
+        event = create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          external_customer_id: customer.external_id,
+          code:,
+          timestamp: values[:timestamp],
+          properties:,
+        )
+
+        events << event
+      end
+
+      events
+    end
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+      event_store.numeric_property = true
+    end
+
+    it 'returns the weighted sum of event properties' do
+      result = event_store.grouped_weighted_sum
+
+      expect(result.count).to eq(3)
+
+      null_group = result.last
+      expect(null_group[:groups]['agent_name']).to be_nil
+      expect(null_group[:groups]['other']).to be_nil
+      expect(null_group[:value].round(5)).to eq(0.02218)
+
+      result[...-1].each do |row|
+        expect(row[:groups]['agent_name']).not_to be_nil
+        expect(row[:groups]['other']).to be_nil
+        expect(row[:value].round(5)).to eq(0.02218)
+      end
+    end
+
+    context 'with no events' do
+      let(:events_values) { [] }
+
+      it 'returns the weighted sum of event properties' do
+        result = event_store.grouped_weighted_sum
+
+        expect(result.count).to eq(0)
+      end
+    end
+
+    context 'with initial values' do
+      let(:initial_values) do
+        [
+          { groups: { 'agent_name' => 'frodo', 'other' => nil }, value: 1000 },
+          { groups: { 'agent_name' => 'aragorn', 'other' => nil }, value: 1000 },
+          { groups: { 'agent_name' => nil, 'other' => nil }, value: 1000 },
+        ]
+      end
+
+      it 'uses the initial value in the aggregation' do
+        result = event_store.grouped_weighted_sum(initial_values:)
+
+        expect(result.count).to eq(3)
+
+        null_group = result.last
+        expect(null_group[:groups]['agent_name']).to be_nil
+        expect(null_group[:groups]['other']).to be_nil
+        expect(null_group[:value].round(5)).to eq(1000.02218)
+
+        result[...-1].each do |row|
+          expect(row[:groups]['agent_name']).not_to be_nil
+          expect(row[:groups]['other']).to be_nil
+          expect(row[:value].round(5)).to eq(1000.02218)
+        end
+      end
+
+      context 'without events' do
+        let(:events_values) { [] }
+
+        it 'uses only the initial value in the aggregation' do
+          result = event_store.grouped_weighted_sum(initial_values:)
+
+          expect(result.count).to eq(3)
+
+          null_group = result.last
+          expect(null_group[:groups]['agent_name']).to be_nil
+          expect(null_group[:groups]['other']).to be_nil
+          expect(null_group[:value].round(5)).to eq(1000)
+
+          result[...-1].each do |row|
+            expect(row[:groups]['agent_name']).not_to be_nil
+            expect(row[:groups]['other']).to be_nil
+            expect(row[:value].round(5)).to eq(1000)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -229,6 +229,18 @@ RSpec.describe Fees::ChargeService do
               )
             end
           end
+
+          context 'with recurring weighted sum aggregation' do
+            let(:billable_metric) { create(:weighted_sum_billable_metric, :recurring, organization:) }
+
+            it 'creates a fee and a quantified event per group' do
+              result = charge_subscription_service.create
+              expect(result).to be_success
+
+              expect(result.fees.count).to eq(2)
+              expect(result.quantified_events.count).to eq(2)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR adds the weighted sum computation logic in the event stores and billable metric aggregations
