### PR TITLE
fix (jobs-inside-transaction): add setup for after commit everywhere and fix customer.vies_check webhook

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'oauth2'
 gem 'rack-cors'
 
 # Database
+gem 'after_commit_everywhere'
 gem 'clickhouse-activerecord', git: 'https://github.com/getlago/clickhouse-activerecord.git'
 gem 'discard', '~> 1.2'
 gem 'kaminari-activerecord'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,9 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     adyen-ruby-api-library (7.0.1)
       faraday
+    after_commit_everywhere (1.4.0)
+      activerecord (>= 4.2)
+      activesupport
     analytics-ruby (2.4.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
@@ -576,6 +579,7 @@ DEPENDENCIES
   activejob-traceable
   activejob-uniqueness
   adyen-ruby-api-library
+  after_commit_everywhere
   analytics-ruby (~> 2.4.0)
   aws-sdk-s3
   bcrypt

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class BaseService
+  include AfterCommitEverywhere
+
   class FailedResult < StandardError
     attr_reader :result
 

--- a/app/services/customers/eu_auto_taxes_service.rb
+++ b/app/services/customers/eu_auto_taxes_service.rb
@@ -25,8 +25,7 @@ module Customers
 
     def vies_check
       vies_check = Valvat.new(customer.tax_identification_number).exists?(detail: true)
-
-      SendWebhookJob.perform_later('customer.vies_check', customer, vies_check:)
+      after_commit { SendWebhookJob.perform_later('customer.vies_check', customer, vies_check:) }
 
       vies_check
     end


### PR DESCRIPTION
## Context

Common scenario in Lago is that we have to trigger active job inside DB transaction. SInce job tries to fetch and use record that is saved inside transaction, we often end up with `ActiveJob::DeserializationError` if job is processed before transaction commit command.

## Description

We usually handle this issue by setting wait parameter to 3 seconds upon calling active job. 

This PR sets up `ActiveCommitEverywhere` gem so that we can handle this issue without a 3 seconds hack.

Also, as part of this PR new library is used to correctly call `customer.vies_check` webhook.
