### PR TITLE
feat(filter): Expose charge filters into GraphQL API

### DIFF
--- a/app/graphql/types/charge_filters/input.rb
+++ b/app/graphql/types/charge_filters/input.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  module ChargeFilters
+    class Input < BaseInputObject
+      graphql_name 'ChargeFilterInput'
+      description 'Charge filters input arguments'
+
+      argument :invoice_display_name, String, required: false
+      argument :properties, Types::Charges::PropertiesInput, required: true
+      argument :values, Types::ChargeFilters::Values, required: true
+    end
+  end
+end

--- a/app/graphql/types/charge_filters/object.rb
+++ b/app/graphql/types/charge_filters/object.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Types
+  module ChargeFilters
+    class Object < Types::BaseObject
+      graphql_name 'ChargeFilter'
+      description 'Charge filters object'
+
+      field :id, ID, null: false
+
+      field :invoice_display_name, String, null: true
+      field :properties, Types::Charges::Properties, null: false
+      field :values, Types::ChargeFilters::Values, null: false
+
+      def values
+        object.values.each_with_object({}) do |filter_value, result|
+          result[filter_value.billable_metric_filter.key] = filter_value.value
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/charge_filters/values.rb
+++ b/app/graphql/types/charge_filters/values.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Types
+  module ChargeFilters
+    class Values < Types::BaseScalar
+      graphql_name 'ChargeFilterValues'
+
+      def self.coerce_input(input_value, _context)
+        input_value.to_h.each_with_object({}) do |(key, value), result|
+          result[key.to_s] = value.to_s
+        end
+      rescue StandardError
+        raise GraphQL::CoercionError, "#{input_value.inspect} is not a valid hash object"
+      end
+
+      def self.coerce_result(ruby_value, _context)
+        ruby_value.to_h
+      end
+    end
+  end
+end

--- a/app/graphql/types/charges/input.rb
+++ b/app/graphql/types/charges/input.rb
@@ -14,6 +14,7 @@ module Types
       argument :pay_in_advance, Boolean, required: false
       argument :prorated, Boolean, required: false
 
+      argument :filters, [Types::ChargeFilters::Input], required: false
       argument :group_properties, [Types::Charges::GroupPropertiesInput], required: false
       argument :properties, Types::Charges::PropertiesInput, required: false
 

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -17,6 +17,8 @@ module Types
       field :properties, Types::Charges::Properties, null: true
       field :prorated, Boolean, null: false
 
+      field :filters, [Types::ChargeFilters::Object], null: true
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -203,6 +203,7 @@ type Charge {
   chargeModel: ChargeModelEnum!
   createdAt: ISO8601DateTime!
   deletedAt: ISO8601DateTime
+  filters: [ChargeFilter!]
   groupProperties: [GroupProperties!]
   id: ID!
   invoiceDisplayName: String
@@ -215,9 +216,31 @@ type Charge {
   updatedAt: ISO8601DateTime!
 }
 
+"""
+Charge filters object
+"""
+type ChargeFilter {
+  id: ID!
+  invoiceDisplayName: String
+  properties: Properties!
+  values: ChargeFilterValues!
+}
+
+"""
+Charge filters input arguments
+"""
+input ChargeFilterInput {
+  invoiceDisplayName: String
+  properties: PropertiesInput!
+  values: ChargeFilterValues!
+}
+
+scalar ChargeFilterValues
+
 input ChargeInput {
   billableMetricId: ID!
   chargeModel: ChargeModelEnum!
+  filters: [ChargeFilterInput!]
   groupProperties: [GroupPropertiesInput!]
   id: ID
   invoiceDisplayName: String

--- a/schema.json
+++ b/schema.json
@@ -1969,6 +1969,28 @@
               ]
             },
             {
+              "name": "filters",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ChargeFilter",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "groupProperties",
               "description": null,
               "type": {
@@ -2153,6 +2175,152 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ChargeFilter",
+          "description": "Charge filters object",
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "properties",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Properties",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "values",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ChargeFilterValues",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ChargeFilterInput",
+          "description": "Charge filters input arguments",
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "properties",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "PropertiesInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "values",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ChargeFilterValues",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ChargeFilterValues",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "ChargeInput",
           "description": null,
@@ -2259,6 +2427,26 @@
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "filters",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ChargeFilterInput",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -64,6 +64,11 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
                 volumeRanges { fromValue, toValue }
               }
             }
