### PR TITLE
feat(unique-count): Add unique count to ClickhouseStore

### DIFF
--- a/app/services/events/stores/clickhouse/unique_count_query.rb
+++ b/app/services/events/stores/clickhouse/unique_count_query.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      class UniqueCountQuery
+        def initialize(store:)
+          @store = store
+        end
+
+        def query
+          # NOTE: First sum calculates all operation values for a specific property
+          # (for instance 2 relevant additions with 1 relevant removal [0, 1, 0, -1, 1] returns 1)
+          # The next sum combines all properties into a single result
+          <<-SQL
+            #{events_cte_sql},
+            event_values AS (
+              SELECT
+                property,
+                SUM(adjusted_value) AS sum_adjusted_value
+              FROM (
+                SELECT
+                  timestamp,
+                  property,
+                  operation_type,
+                  #{operation_value_sql} AS adjusted_value
+                FROM events_data
+                ORDER BY timestamp ASC
+              ) adjusted_event_values
+              GROUP BY property
+            )
+
+            SELECT SUM(sum_adjusted_value) AS aggregation FROM event_values
+          SQL
+        end
+
+        # NOTE: Not used in production, only for debug purpose to check the computed values before aggregation
+        # Returns an array of event's timestamp, property, operation type and operation value
+        # Example:
+        # [
+        #   ["2023-03-16T00:00:00.000Z", "001", "add", 1],
+        #   ["2023-03-17T00:00:00.000Z", "001", "add", 0],
+        #   ["2023-03-17T10:00:00.000Z", "002", "remove", 0],
+        #   ["2023-03-18T00:00:00.000Z", "001", "remove", -1],
+        #   ["2023-03-19T00:00:00.000Z", "002", "add", 1]
+        # ]
+        def breakdown_query
+          <<-SQL
+            #{events_cte_sql}
+
+            SELECT
+              timestamp,
+              property,
+              operation_type,
+              #{operation_value_sql}
+            FROM events_data
+            ORDER BY timestamp ASC
+          SQL
+        end
+
+        private
+
+        attr_reader :store
+
+        delegate :events, :charges_duration, :sanitized_property_name, to: :store
+
+        def events_cte_sql
+          # NOTE: Common table expression returning event's timestamp, property name and operation type.
+          <<-SQL
+            WITH events_data AS (
+              (#{
+                events
+                  .select(
+                    "timestamp, \
+                    #{sanitized_property_name} AS property, \
+                    coalesce(NULLIF(events_raw.properties['operation_type'], ''), 'add') AS operation_type",
+                  )
+                  .group(Events::Stores::ClickhouseStore::DEDUPLICATION_GROUP)
+                  .to_sql
+              })
+            )
+          SQL
+        end
+
+        def operation_value_sql
+          # NOTE: Returns 1 for relevant addition, -1 for relevant removal
+          # If property already added, another addition returns 0 ; it returns 1 otherwise
+          # If property already removed or not yet present, another removal returns 0 ; it returns -1 otherwise
+          <<-SQL
+            if (
+              operation_type = 'add',
+              (if(
+                (lagInFrame(operation_type, 1) OVER (PARTITION BY property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) = 'add',
+                0,
+                1
+              ))
+              ,
+              (if(
+                (lagInFrame(operation_type, 1, 'remove') OVER (PARTITION BY property ORDER BY timestamp ASC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)) = 'remove',
+                -1,
+                0
+              ))
+            )
+          SQL
+        end
+      end
+    end
+  end
+end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -109,6 +109,22 @@ module Events
         prepare_grouped_result(::Clickhouse::EventsRaw.connection.select_all(sql).rows)
       end
 
+      def unique_count
+        query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: self)
+        sql = ActiveRecord::Base.sanitize_sql_for_conditions([query.query])
+        result = ::Clickhouse::EventsRaw.connection.select_one(sql)
+
+        BigDecimal(result['aggregation'])
+      end
+
+      # NOTE: not used in production, only for debug purpose to check the computed values before aggregation
+      def unique_count_breakdown
+        query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: self)
+        ::Clickhouse::EventsRaw.connection.select_all(
+          ActiveRecord::Base.sanitize_sql_for_conditions([query.breakdown_query]),
+        ).rows
+      end
+
       def max
         events.maximum(Arel.sql(sanitized_numeric_property))
       end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -151,6 +151,27 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     end
   end
 
+  describe '#unique_count' do
+    it 'returns the number of unique active event properties' do
+      Clickhouse::EventsRaw.create!(
+        transaction_id: SecureRandom.uuid,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        external_customer_id: customer.external_id,
+        code:,
+        timestamp: boundaries[:from_datetime] + 3.days,
+        properties: {
+          billable_metric.field_name => 2,
+          operation_type: 'remove',
+        },
+      )
+
+      event_store.aggregation_property = billable_metric.field_name
+
+      expect(event_store.unique_count).to eq(4) # 5 events added / 1 removed
+    end
+  end
+
   describe '.events_values' do
     it 'returns the value attached to each event' do
       event_store.aggregation_property = billable_metric.field_name


### PR DESCRIPTION
## Context

The goal is to refactor the way we’re doing the aggregation for the unique count.

## Description

The goal of this PR is to add the method `Events::Stores::ClickhouseStore#unique_count`.

The SQL logic has been extracted into `Events::Stores::Clickhouse::UniqueCountQuery`.