### PR TITLE
feat(filter): Add relation between charge_filter and bm filters

### DIFF
--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -8,6 +8,7 @@ class ChargeFilter < ApplicationRecord
   belongs_to :charge
 
   has_many :values, class_name: 'ChargeFilterValue', dependent: :destroy
+  has_many :billable_metric_filters, through: :values
   has_many :fees
 
   validate :validate_properties

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -45,7 +45,7 @@ module V1
 
     def charge_filters
       ::CollectionSerializer.new(
-        model.filters.includes(:billable_metric_filter),
+        model.filters.includes(:billable_metric_filters),
         ::V1::ChargeFilterSerializer,
         collection_name: 'filters',
       ).serialize


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility in event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds relation between charge_filter and billable metric filters