### PR TITLE
fix(credit-notes): recalculate credit note item upon draft invoice refresh

### DIFF
--- a/app/services/credit_notes/refresh_draft_service.rb
+++ b/app/services/credit_notes/refresh_draft_service.rb
@@ -2,9 +2,10 @@
 
 module CreditNotes
   class RefreshDraftService < BaseService
-    def initialize(credit_note:, fee:)
+    def initialize(credit_note:, fee:, old_fee_values:)
       @credit_note = credit_note
       @fee = fee
+      @old_fee_values = old_fee_values
 
       super
     end
@@ -14,7 +15,16 @@ module CreditNotes
       return result unless credit_note.draft?
 
       credit_note.applied_taxes.destroy_all
-      credit_note.items.update_all(fee_id: fee.id) # rubocop:disable Rails/SkipsModelValidations
+      credit_note.items.each do |item|
+        item.fee_id = fee.id
+
+        if old_fee_values.any?
+          old_entry = old_fee_values.find { |h| h[:credit_note_item_id] == item.id }
+          item.precise_amount_cents = calculate_item_value(item, old_entry[:fee_amount_cents]) if old_entry
+        end
+
+        item.save(validate: false) # rubocop:disable Rails/SkipsModelValidations
+      end
 
       taxes_result = CreditNotes::ApplyTaxesService.call(
         invoice: fee.invoice,
@@ -45,6 +55,10 @@ module CreditNotes
 
     private
 
-    attr_accessor :credit_note, :fee
+    attr_accessor :credit_note, :fee, :old_fee_values
+
+    def calculate_item_value(item, old_fee_amount_cents)
+      (item.precise_amount_cents.fdiv(old_fee_amount_cents)) * fee.amount_cents
+    end
   end
 end

--- a/app/services/credit_notes/refresh_draft_service.rb
+++ b/app/services/credit_notes/refresh_draft_service.rb
@@ -23,7 +23,7 @@ module CreditNotes
           item.precise_amount_cents = calculate_item_value(item, old_entry[:fee_amount_cents]) if old_entry
         end
 
-        item.save(validate: false) # rubocop:disable Rails/SkipsModelValidations
+        item.save!
       end
 
       taxes_result = CreditNotes::ApplyTaxesService.call(
@@ -57,6 +57,8 @@ module CreditNotes
 
     attr_accessor :credit_note, :fee, :old_fee_values
 
+    # NOTE: credit note item value needs to be recalculated based on the ratio between old fee value and
+    #       new fee value
     def calculate_item_value(item, old_fee_amount_cents)
       item.precise_amount_cents.fdiv(old_fee_amount_cents) * fee.amount_cents
     end

--- a/app/services/credit_notes/refresh_draft_service.rb
+++ b/app/services/credit_notes/refresh_draft_service.rb
@@ -58,7 +58,7 @@ module CreditNotes
     attr_accessor :credit_note, :fee, :old_fee_values
 
     def calculate_item_value(item, old_fee_amount_cents)
-      (item.precise_amount_cents.fdiv(old_fee_amount_cents)) * fee.amount_cents
+      item.precise_amount_cents.fdiv(old_fee_amount_cents) * fee.amount_cents
     end
   end
 end

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -873,8 +873,8 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           credit_note = credit_note.reload
           first_invoice = first_invoice.reload
 
-          expect(credit_note.credit_amount_cents).to eq(1_700) # TODO: It needs to be recalculated
-          expect(credit_note.balance_amount_cents).to eq(1_700) # TODO: It needs to be recalculated
+          expect(credit_note.credit_amount_cents).to eq(850)
+          expect(credit_note.balance_amount_cents).to eq(850)
           expect(first_invoice.total_amount_cents).to eq(900)
           expect(first_invoice.fees_amount_cents).to eq(900)
           expect(first_invoice.credit_notes_amount_cents).to eq(0)
@@ -883,8 +883,8 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           credit_note = customer.credit_notes.first
 
           # credit notes are not applied on draft invoice
-          expect(credit_note.credit_amount_cents).to eq(1_700)
-          expect(credit_note.balance_amount_cents).to eq(1_700)
+          expect(credit_note.credit_amount_cents).to eq(850)
+          expect(credit_note.balance_amount_cents).to eq(850)
           expect(terminated_invoice.total_amount_cents).to eq(0) # There are no charges in a period
           expect(terminated_invoice.fees_amount_cents).to eq(0)
           expect(terminated_invoice.credit_notes_amount_cents).to eq(0)
@@ -954,8 +954,8 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           credit_note = credit_note.reload
           first_invoice = first_invoice.reload
 
-          expect(credit_note.credit_amount_cents).to eq(1_700) # TODO: It needs to be recalculated
-          expect(credit_note.balance_amount_cents).to eq(1_700) # TODO: It needs to be recalculated
+          expect(credit_note.credit_amount_cents).to eq(0)
+          expect(credit_note.balance_amount_cents).to eq(0)
           expect(first_invoice.total_amount_cents).to eq(0)
           expect(first_invoice.fees_amount_cents).to eq(0)
           expect(first_invoice.credit_notes_amount_cents).to eq(0)
@@ -964,8 +964,8 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           credit_note = customer.credit_notes.first
 
           # credit notes are not applied on draft invoice
-          expect(credit_note.credit_amount_cents).to eq(1_700)
-          expect(credit_note.balance_amount_cents).to eq(1_700)
+          expect(credit_note.credit_amount_cents).to eq(0)
+          expect(credit_note.balance_amount_cents).to eq(0)
           expect(terminated_invoice.total_amount_cents).to eq(0) # There are no charges in a period
           expect(terminated_invoice.fees_amount_cents).to eq(0)
           expect(terminated_invoice.credit_notes_amount_cents).to eq(0)

--- a/spec/services/credit_notes/refresh_draft_service_spec.rb
+++ b/spec/services/credit_notes/refresh_draft_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CreditNotes::RefreshDraftService, type: :service do
       {
         credit_note_item_id: credit_note_item.id,
         fee_amount_cents: credit_note_item.fee&.amount_cents,
-      }
+      },
     ]
   end
 

