### PR TITLE
feat(filter): Expose filter with fees and usage in GraphQL

### DIFF
--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -12,6 +12,7 @@ module Types
 
         field :billable_metric, Types::BillableMetrics::Object, null: false
         field :charge, Types::Charges::Object, null: false
+        field :filters, [Types::Customers::Usage::ChargeFilter], null: true
         field :grouped_usage, [Types::Customers::Usage::GroupedUsage], null: false
         field :groups, [Types::Customers::Usage::ChargeGroup], null: true
 
@@ -39,6 +40,12 @@ module Types
           object
             .select(&:group)
             .sort_by { |f| f.group.name }
+        end
+
+        def filters
+          object
+            .select(&:filter)
+            .sort_by { |f| f.filter.display_name }
         end
 
         def grouped_usage

--- a/app/graphql/types/customers/usage/charge_filter.rb
+++ b/app/graphql/types/customers/usage/charge_filter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Types
+  module Customers
+    module Usage
+      class ChargeFilter < Types::BaseObject
+        graphql_name 'ChargeFilterUsage'
+
+        field :id, ID, null: false, method: :filter_id
+
+        field :amount_cents, GraphQL::Types::BigInt, null: false
+        field :events_count, Integer, null: false
+        field :invoice_display_name, String, null: true
+        field :units, GraphQL::Types::Float, null: false
+        field :values, Types::ChargeFilters::Values, null: false
+
+        def values
+          object.filter.values.each_with_object({}) do |value, result|
+            result[value.billable_metric_filter.key] = value.values
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/customers/usage/grouped_usage.rb
+++ b/app/graphql/types/customers/usage/grouped_usage.rb
@@ -10,6 +10,7 @@ module Types
         field :events_count, Integer, null: false
         field :units, GraphQL::Types::Float, null: false
 
+        field :filters, [Types::Customers::Usage::ChargeFilter], null: true
         field :grouped_by, GraphQL::Types::JSON, null: true
         field :groups, [Types::Customers::Usage::ChargeGroup], null: true
 
@@ -33,6 +34,12 @@ module Types
           object
             .select(&:group)
             .sort_by { |f| f.group.name }
+        end
+
+        def filters
+          object
+            .select(&:filter)
+            .sort_by { |f| f.filter.display_name }
         end
       end
     end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -9,6 +9,7 @@ module Types
       field :charge, Types::Charges::Object, null: true
       field :currency, Types::CurrencyEnum, null: false
       field :description, String, null: true
+      field :filter_display_name, String, null: true
       field :group_name, String, null: true
       field :grouped_by, GraphQL::Types::JSON, null: false
       field :invoice_display_name, String, null: true
@@ -32,9 +33,6 @@ module Types
       field :adjusted_fee, Boolean, null: false
       field :adjusted_fee_type, Types::AdjustedFees::AdjustedFeeTypeEnum, null: true
 
-      delegate :group_name, to: :object
-      delegate :invoice_name, to: :object
-
       def item_type
         object.fee_type
       end
@@ -52,6 +50,10 @@ module Types
         return nil if object.adjusted_fee.adjusted_display_name?
 
         object.adjusted_fee.adjusted_units? ? 'adjusted_units' : 'adjusted_amount'
+      end
+
+      def filter_display_name
+        object.charge_filter&.display_name
       end
     end
   end

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -14,6 +14,10 @@ class ChargeFilter < ApplicationRecord
 
   default_scope -> { kept }
 
+  def display_name
+    invoice_display_name || values.map(&:value).join(', ')
+  end
+
   private
 
   def validate_properties

--- a/schema.graphql
+++ b/schema.graphql
@@ -235,6 +235,15 @@ input ChargeFilterInput {
   values: ChargeFilterValues!
 }
 
