### PR TITLE
feat(min-spend): Add commitment-related methods to models

### DIFF
--- a/app/models/commitment.rb
+++ b/app/models/commitment.rb
@@ -15,4 +15,8 @@ class Commitment < ApplicationRecord
 
   validates :amount_cents, numericality: { greater_than: 0 }, allow_nil: false
   validates :commitment_type, uniqueness: { scope: :plan_id }
+
+  def invoice_name
+    invoice_display_name.presence || I18n.t('commitment.minimum.name')
+  end
 end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -45,6 +45,7 @@ class Fee < ApplicationRecord
 
   scope :subscription_kind, -> { where(fee_type: :subscription) }
   scope :charge_kind, -> { where(fee_type: :charge) }
+  scope :commitment_kind, -> { where(fee_type: :commitment) }
 
   scope :positive_units, -> { where('units > ?', 0) }
 

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -50,6 +50,15 @@ class InvoiceSubscription < ApplicationRecord
     )
   end
 
+  def previous_invoice_subscription
+    self.class
+      .where(subscription:)
+      .where('from_datetime <= ?', from_datetime)
+      .where.not(id:)
+      .order(from_datetime: :desc)
+      .find(&:subscription_fee)
+  end
+
   def charge_amount_cents
     fees.charge_kind.sum(:amount_cents)
   end
@@ -60,6 +69,10 @@ class InvoiceSubscription < ApplicationRecord
 
   def subscription_fee
     fees.subscription_kind.first
+  end
+
+  def commitment_fee
+    fees.commitment_kind.first
   end
 
   def total_amount_cents

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -58,7 +58,10 @@ module Fees
       return customer.organization.taxes.where(code: tax_codes) if tax_codes
       return fee.add_on.taxes if fee.add_on? && fee.add_on.taxes.any?
       return fee.charge.taxes if fee.charge? && fee.charge.taxes.any?
-      return fee.subscription.plan.taxes if (fee.charge? || fee.subscription?) && fee.subscription.plan.taxes.any?
+      return fee.invoiceable.taxes if fee.commitment? && fee.invoiceable.taxes.any?
+      if (fee.charge? || fee.subscription? || fee.commitment?) && fee.subscription.plan.taxes.any?
+        return fee.subscription.plan.taxes
+      end
       return customer.taxes if customer.taxes.any?
 
       customer.organization.taxes.applied_to_organization

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -84,4 +84,21 @@ FactoryBot.define do
     invoiceable_type { 'AddOn' }
     invoiceable_id { add_on.id }
   end
+
+  factory :minimum_commitment_fee, class: 'Fee' do
+    invoice
+    fee_type { 'commitment' }
+    subscription
+
+    amount_cents { 200 }
+    amount_currency { 'EUR' }
+    taxes_amount_cents { 2 }
+
+    transient do
+      commitment { subscription.plan.minimum_commitment.presence || create(:commitment, plan: subscription.plan) }
+    end
+
+    invoiceable_type { 'Commitment' }
+    invoiceable_id { commitment.id }
+  end
 end

--- a/spec/models/commitment_spec.rb
+++ b/spec/models/commitment_spec.rb
@@ -9,6 +9,26 @@ RSpec.describe Commitment, type: :model do
 
   it { is_expected.to validate_numericality_of(:amount_cents) }
 
+  describe '#invoice_name' do
+    subject(:commitment_invoice_name) { commitment.invoice_name }
+
+    context 'when invoice display name is blank' do
+      let(:commitment) { build_stubbed(:commitment, invoice_display_name: [nil, ''].sample) }
+
+      it 'returns name' do
+        expect(commitment_invoice_name).to eq('Minimum commitment')
+      end
+    end
+
+    context 'when invoice display name is present' do
+      let(:commitment) { build_stubbed(:commitment) }
+
+      it 'returns invoice display name' do
+        expect(commitment_invoice_name).to eq(commitment.invoice_display_name)
+      end
+    end
+  end
+
   describe 'validations' do
     subject(:commitment) { build(:commitment) }
 


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/set-minimum-spend-for-subscriptions

## Context

As a user, I want to define the minimum spend that applies to the customer's plan. Consider the following monthly plan:

- Subscription fee = $50 per month (in arrears);
- Usage-based charge = $10 per unit per month (in arrears); and
- Monthly minimum spend = $100.

If at the end of the month, the customer has consumed 3 units, their total invoice will be: $50 + 3 * $10 = $80 + $20 (true-up fee) = $100.

## Description

This PR adds minimum commitment-related mothod to various models.