### PR TITLE
misc: fix flaky test

### DIFF
--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Fees::ChargeService do
       to_datetime: subscription.started_at.end_of_month.end_of_day,
       charges_from_datetime: subscription.started_at.beginning_of_day,
       charges_to_datetime: subscription.started_at.end_of_month.end_of_day,
+      timestamp: (subscription.started_at.end_of_month + 1.day).end_of_day,
       charges_duration: (
         subscription.started_at.end_of_month.end_of_day - subscription.started_at.beginning_of_month
       ).fdiv(1.day).ceil,


### PR DESCRIPTION
## Context

Timestamp needs to be included in boundaries in fees/charge_service_spec. Timestamp from boundaries is used for calculating true-up. If not present, current time is used which can result in invalid test results
