### PR TITLE
feat(unique-count): Implement basic unique count for PostgresStore

### DIFF
--- a/app/services/events/stores/postgres/unique_count_query.rb
+++ b/app/services/events/stores/postgres/unique_count_query.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Postgres
+      class UniqueCountQuery
+        def initialize(store:)
+          @store = store
+        end
+
+        def query
+          # NOTE: First sum calculates all operation values for a specific property
+          # (for instance 2 relevant additions with 1 relevant removal [0, 1, 0, -1, 1] returns 1)
+          # The next sum combines all properties into a single result
+          <<-SQL
+            #{events_cte_sql},
+            event_values AS (
+              SELECT
+                property,
+                SUM(adjusted_value) AS sum_adjusted_value
+              FROM (
+                SELECT
+                  timestamp,
+                  property,
+                  operation_type,
+                  #{operation_value_sql} AS adjusted_value
+                FROM events_data
+                ORDER BY timestamp ASC
+              ) adjusted_event_values
+              GROUP BY property
+            )
+
+            SELECT SUM(sum_adjusted_value) AS aggregation FROM event_values
+          SQL
+        end
+
+        # NOTE: Not used in production, only for debug purpose to check the computed values before aggregation
+        # Returns an array of event's timestamp, property, operation type and operation value
+        # Example:
+        # [
+        #   ["2023-03-16T00:00:00.000Z", "001", "add", 1],
+        #   ["2023-03-17T00:00:00.000Z", "001", "add", 0],
+        #   ["2023-03-17T10:00:00.000Z", "002", "remove", 0],
+        #   ["2023-03-18T00:00:00.000Z", "001", "remove", -1],
+        #   ["2023-03-19T00:00:00.000Z", "002", "add", 1]
+        # ]
+        def breakdown_query
+          <<-SQL
+            #{events_cte_sql}
+
+            SELECT
+              timestamp,
+              property,
+              operation_type,
+              #{operation_value_sql}
+            FROM events_data
+            ORDER BY timestamp ASC
+          SQL
+        end
+
+        private
+
+        attr_reader :store
+
+        delegate :events, :sanitized_propery_name, to: :store
+
+        def events_cte_sql
+          # NOTE: Common table expression returning event's timestamp, property name and operation type.
+          <<-SQL
+            WITH events_data AS (
+              (#{
+                events
+                  .select(
+                    "timestamp, \
+                    #{sanitized_propery_name} AS property, \
+                    COALESCE(events.properties->>'operation_type', 'add') AS operation_type",
+                  ).to_sql
+              })
+            )
+          SQL
+        end
+
+        def operation_value_sql
+          # NOTE: Returns 1 for relevant addition, -1 for relevant removal
+          # If property already added, another addition returns 0 ; it returns 1 otherwise
+          # If property already removed or not yet present, another removal returns 0 ; it returns -1 otherwise
+          <<-SQL
+            CASE WHEN operation_type = 'add'
+            THEN
+              CASE WHEN LAG(operation_type, 1) OVER (PARTITION BY property ORDER BY timestamp) = 'add'
+              THEN 0
+              ELSE 1
+              END
+            ELSE
+              CASE LAG(operation_type, 1, 'remove') OVER (PARTITION BY property ORDER BY timestamp)
+                WHEN 'remove' THEN 0
+                ELSE -1
+              END
+            END
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -71,6 +71,22 @@ module Events
         prepare_grouped_result(results)
       end
 
+      def unique_count
+        query = Events::Stores::Postgres::UniqueCountQuery.new(store: self)
+        sql = ActiveRecord::Base.sanitize_sql_for_conditions([query.query])
+        result = ActiveRecord::Base.connection.select_one(sql)
+
+        result['aggregation']
+      end
+
+      # NOTE: not used in production, only for debug purpose to check the computed values before aggregation
+      def unique_count_breakdown
+        query = Events::Stores::Postgres::UniqueCountQuery.new(store: self)
+        ActiveRecord::Base.connection.select_all(
+          ActiveRecord::Base.sanitize_sql_for_conditions([query.breakdown_query]),
+        ).rows
+      end
+
       def max
         events.maximum("(#{sanitized_propery_name})::numeric")
       end

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
 
   before { events }
 
-  describe '.events' do
+  describe '#events' do
     it 'returns a list of events' do
       expect(event_store.events.count).to eq(5)
     end
