### PR TITLE
feat(filter): Discard filter and its values

### DIFF
--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -121,5 +121,22 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
         expect(filter_value.reload).to be_discarded
       end
     end
+
+    context 'when a filter is removed' do
+      let(:filters_params) do
+        [
+          {
+            key: 'country',
+            values: %w[USA France Germany],
+          },
+        ]
+      end
+
+      it 'discards the removed filter' do
+        expect { service }.not_to change(BillableMetricFilter, :count)
+
+        expect(filter.reload).to be_discarded
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds the logic to discard  billable metric filters when updating a billable metric