### PR TITLE
feat(min-spend): Add minimum commitment locales

### DIFF
--- a/config/locales/de/commitment.yml
+++ b/config/locales/de/commitment.yml
@@ -1,0 +1,5 @@
+---
+de:
+  commitment:
+    minimum:
+      name: Mindestverpflichtung

--- a/config/locales/en/commitment.yml
+++ b/config/locales/en/commitment.yml
@@ -1,0 +1,5 @@
+---
+en:
+  commitment:
+    minimum:
+      name: Minimum commitment

--- a/config/locales/es/commitment.yml
+++ b/config/locales/es/commitment.yml
@@ -1,0 +1,5 @@
+---
+es:
+  commitment:
+    minimum:
+      name: Compromiso mínimo

--- a/config/locales/fr/commitment.yml
+++ b/config/locales/fr/commitment.yml
@@ -1,0 +1,5 @@
+---
+fr:
+  commitment:
+    minimum:
+      name: Engagement minimum

--- a/config/locales/it/commitment.yml
+++ b/config/locales/it/commitment.yml
@@ -1,0 +1,5 @@
+---
+it:
+  commitment:
+    minimum:
+      name: Impegno minimo

--- a/config/locales/nb/commitment.yml
+++ b/config/locales/nb/commitment.yml
@@ -1,0 +1,5 @@
+---
+nb:
+  commitment:
+    minimum:
+      name: Norge Minimumsforpliktelse

--- a/config/locales/sv/commitment.yml
+++ b/config/locales/sv/commitment.yml
@@ -1,0 +1,5 @@
+---
+sv:
+  commitment:
+    minimum:
+      name: Sverige Minsta åtagande


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/set-minimum-spend-for-subscriptions

## Context

As a user, I want to define the minimum spend that applies to the customer's plan. Consider the following monthly plan:

- Subscription fee = $50 per month (in arrears);
- Usage-based charge = $10 per unit per month (in arrears); and
- Monthly minimum spend = $100.

If at the end of the month, the customer has consumed 3 units, their total invoice will be: $50 + 3 * $10 = $80 + $20 (true-up fee) = $100.

## Description

This PR adds locales for minimum commitment.