### PR TITLE
fix(subscriptions): fix edit subscription attached to parent plan

### DIFF
--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -71,7 +71,7 @@ module Subscriptions
       else
         Plans::OverrideService.call(
           plan: current_plan,
-          params: params[:plan_overrides].to_h.with_indifferent_access
+          params: params[:plan_overrides].to_h.with_indifferent_access,
         )
       end
     end


### PR DESCRIPTION
## Context

Subscription edition works in a way that it changes plan's values. It works fine if subscription is attached to overridden plan.
However, if subscription is attached to parent plan it will change also values on all other subscriptions.
