### PR TITLE
require a SEGMENT_WRITE_KEY

### DIFF
--- a/config/initializers/analytics_ruby.rb
+++ b/config/initializers/analytics_ruby.rb
@@ -17,7 +17,7 @@ unless ENV['LAGO_DISABLE_SEGMENT'] == 'true'
 
   SEGMENT_CLIENT = Segment::Analytics.new(
     {
-      write_key: ENV['SEGMENT_WRITE_KEY'],
+      write_key: ENV.fetch('SEGMENT_WRITE_KEY', 'changeme'),
       on_error: proc { |status, msg| Sentry.capture_exception(SegmentError.new(status, msg)) },
       stub: Rails.env.development? || Rails.env.test?,
     },


### PR DESCRIPTION
Otherwise the app doesn't start with:

Failure/Error: require_relative '../config/environment'

ArgumentError:
  Write key must be initialized

## Context

When doing `rspec` I would get an error.

## Description

Solution was to have:

```
SEGMENT_WRITE_KEY=1
```

or

```
LAGO_DISABLE_SEGMENT=true
```
