### PR TITLE
fix(one-off-invoices): support string as well for one-off units

### DIFF
--- a/app/services/fees/one_off_service.rb
+++ b/app/services/fees/one_off_service.rb
@@ -19,7 +19,7 @@ module Fees
           return result.not_found_failure!(resource: 'add_on') unless add_on
 
           unit_amount_cents = fee[:unit_amount_cents] || add_on.amount_cents
-          units = fee[:units] || 1
+          units = fee[:units]&.to_f || 1
           tax_codes = fee[:tax_codes]
 
           fee = Fee.new(

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -96,5 +96,44 @@ RSpec.describe Fees::OneOffService do
         expect(Fee.find_by(description: add_on_second.description)).to be_nil
       end
     end
+
+    context 'when units is passed as string' do
+      let(:fees) do
+        [
+          {
+            add_on_code: add_on_first.code,
+            unit_amount_cents: 1200,
+            units: 2,
+            description: 'desc-123',
+            tax_codes: [tax2.code],
+          },
+        ]
+      end
+
+      it 'creates fees' do
+        result = one_off_service.create
+
+        expect(result).to be_success
+
+        first_fee = result.fees[0]
+
+        aggregate_failures do
+          expect(first_fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            add_on_id: add_on_first.id,
+            description: 'desc-123',
+            unit_amount_cents: 1200,
+            precise_unit_amount: 12,
+            units: 2,
+            amount_cents: 2400,
+            amount_currency: 'EUR',
+            fee_type: 'add_on',
+            payment_status: 'pending',
+          )
+          expect(first_fee.taxes.map(&:code)).to contain_exactly(tax2.code)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Currently open-api display string as units type for one-off invoices. However, some users already use float.

## Description

In order not to create breaking change we want to support both string and float as one-off invoice unit type.
