### PR TITLE
fix(groupe-by): Ensure all groups appears on invoice

### DIFF
--- a/app/views/templates/invoices/v4/_default_fee.slim
+++ b/app/views/templates/invoices/v4/_default_fee.slim
@@ -1,4 +1,4 @@
-- fee = self.first
+- fee = self
 tr
   td
     .body-1 = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
@@ -8,7 +8,7 @@ tr
       .body-3 = I18n.t('invoice.total_events', count: fee.events_count)
     - if fee.charge.prorated?
       .body-3 = I18n.t('invoice.fee_prorated')
-  td.body-2 = self.sum(&:units)
-  td.body-2 = MoneyHelper.format_with_precision(self.sum(&:precise_unit_amount), fee.unit_amount.currency)
+  td.body-2 = fee.units
+  td.body-2 = MoneyHelper.format_with_precision(fee.precise_unit_amount, fee.unit_amount.currency)
   td.body-2 == TaxHelper.applied_taxes(fee)
-  td.body-2 = MoneyHelper.format(self.sum(&:amount))
+  td.body-2 = MoneyHelper.format(fee.amount)

--- a/app/views/templates/invoices/v4/_fees_without_groups.slim
+++ b/app/views/templates/invoices/v4/_fees_without_groups.slim
@@ -1,7 +1,7 @@
-- fee = self.first
+- fee = self
 
 - if fee.amount.zero? || fee.amount_details.blank?
-  == SlimHelper.render('templates/invoices/v4/_default_fee', self)
+  == SlimHelper.render('templates/invoices/v4/_default_fee', fee)
 - else
   tr.charge-name
     td.body-1

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -36,7 +36,7 @@
               - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
                 - fees.select { |f| f.units.positive? }.each do |fee|
                   - if fee.amount_details.blank?
-                    == SlimHelper.render('templates/invoices/v4/_default_fee', fees)
+                    == SlimHelper.render('templates/invoices/v4/_default_fee', fee)
                   - else
                     == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
 
@@ -46,7 +46,8 @@
 
               / Fees without group
               - else
-                == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
+                - fees.sort_by { |f| f.invoice_sorting_clause }.each do |fee|
+                  == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fee)
 
     / Charge fees section for subscription invoice
     - if subscription? && subscription_fees(subscription.id).charge_kind.any?
@@ -81,7 +82,8 @@
 
               / Fees without group
               - else
-                == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
+                - fees.sort_by { |f| f.invoice_sorting_clause }.each do |fee|
+                  == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fee)
 
       / Charges payed in advance on payed in arrears plan
       - if subscription.plan.charges.where(pay_in_advance: true).any? && !subscription.plan.pay_in_advance? && existing_fees_in_interval?(subscription_id: subscription.id, charge_in_advance: true)
@@ -104,7 +106,7 @@
               - if fees.all? { |f| f.group_id? } && fees.sum(&:units) > 0
                 - fees.select { |f| f.units.positive? }.each do |fee|
                   - if fee.amount_details.blank?
-                    == SlimHelper.render('templates/invoices/v4/_default_fee', fees)
+                    == SlimHelper.render('templates/invoices/v4/_default_fee', fee)
                   - else
                     == SlimHelper.render('templates/invoices/v4/_fee_with_groups', fee)
 
@@ -114,7 +116,8 @@
 
               / Fees without group
               - else
-                == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fees)
+                - fees.sort_by { |f| f.invoice_sorting_clause }.each do |fee|
+                  == SlimHelper.render('templates/invoices/v4/_fees_without_groups', fee)
 
     / Total section
     .invoice-resume.overflow-auto


### PR DESCRIPTION
## Context

Invoice pdf do not display the correct fee when grouped_by

### How to reproduce issue?

1. I created a plan.charge with grouped_by attribute
2. I created a subscription on customer
3. Sends events to this subscription with grouped_by.key values
4. Current usage is displayed correctly ✅
5. I terminate the subscription
6. Invoice on user interface is displayed correctly ✅
7. Invoice on PDF display only 1 fees (looks like it aggregates all fees into one) ❌

## Description

The fix is to ensure that we loop over all fees when rendering the invoice
