### PR TITLE
feat(filter): Add support for filter in plan override

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -99,6 +99,15 @@ module Api
               properties: {},
             },
             {
+              filters: [
+                :invoice_display_name,
+                {
+                  properties: {},
+                  values: {},
+                },
+              ],
+            },
+            {
               group_properties: [
                 :group_id,
                 :invoice_display_name,

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -162,6 +162,15 @@ module Api
               :charge_model,
               { properties: {} },
               {
+                filters: [
+                  :invoice_display_name,
+                  {
+                    properties: {},
+                    values: {},
+                  },
+                ],
+              },
+              {
                 group_properties: [
                   :group_id,
                   { values: {} },

--- a/app/graphql/types/subscriptions/charge_overrides_input.rb
+++ b/app/graphql/types/subscriptions/charge_overrides_input.rb
@@ -6,6 +6,7 @@ module Types
       argument :billable_metric_id, ID, required: true
       argument :id, ID, required: true
 
+      argument :filters, [Types::ChargeFilters::Input], required: false
       argument :group_properties, [Types::Charges::GroupPropertiesInput], required: false
       argument :invoice_display_name, String, required: false
       argument :min_amount_cents, GraphQL::Types::BigInt, required: false

--- a/app/services/charges/override_service.rb
+++ b/app/services/charges/override_service.rb
@@ -18,6 +18,11 @@ module Charges
           c.min_amount_cents = params[:min_amount_cents] if params.key?(:min_amount_cents)
           c.invoice_display_name = params[:invoice_display_name] if params.key?(:invoice_display_name)
           c.group_properties = charge.group_properties.map(&:dup)
+          c.filters = charge.filters.map do |filter|
+            f = filter.dup
+            f.values = filter.values.map(&:dup)
+            f
+          end
           c.plan_id = params[:plan_id]
         end
         new_charge.save!
@@ -28,6 +33,14 @@ module Charges
             properties_params: params[:group_properties],
           )
           return group_result if group_result.error
+        end
+
+        if params.key?(:filters)
+          filters_result = ChargeFilters::CreateOrUpdateBatchService.call(
+            charge: new_charge,
+            filters_params: params[:filters],
+          )
+          return filters_result if filters_result.error
         end
 
         if params.key?(:tax_codes)

--- a/schema.graphql
+++ b/schema.graphql
@@ -272,6 +272,7 @@ enum ChargeModelEnum {
 
 input ChargeOverridesInput {
   billableMetricId: ID!
+  filters: [ChargeFilterInput!]
   groupProperties: [GroupPropertiesInput!]
   id: ID!
   invoiceDisplayName: String

--- a/schema.json
+++ b/schema.json
@@ -2712,6 +2712,26 @@
               "deprecationReason": null
             },
             {
+              "name": "filters",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ChargeFilterInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "groupProperties",
               "description": null,
               "type": {

--- a/spec/graphql/types/subscriptions/charge_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/charge_overrides_input_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Subscriptions::ChargeOverridesInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:billable_metric_id).of_type('ID!') }
+  it { is_expected.to accept_argument(:id).of_type('ID!') }
+  it { is_expected.to accept_argument(:filters).of_type('[ChargeFilterInput!]') }
+  it { is_expected.to accept_argument(:group_properties).of_type('[GroupPropertiesInput!]') }
+  it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
+  it { is_expected.to accept_argument(:min_amount_cents).of_type('BigInt') }
+  it { is_expected.to accept_argument(:properties).of_type('PropertiesInput') }
+  it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
+end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds the override logic for charge filters