### PR TITLE
feat(unique-count): Add prorated unique count method

### DIFF
--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -87,6 +87,21 @@ module Events
         ).rows
       end
 
+      def prorated_unique_count
+        query = Events::Stores::Postgres::UniqueCountQuery.new(store: self)
+        sql = ActiveRecord::Base.sanitize_sql_for_conditions(
+          [
+            query.prorated_query,
+            {
+              to_datetime: to_datetime.ceil,
+            },
+          ],
+        )
+        result = ActiveRecord::Base.connection.select_one(sql)
+
+        result['aggregation']
+      end
+
       def max
         events.maximum("(#{sanitized_property_name})::numeric")
       end


### PR DESCRIPTION
## Context

The goal is to refactor the way we’re doing the aggregation for the unique count.

## Description

The goal of this PR is to add the method `Events::Stores::PostgresStore#prorated_unique_count`.

The SQL logic has been extracted into `Events::Stores::Postgres::UniqueCountQuery`.