### PR TITLE
fix(tax): Block Eu Tax Management if org is not in EU country

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -82,6 +82,10 @@ class Organization < ApplicationRecord
     end
   end
 
+  def eu?
+    country && LagoEuVat::Rate.new.countries_code.include?(country)
+  end
+
   def payment_provider(provider)
     case provider
     when 'stripe'

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -82,7 +82,7 @@ class Organization < ApplicationRecord
     end
   end
 
-  def eu?
+  def eu_vat_eligible?
     country && LagoEuVat::Rate.new.countries_code.include?(country)
   end
 

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -120,9 +120,8 @@ module Organizations
     end
 
     def handle_eu_tax_management(eu_tax_management)
-      org_outside_eu = !organization.eu?
       trying_to_enable_eu_tax_management = params[:eu_tax_management] && !organization.eu_tax_management
-      if org_outside_eu && trying_to_enable_eu_tax_management
+      if !organization.eu_vat_eligible? && trying_to_enable_eu_tax_management
         result.single_validation_failure!(error_code: 'org_must_be_in_eu', field: :eu_tax_management)
           .raise_if_error!
       end

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -120,6 +120,12 @@ module Organizations
     end
 
     def handle_eu_tax_management(eu_tax_management)
+      org_outside_eu = !organization.eu?
+      trying_to_enable_eu_tax_management = params[:eu_tax_management] && !organization.eu_tax_management
+      if org_outside_eu && trying_to_enable_eu_tax_management
+        result.single_validation_failure!(error_code: 'org_must_be_in_eu', field: :eu_tax_management).raise_if_error!
+      end
+
       # NOTE: even if the organization had eu tax management, we call this service again, it uses an upsert for taxes.
       Taxes::AutoGenerateService.new(organization:).call if eu_tax_management
 

--- a/app/services/organizations/update_service.rb
+++ b/app/services/organizations/update_service.rb
@@ -123,7 +123,8 @@ module Organizations
       org_outside_eu = !organization.eu?
       trying_to_enable_eu_tax_management = params[:eu_tax_management] && !organization.eu_tax_management
       if org_outside_eu && trying_to_enable_eu_tax_management
-        result.single_validation_failure!(error_code: 'org_must_be_in_eu', field: :eu_tax_management).raise_if_error!
+        result.single_validation_failure!(error_code: 'org_must_be_in_eu', field: :eu_tax_management)
+          .raise_if_error!
       end
 
       # NOTE: even if the organization had eu tax management, we call this service again, it uses an upsert for taxes.

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Organizations::UpdateService do
       timezone:,
       logo:,
       email_settings:,
-      eu_tax_management: true,
       billing_configuration: {
         invoice_footer: 'invoice footer',
         document_locale: 'fr',
@@ -58,7 +57,6 @@ RSpec.describe Organizations::UpdateService do
 
         expect(result.organization.invoice_footer).to eq('invoice footer')
         expect(result.organization.document_locale).to eq('fr')
-        expect(result.organization.eu_tax_management).to be_truthy
       end
     end
 
@@ -253,20 +251,65 @@ RSpec.describe Organizations::UpdateService do
       end
     end
 
-    context 'when eu tax management is activated' do
-      let(:tax_auto_generate_service) { instance_double(Taxes::AutoGenerateService) }
+    context 'with eu tax management' do
+      context 'with org within the EU' do
+        let(:params) { { eu_tax_management: true, country: 'fr' } }
+        let(:tax_auto_generate_service) { instance_double(Taxes::AutoGenerateService) }
 
-      before do
-        allow(Taxes::AutoGenerateService).to receive(:new).and_return(tax_auto_generate_service)
-        allow(tax_auto_generate_service).to receive(:call)
+        before do
+          allow(Taxes::AutoGenerateService).to receive(:new).and_return(tax_auto_generate_service)
+          allow(tax_auto_generate_service).to receive(:call)
+        end
+
+        it 'calls the taxes auto generate service' do
+          result = update_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(tax_auto_generate_service).to have_received(:call)
+          end
+        end
       end
 
-      it 'calls the taxes auto generate service' do
-        result = update_service.call
+      context 'with org outside the EU' do
+        let(:params) { { eu_tax_management: true, country: 'us' } }
+        let(:tax_auto_generate_service) { instance_double(Taxes::AutoGenerateService) }
 
-        aggregate_failures do
-          expect(result).to be_success
-          expect(tax_auto_generate_service).to have_received(:call)
+        before do
+          allow(Taxes::AutoGenerateService).to receive(:new).and_return(tax_auto_generate_service)
+          allow(tax_auto_generate_service).to receive(:call)
+        end
+
+        it 'calls the taxes auto generate service' do
+          result = update_service.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages).to eq({ eu_tax_management: ['org_must_be_in_eu'] })
+            expect(tax_auto_generate_service).not_to have_received(:call)
+          end
+        end
+      end
+
+      context 'with org is outside the EU but feature is already enabled' do
+        let(:params) { { eu_tax_management: false } }
+        let(:tax_auto_generate_service) { instance_double(Taxes::AutoGenerateService) }
+
+        before do
+          organization.country = 'us'
+          organization.eu_tax_management = true
+          allow(Taxes::AutoGenerateService).to receive(:new).and_return(tax_auto_generate_service)
+          allow(tax_auto_generate_service).to receive(:call)
+        end
+
+        it 'can disable eu_tax_management' do
+          result = update_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(tax_auto_generate_service).not_to have_received(:call)
+          end
         end
       end
     end


### PR DESCRIPTION
## Context

Organization within the EU must charge the VAT of the country of their customers, not their country. This feature should only be available to country within the EU.

This feature is enabled in the **Integrations** tab.

## Description

If your org is outside you get an error message. So far it's a generic error, maybe we can display a better error in the frontend.

If your org is outside the EU but the feature was already enabled, you can still disable it.

If your org is within the EU, you're all good.

**We could do more here, like disabling the _Connect_ button if you select a country outside the EU but for now, we think it's enough effort for the issue.**

<img width="1349" alt="Screenshot 2024-03-21 at 12 10 34" src="https://github.com/getlago/lago-api/assets/1525636/fbdec9e3-4d90-450e-92be-c8511ec835f8">
<img width="1254" alt="Screenshot 2024-03-21 at 12 10 39" src="https://github.com/getlago/lago-api/assets/1525636/50582999-500e-47d9-add1-ea217ac08545">


<img width="1188" alt="Screenshot 2024-03-21 at 12 10 52" src="https://github.com/getlago/lago-api/assets/1525636/e3f73071-2a43-404b-81ca-4f759856fcd6">
<img width="1087" alt="Screenshot 2024-03-21 at 12 10 58" src="https://github.com/getlago/lago-api/assets/1525636/a255d582-1067-4d4a-8237-da5d4d859ddc">

