### PR TITLE
feat (document-template): Adjust credit note and invoice templates

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -104,7 +104,7 @@ class Fee < ApplicationRecord
     return '' unless charge?
     return '' if charge.properties['grouped_by'].blank?
 
-    ' • ' + grouped_by.values.join(' • ')
+    " • #{grouped_by.values.join(' • ')}"
   end
 
   def invoice_sorting_clause

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -100,6 +100,23 @@ class Fee < ApplicationRecord
     charge&.group_properties&.find_by(group:)&.invoice_display_name || group&.name
   end
 
+  def grouped_by_display
+    return '' unless charge?
+    return '' if charge.properties['grouped_by'].blank?
+
+    ' • ' + grouped_by.values.join(' • ')
+  end
+
+  def invoice_sorting_clause
+    base_clause = "#{invoice_name} #{group_name}".downcase
+
+    return base_clause unless charge?
+    return base_clause unless charge.standard?
+    return base_clause if charge.properties['grouped_by'].blank?
+
+    "#{invoice_name} #{grouped_by.values.join} #{group_name}".downcase
+  end
+
   def currency
     amount_currency
   end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -100,13 +100,6 @@ class Fee < ApplicationRecord
     charge&.group_properties&.find_by(group:)&.invoice_display_name || group&.name
   end
 
-  def grouped_by_display
-    return '' unless charge?
-    return '' if charge.properties['grouped_by'].blank?
-
-    " • #{grouped_by.values.join(' • ')}"
-  end
-
   def invoice_sorting_clause
     base_clause = "#{invoice_name} #{group_name}".downcase
 

--- a/app/views/helpers/fee_display_helper.rb
+++ b/app/views/helpers/fee_display_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class FeeDisplayHelper
+  def self.grouped_by_display(fee)
+    return '' unless fee.charge?
+    return '' if fee.charge.properties['grouped_by'].blank?
+
+    " • #{fee.grouped_by.values.join(' • ')}"
+  end
+end

--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -400,7 +400,7 @@ html
                 - if items.all? { |i| i.fee.group_id? }
                   - items.each do |item|
                     tr
-                      td.body-1 = item.fee.invoice_name + item.fee.grouped_by_display + ' • ' + item.fee.group_name
+                      td.body-1 = item.fee.invoice_name + FeeDisplayHelper.grouped_by_display(item.fee) + ' • ' + item.fee.group_name
                       td.body-2 width="20%" == TaxHelper.applied_taxes(item)
                       td.body-2 width="20%" = MoneyHelper.format(item.amount)
                   - items.select { |i| i.fee.true_up_fee.present? }.each do |item|
@@ -411,7 +411,7 @@ html
                         td.body-2 width="20%" = MoneyHelper.format(true_up_item.amount)
                 - else
                   tr
-                    td.body-1 width="60%" = item.fee.invoice_name + item.fee.grouped_by_display
+                    td.body-1 width="60%" = item.fee.invoice_name + FeeDisplayHelper.grouped_by_display(item.fee)
                     td.body-2 width="20%" == TaxHelper.applied_taxes(item)
                     td.body-2 width="20%" = MoneyHelper.format(item.amount)
                   - if item.fee.true_up_fee.present?

--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -398,13 +398,9 @@ html
               - subscription_charge_items(subscription_id).where(fees: { true_up_parent_fee: nil }).group_by { |i| i.fee.charge_id }.each do |_charge_id, items|
                 - item = items.first
                 - if items.all? { |i| i.fee.group_id? }
-                  tr
-                    td.body-1 width="60%" = item.fee.invoice_name
-                    td
-                    td
                   - items.each do |item|
                     tr
-                      td.body-1 style="padding-left: 16px;" = item.fee.group_name
+                      td.body-1 = item.fee.invoice_name + item.fee.grouped_by_display + ' • ' + item.fee.group_name
                       td.body-2 width="20%" == TaxHelper.applied_taxes(item)
                       td.body-2 width="20%" = MoneyHelper.format(item.amount)
                   - items.select { |i| i.fee.true_up_fee.present? }.each do |item|
@@ -415,7 +411,7 @@ html
                         td.body-2 width="20%" = MoneyHelper.format(true_up_item.amount)
                 - else
                   tr
-                    td.body-1 width="60%" = item.fee.invoice_name
+                    td.body-1 width="60%" = item.fee.invoice_name + item.fee.grouped_by_display
                     td.body-2 width="20%" == TaxHelper.applied_taxes(item)
                     td.body-2 width="20%" = MoneyHelper.format(item.amount)
                   - if item.fee.true_up_fee.present?

