### PR TITLE
feat(unique-count): Add grouped prorated unique count to PostgresStore

### DIFF
--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -112,6 +112,19 @@ module Events
         prepare_grouped_result(Event.connection.select_all(sql).rows)
       end
 
+      def grouped_prorated_unique_count
+        query = Events::Stores::Postgres::UniqueCountQuery.new(store: self)
+        sql = ActiveRecord::Base.sanitize_sql_for_conditions(
+          [
+            query.grouped_prorated_query,
+            {
+              to_datetime: to_datetime.ceil,
+            },
+          ],
+        )
+        prepare_grouped_result(Event.connection.select_all(sql).rows)
+      end
+
       def max
         events.maximum("(#{sanitized_property_name})::numeric")
       end


### PR DESCRIPTION
## Context

The goal is to refactor the way we’re doing the aggregation for the unique count.

## Description

The goal of this PR is to add the method `Events::Stores::PostgresStore#grouped_prorated_unique_count`.

The SQL logic has been extracted into `Events::Stores::Postgres::UniqueCountQuery`.