### PR TITLE
feat(filter): Preload charge filter and groups in past usage fees

### DIFF
--- a/app/queries/past_usage_query.rb
+++ b/app/queries/past_usage_query.rb
@@ -39,7 +39,7 @@ class PastUsageQuery < BaseQuery
   end
 
   def fees_query(invoice)
-    query = invoice.fees.charge
+    query = invoice.fees.charge.includes(:charge_filter, :group)
     return query unless filters.billable_metric_code
 
     query.joins(:charge).where(charges: { billable_metric_id: billable_metric.id })


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR ensure that charge_filters (and groups) are preloaded along with the fees when computing the past usage for a customer