### PR TITLE
feat(filter): Create fee for each charge filter

### DIFF
--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -11,6 +11,11 @@ module ChargeFilters
       result.matching_filters = filter.to_h
 
       # NOTE: Check if filters contains some key/values from input filter
+      #       Result will have the following format:
+      #       {
+      #         key1: [value1, value2],
+      #         key2: [value3, value4]
+      #       }
       children = other_filters.find_all do |f|
         child = f.to_h
 
@@ -20,6 +25,17 @@ module ChargeFilters
       end
 
       # NOTE: List of filters that we must ignore to prevent duplicated count of events
+      #       Result will have the following format:
+      #       [
+      #         {
+      #           key1: [value1],
+      #           key2: [value3, value4]
+      #         },
+      #         {
+      #           key1: [value2],
+      #           key2: [value3, value4]
+      #         }
+      #       ]
       result.ignored_filters = children.each_with_object([]) do |child_filter, res|
         child = child_filter.to_h
         child_result = {}

--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -16,9 +16,17 @@ module ChargeFilters
       end
 
       # NOTE: List of filters that we must ignore to prevent duplicated count of events
-      result.ignored_filters = children.map do |child|
-        (child.to_h.to_a - result.matching_filters.to_a).to_h
-      end.flatten.first
+      result.ignored_filters = children.each_with_object({}) do |child, res|
+        keys = (child.to_h.to_a - result.matching_filters.to_a).to_h
+
+        keys.each do |key, values|
+          res[key] ||= []
+          res[key] << values
+          res[key] = res[key].flatten.uniq
+        end
+
+        res
+      end
 
       result
     end

--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module ChargeFilters
+  class MatchingAndIgnoredService < BaseService
+    def initialize(filter:)
+      @filter = filter
+      super
+    end
+
+    def call
+      result.matching_filters = filter.to_h
+
+      children = other_filters.find_all do |f|
+        # NOTE: Check if filters contains all key/values from input filter
+        (result.matching_filters.to_a - f.to_h.to_a).empty?
+      end
+
+      # NOTE: List of filters that we must ignore to prevent duplicated count of events
+      result.ignored_filters = children.map do |child|
+        (child.to_h.to_a - result.matching_filters.to_a).to_h
+      end.flatten.first
+
+      result
+    end
+
+    private
+
+    attr_reader :filter
+
+    delegate :charge, to: :filter
+
+    def other_filters
+      @other_filters ||= charge.filters.where.not(id: filter.id)
+    end
+  end
+end

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -12,6 +12,9 @@ module Events
         @grouped_by = filters[:grouped_by]
         @grouped_by_values = filters[:grouped_by_values]
 
+        @matching_filters = filters[:matching_filters]
+        @ignored_filters = filters[:ignored_filters]
+
         @aggregation_property = nil
         @numeric_property = false
         @use_from_boundary = true
@@ -106,7 +109,7 @@ module Events
 
       protected
 
-      attr_accessor :code, :subscription, :group, :boundaries, :grouped_by_values
+      attr_accessor :code, :subscription, :group, :boundaries, :grouped_by_values, :matching_filters, :ignored_filters
 
       delegate :customer, to: :subscription
 

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -12,8 +12,8 @@ module Events
         @grouped_by = filters[:grouped_by]
         @grouped_by_values = filters[:grouped_by_values]
 
-        @matching_filters = filters[:matching_filters]
-        @ignored_filters = filters[:ignored_filters]
+        @matching_filters = filters[:matching_filters] || {}
+        @ignored_filters = filters[:ignored_filters] || {}
 
         @aggregation_property = nil
         @numeric_property = false

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -470,8 +470,8 @@ module Events
           scope = scope.where('events_raw.properties[?] = ?', key.to_s, value)
         end
 
