### PR TITLE
feat(filter): Add relation between charge filter and cached aggregation

### DIFF
--- a/app/models/cached_aggregation.rb
+++ b/app/models/cached_aggregation.rb
@@ -4,6 +4,7 @@ class CachedAggregation < ApplicationRecord
   belongs_to :organization
   belongs_to :charge
   belongs_to :group, optional: true
+  belongs_to :charge_filter, optional: true
 
   validates :event_id, presence: true
   validates :external_subscription_id, presence: true

--- a/db/migrate/20240301133006_add_charge_filter_id_to_cached_aggregations.rb
+++ b/db/migrate/20240301133006_add_charge_filter_id_to_cached_aggregations.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddChargeFilterIdToCachedAggregations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cached_aggregations, :charge_filter_id, :uuid, null: true
+    add_index :cached_aggregations,
+              %i[organization_id timestamp charge_id charge_filter_id],
+              name: :index_timestamp_filter_lookup
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_27_161430) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_01_133006) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -167,10 +167,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_27_161430) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "grouped_by", default: {}, null: false
+    t.uuid "charge_filter_id"
     t.index ["charge_id"], name: "index_cached_aggregations_on_charge_id"
     t.index ["event_id"], name: "index_cached_aggregations_on_event_id"
     t.index ["external_subscription_id"], name: "index_cached_aggregations_on_external_subscription_id"
     t.index ["group_id"], name: "index_cached_aggregations_on_group_id"
+    t.index ["organization_id", "timestamp", "charge_id", "charge_filter_id"], name: "index_timestamp_filter_lookup"
     t.index ["organization_id", "timestamp", "charge_id", "group_id"], name: "index_timestamp_group_lookup"
     t.index ["organization_id", "timestamp", "charge_id"], name: "index_timestamp_lookup"
     t.index ["organization_id"], name: "index_cached_aggregations_on_organization_id"


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds a new relation between `ChargeFilter` and `CachedAggregation`