### PR TITLE
fix(webhook): retry Errno::EPIPE errors

### DIFF
--- a/app/services/webhooks/base_service.rb
+++ b/app/services/webhooks/base_service.rb
@@ -71,6 +71,7 @@ module Webhooks
            Net::HTTPBadResponse,
            Errno::ECONNRESET,
            Errno::ECONNREFUSED,
+           Errno::EPIPE,
            OpenSSL::SSL::SSLError,
            SocketError,
            EOFError => e


### PR DESCRIPTION
## Context

Some webhook deliveries are ending in the sidekiq deadjob queue because the response from the service was a `Errno::EPIPE`

## Description

This error should be captured and the webhook should be handled by the retry mechanism