### PR TITLE
fix: Credit note calculation with trial period

### DIFF
--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -77,7 +77,7 @@ module CreditNotes
         billed_from = if subscription.trial_end_date > to_date
           to_date
         else
-          subscription.trial_end_date
+          subscription.trial_end_date - 1.day
         end
       end
 

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -217,11 +217,11 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
           credit_note = result.credit_note
           expect(credit_note).to be_available
           expect(credit_note).to be_order_change
-          expect(credit_note.total_amount_cents).to eq(17)
+          expect(credit_note.total_amount_cents).to eq(18) # 15 * 1.2
           expect(credit_note.total_amount_currency).to eq('EUR')
-          expect(credit_note.credit_amount_cents).to eq(17)
+          expect(credit_note.credit_amount_cents).to eq(18)
           expect(credit_note.credit_amount_currency).to eq('EUR')
-          expect(credit_note.balance_amount_cents).to eq(17)
+          expect(credit_note.balance_amount_cents).to eq(18)
           expect(credit_note.balance_amount_currency).to eq('EUR')
 
           expect(credit_note.items.count).to eq(1)


### PR DESCRIPTION
When a credit note is created with a free trial, we were computing the amount based on a wrong period (1 day was missing).
