### PR TITLE
feat(filter): Accept multiple values on a charge_filter_value

### DIFF
--- a/app/graphql/types/charge_filters/values.rb
+++ b/app/graphql/types/charge_filters/values.rb
@@ -6,8 +6,8 @@ module Types
       graphql_name 'ChargeFilterValues'
 
       def self.coerce_input(input_value, _context)
-        input_value.to_h.each_with_object({}) do |(key, value), result|
-          result[key.to_s] = value.to_s
+        input_value.to_h.each_with_object({}) do |(key, values), result|
+          result[key.to_s] = values&.map(&:to_s) || []
         end
       rescue StandardError
         raise GraphQL::CoercionError, "#{input_value.inspect} is not a valid hash object"

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -16,12 +16,12 @@ class ChargeFilter < ApplicationRecord
   default_scope -> { kept }
 
   def display_name
-    invoice_display_name.presence || values.map(&:value).join(', ')
+    invoice_display_name.presence || values.map(&:values).flatten.join(', ')
   end
 
   def to_h
     values.each_with_object({}) do |filter_value, result|
-      result[filter_value.billable_metric_filter.key] = filter_value.value
+      result[filter_value.billable_metric_filter.key] = filter_value.values
     end
   end
 

--- a/app/models/charge_filter_value.rb
+++ b/app/models/charge_filter_value.rb
@@ -5,22 +5,26 @@ class ChargeFilterValue < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
-  MATCH_ALL_FILTER_VALUES = '__LAGO_MATCH_ALL_FILTER_VALUES__'
+  MATCH_ALL_FILTER_VALUES = '__MATCH_ALL_FILTER_VALUES__'
 
   belongs_to :charge_filter
   belongs_to :billable_metric_filter
 
-  validates :value, presence: true
-  validate :validate_value
+  validates :values, presence: true
+  validate :validate_values
 
   default_scope -> { kept }
 
+  delegate :key, to: :billable_metric_filter
+
   private
 
-  def validate_value
-    return if value == MATCH_ALL_FILTER_VALUES
-    return if billable_metric_filter&.values&.include?(value) # rubocop:disable Performance/InefficientHashSearch
+  def validate_values
+    unless values.nil?
+      return if values.count == 1 && values.first == MATCH_ALL_FILTER_VALUES
+      return if values.all? { billable_metric_filter&.values&.include?(_1) } # rubocop:disable Performance/InefficientHashSearch
+    end
 
-    errors.add(:value, :inclusion)
+    errors.add(:values, :inclusion)
   end
 end

--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -27,7 +27,7 @@ module BillableMetricFilters
 
             filter_values = filter.filter_values
               .where(billable_metric_filter_id: filter.id)
-              .where(value: deleted_values)
+              .where(values: deleted_values)
 
             filter_values.each { discard_filter_value(_1) }
           end

--- a/db/migrate/20240314163426_add_multiple_values_to_charge_filter_values.rb
+++ b/db/migrate/20240314163426_add_multiple_values_to_charge_filter_values.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddMultipleValuesToChargeFilterValues < ActiveRecord::Migration[7.0]
+  def up
+    change_table :charge_filter_values, bulk: true do |t|
+      t.remove :value
+      t.string :values, array: true, default: [], null: false
+    end
+  end
+
+  def down
+    change_table :charge_filter_values, bulk: true do |t|
+      t.remove :values
+      t.string :value, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_12_141641) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_14_163426) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -183,10 +183,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_12_141641) do
   create_table "charge_filter_values", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "charge_filter_id", null: false
     t.uuid "billable_metric_filter_id", null: false
-    t.string "value", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.string "values", default: [], null: false, array: true
     t.index ["billable_metric_filter_id"], name: "index_charge_filter_values_on_billable_metric_filter_id"
     t.index ["charge_filter_id"], name: "index_charge_filter_values_on_charge_filter_id"
     t.index ["deleted_at"], name: "index_charge_filter_values_on_deleted_at"

