### PR TITLE
feat(grouped-by): Prorated unique count aggregation

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -13,6 +13,7 @@ module BillableMetrics
         @group = filters[:group]
         @event = filters[:event]
         @grouped_by = filters[:grouped_by]
+        @grouped_by_values = filters[:grouped_by_values]
 
         @boundaries = boundaries
 
@@ -43,7 +44,15 @@ module BillableMetrics
 
       protected
 
-      attr_accessor :event_store_class, :charge, :subscription, :filters, :group, :event, :boundaries, :grouped_by
+      attr_accessor :event_store_class,
+                    :charge,
+                    :subscription,
+                    :filters,
+                    :group,
+                    :event,
+                    :boundaries,
+                    :grouped_by,
+                    :grouped_by_values
 
       delegate :billable_metric, to: :charge
 

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -20,7 +20,7 @@ module BillableMetrics
       end
 
       def aggregate(options: {})
-        if grouped_by.present? && support_grouped_aggregation?
+        if grouped_by.present?
           compute_grouped_by_aggregation(options:)
         else
           compute_aggregation(options:)
@@ -83,10 +83,6 @@ module BillableMetrics
 
         target_result.aggregation = 0 if target_result.aggregation.negative?
         target_result.current_usage_units = 0 if target_result.current_usage_units.negative?
-      end
-
-      def support_grouped_aggregation?
-        false
       end
 
       def empty_results

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -50,12 +50,6 @@ module BillableMetrics
       def compute_per_event_aggregation
         (0...event_store.count).map { |_| 1 }
       end
-
-      protected
-
-      def support_grouped_aggregation?
-        true
-      end
     end
   end
 end

--- a/app/services/billable_metrics/aggregations/latest_service.rb
+++ b/app/services/billable_metrics/aggregations/latest_service.rb
@@ -45,10 +45,6 @@ module BillableMetrics
 
       protected
 
-      def support_grouped_aggregation?
-        true
-      end
-
       def compute_aggregation_value(latest_value)
         result = BigDecimal((latest_value || 0).to_s)
         return BigDecimal(0) if result.negative?

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -58,12 +58,6 @@ module BillableMetrics
           0
         end
       end
-
-      protected
-
-      def support_grouped_aggregation?
-        true
-      end
     end
   end
 end

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -126,10 +126,6 @@ module BillableMetrics
         event_store.events_values(force_from: true)
       end
 
-      def support_grouped_aggregation?
-        true
-      end
-
       # This method fetches the latest cached aggregation in current period. If such a record exists we know that
       # previous aggregation and previous maximum aggregation are stored there. Fetching these values
       # would help us in pay in advance value calculation without iterating through all events in current period

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -59,7 +59,7 @@ module BillableMetrics
 
         newly_applied_units = (operation_type == :add) ? 1 : 0
 
