### PR TITLE
fix(sub-termination): update automatic credit note creation logic

### DIFF
--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -63,7 +63,7 @@ module Invoices
       subscriptions_boundaries.any? do |subscription_id, boundaries|
         subscription = Subscription.includes(:plan).find(subscription_id)
 
-        matching_invoice_subscription?(subscription, boundaries)
+        InvoiceSubscription.matching?(subscription, boundaries)
       end
     end
 
@@ -125,23 +125,7 @@ module Invoices
         charges_duration: dates_service.charges_duration_in_days,
       }
 
-      matching_invoice_subscription?(subscription, previous_period_boundaries) ? boundaries : previous_period_boundaries
-    end
-
-    def matching_invoice_subscription?(subscription, boundaries)
-      base_query = InvoiceSubscription
-        .where(subscription_id: subscription.id)
-        .recurring
-        .where(from_datetime: boundaries[:from_datetime])
-        .where(to_datetime: boundaries[:to_datetime])
-
-      if subscription.plan.yearly? && subscription.plan.bill_charges_monthly?
-        base_query = base_query
-          .where(charges_from_datetime: boundaries[:charges_from_datetime])
-          .where(charges_to_datetime: boundaries[:charges_to_datetime])
-      end
-
-      base_query.exists?
+      InvoiceSubscription.matching?(subscription, previous_period_boundaries) ? boundaries : previous_period_boundaries
     end
   end
 end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -445,6 +445,26 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           end
 
           context 'when old subscription was payed in advance' do
+            let(:creation_time) { Time.current.beginning_of_month - 1.month }
+            let(:date_service) do
+              Subscriptions::DatesService.new_instance(
+                subscription,
+                Time.current.beginning_of_month,
+                current_usage: false,
+              )
+            end
+            let(:invoice_subscription) do
+              create(
+                :invoice_subscription,
+                invoice:,
+                subscription:,
+                recurring: true,
+                from_datetime: date_service.from_datetime,
+                to_datetime: date_service.to_datetime,
+                charges_from_datetime: date_service.charges_from_datetime,
+                charges_to_datetime: date_service.charges_to_datetime,
+              )
+            end
             let(:invoice) do
               create(
                 :invoice,
@@ -476,8 +496,8 @@ RSpec.describe Subscriptions::CreateService, type: :service do
                 customer:,
                 plan: old_plan,
                 status: :active,
-                subscription_at: Time.current - 40.days,
-                started_at: Time.current - 40.days,
+                subscription_at: creation_time,
+                started_at: creation_time,
                 external_id:,
                 billing_time: 'anniversary',
               )
@@ -485,7 +505,10 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
             let(:old_plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true) }
 
-            before { last_subscription_fee }
+            before do
+              invoice_subscription
+              last_subscription_fee
+            end
 
             it 'creates a credit note for the remaining days' do
               expect { create_service.call }.to change(CreditNote, :count)


### PR DESCRIPTION
## Context

When subscription auto-termination feature is used by setting `ending_at`, there is a chance that unnecessary credit note can be created. Described scenario can happen if `ending_at` is set on billing day and if termination job is processed before billing job on that day. In that case, since invoice has not been created, we should not issue a credit note.

## Description

This PR handles described case. New logic that checks the case is added and also specs have been updated and added.
