### PR TITLE
feat(invoice-numbering): add new per_organisation numbering logic

### DIFF
--- a/app/services/users_service.rb
+++ b/app/services/users_service.rb
@@ -30,7 +30,7 @@ class UsersService < BaseService
     end
 
     ActiveRecord::Base.transaction do
-      result.organization = Organization.create!(name: organization_name)
+      result.organization = Organization.create!(name: organization_name, document_numbering: 'per_organization')
 
       create_user_and_membership(result, password)
     end

--- a/spec/scenarios/invoices/invoice_numbering_spec.rb
+++ b/spec/scenarios/invoices/invoice_numbering_spec.rb
@@ -120,8 +120,8 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       numbers = invoices.pluck(:number)
 
       expect(sequential_ids).to match_array([4, 4, 4])
-      expect(organization_sequential_ids).to match_array([1, 2, 3])
-      expect(numbers).to match_array(%w[ORG-11-202310-001 ORG-11-202310-002 ORG-11-202310-003])
+      expect(organization_sequential_ids).to match_array([10, 11, 12])
+      expect(numbers).to match_array(%w[ORG-11-202310-010 ORG-11-202310-011 ORG-11-202310-012])
     end
 
     # NOTE: November 19th: Switching to per_customer numbering and Bill subscription
@@ -170,9 +170,9 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
             ORG-1-001-003
             ORG-1-002-003
             ORG-1-003-003
-            ORG-11-202310-001
-            ORG-11-202310-002
-            ORG-11-202310-003
+            ORG-11-202310-010
+            ORG-11-202310-011
+            ORG-11-202310-012
             ORG-11-001-005
             ORG-11-002-005
             ORG-11-003-005
@@ -194,8 +194,23 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       numbers = invoices.pluck(:number)
 
       expect(sequential_ids).to match_array([6, 6, 7])
-      expect(organization_sequential_ids).to match_array([1, 2, 3])
-      expect(numbers).to match_array(%w[ORG-11-202312-001 ORG-11-202312-002 ORG-11-202312-003])
+      expect(organization_sequential_ids).to match_array([17, 18, 19])
+      expect(numbers).to match_array(%w[ORG-11-202312-017 ORG-11-202312-018 ORG-11-202312-019])
+    end
+
+    # NOTE: January 19th 2024: Billing subscription
+    travel_to(DateTime.new(2024, 1, 19, 12, 12)) do
+      Subscriptions::BillingService.call
+      perform_all_enqueued_jobs
+
+      invoices = organization.invoices.order(created_at: :desc).limit(3)
+      sequential_ids = invoices.pluck(:sequential_id)
+      organization_sequential_ids = invoices.pluck(:organization_sequential_id)
+      numbers = invoices.pluck(:number)
+
+      expect(sequential_ids).to match_array([7, 7, 8])
+      expect(organization_sequential_ids).to match_array([20, 21, 22])
+      expect(numbers).to match_array(%w[ORG-11-202401-020 ORG-11-202401-021 ORG-11-202401-022])
     end
   end
 
@@ -289,8 +304,8 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
         numbers = invoices.pluck(:number)
 
         expect(sequential_ids).to match_array([4, 4, 4])
-        expect(organization_sequential_ids).to match_array([1, 2, 3])
-        expect(numbers).to match_array(%w[ORG-11-202310-001 ORG-11-202310-002 ORG-11-202310-003])
+        expect(organization_sequential_ids).to match_array([10, 11, 12])
+        expect(numbers).to match_array(%w[ORG-11-202310-010 ORG-11-202310-011 ORG-11-202310-012])
       end
     end
   end

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe UsersService, type: :service do
 
       org = Organization.find(result.organization.id)
       expect(org.document_number_prefix).to eq("#{org.name.first(3).upcase}-#{org.id.last(4).upcase}")
+      expect(org.document_numbering).to eq('per_organization')
     end
 
     context 'when user already exists' do


### PR DESCRIPTION
## Context

Due to the accounting regulations, we should not reset our `per_organisation` numbering sequence each month.

Current logic for November 2023:
COM-202311-001
COM-202311-002

Current logic for December 2023:
COM-202312-001
COM-202312-002

Expected Behaviour:
**Feb**
	PRO-377A-202402-001
	PRO-377A-202402-002
	PRO-377A-202402-003
	PRO-377A-202402-004
**March**
	PRO-377A-202403-001
	PRO-377A-202403-002
	**//RELEASE FEATURE**
	PRO-377A-202403-003
	PRO-377A-202403-004
**April**
	PRO-377A-202404-005
	PRO-377A-202404-006
	PRO-377A-202404-007


## Description

This PR covers described `per_organisation` logic change.

There are two main constraints that we had to satisfy and which affected the logic:

1. After releasing the feature we should take the last `organisation_sequence_id` and continue from there (accounting regulations since there should be no gap in a period)
2. If invoice numbering switched from `per_customer` to `per_organisation`, we should simply count all organisation invoices and increment by 1

As addition, from now on, default numbering system is `per_organization`
