### PR TITLE
feat(filter): Sort bm filters and values

### DIFF
--- a/app/graphql/types/billable_metric_filters/object.rb
+++ b/app/graphql/types/billable_metric_filters/object.rb
@@ -10,6 +10,10 @@ module Types
 
       field :key, String, null: false
       field :values, [String], null: false
+
+      def values
+        object.values.sort
+      end
     end
   end
 end

--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -44,8 +44,8 @@ module Types
 
         def filters
           object
-            .select(&:filter)
-            .sort_by { |f| f.filter.display_name }
+            .select(&:charge_filter)
+            .sort_by { |f| f.charge_filter.display_name }
         end
 
         def grouped_usage

--- a/app/graphql/types/customers/usage/charge_filter.rb
+++ b/app/graphql/types/customers/usage/charge_filter.rb
@@ -15,7 +15,7 @@ module Types
         field :values, Types::ChargeFilters::Values, null: false
 
         def values
-          object.filter.values.each_with_object({}) do |value, result|
+          object.charge_filter.values.each_with_object({}) do |value, result|
             result[value.billable_metric_filter.key] = value.values
           end
         end

--- a/app/graphql/types/customers/usage/grouped_usage.rb
+++ b/app/graphql/types/customers/usage/grouped_usage.rb
@@ -38,8 +38,8 @@ module Types
 
         def filters
           object
-            .select(&:filter)
-            .sort_by { |f| f.filter.display_name }
+            .select(&:charge_filter)
+            .sort_by { |f| f.charge_filter.display_name }
         end
       end
     end

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -13,7 +13,7 @@ class BillableMetric < ApplicationRecord
   has_many :coupon_targets
   has_many :coupons, through: :coupon_targets
   has_many :groups, dependent: :delete_all
-  has_many :filters, dependent: :delete_all, class_name: 'BillableMetricFilter'
+  has_many :filters, -> { order(:key) }, dependent: :delete_all, class_name: 'BillableMetricFilter'
 
   AGGREGATION_TYPES = {
     count_agg: 0,

--- a/app/serializers/v1/billable_metric_filter_serializer.rb
+++ b/app/serializers/v1/billable_metric_filter_serializer.rb
@@ -6,7 +6,7 @@ module V1
       {
         lago_id: model.id,
         key: model.key,
-        values: model.values,
+        values: model.values.sort,
       }
     end
   end

--- a/app/serializers/v1/charge_filter_serializer.rb
+++ b/app/serializers/v1/charge_filter_serializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module V1
+  class ChargeFilterSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        invoice_display_name: model.invoice_display_name,
+        properties: model.properties,
+        values:,
+      }
+    end
+
+    private
+
+    def values
+      model.values.each_with_object({}) do |filter_value, result|
+        result[filter_value.billable_metric_filter.key] = filter_value.value
+      end
+    end
+  end
+end

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -17,6 +17,7 @@ module V1
         properties: model.properties,
       }
 
+      payload.merge!(charge_filters)
       payload.merge!(group_properties)
 
       payload.merge!(taxes) if include?(:taxes)
@@ -39,6 +40,14 @@ module V1
         model.taxes,
         ::V1::TaxSerializer,
         collection_name: 'taxes',
+      ).serialize
+    end
+
+    def charge_filters
+      ::CollectionSerializer.new(
+        model.filters.includes(:billable_metric_filter),
+        ::V1::ChargeFilterSerializer,
+        collection_name: 'filters',
       ).serialize
     end
   end

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -6,6 +6,7 @@ module V1
       payload = {
         lago_id: model.id,
         lago_group_id: model.group_id,
+        lago_charge_filter_id: model.charge_filter_id,
         lago_invoice_id: model.invoice_id,
         lago_true_up_fee_id: model.true_up_fee&.id,
         lago_true_up_parent_fee_id: model.true_up_parent_fee_id,
@@ -18,6 +19,7 @@ module V1
           code: model.item_code,
           name: model.item_name,
           invoice_display_name: model.invoice_name,
+          filter_invoice_display_name: model.charge_filter&.display_name,
           group_invoice_display_name: model.group_name,
           lago_item_id: model.item_id,
           item_type: model.item_type,

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
             billableMetric { name code aggregationType }
             charge { chargeModel }
             groups { id key value units amountCents }
+            filters { id units amountCents invoiceDisplayName values eventsCount }
             units
             amountCents
             groupedUsage {
@@ -26,6 +27,7 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
               eventsCount
               groupedBy
               groups { id key value units amountCents }
+              filters { id units amountCents invoiceDisplayName values eventsCount }
             }
           }
         }

