### PR TITLE
fix(weighted-sum): Fix TypeError with grouped weighted sum

### DIFF
--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -132,7 +132,7 @@ module BillableMetrics
           return @grouped_latest_values = quantified_events.map do |quantified_event|
             {
               groups: quantified_event.grouped_by,
-              value: quantified_event.properties.[](QuantifiedEvent::RECURRING_TOTAL_UNITS),
+              value: BigDecimal(quantified_event.properties.[](QuantifiedEvent::RECURRING_TOTAL_UNITS)),
             }
           end
         end

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
             billable_metric:,
             external_subscription_id: subscription.external_id,
             added_at: from_datetime - 1.day,
-            properties: { QuantifiedEvent::RECURRING_TOTAL_UNITS => 1000 },
+            properties: { QuantifiedEvent::RECURRING_TOTAL_UNITS => '1000' },
             grouped_by: { 'agent_name' => 'aragorn' },
           ),
 
@@ -348,7 +348,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
             billable_metric:,
             external_subscription_id: subscription.external_id,
             added_at: from_datetime - 1.day,
-            properties: { QuantifiedEvent::RECURRING_TOTAL_UNITS => 1000 },
+            properties: { QuantifiedEvent::RECURRING_TOTAL_UNITS => '1000' },
             grouped_by: { 'agent_name' => 'frodo' },
           ),
         ]


### PR DESCRIPTION
## Context

This PR fixes the following error:

```
TypeError

no implicit conversion of BigDecimal into String (TypeError)
```

## Description

It happens because the quantified events stores the cached aggregation values as string, but it has to be converted into BigInt.
