### PR TITLE
feat(filter): Add post validation logic for events

### DIFF
--- a/app/serializers/v1/events_validation_errors_serializer.rb
+++ b/app/serializers/v1/events_validation_errors_serializer.rb
@@ -7,6 +7,7 @@ module V1
         invalid_code: model.invalid_code,
         missing_aggregation_property: model.missing_aggregation_property,
         missing_group_key: model.missing_group_key,
+        invalid_filter_values: model.invalid_filter_values,
       }
     end
   end

--- a/app/services/events/post_validation_service.rb
+++ b/app/services/events/post_validation_service.rb
@@ -13,11 +13,13 @@ module Events
         invalid_code: process_query(invalid_code_query),
         missing_aggregation_property: process_query(missing_aggregation_property_query),
         missing_group_key: process_query(missing_group_key_query),
+        invalid_filter_values: process_query(invalid_filter_values_query),
       }
 
       if errors[:invalid_code].present? ||
          errors[:missing_aggregation_property].present? ||
-         errors[:missing_group_key].present?
+         errors[:missing_group_key].present? ||
+         errors[:invalid_filter_values].present?
         deliver_webhook(errors)
       end
 
@@ -71,6 +73,16 @@ module Events
               AND has_child_group_key = 'f'
             )
           )
+      SQL
+    end
+
+    def invalid_filter_values_query
+      <<-SQL
+        SELECT DISTINCT transaction_id
+        FROM last_hour_events_mv
+        WHERE organization_id = '#{organization.id}'
+          AND has_filter_keys = 't'
+          AND has_invalid_filter_values = 't'
       SQL
     end
 

--- a/db/migrate/20240305093058_update_last_hour_events_mv_to_version3.rb
+++ b/db/migrate/20240305093058_update_last_hour_events_mv_to_version3.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UpdateLastHourEventsMvToVersion3 < ActiveRecord::Migration[7.0]
+  def change
+    drop_view :last_hour_events_mv, materialized: true
+    create_view :last_hour_events_mv, materialized: true, version: 3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1045,6 +1045,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_05_164449) do
                LEFT JOIN groups child_groups ON (((child_groups.billable_metric_id = billable_metrics_1.id) AND (child_groups.parent_group_id IS NOT NULL))))
             WHERE (billable_metrics_1.deleted_at IS NULL)
             GROUP BY billable_metrics_1.id, billable_metrics_1.code
+          ), billable_metric_filters AS (
+           SELECT billable_metrics_1.id AS bm_id,
+              billable_metrics_1.code AS bm_code,
+              filters.key AS filter_key,
+              filters."values" AS filter_values
+             FROM (billable_metrics billable_metrics_1
+               JOIN public.billable_metric_filters filters ON ((filters.billable_metric_id = billable_metrics_1.id)))
+            WHERE ((billable_metrics_1.deleted_at IS NULL) AND (filters.deleted_at IS NULL))
           )
    SELECT events.organization_id,
       events.transaction_id,
@@ -1058,10 +1066,22 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_05_164449) do
       (COALESCE(billable_metric_groups.parent_group_count, (0)::bigint) > 0) AS parent_group_mandatory,
       (events.properties ?| (billable_metric_groups.parent_group_keys)::text[]) AS has_parent_group_key,
       (COALESCE(billable_metric_groups.child_group_count, (0)::bigint) > 0) AS child_group_mandatory,
