### PR TITLE
feat(min-spending): Add scenario specs

### DIFF
--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/monthly_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Advance',
+      code: 'in_advance',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'anniversary' }
+  let(:plan_interval) { 'monthly' }
+  let(:subscription_time) { DateTime.new(2024, 2, 28, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '15' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '25' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '30' },
+        },
+      )
+
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 1.month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 1.month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(983_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to(subscription_time + 1.month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to(subscription_time + 2.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 2.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 1.month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 1.month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(983_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to(subscription_time + 1.month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to(subscription_time + 2.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 2.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/quarterly_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Advance',
+      code: 'in_advance',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'anniversary' }
+  let(:plan_interval) { 'quarterly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '15' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '25' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '30' },
+        },
+      )
+
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 3.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 3.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(983_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to(subscription_time + 3.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to(subscription_time + 6.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 6.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 3.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 3.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(983_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to(subscription_time + 3.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to(subscription_time + 6.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 6.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/weekly_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Advance',
+      code: 'in_advance',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'anniversary' }
+  let(:plan_interval) { 'weekly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '15' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '25' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '30' },
+        },
+      )
+
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 1.week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 1.week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(983_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to(subscription_time + 1.week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to(subscription_time + 2.weeks) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 2.weeks) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 1.week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 1.week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(983_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to(subscription_time + 1.week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to(subscription_time + 2.weeks) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 2.weeks) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/yearly_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Advance',
+      code: 'in_advance',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: true,
+      bill_charges_monthly:,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_advance_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'advance_metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'recurring_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'anniversary' }
+  let(:plan_interval) { 'yearly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 5, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_advance_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+    end
+
+    travel_to(subscription_time + 1.hour) do
+      create_event(
+        {
+          code: billable_metric_advance_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '2' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '1' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_advance_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '30' },
+        },
+      )
+
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when billed monthly' do
+    let(:bill_charges_monthly) { true }
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time + 1.minute) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the last period' do
+      before do
+        (1..12).each do |i|
+          travel_to(subscription_time + i.month) do
+            if i == 5
+              create_event(
+                {
+                  code: billable_metric_advance_metered.code,
+                  transaction_id: SecureRandom.uuid,
+                  external_customer_id: customer.external_id,
+                  properties: { total: '55' },
+                },
+              )
+            end
+
+            if i == 11
+              create_event(
+                {
+                  code: billable_metric_metered.code,
+                  transaction_id: SecureRandom.uuid,
+                  external_customer_id: customer.external_id,
+                  properties: { total: '1' },
+                },
+              )
+            end
+
+            Subscriptions::BillingService.new.call
+            perform_all_enqueued_jobs
+          end
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 1.year) do
+          aggregate_failures do
+            expect(invoice.fees.commitment_kind.count).to eq(1)
+            expect(invoice.fees.commitment_kind.sum(:amount_cents)).to eq(981_100)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/monthly_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Advance',
+      code: 'in_advance',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'calendar' }
+  let(:plan_interval) { 'monthly' }
+  let(:subscription_time) { DateTime.new(2024, 2, 28, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '15' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '25' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '30' },
+        },
+      )
+
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 1.month).beginning_of_month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 1.month).beginning_of_month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(61_276)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to((subscription_time + 1.month).beginning_of_month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to((subscription_time + 2.months).beginning_of_month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 2.months).beginning_of_month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 1.month).beginning_of_month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 1.month).beginning_of_month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(61_276)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to((subscription_time + 1.month).beginning_of_month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to((subscription_time + 2.months).beginning_of_month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 2.months).beginning_of_month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/quarterly_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Advance',
+      code: 'in_advance',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'calendar' }
+  let(:plan_interval) { 'quarterly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '15' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '25' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '30' },
+        },
+      )
+
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 3.months).beginning_of_quarter) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 3.months).beginning_of_quarter) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(210_582)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to((subscription_time + 3.months).beginning_of_quarter) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to((subscription_time + 6.months).beginning_of_quarter) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 6.months).beginning_of_quarter) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 3.months).beginning_of_quarter) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 3.months).beginning_of_quarter) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(210_582)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to((subscription_time + 3.months).beginning_of_quarter) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to((subscription_time + 6.months).beginning_of_quarter) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 6.months).beginning_of_quarter) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/weekly_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Advance',
+      code: 'in_advance',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: true,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'calendar' }
+  let(:plan_interval) { 'weekly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '15' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '25' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '30' },
+        },
+      )
+
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 1.week).beginning_of_week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 1.week).beginning_of_week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(841_572)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to((subscription_time + 1.week).beginning_of_week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to((subscription_time + 2.weeks).beginning_of_week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 2.weeks).beginning_of_week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 1.week).beginning_of_week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 1.week).beginning_of_week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(841_572)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the third period' do
+      before do
+        travel_to((subscription_time + 1.week).beginning_of_week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to((subscription_time + 2.weeks).beginning_of_week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 2.weeks).beginning_of_week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(988_500)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/yearly_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Advance',
+      code: 'in_advance',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: true,
+      bill_charges_monthly:,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_advance_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'advance_metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'recurring_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'calendar' }
+  let(:plan_interval) { 'yearly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 5, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_advance_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+    end
+
+    travel_to(subscription_time + 1.hour) do
+      create_event(
+        {
+          code: billable_metric_advance_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '2' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '1' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_advance_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '30' },
+        },
+      )
+
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when billed monthly' do
+    let(:bill_charges_monthly) { true }
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time + 1.minute) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the last period' do
+      before do
+        travel_to(subscription_time + 5.months) do
+          create_event(
+            {
+              code: billable_metric_advance_metered.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { total: '55' },
+            },
+          )
+        end
+
+        travel_to(subscription_time + 11.months) do
+          create_event(
+            {
+              code: billable_metric_metered.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { total: '1' },
+            },
+          )
+        end
+
+        travel_to((subscription_time + 12.months).beginning_of_month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+
+        travel_to((subscription_time + 1.year).beginning_of_year) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 1.year).beginning_of_year) do
+          aggregate_failures do
+            expect(invoice.fees.commitment_kind.count).to eq(1)
+            expect(invoice.fees.commitment_kind.sum(:amount_cents)).to eq(808_186)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_advance_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance_spec.rb
@@ -1,0 +1,772 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:, currency: 'EUR') }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      amount_cents: 100_000,
+      amount_currency: 'EUR',
+      interval: plan_interval,
+      pay_in_advance: true,
+      bill_charges_monthly:,
+    )
+  end
+
+  let(:bill_charges_monthly) { false }
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when plan is billed in advance' do
+    context 'with weekly plan' do
+      let(:plan_interval) { 'weekly' }
+
+      context 'with calendar billing' do
+        let(:billing_time) { 'calendar' }
+        let(:subscription_time) { DateTime.new(2023, 2, 1) }
+        let(:commitment_fee_amount_cents) { 642_857 }
+
+        context 'when there is no previous period' do
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+        end
+
+        context 'when there is a previous period' do
+          let(:current_period_start) { DateTime.new(2023, 2, 6, 10) }
+
+          before do
+            travel_to(current_period_start)
+
+            Subscriptions::BillingService.new.call
+            perform_all_enqueued_jobs
+          end
+
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+              expect(invoice.fees.commitment_kind.count).to eq(1)
+              expect(invoice.fees.commitment_kind.first.amount_cents).to eq(commitment_fee_amount_cents)
+            end
+
+            context 'when subscription is terminated' do
+              let(:invoices) { Invoice.order(:sequential_id) }
+              let(:commitment_fees) { Fee.commitment_kind.pluck(:amount_cents) }
+
+              before do
+                travel_to(DateTime.new(2023, 2, 13, 10))
+                Subscriptions::BillingService.call
+                perform_all_enqueued_jobs
+
+                travel_to(DateTime.new(2023, 2, 15, 10))
+                terminate_subscription(subscription)
+                perform_all_enqueued_jobs
+              end
+
+              it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+                expect(invoices.first.fees.commitment_kind.count).to eq(0)
+                expect(invoices.second.fees.commitment_kind.count).to eq(1)
+                expect(invoices.third.fees.commitment_kind.count).to eq(1)
+                expect(invoices.fourth.fees.commitment_kind.count).to eq(1)
+
+                expect(commitment_fees).to eq([642_857, 900_000, 328_571])
+              end
+            end
+          end
+        end
+      end
+
+      context 'with anniversary billing' do
+        let(:billing_time) { 'anniversary' }
+        let(:subscription_time) { DateTime.new(2023, 2, 1) }
+        let(:commitment_fee_amount_cents) { 900_000 }
+
+        context 'when there is no previous period' do
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+        end
+
+        context 'when there is a previous period' do
+          let(:current_period_start) { DateTime.new(2023, 2, 8, 10) }
+
+          before do
+            travel_to(current_period_start)
+
+            Subscriptions::BillingService.new.call
+            perform_all_enqueued_jobs
+          end
+
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+              expect(invoice.fees.commitment_kind.count).to eq(1)
+              expect(invoice.fees.commitment_kind.first.amount_cents).to eq(commitment_fee_amount_cents)
+            end
+          end
+        end
+      end
+    end
+
+    context 'with monthly plan' do
+      let(:plan_interval) { 'monthly' }
+
+      context 'with calendar billing' do
+        let(:billing_time) { 'calendar' }
+        let(:subscription_time) { DateTime.new(2023, 2, 4) }
+        let(:commitment_fee_amount_cents) { 803_571 }
+
+        context 'when there is no previous period' do
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+        end
+
+        context 'when there is a previous period' do
+          let(:current_period_start) { DateTime.new(2023, 3, 1, 10) }
+
+          before do
+            travel_to(current_period_start)
+
+            Subscriptions::BillingService.new.call
+            perform_all_enqueued_jobs
+          end
+
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+              expect(invoice.fees.commitment_kind.count).to eq(1)
+              expect(invoice.fees.commitment_kind.first.amount_cents).to eq(commitment_fee_amount_cents)
+            end
+          end
+        end
+      end
+
+      context 'with anniversary billing' do
+        let(:billing_time) { 'anniversary' }
+        let(:subscription_time) { DateTime.new(2023, 2, 4) }
+        let(:commitment_fee_amount_cents) { 900_000 }
+
+        context 'when there is no previous period' do
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+        end
+
+        context 'when there is a previous period' do
+          let(:current_period_start) { DateTime.new(2023, 3, 4, 10) }
+
+          before do
+            travel_to(current_period_start)
+
+            Subscriptions::BillingService.new.call
+            perform_all_enqueued_jobs
+          end
+
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+              expect(invoice.fees.commitment_kind.count).to eq(1)
+              expect(invoice.fees.commitment_kind.first.amount_cents).to eq(commitment_fee_amount_cents)
+            end
+          end
+        end
+      end
+    end
+
+    context 'with quarterly plan' do
+      let(:plan_interval) { 'quarterly' }
+
+      context 'with calendar billing' do
+        let(:billing_time) { 'calendar' }
+        let(:subscription_time) { DateTime.new(2023, 2, 4) }
+        let(:commitment_fee_amount_cents) { 560_000 }
+
+        context 'when there is no previous period' do
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+        end
+
+        context 'when there is a previous period' do
+          let(:current_period_start) { DateTime.new(2023, 4, 1, 10) }
+
+          before do
+            travel_to(current_period_start)
+
+            Subscriptions::BillingService.new.call
+            perform_all_enqueued_jobs
+          end
+
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+              expect(invoice.fees.commitment_kind.count).to eq(1)
+              expect(invoice.fees.commitment_kind.first.amount_cents).to eq(commitment_fee_amount_cents)
+            end
+          end
+        end
+      end
+
+      context 'with anniversary billing' do
+        let(:billing_time) { 'anniversary' }
+        let(:subscription_time) { DateTime.new(2023, 2, 4) }
+        let(:commitment_fee_amount_cents) { 900_000 }
+
+        context 'when there is no previous period' do
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+        end
+
+        context 'when there is a previous period' do
+          let(:current_period_start) { DateTime.new(2023, 5, 4, 10) }
+
+          before do
+            travel_to(current_period_start)
+
+            Subscriptions::BillingService.new.call
+            perform_all_enqueued_jobs
+          end
+
+          context 'when plan has no minimum commitment' do
+            let(:minimum_commitment) { nil }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+            it 'creates an invoice without minimum commitment fee' do
+              expect(invoice.fees.commitment_kind.count).to eq(0)
+            end
+          end
+
+          context 'when minimum commitment amount is not reached' do
+            let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+            it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+              expect(invoice.fees.commitment_kind.count).to eq(1)
+              expect(invoice.fees.commitment_kind.first.amount_cents).to eq(commitment_fee_amount_cents)
+            end
+          end
+        end
+      end
+    end
+
+    context 'with yearly plan and yearly charge' do
+      let(:plan_interval) { 'yearly' }
+
+      context 'with calendar billing' do
+        let(:billing_time) { 'calendar' }
+        let(:subscription_time) { DateTime.new(2022, 2, 1) }
+        let(:commitment_fee_amount_cents) { 823_561 }
+
+        context 'when plan is charged yearly' do
+          context 'when there is no previous period' do
+            context 'when plan has no minimum commitment' do
+              let(:minimum_commitment) { nil }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is not reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+          end
+
+          context 'when there is a previous period' do
+            let(:current_period_start) { DateTime.new(2023, 1, 1, 10) }
+
+            before do
+              travel_to(current_period_start)
+
+              Subscriptions::BillingService.new.call
+              perform_all_enqueued_jobs
+            end
+
+            context 'when plan has no minimum commitment' do
+              let(:minimum_commitment) { nil }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is not reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+              it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+                expect(invoice.fees.commitment_kind.count).to eq(1)
+                expect(invoice.fees.commitment_kind.first.amount_cents).to eq(commitment_fee_amount_cents)
+              end
+            end
+          end
+        end
+
+        context 'when plan is charged monthly' do
+          let(:bill_charges_monthly) { true }
+
+          context 'when there is no previous period' do
+            context 'when plan has no minimum commitment' do
+              let(:minimum_commitment) { nil }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is not reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+          end
+
+          context 'when there is a previous period' do
+            let(:current_period_start) { DateTime.new(2023, 1, 1, 10) }
+
+            before do
+              travel_to(current_period_start)
+
+              Subscriptions::BillingService.new.call
+              perform_all_enqueued_jobs
+            end
+
+            context 'when plan has no minimum commitment' do
+              let(:minimum_commitment) { nil }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is not reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+              it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+                expect(invoice.fees.commitment_kind.count).to eq(1)
+                expect(invoice.fees.commitment_kind.first.amount_cents).to eq(commitment_fee_amount_cents)
+              end
+            end
+          end
+        end
+      end
+
+      context 'with anniversary billing' do
+        let(:billing_time) { 'anniversary' }
+        let(:subscription_time) { DateTime.new(2022, 2, 4) }
+        let(:commitment_fee_amount_cents) { 900_000 }
+
+        context 'when plan is charged yearly' do
+          context 'when there is no previous period' do
+            context 'when plan has no minimum commitment' do
+              let(:minimum_commitment) { nil }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is not reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+          end
+
+          context 'when there is a previous period' do
+            let(:current_period_start) { DateTime.new(2023, 2, 4, 10) }
+
+            before do
+              travel_to(current_period_start)
+
+              Subscriptions::BillingService.new.call
+              perform_all_enqueued_jobs
+            end
+
+            context 'when plan has no minimum commitment' do
+              let(:minimum_commitment) { nil }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is not reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+              it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+                expect(invoice.fees.commitment_kind.count).to eq(1)
+                expect(invoice.fees.commitment_kind.first.amount_cents).to eq(commitment_fee_amount_cents)
+              end
+            end
+          end
+        end
+
+        context 'when plan is charged monthly' do
+          let(:bill_charges_monthly) { true }
+
+          context 'when there is no previous period' do
+            context 'when plan has no minimum commitment' do
+              let(:minimum_commitment) { nil }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is not reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+          end
+
+          context 'when there is a previous period' do
+            let(:current_period_start) { DateTime.new(2023, 2, 4, 10) }
+
+            before do
+              travel_to(current_period_start)
+
+              Subscriptions::BillingService.new.call
+              perform_all_enqueued_jobs
+            end
+
+            context 'when plan has no minimum commitment' do
+              let(:minimum_commitment) { nil }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+              it 'creates an invoice without minimum commitment fee' do
+                expect(invoice.fees.commitment_kind.count).to eq(0)
+              end
+            end
+
+            context 'when minimum commitment amount is not reached' do
+              let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+              it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+                expect(invoice.fees.commitment_kind.count).to eq(1)
+                expect(invoice.fees.commitment_kind.first.amount_cents).to eq(commitment_fee_amount_cents)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/monthly_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Arrears',
+      code: 'in_arrears',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: false,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'anniversary' }
+  let(:plan_interval) { 'monthly' }
+  let(:subscription_time) { DateTime.new(2024, 2, 28, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+    end
+
+    travel_to(subscription_time + 1.month) do
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 1.month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(987_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 2.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 2.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 1.month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(987_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 2.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 2.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/quarterly_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Arrears',
+      code: 'in_arrears',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: false,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'anniversary' }
+  let(:plan_interval) { 'quarterly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+    end
+
+    travel_to(subscription_time + 3.months) do
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 3.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(987_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 6.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 6.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 3.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(987_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 6.months) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 6.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/weekly_spec.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Arrears',
+      code: 'in_arrears',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: false,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'anniversary' }
+  let(:plan_interval) { 'weekly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+    end
+
+    travel_to(subscription_time + 1.week) do
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 1.week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(987_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 2.weeks) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 2.weeks) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 1.week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(987_000)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to(subscription_time + 2.weeks) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 2.weeks) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/yearly_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Arrears',
+      code: 'in_arrears',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: false,
+      bill_charges_monthly:,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_advance_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'advance_metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'recurring_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'anniversary' }
+  let(:plan_interval) { 'yearly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 1, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_advance_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+    end
+
+    travel_to(subscription_time + 1.hour) do
+      create_event(
+        {
+          code: billable_metric_advance_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '2' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '1' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_advance_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '30' },
+        },
+      )
+    end
+  end
+
+  context 'when billed monthly' do
+    let(:bill_charges_monthly) { true }
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time + 1.month + 1.day) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the last period' do
+      before do
+        (1..12).each do |i|
+          travel_to(subscription_time + i.month) do
+            if i == 5
+              create_event(
+                {
+                  code: billable_metric_advance_metered.code,
+                  transaction_id: SecureRandom.uuid,
+                  external_customer_id: customer.external_id,
+                  properties: { total: '55' },
+                },
+              )
+            end
+
+            if i == 11
+              create_event(
+                {
+                  code: billable_metric_metered.code,
+                  transaction_id: SecureRandom.uuid,
+                  external_customer_id: customer.external_id,
+                  properties: { total: '1' },
+                },
+              )
+            end
+
+            Subscriptions::BillingService.new.call
+            perform_all_enqueued_jobs
+          end
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 1.year + 1.month) do
+          aggregate_failures do
+            expect(invoice.fees.commitment_kind.count).to eq(1)
+            expect(invoice.fees.commitment_kind.sum(:amount_cents)).to eq(981_100)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/monthly_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Arrears',
+      code: 'in_arrears',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: false,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'calendar' }
+  let(:plan_interval) { 'monthly' }
+  let(:subscription_time) { DateTime.new(2024, 2, 28, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+    end
+
+    travel_to((subscription_time + 1.month).beginning_of_month) do
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 1.month).beginning_of_month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(65_276)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 2.months).beginning_of_month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 2.months).beginning_of_month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+
+      travel_to((subscription_time + 1.month).beginning_of_month) do
+        Subscriptions::BillingService.new.call
+        perform_all_enqueued_jobs
+      end
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 1.month).beginning_of_month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(65_276)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 2.months).beginning_of_month) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 2.months).beginning_of_month) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/quarterly_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Arrears',
+      code: 'in_arrears',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: false,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'calendar' }
+  let(:plan_interval) { 'quarterly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+    end
+
+    travel_to((subscription_time + 3.months).beginning_of_quarter) do
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 3.months).beginning_of_quarter) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(214_582)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 6.months).beginning_of_quarter) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 6.months).beginning_of_quarter) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+
+      travel_to((subscription_time + 3.months).beginning_of_quarter) do
+        Subscriptions::BillingService.new.call
+        perform_all_enqueued_jobs
+      end
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to(subscription_time + 3.months) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(214_582)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 6.months).beginning_of_quarter) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 6.months).beginning_of_quarter) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/weekly_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Arrears',
+      code: 'in_arrears',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: false,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'metered_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'advance_recurring',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'calendar' }
+  let(:plan_interval) { 'weekly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 12, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_metered_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_recurring_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered_advance.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '10' },
+        },
+      )
+    end
+
+    travel_to((subscription_time + 1.week).beginning_of_week) do
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when coupons are not applied' do
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 1.week).beginning_of_week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(845_572)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 2.weeks).beginning_of_week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 2.weeks).beginning_of_week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+
+  context 'when coupon is applied' do
+    let(:coupon) do
+      create(
+        :coupon,
+        organization:,
+        amount_cents: 1_000_000,
+        frequency: :forever,
+      )
+    end
+
+    let(:coupon_target) { create(:coupon_plan, coupon:, plan:) }
+
+    before do
+      apply_coupon(
+        external_customer_id: customer.external_id,
+        coupon_code: coupon_target.coupon.code,
+        amount_cents: 1_000_000,
+      )
+
+      travel_to((subscription_time + 1.week).beginning_of_week) do
+        Subscriptions::BillingService.new.call
+        perform_all_enqueued_jobs
+      end
+    end
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 1.week).beginning_of_week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(845_572)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the second period' do
+      before do
+        travel_to((subscription_time + 2.weeks).beginning_of_week) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 2.weeks).beginning_of_week) do
+          expect(invoice.fees.commitment_kind.first.amount_cents).to eq(989_000)
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/yearly_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
+  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
+  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
+
+  let(:plan) do
+    create(
+      :plan,
+      name: 'In Arrears',
+      code: 'in_arrears',
+      organization:,
+      amount_cents: 10_000,
+      interval: plan_interval,
+      pay_in_advance: false,
+      bill_charges_monthly:,
+    )
+  end
+
+  let(:invoice) { subscription.reload.invoices.order(sequential_id: :desc).first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  let(:billable_metric_advance_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in advance',
+      code: 'advance_metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_metered) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'Metered in arrears',
+      code: 'metered',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: false,
+    )
+  end
+
+  let(:billable_metric_recurring_advance) do
+    create(
+      :billable_metric,
+      organization:,
+      name: 'In advance recurring',
+      code: 'recurring_advance',
+      aggregation_type: 'sum_agg',
+      field_name: 'total',
+      recurring: true,
+    )
+  end
+
+  let(:billing_time) { 'calendar' }
+  let(:plan_interval) { 'yearly' }
+  let(:subscription_time) { DateTime.new(2024, 3, 5, 10) }
+  let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+  before do
+    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:call).and_return(pdf_result)
+
+    minimum_commitment
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_advance_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      billable_metric: billable_metric_metered,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    create(
+      :standard_charge,
+      :pay_in_advance,
+      billable_metric: billable_metric_recurring_advance,
+      invoiceable: true,
+      plan:,
+      properties: { amount: '1' },
+    )
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+    end
+
+    travel_to(subscription_time + 1.hour) do
+      create_event(
+        {
+          code: billable_metric_advance_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '2' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '1' },
+        },
+      )
+
+      create_event(
+        {
+          code: billable_metric_advance_metered.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          properties: { total: '30' },
+        },
+      )
+    end
+
+    travel_to((subscription_time + 1.month).beginning_of_month) do
+      Subscriptions::BillingService.new.call
+      perform_all_enqueued_jobs
+    end
+  end
+
+  context 'when billed monthly' do
+    let(:bill_charges_monthly) { true }
+
+    context 'when subscription is billed for the first period' do
+      it 'creates an invoice with no minimum commitment fee' do
+        travel_to(subscription_time + 1.minute) do
+          expect(invoice.fees.commitment_kind.count).to eq(0)
+        end
+      end
+    end
+
+    context 'when subscription is billed for the last period' do
+      before do
+        travel_to(subscription_time + 5.months) do
+          create_event(
+            {
+              code: billable_metric_advance_metered.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { total: '55' },
+            },
+          )
+        end
+
+        travel_to(subscription_time + 11.months) do
+          create_event(
+            {
+              code: billable_metric_metered.code,
+              transaction_id: SecureRandom.uuid,
+              external_customer_id: customer.external_id,
+              properties: { total: '1' },
+            },
+          )
+        end
+
+        travel_to((subscription_time + 1.year).beginning_of_year) do
+          Subscriptions::BillingService.new.call
+          perform_all_enqueued_jobs
+        end
+      end
+
+      it 'creates an invoice with minimum commitment fee' do
+        travel_to((subscription_time + 1.year).beginning_of_year) do
+          aggregate_failures do
+            expect(invoice.fees.commitment_kind.count).to eq(1)
+            expect(invoice.fees.commitment_kind.sum(:amount_cents)).to eq(808_086)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/scenarios/commitments/minimum/in_arrears_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:, currency: 'EUR') }
+
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      amount_cents: 100_000,
+      amount_currency: 'EUR',
+      interval: plan_interval,
+      pay_in_advance: false,
+      bill_charges_monthly:,
+    )
+  end
+
+  let(:bill_charges_monthly) { false }
+  let(:invoice) { subscription.reload.invoices.first }
+  let(:subscription) { customer.subscriptions.first.reload }
+
+  before do
+    minimum_commitment
+
+    # Create the subscription
+    travel_to(subscription_time) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        },
+      )
+    end
+
+    billing_times.each do |time|
+      travel_to(time) do
+        Subscriptions::BillingService.new.call
+        perform_all_enqueued_jobs
+      end
+    end
+  end
+
+  shared_examples 'a subscription billing' do
+    context 'when plan has no minimum commitment' do
+      let(:minimum_commitment) { nil }
+
+      it 'creates an invoice without minimum commitment fee' do
+        expect(invoice.fees.commitment_kind.count).to eq(0)
+      end
+    end
+
+    context 'when minimum commitment amount is reached' do
+      let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1) }
+
+      it 'creates an invoice without minimum commitment fee' do
+        expect(invoice.fees.commitment_kind.count).to eq(0)
+      end
+    end
+
+    context 'when minimum commitment amount is not reached' do
+      let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
+
+      it 'creates an invoice with minimum commitment fee', :aggregate_failures do
+        expect(invoice.fees.commitment_kind.count).to eq(1)
+        expect(invoice.fees.commitment_kind.first.amount_cents).to eq(commitment_fee_amount_cents)
+      end
+    end
+  end
+
+  context 'when plan is billed in arrears' do
+    context 'with weekly plan' do
+      let(:plan_interval) { 'weekly' }
+
+      context 'with calendar billing' do
+        let(:billing_time) { 'calendar' }
+        let(:subscription_time) { DateTime.new(2023, 2, 1) }
+        let(:billing_times) { [DateTime.new(2023, 2, 6, 1), DateTime.new(2023, 2, 6, 2)] }
+        let(:commitment_fee_amount_cents) { 642_857 }
+
+        it_behaves_like 'a subscription billing'
+      end
+
+      context 'with anniversary billing' do
+        let(:billing_time) { 'anniversary' }
+        let(:subscription_time) { DateTime.new(2023, 2, 1) }
+        let(:billing_times) { [DateTime.new(2023, 2, 15, 1), DateTime.new(2023, 2, 15, 2)] }
+        let(:commitment_fee_amount_cents) { 900_000 }
+
+        it_behaves_like 'a subscription billing'
+      end
+    end
+
+    context 'with monthly plan' do
+      let(:plan_interval) { 'monthly' }
+
+      context 'with calendar billing' do
+        let(:billing_time) { 'calendar' }
+        let(:subscription_time) { DateTime.new(2023, 2, 4) }
+        let(:billing_times) { [DateTime.new(2023, 3, 1, 1), DateTime.new(2023, 3, 1, 2)] }
+        let(:commitment_fee_amount_cents) { 803_571 }
+
+        it_behaves_like 'a subscription billing'
+      end
+
+      context 'with anniversary billing' do
+        let(:billing_time) { 'anniversary' }
+        let(:subscription_time) { DateTime.new(2023, 2, 4) }
+        let(:billing_times) { [DateTime.new(2023, 3, 4, 1), DateTime.new(2023, 3, 4, 2)] }
+        let(:commitment_fee_amount_cents) { 900_000 }
+
+        it_behaves_like 'a subscription billing'
+      end
+    end
+
+    context 'with quarterly plan' do
+      let(:plan_interval) { 'quarterly' }
+
+      context 'with calendar billing' do
+        let(:billing_time) { 'calendar' }
+        let(:subscription_time) { DateTime.new(2023, 2, 4) }
+        let(:billing_times) { [DateTime.new(2023, 4, 1, 1), DateTime.new(2023, 4, 1, 2)] }
+        let(:commitment_fee_amount_cents) { 560_000 }
+
+        it_behaves_like 'a subscription billing'
+      end
+
+      context 'with anniversary billing' do
+        let(:billing_time) { 'anniversary' }
+        let(:subscription_time) { DateTime.new(2023, 2, 4) }
+        let(:billing_times) { [DateTime.new(2023, 5, 4, 1), DateTime.new(2023, 5, 4, 2)] }
+        let(:commitment_fee_amount_cents) { 900_000 }
+
+        it_behaves_like 'a subscription billing'
+      end
+    end
+
+    context 'with yearly plan and yearly charge' do
+      let(:plan_interval) { 'yearly' }
+
+      context 'with calendar billing' do
+        let(:billing_time) { 'calendar' }
+        let(:subscription_time) { DateTime.new(2022, 2, 1) }
+        let(:billing_times) { [DateTime.new(2023, 1, 1, 1), DateTime.new(2023, 1, 1, 2)] }
+        let(:commitment_fee_amount_cents) { 823_561 }
+
+        it_behaves_like 'a subscription billing'
+
+        context 'when plan is charged monthly' do
+          let(:bill_charges_monthly) { false }
+
+          it_behaves_like 'a subscription billing'
+        end
+      end
+
+      context 'with anniversary billing' do
+        let(:billing_time) { 'anniversary' }
+        let(:subscription_time) { DateTime.new(2022, 2, 4) }
+        let(:billing_times) { [DateTime.new(2023, 2, 4, 1), DateTime.new(2023, 2, 4, 2)] }
+        let(:commitment_fee_amount_cents) { 900_000 }
+
+        context 'when plan is charged yearly' do
+          it_behaves_like 'a subscription billing'
+        end
+
+        context 'when plan is charged monthly' do
+          let(:bill_charges_monthly) { false }
+
+          it_behaves_like 'a subscription billing'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/set-minimum-spend-for-subscriptions

## Context

As a user, I want to define the minimum spend that applies to the customer's plan. Consider the following monthly plan:

- Subscription fee = $50 per month (in arrears);
- Usage-based charge = $10 per unit per month (in arrears); and
- Monthly minimum spend = $100.

If at the end of the month, the customer has consumed 3 units, their total invoice will be: $50 + 3 * $10 = $80 + $20 (true-up fee) = $100.

## Description

This PR adds scenario specs.