+            filters {
+              invoiceDisplayName
+              values
+              properties { amount }
+            }
           }
         }
       }
@@ -76,6 +81,16 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
 
   let(:first_group) { create(:group, billable_metric: billable_metrics[1]) }
   let(:second_group) { create(:group, billable_metric: billable_metrics[2]) }
+
+  let(:billable_metric_filter) do
+    create(
+      :billable_metric_filter,
+      billable_metric: billable_metrics[0],
+      key: 'payment_method',
+      values: %w[card physical],
+    )
+  end
+
   let(:tax) { create(:tax, organization:) }
 
   around { |test| lago_premium!(&test) }
@@ -106,6 +121,13 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
               chargeModel: 'standard',
               properties: { amount: '100.00' },
               taxCodes: [charge_tax.code],
+              filters: [
+                {
+                  invoiceDisplayName: 'Payment Method',
+                  properties: { amount: '100.00' },
+                  values: { billable_metric_filter.key => 'card' },
+                },
+              ],
             },
             {
               billableMetricId: billable_metrics[1].id,
@@ -223,6 +245,11 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
       expect(standard_charge['chargeModel']).to eq('standard')
       expect(standard_charge['taxes'].count).to eq(1)
       expect(standard_charge['taxes'].first['code']).to eq(charge_tax.code)
+
+      filter = standard_charge['filters'].first
+      expect(filter['invoiceDisplayName']).to eq('Payment Method')
+      expect(filter['properties']['amount']).to eq('100.00')
+      expect(filter['values']).to eq('payment_method' => 'card')
 
       package_charge = result_data['charges'][1]
       expect(package_charge['chargeModel']).to eq('package')

--- a/spec/graphql/types/charge_filters/input_spec.rb
+++ b/spec/graphql/types/charge_filters/input_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::ChargeFilters::Input do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
+  it { is_expected.to accept_argument(:properties).of_type('PropertiesInput!') }
+  it { is_expected.to accept_argument(:values).of_type('ChargeFilterValues!') }
+end

--- a/spec/graphql/types/charge_filters/object_spec.rb
+++ b/spec/graphql/types/charge_filters/object_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::ChargeFilters::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type('ID!') }
+  it { is_expected.to have_field(:invoice_display_name).of_type('String') }
+  it { is_expected.to have_field(:properties).of_type('Properties!') }
+  it { is_expected.to have_field(:values).of_type('ChargeFilterValues!') }
+end

--- a/spec/graphql/types/charges/input_spec.rb
+++ b/spec/graphql/types/charges/input_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Types::Charges::Input do
   it { is_expected.to accept_argument(:pay_in_advance).of_type('Boolean') }
   it { is_expected.to accept_argument(:prorated).of_type('Boolean') }
 
+  it { is_expected.to accept_argument(:filters).of_type('[ChargeFilterInput!]') }
   it { is_expected.to accept_argument(:group_properties).of_type('[GroupPropertiesInput!]') }
   it { is_expected.to accept_argument(:properties).of_type('PropertiesInput') }
 

--- a/spec/graphql/types/charges/object_spec.rb
+++ b/spec/graphql/types/charges/object_spec.rb
@@ -19,4 +19,5 @@ RSpec.describe Types::Charges::Object do
   it { is_expected.to have_field(:deleted_at).of_type('ISO8601DateTime') }
   it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
   it { is_expected.to have_field(:taxes).of_type('[Tax!]') }
+  it { is_expected.to have_field(:filters).of_type('[ChargeFilter!]') }
 end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds exposes the charge filters and the charge filter values into the GraphQL API