### PR TITLE
feat(filter): Add creation and update logic for charge filters

### DIFF
--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -12,6 +12,7 @@ class Charge < ApplicationRecord
   has_many :fees
   has_many :group_properties, dependent: :destroy
   has_many :filters, dependent: :destroy, class_name: 'ChargeFilter'
+  has_many :filter_values, through: :filters, class_name: 'ChargeFilterValue', source: :values
 
   has_many :applied_taxes, class_name: 'Charge::AppliedTax', dependent: :destroy
   has_many :taxes, through: :applied_taxes

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module ChargeFilters
+  class CreateOrUpdateBatchService < BaseService
+    def initialize(charge:, filters_params:)
+      @charge = charge
+      @filters_params = filters_params
+
+      super
+    end
+
+    def call
+      result.filters = []
+
+      if filters_params.empty?
+        remove_all
+
+        return result
+      end
+
+      ActiveRecord::Base.transaction do
+        filters_params.each do |filter_param|
+          # NOTE: Find the filters matching the values
+          filters = charge.filters.joins(values: :billable_metric_filter)
+            .where(billable_metric_filters: { key: filter_param[:values].keys })
+            .where(charge_filter_values: { value: filter_param[:values].values })
+
+          # NOTE: since a filter could be a refinement of another one, we have to make sure
+          #       that we are targeting the right one
+          filter = filters.find { |f| f.values.count == filter_param[:values].count }
+          filter ||= charge.filters.new
+
+          filter.invoice_display_name = filter_param[:invoice_display_name]
+          filter.properties = filter_param[:properties]
+
+          # NOTE: Create or update the filter values
+          filter_param[:values].each do |key, value|
+            billable_metric_filter = charge.billable_metric.filters.find_by(key:)
+
+            filter_value = filter.values.find_or_initialize_by(
+              billable_metric_filter_id: billable_metric_filter&.id,
+            )
+
+            filter_value.value = value
+          end
+
+          filter.save!
+
+          result.filters << filter
+        end
+
+        charge.filters.where.not(id: result.filters.map(&:id)).find_each do
+          remove_filter(_1)
+        end
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :charge, :filters_params
+
+    def remove_all
+      ActiveRecord::Base.transaction do
+        charge.filters.each { remove_filter(_1) }
+      end
+    end
+
+    def remove_filter(filter)
+      filter.values.each(&:discard!)
+      filter.discard!
+    end
+  end
+end

--- a/app/services/charge_filters/create_or_update_batch_service.rb
+++ b/app/services/charge_filters/create_or_update_batch_service.rb
@@ -49,6 +49,7 @@ module ChargeFilters
           result.filters << filter
         end
 
+        # NOTE: remove old filters that were not created or updated
         charge.filters.where.not(id: result.filters.map(&:id)).find_each do
           remove_filter(_1)
         end

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -91,6 +91,13 @@ module Plans
         properties:,
       ).properties
 
+      if args[:filters].present?
+        ChargeFilters::CreateOrUpdateBatchService.call(
+          charge:,
+          filters_params: args[:filters].map(&:with_indifferent_access),
+        ).raise_if_error!
+      end
+
       if License.premium?
         charge.invoiceable = args[:invoiceable] unless args[:invoiceable].nil?
         charge.min_amount_cents = args[:min_amount_cents] || 0

--- a/db/migrate/20240227161430_add_invoice_display_name_to_charge_filters.rb
+++ b/db/migrate/20240227161430_add_invoice_display_name_to_charge_filters.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddInvoiceDisplayNameToChargeFilters < ActiveRecord::Migration[7.0]
+  def change
+    add_column :charge_filters, :invoice_display_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_05_160647) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_27_161430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -194,6 +194,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_05_160647) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.string "invoice_display_name"
     t.index ["charge_id"], name: "index_charge_filters_on_charge_id"
     t.index ["deleted_at"], name: "index_charge_filters_on_deleted_at"
   end

