### PR TITLE
fix(invoices): assign correct issuing_date for charge pay in advance invoice

### DIFF
--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -2,11 +2,12 @@
 
 module Invoices
   class CreateGeneratingService < BaseService
-    def initialize(customer:, invoice_type:, datetime:, currency:, subscriptions_details: nil)
+    def initialize(customer:, invoice_type:, datetime:, currency:, subscriptions_details: nil, charge_in_advance: false)
       @customer = customer
       @invoice_type = invoice_type
       @currency = currency
       @datetime = datetime
+      @charge_in_advance = charge_in_advance
       @subscriptions_details = subscriptions_details
 
       super
@@ -35,14 +36,14 @@ module Invoices
 
     private
 
-    attr_accessor :customer, :invoice_type, :currency, :datetime, :subscriptions_details
+    attr_accessor :customer, :invoice_type, :currency, :datetime, :subscriptions_details, :charge_in_advance
 
     delegate :organization, to: :customer
 
     # NOTE: accounting date must be in customer timezone
     def issuing_date
       date = datetime.in_time_zone(customer.applicable_timezone).to_date
-      return date unless grace_period?
+      return date if !grace_period? || charge_in_advance
 
       date + customer.applicable_invoice_grace_period.days
     end

--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -2,13 +2,12 @@
 
 module Invoices
   class CreateGeneratingService < BaseService
-    def initialize(customer:, invoice_type:, datetime:, currency:, subscriptions_details: nil, charge_in_advance: false)
+    def initialize(customer:, invoice_type:, datetime:, currency:, charge_in_advance: false)
       @customer = customer
       @invoice_type = invoice_type
       @currency = currency
       @datetime = datetime
       @charge_in_advance = charge_in_advance
-      @subscriptions_details = subscriptions_details
 
       super
     end
@@ -36,7 +35,7 @@ module Invoices
 
     private
 
-    attr_accessor :customer, :invoice_type, :currency, :datetime, :subscriptions_details, :charge_in_advance
+    attr_accessor :customer, :invoice_type, :currency, :datetime, :charge_in_advance
 
     delegate :organization, to: :customer
 

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -64,6 +64,7 @@ module Invoices
         invoice_type: :subscription,
         currency: customer.currency,
         datetime: Time.zone.at(timestamp),
+        charge_in_advance: true,
       ) do |invoice|
         Invoices::CreateInvoiceSubscriptionService
           .call(invoice:, subscriptions: [subscription], timestamp:, recurring: false)

--- a/spec/services/invoices/create_generating_service_spec.rb
+++ b/spec/services/invoices/create_generating_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Invoices::CreateGeneratingService, type: :service do
   subject(:create_service) do
-    described_class.new(customer:, invoice_type:, currency:, datetime:, subscriptions_details:)
+    described_class.new(customer:, invoice_type:, currency:, datetime:, subscriptions_details:, charge_in_advance:)
   end
 
   let(:customer) { create(:customer) }
@@ -12,6 +12,7 @@ RSpec.describe Invoices::CreateGeneratingService, type: :service do
   let(:currency) { 'EUR' }
   let(:datetime) { Time.current }
   let(:subscriptions_details) { [] }
+  let(:charge_in_advance) { false }
   let(:recurring) { false }
 
   describe 'call' do
@@ -94,6 +95,16 @@ RSpec.describe Invoices::CreateGeneratingService, type: :service do
         result = create_service.call
 
         expect(result.invoice.issuing_date.to_s).to eq((datetime + 3.days).to_date.to_s)
+      end
+
+      context 'when charge pay in advance invoice is generated' do
+        let(:charge_in_advance) { true }
+
+        it 'creates an invoice with correct issuing date' do
+          result = create_service.call
+
+          expect(result.invoice.issuing_date.to_s).to eq(datetime.to_date.to_s)
+        end
       end
 
       context 'with customer timezone' do

--- a/spec/services/invoices/create_generating_service_spec.rb
+++ b/spec/services/invoices/create_generating_service_spec.rb
@@ -4,14 +4,13 @@ require 'rails_helper'
 
 RSpec.describe Invoices::CreateGeneratingService, type: :service do
   subject(:create_service) do
-    described_class.new(customer:, invoice_type:, currency:, datetime:, subscriptions_details:, charge_in_advance:)
+    described_class.new(customer:, invoice_type:, currency:, datetime:, charge_in_advance:)
   end
 
   let(:customer) { create(:customer) }
   let(:invoice_type) { :one_off }
   let(:currency) { 'EUR' }
   let(:datetime) { Time.current }
-  let(:subscriptions_details) { [] }
   let(:charge_in_advance) { false }
   let(:recurring) { false }
 

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -199,6 +199,17 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
       end
     end
 
+    context 'with grace period' do
+      let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }
+      let(:timestamp) { DateTime.parse('2022-11-25 08:00:00') }
+
+      it 'assigns the correct issuing date' do
+        result = invoice_service.call
+
+        expect(result.invoice.issuing_date.to_s).to eq('2022-11-25')
+      end
+    end
+
     context 'with provided invoice' do
       let(:invoice) { create(:invoice, organization:, customer:, invoice_type: :subscription, status: :generating) }
 


### PR DESCRIPTION
## Context

When generating charge pay in advance invoice, grace period should be ignored when calculating `issuing_date`.

## Description

This PR fixes described problem and adds related automation tests.