### PR TITLE
fix (date-boundaries): yearly plan boundaries for anniversary interval were incorrect

### DIFF
--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -103,7 +103,7 @@ module Subscriptions
 
       def period_started_in_last_year?(date)
         return true if date.month < subscription_at.month
-        return true if (date.month == subscription_at.month) && (subscription_at.day > date.day)
+        return true if (date.month == subscription_at.month) && (date.day < subscription_at.day)
 
         false
       end

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -102,8 +102,8 @@ module Subscriptions
       end
 
       def period_started_in_last_year?(date)
-        return true if (date.month < subscription_at.month)
-        return true if (date.month == subscription_at.month)  && (subscription_at.day > date.day)
+        return true if date.month < subscription_at.month
+        return true if (date.month == subscription_at.month) && (subscription_at.day > date.day)
 
         false
       end

--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -78,7 +78,7 @@ module Subscriptions
       end
 
       def previous_anniversary_day(date)
-        year = (date.month < subscription_at.month) ? (date.year - 1) : date.year
+        year = period_started_in_last_year?(date) ? (date.year - 1) : date.year
         month = subscription_at.month
         day = subscription_at.day
 
@@ -99,6 +99,13 @@ module Subscriptions
         return monthly_service.compute_charges_duration(from_date:) if plan.bill_charges_monthly
 
         compute_duration(from_date:)
+      end
+
+      def period_started_in_last_year?(date)
+        return true if (date.month < subscription_at.month)
+        return true if (date.month == subscription_at.month)  && (subscription_at.day > date.day)
+
+        false
       end
     end
   end

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
-  subject(:date_service) { described_class.new(subscription, billing_at, false) }
+  subject(:date_service) { described_class.new(subscription, billing_at, current_usage) }
 
   let(:subscription) do
     create(
@@ -19,6 +19,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
   let(:customer) { create(:customer, timezone:) }
   let(:plan) { create(:plan, interval: :yearly, pay_in_advance:) }
   let(:pay_in_advance) { false }
+  let(:current_usage) { false }
 
   let(:subscription_at) { DateTime.parse('02 Feb 2021') }
   let(:billing_at) { DateTime.parse('07 Mar 2022') }
@@ -86,6 +87,16 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
 
       it 'returns the previous year day and month' do
         expect(result).to eq('2021-02-02 00:00:00 UTC')
+      end
+
+      context 'when current usage is true and current month is the same as starting month' do
+        let(:current_usage) { true }
+        let(:subscription_at) { DateTime.parse('29 Mar 2023') }
+        let(:billing_at) { DateTime.parse('15 Mar 2024') }
+
+        it 'returns the previous year day and month' do
+          expect(result).to eq('2023-03-29 00:00:00 UTC')
+        end
       end
 
       context 'when date is before the start date' do


### PR DESCRIPTION
## Context

For current usage, when interval is `anniversary` and plan is `yearly`, we haven't calculated boundaries correctly.

## Description

This fix handles logic for finding starting boundary for yearly plan when interval is anniversary.
