### PR TITLE
fix(stripe): Prevent stripe error form behing reraised

### DIFF
--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -201,7 +201,7 @@ module PaymentProviders
       raise if event.livemode
 
       Rails.logger.warn("Stripe resource not found: #{e.message}. JSON: #{event_json}")
-      result
+      BaseService::Result.new # NOTE: Prevents error from being re-raised
     end
 
     private


### PR DESCRIPTION
## Description

This PR makes sure that error from stripe webhook are not re-raised if stripe is in sandbox mode.
This should prevent noise in Sidekiq  dead jobs for errors related to Sandbox webhooks