### PR TITLE
feat: adding SENTRY_ENVIRONMENT to sentry config

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -5,5 +5,6 @@ if ENV['SENTRY_DSN']
     config.dsn = ENV['SENTRY_DSN']
     config.breadcrumbs_logger = %i[active_support_logger http_logger]
     config.traces_sample_rate = 0
+    config.environment = ENV['SENTRY_ENVIRONMENT'] || "production"
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  [Add support for SENTRY_ENVIRONMENT environment variable](https://getlago.canny.io/developer-experience/p/add-support-for-sentryenvironment-environment-variable)

## Context

Sentry allows environments to be specified in their projects so you can filter issues in production, staging, development, etc.

## Description

This change allows users to use env variable 'SENTRY_ENVIRONMENT' to set whatever name of this installations environment in sentry. If nothing is specified it will default to 'production'

No changes required unless you wish to change the env to something you have already setup.
