### PR TITLE
misc: Add github action to test DB migrations

### DIFF
--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -1,4 +1,4 @@
-name: Run Spec
+name: Run rails migrations
 on:
   push:
     branches:
@@ -6,8 +6,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  run-spec:
-    name: Run Spec
+  run-migrations:
+    name: Run migrations
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -35,6 +35,7 @@ jobs:
       LAGO_CLICKHOUSE_DATABASE: default
       LAGO_CLICKHOUSE_USERNAME: ""
       LAGO_CLICKHOUSE_PASSWORD: ""
+      LAGO_DISABLE_SCHEMA_DUMP: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -49,11 +50,7 @@ jobs:
         shell: bash
       - name: Generate RSA keys
         run: ./scripts/generate.rsa.sh
-      - name: Set up Postgres database schema
-        run: bin/rails db:schema:load:primary
-      - name: Set up Clickhouse database schema
+      - name: Perform Postgres database migrations
+        run: bin/rails db:migrate:primary
+      - name: Perform Clickhouse database migrations
         run: bin/rails db:migrate:clickhouse
-      - name: Set up Clickhouse database schema
-        run: bin/rails db:schema:dump:clickhouse
-      - name: Run tests
-        run: bundle exec rspec

--- a/config/database.yml
+++ b/config/database.yml
@@ -31,9 +31,11 @@ test:
   primary:
     <<: *default
     url: <%= ENV['DATABASE_TEST_URL'].presence || ENV['DATABASE_URL'] %>
+    schema_dump: <% if ENV['LAGO_DISABLE_SCHEMA_DUMP'].present? %> false <% else %> schema.rb <% end %>
   events:
     <<: *default
     url: <%= ENV['DATABASE_TEST_URL'].presence || ENV['DATABASE_URL'] %>
+    schema_dump: false
   clickhouse:
     adapter: clickhouse
     database: <%= ENV.fetch('LAGO_CLICKHOUSE_DATABASE', 'default_test') %>
@@ -41,8 +43,10 @@ test:
     port: <%= ENV.fetch('LAGO_CLICKHOUSE_PORT', 8123) %>
     username: <%= ENV.fetch('LAGO_CLICKHOUSE_USERNAME', 'default') %>
     password: <%= ENV.fetch('LAGO_CLICKHOUSE_PASSWORD', 'default') %>
+    migrations_paths: db/clickhouse_migrate
     debug: true
     database_tasks: <% if ENV['LAGO_CLICKHOUSE_ENABLED'].present? %> true <% else %> false <% end %>
+    schema_dump: <% if ENV['LAGO_DISABLE_SCHEMA_DUMP'].present? %> false <% else %> clickhouse_schema.rb <% end %>
 
 staging:
   primary:

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
-ENHANCED_TASKS = %w[db:migrate db:migrate:primary db:rollback db:rollback:primary db:schema:dump:clickhouse].freeze
+unless defined?(ENHANCED_TASKS)
+  ENHANCED_TASKS = %w[db:migrate db:migrate:primary db:rollback db:rollback:primary db:schema:dump:clickhouse].freeze
 
-ENHANCED_TASKS.each do |task|
-  next unless Rake::Task.task_defined?(task)
+  ENHANCED_TASKS.each do |task|
+    next unless Rake::Task.task_defined?(task)
 
-  Rake::Task[task].enhance do
-    Rake::Task['db:clickhouse:filter'].invoke
+    Rake::Task[task].enhance do
+      Rake::Task['db:clickhouse:filter'].invoke
+    end
   end
 end
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -25,11 +25,10 @@ RSpec.describe Fees::ChargeService do
       to_datetime: subscription.started_at.end_of_month.end_of_day,
       charges_from_datetime: subscription.started_at.beginning_of_day,
       charges_to_datetime: subscription.started_at.end_of_month.end_of_day,
-      timestamp: (subscription.started_at.end_of_month + 1.day).end_of_day,
+      timestamp: subscription.started_at.end_of_month.end_of_day + 1.second,
       charges_duration: (
         subscription.started_at.end_of_month.end_of_day - subscription.started_at.beginning_of_month
       ).fdiv(1.day).ceil,
-      timestamp: subscription.started_at.end_of_month.end_of_day + 1.second,
     }
   end
 


### PR DESCRIPTION
## Context

Few issues were reported in the past with database migrations on a fresh lago install.
Since the migration are not performed from the start when deploying on the cloud instance or on the local instances, some edge case could prevent some migration to perform correctly.

## Description

This PR adds a github CI action to perform the migration from scratch making sure they all perform correctly