### PR TITLE
feat (plan-changes): Adjust boundaries upon subscription upgrade

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -135,4 +135,20 @@ class Subscription < ApplicationRecord
   def invoice_name
     name.presence || plan.invoice_name
   end
+
+  # When upgrade, we want to bill one day less since date of the upgrade will be
+  # included in the first invoice for the new plan
+  def date_diff_with_timezone(from_datetime, to_datetime)
+    number_od_days = Utils::DatetimeService.date_diff_with_timezone(
+      from_datetime,
+      to_datetime,
+      customer.applicable_timezone,
+    )
+
+    return number_od_days unless terminated? && upgraded?
+
+    number_od_days = number_od_days - 1
+
+    number_od_days < 0 ? 0 : number_od_days
+  end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -147,8 +147,8 @@ class Subscription < ApplicationRecord
 
     return number_od_days unless terminated? && upgraded?
 
-    number_od_days = number_od_days - 1
+    number_od_days -= 1
 
-    number_od_days < 0 ? 0 : number_od_days
+    number_od_days.negative? ? 0 : number_od_days
   end
 end

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -102,11 +102,7 @@ module BillableMetrics
       #       we want to bill the persisted metrics at prorata of the full period duration.
       #       ie: the number of day of the terminated period divided by number of days without termination
       def persisted_pro_rata
-        Utils::DatetimeService.date_diff_with_timezone(
-          from_datetime,
-          to_datetime,
-          subscription.customer.applicable_timezone,
-        ).fdiv(period_duration)
+        subscription.date_diff_with_timezone(from_datetime, to_datetime).fdiv(period_duration)
       end
 
       attr_accessor :options

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -139,11 +139,7 @@ module BillableMetrics
       def persisted_sum
         persisted_event_store_instante.prorated_sum(
           period_duration:,
-          persisted_duration: Utils::DatetimeService.date_diff_with_timezone(
-            from_datetime,
-            to_datetime,
-            subscription.customer.applicable_timezone,
-          ),
+          persisted_duration: subscription.date_diff_with_timezone(from_datetime, to_datetime),
         )
       end
 
@@ -180,11 +176,7 @@ module BillableMetrics
       def grouped_persisted_sums
         persisted_event_store_instante.grouped_prorated_sum(
           period_duration:,
-          persisted_duration: Utils::DatetimeService.date_diff_with_timezone(
-            from_datetime,
-            to_datetime,
-            subscription.customer.applicable_timezone,
-          ),
+          persisted_duration: subscription.date_diff_with_timezone(from_datetime, to_datetime),
         )
       end
     end

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -71,7 +71,7 @@ module CreditNotes
 
     def remaining_duration
       billed_from = terminated_at_in_timezone.end_of_day.utc.to_date
-      billed_from = billed_from - 1.day if upgrade
+      billed_from -= 1.day if upgrade
 
       if plan.has_trial? && subscription.trial_end_date >= billed_from
         billed_from = if subscription.trial_end_date > to_date
@@ -83,7 +83,7 @@ module CreditNotes
 
       duration = (to_date - billed_from).to_i
 
-      duration < 0 ? 0 : duration
+      duration.negative? ? 0 : duration
     end
 
     def creditable_amount_cents(item_amount)

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -2,9 +2,10 @@
 
 module CreditNotes
   class CreateFromTermination < BaseService
-    def initialize(subscription:, reason: 'order_change')
+    def initialize(subscription:, reason: 'order_change', upgrade: false)
       @subscription = subscription
       @reason = reason
+      @upgrade = upgrade
 
       super
     end
@@ -37,7 +38,7 @@ module CreditNotes
 
     private
 
-    attr_accessor :subscription, :reason
+    attr_accessor :subscription, :reason, :upgrade
 
     delegate :plan, :terminated_at, :customer, to: :subscription
 
@@ -70,6 +71,7 @@ module CreditNotes
 
     def remaining_duration
       billed_from = terminated_at_in_timezone.end_of_day.utc.to_date
