### PR TITLE
feat(grouped-by): Quantified event processing after event creation

### DIFF
--- a/spec/scenarios/billable_metrics/unique_count_spec.rb
+++ b/spec/scenarios/billable_metrics/unique_count_spec.rb
@@ -74,7 +74,7 @@ describe 'Aggregation - Unique Count Scenarios', :scenarios, type: :request, tra
       )
 
       fetch_current_usage(customer:)
-      expect(json[:customer_usage][:total_amount_cents]).to eq(200)
+      expect(json[:customer_usage][:total_amount_cents]).to eq(300)
     end
   end
 
@@ -193,8 +193,7 @@ describe 'Aggregation - Unique Count Scenarios', :scenarios, type: :request, tra
         expect(Fee.count).to eq(3)
 
         fetch_current_usage(customer:)
-        # TODO: change after merge of quantified event handling
-        expect(json[:customer_usage][:total_amount_cents]).to eq(0)
+        expect(json[:customer_usage][:total_amount_cents]).to eq(2900)
       end
     end
   end


### PR DESCRIPTION
## Context

Some customers have requested a way to group usage fees on an invoice using an event property. The same charge model properties should be applied to each group. The logic will only apply to `standard` charge model.

## Description

This PR is the last of the epic, it simply ensure that `QuantifiedEvent` are created for events related to a standard charge with `grouped_by` attribute properties when if it's related to a unique count aggregation.