--- a/app/views/templates/invoices/v4/_default_fee.slim
+++ b/app/views/templates/invoices/v4/_default_fee.slim
@@ -1,7 +1,7 @@
 - fee = self.first
 tr
   td
-    .body-1 = fee.invoice_name + fee.grouped_by_display
+    .body-1 = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
     - if fee.billable_metric.weighted_sum_agg?
       .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(fee.subscription.plan.interval))
     - if fee.charge.percentage?

--- a/app/views/templates/invoices/v4/_default_fee.slim
+++ b/app/views/templates/invoices/v4/_default_fee.slim
@@ -1,7 +1,7 @@
 - fee = self.first
 tr
   td
-    .body-1 = fee.invoice_name
+    .body-1 = fee.invoice_name + fee.grouped_by_display
     - if fee.billable_metric.weighted_sum_agg?
       .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(fee.subscription.plan.interval))
     - if fee.charge.percentage?

--- a/app/views/templates/invoices/v4/_default_fee_with_groups.slim
+++ b/app/views/templates/invoices/v4/_default_fee_with_groups.slim
@@ -1,6 +1,6 @@
 tr
   td
-    .body-1 = self.invoice_name + self.grouped_by_display + ' • ' + self.group_name
+    .body-1 = self.invoice_name + FeeDisplayHelper.grouped_by_display(self) + ' • ' + self.group_name
     - if self.billable_metric.weighted_sum_agg?
       .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(self.subscription.plan.interval))
     - if self.charge.percentage?

--- a/app/views/templates/invoices/v4/_default_fee_with_groups.slim
+++ b/app/views/templates/invoices/v4/_default_fee_with_groups.slim
@@ -1,6 +1,6 @@
 tr
   td
-    .body-1 = self.invoice_name + ' • ' + self.group_name
+    .body-1 = self.invoice_name + self.grouped_by_display + ' • ' + self.group_name
     - if self.billable_metric.weighted_sum_agg?
       .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(self.subscription.plan.interval))
     - if self.charge.percentage?

--- a/app/views/templates/invoices/v4/_fee_with_groups.slim
+++ b/app/views/templates/invoices/v4/_fee_with_groups.slim
@@ -1,6 +1,6 @@
 tr.charge-name
   td.body-1
-    = self.invoice_name + self.grouped_by_display + ' • ' + self.group_name
+    = self.invoice_name + FeeDisplayHelper.grouped_by_display(self) + ' • ' + self.group_name
     - if self.billable_metric.weighted_sum_agg?
       .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(self.subscription.plan.interval))
     - if self.charge.percentage?

--- a/app/views/templates/invoices/v4/_fee_with_groups.slim
+++ b/app/views/templates/invoices/v4/_fee_with_groups.slim
@@ -1,6 +1,6 @@
 tr.charge-name
   td.body-1
-    = self.invoice_name + ' • ' + self.group_name
+    = self.invoice_name + self.grouped_by_display + ' • ' + self.group_name
     - if self.billable_metric.weighted_sum_agg?
       .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(self.subscription.plan.interval))
     - if self.charge.percentage?

--- a/app/views/templates/invoices/v4/_fees_without_groups.slim
+++ b/app/views/templates/invoices/v4/_fees_without_groups.slim
@@ -5,7 +5,7 @@
 - else
   tr.charge-name
     td.body-1
-      = fee.invoice_name
+      = fee.invoice_name + fee.grouped_by_display
       - if fee.billable_metric.weighted_sum_agg?
         .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(fee.subscription.plan.interval))
       - if fee.charge.percentage?

--- a/app/views/templates/invoices/v4/_fees_without_groups.slim
+++ b/app/views/templates/invoices/v4/_fees_without_groups.slim
@@ -5,7 +5,7 @@
 - else
   tr.charge-name
     td.body-1
-      = fee.invoice_name + fee.grouped_by_display
+      = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
       - if fee.billable_metric.weighted_sum_agg?
         .body-3 = I18n.t('invoice.units_prorated_per_period', period: IntervalHelper.interval_name(fee.subscription.plan.interval))
       - if fee.charge.percentage?

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -3,91 +3,53 @@
     - if subscriptions.count > 1
       h2.title-2.mb-24 class="#{'invoice-details-title' if subscriptions.count > 1}" = I18n.t('invoice.details', resource: subscription.invoice_name)
 