-        cached_aggregation = find_cached_aggregation
+        cached_aggregation = find_cached_aggregation(grouped_by: grouped_by_values)
 
         unless cached_aggregation
           handle_event_metadata(

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -153,10 +153,6 @@ module BillableMetrics
 
       protected
 
-      def support_grouped_aggregation?
-        true
-      end
-
       def operation_type
         @operation_type ||= event.properties.fetch('operation_type', 'add')&.to_sym
       end

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -67,10 +67,6 @@ module BillableMetrics
 
       private
 
-      def support_grouped_aggregation?
-        true
-      end
-
       def initial_value
         return 0 unless billable_metric.recurring?
 

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -7,13 +7,6 @@ module BillableMetrics
         @aggregation_without_proration ||= base_aggregator.aggregate(options:)
       end
 
-      def cached_aggregation
-        @cached_aggregation ||= base_aggregator.find_cached_aggregation(
-          with_from_datetime: from_datetime,
-          with_to_datetime: to_datetime,
-        )
-      end
-
       def compute_pay_in_advance_aggregation
         return BigDecimal(0) unless event
         return BigDecimal(0) if event.properties.blank?
@@ -42,6 +35,12 @@ module BillableMetrics
       def extend_cached_aggregation(prorated_value)
         result.max_aggregation = aggregation_without_proration.max_aggregation
         result.current_aggregation = aggregation_without_proration.current_aggregation
+
+        cached_aggregation = base_aggregator.find_cached_aggregation(
+          with_from_datetime: from_datetime,
+          with_to_datetime: to_datetime,
+          grouped_by: grouped_by_values,
+        )
 
         unless cached_aggregation
           result.max_aggregation_with_proration = prorated_value.to_s

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -102,10 +102,6 @@ module BillableMetrics
 
       protected
 
-      def support_grouped_aggregation?
-        true
-      end
-
       def persisted_event_store_instante
         event_store = event_store_class.new(
           code: billable_metric.code,

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -50,6 +50,7 @@ module BillableMetrics
         return aggregation_without_proration if event.nil? && options[:is_pay_in_advance] && !options[:is_current_usage]
 
         aggregations = compute_grouped_event_aggregation
+        return empty_results if aggregations.blank?
 
         result.aggregations = aggregations.map do |aggregation|
           aggregation_value = aggregation[:value].ceil(5)

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -92,10 +92,6 @@ module BillableMetrics
 
       protected
 
-      def support_grouped_aggregation?
-        true
-      end
-
       def compute_prorated_aggregation
         ActiveRecord::Base.connection.execute(prorated_aggregation_query).first['aggregation_result']
       end

--- a/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/unique_count_service.rb
@@ -54,6 +54,11 @@ module BillableMetrics
             agg.grouped_by == aggregation[:groups]
           end
 
+          unless group_result_without_proration
+            group_result_without_proration = empty_results.aggregations.first
+            group_result_without_proration.grouped_by = aggregation[:groups]
+          end
+
           group_result = BaseService::Result.new
           group_result.grouped_by = aggregation[:groups]
           group_result.full_units_number = group_result_without_proration&.aggregation || 0

--- a/spec/scenarios/billable_metrics/unique_count_spec.rb
+++ b/spec/scenarios/billable_metrics/unique_count_spec.rb
@@ -74,8 +74,128 @@ describe 'Aggregation - Unique Count Scenarios', :scenarios, type: :request, tra
       )
 
       fetch_current_usage(customer:)
-      # TODO: change after merge of quantified event handling
       expect(json[:customer_usage][:total_amount_cents]).to eq(200)
+    end
+  end
+
+  context 'with in advance charge' do
+    let(:charge) do
+      create(
+        :standard_charge,
+        billable_metric:,
+        plan:,
+        prorated: true,
+        pay_in_advance: true,
+        properties: {
+          amount: '29',
+          grouped_by: %w[key_1 key_2 key_3],
+        },
+      )
+    end
+
+    it 'creates fees for each events' do
+      travel_to(DateTime.new(2024, 2, 1)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+      end
+
+      subscription = customer.subscriptions.first
+
+      travel_to(DateTime.new(2024, 2, 1)) do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: {
+              'item_id' => '001',
+              'operation_type' => 'remove',
+              'key_1' => '2024',
+              'key_2' => 'Feb',
+              'key_3' => '06',
+            },
+          },
+        )
+
+        expect(Fee.count).to eq(1)
+
+        fetch_current_usage(customer:)
+        expect(json[:customer_usage][:total_amount_cents]).to eq(0)
+
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: {
+              'item_id' => '001',
+              'operation_type' => 'add',
+              'key_1' => '2024',
+              'key_2' => 'Feb',
+              'key_3' => '06',
+            },
+          },
+        )
+
+        expect(Fee.count).to eq(2)
+
+        fetch_current_usage(customer:)
+        expect(json[:customer_usage][:total_amount_cents]).to eq(2900)
+      end
+
+      travel_to(DateTime.new(2024, 2, 2)) do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: {
+              'item_id' => '001',
+              'operation_type' => 'add',
+              'key_1' => '2024',
+              'key_2' => 'Feb',
+              'key_3' => '06',
+            },
+          },
+        )
+
+        expect(Fee.count).to eq(2)
+
+        fetch_current_usage(customer:)
+        expect(json[:customer_usage][:total_amount_cents]).to eq(2900)
+      end
+
+      travel_to(DateTime.new(2024, 2, 3)) do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: {
+              'item_id' => '001',
+              'operation_type' => 'remove',
+              'key_1' => '2024',
+              'key_2' => 'Feb',
+              'key_3' => '06',
+            },
+          },
+        )
+
+        expect(Fee.count).to eq(3)
+
+        fetch_current_usage(customer:)
+        # TODO: change after merge of quantified event handling
+        expect(json[:customer_usage][:total_amount_cents]).to eq(0)
+      end
     end
   end
 end

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -12,14 +12,12 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
         from_datetime:,
         to_datetime:,
       },
