### PR TITLE
fix(weighted-sum): Turn kafka timestamp into a string

### DIFF
--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -49,7 +49,7 @@ module Events
           external_customer_id: event.external_customer_id,
           external_subscription_id: event.external_subscription_id,
           transaction_id: event.transaction_id,
-          timestamp: event.timestamp.to_f,
+          timestamp: event.timestamp.iso8601[...-1], # NOTE: Removes trailing 'Z' to allow clickhouse parsing
           code: event.code,
           properties: event.properties,
         }.to_json,

--- a/db/clickhouse_migrate/20231026124912_create_events_raw_queue.rb
+++ b/db/clickhouse_migrate/20231026124912_create_events_raw_queue.rb
@@ -16,7 +16,7 @@ class CreateEventsRawQueue < ActiveRecord::Migration[7.0]
       t.string :external_customer_id, null: false
       t.string :external_subscription_id, null: false
       t.string :transaction_id, null: false
-      t.float :timestamp, null: false
+      t.string :timestamp, null: false
       t.string :code, null: false
       t.string :properties, null: false
     end

--- a/db/clickhouse_schema.rb
+++ b/db/clickhouse_schema.rb
@@ -3,7 +3,7 @@
 # incrementally modify your database, and then regenerate this schema definition.
 #
 # This file is the source Rails uses to define your schema when running `rails
-# clickhouse:schema:load`. When creating a new database, `rails clickhouse:schema:load` tends to
+# *****:schema:load`. When creating a new database, `rails *****:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
@@ -25,13 +25,13 @@ ClickhouseActiverecord::Schema.define(version: 2023_10_30_163703) do
   end
 
   # TABLE: events_raw_queue
-  # SQL: CREATE TABLE default.events_raw_queue ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` Float32, `code` String, `properties` String ) ENGINE = Kafka SETTINGS kafka_broker_list = '*****', kafka_topic_list = '*****', kafka_group_name = '*****', kafka_format = 'JSONEachRow'
+  # SQL: CREATE TABLE default.events_raw_queue ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` String, `code` String, `properties` String ) ENGINE = Kafka SETTINGS kafka_broker_list = '*****', kafka_topic_list = '*****', kafka_group_name = '*****', kafka_format = 'JSONEachRow'
   create_table "events_raw_queue", id: false, options: "Kafka SETTINGS kafka_broker_list = '*****', kafka_topic_list = '*****', kafka_group_name = '*****', kafka_format = 'JSONEachRow'", force: :cascade do |t|
     t.string "organization_id", null: false
     t.string "external_customer_id", null: false
     t.string "external_subscription_id", null: false
     t.string "transaction_id", null: false
-    t.float "timestamp", null: false
+    t.string "timestamp", null: false
     t.string "code", null: false
     t.string "properties", null: false
   end


### PR DESCRIPTION
## Context

An issue have been identified with the event timestamp conversion from float to datetime in Clickhouse events_raw.

`1706745600` (2024-02-01T00:00:00.000Z) is stored as `Thu, 01 Feb 2024 00:00:59.392000000 UTC +00:00`

## Description

To fix the issue, we decided to turn the float into a string and to send timestamp as an iso8601 datetime