### PR TITLE
feat(grouped_by): Add support for unique count

### DIFF
--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -33,7 +33,7 @@ module BillableMetrics
       #       as pay in advance aggregation will be computed on a single group
       #       with the grouped_by_values filter
       def compute_grouped_by_aggregation(_options)
-        aggregations = [compute_single_aggregation.ceil(5)] # TODO: compute_grouped_aggregations
+        aggregations = compute_grouped_aggregations
         return empty_results if aggregations.blank?
 
         result.aggregations = aggregations.map do |aggregation|


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR adds the new grouping logic for the unique count aggregation (without pro-ration)
