### PR TITLE
feat(unique_count): Reafact queries and add prorated breakdown

### DIFF
--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -94,13 +94,30 @@ module Events
             query.prorated_query,
             {
               from_datetime:,
-              to_datetime: to_datetime.ceil,
+              to_datetime:,
+              timezone: customer.applicable_timezone,
             },
           ],
         )
         result = ActiveRecord::Base.connection.select_one(sql)
 
         result['aggregation']
+      end
+
+      def prorated_unique_count_breakdown(with_remove: false)
+        query = Events::Stores::Postgres::UniqueCountQuery.new(store: self)
+        sql = ActiveRecord::Base.sanitize_sql_for_conditions(
+          [
+            query.prorated_breakdown_query(with_remove:),
+            {
+              from_datetime:,
+              to_datetime:,
+              timezone: customer.applicable_timezone,
+            },
+          ],
+        )
+
+        ActiveRecord::Base.connection.select_all(sql).to_a
       end
 
       def grouped_unique_count
@@ -120,7 +137,8 @@ module Events
             query.grouped_prorated_query,
             {
               from_datetime:,
-              to_datetime: to_datetime.ceil,
+              to_datetime:,
+              timezone: customer.applicable_timezone,
             },
           ],
         )

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
         external_subscription_id: subscription.external_id,
         external_customer_id: customer.external_id,
         code:,
-        timestamp: boundaries[:from_datetime] + 2.days - 1.second,
+        timestamp: (boundaries[:from_datetime] + 1.day).end_of_day,
         properties: {
           billable_metric.field_name => 2,
           operation_type: 'remove',
@@ -316,7 +316,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
           external_subscription_id: subscription.external_id,
           external_customer_id: customer.external_id,
           code:,
-          timestamp: boundaries[:from_datetime] + 2.days,
+          timestamp: (boundaries[:from_datetime] + 1.day).end_of_day,
           properties: {
             billable_metric.field_name => 2,
             agent_name: 'aragorn',
@@ -358,6 +358,72 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
         result = event_store.grouped_prorated_unique_count
         expect(result.count).to eq(0)
       end
+    end
+  end
+
+  describe '#prorated_unique_count_breakdown' do
+    it 'returns the breakdown of add and remove of unique event properties' do
+      Clickhouse::EventsRaw.create!(
+        transaction_id: SecureRandom.uuid,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        external_customer_id: customer.external_id,
+        code:,
+        timestamp: boundaries[:from_datetime] + 1.day,
+        properties: {
+          billable_metric.field_name => 2,
+        },
+      )
+
+      Clickhouse::EventsRaw.create!(
+        transaction_id: SecureRandom.uuid,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        external_customer_id: customer.external_id,
+        code:,
+        timestamp: (boundaries[:from_datetime] + 1.day).end_of_day,
+        properties: {
+          billable_metric.field_name => 2,
+          operation_type: 'remove',
+        },
+      )
+
+      event_store.aggregation_property = billable_metric.field_name
+
+      result = event_store.prorated_unique_count_breakdown
+      expect(result.count).to eq(6)
+
+      grouped_result = result.group_by { |r| r['property'] }
+
+      # NOTE: group with property 1
+      group = grouped_result['1']
+      expect(group.count).to eq(1)
+      expect(group.first['prorated_value'].round(3)).to eq(0.516) # 16/31
+      expect(group.first['operation_type']).to eq('add')
+
+      # NOTE: group with property 2 (added and removed)
+      group = grouped_result['2']
+      expect(group.first['prorated_value'].round(3)).to eq(0.032) # 1/31
+      expect(group.last['prorated_value'].round(3)).to eq(0.484) # 15/31
+      expect(group.count).to eq(2)
+
+      # NOTE: group with property 3
+      group = grouped_result['3']
+      expect(group.count).to eq(1)
+      expect(group.first['prorated_value'].round(3)).to eq(0.452) # 14/31
+      expect(group.first['operation_type']).to eq('add')
+
+      # NOTE: group with property 4
+      group = grouped_result['4']
+      expect(group.count).to eq(1)
+      expect(group.first['prorated_value'].round(3)).to eq(0.419) # 13/31
+      expect(group.first['operation_type']).to eq('add')
+
+      # NOTE: group with property 5
+      group = grouped_result['5']
+      expect(group.count).to eq(1)
+      expect(group.first['prorated_value'].round(3)).to eq(0.387) # 12/31
+      expect(group.first['operation_type']).to eq('add')
     end
   end
 


### PR DESCRIPTION
## Context

The goal is to refactor the way we’re doing the aggregation for the unique count.

## Description

The goal of this PR is to add the method `Events::Stores::ClickhouseStore#prorated_unique_count_breakdown` and  `Events::Stores::PostgresStore#prorated_unique_count_breakdown`.

The SQL logic has been extracted into `Events::Stores::Clickhouse::UniqueCountQuery`.