### PR TITLE
Fix flaky test for invoice finalize service

### DIFF
--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -50,9 +50,11 @@ RSpec.describe Invoices::FinalizeService, type: :service do
       invoice.customer.update(timezone: 'America/New_York')
 
       freeze_time do
+        current_date = Time.current.in_time_zone("America/New_York").to_date
+
         expect { finalize_service.call }
-          .to change { invoice.reload.issuing_date }.to(Time.current.to_date)
-          .and change { invoice.reload.payment_due_date }.to(Time.current.to_date)
+          .to change { invoice.reload.issuing_date }.to(current_date)
+          .and change { invoice.reload.payment_due_date }.to(current_date)
       end
     end
 


### PR DESCRIPTION
When run early in the day, the test would fail because of a wrong date.

This is because the customer is in New York timezone and the default time zone is UTC

```
  1) Invoices::FinalizeService#call updates the issuing date
     Failure/Error:
       expect { finalize_service.call }
         .to change { invoice.reload.issuing_date }.to(Time.current.to_date)
         .and change { invoice.reload.payment_due_date }.to(Time.current.to_date)

          expected `invoice.reload.issuing_date` to have changed to Fri, 23 Feb 2024, but is now Thu, 22 Feb 2024

       ...and:

          expected `invoice.reload.payment_due_date` to have changed to Fri, 23 Feb 2024, but is now Thu, 22 Feb 2024
     # ./spec/services/invoices/finalize_service_spec.rb:53:in `block (4 levels) in <top (required)>'
     # ./spec/services/invoices/finalize_service_spec.rb:52:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:31:in `block (3 levels) in <top (required)>'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/strategy.rb:30:in `cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:34:in `block (2 levels) in cleaning'
     # /usr/local/bundle/gems/database_cleaner-core-2.0.1/lib/database_cleaner/cleaners.rb:35:in `cleaning'
     # ./spec/spec_helper.rb:30:in `block (2 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.14.0/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```