### PR TITLE
feat(filter): Take match_all into account for aggregation

### DIFF
--- a/app/models/billable_metric_filter.rb
+++ b/app/models/billable_metric_filter.rb
@@ -5,7 +5,7 @@ class BillableMetricFilter < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
-  belongs_to :billable_metric
+  belongs_to :billable_metric, -> { with_discarded }
 
   has_many :filter_values, class_name: 'ChargeFilterValue', dependent: :destroy
   has_many :charge_filters, through: :filter_values

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -25,6 +25,15 @@ class ChargeFilter < ApplicationRecord
     end
   end
 
+  def to_h_with_all_values
+    values.each_with_object({}) do |filter_value, result|
+      values = filter_value.values
+      values = filter_value.billable_metric_filter.values if values == [ChargeFilterValue::MATCH_ALL_FILTER_VALUES]
+
+      result[filter_value.billable_metric_filter.key] = values
+    end
+  end
+
   private
 
   def validate_properties

--- a/app/models/charge_filter_value.rb
+++ b/app/models/charge_filter_value.rb
@@ -8,7 +8,7 @@ class ChargeFilterValue < ApplicationRecord
   MATCH_ALL_FILTER_VALUES = '__MATCH_ALL_FILTER_VALUES__'
 
   belongs_to :charge_filter
-  belongs_to :billable_metric_filter
+  belongs_to :billable_metric_filter, -> { with_discarded }
 
   validates :values, presence: true
   validate :validate_values

--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -8,7 +8,7 @@ module ChargeFilters
     end
 
     def call
-      result.matching_filters = filter.to_h
+      result.matching_filters = filter.to_h_with_all_values
 
       # NOTE: Check if filters contains some key/values from input filter
       #       Result will have the following format:
@@ -17,7 +17,7 @@ module ChargeFilters
       #         key2: [value3, value4]
       #       }
       children = other_filters.find_all do |f|
-        child = f.to_h
+        child = f.to_h_with_all_values
 
         result.matching_filters.all? do |key, values|
           values.any? { (child[key] || []).include?(_1) }
@@ -37,7 +37,7 @@ module ChargeFilters
       #         }
       #       ]
       result.ignored_filters = children.each_with_object([]) do |child_filter, res|
-        child = child_filter.to_h
+        child = child_filter.to_h_with_all_values
         child_result = {}
 
         child.each do |key, values|

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -366,4 +366,30 @@ RSpec.describe ChargeFilter, type: :model do
       )
     end
   end
+
+  describe '#to_h_with_all_values' do
+    subject(:charge_filter) { build(:charge_filter, values:) }
+
+    let(:card) { create(:billable_metric_filter, key: 'card', values: %w[credit debit]) }
+    let(:scheme) { create(:billable_metric_filter, key: 'scheme', values: %w[visa mastercard]) }
+    let(:values) do
+      [
+        build(:charge_filter_value, values: ['credit'], billable_metric_filter: card),
+        build(
+          :charge_filter_value,
+          values: [ChargeFilterValue::MATCH_ALL_FILTER_VALUES],
+          billable_metric_filter: scheme,
+        ),
+      ]
+    end
+
+    it 'returns all values as a hash' do
+      expect(charge_filter.to_h_with_all_values).to eq(
+        {
+          'card' => ['credit'],
+          'scheme' => %w[visa mastercard],
+        },
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds the logic for the `MATCH_ALL_FILTER_VALUES` in the aggregation process