### PR TITLE
feat(events) Modify events batch length limit

### DIFF
--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -2,7 +2,7 @@
 
 module Events
   class CreateBatchService < BaseService
-    MAX_LENGTH = 100
+    MAX_LENGTH = ENV.fetch("LAGO_EVENTS_BATCH_MAX_LENGTH", 100).to_i
 
     def initialize(organization:, events_params:, timestamp:, metadata:)
       @organization = organization


### PR DESCRIPTION
Added the ability to modify the value of MAX_LENGTH for events batching

## Context

 I've added support for configuring the maximum length of events batching by introducing the `LAGO_EVENTS_BATCH_MAX_LENGTH` env variable.

## Description

Now, users can easily customize the batch length according to their specific requirements without modifying the codebase directly.