### PR TITLE
feat(filter): Add missing charge filter id relations

### DIFF
--- a/db/migrate/20240305164449_add_missing_charge_filter_id_relations.rb
+++ b/db/migrate/20240305164449_add_missing_charge_filter_id_relations.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddMissingChargeFilterIdRelations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :quantified_events, :charge_filter_id, :uuid, null: true
+    add_index :quantified_events, :charge_filter_id
+
+    add_column :adjusted_fees, :charge_filter_id, :uuid, null: true
+    add_index :adjusted_fees, :charge_filter_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_01_133006) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_05_164449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -89,6 +89,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_01_133006) do
     t.datetime "updated_at", null: false
     t.uuid "group_id"
     t.jsonb "grouped_by", default: {}, null: false
+    t.uuid "charge_filter_id"
+    t.index ["charge_filter_id"], name: "index_adjusted_fees_on_charge_filter_id"
     t.index ["charge_id"], name: "index_adjusted_fees_on_charge_id"
     t.index ["fee_id"], name: "index_adjusted_fees_on_fee_id"
     t.index ["group_id"], name: "index_adjusted_fees_on_group_id"
@@ -780,7 +782,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_01_133006) do
     t.uuid "group_id"
     t.uuid "organization_id", null: false
     t.jsonb "grouped_by", default: {}, null: false
+    t.uuid "charge_filter_id"
     t.index ["billable_metric_id"], name: "index_quantified_events_on_billable_metric_id"
+    t.index ["charge_filter_id"], name: "index_quantified_events_on_charge_filter_id"
     t.index ["deleted_at"], name: "index_quantified_events_on_deleted_at"
     t.index ["external_id"], name: "index_quantified_events_on_external_id"
     t.index ["group_id"], name: "index_quantified_events_on_group_id"


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds:
- `charge_filter_id` to `quantified_events`
- `charge_filter_id` to `adjusted_fees`