### PR TITLE
Add arm64-darwin-23 platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -570,6 +570,7 @@ PLATFORMS
   aarch64-linux
   aarch64-linux-musl
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux


### PR DESCRIPTION
It's added when doing `bundle` on a recent macOS

## Context

When doing `bundle` or `bundle install` on a recent Macbook (Air in my case) with a recent version of macOS, bundler will add a platform.

## Description

I just add the platform