### PR TITLE
feat(edit-plan-amount-cents): Allow editing plan amount cents

### DIFF
--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -206,8 +206,8 @@ module Plans
     def process_downgraded_subscriptions
       return unless plan.subscriptions.active.exists?
 
-      Subscription.where(previous_subscription_id: plan.subscriptions.active, status: :pending).find_each do |sub|
-        sub.destroy! if plan.amount_cents < sub.plan.amount_cents
+      Subscription.where(previous_subscription: plan.subscriptions.active, status: :pending).find_each do |sub|
+        sub.mark_as_canceled! if plan.amount_cents < sub.plan.amount_cents
       end
     end
   end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -206,7 +206,7 @@ module Plans
     def process_downgraded_subscriptions
       return unless plan.subscriptions.active.exists?
 
-      Subscription.where(previous_subscription_id: plan.subscriptions.active, status: :pending).each do |sub|
+      Subscription.where(previous_subscription_id: plan.subscriptions.active, status: :pending).find_each do |sub|
         sub.destroy! if plan.amount_cents < sub.plan.amount_cents
       end
     end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -204,6 +204,8 @@ module Plans
     #       if plan has been downgraded but amount cents became less than downgraded value. This pending subscription
     #       is not relevant in this case and downgrade should be ignored
     def process_downgraded_subscriptions
+      return unless plan.subscriptions.active.exists?
+
       Subscription.where(previous_subscription_id: plan.subscriptions.active, status: :pending).each do |sub|
         sub.destroy! if plan.amount_cents < sub.plan.amount_cents
       end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -160,14 +160,14 @@ RSpec.describe Plans::UpdateService, type: :service do
 
         before { pending_subscription }
 
-        it 'correctly removes pending subscriptions' do
+        it 'correctly cancels pending subscriptions' do
           result = plans_service.call
 
           updated_plan = result.plan
           aggregate_failures do
             expect(updated_plan.name).to eq('Updated plan name')
             expect(updated_plan.amount_cents).to eq(5)
-            expect(Subscription.find_by(id: pending_subscription.id)).to be nil
+            expect(Subscription.find_by(id: pending_subscription.id).status).to eq('canceled')
           end
         end
       end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -126,6 +126,53 @@ RSpec.describe Plans::UpdateService, type: :service do
       end
     end
 
+    context 'when plan amount is updated' do
+      let(:new_customer) { create(:customer, organization:) }
+      let(:subscription) { create(:subscription, plan:, customer: new_customer) }
+      let(:update_args) do
+        {
+          name: plan_name,
+          code: 'new_plan',
+          interval: 'monthly',
+          pay_in_advance: false,
+          amount_cents: 5,
+          amount_currency: 'EUR',
+        }
+      end
+
+      before { subscription }
+
+      it 'correctly updates plan' do
+        result = plans_service.call
+
+        updated_plan = result.plan
+        aggregate_failures do
+          expect(updated_plan.name).to eq('Updated plan name')
+          expect(updated_plan.amount_cents).to eq(5)
+        end
+      end
+
+      context 'when there are pending subscriptions which are not relevant after the amount cents update' do
+        let(:pending_plan) { create(:plan, organization:, amount_cents: 10) }
+        let(:pending_subscription) do
+          create(:subscription, plan: pending_plan, status: :pending, previous_subscription_id: subscription.id)
+        end
+
+        before { pending_subscription }
+
+        it 'correctly removes pending subscriptions' do
+          result = plans_service.call
+
+          updated_plan = result.plan
+          aggregate_failures do
+            expect(updated_plan.name).to eq('Updated plan name')
+            expect(updated_plan.amount_cents).to eq(5)
+            expect(Subscription.find_by(id: pending_subscription.id)).to be nil
+          end
+        end
+      end
+    end
+
     context 'when plan is not found' do
       let(:applied_tax) { nil }
       let(:plan) { nil }


### PR DESCRIPTION
## Context

Currently it is not possible to edit plan amount cents on edit plan page and on edit subscription page.

## Description

We want to allow users to edit plan/subscription amount cents so that they don't need to create new plan with each change.

Also, if downgraded plan's amount cents is updated to the value that is less than the one in downgraded plan, pending subscription should be destroyed.