### PR TITLE
feat(unique_count): Add active_unique_property to event stores

### DIFF
--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -112,7 +112,7 @@ module BillableMetrics
 
       protected
 
-      def persisted_event_store_instante
+      def persisted_event_store_instance
         event_store = event_store_class.new(
           code: billable_metric.code,
           subscription:,
@@ -137,7 +137,7 @@ module BillableMetrics
       end
 
       def persisted_sum
-        persisted_event_store_instante.prorated_sum(
+        persisted_event_store_instance.prorated_sum(
           period_duration:,
           persisted_duration: subscription.date_diff_with_timezone(from_datetime, to_datetime),
         )
@@ -147,7 +147,7 @@ module BillableMetrics
         previous_charge_fee_units = previous_charge_fee&.units
         return previous_charge_fee_units if previous_charge_fee_units
 
-        recurring_value_before_first_fee = persisted_event_store_instante.sum
+        recurring_value_before_first_fee = persisted_event_store_instance.sum
 
         ((recurring_value_before_first_fee || 0) <= 0) ? nil : recurring_value_before_first_fee
       end
@@ -174,7 +174,7 @@ module BillableMetrics
       end
 
       def grouped_persisted_sums
-        persisted_event_store_instante.grouped_prorated_sum(
+        persisted_event_store_instance.grouped_prorated_sum(
           period_duration:,
           persisted_duration: subscription.date_diff_with_timezone(from_datetime, to_datetime),
         )

--- a/app/services/utils/timezone_service.rb
+++ b/app/services/utils/timezone_service.rb
@@ -10,7 +10,7 @@ module Utils
       end
       sanitized_timezone = ActiveRecord::Base.sanitize_sql_for_conditions(customer.applicable_timezone)
 
-      "#{sanitized_field_name}::timestamptz AT TIME ZONE '#{sanitized_timezone}'"
+      "(#{sanitized_field_name})::timestamptz AT TIME ZONE '#{sanitized_timezone}'"
     end
 
     def self.at_time_zone

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -139,6 +139,87 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
   end
 
+  describe '#active_unique_property?' do
+    before { event_store.aggregation_property = billable_metric.field_name }
+
+    it 'returns false when no previous events exist' do
+      event = create(
+        :event,
+        organization_id: organization.id,
+        external_subscription_id: subscription.external_id,
+        external_customer_id: customer.external_id,
+        code:,
+        timestamp: (boundaries[:from_datetime] + 2.days).end_of_day,
+        properties: {
+          billable_metric.field_name => SecureRandom.uuid,
+        },
+      )
+
+      expect(event_store).not_to be_active_unique_property(event)
+    end
+
+    context 'when event is already active' do
+      it 'returns true if the event property is active' do
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          external_customer_id: customer.external_id,
+          code:,
+          timestamp: (boundaries[:from_datetime] + 2.days).end_of_day,
+          properties: {
+            billable_metric.field_name => 2,
+          },
+        )
+
+        event = create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          external_customer_id: customer.external_id,
+          code:,
+          timestamp: (boundaries[:from_datetime] + 3.days).end_of_day,
+          properties: {
+            billable_metric.field_name => 2,
+          },
+        )
+
+        expect(event_store).to be_active_unique_property(event)
+      end
+    end
+
+    context 'with a previous removed event' do
+      it 'returns false' do
+        create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          external_customer_id: customer.external_id,
+          code:,
+          timestamp: (boundaries[:from_datetime] + 2.days).end_of_day,
+          properties: {
+            billable_metric.field_name => 2,
+            operation_type: 'remove',
+          },
+        )
+
+        event = create(
+          :event,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          external_customer_id: customer.external_id,
+          code:,
+          timestamp: (boundaries[:from_datetime] + 3.days).end_of_day,
+          properties: {
+            billable_metric.field_name => 2,
+          },
+        )
+
+        expect(event_store).not_to be_active_unique_property(event)
+      end
+    end
+  end
+
   describe '#unique_count' do
     it 'returns the number of unique active event properties' do
       create(


### PR DESCRIPTION
## Context

The goal is to refactor the way we’re doing the aggregation for the unique count.

## Description

The goal of this PR is to add the method `Events::Stores::ClickhouseStore#active_unique_property?` and  `Events::Stores::PostgresStore#active_unique_property?`.

The PR also adds small fixes and refact