--- a/spec/factories/charge_filter_values.rb
+++ b/spec/factories/charge_filter_values.rb
@@ -8,6 +8,6 @@ FactoryBot.define do
 
     charge_filter
     billable_metric_filter_id { billable_metric_filter.id }
-    value { billable_metric_filter.values.sample }
+    values { [billable_metric_filter.values.sample] }
   end
 end

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
       :billable_metric_filter,
       billable_metric: billable_metrics[0],
       key: 'payment_method',
-      values: %w[card physical],
+      values: %w[card sepa],
     )
   end
 
@@ -125,7 +125,7 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
                 {
                   invoiceDisplayName: 'Payment Method',
                   properties: { amount: '100.00' },
-                  values: { billable_metric_filter.key => 'card' },
+                  values: { billable_metric_filter.key => %w[card sepa] },
                 },
               ],
             },
@@ -249,7 +249,7 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
       filter = standard_charge['filters'].first
       expect(filter['invoiceDisplayName']).to eq('Payment Method')
       expect(filter['properties']['amount']).to eq('100.00')
-      expect(filter['values']).to eq('payment_method' => 'card')
+      expect(filter['values']).to eq('payment_method' => %w[card sepa])
 
       package_charge = result_data['charges'][1]
       expect(package_charge['chargeModel']).to eq('package')

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -327,8 +327,8 @@ RSpec.describe ChargeFilter, type: :model do
     let(:invoice_display_name) { Faker::Fantasy::Tolkien.character }
     let(:values) do
       [
-        build(:charge_filter_value, value: 'card'),
-        build(:charge_filter_value, value: 'visa'),
+        build(:charge_filter_value, values: ['card']),
+        build(:charge_filter_value, values: ['visa']),
       ]
     end
 
@@ -352,16 +352,16 @@ RSpec.describe ChargeFilter, type: :model do
     let(:scheme) { create(:billable_metric_filter, key: 'scheme') }
     let(:values) do
       [
-        build(:charge_filter_value, value: 'credit', billable_metric_filter: card),
-        build(:charge_filter_value, value: 'visa', billable_metric_filter: scheme),
+        build(:charge_filter_value, values: ['credit'], billable_metric_filter: card),
+        build(:charge_filter_value, values: ['visa'], billable_metric_filter: scheme),
       ]
     end
 
     it 'returns the values as a hash' do
       expect(charge_filter.to_h).to eq(
         {
-          'card' => 'credit',
-          'scheme' => 'visa',
+          'card' => ['credit'],
+          'scheme' => ['visa'],
         },
       )
     end

--- a/spec/models/charge_filter_value_spec.rb
+++ b/spec/models/charge_filter_value_spec.rb
@@ -10,29 +10,38 @@ RSpec.describe ChargeFilterValue, type: :model do
   it { is_expected.to belong_to(:charge_filter) }
   it { is_expected.to belong_to(:billable_metric_filter) }
 
-  it { is_expected.to validate_presence_of(:value) }
+  it { is_expected.to validate_presence_of(:values) }
 
-  describe '#valdiate_value' do
+  describe '#valdiate_values' do
     subject(:charge_filter_value) do
-      build(:charge_filter_value, billable_metric_filter:, value:)
+      build(:charge_filter_value, billable_metric_filter:, values:)
     end
 
     let(:billable_metric_filter) { create(:billable_metric_filter) }
-    let(:value) { billable_metric_filter.values.first }
+    let(:values) { [billable_metric_filter.values.first] }
 
     it { expect(charge_filter_value).to be_valid }
 
     context 'when value is not included in billable_metric_filter values' do
-      let(:value) { 'invalid_value' }
+      let(:values) { ['invalid_value'] }
 
       it do
         expect(charge_filter_value).to be_invalid
-        expect(charge_filter_value.errors[:value]).to include('value_is_invalid')
+        expect(charge_filter_value.errors[:values]).to include('value_is_invalid')
+      end
+    end
+
+    context 'when values are empty' do
+      let(:values) { [] }
+
+      it do
+        expect(charge_filter_value).to be_invalid
+        expect(charge_filter_value.errors[:values]).to include('value_is_mandatory')
       end
     end
 
     context 'when value is MATCH_ALL_FILTER_VALUES' do
