### PR TITLE
fix: Deliver email with SendEmailJob

### DIFF
--- a/app/jobs/send_email_job.rb
+++ b/app/jobs/send_email_job.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SendEmailJob < ActionMailer::MailDeliveryJob
+  queue_as 'mailers'
+
+  retry_on ActiveJob::DeserializationError, wait: :exponentially_longer, attempts: 6
+  retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 6
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,4 +2,6 @@
 
 class ApplicationMailer < ActionMailer::Base
   layout 'mailer'
+
+  self.delivery_job = SendEmailJob
 end

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -196,6 +196,11 @@ module PaymentProviders
             metadata: event.data.object.metadata.to_h.symbolize_keys,
           )
       end
+    rescue BaseService::NotFoundFailure => e
+      # NOTE: Error with stripe sandbox should be ignord
+      raise if event.livemode
+
+      Rails.logger.warn("Stripe resource not found: #{e.message}. JSON: #{event_json}")
     end
 
     private

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,6 +3,7 @@ timeout: 25
 retry: 1
 queues:
   - default
+  - mailers
   - clock
   - providers
   - billing

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -127,16 +127,16 @@ RSpec.describe CreditNotes::CreateService, type: :service do
     it 'delivers an email' do
       expect do
         create_service.call
-      end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      end.to have_enqueued_job(SendEmailJob)
     end
 
     context 'when organization does not have right email settings' do
       before { invoice.organization.update!(email_settings: []) }
 
-      it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+      it 'does not enqueue an SendEmailJob' do
         expect do
           create_service.call
-        end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+        end.not_to have_enqueued_job(SendEmailJob)
       end
     end
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Fees::ChargeService do
       charges_duration: (
         subscription.started_at.end_of_month.end_of_day - subscription.started_at.beginning_of_month
       ).fdiv(1.day).ceil,
+      timestamp: subscription.started_at.end_of_month.end_of_day + 1.second,
     }
   end
 
@@ -327,6 +328,7 @@ RSpec.describe Fees::ChargeService do
             charges_from_datetime: subscription.started_at,
             charges_to_datetime: Time.zone.parse('30 Apr 2022 00:01:00'),
             charges_duration: 30,
+            timestamp: Time.zone.parse('2022-05-01T00:01:00'),
           }
         end
 

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -54,28 +54,28 @@ RSpec.describe Invoices::AddOnService, type: :service do
       end.to have_enqueued_job(SendWebhookJob)
     end
 
-    it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+    it 'does not enqueue an SendEmailJob' do
       expect do
         invoice_service.create
-      end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      end.not_to have_enqueued_job(SendEmailJob)
     end
 
     context 'with lago_premium' do
       around { |test| lago_premium!(&test) }
 
-      it 'enqueues an ActionMailer::MailDeliveryJob' do
+      it 'enqueues an SendEmailJob' do
         expect do
           invoice_service.create
-        end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+        end.to have_enqueued_job(SendEmailJob)
       end
 
       context 'when organization does not have right email settings' do
         before { applied_add_on.customer.organization.update!(email_settings: []) }
 
-        it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+        it 'does not enqueue an SendEmailJob' do
           expect do
             invoice_service.create
-          end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+          end.not_to have_enqueued_job(SendEmailJob)
         end
       end
     end

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -151,28 +151,28 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
       end.to have_enqueued_job(SendWebhookJob).with('fee.created', Fee)
     end
 
-    it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+    it 'does not enqueue an SendEmailJob' do
       expect do
         invoice_service.call
-      end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      end.not_to have_enqueued_job(SendEmailJob)
     end
 
     context 'with lago_premium' do
       around { |test| lago_premium!(&test) }
 
-      it 'enqueues an ActionMailer::MailDeliveryJob' do
+      it 'enqueues an SendEmailJob' do
         expect do
           invoice_service.call
-        end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+        end.to have_enqueued_job(SendEmailJob)
       end
 
       context 'when organization does not have right email settings' do
         let(:email_settings) { [] }
 
-        it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+        it 'does not enqueue an SendEmailJob' do
           expect do
             invoice_service.call
-          end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+          end.not_to have_enqueued_job(SendEmailJob)
         end
       end
     end

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -94,10 +94,10 @@ RSpec.describe Invoices::CreateService, type: :service do
       end.to have_enqueued_job(SendWebhookJob)
     end
 
-    it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+    it 'does not enqueue an SendEmailJob' do
       expect do
         create_service.call
-      end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      end.not_to have_enqueued_job(SendEmailJob)
     end
 
     context 'when invoice amount in cents is zero' do
@@ -138,19 +138,19 @@ RSpec.describe Invoices::CreateService, type: :service do
     context 'with lago_premium' do
       around { |test| lago_premium!(&test) }
 
-      it 'enqueues an ActionMailer::MailDeliveryJob' do
+      it 'enqueues an SendEmailJob' do
         expect do
           create_service.call