+      billed_from = billed_from - 1.day if upgrade
 
       if plan.has_trial? && subscription.trial_end_date >= billed_from
         billed_from = if subscription.trial_end_date > to_date

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -81,7 +81,9 @@ module CreditNotes
         end
       end
 
-      (to_date - billed_from).to_i
+      duration = (to_date - billed_from).to_i
+
+      duration < 0 ? 0 : duration
     end
 
     def creditable_amount_cents(item_amount)

--- a/app/services/fees/create_true_up_service.rb
+++ b/app/services/fees/create_true_up_service.rb
@@ -39,11 +39,7 @@ module Fees
       # NOTE: number of days between beginning of the period and the termination date
       from_datetime = boundaries.charges_from_datetime.to_time
       to_datetime = boundaries.charges_to_datetime.to_time
-      number_of_day_to_bill = Utils::DatetimeService.date_diff_with_timezone(
-        from_datetime,
-        to_datetime,
-        subscription.customer.applicable_timezone,
-      )
+      number_of_day_to_bill = subscription.date_diff_with_timezone(from_datetime, to_datetime)
 
       date_service.charge_single_day_price(charge:) * number_of_day_to_bill
     end

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -181,11 +181,7 @@ module Fees
       end
 
       # NOTE: number of days between beginning of the period and the termination date
-      number_of_day_to_bill = Utils::DatetimeService.date_diff_with_timezone(
-        from_datetime,
-        to_datetime,
-        customer.applicable_timezone,
-      )
+      number_of_day_to_bill = subscription.date_diff_with_timezone(from_datetime, to_datetime)
 
       # Remove later customer timezone fix while passing optional_from_date
       # single_day_price method should return correct amount even without the timezone fix since

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -148,7 +148,7 @@ module Subscriptions
 
       # NOTE: When upgrading, the new subscription becomes active immediatly
       #       The previous one must be terminated
-      Subscriptions::TerminateService.call(subscription: current_subscription)
+      Subscriptions::TerminateService.call(subscription: current_subscription, upgrade: true)
 
       new_subscription.mark_as_active!
       perform_later(job_class: SendWebhookJob, arguments: ['subscription.started', new_subscription])

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -2,9 +2,10 @@
 
 module Subscriptions
   class TerminateService < BaseService
-    def initialize(subscription:, async: true)
+    def initialize(subscription:, async: true, upgrade: false)
       @subscription = subscription
       @async = async
+      @upgrade = upgrade
 
       super
     end
@@ -25,6 +26,7 @@ module Subscriptions
           credit_note_result = CreditNotes::CreateFromTermination.new(
             subscription:,
             reason: 'order_cancellation',
+            upgrade:,
           ).call
           credit_note_result.raise_if_error!
         end
@@ -76,7 +78,7 @@ module Subscriptions
 
     private
 
-    attr_reader :subscription, :async
+    attr_reader :subscription, :async, :upgrade
 
     def bill_subscription
       if async

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -396,4 +396,50 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe '.date_diff_with_timezone' do
+    let(:from_datetime) { Time.zone.parse('2023-08-31T23:10:00') }
+    let(:to_datetime) { Time.zone.parse('2023-09-30T22:59:59') }
+    let(:customer) { create(:customer, timezone:) }
+    let(:terminated_at) { nil }
+    let(:timezone) { 'Europe/Paris' }
+
+    let(:subscription) do
+      create(
+        :subscription,
+        plan:,
+        customer:,
+        terminated_at:,
+      )
+    end
+
+    let(:result) do
+      subscription.date_diff_with_timezone(from_datetime, to_datetime)
+    end
+
+    it 'returns the number of days between the two datetime' do
+      expect(result).to eq(30)
+    end
+
+    context 'with terminated and upgraded subscription' do
+      let(:terminated_at) { Time.zone.parse('2023-09-30T22:59:59') }
+      let(:new_subscription) do
+        create(
+          :subscription,
+          plan:,
+          customer:,
+          previous_subscription_id: subscription.id,
+        )
+      end
+
+      before do
+        subscription.terminated!
+        new_subscription
+      end
+
+      it 'takes the daylight saving time into account' do
+        expect(result).to eq(29)
+      end
+    end
+  end
 end

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -566,7 +566,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
 
           subscription = customer.subscriptions.first
 
