### PR TITLE
test(subscriptions): more list-subscriptions tests

### DIFF
--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe SubscriptionsQuery, type: :query do
       it 'returns correct subscriptions' do
         create(:pending_subscription, customer:, plan:)
         create(:subscription, customer:, plan:, status: :canceled)
+        create(:subscription, customer:, plan:, status: :terminated)
         result = subscriptions_query.call
 
         aggregate_failures do
@@ -82,6 +83,7 @@ RSpec.describe SubscriptionsQuery, type: :query do
           expect(result.subscriptions.active.count).to eq(1)
           expect(result.subscriptions.pending.count).to eq(1)
           expect(result.subscriptions.canceled.count).to eq(0)
+          expect(result.subscriptions.terminated.count).to eq(0)
         end
       end
     end
@@ -91,6 +93,8 @@ RSpec.describe SubscriptionsQuery, type: :query do
 
       it 'returns only pending subscriptions' do
         create(:pending_subscription, customer:, plan:)
+        create(:subscription, customer:, plan:, status: :canceled)
+        create(:subscription, customer:, plan:, status: :terminated)
 
         result = subscriptions_query.call
 
@@ -99,6 +103,50 @@ RSpec.describe SubscriptionsQuery, type: :query do
           expect(result.subscriptions.count).to eq(1)
           expect(result.subscriptions.active.count).to eq(0)
           expect(result.subscriptions.pending.count).to eq(1)
+          expect(result.subscriptions.canceled.count).to eq(0)
+          expect(result.subscriptions.terminated.count).to eq(0)
+        end
+      end
+    end
+
+    context 'with canceled status filter' do
+      let(:query_filters) { { status: [:canceled] } }
+
+      it 'returns only pending subscriptions' do
+        create(:pending_subscription, customer:, plan:)
+        create(:subscription, customer:, plan:, status: :canceled)
+        create(:subscription, customer:, plan:, status: :terminated)
+
+        result = subscriptions_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.subscriptions.count).to eq(1)
+          expect(result.subscriptions.active.count).to eq(0)
+          expect(result.subscriptions.pending.count).to eq(0)
+          expect(result.subscriptions.canceled.count).to eq(1)
+          expect(result.subscriptions.terminated.count).to eq(0)
+        end
+      end
+    end
+
+    context 'with terminated status filter' do
+      let(:query_filters) { { status: [:terminated] } }
+
+      it 'returns only pending subscriptions' do
+        create(:pending_subscription, customer:, plan:)
+        create(:subscription, customer:, plan:, status: :canceled)
+        create(:subscription, customer:, plan:, status: :terminated)
+
+        result = subscriptions_query.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.subscriptions.count).to eq(1)
+          expect(result.subscriptions.active.count).to eq(0)
+          expect(result.subscriptions.pending.count).to eq(0)
+          expect(result.subscriptions.canceled.count).to eq(0)
+          expect(result.subscriptions.terminated.count).to eq(1)
         end
       end
     end
@@ -114,6 +162,8 @@ RSpec.describe SubscriptionsQuery, type: :query do
           expect(result.subscriptions.count).to eq(1)
           expect(result.subscriptions.active.count).to eq(1)
           expect(result.subscriptions.pending.count).to eq(0)
+          expect(result.subscriptions.canceled.count).to eq(0)
+          expect(result.subscriptions.terminated.count).to eq(0)
         end
       end
     end

--- a/spec/requests/api/v1/subscriptions_spec.rb
+++ b/spec/requests/api/v1/subscriptions_spec.rb
@@ -363,5 +363,19 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
         expect(json[:subscriptions].first[:lago_id]).to eq(subscription1.id)
       end
     end
+
+    context 'with terminated status' do
+      let(:subscription3) { create(:subscription, customer:, plan: create(:plan, organization:), status: :terminated) }
+
+      before { subscription3 }
+
+      it 'returns terminated subscriptions' do
+        get_with_token(organization, "/api/v1/subscriptions?external_customer_id=#{customer.external_id}&status[]=terminated")
+
+        expect(response).to have_http_status(:success)
+        expect(json[:subscriptions].count).to eq(1)
+        expect(json[:subscriptions].first[:lago_id]).to eq(subscription3.id)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Roadmap Task

None.

## Context

The `status` parameter for the list all subscriptions api endpoint status parameter doesn't appear to do anything. After digging into the code, I have narrowed it down to the query string construction in the `lago-javascript-client`. The `GET /subscriptions` endpoint expects status query params in this format `status[]=terminated&status[]=active` but the javascript client is sending in `status=terminated&status=active` . This results in the status filter param being set to a string and then filtered out by [this line](https://github.com/getlago/lago-api/blob/00ab5ce06f888afc05ac93a2613d3d163a804abb/app/controllers/api/v1/subscriptions_controller.rb#L171) of code.

So I don't think the problem is this repo (lago-api), but I added these tests along the way and thought you might want to keep them.

## Description

I thought you guys might appreciate more test cases for listing subscriptions. I followed the patterns in the test files and I hope this checks out. I have not run the tests.