### PR TITLE
feat(filter): Pay in advance aggregation support

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -11,6 +11,7 @@ module BillableMetrics
 
         @filters = filters
         @group = filters[:group]
+        @charge_filter = filters[:charge_filter]
         @event = filters[:event]
         @grouped_by = filters[:grouped_by]
         @grouped_by_values = filters[:grouped_by_values]
@@ -49,6 +50,7 @@ module BillableMetrics
                     :subscription,
                     :filters,
                     :group,
+                    :charge_filter,
                     :event,
                     :boundaries,
                     :grouped_by,

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -145,6 +145,7 @@ module BillableMetrics
 
         query = query.where.not(event_id: event.id) if event.present?
         query = query.where(group_id: group.id) if group
+        query = query.where(charge_filter_id: charge_filter.id) if charge_filter
 
         query.first
       end

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -134,6 +134,7 @@ module BillableMetrics
 
         query = query.where.not(event_id: event.id) if event.present?
         query = query.where(group_id: group.id) if group
+        query = query.where(charge_filter_id: charge_filter.id) if charge_filter
 
         query.first
       end

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -77,6 +77,7 @@ module BillableMetrics
       def latest_value
         return @latest_value if @latest_value
 
+        # TODO: Should be moved to CachedAggregation
         quantified_events = QuantifiedEvent
           .where(billable_metric_id: billable_metric.id)
           .where(organization_id: billable_metric.organization_id)
@@ -86,6 +87,7 @@ module BillableMetrics
           .order(added_at: :desc)
 
         quantified_events = quantified_events.where(group_id: group.id) if group
+        quantified_events = quantified_events.where(charge_filter_id: charge_filter.id) if charge_filter
         quantified_event = quantified_events.first
 
         if quantified_event
@@ -116,6 +118,7 @@ module BillableMetrics
       def grouped_latest_values
         return @grouped_latest_values if @grouped_latest_values
 
+        # TODO: Should be moved to CachedAggregation
         quantified_events = QuantifiedEvent
           .where(billable_metric_id: billable_metric.id)
           .where(organization_id: billable_metric.organization_id)
@@ -128,6 +131,7 @@ module BillableMetrics
         end
 
         quantified_events = quantified_events.where(group_id: group.id) if group
+        quantified_events = quantified_events.where(charge_filter_id: charge_filter.id) if charge_filter
 
         if quantified_events.all.any?
           return @grouped_latest_values = quantified_events.map do |quantified_event|

--- a/app/services/charge_filters/event_matching_service.rb
+++ b/app/services/charge_filters/event_matching_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ChargeFilters
+  class EventMatchingService < BaseService
+    def initialize(charge:, event:)
+      @charge = charge
+      @event = event
+
+      super
+    end
+
+    def call
+      # NOTE: Find all filters matching event properties
+      matching_filters = filters.all.select do |filter|
+        filter.to_h.all? do |key, values|
+          applicable_event_properties.key?(key) && applicable_event_properties[key].in?(values)
+        end
+      end
+
+      # NOTE: An event could match multiple filters,
+      #       but we must take only the one matching the most properties
+      result.charge_filter = matching_filters.max_by { |filter| filter.to_h.keys.size }
+      result
+    end
+
+    private
+
+    attr_reader :charge, :event
+
+    # NOTE: Exclude event properties not matching a billable metric filter
+    def applicable_event_properties
+      @applicable_event_properties ||= event.properties.slice(*charge.billable_metric.filters.pluck(:key))
+    end
+
+    def filters
+      charge.filters.includes(values: :billable_metric_filter)
+    end
+  end
+end

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -13,7 +13,7 @@ module Events
         @grouped_by_values = filters[:grouped_by_values]
 
         @matching_filters = filters[:matching_filters] || {}
-        @ignored_filters = filters[:ignored_filters] || {}
+        @ignored_filters = filters[:ignored_filters] || []
 
         @aggregation_property = nil
         @numeric_property = false

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -182,6 +182,7 @@ module Fees
         persist_recurring_value(
           aggregation_result.aggregations || [aggregation_result],
           group,
+          charge_filter,
         )
       end
 
@@ -219,7 +220,7 @@ module Fees
       )
     end
 
-    def persist_recurring_value(aggregation_results, group)
+    def persist_recurring_value(aggregation_results, group, charge_filter)
       return if is_current_usage
 
       # NOTE: Only weighted sum aggregation is setting this value
@@ -233,6 +234,7 @@ module Fees
           organization_id: billable_metric.organization_id,
           external_subscription_id: subscription.external_id,
           group_id: group&.id,
+          charge_filter_id: charge_filter&.id,
           billable_metric_id: billable_metric.id,
           added_at: aggregation_result.recurring_updated_at,
           grouped_by: aggregation_result.grouped_by || {},
@@ -252,6 +254,7 @@ module Fees
 
       if charge_filter.present?
         result = ChargeFilters::MatchingAndIgnoredService.call(filter: charge_filter)
+        filters[:charge_filter] = charge_filter
         filters[:matching_filters] = result.matching_filters
         filters[:ignored_filters] = result.ignored_filters
       end

