### PR TITLE
fix: Fix a small edge case with datetime diff computation

### DIFF
--- a/app/services/utils/datetime_service.rb
+++ b/app/services/utils/datetime_service.rb
@@ -12,6 +12,7 @@ module Utils
 
       to = to_datetime
       to = Time.zone.parse(to.to_s) unless to.is_a?(ActiveSupport::TimeWithZone)
+      to += 1.second if to == to.beginning_of_day # To make sure we do not miss a day
 
       from_offset = from.in_time_zone(timezone).utc_offset
       to_offset = to.in_time_zone(timezone).utc_offset

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -403,7 +403,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             aggregate_failures do
               expect(subscription.reload).to be_terminated
               expect(subscription.reload.invoices.count).to eq(1)
-              expect(invoice.total_amount_cents).to eq(226)
+              expect(invoice.total_amount_cents).to eq(258)
               expect(invoice.issuing_date.iso8601).to eq('2023-12-07')
             end
           end
@@ -1050,7 +1050,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             aggregate_failures do
               expect(subscription.reload).to be_terminated
               expect(subscription.reload.invoices.count).to eq(1)
-              expect(invoice.total_amount_cents).to eq(4_145)
+              expect(invoice.total_amount_cents).to eq(4_161)
               expect(invoice.issuing_date.iso8601).to eq('2023-12-07')
             end
           end

--- a/spec/services/utils/datetime_service_spec.rb
+++ b/spec/services/utils/datetime_service_spec.rb
@@ -59,6 +59,16 @@ RSpec.describe Utils::DatetimeService, type: :service do
         expect(result).to eq(31)
       end
     end
+
+    context 'with to date is the beginning of the day' do
+      let(:from_datetime) { Time.zone.parse('2023-12-01T00:00:00') }
+      let(:to_datetime) { Time.zone.parse('2023-12-07T00:00:00') }
+      let(:timezone) { 'UTC' }
+
+      it 'ensures it counts the full days' do
+        expect(result).to eq(7)
+      end
+    end
   end
 
   describe '.period_total_length_in_days' do


### PR DESCRIPTION
## Context

An issue has been identified in the `Utils::DatetimeService.date_diff_with_timezone` method when the provided to_date is a the beginning of the day.

```
to
=> Thu, 07 Dec 2023 00:00:00.000000000 UTC +00:00

from
=> Fri, 01 Dec 2023 00:00:00.000000000 UTC +00:00

Utils::DatetimeService.date_diff_with_timezone(from, to, 'UTC')
=> 6
```

The expected result is 7

## Description

The PR adds a second to the `to` value when it is the beginning of the day
