### PR TITLE
fix(currency): Add missing KWD currency

### DIFF
--- a/app/models/concerns/currencies.rb
+++ b/app/models/concerns/currencies.rb
@@ -69,6 +69,7 @@ module Currencies
     KHR: 'Cambodian Riel',
     KMF: 'Comorian Franc',
     KRW: 'South Korean Won',
+    KWD: 'Kuwaiti Dinar',
     KYD: 'Cayman Islands Dollar',
     KZT: 'Kazakhstani Tenge',
     LAK: 'Lao Kip',

--- a/schema.graphql
+++ b/schema.graphql
@@ -2282,6 +2282,11 @@ enum CurrencyEnum {
   KRW
 
   """
+  Kuwaiti Dinar
+  """
+  KWD
+
+  """
   Cayman Islands Dollar
   """
   KYD

--- a/schema.json
+++ b/schema.json
@@ -8460,6 +8460,12 @@
               "deprecationReason": null
             },
             {
+              "name": "KWD",
+              "description": "Kuwaiti Dinar",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "KYD",
               "description": "Cayman Islands Dollar",
               "isDeprecated": false,


### PR DESCRIPTION
## Context

A user reported that the `KWD` currency is missing in the accepted currency list

## Description

This PR adds the missing currency and expose it in the GraphQL api