### PR TITLE
feat(filter): Add post event validation (again)

### DIFF
--- a/app/services/events/post_validation_service.rb
+++ b/app/services/events/post_validation_service.rb
@@ -13,7 +13,7 @@ module Events
         invalid_code: process_query(invalid_code_query),
         missing_aggregation_property: process_query(missing_aggregation_property_query),
         missing_group_key: process_query(missing_group_key_query),
-        # TODO: Fix performance issue - invalid_filter_values: process_query(invalid_filter_values_query),
+        invalid_filter_values: process_query(invalid_filter_values_query),
       }
 
       if errors[:invalid_code].present? ||
@@ -82,7 +82,7 @@ module Events
         FROM last_hour_events_mv
         WHERE organization_id = '#{organization.id}'
           AND has_filter_keys = 't'
-          AND has_invalid_filter_values = 't'
+          AND has_valid_filter_values = 'f'
       SQL
     end
 

--- a/db/migrate/20240308150801_update_last_hour_events_mv.rb
+++ b/db/migrate/20240308150801_update_last_hour_events_mv.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class UpdateLastHourEventsMv < ActiveRecord::Migration[7.0]
+  def change
+    drop_view :last_hour_events_mv, materialized: true
+    create_view :last_hour_events_mv, materialized: { no_data: true }, version: 3
+    add_index :last_hour_events_mv, :organization_id
+  end
+end

--- a/db/migrate/20240311091817_add_index_on_last_hour_events_mv.rb
+++ b/db/migrate/20240311091817_add_index_on_last_hour_events_mv.rb
@@ -4,6 +4,6 @@ class AddIndexOnLastHourEventsMv < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
   def change
-    add_index :last_hour_events_mv, :organization_id
+    add_index :last_hour_events_mv, :organization_id, if_not_exists: true
   end
 end

--- a/db/migrate/20240312141641_add_new_index_to_groups.rb
+++ b/db/migrate/20240312141641_add_new_index_to_groups.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddNewIndexToGroups < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :groups, %w[billable_metric_id parent_group_id]
+  end
+end

--- a/db/views/last_hour_events_mv_v03.sql
+++ b/db/views/last_hour_events_mv_v03.sql
@@ -1,40 +1,43 @@
 WITH billable_metric_groups AS (
   SELECT
-		billable_metrics.id AS bm_id,
-		billable_metrics.code AS bm_code,
-		COUNT(parent_groups.id) AS parent_group_count,
-		array_agg(parent_groups.key) AS parent_group_keys,
-		COUNT(child_groups.id) AS child_group_count,
-		array_agg(child_groups.key) AS child_group_keys
-	FROM billable_metrics
-		LEFT JOIN groups AS parent_groups
-			ON parent_groups.billable_metric_id = billable_metrics.id
-			AND parent_groups.parent_group_id IS NULL
-		LEFT JOIN groups AS child_groups
-			ON child_groups.billable_metric_id = billable_metrics.id
-			AND child_groups.parent_group_id IS NOT NULL
-	WHERE billable_metrics.deleted_at IS NULL
-	GROUP BY billable_metrics.id, billable_metrics.code
+    billable_metrics.organization_id as bm_organization_id,
+    billable_metrics.id AS bm_id,
+    billable_metrics.code AS bm_code,
+    COUNT(parent_groups.id) AS parent_group_count,
+    array_agg(parent_groups.key) AS parent_group_keys,
+    COUNT(child_groups.id) AS child_group_count,
+    array_agg(child_groups.key) AS child_group_keys
+  FROM billable_metrics
+    LEFT JOIN groups AS parent_groups
+      ON parent_groups.billable_metric_id = billable_metrics.id
+      AND parent_groups.parent_group_id IS NULL
+      AND parent_groups.deleted_at IS NULL
+    LEFT JOIN groups AS child_groups
+      ON child_groups.billable_metric_id = billable_metrics.id
+      AND child_groups.parent_group_id IS NOT NULL
+      AND child_groups.deleted_at IS NULL
+  WHERE billable_metrics.deleted_at IS NULL
+  GROUP BY billable_metrics.id, billable_metrics.code
 ),
 billable_metric_filters as (
-	SELECT
-		billable_metrics.id AS bm_id,
-		billable_metrics.code AS bm_code,
-		filters.key AS filter_key,
-		filters.values AS filter_values
-	FROM billable_metrics
-		INNER JOIN billable_metric_filters filters
-			ON filters.billable_metric_id = billable_metrics.id
-	WHERE
-		billable_metrics.deleted_at IS NULL
-		AND filters.deleted_at IS NULL
+  SELECT
+    billable_metrics.organization_id as bm_organization_id,
+    billable_metrics.id AS bm_id,
+    billable_metrics.code AS bm_code,
+    filters.key AS filter_key,
+    filters.values AS filter_values
+  FROM billable_metrics
+    INNER JOIN billable_metric_filters filters
+ 		  ON filters.billable_metric_id = billable_metrics.id
+  WHERE
+    billable_metrics.deleted_at IS NULL
+    AND filters.deleted_at IS NULL
 )
 
 
 SELECT
   events.organization_id,
   events.transaction_id,
