### PR TITLE
fix(stripe): Handle validation error in PaymentProviders::Stripe::HandleEventJob

### DIFF
--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -333,6 +333,22 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
         end
       end
     end
+
+    context 'when stripe customer id is missing' do
+      it 'returns a not found error' do
+        result = stripe_service.update_provider_default_payment_method(
+          organization_id: organization.id,
+          stripe_customer_id: nil,
+          payment_method_id: 'pm_123456',
+        )
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.message).to eq('stripe_customer_not_found')
+        end
+      end
+    end
   end
 
   describe '#update_payment_method' do


### PR DESCRIPTION
## Context

This PR aims to fix the handling of the ` BaseService::ValidationFailure` in `PaymentProviders::Stripe::HandleEventJob` when the webhook type is `setup_intent.succeeded` and the provided `customer` is nil.

The service was still looking for the customer, and for some reason was retrieving a random one having `stripe_customer_id` set to nil. It was then failing while trying to update the customer on Stripe with the following error:

```
Unrecognized request URL (POST: /v1/customers/). If you are trying to list objects, remove the trailing slash. If you are trying to retrieve an object, make sure you passed a valid (non-empty) identifier in your code. Please see https://stripe.com/docs or we can help at https://support.stripe.com/. (Stripe::InvalidRequestError)
```

## Description

The fix is to return a `BaseService::NotFoundError` that could be handled correctly on the webhook service.