-        ignored_filters.each do |key, value|
-          scope = scope.where.not('events_raw.properties[?] = ?', key.to_s, value)
+        ignored_filters.each do |key, values|
+          scope = scope.where('events_raw.properties[?] NOT IN (?)', key.to_s, values)
         end
 
         scope

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -466,12 +466,18 @@ module Events
       end
 
       def filters_scope(scope)
-        matching_filters.each do |key, value|
-          scope = scope.where('events_raw.properties[?] = ?', key.to_s, value)
+        matching_filters.each do |key, values|
+          scope = scope.where('events_raw.properties[?] IN ?', key.to_s, values)
         end
 
-        ignored_filters.each do |key, values|
-          scope = scope.where('events_raw.properties[?] NOT IN (?)', key.to_s, values)
+        ignored_filters.each do |filters|
+          sql = filters.map do |key, values|
+            ActiveRecord::Base.sanitize_sql_for_conditions(
+              ["(coalesce(events_raw.properties[?], '') IN (?))", key.to_s, values.map(&:to_s)],
+            )
+          end.join(' OR ')
+
+          scope = scope.where.not(sql)
         end
 
         scope

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -335,14 +335,14 @@ module Events
         matching_filters.each do |key, value|
           scope = scope.where(
             'events.properties @> ?',
-            { key.to_s => value }.to_json
+            { key.to_s => value }.to_json,
           )
         end
 
-        ignored_filters.each do |key, value|
+        ignored_filters.each do |key, values|
           scope = scope.where.not(
             'events.properties @> ?',
-            { key.to_s => value }.to_json
+            { key.to_s => values }.to_json,
           )
         end
 

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -63,12 +63,15 @@ module Fees
           init_charge_fees(properties: charge.properties, group:)
         end
       else
-        init_charge_fees(properties: charge.properties) unless charge.filters.any?
+        return init_charge_fees(properties: charge.properties) unless charge.filters.any?
 
         # NOTE: Create a fee for each filters defined on the charge.
         charge.filters.each do |charge_filter|
           init_charge_fees(properties: charge_filter.properties, charge_filter:)
         end
+
+        # NOTE: Create a fee for events not matching any filters.
+        init_charge_fees(properties: charge.properties, charge_filter: ChargeFilter.new(charge:))
       end
     end
 

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -63,20 +63,25 @@ module Fees
           init_charge_fees(properties: charge.properties, group:)
         end
       else
-        init_charge_fees(properties: charge.properties)
+        init_charge_fees(properties: charge.properties) unless charge.filters.any?
+
+        # NOTE: Create a fee for each filters defined on the charge.
+        charge.filters.each do |charge_filter|
+          init_charge_fees(properties: charge_filter.properties, charge_filter:)
+        end
       end
     end
 
-    def init_charge_fees(properties:, group: nil)
-      charge_model_result = apply_aggregation_and_charge_model(properties:, group:)
+    def init_charge_fees(properties:, group: nil, charge_filter: nil)
+      charge_model_result = apply_aggregation_and_charge_model(properties:, group:, charge_filter:)
       return result.fail_with_error!(charge_model_result.error) unless charge_model_result.success?
 
       (charge_model_result.grouped_results || [charge_model_result]).each do |amount_result|
-        init_fee(amount_result, properties:, group:)
+        init_fee(amount_result, properties:, group:, charge_filter:)
       end
     end
 