-      filters: {
-        group:,
-        event: pay_in_advance_event,
-      },
+      filters:,
     )
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:filters) { { group:, event: pay_in_advance_event, grouped_by: } }
 
   let(:subscription) do
     create(
@@ -37,6 +35,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
   let(:group) { nil }
+  let(:grouped_by) { nil }
 
   let(:billable_metric) do
     create(
@@ -435,6 +434,306 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
         it 'assigns a pay_in_advance aggregation' do
           expect(result.pay_in_advance_aggregation).to eq(0)
           expect(result.units_applied).to eq(1)
+        end
+      end
+    end
+  end
+
+  describe '.grouped_by_aggregation' do
+    let(:result) { unique_count_service.aggregate(options:) }
+
+    let(:grouped_by) { ['agent_name'] }
+    let(:agent_names) { %w[aragorn frodo] }
+
+    let(:quantified_event) { nil }
+
+    let(:quantified_events) do
+      agent_names.each do |agent_name|
+        create(
+          :quantified_event,
+          added_at:,
+          removed_at:,
+          external_subscription_id: subscription.external_id,
+          billable_metric:,
+          grouped_by: { agent_name: },
+        )
+      end
+    end
+
+    before { quantified_events }
+
+    context 'with persisted metric on full period' do
+      it 'returns the number of persisted metric' do
+        expect(result.aggregations.count).to eq(2)
+
+        result.aggregations.each do |aggregation|
+          expect(aggregation.grouped_by.keys).to include('agent_name')
+          expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+          expect(aggregation.count).to eq(1)
+          expect(aggregation.aggregation).to eq(1)
+          expect(aggregation.full_units_number).to eq(1)
+        end
+      end
+
+      context 'when there is persisted event and event added in period' do
+        let(:new_quantified_events) do
+          agent_names.each do |agent_name|
+            create(
+              :quantified_event,
+              added_at: from_datetime + 10.days,
+              removed_at:,
+              external_subscription_id: subscription.external_id,
+              billable_metric:,
+              grouped_by: { agent_name: },
+            )
+          end
+        end
+
+        before { new_quantified_events }
+
+        it 'returns the correct number' do
+          expect(result.aggregations.count).to eq(2)
+
+          result.aggregations.each do |aggregation|
+            expect(aggregation.grouped_by.keys).to include('agent_name')
+            expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+            expect(aggregation.aggregation).to eq((1 + 21.fdiv(31)).ceil(5))
+            expect(aggregation.full_units_number).to eq(2)
+          end
+        end
+      end
+
+      context 'when dimensions are used' do
+        let(:quantified_events) do
+          agent_names.each do |agent_name|
+            create(
+              :quantified_event,
+              added_at:,
+              removed_at:,
+              external_subscription_id: subscription.external_id,
+              billable_metric:,
+              properties: { unique_id: '111', region: 'europe' },
+              grouped_by: { agent_name: },
+            )
+          end
+        end
+
+        let(:group) do
+          create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
+        end
+
+        it 'returns the number of persisted metric' do
+          expect(result.aggregations.count).to eq(2)
+
+          result.aggregations.each do |aggregation|
+            expect(aggregation.grouped_by.keys).to include('agent_name')
+            expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+            expect(aggregation.aggregation).to eq(1)
+            expect(aggregation.full_units_number).to eq(1)
+          end
+        end
+      end
+    end
+
+    context 'with persisted metrics added in the period' do
+      let(:added_at) { from_datetime + 15.days }
+
+      it 'returns the prorata of the full duration' do
+        expect(result.aggregations.count).to eq(2)
+
+        result.aggregations.each do |aggregation|
+          expect(aggregation.grouped_by.keys).to include('agent_name')
+          expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+          expect(aggregation.aggregation).to eq(16.fdiv(31).ceil(5))
+          expect(aggregation.full_units_number).to eq(1)
+        end
+      end
+
+      context 'when added on the first day of the period' do
+        let(:added_at) { from_datetime }
+
+        it 'returns the full duration' do
+          expect(result.aggregations.count).to eq(2)
+
+          result.aggregations.each do |aggregation|
+            expect(aggregation.grouped_by.keys).to include('agent_name')
+            expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+            expect(aggregation.aggregation).to eq(1)
+            expect(aggregation.full_units_number).to eq(1)
+          end
+        end
+      end
+    end
+
+    context 'with persisted metrics terminated in the period' do
+      let(:removed_at) { to_datetime - 15.days }
+
+      it 'returns the prorata of the full duration' do
+        expect(result.aggregations.count).to eq(2)
+
+        result.aggregations.each do |aggregation|
+          expect(aggregation.grouped_by.keys).to include('agent_name')
+          expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+          expect(aggregation.aggregation).to eq(16.fdiv(31).ceil(5))
+        end
+      end
+
+      context 'when removed on the last day of the period' do
+        let(:removed_at) { to_datetime }
+
+        it 'returns the full duration' do
+          expect(result.aggregations.count).to eq(2)
+
+          result.aggregations.each do |aggregation|
+            expect(aggregation.grouped_by.keys).to include('agent_name')
+            expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+            expect(aggregation.aggregation).to eq(1)
+          end
+        end
+      end
+    end
+
+    context 'with persisted metrics added and terminated in the period' do
+      let(:added_at) { from_datetime + 1.day }
+      let(:removed_at) { to_datetime - 1.day }
+
+      it 'returns the prorata of the full duration' do
+        expect(result.aggregations.count).to eq(2)
+
+        result.aggregations.each do |aggregation|
+          expect(aggregation.grouped_by.keys).to include('agent_name')
+          expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+          expect(aggregation.aggregation).to eq(29.fdiv(31).ceil(5))
+        end
+      end
+
+      context 'when added and removed the same day' do
+        let(:added_at) { from_datetime + 1.day }
+        let(:removed_at) { added_at.end_of_day }
+
+        it 'returns a 1 day duration' do
+          expect(result.aggregations.count).to eq(2)
+
+          result.aggregations.each do |aggregation|
+            expect(aggregation.grouped_by.keys).to include('agent_name')
+            expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+            expect(aggregation.aggregation).to eq(1.fdiv(31).ceil(5))
+          end
+        end
+      end
+    end
+
+    context 'when current usage context and charge is pay in arrear' do
+      let(:options) do
+        { is_pay_in_advance: false, is_current_usage: true }
+      end
+      let(:new_quantified_events) do
+        agent_names.map do |agent_name|
+          create(
+            :quantified_event,
+            added_at: from_datetime + 10.days,
+            removed_at:,
+            external_subscription_id: subscription.external_id,
+            billable_metric:,
+            grouped_by: { agent_name: },
+          )
+        end
+      end
+
+      before { new_quantified_events }
+
+      it 'returns correct result' do
+        expect(result.aggregations.count).to eq(2)
+
+        result.aggregations.each do |aggregation|
+          expect(aggregation.grouped_by.keys).to include('agent_name')
+          expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+          expect(aggregation.aggregation).to eq((1 + 21.fdiv(31)).ceil(5))
+          expect(aggregation.current_usage_units).to eq(2)
+        end
+      end
+    end
+
+    context 'when current usage context and charge is pay in advance' do
+      let(:options) do
+        { is_pay_in_advance: true, is_current_usage: true }
+      end
+
+      let(:previous_events) do
+        agent_names.map.with_index do |agent_name, index|
+          create(
+            :event,
+            organization_id: organization.id,
+            code: billable_metric.code,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            timestamp: from_datetime + 5.days,
+            properties: {
+              unique_id: previous_quantified_events[index].external_id,
+              agent_name:,
+            },
+          )
+        end
+      end
+
+      let(:previous_quantified_events) do
+        agent_names.map do |agent_name|
+          create(
+            :quantified_event,
+            organization:,
+            added_at: from_datetime + 5.days,
+            removed_at:,
+            external_id: '000',
+            external_subscription_id: subscription.external_id,
+            billable_metric:,
+            grouped_by: { agent_name: },
+          )
+        end
+      end
+
+      let(:cached_aggregations) do
+        agent_names.map.with_index do |agent_name, index|
+          create(
+            :cached_aggregation,
+            organization:,
+            charge:,
+            event_id: previous_events[index].id,
+            external_subscription_id: subscription.external_id,
+            timestamp: from_datetime + 5.days,
+            current_aggregation: '1',
+            max_aggregation: '1',
+            max_aggregation_with_proration: '0.8',
+            grouped_by: { agent_name: },
+          )
+        end
+      end
+
+      before { cached_aggregations }
+
+      it 'returns period maximum as aggregation' do
+        expect(result.aggregations.count).to eq(2)
+
+        result.aggregations.each do |aggregation|
+          expect(aggregation.grouped_by.keys).to include('agent_name')
+          expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+          expect(aggregation.aggregation).to eq(1.8)
+          expect(aggregation.current_usage_units).to eq(2)
+        end
+      end
+
+      context 'when cached aggregation does not exist' do
+        let(:cached_aggregations) { nil }
+
+        it 'returns only the past aggregation' do
+          expect(result.aggregations.count).to eq(2)
+
+          result.aggregations.each do |aggregation|
+            expect(aggregation.grouped_by.keys).to include('agent_name')
+            expect(aggregation.grouped_by['agent_name']).to eq('frodo').or eq('aragorn')
+            expect(aggregation.aggregation).to eq(1)
+            expect(aggregation.current_usage_units).to eq(1)
+            expect(aggregation.full_units_number).to eq(1)
+          end
         end
       end
     end


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR adds the new grouping logic for the prorated unique count aggregation
