### PR TITLE
fix(credit_note): Handle consecutive subscription upgrade

### DIFF
--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -16,6 +16,11 @@ module CreditNotes
       amount = compute_amount
       return result unless amount.positive?
 
+      # NOTE: In some cases, if the fee was already prorated (in case of multiple upgrade) the amount
+      #       could be greater than the last subscription fee amount.
+      #       In that case, we have to use the last subscription fee amount
+      amount = last_subscription_fee.amount_cents if amount > last_subscription_fee.amount_cents
+
       # NOTE: if credit notes were already issued on the fee,
       #       we have to deduct them from the prorated amount
       amount -= last_subscription_fee.credit_note_items.sum(:amount_cents)

--- a/spec/scenarios/subscriptions/multiple_upgrade_spec.rb
+++ b/spec/scenarios/subscriptions/multiple_upgrade_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Multiple Subscription Upgrade Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: false, email_settings: []) }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:tax) { create(:tax, organization:, rate: 25, applied_to_organization: true) }
+
+  let(:plan1) do
+    create(
+      :plan,
+      organization:,
+      interval: 'monthly',
+      amount_cents: 1_000,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:plan2) do
+    create(
+      :plan,
+      organization:,
+      interval: 'monthly',
+      amount_cents: 1_500,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:plan3) do
+    create(
+      :plan,
+      organization:,
+      interval: 'monthly',
+      amount_cents: 1_900,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:subscription_at) { Time.zone.parse('2024-03-05T12:12:00') }
+
+  before { tax }
+
+  context 'with calendar billing' do
+    it 'upgrades and bill subscriptions' do
+      subscription = nil
+
+      travel_to(subscription_at) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan1.code,
+            billing_time: 'calendar',
+          },
+        )
+
+        expect(customer.invoices.count).to eq(1)
+
+        subscription = customer.subscriptions.first
+        expect(subscription).to be_active
+        expect(subscription.invoices.count).to eq(1)
+
+        invoice = subscription.invoices.first
+        expect(invoice.fees_amount_cents).to eq(871) # 1000 / 31 * (31 - 4)
+      end
+
+      travel_to(Time.zone.parse('2024-03-12T12:12:00')) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan2.code,
+            billing_time: 'calendar',
+          },
+        )
+
+        expect(customer.invoices.count).to eq(2)
+        expect(subscription.reload).to be_terminated
+
+        subscription = customer.subscriptions.order(created_at: :desc).first
+        expect(subscription).to be_active
+
+        expect(subscription.invoices.count).to eq(1)
+        invoice = subscription.invoices.first
+        expect(invoice.fees_amount_cents).to eq(968) # 1500 / 31 * 20
+
+        expect(customer.credit_notes.count).to eq(1)
+        credit_note = customer.credit_notes.first
+        expect(credit_note.credit_amount_cents).to eq(806) # 1000 / 31 * 20 * 1.25
+      end
+
+      travel_to(Time.zone.parse('2024-03-12T13:12:00')) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan3.code,
+            billing_time: 'calendar',
+          },
+        )
+
+        perform_all_enqueued_jobs
+        expect(customer.invoices.count).to eq(3)
+        expect(subscription.reload).to be_terminated
+
+        subscription = customer.subscriptions.order(created_at: :desc).first
+        expect(subscription).to be_active
+
+        expect(subscription.invoices.count).to eq(1)
+        invoice = subscription.invoices.first
+        expect(invoice.fees_amount_cents).to eq(1226) # 1900 / 31 * 20
+
+        expect(customer.credit_notes.count).to eq(2)
+        credit_note = customer.credit_notes.order(created_at: :desc).first
+        expect(credit_note.credit_amount_cents).to eq(1210) # 1500 / 31 * 20 * 1.25
+      end
+    end
+  end
+
+  context 'with anniversary billing' do
+    it 'upgrades and bill subscriptions' do
+      subscription = nil
+
+      travel_to(subscription_at) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan1.code,
+            billing_time: 'anniversary',
+          },
+        )
+
+        expect(customer.invoices.count).to eq(1)
+
+        subscription = customer.subscriptions.first
+        expect(subscription).to be_active
+        expect(subscription.invoices.count).to eq(1)
+
+        invoice = subscription.invoices.first
+        expect(invoice.fees_amount_cents).to eq(1000)
+      end
+
+      travel_to(Time.zone.parse('2024-03-12T12:12:00')) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan2.code,
+            billing_time: 'anniversary',
+          },
+        )
+
+        expect(customer.invoices.count).to eq(2)
+        expect(subscription.reload).to be_terminated
+
+        subscription = customer.subscriptions.order(created_at: :desc).first
+        expect(subscription).to be_active
+
+        expect(subscription.invoices.count).to eq(1)
+        invoice = subscription.invoices.first
+        expect(invoice.fees_amount_cents).to eq(1161) # 1500 / 31 * 24
+
+        expect(customer.credit_notes.count).to eq(1)
+        credit_note = customer.credit_notes.first
+        expect(credit_note.credit_amount_cents).to eq(968) # 1000 / 31 * 24 * 1.25
+      end
+
+      travel_to(Time.zone.parse('2024-03-12T13:12:00')) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan3.code,
+            billing_time: 'anniversary',
+          },
+        )
+
+        perform_all_enqueued_jobs
+        expect(customer.invoices.count).to eq(3)
+        expect(subscription.reload).to be_terminated
+
+        subscription = customer.subscriptions.order(created_at: :desc).first
+        expect(subscription).to be_active
+
+        expect(subscription.invoices.count).to eq(1)
+        invoice = subscription.invoices.first
+        expect(invoice.fees_amount_cents).to eq(1471) # 1900 / 31 * 24
+
+        expect(customer.credit_notes.count).to eq(2)
+        credit_note = customer.credit_notes.order(created_at: :desc).first
+        expect(credit_note.credit_amount_cents).to eq(1451) # 1500 / 31 * 24 * 1.25
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

In some cases of multiple subscription upgrade, a subscription fee could be already prorated when computing the prorated credit note amount . The result of the proration could then be greater than the last subscription fee amount.
In that case, we have to use this last subscription fee amount

## Description

In that case, we have to use this last subscription fee amount as base for the credit note creation