-          travel_to(DateTime.new(2023, 10, 18)) do
+          travel_to(DateTime.new(2023, 10, 18, 5, 20)) do
             create(
               :graduated_charge,
               billable_metric:,
@@ -608,7 +608,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
 
             invoice = subscription.invoices.order(created_at: :desc).first
             expect(invoice.fees.charge_kind.count).to eq(1)
-            # 30226 (17 / 31 * 75 units) + 2.58 = 2 / 31 * 20 units (prorated event in termination period)
+            # 30226 (17 / 31 * 75 units) + 2.58 (2 / 31 * 20 units - prorated event in termination period)
             expect(invoice.total_amount_cents).to eq(27_323)
           end
 

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -447,7 +447,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
     end
 
-    it 'does bill correctly fees' do
+    it 'bills fees correctly' do
       travel_to(DateTime.new(2024, 1, 1)) do
         create(
           :standard_charge,
@@ -501,8 +501,8 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         credit_note = customer.credit_notes.first
 
         expect(credit_note.credit_amount_cents).to eq(1_800)
-        expect(terminated_invoice.total_amount_cents).to eq(0) # 12/29 x 5 = 207 - 207(CN)
-        expect(new_subscription_invoice.total_amount_cents).to eq(18_000 - (1_800 - 207))
+        expect(terminated_invoice.total_amount_cents).to eq(0) # 11/29 x 5 = 190 - 190(CN)
+        expect(new_subscription_invoice.total_amount_cents).to eq(18_000 - (1_800 - 190))
       end
     end
   end

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -458,6 +458,15 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           properties: { amount: '1' },
         )
 
+        create(
+          :standard_charge,
+          plan: plan_new,
+          billable_metric: metric,
+          pay_in_advance: false,
+          prorated: true,
+          properties: { amount: '1' },
+        )
+
         create_subscription(
           {
             external_customer_id: customer.external_id,
@@ -501,8 +510,238 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         credit_note = customer.credit_notes.first
 
         expect(credit_note.credit_amount_cents).to eq(1_800)
-        expect(terminated_invoice.total_amount_cents).to eq(0) # 11/29 x 5 = 190 - 190(CN)
+        expect(terminated_invoice.total_amount_cents).to eq(0) # 11/29 x 500 = 190 - 190(CN)
         expect(new_subscription_invoice.total_amount_cents).to eq(18_000 - (1_800 - 190))
+      end
+
+      travel_to(DateTime.new(2024, 3, 1, 12, 12)) do
+        Subscriptions::BillingService.call
+        perform_all_enqueued_jobs
+
+        invoice = customer.subscriptions.active.first.invoices.order(created_at: :desc).first
+
+        expect(invoice.total_amount_cents).to eq((29_000 + (18.fdiv(29) * 500)).round)
+      end
+    end
+  end
+
+  context 'when pay in arrear subscription is upgraded' do
+    let(:customer) { create(:customer, organization:) }
+    let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: false) }
+    let(:plan_new) { create(:plan, organization:, amount_cents: 29_000, pay_in_advance: false) }
+    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:metric) do
+      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+    end
+
+    it 'bills fees correctly' do
+      travel_to(DateTime.new(2024, 1, 1)) do
+        create(
+          :standard_charge,
+          plan:,
+          billable_metric: metric,
+          pay_in_advance: false,
+          prorated: true,
+          properties: { amount: '1' },
+        )
+
+        create(
+          :standard_charge,
+          plan: plan_new,
+          billable_metric: metric,
+          pay_in_advance: false,
+          prorated: true,
+          properties: { amount: '1' },
+        )
+
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+            billing_time: 'calendar',
+          },
+        )
+      end
+
+      subscription = customer.subscriptions.first
+
+      travel_to(DateTime.new(2024, 1, 2)) do
+        create_event(
+          {
+            code: metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: { amount: '5' },
+          },
+        )
+      end
+
+      travel_to(DateTime.parse('2024-02-12 06:00:00')) do
+        expect {
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan_new.code,
+              billing_time: 'calendar',
+            },
+          )
+          perform_all_enqueued_jobs
+        }.to change { subscription.reload.status }.from('active').to('terminated')
+          .and change { customer.invoices.count }.from(0).to(1)
+
+        terminated_invoice = subscription.invoices.order(created_at: :desc).first
+
+        expect(terminated_invoice.total_amount_cents).to eq((1_100 + (11.fdiv(29) * 500)).round) # 11 + 11/29 x 5
+      end
+
+      travel_to(DateTime.new(2024, 3, 1, 12, 12)) do
+        Subscriptions::BillingService.call
+        perform_all_enqueued_jobs
+
+        invoice = customer.subscriptions.active.first.invoices.order(created_at: :desc).first
+
+        expect(invoice.total_amount_cents).to eq((18_000 + (18.fdiv(29) * 500)).round)
+      end
+    end
+  end
+
+  context 'when pay in advance subscription is terminated' do
+    let(:customer) { create(:customer, organization:) }
+    let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: true) }
+    let(:plan_new) { create(:plan, organization:, amount_cents: 29_000, pay_in_advance: true) }
+    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:metric) do
+      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+    end
+
+    it 'bills fees correctly' do
+      travel_to(DateTime.new(2024, 1, 1)) do
+        create(
+          :standard_charge,
+          plan:,
+          billable_metric: metric,
+          pay_in_advance: false,
+          prorated: true,
+          properties: { amount: '1' },
+        )
+
+        create(
+          :standard_charge,
+          plan: plan_new,
+          billable_metric: metric,
+          pay_in_advance: false,
+          prorated: true,
+          properties: { amount: '1' },
+        )
+
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+            billing_time: 'calendar',
+          },
+        )
+      end
+
+      subscription = customer.subscriptions.first
+
+      travel_to(DateTime.new(2024, 1, 2)) do
+        create_event(
+          {
+            code: metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: { amount: '5' },
+          },
+        )
+      end
+
+      travel_to(DateTime.parse('2024-02-12 06:00:00')) do
+        expect {
+          terminate_subscription(subscription)
+          perform_all_enqueued_jobs
+        }.to change { subscription.reload.status }.from('active').to('terminated')
+          .and change { customer.invoices.count }.from(1).to(2)
+
+        terminated_invoice = subscription.invoices.order(created_at: :desc).first
+        credit_note = customer.credit_notes.first
+
+        expect(credit_note.credit_amount_cents).to eq(1_700)
+        expect(terminated_invoice.total_amount_cents).to eq(0) # 12/29 x 500 = 207 - 207(CN)
+        expect(terminated_invoice.fees_amount_cents).to eq(207)
+        expect(terminated_invoice.credit_notes_amount_cents).to eq(207)
+      end
+    end
+  end
+
+  context 'when pay in arrear subscription is terminated' do
+    let(:customer) { create(:customer, organization:) }
+    let(:plan) { create(:plan, organization:, amount_cents: 2_900, pay_in_advance: false) }
+    let(:plan_new) { create(:plan, organization:, amount_cents: 29_000, pay_in_advance: false) }
+    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:metric) do
+      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: true, field_name: 'amount')
+    end
+
+    it 'bills fees correctly' do
+      travel_to(DateTime.new(2024, 1, 1)) do
+        create(
+          :standard_charge,
+          plan:,
+          billable_metric: metric,
+          pay_in_advance: false,
+          prorated: true,
+          properties: { amount: '1' },
+        )
+
+        create(
+          :standard_charge,
+          plan: plan_new,
+          billable_metric: metric,
+          pay_in_advance: false,
+          prorated: true,
+          properties: { amount: '1' },
+        )
+
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+            billing_time: 'calendar',
+          },
+        )
+      end
+
+      subscription = customer.subscriptions.first
+
+      travel_to(DateTime.new(2024, 1, 2)) do
+        create_event(
+          {
+            code: metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: { amount: '5' },
+          },
+        )
+      end
+
+      travel_to(DateTime.parse('2024-02-12 06:00:00')) do
+        expect {
+          terminate_subscription(subscription)
+          perform_all_enqueued_jobs
+        }.to change { subscription.reload.status }.from('active').to('terminated')
+          .and change { customer.invoices.count }.from(0).to(1)
+
+        terminated_invoice = subscription.invoices.order(created_at: :desc).first
+
+        expect(terminated_invoice.total_amount_cents).to eq((1_200 + (12.fdiv(29) * 500)).round) # 12 + 12/29 x 5
       end
     end
   end