+type ChargeFilterUsage {
+  amountCents: BigInt!
+  eventsCount: Int!
+  id: ID!
+  invoiceDisplayName: String
+  units: Float!
+  values: ChargeFilterValues!
+}
+
 scalar ChargeFilterValues
 
 input ChargeInput {
@@ -276,6 +285,7 @@ type ChargeUsage {
   billableMetric: BillableMetric!
   charge: Charge!
   eventsCount: Int!
+  filters: [ChargeFilterUsage!]
   groupedUsage: [GroupedChargeUsage!]!
   groups: [GroupUsage!]
   units: Float!
@@ -3116,6 +3126,7 @@ type Fee implements InvoiceItem {
   description: String
   eventsCount: BigInt
   feeType: FeeTypesEnum!
+  filterDisplayName: String
   group: Group
   groupName: String
   groupedBy: JSON!
@@ -3335,6 +3346,7 @@ type GroupUsage {
 type GroupedChargeUsage {
   amountCents: BigInt!
   eventsCount: Int!
+  filters: [ChargeFilterUsage!]
   groupedBy: JSON
   groups: [GroupUsage!]
   units: Float!

--- a/schema.json
+++ b/schema.json
@@ -2311,6 +2311,123 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ChargeFilterUsage",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "eventsCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "units",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "values",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ChargeFilterValues",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
           "kind": "SCALAR",
           "name": "ChargeFilterValues",
           "description": null,
@@ -2746,6 +2863,28 @@
                   "kind": "SCALAR",
                   "name": "Int",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "filters",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ChargeFilterUsage",
+                    "ofType": null
+                  }
                 }
               },
               "isDeprecated": false,
@@ -12090,6 +12229,20 @@
               ]
             },
             {
+              "name": "filterDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "group",
               "description": null,
               "type": {
@@ -14378,6 +14531,28 @@
                   "kind": "SCALAR",
                   "name": "Int",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "filters",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ChargeFilterUsage",
+                    "ofType": null
+                  }
                 }
               },
               "isDeprecated": false,

--- a/spec/graphql/types/customers/usage/charge_filter_spec.rb
+++ b/spec/graphql/types/customers/usage/charge_filter_spec.rb
@@ -2,13 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe Types::Customers::Usage::GroupedUsage do
+RSpec.describe Types::Customers::Usage::ChargeFilter do
   subject { described_class }
 
+  it { is_expected.to have_field(:id).of_type('ID!') }
   it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:events_count).of_type('Int!') }
+  it { is_expected.to have_field(:invoice_display_name).of_type('String') }
   it { is_expected.to have_field(:units).of_type('Float!') }
-  it { is_expected.to have_field(:filters).of_type('[ChargeFilterUsage!]') }
-  it { is_expected.to have_field(:grouped_by).of_type('JSON') }
-  it { is_expected.to have_field(:groups).of_type('[GroupUsage!]') }
+  it { is_expected.to have_field(:values).of_type('ChargeFilterValues!') }
 end

--- a/spec/graphql/types/customers/usage/charge_spec.rb
+++ b/spec/graphql/types/customers/usage/charge_spec.rb
@@ -12,4 +12,5 @@ RSpec.describe Types::Customers::Usage::Charge do
   it { is_expected.to have_field(:charge).of_type('Charge!') }
   it { is_expected.to have_field(:grouped_usage).of_type('[GroupedChargeUsage!]!') }
   it { is_expected.to have_field(:groups).of_type('[GroupUsage!]') }
+  it { is_expected.to have_field(:filters).of_type('[ChargeFilterUsage!]') }
 end

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -21,4 +21,7 @@ RSpec.describe Types::Fees::Object do
   it { is_expected.to have_field(:adjusted_fee).of_type('Boolean!') }
   it { is_expected.to have_field(:adjusted_fee_type).of_type('AdjustedFeeTypeEnum') }
   it { is_expected.to have_field(:grouped_by).of_type('JSON!') }
+
+  it { is_expected.to have_field(:filter_display_name).of_type('String') }
+  it { is_expected.to have_field(:group_name).of_type('String') }
 end

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -320,4 +320,28 @@ RSpec.describe ChargeFilter, type: :model do
       end
     end
   end
+
+  describe '#display_name' do
+    subject(:charge_filter) { build(:charge_filter, invoice_display_name:, values:) }
+
+    let(:invoice_display_name) { Faker::Fantasy::Tolkien.character }
+    let(:values) do
+      [
+        build(:charge_filter_value, value: 'card'),
+        build(:charge_filter_value, value: 'visa'),
+      ]
+    end
+
+    it 'returns the invoice display name' do
+      expect(charge_filter.display_name).to eq(invoice_display_name)
+    end
+
+    context 'when invoice display name is not present' do
+      let(:invoice_display_name) { nil }
+
+      it 'returns the values joined' do
+        expect(charge_filter.display_name).to eq('card, visa')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR exposes the charge filters details in Fee and Usage types for GraphQL API