### PR TITLE
 feat(grouped-by): Basic refactoring for unique count aggregation 

### DIFF
--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -24,7 +24,7 @@ module Types
       field :taxes, [Types::Taxes::Object]
 
       def properties
-        return unless object.properties == '{}'
+        return object.properties unless object.properties == '{}'
 
         JSON.parse(object.properties)
       end

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -23,6 +23,12 @@ module Types
 
       field :taxes, [Types::Taxes::Object]
 
+      def properties
+        return unless object.properties == '{}'
+
+        JSON.parse(object.properties)
+      end
+
       def billable_metric
         return object.billable_metric unless object.discarded?
 

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -66,13 +66,6 @@ module BillableMetrics
         boundaries[:to_datetime]
       end
 
-      def count_unique_group_scope(events)
-        events = events.where('quantified_events.properties @> ?', { group.key.to_s => group.value }.to_json)
-        return events unless group.parent
-
-        events.where('quantified_events.properties @> ?', { group.parent.key.to_s => group.parent.value }.to_json)
-      end
-
       def handle_in_advance_current_usage(total_aggregation, target_result: result)
         cached_aggregation = find_cached_aggregation(grouped_by: target_result.grouped_by)
 

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -142,10 +142,10 @@ module BillableMetrics
           .to_datetime(with_to_datetime)
           .order(timestamp: :desc)
 
-        if grouped_by.present?
-          grouped_by.each do |key, value|
-            query = query.where('cached_aggregations.grouped_by @> ?', { key.to_s => value.to_s }.to_json)
-          end
+        query = if grouped_by.present?
+          query.where(grouped_by:)
+        else
+          query.where(grouped_by: {})
         end
 
         query = query.where.not(event_id: event.id) if event.present?

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -109,7 +109,7 @@ module BillableMetrics
 
         return quantified_events unless group
 
-        count_unique_group_scope(quantified_events)
+        base_aggregator.count_unique_group_scope(quantified_events)
       end
 
       # NOTE: Compute pro-rata of the duration in days between the datetimes over the duration of the billing period

--- a/spec/graphql/resolvers/plan_resolver_spec.rb
+++ b/spec/graphql/resolvers/plan_resolver_spec.rb
@@ -17,6 +17,35 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
           charges {
             id
             taxes { id rate }
+            properties {
+              amount
+              groupedBy
+              freeUnits
+              packageSize
+              fixedAmount
+              freeUnitsPerEvents
+              freeUnitsPerTotalAggregation
+              perTransactionMaxAmount
+              perTransactionMinAmount
+              rate
+            }
+            groupProperties {
+              groupId
+              invoiceDisplayName
+              values {
+                amount
+                groupedBy
+                freeUnits
+                packageSize
+                fixedAmount
+                freeUnitsPerEvents
+                freeUnitsPerTotalAggregation
+                perTransactionMaxAmount
+                perTransactionMinAmount
+                rate
+              }
+              deletedAt
+            }
           }
         }
       }
@@ -27,9 +56,15 @@ RSpec.describe Resolvers::PlanResolver, type: :graphql do
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
   let(:plan) { create(:plan, organization:) }
+  let(:group) { create(:group, billable_metric:) }
+  let(:group_property) { create(:group_property, group:, charge:) }
+
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:charge) { create(:standard_charge, billable_metric:, plan:) }
 
   before do
     customer
+    group_property
     create_list(:subscription, 2, customer:, plan:)
   end
 


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR is a small refactor to ease implementation of group by on the unique count aggregation