--- a/spec/services/credit_notes/refresh_draft_service_spec.rb
+++ b/spec/services/credit_notes/refresh_draft_service_spec.rb
@@ -3,15 +3,26 @@
 require 'rails_helper'
 
 RSpec.describe CreditNotes::RefreshDraftService, type: :service do
-  subject(:refresh_service) { described_class.new(credit_note:, fee:) }
+  subject(:refresh_service) { described_class.new(credit_note:, fee:, old_fee_values:) }
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:tax) { create(:tax, organization:, rate: 20) }
   let(:invoice) { create(:invoice, organization:, customer:, fees_amount_cents: 100, coupons_amount_cents: 20) }
+  let(:old_fee_values) do
+    [
+      {
+        credit_note_item_id: credit_note_item.id,
+        fee_amount_cents: credit_note_item.fee&.amount_cents,
+      }
+    ]
+  end
 
   describe '#call' do
     let(:status) { :draft }
+    let(:fee) { create(:fee, invoice:, taxes_rate: 20, amount_cents: 100, precise_coupons_amount_cents: 20) }
+    let(:applied_tax) { create(:fee_applied_tax, tax:, fee:, amount_cents: 0) }
+    let(:credit_note_item) { create(:credit_note_item, credit_note:, fee: create(:fee, invoice:, taxes_rate: 0)) }
     let(:credit_note) do
       create(
         :credit_note,
@@ -24,12 +35,10 @@ RSpec.describe CreditNotes::RefreshDraftService, type: :service do
         total_amount_cents: 100,
       )
     end
-    let(:fee) { create(:fee, invoice:, taxes_rate: 20, amount_cents: 100, precise_coupons_amount_cents: 20) }
-    let(:applied_tax) { create(:fee_applied_tax, tax:, fee:, amount_cents: 0) }
 
     before do
       applied_tax
-      create(:credit_note_item, credit_note:, fee: create(:fee, invoice:, taxes_rate: 0))
+      credit_note_item
     end
 
     context 'when credit_note is finalized' do
@@ -46,11 +55,11 @@ RSpec.describe CreditNotes::RefreshDraftService, type: :service do
 
     it 'updates vat amounts of the credit note' do
       expect { refresh_service.call }
-        .to change { credit_note.reload.taxes_amount_cents }.from(0).to(16)
-        .and change(credit_note, :coupons_adjustment_amount_cents).from(0).to(20)
-        .and change(credit_note, :credit_amount_cents).from(100).to(96)
-        .and change(credit_note, :balance_amount_cents).from(100).to(96)
-        .and change(credit_note, :total_amount_cents).from(100).to(96)
+        .to change { credit_note.reload.taxes_amount_cents }.from(0).to(8)
+        .and change(credit_note, :coupons_adjustment_amount_cents).from(0).to(10)
+        .and change(credit_note, :credit_amount_cents).from(100).to(48)
+        .and change(credit_note, :balance_amount_cents).from(100).to(48)
+        .and change(credit_note, :total_amount_cents).from(100).to(48)
     end
   end
 end


### PR DESCRIPTION
## Context

When draft invoice fee got changed, we do not recalculate attached credit note item value. It has to change because end-user could end up with invalid credit note amount that would be later applied.

## Description

This PR handles credit note recalculation upon fee change.

In prior PR - https://github.com/getlago/lago-api/pull/1733 scenario tests for this case were added. The goal of this change is to cover credit note item recalculation so that scenario tests passes with expected values.
