### PR TITLE
fix: Add Net::HTTPBadResponse in the webhook error retry list

### DIFF
--- a/app/services/webhooks/base_service.rb
+++ b/app/services/webhooks/base_service.rb
@@ -68,6 +68,7 @@ module Webhooks
     rescue LagoHttpClient::HttpError,
            Net::OpenTimeout,
            Net::ReadTimeout,
+           Net::HTTPBadResponse,
            Errno::ECONNRESET,
            Errno::ECONNREFUSED,
            OpenSSL::SSL::SSLError,


### PR DESCRIPTION
## Context

Some webhook deliveries are ending in the sidekiq deadjob queue because the response from the service was a `Net::HTTPBadResponse`

## Description

This error should be captured and the webhook should be handled by the retry mechanism