--- a/spec/scenarios/subscriptions/upgrade_spec.rb
+++ b/spec/scenarios/subscriptions/upgrade_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'Subscription Upgrade Scenario', :scenarios, type: :request, transaction: false do
-  let(:organization) { create(:organization, webhook_url: false) }
+  let(:organization) { create(:organization, webhook_url: false, email_settings: []) }
 
   let(:customer) { create(:customer, organization:) }
 

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
         end
 
         it 'returns the prorata of the full duration' do
-          expect(result.aggregation).to eq(16.fdiv(31).ceil(5))
+          expect(result.aggregation).to eq(15.fdiv(31).ceil(5))
         end
       end
 

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -244,6 +244,29 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
       end
     end
 
+    context 'when plan has trial period ending after terminated_at' do
+      it 'excludes the trial from the credit amount' do
+        result = described_class.new(subscription:, upgrade: true).call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          credit_note = result.credit_note
+          expect(credit_note).to be_available
+          expect(credit_note).to be_order_change
+          expect(credit_note.total_amount_cents).to eq(20)
+          expect(credit_note.total_amount_currency).to eq('EUR')
+          expect(credit_note.credit_amount_cents).to eq(20)
+          expect(credit_note.credit_amount_currency).to eq('EUR')
+          expect(credit_note.balance_amount_cents).to eq(20)
+          expect(credit_note.balance_amount_currency).to eq('EUR')
+          expect(credit_note.reason).to eq('order_change')
+
+          expect(credit_note.items.count).to eq(1)
+        end
+      end
+    end
+
     context 'with a different timezone' do
       let(:started_at) { Time.zone.parse('2022-09-01 12:00') }
       let(:terminated_at) { Time.zone.parse('2022-10-15 01:00') }

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -244,8 +244,8 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
       end
     end
 
