### PR TITLE
feat(unique-count): Add prorated unique count to ClickhouseStore

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -125,6 +125,22 @@ module Events
         ).rows
       end
 
+      def prorated_unique_count
+        query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: self)
+        sql = ActiveRecord::Base.sanitize_sql_for_conditions(
+          [
+            query.prorated_query,
+            {
+              to_datetime: to_datetime.ceil,
+              decimal_scale: DECIMAL_SCALE,
+            },
+          ],
+        )
+        result = ::Clickhouse::EventsRaw.connection.select_one(sql)
+
+        result['aggregation']
+      end
+
       def max
         events.maximum(Arel.sql(sanitized_numeric_property))
       end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -172,6 +172,40 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     end
   end
 
+  describe '#prorated_unique_count' do
+    it 'returns the number of unique active event properties' do
+      Clickhouse::EventsRaw.create!(
+        transaction_id: SecureRandom.uuid,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        external_customer_id: customer.external_id,
+        code:,
+        timestamp: boundaries[:from_datetime] + 1.day,
+        properties: {
+          billable_metric.field_name => 2,
+        },
+      )
+
+      Clickhouse::EventsRaw.create!(
+        transaction_id: SecureRandom.uuid,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        external_customer_id: customer.external_id,
+        code:,
+        timestamp: boundaries[:from_datetime] + 2.days - 1.second,
+        properties: {
+          billable_metric.field_name => 2,
+          operation_type: 'remove',
+        },
+      )
+
+      event_store.aggregation_property = billable_metric.field_name
+
+      # NOTE: Events calculation: 16/31 + 1/31 + + 15/31 + 14/31 + 13/31 + 12/31
+      expect(event_store.prorated_unique_count.round(3)).to eq(2.29)
+    end
+  end
+
   describe '.events_values' do
     it 'returns the value attached to each event' do
       event_store.aggregation_property = billable_metric.field_name

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
         external_subscription_id: subscription.external_id,
         external_customer_id: customer.external_id,
         code:,
-        timestamp: boundaries[:from_datetime] + 2.days,
+        timestamp: boundaries[:from_datetime] + 2.days - 1.second,
         properties: {
           billable_metric.field_name => 2,
           operation_type: 'remove',
@@ -187,8 +187,8 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
 
       event_store.aggregation_property = billable_metric.field_name
 
-      # NOTE: Events calculation: 16/31 + 1/31 + 14/31 + 13/31 + 12/31
-      expect(event_store.prorated_unique_count.round(3)).to eq(1.806)
+      # NOTE: Events calculation: 16/31 + 1/31 + + 15/31 + 14/31 + 13/31 + 12/31
+      expect(event_store.prorated_unique_count.round(3)).to eq(2.29)
     end
   end
 


### PR DESCRIPTION
## Context

The goal is to refactor the way we’re doing the aggregation for the unique count.

## Description

The goal of this PR is to add the method `Events::Stores::ClickhouseStore#prorated_unique_count`.

The SQL logic has been extracted into `Events::Stores::Clickhouse::UniqueCountQuery`.