### PR TITLE
misc: Add started_at value to the default subscription factory

### DIFF
--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -6,11 +6,7 @@ FactoryBot.define do
     plan
     status { :active }
     external_id { SecureRandom.uuid }
-
-    factory :active_subscription do
-      status { :active }
-      started_at { 1.day.ago }
-    end
+    started_at { 1.day.ago }
 
     factory :pending_subscription do
       status { :pending }

--- a/spec/graphql/mutations/applied_coupons/create_spec.rb
+++ b/spec/graphql/mutations/applied_coupons/create_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Mutations::AppliedCoupons::Create, type: :graphql do
   let(:customer) { create(:customer, organization:) }
 
   before do
-    create(:active_subscription, customer:)
+    create(:subscription, customer:)
   end
 
   it 'assigns a coupon to the customer' do

--- a/spec/graphql/resolvers/subscription_resolver_spec.rb
+++ b/spec/graphql/resolvers/subscription_resolver_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Resolvers::SubscriptionResolver, type: :graphql do
     expect(subscription_response).to include(
       'id' => subscription.id,
       'name' => subscription.name,
-      'startedAt' => subscription.started_at,
+      'startedAt' => subscription.started_at.iso8601,
       'endingAt' => subscription.ending_at,
     )
 

--- a/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
+++ b/spec/jobs/clock/subscriptions_to_be_terminated_job_spec.rb
@@ -7,9 +7,9 @@ describe Clock::SubscriptionsToBeTerminatedJob, job: true do
 
   describe '.perform' do
     let(:ending_at) { (Time.current + 2.months + 15.days).beginning_of_day }
-    let(:subscription1) { create(:active_subscription, ending_at:) }
-    let(:subscription2) { create(:active_subscription, ending_at: ending_at + 1.year) }
-    let(:subscription3) { create(:active_subscription, ending_at: nil) }
+    let(:subscription1) { create(:subscription, ending_at:) }
+    let(:subscription2) { create(:subscription, ending_at: ending_at + 1.year) }
+    let(:subscription3) { create(:subscription, ending_at: nil) }
     let(:webhook_started1) do
       create(:webhook, :succeeded, object_id: subscription1.id, webhook_type: 'subscription.started')
     end

--- a/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
+++ b/spec/jobs/clock/terminate_ended_subscriptions_job_spec.rb
@@ -7,9 +7,9 @@ describe Clock::TerminateEndedSubscriptionsJob, job: true do
 
   describe '.perform' do
     let(:ending_at) { (Time.current + 2.months).beginning_of_day }
-    let(:subscription1) { create(:active_subscription, ending_at:) }
-    let(:subscription2) { create(:active_subscription, ending_at: ending_at + 1.year) }
-    let(:subscription3) { create(:active_subscription, ending_at: nil) }
+    let(:subscription1) { create(:subscription, ending_at:) }
+    let(:subscription2) { create(:subscription, ending_at: ending_at + 1.year) }
+    let(:subscription3) { create(:subscription, ending_at: nil) }
 
     before do
       subscription1

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Subscription, type: :model do
-  subject(:subscription) { create(:active_subscription, plan:) }
+  subject(:subscription) { create(:subscription, plan:) }
 
   let(:plan) { create(:plan) }
 