-    def init_fee(amount_result, properties:, group:)
+    def init_fee(amount_result, properties:, group:, charge_filter:)
       # NOTE: Build fee for case when there is adjusted fee and units or amount has been adjusted.
       # Base fee creation flow handles case when only name has been adjusted
       if invoice.draft? && (adjusted = adjusted_fee(
@@ -129,6 +134,7 @@ module Fees
         precise_unit_amount: amount_result.unit_amount,
         amount_details: amount_result.amount_details,
         grouped_by: amount_result.grouped_by || {},
+        charge_filter:,
       )
 
       if (adjusted = adjusted_fee(group, amount_result.grouped_by))&.adjusted_display_name?
@@ -165,8 +171,8 @@ module Fees
       result.fees << true_up_fee if true_up_fee
     end
 
-    def apply_aggregation_and_charge_model(properties:, group: nil)
-      aggregation_result = aggregator(group:).aggregate(options: options(properties))
+    def apply_aggregation_and_charge_model(properties:, group: nil, charge_filter: nil)
+      aggregation_result = aggregator(group:, charge_filter:).aggregate(options: options(properties))
       return aggregation_result unless aggregation_result.success?
 
       if billable_metric.recurring?
@@ -196,7 +202,7 @@ module Fees
       true
     end
 
-    def aggregator(group:)
+    def aggregator(group:, charge_filter:)
       BillableMetrics::AggregationFactory.new_instance(
         charge:,
         current_usage: is_current_usage,
@@ -206,7 +212,7 @@ module Fees
           to_datetime: boundaries.charges_to_datetime,
           charges_duration: boundaries.charges_duration,
         },
-        filters: aggregation_filters(group:),
+        filters: aggregation_filters(group:, charge_filter:),
       )
     end
 
@@ -234,11 +240,17 @@ module Fees
       end
     end
 
-    def aggregation_filters(group:)
+    def aggregation_filters(group:, charge_filter: nil)
       filters = { group: }
 
       if charge.standard? && charge.properties['grouped_by'].present?
         filters[:grouped_by] = charge.properties['grouped_by']
+      end
+
+      if charge_filter.present?
+        result = ChargeFilters::MatchingAndIgnoredService.call(filter: charge_filter)
+        filters[:matching_filters] = result.matching_filters
+        filters[:ignored_filters] = result.ignored_filters
       end
 
       filters

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 RSpec.describe ChargeFilters::MatchingAndIgnoredService do
   subject(:service) { described_class.call(filter: filter1) }
 
-  let(:payment_method) { create(:billable_metric_filter, key: 'payment_method', values: %i[card transfer]) }
+  let(:payment_method) do
+    create(:billable_metric_filter, key: 'payment_method', values: %i[card virtual_card transfer])
+  end
   let(:card_location) { create(:billable_metric_filter, key: 'card_location', values: %i[domestic]) }
   let(:scheme) { create(:billable_metric_filter, key: 'scheme', values: %i[visa mastercard]) }
   let(:card_type) { create(:billable_metric_filter, key: 'card_type', values: %i[credit debit]) }
@@ -13,19 +15,29 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
   let(:filter1) { create(:charge_filter) }
   let(:filter1_values) do
     [
-      create(:charge_filter_value, value: 'card', billable_metric_filter: payment_method, charge_filter: filter1),
-      create(:charge_filter_value, value: 'domestic', billable_metric_filter: card_location, charge_filter: filter1),
-      create(:charge_filter_value, value: 'visa', billable_metric_filter: scheme, charge_filter: filter1),
+      create(:charge_filter_value, values: ['card'], billable_metric_filter: payment_method, charge_filter: filter1),
+      create(:charge_filter_value, values: ['domestic'], billable_metric_filter: card_location, charge_filter: filter1),
+      create(
+        :charge_filter_value,
+        values: %w[visa mastercard],
+        billable_metric_filter: scheme,
+        charge_filter: filter1,
+      ),
     ]
   end
 
   let(:filter2) { create(:charge_filter, charge: filter1.charge) }
   let(:filter2_values) do
     [
-      create(:charge_filter_value, value: 'card', billable_metric_filter: payment_method, charge_filter: filter2),
-      create(:charge_filter_value, value: 'domestic', billable_metric_filter: card_location, charge_filter: filter2),
-      create(:charge_filter_value, value: 'visa', billable_metric_filter: scheme, charge_filter: filter2),
-      create(:charge_filter_value, value: 'credit', billable_metric_filter: card_type, charge_filter: filter2),
+      create(:charge_filter_value, values: ['card'], billable_metric_filter: payment_method, charge_filter: filter2),
+      create(:charge_filter_value, values: ['domestic'], billable_metric_filter: card_location, charge_filter: filter2),
+      create(
+        :charge_filter_value,
+        values: %w[visa mastercard],
+        billable_metric_filter: scheme,
+        charge_filter: filter2,
+      ),
+      create(:charge_filter_value, values: ['credit'], billable_metric_filter: card_type, charge_filter: filter2),
     ]
   end
 
