### PR TITLE
fix: Aggregation of weighted sum bm linked to a percentage charge model

### DIFF
--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -15,6 +15,7 @@ module BillableMetrics
         result.count = event_store.count
         result.variation = event_store.sum || 0
         result.total_aggregated_units = result.variation
+        result.options = {}
 
         if billable_metric.recurring?
           result.total_aggregated_units = latest_value + result.variation

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
 
       expect(result.aggregation.round(5).to_s).to eq('0.0')
       expect(result.count).to eq(0)
+      expect(result.options).to eq({})
     end
   end
 


### PR DESCRIPTION
The goal of this PR is to be able to process aggregation for a `weighted sum` billable metric linked to a `percentage` charge model.