@@ -112,7 +112,7 @@ RSpec.describe Subscription, type: :model do
     context 'with a previous subscription' do
       let(:subscription) do
         create(
-          :active_subscription,
+          :subscription,
           previous_subscription:,
           started_at: Time.zone.yesterday,
           plan:,
@@ -159,7 +159,7 @@ RSpec.describe Subscription, type: :model do
     context 'with a previous subscription' do
       let(:subscription) do
         create(
-          :active_subscription,
+          :subscription,
           previous_subscription:,
           started_at: Time.zone.yesterday,
           plan:,
@@ -250,7 +250,7 @@ RSpec.describe Subscription, type: :model do
     let(:external_id) { SecureRandom.uuid }
     let(:subscription) do
       create(
-        :active_subscription,
+        :subscription,
         plan:,
         customer: create(:customer, organization:),
       )
@@ -258,7 +258,7 @@ RSpec.describe Subscription, type: :model do
 
     let(:new_subscription) do
       build(
-        :active_subscription,
+        :subscription,
         plan:,
         external_id:,
         customer: create(:customer, organization:),
@@ -310,7 +310,7 @@ RSpec.describe Subscription, type: :model do
 
   describe '#starting_in_the_future?' do
     context 'when subscription is active' do
-      let(:subscription) { create(:active_subscription) }
+      let(:subscription) { create(:subscription) }
 
       it 'returns false' do
         expect(subscription.starting_in_the_future?).to be false
@@ -326,7 +326,7 @@ RSpec.describe Subscription, type: :model do
     end
 
     context 'when subscription is pending and downgraded' do
-      let(:old_subscription) { create(:active_subscription) }
+      let(:old_subscription) { create(:subscription) }
       let(:subscription) { create(:pending_subscription, previous_subscription: old_subscription) }
 
       it 'returns false' do

--- a/spec/requests/api/v1/applied_coupons_spec.rb
+++ b/spec/requests/api/v1/applied_coupons_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::V1::AppliedCouponsController, type: :request do
 
   describe 'apply' do
     before do
-      create(:active_subscription, customer:)
+      create(:subscription, customer:)
     end
 
     let(:params) do

--- a/spec/requests/api/v1/events_spec.rb
+++ b/spec/requests/api/v1/events_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
   let(:customer) { create(:customer, organization:) }
   let(:metric) { create(:billable_metric, organization:) }
   let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:active_subscription, customer:, organization:, plan:, started_at: 1.month.ago) }
+  let(:subscription) { create(:subscription, customer:, organization:, plan:, started_at: 1.month.ago) }
 
   before { subscription }
 

--- a/spec/scenarios/create_event_spec.rb
+++ b/spec/scenarios/create_event_spec.rb
@@ -6,7 +6,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
   let(:billable_metric) { create(:billable_metric, organization:) }
-  let(:subscription) { create(:active_subscription, customer:) }
+  let(:subscription) { create(:subscription, customer:) }
   let(:params) do
     { code: billable_metric.code, transaction_id: SecureRandom.uuid }
   end
@@ -123,7 +123,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
   context 'with external_subscription_id from another organization' do
     let(:organization2) { create(:organization, webhook_url: nil) }
     let(:customer2) { create(:customer, organization: organization2) }
-    let(:subscription2) { create(:active_subscription, customer: customer2) }
+    let(:subscription2) { create(:subscription, customer: customer2) }
 
     it 'returns the created event' do
       result = create_event(params.merge(external_subscription_id: subscription2.external_id))
@@ -161,7 +161,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
   end
 
   context 'with not yet started subscription' do
-    let(:subscription) { create(:active_subscription, customer:, started_at: 1.day.from_now) }
+    let(:subscription) { create(:subscription, customer:, started_at: 1.day.from_now) }
 
     it 'returns the created event' do
       result = create_event(params.merge(external_subscription_id: subscription.external_id))
@@ -181,7 +181,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
   end
 
   context 'with subscription started in the same second' do
-    let(:subscription) { create(:active_subscription, customer:, started_at: Time.current) }
+    let(:subscription) { create(:subscription, customer:, started_at: Time.current) }
 
     it 'returns the created event' do
       expect do
@@ -263,7 +263,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
   end
 
   context 'with external_customer_id but multiple subscriptions' do
-    let(:subscription2) { create(:active_subscription, customer:, started_at: subscription.started_at - 1.day) }
+    let(:subscription2) { create(:subscription, customer:, started_at: subscription.started_at - 1.day) }
 
     before { subscription2 }
 
@@ -285,7 +285,7 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
   end
 
   context 'with external_customer_id and external_subscription_id and multiple subscriptions' do
-    let(:subscription2) { create(:active_subscription, customer:, started_at: subscription.started_at - 1.day) }
+    let(:subscription2) { create(:subscription, customer:, started_at: subscription.started_at - 1.day) }
 
     before { subscription2 }
 

--- a/spec/services/applied_coupons/create_service_spec.rb
+++ b/spec/services/applied_coupons/create_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe AppliedCoupons::CreateService, type: :service do
   let(:create_subscription) { customer.present? }
 
   before do
-    create(:active_subscription, customer:) if create_subscription
+    create(:subscription, customer:) if create_subscription
   end
 
   describe 'create' do

--- a/spec/services/customers/terminate_relations_service_spec.rb
+++ b/spec/services/customers/terminate_relations_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Customers::TerminateRelationsService, type: :service do
   let(:customer) { create(:customer, :deleted) }
 
   context 'with an active subscription' do
-    let(:subscription) { create(:active_subscription, customer:) }
+    let(:subscription) { create(:subscription, customer:) }
 
     before { subscription }
 
@@ -36,7 +36,7 @@ RSpec.describe Customers::TerminateRelationsService, type: :service do
   end
 
   context 'with draft invoices' do
-    let(:subscription) { create(:active_subscription, customer:) }
+    let(:subscription) { create(:subscription, customer:) }
     let(:invoices) { create_list(:invoice, 2, :draft, customer:) }
 
     before do

--- a/spec/services/events/validate_creation_service_spec.rb
+++ b/spec/services/events/validate_creation_service_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Events::ValidateCreationService, type: :service do
   let(:organization) { create(:organization) }
   let(:result) { BaseService::Result.new }
   let(:customer) { create(:customer, organization:) }
-  let!(:subscription) { create(:active_subscription, customer:, organization:) }
+  let!(:subscription) { create(:subscription, customer:, organization:) }
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:transaction_id) { SecureRandom.uuid }
   let(:params) do