@@ -37,14 +49,14 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
   it 'returns a formatted hash', :aggregate_failures do
     expect(service.matching_filters).to eq(
       {
-        'payment_method' => 'card',
-        'card_location' => 'domestic',
-        'scheme' => 'visa',
+        'payment_method' => ['card'],
+        'card_location' => ['domestic'],
+        'scheme' => %w[visa mastercard],
       },
     )
 
     expect(service.ignored_filters).to eq(
-      { 'card_type' => ['credit'] },
+      [{ 'card_type' => ['credit'] }],
     )
   end
 
@@ -54,14 +66,14 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     it 'returns a formatted hash', :aggregate_failures do
       expect(service.matching_filters).to eq(
         {
-          'payment_method' => 'card',
-          'card_location' => 'domestic',
-          'scheme' => 'visa',
-          'card_type' => 'credit',
+          'payment_method' => ['card'],
+          'card_location' => ['domestic'],
+          'scheme' => %w[visa mastercard],
+          'card_type' => ['credit'],
         },
       )
 
-      expect(service.ignored_filters).to eq({})
+      expect(service.ignored_filters).to eq([])
     end
   end
 
@@ -71,12 +83,66 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     it 'returns all filter values as ignored filters' do
       expect(service.matching_filters).to eq({})
       expect(service.ignored_filters).to eq(
+        [
+          {
+            'payment_method' => ['card'],
+            'card_location' => ['domestic'],
+            'scheme' => %w[visa mastercard],
+          },
+          {
+            'payment_method' => ['card'],
+            'card_location' => ['domestic'],
+            'scheme' => %w[visa mastercard],
+            'card_type' => ['credit'],
+          },
+        ],
+      )
+    end
+  end
+
+  context 'when filter has children that only match part of the values' do
+    let(:filter1_values) do
+      [
+        create(
+          :charge_filter_value,
+          values: %w[card virtual_card],
+          billable_metric_filter: payment_method,
+          charge_filter: filter1,
+        ),
+      ]
+    end
+
+    let(:filter2_values) do
+      [
+        create(
+          :charge_filter_value,
+          values: %w[card],
+          billable_metric_filter: payment_method,
+          charge_filter: filter2,
+        ),
+        create(
+          :charge_filter_value,
+          values: %w[visa],
+          billable_metric_filter: scheme,
+          charge_filter: filter2,
+        ),
+      ]
+    end
+
+    it 'returns a formatted hash', :aggregate_failures do
+      expect(service.matching_filters).to eq(
         {
-          'payment_method' => ['card'],
-          'card_location' => ['domestic'],
-          'scheme' => ['visa'],
-          'card_type' => ['credit'],
+          'payment_method' => %w[card virtual_card],
         },
+      )
+
+      expect(service.ignored_filters).to eq(
+        [
+          {
+            'payment_method' => ['card'],
+            'scheme' => ['visa'],
+          },
+        ],
       )
     end
   end

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChargeFilters::MatchingAndIgnoredService do
+  subject(:service) { described_class.call(filter: filter1) }
+
+  let(:payment_method) { create(:billable_metric_filter, key: 'payment_method', values: %i[card transfer]) }
+  let(:card_location) { create(:billable_metric_filter, key: 'card_location', values: %i[domestic]) }
+  let(:scheme) { create(:billable_metric_filter, key: 'scheme', values: %i[visa mastercard]) }
+  let(:card_type) { create(:billable_metric_filter, key: 'card_type', values: %i[credit debit]) }
+
+  let(:filter1) { create(:charge_filter) }
+  let(:filter1_values) do
+    [
+      create(:charge_filter_value, value: 'card', billable_metric_filter: payment_method, charge_filter: filter1),
+      create(:charge_filter_value, value: 'domestic', billable_metric_filter: card_location, charge_filter: filter1),
+      create(:charge_filter_value, value: 'visa', billable_metric_filter: scheme, charge_filter: filter1),
+    ]
+  end
+
+  let(:filter2) { create(:charge_filter, charge: filter1.charge) }
+  let(:filter2_values) do
+    [
+      create(:charge_filter_value, value: 'card', billable_metric_filter: payment_method, charge_filter: filter2),
+      create(:charge_filter_value, value: 'domestic', billable_metric_filter: card_location, charge_filter: filter2),
+      create(:charge_filter_value, value: 'visa', billable_metric_filter: scheme, charge_filter: filter2),
+      create(:charge_filter_value, value: 'credit', billable_metric_filter: card_type, charge_filter: filter2),
+    ]
+  end
+
+  before do
+    filter1_values
+    filter2_values
+  end
+
+  it 'returns a formatted hash', :aggregate_failures do
+    expect(service.matching_filters).to eq(
+      {
+        'payment_method' => 'card',
+        'card_location' => 'domestic',
+        'scheme' => 'visa',
+      },
+    )
+
+    expect(service.ignored_filters).to eq(
+      { 'card_type' => 'credit' },
+    )
+  end
+end

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -44,7 +44,40 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     )
 
     expect(service.ignored_filters).to eq(
-      { 'card_type' => 'credit' },
+      { 'card_type' => ['credit'] },
     )
