### PR TITLE
Initial groundwork for a TOTP implementation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,10 @@ gem 'karafka'
 # Taxes
 gem 'valvat', require: false
 
+# One-time Password
+gem 'rotp', '~> 6.3'
+gem 'rqrcode', '~> 2.2'
+
 group :development, :test, :staging do
   gem 'factory_bot_rails'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
+    chunky_png (1.4.0)
     clockwork (3.0.2)
       activesupport
       tzinfo
@@ -412,6 +413,11 @@ GEM
       rack (>= 1.4)
     retriable (3.1.2)
     rexml (3.2.5)
+    rotp (6.3.0)
+    rqrcode (2.2.0)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 1.0)
+    rqrcode_core (1.2.0)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -615,6 +621,8 @@ DEPENDENCIES
   rack-cors
   rails (~> 7.0.8)
   ransack (~> 4.0.0)
+  rotp (~> 6.3)
+  rqrcode (~> 2.2)
   rspec-graphql_matchers
   rspec-rails
   rubocop-graphql

--- a/app/graphql/mutations/login_user.rb
+++ b/app/graphql/mutations/login_user.rb
@@ -7,11 +7,12 @@ module Mutations
 
     argument :email, String, required: true
     argument :password, String, required: true
+    argument :otp_attempt, String, required: false
 
     type Types::Payloads::LoginUserType
 
-    def resolve(email:, password:)
-      result = UsersService.new.login(email, password)
+    def resolve(email:, password:, otp_attempt: nil)
+      result = UsersService.new.login(email, password, otp_attempt)
       result.success? ? result : result_error(result)
     end
   end

--- a/app/models/concerns/otp_authenticatable.rb
+++ b/app/models/concerns/otp_authenticatable.rb
@@ -1,0 +1,76 @@
+module OtpAuthenticatable
+  extend ActiveSupport::Concern
+
+  included do
+    attribute :otp_attempt, :string
+  end
+
+  def otp_enabled?
+    !!(otp_secret.present? && otp_required_for_login)
+  end
+
+  def set_otp_secret!
+    update!(otp_secret: ::ROTP::Base32.random)
+  end
+
+  def set_otp_backup_codes!(count = 5, length = 14)
+    codes = []
+    count.times do
+      codes.append(SecureRandom.hex(length / 2))
+    end
+    update!(otp_backup_codes: codes)
+  end
+
+  def verify_otp!(code)
+    return true if consume_otp!(code)
+    return true if consume_backup_code!(code)
+
+    false
+  end
+
+  def totp(issuer = 'Lago')
+    @totp ||= ::ROTP::TOTP.new(otp_secret, issuer: issuer)
+  end
+
+  def otp_provisioning_uri
+    totp.provisioning_uri(email)
+  end
+
+  def otp_qrcode_svg
+    qrcode = ::RQRCode::QRCode.new(otp_provisioning_uri)
+    qrcode.as_svg(module_size: 4)
+  end
+
+  def enable_otp!(code)
+    return false unless consume_otp!(code.to_s)
+    update!(otp_required_for_login: true)
+  end
+
+  def disable_otp!
+    update!(otp_required_for_login: false, otp_secret: nil, otp_backup_codes: [])
+  end
+
+  private
+
+  def consume_otp!(code)
+    timestep = totp.verify(code, after: last_otp_timestep)
+    return false if timestep.blank?
+
+    update(consumed_timestep: timestep)
+    true
+  end
+
+  def last_otp_timestep
+    return consumed_timestep if consumed_timestep.present?
+
+    0
+  end
+
+  def consume_backup_code!(code)
+    return false if otp_backup_codes.blank?
+    return false unless otp_backup_codes.include?(code)
+
+    otp_backup_codes.delete(code)
+    save
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   include PaperTrailTraceable
+  include OtpAuthenticatable
   has_secure_password
 
   has_many :password_resets
@@ -19,5 +20,5 @@ class User < ApplicationRecord
   has_many :subscriptions, through: :customers
 
   validates :email, presence: true
-  validates :password, presence: true
+  validates :password, presence: true, unless: :password_digest?
 end

--- a/db/migrate/20240220145100_add_otp_to_users.rb
+++ b/db/migrate/20240220145100_add_otp_to_users.rb
@@ -1,0 +1,8 @@
+class AddOtpToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :otp_secret, :string
+    add_column :users, :consumed_timestep, :integer
+    add_column :users, :otp_required_for_login, :boolean
+    add_column :users, :otp_backup_codes, :text, array: true
+  end
+end


### PR DESCRIPTION
## Feature Request

👉  https://getlago.canny.io/feature-requests/p/multi-factor-authentication

## Context

Lago currently only provides password authentication. This can be considered a security risk, as, if a staff's password was to be leaked or cracked, it could potentially expose a lot of private user / payments information.

[TOTP](https://en.wikipedia.org/w/index.php?title=Time-based_one-time_password) is an industry standard for Multi Factor Authentication, and is fairly easy to implement.

## Description
I have added two gems; [ROTP](https://github.com/mdp/rotp) (for the TOTP implementation) and [RQRCode](https://github.com/whomwah/rqrcode) (as to provide a scannable code for users to quickly add the OTP).

I have added a new concern, `OtpAuthenticable`, and have included it in the `User` model. I have used this concern in multiple other projects I have worked on, and it provides many helper methods to assign OTP and Backup codes, as well as to generate the QR Code for the OTP (as an SVG string).

I have also added a migration to the database, adding the necessary fields required for OTP to the `users` table.

I also added a check to the authentication code, to verify the `otp_attempt` the user makes, or return an error if they have OTP enabled, and did not provide the correct code.

## What's Next
I am unfamiliar with Typescript, and as such wasn't able to implement any UI to accompany this. I'm hoping someone familiar with the Lago UI can implement that side of things.

There are two main UIs that need to be implemented.
1. The OTP field on sign in.
2. The section to enable / disable OTP on the user.

The following are my suggestions / notes for the rest of the OTP implementation.

### Sign In
If a user tries to sign in that has enabled OTP, but no OTP is provided, an error code of `no_otp_attempt` will be returned. Assumedly, the UI could respond to this error by showing an OTP field on sign in page, such that then the user can write their OTP. Alternately, the OTP field could always be visible, but then it might cause confusion for users that do not have it enabled.

The form parameter for the OTP attempt is `otp_attempt`.

### Enable OTP
To enable the OTP for a user, first they must be assigned a secret, and optionally, backup codes. I have implemented this before in a two step process, where first they are assigned backup codes, and are shown them such that they can copy them down.

Backup codes can be assigned to a user, by calling the `set_otp_backup_codes!` method on them. These backup codes are stored as an array, and are kept in the attribute `otp_backup_codes`.

After assigning their codes, the user should be assigned an OTP secret. This secret should be displayed on the next page in the flow, alongside a QR Code they can scan. Many 2fa apps should work with this QR Code.

The OTP secret can be assigned to the user with the `set_otp_secret!` method, and is kept in the attribute `otp_secret`.

The SVG string for the QR Code can be obtained through the `otp_qrcode_svg` method on the user. Make sure you have assigned their OTP secret before this is called.

When the user has added the OTP secret to their 2fa app of choice, they should be prompted to provide a code generated by their app. This code can be passed to the `enable_otp!` method on the user, which, granted the code is correct, will mark the user as requiring OTP for login (setting attribute `otp_required_for_login` to true). If the code is incorrect, this method will return `false` instead.

### Disable OTP
Running the `disable_otp!` method on the user will disable OTP for them, resetting `otp_secret`, `otp_backup_codes` and setting `otp_required_for_login` to false.