### PR TITLE
feat(events-batch): Handle errors in events batch

### DIFF
--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -20,7 +20,7 @@ module Events
 
       validate_events
 
-      return result.validation_failure!(errors: result.errors) if result.errors.present?
+      return result.validation_failure!(errors: result.errors) if result.events.size() == 0
 
       post_validate_events
 
@@ -46,8 +46,12 @@ module Events
         event.metadata = metadata || {}
         event.timestamp = Time.zone.at(event_params[:timestamp] ? event_params[:timestamp].to_f : timestamp)
 
-        result.events.push(event)
-        result.errors = result.errors.merge({ index => event.errors.messages }) unless event.valid?
+        if event.valid?
+          result.events.push(event)
+        else
+          Rails.logger.warn("Event with transactionID #{event.transaction_id} validation error: #{event.errors.full_messages}")
+          result.errors = result.errors.merge({ index => event.errors.messages })
+        end
       end
     end
 


### PR DESCRIPTION
## Context

Currently, the system returns an error for the entire batch if any of the events fail validation.
imho, this behavior is unfair.

## Description

Implemented validation error handling for events batch processing: now returns error only if all events fail validation; allows operation if a subset of events have validation errors and return list of accepted events.
For example: if the user has sent 3 events in a batch and 1 event fails validation, it returns as follows: `{"events":[{$valid_event0}, {$valid_event1}]}`

What do you think about this change? 