### PR TITLE
feat(filter): Update ALL_FILTER_VALUES constant

### DIFF
--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -28,7 +28,7 @@ class ChargeFilter < ApplicationRecord
   def to_h_with_all_values
     values.each_with_object({}) do |filter_value, result|
       values = filter_value.values
-      values = filter_value.billable_metric_filter.values if values == [ChargeFilterValue::MATCH_ALL_FILTER_VALUES]
+      values = filter_value.billable_metric_filter.values if values == [ChargeFilterValue::ALL_FILTER_VALUES]
 
       result[filter_value.billable_metric_filter.key] = values
     end

--- a/app/models/charge_filter_value.rb
+++ b/app/models/charge_filter_value.rb
@@ -5,7 +5,7 @@ class ChargeFilterValue < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
-  MATCH_ALL_FILTER_VALUES = '__MATCH_ALL_FILTER_VALUES__'
+  ALL_FILTER_VALUES = '__ALL_FILTER_VALUE__'
 
   belongs_to :charge_filter
   belongs_to :billable_metric_filter, -> { with_discarded }
@@ -21,7 +21,7 @@ class ChargeFilterValue < ApplicationRecord
 
   def validate_values
     unless values.nil?
-      return if values.count == 1 && values.first == MATCH_ALL_FILTER_VALUES
+      return if values.count == 1 && values.first == ALL_FILTER_VALUES
       return if values.all? { billable_metric_filter&.values&.include?(_1) } # rubocop:disable Performance/InefficientHashSearch
     end
 

--- a/app/models/charge_filter_value.rb
+++ b/app/models/charge_filter_value.rb
@@ -5,7 +5,7 @@ class ChargeFilterValue < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
-  ALL_FILTER_VALUES = '__ALL_FILTER_VALUE__'
+  ALL_FILTER_VALUES = '__ALL_FILTER_VALUES__'
 
   belongs_to :charge_filter
   belongs_to :billable_metric_filter, -> { with_discarded }

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -377,7 +377,7 @@ RSpec.describe ChargeFilter, type: :model do
         build(:charge_filter_value, values: ['credit'], billable_metric_filter: card),
         build(
           :charge_filter_value,
-          values: [ChargeFilterValue::MATCH_ALL_FILTER_VALUES],
+          values: [ChargeFilterValue::ALL_FILTER_VALUES],
           billable_metric_filter: scheme,
         ),
       ]

--- a/spec/models/charge_filter_value_spec.rb
+++ b/spec/models/charge_filter_value_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe ChargeFilterValue, type: :model do
       end
     end
 
-    context 'when value is MATCH_ALL_FILTER_VALUES' do
-      let(:values) { [ChargeFilterValue::MATCH_ALL_FILTER_VALUES] }
+    context 'when value is ALL_FILTER_VALUES' do
+      let(:values) { [ChargeFilterValue::ALL_FILTER_VALUES] }
 
       it { expect(charge_filter_value).to be_valid }
     end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR changes the ALL_FILTER_VALUES constant value from `__MATCH_ALL_FILTER_VALUES__` to `__ALL_FILTER_VALUE__`