### PR TITLE
fix: cover edge case when pending subscriptions need to be canceled

### DIFF
--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -46,8 +46,10 @@ module Plans
 
         process_charges(plan, params[:charges]) if params[:charges]
         process_minimum_commitment(plan, params[:minimum_commitment]) if params[:minimum_commitment] && License.premium?
-        process_downgraded_subscriptions if old_amount_cents != plan.amount_cents
-        process_pending_subscriptions if old_amount_cents != plan.amount_cents
+        if old_amount_cents != plan.amount_cents
+          process_downgraded_subscriptions
+          process_pending_subscriptions
+        end
       end
 
       result.plan = plan.reload

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         end
       end
 
-      context 'when there are pending subscriptions which are not relevant after the amount cents update' do
+      context 'when there are pending subscriptions which are not relevant after the amount cents decrease' do
         let(:pending_plan) { create(:plan, organization:, amount_cents: 10) }
         let(:pending_subscription) do
           create(:subscription, plan: pending_plan, status: :pending, previous_subscription_id: subscription.id)
@@ -172,7 +172,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         end
       end
 
-      context 'when there are pending subscriptions which are not relevant after the amount cents update' do
+      context 'when there are pending subscriptions which are not relevant after the amount cents increase' do
         let(:original_plan) { create(:plan, organization:, amount_cents: 150) }
         let(:subscription) { create(:subscription, plan: original_plan, customer: new_customer) }
         let(:pending_subscription) do


### PR DESCRIPTION
## Context

This edge case is originally part of update-plan-subscription-fee feature. If plan that got updated has pending subscription whose new subscription fee is greater that the one from original plan, pending subscription needs to be canceled..

## Description

This PR covers the described edge case and adds related specs