@@ -93,13 +93,13 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.count' do
+  describe '#count' do
     it 'returns the number of unique events' do
       expect(event_store.count).to eq(5)
     end
   end
 
-  describe '.grouped_count' do
+  describe '#grouped_count' do
     let(:grouped_by) { %w[cloud] }
 
     it 'returns the number of unique events grouped by the provided group' do
@@ -139,7 +139,28 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.events_values' do
+  describe '#unique_count' do
+    it 'returns the number of unique active event properties' do
+      create(
+        :event,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        external_customer_id: customer.external_id,
+        code:,
+        timestamp: boundaries[:from_datetime] + 2.days,
+        properties: {
+          billable_metric.field_name => 2,
+          operation_type: 'remove',
+        },
+      )
+
+      event_store.aggregation_property = billable_metric.field_name
+
+      expect(event_store.unique_count).to eq(4) # 5 events added / 1 removed
+    end
+  end
+
+  describe '#events_values' do
     it 'returns the value attached to each event' do
       event_store.aggregation_property = billable_metric.field_name
       event_store.numeric_property = true
@@ -148,7 +169,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.last_event' do
+  describe '#last_event' do
     it 'returns the last event' do
       event_store.aggregation_property = billable_metric.field_name
       event_store.numeric_property = true
@@ -157,7 +178,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.grouped_last_event' do
+  describe '#grouped_last_event' do
     let(:grouped_by) { %w[cloud] }
 
     before do
@@ -206,7 +227,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.prorated_events_values' do
+  describe '#prorated_events_values' do
     it 'returns the value attached to each event prorated on the provided duration' do
       event_store.aggregation_property = billable_metric.field_name
       event_store.numeric_property = true
@@ -217,7 +238,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.max' do
+  describe '#max' do
     it 'returns the max value' do
       event_store.aggregation_property = billable_metric.field_name
       event_store.numeric_property = true
@@ -226,7 +247,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.grouped_max' do
+  describe '#grouped_max' do
     let(:grouped_by) { %w[cloud] }
 
     before do
@@ -271,7 +292,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.last' do
+  describe '#last' do
     it 'returns the last event' do
       event_store.aggregation_property = billable_metric.field_name
       event_store.numeric_property = true
@@ -280,7 +301,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.grouped_last' do
+  describe '#grouped_last' do
     let(:grouped_by) { %w[cloud] }
 
     before do
@@ -325,7 +346,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.sum' do
+  describe '#sum' do
     it 'returns the sum of event values' do
       event_store.aggregation_property = billable_metric.field_name
       event_store.numeric_property = true
@@ -334,7 +355,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.grouped_sum' do
+  describe '#grouped_sum' do
     let(:grouped_by) { %w[cloud] }
 
     before do
@@ -379,7 +400,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.prorated_sum' do
+  describe '#prorated_sum' do
     it 'returns the prorated sum of event properties' do
       event_store.aggregation_property = billable_metric.field_name
       event_store.numeric_property = true
@@ -397,7 +418,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.grouped_prorated_sum' do
+  describe '#grouped_prorated_sum' do
     let(:grouped_by) { %w[cloud] }
 
     it 'returns the prorated sum of event properties' do
@@ -463,7 +484,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.sum_date_breakdown' do
+  describe '#sum_date_breakdown' do
     it 'returns the sum grouped by day' do
       event_store.aggregation_property = billable_metric.field_name
       event_store.numeric_property = true
@@ -479,7 +500,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.weighted_sum' do
+  describe '#weighted_sum' do
     let(:started_at) { Time.zone.parse('2023-03-01') }
 
     let(:events_values) do
@@ -590,7 +611,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
-  describe '.grouped_weighted_sum' do
+  describe '#grouped_weighted_sum' do
     let(:grouped_by) { %w[agent_name other] }
 
     let(:started_at) { Time.zone.parse('2023-03-01') }


### PR DESCRIPTION
## Context

The goal is to refactor the way we’re doing the aggregation for the unique count.

## Description

The goal of this PR is to add the method `Events::Stores::PostgresStore#unique_count`.

The SQL logic has been extracted into `Events::Stores::Postgres::UniqueCountQuery`.

We've added the method `Events::Stores::PostgresStore#unique_count_breakdown' to facilitate the debugging.