### PR TITLE
fix(payment): Stop failing all the process when failing to enqueue a payment

### DIFF
--- a/app/services/invoices/payments/create_service.rb
+++ b/app/services/invoices/payments/create_service.rb
@@ -18,6 +18,8 @@ module Invoices
         when :adyen
           Invoices::Payments::AdyenCreateJob.perform_later(invoice)
         end
+      rescue ActiveJob::Uniqueness::JobNotUnique => e
+        Sentry.capture_exception(e)
       end
 
       private


### PR DESCRIPTION
## Context

Today, when a payment attempt failed to enqueue because of a `ActiveJob::Uniqueness::JobNotUnique` the complete process is stopped, leading to a lot of dead jobs and unpredictable inconsistent states for invoices or customers (and their attached objects).

## Description

This PR makes sure that the `ActiveJob::Uniqueness::JobNotUnique` remains captured but that the execution is not stopped for the rest of the process