### PR TITLE
fix(credit-note): Store plan amount on fees to compute termination credit note

### DIFF
--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -57,12 +57,16 @@ module CreditNotes
       )
     end
 
+    def plan_amount_cents
+      last_subscription_fee&.amount_details&.[]('plan_amount_cents') || plan.amount_cents
+    end
+
     def to_date
       date_service.next_end_of_period.to_date
     end
 
     def day_price
-      date_service.single_day_price
+      date_service.single_day_price(plan_amount_cents:)
     end
 
     def terminated_at_in_timezone

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -49,6 +49,7 @@ module Fees
         payment_status: :pending,
         taxes_amount_cents: 0,
         unit_amount_cents: new_amount_cents,
+        amount_details: { plan_amount_cents: plan.amount_cents },
       )
 
       return base_fee if !invoice.draft? || !adjusted_fee

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -110,9 +110,9 @@ module Subscriptions
       customer_timezone_shift(beginning_utc)
     end
 
-    def single_day_price(optional_from_date: nil)
+    def single_day_price(optional_from_date: nil, plan_amount_cents: nil)
       duration = compute_duration(from_date: optional_from_date || compute_from_date)
-      plan.amount_cents.fdiv(duration.to_i)
+      (plan_amount_cents || plan.amount_cents).fdiv(duration.to_i)
     end
 
     def charge_single_day_price(charge:)

--- a/spec/services/fees/subscription_service_spec.rb
+++ b/spec/services/fees/subscription_service_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe Fees::SubscriptionService do
         payment_status: 'pending',
         unit_amount_cents: 100,
         precise_unit_amount: 1,
+        amount_details: { 'plan_amount_cents' => 100 },
       )
     end
 
@@ -83,6 +84,7 @@ RSpec.describe Fees::SubscriptionService do
             amount_cents: 90,
             unit_amount_cents: 90,
             precise_unit_amount: 0.9,
+            amount_details: { 'plan_amount_cents' => 100 },
           )
         end
       end

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -611,6 +611,14 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         expect(result).to eq(plan.amount_cents.fdiv(28))
       end
 
+      context 'when passing the plan amount' do
+        let(:result) { date_service.single_day_price(plan_amount_cents: 1000) }
+
+        it 'returns the price of single day' do
+          expect(result).to eq(1_000.fdiv(28))
+        end
+      end
+
       context 'when on a leap year' do
         let(:subscription_at) { DateTime.parse('28 Feb 2019') }
         let(:billing_at) { DateTime.parse('01 Mar 2020') }


### PR DESCRIPTION
## Context

Credit note creation for payed in advance plan termination is failing when the plan#amount_cents is updated between the previous subscription fee creation and the termination.

This happen because the proration is computed with the updated plan amount rather than with the one used to initially create the fee 

## Description

This PR stores the plan amount cents in the `fee#amount_details[plan_amount_cents]` to make sure that the right value is used to create the credit note.