+  end
+
+  context 'when filter does not have children' do
+    subject(:service) { described_class.call(filter: filter2) }
+
+    it 'returns a formatted hash', :aggregate_failures do
+      expect(service.matching_filters).to eq(
+        {
+          'payment_method' => 'card',
+          'card_location' => 'domestic',
+          'scheme' => 'visa',
+          'card_type' => 'credit',
+        },
+      )
+
+      expect(service.ignored_filters).to eq({})
+    end
+  end
+
+  context 'when provided filter is empty' do
+    subject(:service) { described_class.call(filter: ChargeFilter.new(charge: filter1.charge)) }
+
+    it 'returns all filter values as ignored filters' do
+      expect(service.matching_filters).to eq({})
+      expect(service.ignored_filters).to eq(
+        {
+          'payment_method' => ['card'],
+          'card_location' => ['domestic'],
+          'scheme' => ['visa'],
+          'card_type' => ['credit'],
+        },
+      )
+    end
   end
 end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -60,9 +60,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
         end
       end
 
-      if i.zero?
-        ignored_filters.each { |key, value| properties[key] = value }
-      end
+      ignored_filters.each { |key, values| properties[key] = values.first } if i.zero?
 
       events << Clickhouse::EventsRaw.create!(
         transaction_id: SecureRandom.uuid,
@@ -117,7 +115,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
     context 'with filters' do
       let(:matching_filters) { { 'region' => 'europe', 'country' => 'france' } }
-      let(:ignored_filters) { { 'city' => 'paris' } }
+      let(:ignored_filters) { { 'city' => ['paris'] } }
 
       it 'returns a list of events' do
         expect(event_store.events.count).to eq(2) # 1st event is ignored

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
 
     context 'with filters' do
       let(:matching_filters) { { 'region' => 'europe', 'country' => 'france' } }
-      let(:ignored_filters) { { 'city' => 'paris' } }
+      let(:ignored_filters) { { 'city' => ['paris'] } }
 
       it 'returns a list of events' do
         expect(event_store.events.count).to eq(2) # 1st event is ignored

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -1590,17 +1590,17 @@ RSpec.describe Fees::ChargeService do
 
       let(:filter1) { create(:charge_filter, charge:, properties: { amount: '20' }) }
       let(:filter1_values) do
-        [create(:charge_filter_value, value: 'europe', billable_metric_filter: region, charge_filter: filter1)]
+        [create(:charge_filter_value, values: ['europe'], billable_metric_filter: region, charge_filter: filter1)]
       end
 
       let(:filter2) { create(:charge_filter, charge:, properties: { amount: '50' }) }
       let(:filter2_values) do
-        [create(:charge_filter_value, value: 'usa', billable_metric_filter: region, charge_filter: filter2)]
+        [create(:charge_filter_value, values: ['usa'], billable_metric_filter: region, charge_filter: filter2)]
       end
 
       let(:filter3) { create(:charge_filter, charge:, properties: { amount: '10.12345' }) }
       let(:filter3_values) do
-        [create(:charge_filter_value, value: 'france', billable_metric_filter: country, charge_filter: filter3)]
+        [create(:charge_filter_value, values: ['france'], billable_metric_filter: country, charge_filter: filter3)]
       end
 
       let(:charge) do

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -1584,6 +1584,116 @@ RSpec.describe Fees::ChargeService do
       end
     end
 
+    context 'with filters' do
+      let(:region) { create(:billable_metric_filter, key: 'region', values: %i[europe usa]) }
+      let(:country) { create(:billable_metric_filter, key: 'country', values: %i[france]) }
+
+      let(:filter1) { create(:charge_filter, charge:, properties: { amount: '20' }) }
+      let(:filter1_values) do
+        [create(:charge_filter_value, value: 'europe', billable_metric_filter: region, charge_filter: filter1)]
+      end
+
+      let(:filter2) { create(:charge_filter, charge:, properties: { amount: '50' }) }
+      let(:filter2_values) do
+        [create(:charge_filter_value, value: 'usa', billable_metric_filter: region, charge_filter: filter2)]
+      end
+
+      let(:filter3) { create(:charge_filter, charge:, properties: { amount: '10.12345' }) }
+      let(:filter3_values) do
+        [create(:charge_filter_value, value: 'france', billable_metric_filter: country, charge_filter: filter3)]
+      end
+
+      let(:charge) do
+        create(
+          :standard_charge,
+          plan: subscription.plan,
+          billable_metric:,
+          properties: { amount: '10.12345' },
+        )
+      end
+
+      before do
+        filter1_values
+        filter2_values
+        filter3_values
+
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription:,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'usa' },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription:,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe' },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription:,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { region: 'europe' },
+        )
+        create(
+          :event,
+          organization: subscription.organization,
+          customer: subscription.customer,
+          subscription:,
+          code: charge.billable_metric.code,
+          timestamp: DateTime.parse('2022-03-16'),
+          properties: { country: 'france' },
+        )
+      end
+
+      it 'creates expected fees' do
+        result = charge_subscription_service.create
+        expect(result).to be_success
+        created_fees = result.fees
+
+        aggregate_failures do
+          expect(created_fees.count).to eq(3)
+          expect(created_fees).to all(
+            have_attributes(
+              invoice_id: invoice.id,
+              charge_id: charge.id,
+              amount_currency: 'EUR',
+            ),
+          )
+
+          expect(created_fees.find { |f| f.charge_filter_id == filter1.id }).to have_attributes(
+            amount_cents: 4000,
+            units: 2,
+            unit_amount_cents: 2000,
+            precise_unit_amount: 20,
+          )
+
+          expect(created_fees.find { |f| f.charge_filter_id == filter2.id }).to have_attributes(
+            amount_cents: 5000,
+            units: 1,
+            unit_amount_cents: 5000,
+            precise_unit_amount: 50,
+          )
+
+          expect(created_fees.find { |f| f.charge_filter_id == filter3.id }).to have_attributes(
+            amount_cents: 1012,
+            units: 1,
+            unit_amount_cents: 1012,
+            precise_unit_amount: 10.12345,
+          )
+        end
+      end
+    end
+
     context 'with aggregation error' do
       let(:billable_metric) do
         create(


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds back the aggregation logic for filters