-        end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+        end.to have_enqueued_job(SendEmailJob)
       end
 
       context 'when organization does not have right email settings' do
         before { customer.organization.update!(email_settings: []) }
 
-        it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+        it 'does not enqueue an SendEmailJob' do
           expect do
             create_service.call
-          end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+          end.not_to have_enqueued_job(SendEmailJob)
         end
       end
     end

--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Invoices::FinalizeService, type: :service do
       invoice.customer.update(timezone: 'America/New_York')
 
       freeze_time do
-        current_date = Time.current.in_time_zone("America/New_York").to_date
+        current_date = Time.current.in_time_zone('America/New_York').to_date
 
         expect { finalize_service.call }
           .to change { invoice.reload.issuing_date }.to(current_date)
@@ -74,28 +74,28 @@ RSpec.describe Invoices::FinalizeService, type: :service do
       end.to have_enqueued_job(SendWebhookJob).with('invoice.created', Invoice)
     end
 
-    it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+    it 'does not enqueue an SendEmailJob' do
       expect do
         finalize_service.call
-      end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      end.not_to have_enqueued_job(SendEmailJob)
     end
 
     context 'with lago_premium' do
       around { |test| lago_premium!(&test) }
 
-      it 'enqueues an ActionMailer::MailDeliveryJob' do
+      it 'enqueues an SendEmailJob' do
         expect do
           finalize_service.call
-        end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+        end.to have_enqueued_job(SendEmailJob)
       end
 
       context 'when organization does not have right email settings' do
         before { invoice.organization.update!(email_settings: []) }
 
-        it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+        it 'does not enqueue an SendEmailJob' do
           expect do
             finalize_service.call
-          end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+          end.not_to have_enqueued_job(SendEmailJob)
         end
       end
     end

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -56,28 +56,28 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
       end.to have_enqueued_job(SendWebhookJob)
     end
 
-    it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+    it 'does not enqueue an SendEmailJob' do
       expect do
         invoice_service.call
-      end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      end.not_to have_enqueued_job(SendEmailJob)
     end
 
     context 'with lago_premium' do
       around { |test| lago_premium!(&test) }
 
-      it 'enqueues an ActionMailer::MailDeliveryJob' do
+      it 'enqueues an SendEmailJob' do
         expect do
           invoice_service.call
-        end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+        end.to have_enqueued_job(SendEmailJob)
       end
 
       context 'when organization does not have right email settings' do
         before { customer.organization.update!(email_settings: []) }
 
-        it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+        it 'does not enqueue an SendEmailJob' do
           expect do
             invoice_service.call
-          end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+          end.not_to have_enqueued_job(SendEmailJob)
         end
       end
     end

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -108,10 +108,10 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
       end.to have_enqueued_job(SendWebhookJob).with('invoice.created', Invoice)
     end
 
-    it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+    it 'does not enqueue an SendEmailJob' do
       expect do
         invoice_service.call
-      end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      end.not_to have_enqueued_job(SendEmailJob)
     end
 
     context 'when recurring but no active subscriptions' do
@@ -124,19 +124,19 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
     context 'with lago_premium' do
       around { |test| lago_premium!(&test) }
 
-      it 'enqueues an ActionMailer::MailDeliveryJob' do
+      it 'enqueues an SendEmailJob' do
         expect do
           invoice_service.call
-        end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+        end.to have_enqueued_job(SendEmailJob)
       end
 
       context 'when organization does not have right email settings' do
         before { subscription.customer.organization.update!(email_settings: []) }
 
-        it 'does not enqueue an ActionMailer::MailDeliveryJob' do
+        it 'does not enqueue an SendEmailJob' do
           expect do
             invoice_service.call
-          end.not_to have_enqueued_job(ActionMailer::MailDeliveryJob)
+          end.not_to have_enqueued_job(SendEmailJob)
         end
       end
     end

--- a/spec/services/password_resets/create_service_spec.rb
+++ b/spec/services/password_resets/create_service_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe PasswordResets::CreateService, type: :service do
       end
     end
 
-    it 'enqueues an ActionMailer::MailDeliveryJob' do
+    it 'enqueues an SendEmailJob' do
       expect do
         create_service.call(**create_args)
-      end.to have_enqueued_job(ActionMailer::MailDeliveryJob)
+      end.to have_enqueued_job(SendEmailJob)
     end
   end
 end


### PR DESCRIPTION
## Context

This PR is an attempt to handle retry and errors with email deliveries.

## Description

The PR changes the jobs used to deliver email from the default `ActionMailer::MailDeliveryJob` to an app specific `SendEmailJob`. The new job simply inherit from the first one to keep the delivery behavior


The goal is to allow us:
- To use a custom sidekiq queue rather than the `default` one
- To handle error catching and retry (`ActiveJob::DeserializationError` and `LagoHttpClient::HttpError` for now)