### PR TITLE
fix(subscription-boundaries): adapt charges boundaries for upgrade case

### DIFF
--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -102,11 +102,7 @@ module BillableMetrics
       #       we want to bill the persisted metrics at prorata of the full period duration.
       #       ie: the number of day of the terminated period divided by number of days without termination
       def persisted_pro_rata
-        Utils::DatetimeService.date_diff_with_timezone(
-          from_datetime,
-          to_datetime,
-          subscription.customer.applicable_timezone,
-        ).fdiv(period_duration)
+        subscription.date_diff_with_timezone(from_datetime, to_datetime).fdiv(period_duration)
       end
 
       attr_accessor :options

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -71,27 +71,14 @@ module Subscriptions
         datetime = new_datetime if ((datetime.in_time_zone - new_datetime.in_time_zone) / 1.hour).abs < 26
       end
 
-      if datetime < subscription.started_at
-        datetime = subscription.started_at
-
-        if subscription.previous_subscription&.terminated? && subscription.previous_subscription&.upgraded?
-          datetime = datetime.in_time_zone(customer.applicable_timezone).beginning_of_day.utc
-        end
-      end
+      datetime = subscription.started_at if datetime < subscription.started_at
 
       datetime
     end
 
     def charges_to_datetime
       datetime = customer_timezone_shift(compute_charges_to_date, end_of_day: true)
-      if subscription.terminated? && datetime > subscription.terminated_at
-        datetime = subscription.terminated_at
-
-        if subscription.upgraded?
-          new_datetime = customer_timezone_shift(datetime - 1.day, end_of_day: true)
-          datetime = (new_datetime < charges_from_datetime) ? charges_from_datetime : new_datetime
-        end
-      end
+      datetime = subscription.terminated_at if subscription.terminated? && datetime > subscription.terminated_at
 
       datetime
     end

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -609,9 +609,8 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             invoice = subscription.invoices.order(created_at: :desc).first
             expect(invoice.fees.charge_kind.count).to eq(1)
 
-            # NOTE: the charges from the termination day will be billed on the upgraded subscription
-            # 30226 (16 / 31 * 75 units) + 2.58 (1 / 31 * 20 units - prorated event in termination period)
-            expect(invoice.total_amount_cents).to eq(27_194)
+            # 30226 (17 / 31 * 75 units) + 2.58 (2 / 31 * 20 units - prorated event in termination period)
+            expect(invoice.total_amount_cents).to eq(27_323)
           end
 
           travel_to(DateTime.new(2023, 11, 1)) do

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -606,8 +606,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         credit_note = customer.credit_notes.first
 
         expect(credit_note.credit_amount_cents).to eq(1_800)
-        # NOTE: the charges from the termination day will be billed on the upgraded subscription
-        expect(invoice.total_amount_cents).to eq(18_000 + 172 - 1_800) # 10/29 x 500 = 172
+        expect(invoice.total_amount_cents).to eq(18_000 + 190 - 1_800) # 11/29 x 500 = 172
       end
 
       travel_to(DateTime.new(2024, 3, 1, 12, 12)) do
@@ -695,8 +694,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
 
         terminated_invoice = subscription.invoices.order(created_at: :desc).first
 
-        # NOTE: the charges from the termination day will be billed on the upgraded subscription
-        expect(terminated_invoice.total_amount_cents).to eq((1_100 + (10.fdiv(29) * 500)).round) # 11 + 10/29 x 5
+        expect(terminated_invoice.total_amount_cents).to eq((1_100 + (11.fdiv(29) * 500)).round) # 11 + 10/29 x 5
       end
 
       travel_to(DateTime.new(2024, 3, 1, 12, 12)) do
@@ -706,6 +704,135 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
         invoice = customer.subscriptions.active.first.invoices.order(created_at: :desc).first
 
         expect(invoice.total_amount_cents).to eq((18_000 + (18.fdiv(29) * 500)).round)
