### PR TITLE
feat(filter): Add match all value for charge_filters

### DIFF
--- a/app/models/charge_filter_value.rb
+++ b/app/models/charge_filter_value.rb
@@ -5,6 +5,8 @@ class ChargeFilterValue < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
+  MATCH_ALL_FILTER_VALUES = '__LAGO_MATCH_ALL_FILTER_VALUES__'
+
   belongs_to :charge_filter
   belongs_to :billable_metric_filter
 
@@ -16,6 +18,7 @@ class ChargeFilterValue < ApplicationRecord
   private
 
   def validate_value
+    return if value == MATCH_ALL_FILTER_VALUES
     return if billable_metric_filter&.values&.include?(value) # rubocop:disable Performance/InefficientHashSearch
 
     errors.add(:value, :inclusion)

--- a/spec/models/charge_filter_value_spec.rb
+++ b/spec/models/charge_filter_value_spec.rb
@@ -30,5 +30,11 @@ RSpec.describe ChargeFilterValue, type: :model do
         expect(charge_filter_value.errors[:value]).to include('value_is_invalid')
       end
     end
+
+    context 'when value is MATCH_ALL_FILTER_VALUES' do
+      let(:value) { ChargeFilterValue::MATCH_ALL_FILTER_VALUES }
+
+      it { expect(charge_filter_value).to be_valid }
+    end
   end
 end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds a validation rule on `ChargeFilterValue` to accept `__LAGO_MATCH_ALL_FILTER_VALUES__` as a "match all" value