### PR TITLE
feat(filter): current usage charge with applied filters

### DIFF
--- a/app/graphql/types/customers/usage/charge_filter.rb
+++ b/app/graphql/types/customers/usage/charge_filter.rb
@@ -6,13 +6,17 @@ module Types
       class ChargeFilter < Types::BaseObject
         graphql_name 'ChargeFilterUsage'
 
-        field :id, ID, null: false, method: :filter_id
+        field :id, ID, null: false, method: :charge_filter_id
 
         field :amount_cents, GraphQL::Types::BigInt, null: false
         field :events_count, Integer, null: false
         field :invoice_display_name, String, null: true
         field :units, GraphQL::Types::Float, null: false
-        field :values, Types::ChargeFilters::Values, null: false, method: :to_h
+        field :values, Types::ChargeFilters::Values, null: false
+
+        def values
+          object.charge_filter.to_h
+        end
       end
     end
   end

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -82,11 +82,20 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
     )
   end
 
+  let(:billable_metric_filter) do
+    create(:billable_metric_filter, billable_metric: metric, key: 'cloud', values: %w[aws gcp])
+  end
+
+  let(:charge_filter) { create(:charge_filter, charge: standard_charge, invoice_display_name: nil) }
+  let(:charge_filter_value) do
+    create(:charge_filter_value, charge_filter:, billable_metric_filter:, values: ['aws'])
+  end
+
   before do
     subscription
     charge
-    standard_charge
     tax
+    charge_filter_value
 
     create_list(
       :event,
@@ -108,6 +117,7 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
       timestamp: Time.zone.now,
       properties: {
         agent_name: 'frodo',
+        cloud: 'aws',
         item_id: 1,
       },
     )


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR ensure that the customer usage with charge filter is correctly rendered in the GraphQL api