### PR TITLE
Syncronize with db/schema.rb generated by rails db:migrate

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -433,8 +433,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_05_160647) do
     t.jsonb "metadata", default: {}, null: false
     t.uuid "subscription_id"
     t.datetime "deleted_at"
-    t.string "external_subscription_id"
     t.string "external_customer_id"
+    t.string "external_subscription_id"
     t.index ["customer_id"], name: "index_events_on_customer_id"
     t.index ["deleted_at"], name: "index_events_on_deleted_at"
     t.index ["organization_id", "code", "created_at"], name: "index_events_on_organization_id_and_code_and_created_at", where: "(deleted_at IS NULL)"
@@ -670,9 +670,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_05_160647) do
     t.string "tax_identification_number"
     t.integer "net_payment_term", default: 0, null: false
     t.string "default_currency", default: "USD", null: false
-    t.boolean "eu_tax_management", default: false
     t.integer "document_numbering", default: 0, null: false
     t.string "document_number_prefix"
+    t.boolean "eu_tax_management", default: false
     t.boolean "clickhouse_aggregation", default: false, null: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"


### PR DESCRIPTION
It's just the order of two columns

This will prevent changes from appearing when there is no change to the database

## Context

I was running `rake db:migrate` and got a different `db/schema.rb`

## Description

Only two columns are in the wrong position