-      (events.properties ?| (billable_metric_groups.child_group_keys)::text[]) AS has_child_group_key
-     FROM ((events
+      (events.properties ?| (billable_metric_groups.child_group_keys)::text[]) AS has_child_group_key,
+      (sum(
+          CASE
+              WHEN (events.properties ? (billable_metric_filters.filter_key)::text) THEN 1
+              ELSE 0
+          END) > 0) AS has_filter_keys,
+      (sum(
+          CASE
+              WHEN ((events.properties ->> (billable_metric_filters.filter_key)::text) = ANY ((billable_metric_filters.filter_values)::text[])) THEN 0
+              ELSE 1
+          END) > 0) AS has_invalid_filter_values
+     FROM (((events
        LEFT JOIN billable_metrics ON ((((billable_metrics.code)::text = (events.code)::text) AND (events.organization_id = billable_metrics.organization_id))))
        LEFT JOIN billable_metric_groups ON ((billable_metrics.id = billable_metric_groups.bm_id)))
-    WHERE ((events.deleted_at IS NULL) AND (events.created_at >= (date_trunc('hour'::text, now()) - 'PT1H'::interval)) AND (events.created_at < date_trunc('hour'::text, now())) AND (billable_metrics.deleted_at IS NULL));
+       LEFT JOIN billable_metric_filters ON ((billable_metric_filters.bm_id = billable_metrics.id)))
+    WHERE ((events.deleted_at IS NULL) AND (events.created_at >= (date_trunc('hour'::text, now()) - 'PT1H'::interval)) AND (events.created_at < date_trunc('hour'::text, now())) AND (billable_metrics.deleted_at IS NULL))
+    GROUP BY events.organization_id, events.transaction_id, events."timestamp", events.properties, billable_metrics.code, billable_metrics.field_name, billable_metrics.aggregation_type, billable_metric_groups.parent_group_count, billable_metric_groups.parent_group_keys, billable_metric_groups.child_group_count, billable_metric_groups.child_group_keys;
   SQL
 end

--- a/db/views/last_hour_events_mv_v03.sql
+++ b/db/views/last_hour_events_mv_v03.sql
@@ -1,0 +1,79 @@
+WITH billable_metric_groups AS (
+  SELECT
+		billable_metrics.id AS bm_id,
+		billable_metrics.code AS bm_code,
+		COUNT(parent_groups.id) AS parent_group_count,
+		array_agg(parent_groups.key) AS parent_group_keys,
+		COUNT(child_groups.id) AS child_group_count,
+		array_agg(child_groups.key) AS child_group_keys
+	FROM billable_metrics
+		LEFT JOIN groups AS parent_groups
+			ON parent_groups.billable_metric_id = billable_metrics.id
+			AND parent_groups.parent_group_id IS NULL
+		LEFT JOIN groups AS child_groups
+			ON child_groups.billable_metric_id = billable_metrics.id
+			AND child_groups.parent_group_id IS NOT NULL
+	WHERE billable_metrics.deleted_at IS NULL
+	GROUP BY billable_metrics.id, billable_metrics.code
+),
+billable_metric_filters as (
+	SELECT
+		billable_metrics.id AS bm_id,
+		billable_metrics.code AS bm_code,
+		filters.key AS filter_key,
+		filters.values AS filter_values
+	FROM billable_metrics
+		INNER JOIN billable_metric_filters filters
+			ON filters.billable_metric_id = billable_metrics.id
+	WHERE
+		billable_metrics.deleted_at IS NULL
+		AND filters.deleted_at IS NULL
+)
+
+
+SELECT
+  events.organization_id,
+  events.transaction_id,
+  events.timestamp,
+  events.properties,
+  billable_metrics.code AS billable_metric_code,
+  billable_metrics.aggregation_type != 0 AS field_name_mandatory,
+  billable_metrics.aggregation_type IN (1,2,5,6) AS numeric_field_mandatory,
+  events.properties ->> billable_metrics.field_name::text AS field_value,
+  events.properties ->> billable_metrics.field_name::text ~ '^-?\d+(\.\d+)?$' AS is_numeric_field_value,
+  COALESCE(billable_metric_groups.parent_group_count, 0) > 0 AS parent_group_mandatory,
+  events.properties ?| billable_metric_groups.parent_group_keys AS has_parent_group_key,
+  COALESCE(billable_metric_groups.child_group_count, 0) > 0 AS child_group_mandatory,
+  events.properties ?| billable_metric_groups.child_group_keys AS has_child_group_key,
+  SUM(
+    CASE WHEN (events.properties ? billable_metric_filters.filter_key)
+    THEN 1 ELSE 0 END
+  ) > 0 as has_filter_keys,
+  sum(
+  	CASE WHEN (events.properties ->> billable_metric_filters.filter_key) = ANY (billable_metric_filters.filter_values)
+  	THEN 0 ELSE 1
+	  END
+  ) > 0 has_invalid_filter_values
+FROM
+  events
+    LEFT JOIN billable_metrics ON billable_metrics.code = events.code
+      AND events.organization_id = billable_metrics.organization_id
+    LEFT JOIN billable_metric_groups ON billable_metrics.id = billable_metric_groups.bm_id
+    LEFT JOIN billable_metric_filters on billable_metric_filters.bm_id = billable_metrics.id
+WHERE
+  events.deleted_at IS NULL
+  AND events.created_at >= date_trunc('hour', NOW()) - INTERVAL '1 hour'
+  AND events.created_at < date_trunc('hour', NOW())
+  AND billable_metrics.deleted_at IS NULL
+GROUP BY
+  events.organization_id,
+  events.transaction_id,
+  events.timestamp,
+  events.properties,
+  billable_metrics.code,
+  billable_metrics.field_name,
+  billable_metrics.aggregation_type,
+  billable_metric_groups.parent_group_count,
+  billable_metric_groups.parent_group_keys,
+  billable_metric_groups.child_group_count,
+  billable_metric_groups.child_group_keys

--- a/spec/serializers/v1/events_validation_errors_serializer_spec.rb
+++ b/spec/serializers/v1/events_validation_errors_serializer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe ::V1::EventsValidationErrorsSerializer do
       invalid_code: [SecureRandom.uuid],
       missing_aggregation_property: [SecureRandom.uuid],
       missing_group_key: [SecureRandom.uuid],
+      invalid_filter_values: [SecureRandom.uuid],
     )
   end
 
@@ -21,6 +22,7 @@ RSpec.describe ::V1::EventsValidationErrorsSerializer do
         'invalid_code' => Array,
         'missing_aggregation_property' => Array,
         'missing_group_key' => Array,
+        'invalid_filter_values' => Array,
       )
     end
   end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds the post validation logic for the events when they belongs to a billable metric with filters