### PR TITLE
fix(filter): Return default filter in usage

### DIFF
--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -43,9 +43,7 @@ module Types
         end
 
         def filters
-          object
-            .select(&:charge_filter)
-            .sort_by { |f| f.charge_filter.display_name }
+          object.sort_by { |f| f&.charge_filter&.display_name || '' }
         end
 
         def grouped_usage

--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -43,7 +43,7 @@ module Types
         end
 
         def filters
-          object.sort_by { |f| f&.charge_filter&.display_name || '' }
+          object.sort_by { |f| f&.charge_filter&.display_name.to_s }
         end
 
         def grouped_usage

--- a/app/graphql/types/customers/usage/charge_filter.rb
+++ b/app/graphql/types/customers/usage/charge_filter.rb
@@ -15,11 +15,11 @@ module Types
         field :values, Types::ChargeFilters::Values, null: false
 
         def values
-          object&.charge_filter&.to_h || {} # rubocop:disable Lint/RedundantSafeNavigation
+          object.charge_filter&.to_h || {} # rubocop:disable Lint/RedundantSafeNavigation
         end
 
         def invoice_display_name
-          object&.charge_filter&.display_name
+          object.charge_filter&.display_name
         end
       end
     end

--- a/app/graphql/types/customers/usage/charge_filter.rb
+++ b/app/graphql/types/customers/usage/charge_filter.rb
@@ -15,7 +15,11 @@ module Types
         field :values, Types::ChargeFilters::Values, null: false
 
         def values
-          object.charge_filter.to_h
+          object&.charge_filter&.to_h || {} # rubocop:disable Lint/RedundantSafeNavigation
+        end
+
+        def invoice_display_name
+          object&.charge_filter&.display_name
         end
       end
     end

--- a/app/graphql/types/customers/usage/grouped_usage.rb
+++ b/app/graphql/types/customers/usage/grouped_usage.rb
@@ -37,9 +37,7 @@ module Types
         end
 
         def filters
-          object
-            .select(&:charge_filter)
-            .sort_by { |f| f.charge_filter.display_name }
+          object.sort_by { |f| f&.charge_filter&.display_name }
         end
       end
     end

--- a/app/graphql/types/customers/usage/grouped_usage.rb
+++ b/app/graphql/types/customers/usage/grouped_usage.rb
@@ -37,7 +37,7 @@ module Types
         end
 
         def filters
-          object.sort_by { |f| f&.charge_filter&.display_name }
+          object.sort_by { |f| f.charge_filter&.display_name }
         end
       end
     end

--- a/app/graphql/types/fees/object.rb
+++ b/app/graphql/types/fees/object.rb
@@ -9,7 +9,6 @@ module Types
       field :charge, Types::Charges::Object, null: true
       field :currency, Types::CurrencyEnum, null: false
       field :description, String, null: true
-      field :filter_display_name, String, null: true
       field :group_name, String, null: true
       field :grouped_by, GraphQL::Types::JSON, null: false
       field :invoice_display_name, String, null: true
@@ -33,6 +32,8 @@ module Types
       field :adjusted_fee, Boolean, null: false
       field :adjusted_fee_type, Types::AdjustedFees::AdjustedFeeTypeEnum, null: true
 
+      field :charge_filter, Types::ChargeFilters::Object, null: true
+
       def item_type
         object.fee_type
       end
@@ -50,10 +51,6 @@ module Types
         return nil if object.adjusted_fee.adjusted_display_name?
 
         object.adjusted_fee.adjusted_units? ? 'adjusted_units' : 'adjusted_amount'
-      end
-
-      def filter_display_name
-        object.charge_filter&.display_name
       end
     end
   end

--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -54,7 +54,7 @@ module V1
             amount_cents: f.amount_cents,
             events_count: f.events_count,
             invoice_display_name: f&.charge_filter&.display_name,
-            values: f&.charge_filter&.to_h,
+            values: f.charge_filter&.to_h,
           }
         end.compact
       end

--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -49,14 +49,12 @@ module V1
 
       def filters(fees)
         fees.sort_by { |f| f.charge_filter&.display_name.to_s }.map do |f|
-          next unless f.charge_filter
-
           {
             units: f.units,
             amount_cents: f.amount_cents,
             events_count: f.events_count,
-            invoice_display_name: f.charge_filter.display_name,
-            values: f.charge_filter.to_h,
+            invoice_display_name: f&.charge_filter&.display_name,
+            values: f&.charge_filter&.to_h,
           }
         end.compact
       end

--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -53,7 +53,7 @@ module V1
             units: f.units,
             amount_cents: f.amount_cents,
             events_count: f.events_count,
-            invoice_display_name: f&.charge_filter&.display_name,
+            invoice_display_name: f.charge_filter&.display_name,
             values: f.charge_filter&.to_h,
           }
         end.compact

--- a/schema.graphql
+++ b/schema.graphql
@@ -3134,12 +3134,12 @@ type Fee implements InvoiceItem {
   amountDetails: FeeAmountDetails
   appliedTaxes: [FeeAppliedTax!]
   charge: Charge
+  chargeFilter: ChargeFilter
   creditableAmountCents: BigInt!
   currency: CurrencyEnum!
   description: String
   eventsCount: BigInt
   feeType: FeeTypesEnum!
-  filterDisplayName: String
   group: Group
   groupName: String
   groupedBy: JSON!

--- a/schema.json
+++ b/schema.json
@@ -12249,6 +12249,20 @@
               ]
             },
             {
+              "name": "chargeFilter",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "ChargeFilter",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "creditableAmountCents",
               "description": null,
               "type": {
@@ -12323,20 +12337,6 @@
                   "name": "FeeTypesEnum",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "filterDisplayName",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/types/fees/object_spec.rb
+++ b/spec/graphql/types/fees/object_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Types::Fees::Object do
   it { is_expected.to have_field(:adjusted_fee_type).of_type('AdjustedFeeTypeEnum') }
   it { is_expected.to have_field(:grouped_by).of_type('JSON!') }
 
-  it { is_expected.to have_field(:filter_display_name).of_type('String') }
   it { is_expected.to have_field(:group_name).of_type('String') }
+
+  it { is_expected.to have_field(:charge_filter).of_type('ChargeFilter') }
 end

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -48,7 +48,15 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
           'code' => billable_metric.code,
           'aggregation_type' => billable_metric.aggregation_type,
         },
-        'filters' => [],
+        'filters' => [
+          {
+            'amount_cents' => 100,
+            'events_count' => 12,
+            'invoice_display_name' => nil,
+            'units' => 10,
+            'values' => nil,
+          },
+        ],
         'groups' => [],
         'grouped_usage' => [
           {
@@ -56,7 +64,15 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
             'events_count' => 12,
             'units' => '10.0',
             'grouped_by' => { 'card_type' => 'visa' },
-            'filters' => [],
+            'filters' => [
+              {
+                'amount_cents' => 100,
+                'events_count' => 12,
+                'invoice_display_name' => nil,
+                'units' => 10,
+                'values' => nil,
+              },
+            ],
             'groups' => [],
           },
         ],


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR ensure that the default filter is exposed in the current usage in both GraphQL and REST API, with both grouped_by or no