### PR TITLE
fix: Ensure subscription activation clock job cannot be enqueued twice

### DIFF
--- a/app/jobs/clock/activate_subscriptions_job.rb
+++ b/app/jobs/clock/activate_subscriptions_job.rb
@@ -4,6 +4,8 @@ module Clock
   class ActivateSubscriptionsJob < ApplicationJob
     queue_as 'clock'
 
+    unique :until_executed, on_conflict: :log
+
     def perform
       Subscriptions::ActivateService.new(timestamp: Time.current.to_i).activate_all_pending
     end


### PR DESCRIPTION
## Context

We recently add some invoice duplication related to the subscription activation process when the workers are on heavy load on a billing day (first day of a month).

Many multiple activation jobs were enqueued but not processed during a period of time because no worker were available to process them. Since the clock jobs have priority over the billing ones, they were all executed immediately in parallel when some worker get free.

In the  `Clock::ActivateSubscriptionsJob`, subscriptions are filtered to only take the pending one, but since the job were executed in parallel, the status was not updated yet.

## Description

This PR adds the `activejob-uniqueness` protection to ensure that only one instance of the  `Clock::ActivateSubscriptionsJob` can be executed at a time.