-  events.timestamp,
   events.properties,
   billable_metrics.code AS billable_metric_code,
   billable_metrics.aggregation_type != 0 AS field_name_mandatory,
@@ -45,35 +48,16 @@ SELECT
   events.properties ?| billable_metric_groups.parent_group_keys AS has_parent_group_key,
   COALESCE(billable_metric_groups.child_group_count, 0) > 0 AS child_group_mandatory,
   events.properties ?| billable_metric_groups.child_group_keys AS has_child_group_key,
-  SUM(
-    CASE WHEN (events.properties ? billable_metric_filters.filter_key)
-    THEN 1 ELSE 0 END
-  ) > 0 as has_filter_keys,
-  sum(
-  	CASE WHEN (events.properties ->> billable_metric_filters.filter_key) = ANY (billable_metric_filters.filter_values)
-  	THEN 0 ELSE 1
-	  END
-  ) > 0 has_invalid_filter_values
+  events.properties ? billable_metric_filters.filter_key as has_filter_keys,
+  (events.properties ->> billable_metric_filters.filter_key) = ANY (billable_metric_filters.filter_values) as has_valid_filter_values
 FROM
   events
     LEFT JOIN billable_metrics ON billable_metrics.code = events.code
       AND events.organization_id = billable_metrics.organization_id
     LEFT JOIN billable_metric_groups ON billable_metrics.id = billable_metric_groups.bm_id
-    LEFT JOIN billable_metric_filters on billable_metric_filters.bm_id = billable_metrics.id
+    LEFT JOIN billable_metric_filters ON billable_metrics.id = billable_metric_filters.bm_id
 WHERE
   events.deleted_at IS NULL
   AND events.created_at >= date_trunc('hour', NOW()) - INTERVAL '1 hour'
   AND events.created_at < date_trunc('hour', NOW())
   AND billable_metrics.deleted_at IS NULL
-GROUP BY
-  events.organization_id,
-  events.transaction_id,
-  events.timestamp,
-  events.properties,
-  billable_metrics.code,
-  billable_metrics.field_name,
-  billable_metrics.aggregation_type,
-  billable_metric_groups.parent_group_count,
-  billable_metric_groups.parent_group_keys,
-  billable_metric_groups.child_group_count,
-  billable_metric_groups.child_group_keys

--- a/spec/services/events/post_validation_service_spec.rb
+++ b/spec/services/events/post_validation_service_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Events::PostValidationService, type: :service, transaction: false
           missing_parent_group_key_event.transaction_id,
           missing_child_group_key_event.transaction_id,
         )
-      # expect(result.errors[:invalid_filter_values]).to include(invalid_filter_values_event.transaction_id)
+      expect(result.errors[:invalid_filter_values]).to include(invalid_filter_values_event.transaction_id)
     end
 
     it 'delivers a webhook with the list of transaction_id' do
@@ -169,7 +169,7 @@ RSpec.describe Events::PostValidationService, type: :service, transaction: false
             invalid_code: [invalid_code_event.transaction_id],
             missing_aggregation_property: [missing_aggregation_property_event.transaction_id],
             missing_group_key: Array,
-            # invalid_filter_values: [invalid_filter_values_event.transaction_id],
+            invalid_filter_values: [invalid_filter_values_event.transaction_id],
           },
         )
     end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds back the post validation logic for filters on events