### PR TITLE
feat(unique-count): Add grouped unique count to PostgresStore

### DIFF
--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -102,6 +102,16 @@ module Events
         result['aggregation']
       end
 
+      def grouped_unique_count
+        query = Events::Stores::Postgres::UniqueCountQuery.new(store: self)
+
+        sql = ActiveRecord::Base.sanitize_sql_for_conditions(
+          [query.grouped_query],
+        )
+
+        prepare_grouped_result(Event.connection.select_all(sql).rows)
+      end
+
       def max
         events.maximum("(#{sanitized_property_name})::numeric")
       end

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -192,6 +192,88 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
+  describe '#grouped_unique_count' do
+    let(:grouped_by) { %w[agent_name other] }
+    let(:started_at) { Time.zone.parse('2023-03-01') }
+
+    let(:events) do
+      [
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          external_customer_id: customer.external_id,
+          code:,
+          timestamp: boundaries[:from_datetime] + 1.hour,
+          properties: {
+            billable_metric.field_name => 2,
+            agent_name: 'frodo',
+          },
+        ),
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          external_customer_id: customer.external_id,
+          code:,
+          timestamp: boundaries[:from_datetime] + 1.day,
+          properties: {
+            billable_metric.field_name => 2,
+            agent_name: 'aragorn',
+          },
+        ),
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          external_customer_id: customer.external_id,
+          code:,
+          timestamp: boundaries[:from_datetime] + 2.days,
+          properties: {
+            billable_metric.field_name => 2,
+            agent_name: 'aragorn',
+            operation_type: 'remove',
+          },
+        ),
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          external_customer_id: customer.external_id,
+          code:,
+          timestamp: boundaries[:from_datetime] + 2.days,
+          properties: { billable_metric.field_name => 2 },
+        ),
+      ]
+    end
+
+    before do
+      event_store.aggregation_property = billable_metric.field_name
+    end
+
+    it 'returns the unique count of event properties' do
+      result = event_store.grouped_unique_count
+
+      expect(result.count).to eq(3)
+
+      null_group = result.last
+      expect(null_group[:groups]['agent_name']).to be_nil
+      expect(null_group[:groups]['other']).to be_nil
+      expect(null_group[:value]).to eq(1)
+
+      expect(result[...-1].map { |r| r[:value] }).to contain_exactly(1, 0)
+    end
+
+    context 'with no events' do
+      let(:events) { [] }
+
+      it 'returns the unique count of event properties' do
+        result = event_store.grouped_unique_count
+        expect(result.count).to eq(0)
+      end
+    end
+  end
+
   describe '#events_values' do
     it 'returns the value attached to each event' do
       event_store.aggregation_property = billable_metric.field_name


### PR DESCRIPTION
## Context

The goal is to refactor the way we’re doing the aggregation for the unique count.

## Description

The goal of this PR is to add the method `Events::Stores::PostgresStore#grouped_unique_count`.

The SQL logic has been extracted into `Events::Stores::Postgres::UniqueCountQuery`.