+      end
+    end
+  end
+
+  context 'when pay in arrear plan events are ingested on the plan change date' do
+    let(:customer) { create(:customer, organization:) }
+    let(:plan) { create(:plan, organization:, amount_cents: 0, pay_in_advance: false) }
+    let(:plan_new) { create(:plan, organization:, amount_cents: 0, pay_in_advance: false) }
+    let(:tax) { create(:tax, organization:, rate: 0) }
+    let(:metric) do
+      create(:billable_metric, organization:, aggregation_type: 'sum_agg', recurring: false, field_name: 'amount')
+    end
+
+    it 'bills fees correctly' do
+      travel_to(DateTime.new(2024, 1, 10, 6, 20)) do
+        create(
+          :standard_charge,
+          plan:,
+          billable_metric: metric,
+          pay_in_advance: false,
+          prorated: false,
+          properties: { amount: '0' },
+        )
+
+        create(
+          :standard_charge,
+          plan: plan_new,
+          billable_metric: metric,
+          pay_in_advance: false,
+          prorated: false,
+          properties: { amount: '1' },
+        )
+
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+            billing_time: 'anniversary',
+          },
+        )
+      end
+
+      subscription = customer.subscriptions.first
+
+      travel_to(DateTime.new(2024, 1, 10, 8, 20)) do
+        create_event(
+          {
+            code: metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: { amount: '10' },
+          },
+        )
+
+        fetch_current_usage(customer:, subscription:)
+        expect(json[:customer_usage][:amount_cents].round(2)).to eq(0)
+        expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(0)
+        expect(json[:customer_usage][:charges_usage][0][:units]).to eq('10.0')
+      end
+
+      travel_to(DateTime.new(2024, 1, 10, 8, 30)) do
+        expect {
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan_new.code,
+              billing_time: 'anniversary',
+            },
+          )
+          perform_all_enqueued_jobs
+        }.to change { subscription.reload.status }.from('active').to('terminated')
+          .and change { customer.invoices.count }.from(0).to(1)
+
+        terminated_invoice = subscription.invoices.order(created_at: :desc).first
+        active_subscription = customer.reload.subscriptions.active.order(created_at: :desc).first
+
+        expect(terminated_invoice.total_amount_cents).to eq(0)
+
+        fetch_current_usage(customer:, subscription: active_subscription)
+        expect(json[:customer_usage][:amount_cents].round(2)).to eq(0)
+        expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(0)
+        expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.0')
+      end
+
+      active_subscription = customer.subscriptions.active.first
+
+      travel_to(DateTime.new(2024, 1, 10, 8, 35)) do
+        create_event(
+          {
+            code: metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: active_subscription.external_id,
+            properties: { amount: '10000' },
+          },
+        )
+
+        fetch_current_usage(customer:, subscription:)
+        expect(json[:customer_usage][:amount_cents].round(2)).to eq(1_000_000)
+        expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(1_000_000)
+        expect(json[:customer_usage][:charges_usage][0][:units]).to eq('10000.0')
+      end
+
+      travel_to(DateTime.new(2024, 1, 10, 8, 40)) do
+        expect {
+          create_subscription(
+            {
+              external_customer_id: customer.external_id,
+              external_id: customer.external_id,
+              plan_code: plan.code,
+              billing_time: 'anniversary',
+            },
+          )
+          perform_all_enqueued_jobs
+        }.to change { active_subscription.reload.status }.from('active').to('terminated')
+          .and change { customer.invoices.count }.from(1).to(2)
+
+        terminated_invoice = active_subscription.invoices.order(created_at: :desc).first
+        active_subscription = customer.reload.subscriptions.active.order(created_at: :desc).first
+
+        expect(terminated_invoice.total_amount_cents).to eq(1_000_000)
+
+        fetch_current_usage(customer:, subscription: active_subscription)
+        expect(json[:customer_usage][:amount_cents].round(2)).to eq(0)
+        expect(json[:customer_usage][:total_amount_cents].round(2)).to eq(0)
+        expect(json[:customer_usage][:charges_usage][0][:units]).to eq('0.0')
       end
     end
   end

--- a/spec/scenarios/subscriptions/upgrade_spec.rb
+++ b/spec/scenarios/subscriptions/upgrade_spec.rb
@@ -104,7 +104,7 @@ describe 'Subscription Upgrade Scenario', :scenarios, type: :request, transactio
       expect(subscription.invoice_subscriptions.order(created_at: :desc).first.charges_from_datetime.iso8601)
         .to eq('2023-08-29T00:00:00Z')
       expect(subscription.invoice_subscriptions.order(created_at: :desc).first.charges_to_datetime.iso8601)
-        .to eq('2023-09-27T23:59:59Z')
+        .to eq('2023-09-28T05:00:00Z')
 
       new_subscription = customer.subscriptions.order(created_at: :asc).last
       expect(new_subscription.plan.code).to eq(yearly_plan.code)

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -373,7 +373,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         end
 
         it 'returns the beginning of the start date' do
-          expect(result).to eq(subscription.started_at.beginning_of_day.utc.to_s)
+          expect(result).to eq(subscription.started_at.utc.to_s) # boundary should be terminated_at
         end
       end
     end
@@ -443,8 +443,8 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
             )
           end
 
-          it 'returns the previous end of day' do
-            expect(result).to eq((subscription.terminated_at - 1.day).end_of_day.to_s)
+          it 'returns the terminated_at' do
+            expect(result).to eq(subscription.terminated_at.to_s)
           end
 
           context 'when end of previous day is before charges_from_datetime' do
@@ -452,7 +452,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
             let(:terminated_at) { Time.zone.parse('2022-03-06T12:23:00') }
 
             it 'returns the charges_from_datetime' do
-              expect(result).to eq(subscription.started_at.to_s)
+              expect(result).to eq(subscription.terminated_at.to_s)
             end
           end
         end


### PR DESCRIPTION
## Context

When performing upgrade, we want the boundary for charges to be `terminated_at`.

## Description

Last month we implemented the new logic where the upgrade day is billed with the next subscription. However, we found few other edge cases that does not work with the new logic so we decided to have the old logic for calculating boundaries upon the upgrade.
