### PR TITLE
feat(filter): Remove *_filters#lago_id in API

### DIFF
--- a/app/serializers/v1/billable_metric_filter_serializer.rb
+++ b/app/serializers/v1/billable_metric_filter_serializer.rb
@@ -4,7 +4,6 @@ module V1
   class BillableMetricFilterSerializer < ModelSerializer
     def serialize
       {
-        lago_id: model.id,
         key: model.key,
         values: model.values.sort,
       }

--- a/app/serializers/v1/charge_filter_serializer.rb
+++ b/app/serializers/v1/charge_filter_serializer.rb
@@ -4,7 +4,6 @@ module V1
   class ChargeFilterSerializer < ModelSerializer
     def serialize
       {
-        lago_id: model.id,
         invoice_display_name: model.invoice_display_name,
         properties: model.properties,
         values:,

--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -52,7 +52,6 @@ module V1
           next unless f.charge_filter
 
           {
-            lago_id: f.charge_filter.id,
             units: f.units,
             amount_cents: f.amount_cents,
             events_count: f.events_count,

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -201,6 +201,7 @@ module PaymentProviders
       raise if event.livemode
 
       Rails.logger.warn("Stripe resource not found: #{e.message}. JSON: #{event_json}")
+      result
     end
 
     private

--- a/spec/serializers/v1/billable_metric_filter_serializer_spec.rb
+++ b/spec/serializers/v1/billable_metric_filter_serializer_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe ::V1::BillableMetricFilterSerializer do
   it 'serializes the object' do
     aggregate_failures do
       expect(result['billable_metric_filter']).to include(
-        'lago_id' => billable_metric_filter.id,
         'key' => billable_metric_filter.key,
         'values' => billable_metric_filter.values.sort,
       )

--- a/spec/serializers/v1/charge_filter_serializer_spec.rb
+++ b/spec/serializers/v1/charge_filter_serializer_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe ::V1::ChargeFilterSerializer do
     result = JSON.parse(serializer.to_json)
 
     aggregate_failures do
-      expect(result['filter']['lago_id']).to eq(charge_filter.id)
       expect(result['filter']['invoice_display_name']).to eq(charge_filter.invoice_display_name)
       expect(result['filter']['properties']).to eq(charge_filter.properties)
       expect(result['filter']['values']).to eq(

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -149,7 +149,6 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
 
     it 'returns filters array' do
       expect(result['charges'].first['filters'].first).to include(
-        'lago_id' => charge_filter.id,
         'units' => '10.0',
         'amount_cents' => 100,
         'events_count' => 12,
@@ -158,7 +157,6 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
       )
 
       expect(result['charges'].first['grouped_usage'].first['filters'].first).to include(
-        'lago_id' => charge_filter.id,
         'units' => '10.0',
         'amount_cents' => 100,
         'events_count' => 12,


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR removes all reference to `"*_lago_id` in REST API as they are not usable to retrieve values