### PR TITLE
fix(filter): Invoice should be created when default prices is set

### DIFF
--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -137,7 +137,7 @@ module Fees
         precise_unit_amount: amount_result.unit_amount,
         amount_details: amount_result.amount_details,
         grouped_by: amount_result.grouped_by || {},
-        charge_filter:,
+        charge_filter_id: charge_filter&.id,
       )
 
       if (adjusted = adjusted_fee(group, amount_result.grouped_by))&.adjusted_display_name?


### PR DESCRIPTION
## Context

Invoice is not generating when filters are attached to a charge.
The issue is related to the fee creation with default properties, created for events that does not match any filter. The fee generation uses a non persisted charge filter with default properties, but it tries to attach it to the generated fee, leading to a validation error.

## Description

This fix makes sure that the charge filter is not attached to the fee