### PR TITLE
misc: Add a test case for the 29th of february

### DIFF
--- a/app/services/subscriptions/billing_service.rb
+++ b/app/services/subscriptions/billing_service.rb
@@ -227,7 +227,6 @@ module Subscriptions
         conditions: [billing_month, billing_day],
       )
     end
-    # rubocop:enable Layout/LineLength
 
     def yearly_anniversary
       billing_month = <<-SQL

--- a/spec/scenarios/subscriptions/billing_spec.rb
+++ b/spec/scenarios/subscriptions/billing_spec.rb
@@ -312,6 +312,9 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 10, 31, 2),
             DateTime.new(2023, 11, 30, 2),
             DateTime.new(2023, 12, 31, 2),
+            DateTime.new(2024, 1, 31, 2),
+            DateTime.new(2024, 2, 29, 2),
+            DateTime.new(2024, 3, 31, 2),
           ]
         end
 
@@ -335,6 +338,8 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 10, 30, 2),
             DateTime.new(2023, 11, 30, 2),
             DateTime.new(2023, 12, 30, 2),
+            DateTime.new(2024, 2, 29, 2),
+            DateTime.new(2024, 3, 30, 2),
           ]
         end
 


### PR DESCRIPTION
## Context

This PR adds a specific test case for the anniversary billing on the 29th of february when a subscription anniversary is on 30, or 31