### PR TITLE
fix: remove zero units fees from PDF template

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -46,6 +46,8 @@ class Fee < ApplicationRecord
   scope :subscription_kind, -> { where(fee_type: :subscription) }
   scope :charge_kind, -> { where(fee_type: :charge) }
 
+  scope :positive_units, -> { where('units > ?', 0) }
+
   # NOTE: pay_in_advance fees are not be linked to any invoice, but add_on fees does not have any subscriptions
   #       so we need a bit of logic to find the fee in the right organization scope
   scope :from_organization,

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -23,7 +23,7 @@
           / Charges payed in advance on payed in advance plan
           - if subscription.plan.charges.where(pay_in_advance: true).any? && subscription.plan.pay_in_advance?
             / Loop over all top level fees
-            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| f.invoice_sorting_clause }.group_by(&:charge_id).each do |_charge_id, fees|
+            - subscription_fees(subscription.id).charge_kind.positive_units.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| f.invoice_sorting_clause }.group_by(&:charge_id).each do |_charge_id, fees|
               - fee = fees.first
               - next unless fee.charge.pay_in_advance?
 
@@ -58,7 +58,7 @@
                 td.body-2 = I18n.t('invoice.amount')
 
             / Loop over all top level fees
-            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| f.invoice_sorting_clause }.group_by(&:charge_id).each do |_charge_id, fees|
+            - subscription_fees(subscription.id).charge_kind.positive_units.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| f.invoice_sorting_clause }.group_by(&:charge_id).each do |_charge_id, fees|
               - fee = fees.first
               - next if fee.charge.pay_in_advance?
 
@@ -91,7 +91,7 @@
               td.body-2 = I18n.t('invoice.amount')
 
             / Loop over all top level fees
-            - subscription_fees(subscription.id).charge_kind.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| f.invoice_sorting_clause }.group_by(&:charge_id).each do |_charge_id, fees|
+            - subscription_fees(subscription.id).charge_kind.positive_units.where(true_up_parent_fee: nil).joins(charge: :billable_metric).sort_by { |f| f.invoice_sorting_clause }.group_by(&:charge_id).each do |_charge_id, fees|
               - fee = fees.first
               - next unless fee.charge.pay_in_advance?
 


### PR DESCRIPTION
In PDF invoice, template fees with zero unit value need to be removed