### PR TITLE
fix: Updating plan with new charge

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -159,6 +159,7 @@ module Api
               :billable_metric_id,
               :min_amount_cents,
               :invoice_display_name,
+              :charge_model,
               { properties: {} },
               {
                 group_properties: [

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -433,8 +433,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_05_160647) do
     t.jsonb "metadata", default: {}, null: false
     t.uuid "subscription_id"
     t.datetime "deleted_at"
-    t.string "external_customer_id"
     t.string "external_subscription_id"
+    t.string "external_customer_id"
     t.index ["customer_id"], name: "index_events_on_customer_id"
     t.index ["deleted_at"], name: "index_events_on_deleted_at"
     t.index ["organization_id", "code", "created_at"], name: "index_events_on_organization_id_and_code_and_created_at", where: "(deleted_at IS NULL)"

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -153,6 +153,29 @@ RSpec.describe Plans::UpdateService, type: :service do
         end
       end
 
+      context 'with new charge' do
+        let(:plan_name) { 'foo' }
+
+        let(:charges_args) do
+          [
+            {
+              billable_metric_id: sum_billable_metric.id,
+              charge_model: 'standard',
+              pay_in_advance: false,
+              invoiceable: true,
+              properties: {
+                amount: '100',
+              },
+            },
+          ]
+        end
+
+        it 'updates the plan' do
+          result = plans_service.call
+          expect(result.plan.charges.count).to eq(1)
+        end
+      end
+
       context 'with premium charge model' do
         let(:plan_name) { 'foo' }
 


### PR DESCRIPTION
Updating a plan by passing `charge_model` was not possible when a new charge is given.