-    / PAY IN ARREARS PLAN INTERVAL
-    - if subscription? && !subscription.plan.pay_in_advance?
-      .invoice-resume.overflow-auto class="#{'mb-24' if subscription_fees(subscription.id).charge_kind.any? && different_boundaries_for_subscription_and_charges(subscription)}"
-        table.invoice-resume-table width="100%"
-          tr.first_child
-            td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date, format: :default), to_date: I18n.l(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date, format: :default))
-            td.body-2 = I18n.t('invoice.units')
-            td.body-2 = I18n.t('invoice.unit_price')
-            td.body-2 = I18n.t('invoice.tax_rate')
-            td.body-2 = I18n.t('invoice.amount')
-          tr
-            td.body-1 = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.invoice_name)
-            td.body-2 = 1
-            td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).subscription_amount)
-            td.body-2 == TaxHelper.applied_taxes(invoice_subscription(subscription.id).subscription_fee)
-            td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).subscription_amount)
+    / Subscription fee section
+    .invoice-resume.overflow-auto class="#{'mb-24' if subscription_fees(subscription.id).charge_kind.any? && different_boundaries_for_subscription_and_charges(subscription)}"
+      table.invoice-resume-table width="100%"
+        tr.first_child
+          td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date, format: :default), to_date: I18n.l(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date, format: :default))
+          td.body-2 = I18n.t('invoice.units')
+          td.body-2 = I18n.t('invoice.unit_price')
+          td.body-2 = I18n.t('invoice.tax_rate')
+          td.body-2 = I18n.t('invoice.amount')
+        tr
+          td.body-1 = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.invoice_name)
+          td.body-2 = 1
+          td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).subscription_amount)
+          td.body-2 == TaxHelper.applied_taxes(invoice_subscription(subscription.id).subscription_fee)
+          td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).subscription_amount)
 
-      / Charge fees section for subscription invoice
-      - if subscription? && subscription_fees(subscription.id).charge_kind.any?
-        / Charges payed in arrears
-        - if subscription.plan.charges.where(pay_in_advance: false).any?
-          .invoice-resume.overflow-auto class="#{'mb-24' if subscription.plan.charges.where(pay_in_advance: true).any?}"
-            table.invoice-resume-table width="100%"
-              / Loop over all top level fees
-              - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}".downcase }.group_by(&:charge_id).each do |_charge_id, fees|
-                - fee = fees.first
-                - next if fee.charge.pay_in_advance?
+        - if subscription? && subscription_fees(subscription.id).charge_kind.any?
+          / Charges payed in advance on payed in advance plan
+          - if subscription.plan.charges.where(pay_in_advance: true).any? && subscription.plan.pay_in_advance?
+            / Loop over all top level fees
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}" }.group_by(&:charge_id).each do |_charge_id, fees|
+              - fee = fees.first
+              - next unless fee.charge.pay_in_advance?
 
-                / Fees for groups
-                - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
-                  - fees.select { |f| f.units.positive? }.each do |fee|
-                    - if fee.amount_details.blank?
-                      == SlimHelper.render('templates/invoices/v4/_default_fee_with_groups', fee)
-                    - else
-                      == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
+              / Fees for groups
+              - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
+                - fees.select { |f| f.units.positive? }.each do |fee|
+                  - if fee.amount_details.blank?
+                    == SlimHelper.render('templates/invoices/v4/_default_fee', fees)
+                  - else
+                    == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
 
-                  / True up fees attached to the fee
-                  - fees.select { |f| f.true_up_fee.present? }.each do |fee|
-                    == SlimHelper.render('templates/invoices/v4/_true_up_fee', fee)
+                / True up fees attached to the fee
+                - if fee.true_up_fee.present?
+                  == SlimHelper.render('templates/invoices/v4/_true_up_fee', fee)
 
-                / Fees without group
-                - else
-                  == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
+              / Fees without group
+              - else
+                == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
 
