### PR TITLE
misc: Replace each with find_each in plan and customer delete services

### DIFF
--- a/app/services/coupons/destroy_service.rb
+++ b/app/services/coupons/destroy_service.rb
@@ -14,7 +14,7 @@ module Coupons
         coupon.discard!
         coupon.coupon_targets.discard_all
 
-        coupon.applied_coupons.active.each do |applied_coupon|
+        coupon.applied_coupons.active.find_each do |applied_coupon|
           AppliedCoupons::TerminateService.call(applied_coupon:)
         end
       end

--- a/app/services/customers/terminate_relations_service.rb
+++ b/app/services/customers/terminate_relations_service.rb
@@ -11,21 +11,23 @@ module Customers
       return result.not_found_failure!(resource: 'customer') unless customer
 
       # NOTE: Terminate active subscriptions.
-      customer.subscriptions.active.each do |subscription|
+      customer.subscriptions.active.find_each do |subscription|
         Subscriptions::TerminateService.call(subscription:, async: false)
       end
 
       # NOTE: Cancel pending subscriptions
-      customer.subscriptions.pending.each(&:mark_as_canceled!)
+      customer.subscriptions.pending.find_each(&:mark_as_canceled!)
 
       # NOTE: Finalize all draft invoices.
-      customer.invoices.draft.each { |invoice| Invoices::FinalizeService.call(invoice:) }
+      customer.invoices.draft.find_each { |invoice| Invoices::FinalizeService.call(invoice:) }
 
       # NOTE: Terminate applied coupons
-      customer.applied_coupons.active.each { |applied_coupon| AppliedCoupons::TerminateService.call(applied_coupon:) }
+      customer.applied_coupons.active.find_each do |applied_coupon|
+        AppliedCoupons::TerminateService.call(applied_coupon:)
+      end
 
       # NOTE: Terminate wallets
-      customer.wallets.active.each { |wallet| Wallets::TerminateService.call(wallet:) }
+      customer.wallets.active.find_each { |wallet| Wallets::TerminateService.call(wallet:) }
 
       result.customer = customer
       result

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -11,7 +11,7 @@ module Plans
       return result.not_found_failure!(resource: 'plan') unless plan
 
       # NOTE: Terminate active subscriptions.
-      plan.subscriptions.active.each do |subscription|
+      plan.subscriptions.active.find_each do |subscription|
         Subscriptions::TerminateService.call(subscription:, async: false)
       end
 
@@ -20,7 +20,7 @@ module Plans
 
       # NOTE: Finalize all draft invoices.
       invoices = Invoice.draft.joins(:plans).where(plans: { id: plan.id }).distinct
-      invoices.each { |invoice| Invoices::FinalizeService.call(invoice:) }
+      invoices.find_each { |invoice| Invoices::FinalizeService.call(invoice:) }
 
       plan.pending_deletion = false
       plan.discard!


### PR DESCRIPTION
## Context

This PR intends to replace some calls to `each` with `find_each` when looping over DB resources in Plans and Customers deletion services, in order to reduce the memory usage when dealing with a lot of resources.