-      let(:value) { ChargeFilterValue::MATCH_ALL_FILTER_VALUES }
+      let(:values) { [ChargeFilterValue::MATCH_ALL_FILTER_VALUES] }
 
       it { expect(charge_filter_value).to be_valid }
     end

--- a/spec/serializers/v1/charge_filter_serializer_spec.rb
+++ b/spec/serializers/v1/charge_filter_serializer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ::V1::ChargeFilterSerializer do
       :charge_filter_value,
       charge_filter:,
       billable_metric_filter: filter,
-      value: filter.values.first,
+      values: [filter.values.first],
     )
   end
 
@@ -27,7 +27,7 @@ RSpec.describe ::V1::ChargeFilterSerializer do
       expect(result['filter']['properties']).to eq(charge_filter.properties)
       expect(result['filter']['values']).to eq(
         {
-          filter.key => filter_value.value,
+          filter.key => filter_value.values,
         },
       )
     end

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
           :charge_filter_value,
           charge_filter:,
           billable_metric_filter: filter,
-          value: filter.values.first,
+          values: [filter.values.first],
         )
       end
 
@@ -106,7 +106,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
         create(
           :charge_filter_value,
           billable_metric_filter: filter,
-          value: 'US',
+          values: ['US'],
         )
       end
 

--- a/spec/services/charges/override_service_spec.rb
+++ b/spec/services/charges/override_service_spec.rb
@@ -128,13 +128,13 @@ RSpec.describe Charges::OverrideService, type: :service do
               :charge_filter_value,
               charge_filter: filters.first,
               billable_metric_filter:,
-              value: billable_metric_filter.values.first,
+              values: [billable_metric_filter.values.first],
             ),
             create(
               :charge_filter_value,
               charge_filter: filters.second,
               billable_metric_filter:,
-              value: billable_metric_filter.values.second,
+              values: [billable_metric_filter.values.second],
             ),
           ]
         end
@@ -150,7 +150,7 @@ RSpec.describe Charges::OverrideService, type: :service do
               {
                 properties: { amount: '10' },
                 invoice_display_name: 'invoice display name',
-                values: { billable_metric_filter.key => billable_metric_filter.values.first },
+                values: { billable_metric_filter.key => [billable_metric_filter.values.first] },
               },
             ],
           }
@@ -174,7 +174,7 @@ RSpec.describe Charges::OverrideService, type: :service do
           expect(charge.filters.first.values.count).to eq(1)
           expect(charge.filters.first.values.first).to have_attributes(
             billable_metric_filter_id: billable_metric_filter.id,
-            value: billable_metric_filter.values.first,
+            values: [billable_metric_filter.values.first],
           )
         end
       end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Plans::CreateService, type: :service do
           ],
           filters: [
             {
-              values: { billable_metric_filter.key => 'card' },
+              values: { billable_metric_filter.key => ['card'] },
               invoice_display_name: 'Card filter',
               properties: { amount: '90' },
             },
@@ -142,7 +142,7 @@ RSpec.describe Plans::CreateService, type: :service do
       )
       expect(standard_charge.filters.first.values.first).to have_attributes(
         billable_metric_filter_id: billable_metric_filter.id,
-        value: 'card',
+        values: ['card'],
       )
 
       expect(graduated_charge).to have_attributes(pay_in_advance: true, invoiceable: true, prorated: false)

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe Plans::UpdateService, type: :service do
                 {
                   invoice_display_name: 'Card filter',
                   properties: { amount: '90' },
-                  values: { billable_metric_filter.key => 'card' },
+                  values: { billable_metric_filter.key => ['card'] },
                 },
               ],
             },
@@ -587,7 +587,7 @@ RSpec.describe Plans::UpdateService, type: :service do
         )
         expect(existing_charge.filters.first.values.first).to have_attributes(
           billable_metric_filter_id: billable_metric_filter.id,
-          value: 'card',
+          values: ['card'],
         )
       end
 


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR turns `change_filter_values#value` into `change_filter_values#values` to accept multiple values for a single filter.