--- a/spec/services/charge_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/charge_filters/create_or_update_batch_service_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
+  subject(:service) { described_class.call(charge:, filters_params:) }
+
+  let(:charge) { create(:standard_charge) }
+  let(:filters_params) { {} }
+
+  let(:card_location_filter) do
+    create(
+      :billable_metric_filter,
+      billable_metric: charge.billable_metric,
+      key: 'card_location',
+      values: %w[domestic international],
+    )
+  end
+
+  let(:scheme_filter) do
+    create(
+      :billable_metric_filter,
+      billable_metric: charge.billable_metric,
+      key: 'scheme',
+      values: %w[visa mastercard],
+    )
+  end
+
+  let(:card_type_filter) do
+    create(
+      :billable_metric_filter,
+      billable_metric: charge.billable_metric,
+      key: 'card_type',
+      values: %w[debit credit],
+    )
+  end
+
+  context 'when filter params is empty' do
+    it 'does not create any filters' do
+      expect { service }.not_to change(ChargeFilter, :count)
+    end
+
+    context 'when there are existing filters' do
+      let(:filter) { create(:charge_filter, charge:) }
+
+      let(:filter_value) do
+        create(
+          :charge_filter_value,
+          charge_filter: filter,
+          billable_metric_filter: card_location_filter,
+          value: card_location_filter.values.first,
+        )
+      end
+
+      before { filter_value }
+
+      it 'discards all filters and the related values' do
+        expect { service }.to change { filter.reload.discarded? }.to(true)
+          .and change { filter_value.reload.discarded? }.to(true)
+      end
+    end
+  end
+
+  context 'with new filters' do
+    let(:filters_params) do
+      [
+        {
+          values: {
+            card_location_filter.key => 'domestic',
+            scheme_filter.key => 'visa',
+          },
+          invoice_display_name: 'Visa domestic card payment',
+          properties: { amount: '10' },
+        },
+        {
+          values: {
+            card_location_filter.key => 'domestic',
+            scheme_filter.key => 'visa',
+            card_type_filter.key => 'debit',
+          },
+          invoice_display_name: 'Visa debit domestic card payment',
+          properties: { amount: '20' },
+        },
+      ]
+    end
+
+    it 'creates the filters and their values' do
+      expect { service }.to change(ChargeFilter, :count).by(2)
+
+      filter1 = charge.filters.find_by(invoice_display_name: 'Visa domestic card payment')
+      expect(filter1).to have_attributes(
+        invoice_display_name: 'Visa domestic card payment',
+        properties: { 'amount' => '10' },
+      )
+      expect(filter1.values.count).to eq(2)
+      expect(filter1.values.pluck(:value)).to match_array(%w[domestic visa])
+
+      filter2 = charge.filters.find_by(invoice_display_name: 'Visa debit domestic card payment')
+      expect(filter2).to have_attributes(
+        invoice_display_name: 'Visa debit domestic card payment',
+        properties: { 'amount' => '20' },
+      )
+      expect(filter2.values.count).to eq(3)
+      expect(filter2.values.pluck(:value)).to match_array(%w[domestic visa debit])
+    end
+  end
+
+  context 'with existing filters' do
+    let(:filter) { create(:charge_filter, charge:) }
+    let(:filter_values) do
+      [
+        create(
+          :charge_filter_value,
+          charge_filter: filter,
+          billable_metric_filter: card_location_filter,
+          value: 'domestic',
+        ),
+        create(
+          :charge_filter_value,
+          charge_filter: filter,
+          billable_metric_filter: scheme_filter,
+          value: 'visa',
+        ),
+      ]
+    end
+
+    let(:filters_params) do
+      [
+        {
+          values: {
+            card_location_filter.key => 'domestic',
+            scheme_filter.key => 'visa',
+          },
+          invoice_display_name: 'New display name',
+          properties: { amount: '20' },
+        },
+      ]
+    end
+
+    before { filter_values }
+
+    it 'updates the filter' do
+      expect { service }.not_to change(ChargeFilter, :count)
+      expect(filter.reload).to have_attributes(
+        invoice_display_name: 'New display name',
+        properties: { 'amount' => '20' },
+      )
+      expect(filter.values.count).to eq(2)
+      expect(filter.values.pluck(:value)).to match_array(%w[domestic visa])
+    end
+
+    context 'when changing filter values' do
+      let(:filters_params) do
+        [
+          {
+            values: {
+              card_location_filter.key => 'international',
+              scheme_filter.key => 'mastercard',
+            },
+            invoice_display_name: 'New display name',
+            properties: { amount: '20' },
+          },
+        ]
+      end
+
+      it 'creates a new filter and removes the existing one' do
+        result = service
+
+        expect(result.filters.count).to eq(1)
+        expect(filter.reload).to be_discarded
+
+        new_filter = result.filters.first
+        expect(new_filter.values.count).to eq(2)
+        expect(new_filter.values.pluck(:value)).to match_array(%w[international mastercard])
+      end
+    end
+  end
+end

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -477,6 +477,15 @@ RSpec.describe Plans::UpdateService, type: :service do
         )
       end
 
+      let(:billable_metric_filter) do
+        create(
+          :billable_metric_filter,
+          billable_metric: sum_billable_metric,
+          key: 'payment_method',
+          values: %w[card physical],
+        )
+      end
+
       let(:update_args) do
         {
           id: plan.id,
@@ -498,6 +507,13 @@ RSpec.describe Plans::UpdateService, type: :service do
                 {
                   group_id: group.id,
                   values: { amount: '100' },
+                },
+              ],
+              filters: [
+                {
+                  invoice_display_name: 'Card filter',
+                  properties: { amount: '90' },
+                  values: { billable_metric_filter.key => 'card' },
                 },
               ],
             },
@@ -532,6 +548,15 @@ RSpec.describe Plans::UpdateService, type: :service do
         expect(existing_charge.group_properties.first).to have_attributes(
           group_id: group.id,
           values: { 'amount' => '100' },
+        )
+
+        expect(existing_charge.filters.first).to have_attributes(
+          invoice_display_name: 'Card filter',
+          properties: { 'amount' => '90' },
+        )
+        expect(existing_charge.filters.first.values.first).to have_attributes(
+          billable_metric_filter_id: billable_metric_filter.id,
+          value: 'card',
         )
       end
 


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds the logic to create, update or remove a `ChargeFilter` and its associated `ChargeFilterValues` in a dedicated `ChargeFilters::CreateOrUpdateBatchService`