-        / Charges payed in advance on payed in arrears plan
-        - if subscription.plan.charges.where(pay_in_advance: true).any?
-          .invoice-resume.overflow-auto
-            table.invoice-resume-table width="100%"
-              tr.first_child
-                - pay_in_advance_interval = charge_pay_in_advance_interval(invoice_subscription(subscription.id).timestamp, subscription)
-                td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(pay_in_advance_interval[:charges_from_date], format: :default), to_date: I18n.l(pay_in_advance_interval[:charges_to_date], format: :default))
-                td.body-2 = I18n.t('invoice.units')
-                td.body-2 = I18n.t('invoice.unit_price')
-                td.body-2 = I18n.t('invoice.tax_rate')
-                td.body-2 = I18n.t('invoice.amount')
-
-              / Loop over all top level fees
-              - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}".downcase }.group_by(&:charge_id).each do |_charge_id, fees|
-                - fee = fees.first
-                - next unless fee.charge.pay_in_advance?
-
-                / Fees for groups
-                - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
-                  - fees.select { |f| f.units.positive? }.each do |fee|
-                    - if fee.amount_details.blank?
-                      == SlimHelper.render('templates/invoices/v4/_default_fee', fees)
-                    - else
-                      == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
-
-                  / True up fees attached to the fee
-                  - if fee.true_up_fee.present?
-                    == SlimHelper.render('templates/invoices/v4/_true_up_fee', fee)
-
-                / Fees without group
-                - else
-                  == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
-
-    / PAY IN ADVANCE PLAN INTERVAL
-    - if subscription? && subscription.plan.pay_in_advance?
-      / Charge fees section for subscription invoice
-      - if subscription_fees(subscription.id).charge_kind.any?
-        / Charges payed in arrears
-        - if subscription.plan.charges.where(pay_in_advance: false).any?
-          .invoice-resume.overflow-auto class="mb-24"
-            table.invoice-resume-table width="100%"
+    / Charge fees section for subscription invoice
+    - if subscription? && subscription_fees(subscription.id).charge_kind.any?
+      / Charges payed in arrears OR charges and plan payed in advance
+      - if subscription.plan.charges.where(pay_in_advance: false).any?
+        .invoice-resume.overflow-auto
+          table.invoice-resume-table width="100%"
+            - if different_boundaries_for_subscription_and_charges(subscription)
               tr.first_child
                 td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(invoice_subscription(subscription.id).charges_from_datetime_in_customer_timezone&.to_date, format: :default), to_date: I18n.l(invoice_subscription(subscription.id).charges_to_datetime_in_customer_timezone&.to_date, format: :default))
                 td.body-2 = I18n.t('invoice.units')
@@ -95,65 +57,59 @@
                 td.body-2 = I18n.t('invoice.tax_rate')
                 td.body-2 = I18n.t('invoice.amount')
 
-              / Loop over all top level fees
-              - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}".downcase }.group_by(&:charge_id).each do |_charge_id, fees|
-                - fee = fees.first
-                - next if fee.charge.pay_in_advance?
+            / Loop over all top level fees
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}" }.group_by(&:charge_id).each do |_charge_id, fees|
+              - fee = fees.first
+              - next if fee.charge.pay_in_advance?
 
-                / Fees for groups
-                - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
-                  - fees.select { |f| f.units.positive? }.each do |fee|
-                    - if fee.amount_details.blank?
-                      == SlimHelper.render('templates/invoices/v4/_default_fee_with_groups', fee)
-                    - else
-                      == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
+              / Fees for groups
+              - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
+                - fees.select { |f| f.units.positive? }.each do |fee|
+                  - if fee.amount_details.blank?
+                    == SlimHelper.render('templates/invoices/v4/_default_fee_with_groups', fee)
+                  - else
+                    == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
 
-                  / True up fees attached to the fee
-                  - fees.select { |f| f.true_up_fee.present? }.each do |fee|
-                    == SlimHelper.render('templates/invoices/v4/_true_up_fee', fee)
+                / True up fees attached to the fee
+                - fees.select { |f| f.true_up_fee.present? }.each do |fee|
+                  == SlimHelper.render('templates/invoices/v4/_true_up_fee', fee)
 
-                / Fees without group
-                - else
-                  == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
+              / Fees without group
+              - else
+                == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
 