--- a/spec/services/charge_filters/event_matching_service_spec.rb
+++ b/spec/services/charge_filters/event_matching_service_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ChargeFilters::EventMatchingService, type: :service do
+  subject(:service_result) { described_class.call(charge:, event:) }
+
+  let(:organization) { create(:organization) }
+
+  let(:event_properties) do
+    {
+      payment_method: 'card',
+      card_location: 'domestic',
+      scheme: 'visa',
+      card_type: 'credit',
+    }
+  end
+
+  let(:event) do
+    create(
+      :event,
+      organization_id: organization.id,
+      code: billable_metric.code,
+      properties: event_properties,
+    )
+  end
+
+  let(:billable_metric) { create(:billable_metric, organization:) }
+
+  let(:charge) { create(:standard_charge, billable_metric:) }
+
+  let(:payment_method) do
+    create(:billable_metric_filter, billable_metric:, key: 'payment_method', values: %i[card virtual_card transfer])
+  end
+  let(:card_location) { create(:billable_metric_filter, billable_metric:, key: 'card_location', values: %i[domestic]) }
+  let(:scheme) { create(:billable_metric_filter, billable_metric:, key: 'scheme', values: %i[visa mastercard]) }
+  let(:card_type) { create(:billable_metric_filter, billable_metric:, key: 'card_type', values: %i[credit debit]) }
+
+  let(:filter1) { create(:charge_filter, charge:) }
+  let(:filter1_values) do
+    [
+      create(:charge_filter_value, values: ['card'], billable_metric_filter: payment_method, charge_filter: filter1),
+      create(:charge_filter_value, values: ['domestic'], billable_metric_filter: card_location, charge_filter: filter1),
+      create(
+        :charge_filter_value,
+        values: %w[visa mastercard],
+        billable_metric_filter: scheme,
+        charge_filter: filter1,
+      ),
+    ]
+  end
+
+  let(:filter2) { create(:charge_filter, charge:) }
+  let(:filter2_values) do
+    [
+      create(:charge_filter_value, values: ['card'], billable_metric_filter: payment_method, charge_filter: filter2),
+      create(:charge_filter_value, values: ['domestic'], billable_metric_filter: card_location, charge_filter: filter2),
+      create(
+        :charge_filter_value,
+        values: %w[visa mastercard],
+        billable_metric_filter: scheme,
+        charge_filter: filter2,
+      ),
+      create(:charge_filter_value, values: ['credit'], billable_metric_filter: card_type, charge_filter: filter2),
+    ]
+  end
+
+  before do
+    filter1_values
+    filter2_values
+  end
+
+  it 'returns the filter matching the most properties' do
+    expect(service_result.charge_filter).to eq(filter2)
+  end
+
+  context 'when event does not match any filter' do
+    let(:event_properties) { {} }
+
+    it 'returns nil' do
+      expect(service_result.charge_filter).to be_nil
+    end
+  end
+end

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -4,13 +4,14 @@ require 'rails_helper'
 
 RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
   subject(:agg_service) do
-    described_class.new(charge:, boundaries:, group:, properties:, event:)
+    described_class.new(charge:, boundaries:, group:, properties:, event:, charge_filter:)
   end
 
   let(:organization) { create(:organization) }
   let(:billable_metric) { create(:billable_metric, organization:, aggregation_type:, field_name: 'item_id') }
   let(:charge) { create(:standard_charge, billable_metric:, pay_in_advance: true) }
   let(:group) { create(:group) }
+  let(:charge_filter) { nil }
   let(:aggregation_type) { 'count_agg' }
   let(:event) { create(:event, organization:, external_subscription_id: subscription.external_id) }
   let(:properties) { {} }
@@ -98,6 +99,51 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
                 group:,
                 event:,
                 grouped_by_values: { 'operator' => 'foo' },
+              },
+            )
+
+          expect(count_service).to have_received(:aggregate).with(
+            options: { free_units_per_events: 0, free_units_per_total_aggregation: 0 },
+          )
+        end
+      end
+
+      describe 'when charge filter is present' do
+        let(:charge_filter) { create(:charge_filter, charge:) }
+        let(:filter) { create(:billable_metric_filter, billable_metric: charge.billable_metric) }
+
+        let(:filter_value) do
+          create(
+            :charge_filter_value,
+            charge_filter:,
+            billable_metric_filter: filter,
+            values: [filter.values.first],
+          )
+        end
+
+        before { filter_value }
+
+        it 'delegates to the count aggregation service' do
+          allow(BillableMetrics::Aggregations::CountService).to receive(:new).and_return(count_service)
+
+          agg_service.call
+
+          expect(BillableMetrics::Aggregations::CountService).to have_received(:new)
+            .with(
+              event_store_class: Events::Stores::PostgresStore,
+              charge:,
+              subscription:,
+              boundaries: {
+                from_datetime: boundaries[:charges_from_datetime],
+                to_datetime: boundaries[:charges_to_datetime],
+                charges_duration: boundaries[:charges_duration],
+              },
+              filters: {
+                group:,
+                event:,
+                charge_filter:,
+                matching_filters: charge_filter.to_h,
+                ignored_filters: [],
               },
             )
 

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
 
     before do
       allow(Charges::PayInAdvanceAggregationService).to receive(:call)
-        .with(charge:, boundaries: Hash, group:, properties: Hash, event:)
+        .with(charge:, boundaries: Hash, group:, properties: Hash, event:, charge_filter: nil)
         .and_return(aggregation_result)
 
       allow(Charges::ApplyPayInAdvanceChargeModelService).to receive(:call)


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds the logic to apply filters for the pay in advance aggregation