### PR TITLE
fix(invoice-pdf): add new PDF template updates

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -137,6 +137,16 @@ class Invoice < ApplicationRecord
     invoice_subscription(subscription_id).fees
   end
 
+  def existing_fees_in_interval?(subscription_id:, charge_in_advance: false)
+    subscription_fees(subscription_id)
+      .charge_kind
+      .positive_units
+      .where(true_up_parent_fee: nil)
+      .joins(:charge)
+      .where(charge: { pay_in_advance: charge_in_advance })
+      .any?
+  end
+
   def recurring_fees(subscription_id)
     subscription_fees(subscription_id)
       .joins(charge: :billable_metric)

--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -196,6 +196,9 @@ html
       .mb-24 {
         margin-bottom: 24px;
       }
+      .mt-24 {
+        margin-top: 24px;
+      }
 
       .overflow-auto {
         overflow: auto;
@@ -439,7 +442,7 @@ html
               = customer.city
           .body-2 = customer.state
           .body-2 = ISO3166::Country.new(customer.country)&.common_name
-          .body-2 = customer.email.gsub(/,\s*/, ', ')
+          .body-2 = customer.email&.gsub(/,\s*/, ', ')
           - if customer.tax_identification_number.present?
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: customer.tax_identification_number)
 

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -51,7 +51,7 @@
     / Charge fees section for subscription invoice
     - if subscription? && subscription_fees(subscription.id).charge_kind.any?
       / Charges payed in arrears OR charges and plan payed in advance
-      - if subscription.plan.charges.where(pay_in_advance: false).any?
+      - if subscription.plan.charges.where(pay_in_advance: false).any? && existing_fees_in_interval?(subscription_id: subscription.id)
         .invoice-resume.overflow-auto
           table.invoice-resume-table width="100%"
             - if different_boundaries_for_subscription_and_charges(subscription)
@@ -84,8 +84,8 @@
                 == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
 
       / Charges payed in advance on payed in arrears plan
-      - if subscription.plan.charges.where(pay_in_advance: true).any? && !subscription.plan.pay_in_advance?
-        .invoice-resume.overflow-auto
+      - if subscription.plan.charges.where(pay_in_advance: true).any? && !subscription.plan.pay_in_advance? && existing_fees_in_interval?(subscription_id: subscription.id, charge_in_advance: true)
+        .invoice-resume.overflow-auto class="mt-24"
           table.invoice-resume-table width="100%"
             tr.first_child
               - pay_in_advance_interval = charge_pay_in_advance_interval(invoice_subscription.timestamp, subscription)


### PR DESCRIPTION
## Context

This PR fixes:
- remove fees table header if there are no positive fees inside
- setting margins
- prevent error when there is no email since we call `gsub` method on it
