### PR TITLE
fix(fees): Fix creating yearly in-arrears subscription fee

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -190,7 +190,8 @@ module Invoices
       # - Plan is pay in advance, we're at the beginning of the period or subscription has never been billed
       # - Plan is pay in arrear and we're at the beginning of the period
       date_service(subscription).first_month_in_yearly_period? ||
-        subscription.plan.pay_in_advance && !subscription.already_billed?
+        (subscription.plan.pay_in_advance && !subscription.already_billed?) ||
+        (subscription.plan.pay_in_arrear? && subscription.terminated?)
     end
 
     def should_create_charge_fees?(subscription)


### PR DESCRIPTION
## Context

After terminating a subscription for a yearly plan with a subscription fee paid in arrears, the invoice does not include any fees.

## Description

This PR fixes a bug in `Invoices::CalculateFeesService::should_create_yearly_subscription_fee?` method that now handles terminated subscriptions for plans paid in arrears.