-      .invoice-resume.overflow-auto
-        table.invoice-resume-table width="100%"
-          tr.first_child
-            td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(invoice_subscription(subscription.id).from_datetime_in_customer_timezone&.to_date, format: :default), to_date: I18n.l(invoice_subscription(subscription.id).to_datetime_in_customer_timezone&.to_date, format: :default))
-            td.body-2 = I18n.t('invoice.units')
-            td.body-2 = I18n.t('invoice.unit_price')
-            td.body-2 = I18n.t('invoice.tax_rate')
-            td.body-2 = I18n.t('invoice.amount')
-          tr
-            td.body-1 = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.invoice_name)
-            td.body-2 = 1
-            td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).subscription_amount)
-            td.body-2 == TaxHelper.applied_taxes(invoice_subscription(subscription.id).subscription_fee)
-            td.body-2 = MoneyHelper.format(invoice_subscription(subscription.id).subscription_amount)
+      / Charges payed in advance on payed in arrears plan
+      - if subscription.plan.charges.where(pay_in_advance: true).any? && !subscription.plan.pay_in_advance?
+        .invoice-resume.overflow-auto
+          table.invoice-resume-table width="100%"
+            tr
+              - pay_in_advance_interval = charge_pay_in_advance_interval(invoice_subscription(subscription.id).timestamp, subscription)
+              td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(pay_in_advance_interval[:charges_from_date], format: :default), to_date: I18n.l(pay_in_advance_interval[:charges_to_date], format: :default))
+              td.body-2 = I18n.t('invoice.units')
+              td.body-2 = I18n.t('invoice.unit_price')
+              td.body-2 = I18n.t('invoice.tax_rate')
+              td.body-2 = I18n.t('invoice.amount')
 
-          - if subscription? && subscription_fees(subscription.id).charge_kind.any?
-            / Charges payed in advance on payed in advance plan
-            - if subscription.plan.charges.where(pay_in_advance: true).any?
-              / Loop over all top level fees
-              - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}".downcase }.group_by(&:charge_id).each do |_charge_id, fees|
-                - fee = fees.first
-                - next unless fee.charge.pay_in_advance?
+            / Loop over all top level fees
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}" }.group_by(&:charge_id).each do |_charge_id, fees|
+              - fee = fees.first
+              - next unless fee.charge.pay_in_advance?
 
-                / Fees for groups
-                - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
-                  - fees.select { |f| f.units.positive? }.each do |fee|
-                    - if fee.amount_details.blank?
-                      == SlimHelper.render('templates/invoices/v4/_default_fee', fees)
-                    - else
-                      == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
+              / Fees for groups
+              - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
+                - fees.select { |f| f.units.positive? }.each do |fee|
+                  - if fee.amount_details.blank?
+                    == SlimHelper.render('templates/invoices/v4/_default_fee', fees)
+                  - else
+                    == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
 
-                  / True up fees attached to the fee
-                  - if fee.true_up_fee.present?
-                    == SlimHelper.render('templates/invoices/v4/_true_up_fee', fee)
+                / True up fees attached to the fee
+                - if fee.true_up_fee.present?
+                  == SlimHelper.render('templates/invoices/v4/_true_up_fee', fee)
 
-                / Fees without group
-                - else
-                  == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
+              / Fees without group
+              - else
+                == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
 
     / Total section
     .invoice-resume.overflow-auto

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -23,7 +23,7 @@
           / Charges payed in advance on payed in advance plan
           - if subscription.plan.charges.where(pay_in_advance: true).any? && subscription.plan.pay_in_advance?
             / Loop over all top level fees
-            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}" }.group_by(&:charge_id).each do |_charge_id, fees|
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}".downcase }.group_by(&:charge_id).each do |_charge_id, fees|
               - fee = fees.first
               - next unless fee.charge.pay_in_advance?
 
@@ -58,7 +58,7 @@
                 td.body-2 = I18n.t('invoice.amount')
 
             / Loop over all top level fees
-            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}" }.group_by(&:charge_id).each do |_charge_id, fees|
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}".downcase }.group_by(&:charge_id).each do |_charge_id, fees|
               - fee = fees.first
               - next if fee.charge.pay_in_advance?
 
@@ -91,7 +91,7 @@
               td.body-2 = I18n.t('invoice.amount')
 
             / Loop over all top level fees
-            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}" }.group_by(&:charge_id).each do |_charge_id, fees|
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}".downcase }.group_by(&:charge_id).each do |_charge_id, fees|
               - fee = fees.first
               - next unless fee.charge.pay_in_advance?
 

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -23,7 +23,7 @@
           / Charges payed in advance on payed in advance plan
           - if subscription.plan.charges.where(pay_in_advance: true).any? && subscription.plan.pay_in_advance?
             / Loop over all top level fees
-            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}".downcase }.group_by(&:charge_id).each do |_charge_id, fees|
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| f.invoice_sorting_clause }.group_by(&:charge_id).each do |_charge_id, fees|
               - fee = fees.first
               - next unless fee.charge.pay_in_advance?
 
