### PR TITLE
chore(rubocop): disable new cops by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ require:
   - rubocop-graphql
 
 AllCops:
+  NewCops: disable
   DisplayStyleGuide: true
   Exclude:
     - 'bin/**/*'


### PR DESCRIPTION
## Context

When running `rubocop` from the command line, there is a warning about all the new cops available, which I think is annoying.

<img width="1179" alt="Screenshot 2024-03-22 at 09 15 47" src="https://github.com/getlago/lago-api/assets/1525636/6a22fe93-f114-4310-9379-8f07a2516efb">

(Yes, my terminal is light mode)

## Description

Disabling NewCops is how it works now, all new cops are printed in the console but they are not enabled. I'm not against enabling more cops but first, I'd love to be able to run rubocop on the entire codebase with no error.

If we want to enable all the new cops by default, the number for issue almost 10x 🙈 I'm in favor of: 
1. disabling new cops to get rid of the warning
2. fixing the 173 offences
3. enabling whatever new cops we want

Even if a lot of offenses are autocorrectable, it will make the codebase "change a lot", making `git blame` harder to follow, creating conflict with open PRs..

```diff
- 1843 files inspected, 173 offenses detected, 41 offenses autocorrectable
+ 1843 files inspected, 1390 offenses detected, 1006 offenses autocorrectable 
```