--- a/spec/serializers/v1/billable_metric_filter_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_filter_serializer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ::V1::BillableMetricFilterSerializer do
       expect(result['billable_metric_filter']).to include(
         'lago_id' => billable_metric_filter.id,
         'key' => billable_metric_filter.key,
-        'values' => billable_metric_filter.values,
+        'values' => billable_metric_filter.values.sort,
       )
     end
   end

--- a/spec/serializers/v1/charge_filter_serializer_spec.rb
+++ b/spec/serializers/v1/charge_filter_serializer_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::ChargeFilterSerializer do
+  subject(:serializer) { described_class.new(charge_filter, root_name: 'filter') }
+
+  let(:charge_filter) { create(:charge_filter) }
+  let(:filter) { create(:billable_metric_filter) }
+
+  let(:filter_value) do
+    create(
+      :charge_filter_value,
+      charge_filter:,
+      billable_metric_filter: filter,
+      value: filter.values.first,
+    )
+  end
+
+  before { filter_value }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['filter']['lago_id']).to eq(charge_filter.id)
+      expect(result['filter']['invoice_display_name']).to eq(charge_filter.invoice_display_name)
+      expect(result['filter']['properties']).to eq(charge_filter.properties)
+      expect(result['filter']['values']).to eq(
+        {
+          filter.key => filter_value.value,
+        },
+      )
+    end
+  end
+end

--- a/spec/serializers/v1/charge_serializer_spec.rb
+++ b/spec/serializers/v1/charge_serializer_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ::V1::ChargeSerializer do
       expect(result['charge']['charge_model']).to eq(charge.charge_model)
       expect(result['charge']['pay_in_advance']).to eq(charge.pay_in_advance)
       expect(result['charge']['properties']).to eq(charge.properties)
+      expect(result['charge']['filters']).to eq([])
 
       expect(result['charge']['taxes']).to eq([])
     end

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
           'code' => billable_metric.code,
           'aggregation_type' => billable_metric.aggregation_type,
         },
+        'filters' => [],
         'groups' => [],
         'grouped_usage' => [
           {
@@ -55,6 +56,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
             'events_count' => 12,
             'units' => '10.0',
             'grouped_by' => { 'card_type' => 'visa' },
+            'filters' => [],
             'groups' => [],
           },
         ],
@@ -118,6 +120,51 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
       it 'returns groups array' do
         expect(serializer_groups).to eq(groups)
       end
+    end
+  end
+
+  describe '#filters' do
+    let(:charge_filter) { create(:charge_filter) }
+
+    let(:usage) do
+      [
+        OpenStruct.new(
+          charge_id: charge.id,
+          billable_metric:,
+          charge:,
+          units: '10.0',
+          events_count: 12,
+          amount_cents: 100,
+          amount_currency: 'EUR',
+          invoice_display_name: charge.invoice_display_name,
+          lago_id: billable_metric.id,
+          name: billable_metric.name,
+          code: billable_metric.code,
+          aggregation_type: billable_metric.aggregation_type,
+          grouped_by: { 'card_type' => 'visa' },
+          charge_filter:,
+        ),
+      ]
+    end
+
+    it 'returns filters array' do
+      expect(result['charges'].first['filters'].first).to include(
+        'lago_id' => charge_filter.id,
+        'units' => '10.0',
+        'amount_cents' => 100,
+        'events_count' => 12,
+        'invoice_display_name' => charge_filter.display_name,
+        'values' => {},
+      )
+
+      expect(result['charges'].first['grouped_usage'].first['filters'].first).to include(
+        'lago_id' => charge_filter.id,
+        'units' => '10.0',
+        'amount_cents' => 100,
+        'events_count' => 12,
+        'invoice_display_name' => charge_filter.display_name,
+        'values' => {},
+      )
     end
   end
 end

--- a/spec/serializers/v1/fee_serializer_spec.rb
+++ b/spec/serializers/v1/fee_serializer_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe ::V1::FeeSerializer do
       expect(result['fee']).to include(
         'lago_id' => fee.id,
         'lago_group_id' => fee.group_id,
+        'lago_charge_filter_id' => fee.charge_filter_id,
         'lago_invoice_id' => fee.invoice_id,
         'lago_true_up_fee_id' => fee.true_up_fee&.id,
         'lago_true_up_parent_fee_id' => fee.true_up_parent_fee_id,
@@ -55,6 +56,7 @@ RSpec.describe ::V1::FeeSerializer do
         'code' => fee.item_code,
         'name' => fee.item_name,
         'invoice_display_name' => fee.invoice_name,
+        'filter_invoice_display_name' => fee.charge_filter&.display_name,
         'lago_item_id' => fee.item_id,
         'item_type' => fee.item_type,
         'grouped_by' => fee.grouped_by,


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR exposes the bm filter details sorted alphabetically