-    context 'when plan has trial period ending after terminated_at' do
-      it 'excludes the trial from the credit amount' do
+    context 'when plan has been upgraded' do
+      it 'calculates credit note correctly' do
         result = described_class.new(subscription:, upgrade: true).call
 
         aggregate_failures do

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -997,7 +997,7 @@ RSpec.describe Fees::SubscriptionService do
         expect(result.fee).to have_attributes(
           id: String,
           invoice_id: invoice.id,
-          amount_cents: 65,
+          amount_cents: 61, # 100/31 * 19
           amount_currency: plan.amount_currency,
           units: 1,
         )
@@ -1016,7 +1016,7 @@ RSpec.describe Fees::SubscriptionService do
         it 'creates a fee with prorated amount based on trial period' do
           result = fees_subscription_service.create
 
-          expect(result.fee.amount_cents).to eq(10)
+          expect(result.fee.amount_cents).to eq(6) # 2 days * (100 / 31)
         end
       end
 


### PR DESCRIPTION
## Context

When performing upgrade in some scenarios, date of the upgrade has been included in both termination invoice and first invoice for the new plan.

## Description

In all scenarios date of the upgrade will be included in calculation in the first invoice of the new plan.

This PR includes following changes:

Upgrade:
- adjust credit note for plan pay in advance so that date of the upgrade is also included in credit note
- prorated subscription fee should not include date of the upgrade
- charges should not include date of the upgrade (recurring ones)

Termination:
- subscription fee should include date of upgrade
- charges should include date of the upgrade (recurring ones)