@@ -43,7 +43,7 @@ RSpec.describe Events::ValidateCreationService, type: :service do
     end
 
     context 'when customer has two active subscriptions' do
-      before { create(:active_subscription, customer:, organization:) }
+      before { create(:subscription, customer:, organization:) }
 
       let(:params) do
         { code: billable_metric.code, external_subscription_id: subscription.external_id, transaction_id: }
@@ -77,7 +77,7 @@ RSpec.describe Events::ValidateCreationService, type: :service do
     end
 
     context 'when there are two active subscriptions but external_subscription_id is not given' do
-      let(:subscription2) { create(:active_subscription, customer:, organization:) }
+      let(:subscription2) { create(:subscription, customer:, organization:) }
 
       let(:validate_event) do
         described_class.call(
@@ -110,7 +110,7 @@ RSpec.describe Events::ValidateCreationService, type: :service do
         }
       end
 
-      let(:subscription2) { create(:active_subscription, customer:, organization:) }
+      let(:subscription2) { create(:subscription, customer:, organization:) }
 
       let(:validate_event) do
         described_class.call(
@@ -149,7 +149,7 @@ RSpec.describe Events::ValidateCreationService, type: :service do
 
       before do
         subscription
-        create(:active_subscription, customer:, organization:, external_id:)
+        create(:subscription, customer:, organization:, external_id:)
       end
 
       it 'does not return any validation errors' do

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:active_subscription, customer:, plan:) }
+  let(:subscription) { create(:subscription, customer:, plan:) }
   let(:tax) { create(:tax, organization:, rate: 20) }
 
   let(:group) { nil }

--- a/spec/services/fees/estimate_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/estimate_pay_in_advance_service_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Fees::EstimatePayInAdvanceService do
       context 'when customer has an active subscription' do
         let(:subscription) do
           create(
-            :active_subscription,
+            :subscription,
             customer:,
             plan:,
             started_at: 1.year.ago,

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }
-  let(:subscription) { create(:active_subscription, customer:, plan:) }
+  let(:subscription) { create(:subscription, customer:, plan:) }
   let(:charge) { create(:standard_charge, :pay_in_advance, billable_metric:, plan:) }
   let(:group) { nil }
 

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Plans::DestroyService, type: :service do
     end
 
     context 'with active subscriptions' do
-      let(:subscriptions) { create_list(:active_subscription, 2, plan:) }
+      let(:subscriptions) { create_list(:subscription, 2, plan:) }
 
       before { subscriptions }
 
@@ -99,7 +99,7 @@ RSpec.describe Plans::DestroyService, type: :service do
     end
 
     context 'with draft invoices' do
-      let(:subscription) { create(:active_subscription, plan:) }
+      let(:subscription) { create(:subscription, plan:) }
       let(:invoices) { create_list(:invoice, 2, :draft) }
 
       before do

--- a/spec/services/quantified_events/create_or_update_service_spec.rb
+++ b/spec/services/quantified_events/create_or_update_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe QuantifiedEvents::CreateOrUpdateService, type: :service do
   end
 
   let(:customer) { create(:customer) }
-  let(:subscription) { create(:active_subscription, started_at: event_timestamp - 3.days, customer:) }
+  let(:subscription) { create(:subscription, started_at: event_timestamp - 3.days, customer:) }
   let(:organization) { customer.organization }
 
   let(:billable_metric) do

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Subscriptions::ActivateService, type: :service do
   let(:timestamp) { Time.current }
 
   describe 'activate_all_expired' do
-    let(:active_subscription) { create(:active_subscription) }
+    let(:active_subscription) { create(:subscription) }
     let(:pending_subscriptions) { create_list(:pending_subscription, 3, subscription_at: timestamp) }
 
     let(:future_pending_subscriptions) do


### PR DESCRIPTION
Before, each time we were creating a `subscription` via FactoryBot, `started_at` was null but `status` active. 