### PR TITLE
fix (invoice-number): use organization timezone in per org numbering

### DIFF
--- a/db/migrate/20240205160647_remove_organization_sequential_id_index_from_invoices.rb
+++ b/db/migrate/20240205160647_remove_organization_sequential_id_index_from_invoices.rb
@@ -2,6 +2,8 @@
 
 class RemoveOrganizationSequentialIdIndexFromInvoices < ActiveRecord::Migration[7.0]
   def change
-    remove_index :invoices, name: 'unique_organization_sequential_id'
+    remove_index :invoices,
+                 "organization_id, organization_sequential_id, (date_trunc('month', created_at)::date)",
+                 name: 'unique_organization_sequential_id'
   end
 end

--- a/db/migrate/20240205160647_remove_organization_sequential_id_index_from_invoices.rb
+++ b/db/migrate/20240205160647_remove_organization_sequential_id_index_from_invoices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveOrganizationSequentialIdIndexFromInvoices < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :invoices, name: 'unique_organization_sequential_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_29_155938) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_05_160647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -609,7 +609,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_29_155938) do
     t.datetime "voided_at"
     t.integer "organization_sequential_id", default: 0, null: false
     t.boolean "ready_to_be_refreshed", default: false, null: false
-    t.index "organization_id, organization_sequential_id, ((date_trunc('month'::text, created_at))::date)", name: "unique_organization_sequential_id", unique: true, where: "(organization_sequential_id <> 0)"
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"


### PR DESCRIPTION
## Context

When generating invoice number in `per_organization` mode, we should use organization timezone.

## Description

`organization_sequential_id` usually have following pattern: `prefix-202402-001`. Middle part and sequential id should be generated in the organization scope and based on existing month. However, month scope should take organization timezone into account.
