### PR TITLE
feat(stripe-payment-methods): update stripe payment provider method list

### DIFF
--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -2,7 +2,7 @@
 
 module PaymentProviderCustomers
   class StripeCustomer < BaseCustomer
-    PAYMENT_METHODS = %w[card sepa_debit].freeze
+    PAYMENT_METHODS = %w[card sepa_debit us_bank_account bacs_debit].freeze
 
     validates :provider_payment_methods, presence: true
     validate :allowed_provider_payment_methods

--- a/schema.graphql
+++ b/schema.graphql
@@ -4382,8 +4382,10 @@ input ProviderCustomerInput {
 }
 
 enum ProviderPaymentMethodsEnum {
+  bacs_debit
   card
   sepa_debit
+  us_bank_account
 }
 
 enum ProviderTypeEnum {

--- a/schema.json
+++ b/schema.json
@@ -20681,6 +20681,18 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "us_bank_account",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "bacs_debit",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },


### PR DESCRIPTION
## Context

Currently BACS and ACH payment method schemas cannot be used in Lago

## Description

This PR enables customers to use both BACS and ACH