@@ -58,7 +58,7 @@
                 td.body-2 = I18n.t('invoice.amount')
 
             / Loop over all top level fees
-            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}".downcase }.group_by(&:charge_id).each do |_charge_id, fees|
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| f.invoice_sorting_clause }.group_by(&:charge_id).each do |_charge_id, fees|
               - fee = fees.first
               - next if fee.charge.pay_in_advance?
 
@@ -91,7 +91,7 @@
               td.body-2 = I18n.t('invoice.amount')
 
             / Loop over all top level fees
-            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| "#{f.invoice_name}#{f.group_name}".downcase }.group_by(&:charge_id).each do |_charge_id, fees|
+            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| f.invoice_sorting_clause }.group_by(&:charge_id).each do |_charge_id, fees|
               - fee = fees.first
               - next unless fee.charge.pay_in_advance?
 

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -82,7 +82,7 @@
       - if subscription.plan.charges.where(pay_in_advance: true).any? && !subscription.plan.pay_in_advance?
         .invoice-resume.overflow-auto
           table.invoice-resume-table width="100%"
-            tr
+            tr.first_child
               - pay_in_advance_interval = charge_pay_in_advance_interval(invoice_subscription(subscription.id).timestamp, subscription)
               td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(pay_in_advance_interval[:charges_from_date], format: :default), to_date: I18n.l(pay_in_advance_interval[:charges_to_date], format: :default))
               td.body-2 = I18n.t('invoice.units')

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -281,4 +281,41 @@ RSpec.describe Fee, type: :model do
 
     it { expect(fee.total_amount_currency).to eq('EUR') }
   end
+
+  describe '#invoice_sorting_clause' do
+    let(:charge) { create(:standard_charge, properties:) }
+    let(:fee) { fee_model.new(charge:, fee_type: 'charge', grouped_by:) }
+    let(:grouped_by) do
+      {
+        'key_1' => 'mercredi',
+        'key_2' => 'week_01',
+        'key_3' => '2024',
+      }
+    end
+    let(:properties) do
+      {
+        'amount' => '5',
+        'grouped_by' => %w[key_1 key_2 key_3],
+      }
+    end
+
+    context 'when it is standard charge fee with grouped_by property' do
+      it 'returns valid response' do
+        expect(fee.invoice_sorting_clause)
+          .to eq("#{fee.invoice_name} #{fee.grouped_by.values.join} #{fee.group_name}".downcase)
+      end
+    end
+
+    context 'when missing grouped_by property' do
+      let(:properties) do
+        {
+          'amount' => '5',
+        }
+      end
+
+      it 'returns valid response' do
+        expect(fee.invoice_sorting_clause).to eq("#{fee.invoice_name} #{fee.group_name}".downcase)
+      end
+    end
+  end
 end

--- a/spec/views/helpers/fee_display_helper_spec.rb
+++ b/spec/views/helpers/fee_display_helper_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FeeDisplayHelper do
+  subject(:helper) { described_class }
+
+  describe '.grouped_by_display' do
+    let(:charge) { create(:standard_charge, properties:) }
+    let(:fee) { create(:fee, charge:, fee_type: 'charge', grouped_by:, total_aggregated_units: 10) }
+    let(:grouped_by) do
+      {
+        'key_1' => 'mercredi',
+        'key_2' => 'week_01',
+        'key_3' => '2024',
+      }
+    end
+    let(:properties) do
+      {
+        'amount' => '5',
+        'grouped_by' => %w[key_1 key_2 key_3],
+      }
+    end
+
+    context 'when it is standard charge fee with grouped_by property' do
+      it 'returns valid response' do
+        expect(helper.grouped_by_display(fee)).to eq(' • mercredi • week_01 • 2024')
+      end
+    end
+
+    context 'when missing grouped_by property' do
+      let(:properties) do
+        {
+          'amount' => '5',
+        }
+      end
+
+      it 'returns valid response' do
+        expect(helper.grouped_by_display(fee)).to eq('')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Existing PDF templates miss support for `grouped_by` feature. Also, currently, we always display pay in arrear fees first and after that pay in advance fees. However, we need to change it in a way that subscription fee is always on the top, no matter if pay in arrear or pay in advance. Basically, fees ordering should use logic that was implemented before so this part has been reverted.

## Description

This PR covers:
- support for grouped_by feature
- reorder fees
