### PR TITLE
feat (invoice-numbering): generate invoice number upon invoice finalization

### DIFF
--- a/app/models/concerns/sequenced.rb
+++ b/app/models/concerns/sequenced.rb
@@ -12,7 +12,7 @@ module Sequenced
 
     def ensure_sequential_id
       return if sequential_id.present?
-      return if self.class.to_s == 'Invoice' && !status_changed_to_finalized?
+      return if self.instance_of?(::Invoice) && !status_changed_to_finalized?
 
       self.sequential_id = generate_sequential_id
     end

--- a/app/models/concerns/sequenced.rb
+++ b/app/models/concerns/sequenced.rb
@@ -12,6 +12,7 @@ module Sequenced
 
     def ensure_sequential_id
       return if sequential_id.present?
+      return if self.class.to_s == 'Invoice' && !status_changed_to_finalized?
 
       self.sequential_id = generate_sequential_id
     end

--- a/app/models/concerns/sequenced.rb
+++ b/app/models/concerns/sequenced.rb
@@ -12,9 +12,13 @@ module Sequenced
 
     def ensure_sequential_id
       return if sequential_id.present?
-      return if instance_of?(::Invoice) && !status_changed_to_finalized?
+      return unless should_assign_sequential_id?
 
       self.sequential_id = generate_sequential_id
+    end
+
+    def should_assign_sequential_id?
+      true
     end
 
     def generate_sequential_id

--- a/app/models/concerns/sequenced.rb
+++ b/app/models/concerns/sequenced.rb
@@ -12,7 +12,7 @@ module Sequenced
 
     def ensure_sequential_id
       return if sequential_id.present?
-      return if self.instance_of?(::Invoice) && !status_changed_to_finalized?
+      return if instance_of?(::Invoice) && !status_changed_to_finalized?
 
       self.sequential_id = generate_sequential_id
     end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -265,6 +265,10 @@ class Invoice < ApplicationRecord
 
   private
 
+  def should_assign_sequential_id?
+    status_changed_to_finalized?
+  end
+
   def void_invoice!
     update!(ready_for_payment_processing: false)
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -270,12 +270,9 @@ class Invoice < ApplicationRecord
   end
 
   def ensure_number
-    return if number.present? && (finalized? || voided?) && !status_changed_to_finalized?
+    self.number = "#{organization.document_number_prefix}-DRAFT" if number.blank? && !status_changed_to_finalized?
 
-    unless status_changed_to_finalized?
-      self.number = "#{organization.document_number_prefix}-DRAFT"
-      return
-    end
+    return unless status_changed_to_finalized?
 
     if organization.per_customer?
       # NOTE: Example of expected customer slug format is ORG_PREFIX-005

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -9,8 +9,8 @@ class Invoice < ApplicationRecord
   CREDIT_NOTES_MIN_VERSION = 2
   COUPON_BEFORE_VAT_VERSION = 3
 
-  before_create :ensure_organization_sequential_id, if: -> { organization.per_organization? }
-  before_create :ensure_number
+  before_save :ensure_organization_sequential_id, if: -> { organization.per_organization? }
+  before_save :ensure_number
 
   belongs_to :customer, -> { with_discarded }
   belongs_to :organization
@@ -73,6 +73,7 @@ class Invoice < ApplicationRecord
   sequenced scope: ->(invoice) { invoice.customer.invoices },
             lock_key: ->(invoice) { invoice.customer_id }
 
+  scope :with_generated_number, -> { where(status: %w[finalized voided]) }
   scope :ready_to_be_refreshed, -> { where(ready_to_be_refreshed: true) }
   scope :ready_to_be_finalized,
         lambda {
@@ -269,7 +270,12 @@ class Invoice < ApplicationRecord
   end
 
   def ensure_number
-    return if number.present?
+    return if number.present? && (finalized? || voided?) && !status_changed_to_finalized?
+
+    unless status_changed_to_finalized?
+      self.number = "#{organization.document_number_prefix}-DRAFT"
+      return
+    end
 
     if organization.per_customer?
       # NOTE: Example of expected customer slug format is ORG_PREFIX-005
@@ -287,13 +293,14 @@ class Invoice < ApplicationRecord
 
   def ensure_organization_sequential_id
     return if organization_sequential_id.present? && organization_sequential_id.positive?
+    return unless status_changed_to_finalized?
 
     self.organization_sequential_id = generate_organization_sequential_id
   end
 
   def generate_organization_sequential_id
     timezone = organization.timezone || 'UTC'
-    organization_sequence_scope = organization.invoices.where(
+    organization_sequence_scope = organization.invoices.with_generated_number.where(
       "date_trunc('month', created_at::timestamptz AT TIME ZONE ?)::date = ?",
       timezone,
       Time.now.in_time_zone(timezone).beginning_of_month.to_date,
@@ -306,7 +313,7 @@ class Invoice < ApplicationRecord
     ) do
       # If previous invoice had different numbering, base sequential id is the total number of invoices
       organization_sequential_id = if switched_from_customer_numbering?
-        organization.invoices.count
+        organization.invoices.with_generated_number.count
       else
         organization
           .invoices
@@ -331,10 +338,14 @@ class Invoice < ApplicationRecord
   end
 
   def switched_from_customer_numbering?
-    last_invoice = organization.invoices.order(created_at: :desc).first
+    last_invoice = organization.invoices.order(created_at: :desc).with_generated_number.first
 
     return false unless last_invoice
 
     last_invoice&.organization_sequential_id&.zero?
+  end
+
+  def status_changed_to_finalized?
+    status_changed?(from: 'draft', to: 'finalized') || status_changed?(from: 'generating', to: 'finalized')
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -159,6 +159,110 @@ RSpec.describe Invoice, type: :model do
           expect(invoice.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime('%Y%m')}-016")
         end
       end
+
+      context 'with existing draft invoices that have generated sequential ids' do
+        let(:created_at) { Time.now.utc }
+
+        let(:invoice1) do
+          create(
+            :invoice,
+            customer:,
+            organization:,
+            sequential_id: 4,
+            organization_sequential_id: 14,
+            created_at:,
+            status: :draft,
+            number: "LAG-#{organization.id.last(4).upcase}-#{Time.now.utc.strftime('%Y%m')}-014"
+          )
+        end
+        let(:invoice2) do
+          create(
+            :invoice,
+            customer:,
+            organization:,
+            sequential_id: 5,
+            organization_sequential_id: 15,
+            created_at:,
+            number: "LAG-#{organization.id.last(4).upcase}-#{Time.now.utc.strftime('%Y%m')}-015"
+          )
+        end
+
+        before do
+          invoice1
+          invoice2
+        end
+
+        it 'scopes the organization_sequential_id to the organization and month' do
+          invoice.save!
+          invoice.finalized!
+
+          organization_id_substring = organization.id.last(4).upcase
+
+          expect(invoice.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime('%Y%m')}-016")
+
+          invoice1.update!(payment_due_date: invoice1.payment_due_date + 1.day)
+          invoice2.update!(payment_due_date: invoice2.payment_due_date + 1.day)
+
+          expect(invoice1.reload.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime('%Y%m')}-014")
+          expect(invoice2.reload.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime('%Y%m')}-015")
+
+          invoice1.finalized!
+
+          expect(invoice1.reload.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime('%Y%m')}-014")
+        end
+      end
+
+      context 'with existing draft invoices that does not have generated sequential ids' do
+        let(:created_at) { Time.now.utc }
+
+        let(:invoice1) do
+          create(
+            :invoice,
+            customer:,
+            organization:,
+            sequential_id: nil,
+            organization_sequential_id: 0,
+            created_at:,
+            status: :draft,
+            number: "LAG-#{organization.id.last(4).upcase}-DRAFT"
+          )
+        end
+        let(:invoice2) do
+          create(
+            :invoice,
+            customer:,
+            organization:,
+            sequential_id: 4,
+            organization_sequential_id: 14,
+            created_at:,
+            number: "LAG-#{organization.id.last(4).upcase}-#{Time.now.utc.strftime('%Y%m')}-014"
+          )
+        end
+
+        before do
+          invoice1
+          invoice2
+        end
+
+        it 'scopes the organization_sequential_id to the organization and month' do
+          invoice.save!
+          invoice.finalized!
+
+          organization_id_substring = organization.id.last(4).upcase
+
+          expect(invoice.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime('%Y%m')}-015")
+
+          invoice1.update!(payment_due_date: invoice1.payment_due_date + 1.day)
+          invoice2.update!(payment_due_date: invoice2.payment_due_date + 1.day)
+
+          expect(invoice1.reload.number).to eq("LAG-#{organization_id_substring}-DRAFT")
+          expect(invoice2.reload.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime('%Y%m')}-014")
+
+          invoice1.finalized!
+
+          expect(invoice1.reload.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime('%Y%m')}-016")
+        end
+      end
     end
   end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Invoice, type: :model do
             organization_sequential_id: 14,
             created_at:,
             status: :draft,
-            number: "LAG-#{organization.id.last(4).upcase}-#{Time.now.utc.strftime('%Y%m')}-014"
+            number: "LAG-#{organization.id.last(4).upcase}-#{Time.now.utc.strftime('%Y%m')}-014",
           )
         end
         let(:invoice2) do
@@ -183,7 +183,7 @@ RSpec.describe Invoice, type: :model do
             sequential_id: 5,
             organization_sequential_id: 15,
             created_at:,
-            number: "LAG-#{organization.id.last(4).upcase}-#{Time.now.utc.strftime('%Y%m')}-015"
+            number: "LAG-#{organization.id.last(4).upcase}-#{Time.now.utc.strftime('%Y%m')}-015",
           )
         end
 
@@ -224,7 +224,7 @@ RSpec.describe Invoice, type: :model do
             organization_sequential_id: 0,
             created_at:,
             status: :draft,
-            number: "LAG-#{organization.id.last(4).upcase}-DRAFT"
+            number: "LAG-#{organization.id.last(4).upcase}-DRAFT",
           )
         end
         let(:invoice2) do
@@ -235,7 +235,7 @@ RSpec.describe Invoice, type: :model do
             sequential_id: 4,
             organization_sequential_id: 14,
             created_at:,
-            number: "LAG-#{organization.id.last(4).upcase}-#{Time.now.utc.strftime('%Y%m')}-014"
+            number: "LAG-#{organization.id.last(4).upcase}-#{Time.now.utc.strftime('%Y%m')}-014",
           )
         end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe Invoice, type: :model do
 
   describe 'sequential_id' do
     let(:customer) { create(:customer, organization:) }
-    let(:invoice) { build(:invoice, customer:, organization:, organization_sequential_id: 0) }
+    let(:invoice) { build(:invoice, customer:, organization:, organization_sequential_id: 0, status: :generating) }
 
     it 'assigns a sequential id and organization sequential id to a new invoice' do
-      invoice.save
+      invoice.save!
+      invoice.finalized!
 
       aggregate_failures do
         expect(invoice).to be_valid
@@ -30,7 +31,8 @@ RSpec.describe Invoice, type: :model do
       end
 
       it 'does not replace the sequential_id and organization_sequential_id' do
-        invoice.save
+        invoice.save!
+        invoice.finalized!
 
         aggregate_failures do
           expect(invoice).to be_valid
@@ -47,7 +49,8 @@ RSpec.describe Invoice, type: :model do
       end
 
       it 'takes the next available id' do
-        invoice.save
+        invoice.save!
+        invoice.finalized!
 
         aggregate_failures do
           expect(invoice).to be_valid
@@ -63,7 +66,8 @@ RSpec.describe Invoice, type: :model do
       end
 
       it 'scopes the sequence to the organization' do
-        invoice.save
+        invoice.save!
+        invoice.finalized!
 
         aggregate_failures do
           expect(invoice).to be_valid
@@ -83,7 +87,8 @@ RSpec.describe Invoice, type: :model do
       end
 
       it 'scopes the organization_sequential_id to the organization and month' do
-        invoice.save
+        invoice.save!
+        invoice.finalized!
 
         aggregate_failures do
           expect(invoice).to be_valid
@@ -98,10 +103,11 @@ RSpec.describe Invoice, type: :model do
     let(:organization) { create(:organization, name: 'LAGO') }
     let(:customer) { create(:customer, organization:) }
     let(:subscription) { create(:subscription, organization:, customer:) }
-    let(:invoice) { build(:invoice, customer:, organization:, organization_sequential_id: 0) }
+    let(:invoice) { build(:invoice, customer:, organization:, organization_sequential_id: 0, status: :generating) }
 
     it 'generates the invoice number' do
-      invoice.save
+      invoice.save!
+      invoice.finalized!
       organization_id_substring = organization.id.last(4).upcase
 
       expect(invoice.number).to eq("LAG-#{organization_id_substring}-001-001")
@@ -111,7 +117,8 @@ RSpec.describe Invoice, type: :model do
       let(:organization) { create(:organization, document_numbering: 'per_organization', name: 'lago') }
 
       it 'scopes the organization_sequential_id to the organization and month' do
-        invoice.save
+        invoice.save!
+        invoice.finalized!
         organization_id_substring = organization.id.last(4).upcase
 
         expect(invoice.number).to eq("LAG-#{organization_id_substring}-#{Time.now.utc.strftime('%Y%m')}-001")
@@ -126,7 +133,8 @@ RSpec.describe Invoice, type: :model do
         end
 
         it 'scopes the organization_sequential_id to the organization and month' do
-          invoice.save
+          invoice.save!
+          invoice.finalized!
 
           organization_id_substring = organization.id.last(4).upcase
 
@@ -143,7 +151,8 @@ RSpec.describe Invoice, type: :model do
         end
 
         it 'scopes the organization_sequential_id to the organization and month' do
-          invoice.save
+          invoice.save!
+          invoice.finalized!
 
           organization_id_substring = organization.id.last(4).upcase
 

--- a/spec/scenarios/invoices/invoice_numbering_spec.rb
+++ b/spec/scenarios/invoices/invoice_numbering_spec.rb
@@ -418,9 +418,9 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       end
 
       travel_to(time + 1.hour) do
-        draft_invoice_1 = customer_second.reload.invoices.draft.order(created_at: :asc).first
+        draft_invoice1 = customer_second.reload.invoices.draft.order(created_at: :asc).first
 
-        finalize_invoice(draft_invoice_1)
+        finalize_invoice(draft_invoice1)
 
         invoices = organization.reload.invoices.order(created_at: :desc)
 
@@ -437,9 +437,9 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       end
 
       travel_to(time + 2.hours) do
-        draft_invoice_2 = customer_second.reload.invoices.draft.order(created_at: :asc).last
+        draft_invoice2 = customer_second.reload.invoices.draft.order(created_at: :asc).last
 
-        finalize_invoice(draft_invoice_2)
+        finalize_invoice(draft_invoice2)
 
         invoices = organization.reload.invoices.order(created_at: :desc)
 
@@ -626,9 +626,9 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       end
 
       travel_to(time + 1.hour) do
-        draft_invoice_1 = customer_second.reload.invoices.draft.order(created_at: :asc).first
+        draft_invoice1 = customer_second.reload.invoices.draft.order(created_at: :asc).first
 
-        finalize_invoice(draft_invoice_1)
+        finalize_invoice(draft_invoice1)
 
         invoices = organization.reload.invoices.order(created_at: :desc)
 
@@ -645,9 +645,9 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       end
 
       travel_to(time + 2.hours) do
-        draft_invoice_2 = customer_second.reload.invoices.draft.order(created_at: :asc).last
+        draft_invoice2 = customer_second.reload.invoices.draft.order(created_at: :asc).last
 
-        finalize_invoice(draft_invoice_2)
+        finalize_invoice(draft_invoice2)
 
         invoices = organization.reload.invoices.order(created_at: :desc)
 
@@ -721,9 +721,9 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
       end
 
       travel_to(DateTime.new(2023, 9, 20, 12, 12)) do
-        draft_invoice_1 = customer_second.reload.invoices.draft.order(created_at: :asc).first
+        draft_invoice1 = customer_second.reload.invoices.draft.order(created_at: :asc).first
 
-        finalize_invoice(draft_invoice_1)
+        finalize_invoice(draft_invoice1)
 
         invoices = organization.reload.invoices.order(created_at: :desc)
 

--- a/spec/scenarios/invoices/invoice_numbering_spec.rb
+++ b/spec/scenarios/invoices/invoice_numbering_spec.rb
@@ -9,7 +9,13 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
   let(:subscription_at) { DateTime.new(2023, 7, 19, 12, 12) }
 
   let(:organization) do
-    create(:organization, webhook_url: false, document_numbering: 'per_customer', timezone: 'Europe/Paris')
+    create(
+      :organization,
+      webhook_url: nil,
+      document_numbering: 'per_customer',
+      timezone: 'Europe/Paris',
+      email_settings: [],
+    )
   end
 
   let(:monthly_plan) do
@@ -306,6 +312,437 @@ describe 'Invoice Numbering Scenario', :scenarios, type: :request, transaction: 
         expect(sequential_ids).to match_array([4, 4, 4])
         expect(organization_sequential_ids).to match_array([10, 11, 12])
         expect(numbers).to match_array(%w[ORG-11-202310-010 ORG-11-202310-011 ORG-11-202310-012])
+      end
+    end
+  end
+
+  context 'with grace period and per_customer numbering' do
+    let(:customer_second) { create(:customer, organization:, invoice_grace_period: 2) }
+
+    it 'creates invoice numbers correctly' do
+      # NOTE: Jul 19th: create the subscription
+      travel_to(subscription_at) do
+        create_subscription(
+          {
+            external_customer_id: customer_first.external_id,
+            external_id: customer_first.external_id,
+            plan_code: monthly_plan.code,
+            billing_time: 'anniversary',
+            subscription_at: subscription_at.iso8601,
+          },
+        )
+        create_subscription(
+          {
+            external_customer_id: customer_second.external_id,
+            external_id: customer_second.external_id,
+            plan_code: monthly_plan.code,
+            billing_time: 'anniversary',
+            subscription_at: subscription_at.iso8601,
+          },
+        )
+        create_subscription(
+          {
+            external_customer_id: customer_third.external_id,
+            external_id: customer_third.external_id,
+            plan_code: monthly_plan.code,
+            billing_time: 'anniversary',
+            subscription_at: subscription_at.iso8601,
+          },
+        )
+
+        invoices = organization.invoices.order(created_at: :desc).limit(3)
+        sequential_ids = invoices.pluck(:sequential_id)
+        organization_sequential_ids = invoices.pluck(:organization_sequential_id)
+        numbers = invoices.pluck(:number)
+
+        expect(sequential_ids).to match_array([1, nil, 1])
+        expect(organization_sequential_ids).to match_array([0, 0, 0])
+        expect(numbers).to match_array(%w[ORG-1-001-001 ORG-1-DRAFT ORG-1-003-001])
+      end
+
+      # NOTE: Jul 20th: New subscription for the first customer
+      time = subscription_at + 1.day
+      travel_to(time) do
+        create_subscription(
+          {
+            external_customer_id: customer_first.external_id,
+            external_id: 'new_external_id',
+            plan_code: yearly_plan.code,
+            billing_time: 'anniversary',
+            subscription_at: time.iso8601,
+          },
+        )
+
+        invoices = organization.reload.invoices.order(created_at: :desc)
+
+        expect(invoices.first.sequential_id).to eq(2)
+        expect(invoices.first.organization_sequential_id).to eq(0)
+        expect(invoices.pluck(:number))
+          .to match_array(
+            %w[
+              ORG-1-001-001
+              ORG-1-DRAFT
+              ORG-1-003-001
+              ORG-1-001-002
+            ],
+          )
+      end
+
+      # NOTE: Jul 21st: New subscription for the second customer
+      time = subscription_at + 2.days
+      travel_to(time) do
+        create_subscription(
+          {
+            external_customer_id: customer_second.external_id,
+            external_id: 'new_external_id_2',
+            plan_code: yearly_plan.code,
+            billing_time: 'anniversary',
+            subscription_at: time.iso8601,
+          },
+        )
+
+        invoices = organization.reload.invoices.order(created_at: :desc)
+
+        expect(invoices.first.sequential_id).to eq(nil)
+        expect(invoices.first.organization_sequential_id).to eq(0)
+        expect(invoices.pluck(:number))
+          .to match_array(
+            %w[
+              ORG-1-001-001
+              ORG-1-DRAFT
+              ORG-1-003-001
+              ORG-1-001-002
+              ORG-1-DRAFT
+            ],
+          )
+      end
+
+      travel_to(time + 1.hour) do
+        draft_invoice_1 = customer_second.reload.invoices.draft.order(created_at: :asc).first
+
+        finalize_invoice(draft_invoice_1)
+
+        invoices = organization.reload.invoices.order(created_at: :desc)
+
+        expect(invoices.pluck(:number))
+          .to match_array(
+            %w[
+              ORG-1-001-001
+              ORG-1-002-001
+              ORG-1-003-001
+              ORG-1-001-002
+              ORG-1-DRAFT
+            ],
+          )
+      end
+
+      travel_to(time + 2.hours) do
+        draft_invoice_2 = customer_second.reload.invoices.draft.order(created_at: :asc).last
+
+        finalize_invoice(draft_invoice_2)
+
+        invoices = organization.reload.invoices.order(created_at: :desc)
+
+        expect(invoices.pluck(:number))
+          .to match_array(
+            %w[
+              ORG-1-001-001
+              ORG-1-002-001
+              ORG-1-003-001
+              ORG-1-001-002
+              ORG-1-002-002
+            ],
+          )
+      end
+
+      # NOTE: August 19th: Bill subscription
+      travel_to(DateTime.new(2023, 8, 19, 12, 12)) do
+        Subscriptions::BillingService.call
+        perform_all_enqueued_jobs
+
+        invoices = organization.invoices.order(created_at: :desc).limit(3)
+        sequential_ids = invoices.pluck(:sequential_id)
+        organization_sequential_ids = invoices.pluck(:organization_sequential_id)
+        numbers = organization.reload.invoices.order(created_at: :desc).pluck(:number)
+
+        expect(sequential_ids).to match_array([3, nil, 2])
+        expect(organization_sequential_ids).to match_array([0, 0, 0])
+        expect(numbers)
+          .to match_array(
+            %w[
+              ORG-1-001-001
+              ORG-1-002-001
+              ORG-1-003-001
+              ORG-1-001-002
+              ORG-1-002-002
+              ORG-1-001-003
+              ORG-1-DRAFT
+              ORG-1-003-002
+            ],
+          )
+      end
+
+      # NOTE: September 19th: Bill subscription
+      travel_to(DateTime.new(2023, 9, 19, 12, 12)) do
+        Subscriptions::BillingService.call
+        perform_all_enqueued_jobs
+
+        invoices = organization.invoices.order(created_at: :desc).limit(3)
+        sequential_ids = invoices.pluck(:sequential_id)
+        organization_sequential_ids = invoices.pluck(:organization_sequential_id)
+        numbers = organization.reload.invoices.order(created_at: :desc).pluck(:number)
+
+        expect(sequential_ids).to match_array([4, nil, 3])
+        expect(organization_sequential_ids).to match_array([0, 0, 0])
+        expect(numbers)
+          .to match_array(
+            %w[
+              ORG-1-001-001
+              ORG-1-002-001
+              ORG-1-003-001
+              ORG-1-001-002
+              ORG-1-002-002
+              ORG-1-001-003
+              ORG-1-DRAFT
+              ORG-1-003-002
+              ORG-1-001-004
+              ORG-1-DRAFT
+              ORG-1-003-003
+            ],
+          )
+      end
+    end
+  end
+
+  context 'with grace period and per_organization numbering' do
+    let(:customer_second) { create(:customer, organization:, invoice_grace_period: 2) }
+
+    let(:organization) do
+      create(
+        :organization,
+        webhook_url: nil,
+        document_numbering: 'per_organization',
+        timezone: 'Europe/Paris',
+        email_settings: [],
+      )
+    end
+
+    it 'creates invoice numbers correctly' do
+      # NOTE: Jul 19th: create the subscription
+      travel_to(subscription_at) do
+        create_subscription(
+          {
+            external_customer_id: customer_first.external_id,
+            external_id: customer_first.external_id,
+            plan_code: monthly_plan.code,
+            billing_time: 'anniversary',
+            subscription_at: subscription_at.iso8601,
+          },
+        )
+        create_subscription(
+          {
+            external_customer_id: customer_second.external_id,
+            external_id: customer_second.external_id,
+            plan_code: monthly_plan.code,
+            billing_time: 'anniversary',
+            subscription_at: subscription_at.iso8601,
+          },
+        )
+        create_subscription(
+          {
+            external_customer_id: customer_third.external_id,
+            external_id: customer_third.external_id,
+            plan_code: monthly_plan.code,
+            billing_time: 'anniversary',
+            subscription_at: subscription_at.iso8601,
+          },
+        )
+
+        invoices = organization.invoices.order(created_at: :desc).limit(3)
+        sequential_ids = invoices.pluck(:sequential_id)
+        organization_sequential_ids = invoices.pluck(:organization_sequential_id)
+        numbers = invoices.pluck(:number)
+
+        expect(sequential_ids).to match_array([1, nil, 1])
+        expect(organization_sequential_ids).to match_array([1, 0, 2])
+        expect(numbers).to match_array(%w[ORG-1-202307-001 ORG-1-DRAFT ORG-1-202307-002])
+      end
+
+      # NOTE: Jul 20th: New subscription for the first customer
+      time = subscription_at + 1.day
+      travel_to(time) do
+        create_subscription(
+          {
+            external_customer_id: customer_first.external_id,
+            external_id: 'new_external_id',
+            plan_code: yearly_plan.code,
+            billing_time: 'anniversary',
+            subscription_at: time.iso8601,
+          },
+        )
+
+        invoices = organization.reload.invoices.order(created_at: :desc)
+
+        expect(invoices.first.sequential_id).to eq(2)
+        expect(invoices.first.organization_sequential_id).to eq(3)
+        expect(invoices.pluck(:number))
+          .to match_array(
+            %w[
+              ORG-1-202307-001
+              ORG-1-DRAFT
+              ORG-1-202307-002
+              ORG-1-202307-003
+            ],
+          )
+      end
+
+      # NOTE: Jul 21st: New subscription for the second customer
+      time = subscription_at + 2.days
+      travel_to(time) do
+        create_subscription(
+          {
+            external_customer_id: customer_second.external_id,
+            external_id: 'new_external_id_2',
+            plan_code: yearly_plan.code,
+            billing_time: 'anniversary',
+            subscription_at: time.iso8601,
+          },
+        )
+
+        invoices = organization.reload.invoices.order(created_at: :desc)
+
+        expect(invoices.first.sequential_id).to eq(nil)
+        expect(invoices.first.organization_sequential_id).to eq(0)
+        expect(invoices.pluck(:number))
+          .to match_array(
+            %w[
+              ORG-1-202307-001
+              ORG-1-DRAFT
+              ORG-1-202307-002
+              ORG-1-202307-003
+              ORG-1-DRAFT
+            ],
+          )
+      end
+
+      travel_to(time + 1.hour) do
+        draft_invoice_1 = customer_second.reload.invoices.draft.order(created_at: :asc).first
+
+        finalize_invoice(draft_invoice_1)
+
+        invoices = organization.reload.invoices.order(created_at: :desc)
+
+        expect(invoices.pluck(:number))
+          .to match_array(
+            %w[
+              ORG-1-202307-001
+              ORG-1-202307-004
+              ORG-1-202307-002
+              ORG-1-202307-003
+              ORG-1-DRAFT
+            ],
+          )
+      end
+
+      travel_to(time + 2.hours) do
+        draft_invoice_2 = customer_second.reload.invoices.draft.order(created_at: :asc).last
+
+        finalize_invoice(draft_invoice_2)
+
+        invoices = organization.reload.invoices.order(created_at: :desc)
+
+        expect(invoices.pluck(:number))
+          .to match_array(
+            %w[
+              ORG-1-202307-001
+              ORG-1-202307-004
+              ORG-1-202307-002
+              ORG-1-202307-003
+              ORG-1-202307-005
+            ],
+          )
+      end
+
+      # NOTE: August 19th: Bill subscription
+      travel_to(DateTime.new(2023, 8, 19, 12, 12)) do
+        Subscriptions::BillingService.call
+        perform_all_enqueued_jobs
+
+        invoices = organization.invoices.order(created_at: :desc).limit(3)
+        sequential_ids = invoices.pluck(:sequential_id)
+        organization_sequential_ids = invoices.pluck(:organization_sequential_id)
+        numbers = organization.reload.invoices.order(created_at: :desc).pluck(:number)
+
+        expect(sequential_ids).to match_array([3, nil, 2])
+        expect(organization_sequential_ids).to match_array([6, 0, 7])
+        expect(numbers)
+          .to match_array(
+            %w[
+              ORG-1-202307-001
+              ORG-1-202307-004
+              ORG-1-202307-002
+              ORG-1-202307-003
+              ORG-1-202307-005
+              ORG-1-202308-006
+              ORG-1-DRAFT
+              ORG-1-202308-007
+            ],
+          )
+      end
+
+      # NOTE: September 19th: Bill subscription
+      travel_to(DateTime.new(2023, 9, 19, 12, 12)) do
+        Subscriptions::BillingService.call
+        perform_all_enqueued_jobs
+
+        invoices = organization.invoices.order(created_at: :desc).limit(3)
+        sequential_ids = invoices.pluck(:sequential_id)
+        organization_sequential_ids = invoices.pluck(:organization_sequential_id)
+        numbers = organization.reload.invoices.order(created_at: :desc).pluck(:number)
+
+        expect(sequential_ids).to match_array([4, nil, 3])
+        expect(organization_sequential_ids).to match_array([8, 0, 9])
+        expect(numbers)
+          .to match_array(
+            %w[
+              ORG-1-202307-001
+              ORG-1-202307-004
+              ORG-1-202307-002
+              ORG-1-202307-003
+              ORG-1-202307-005
+              ORG-1-202308-006
+              ORG-1-DRAFT
+              ORG-1-202308-007
+              ORG-1-202309-008
+              ORG-1-DRAFT
+              ORG-1-202309-009
+            ],
+          )
+      end
+
+      travel_to(DateTime.new(2023, 9, 20, 12, 12)) do
+        draft_invoice_1 = customer_second.reload.invoices.draft.order(created_at: :asc).first
+
+        finalize_invoice(draft_invoice_1)
+
+        invoices = organization.reload.invoices.order(created_at: :desc)
+
+        expect(invoices.pluck(:number))
+          .to match_array(
+            %w[
+              ORG-1-202307-001
+              ORG-1-202307-004
+              ORG-1-202307-002
+              ORG-1-202307-003
+              ORG-1-202307-005
+              ORG-1-202308-006
+              ORG-1-202309-010
+              ORG-1-202308-007
+              ORG-1-202309-008
+              ORG-1-DRAFT
+              ORG-1-202309-009
+            ],
+          )
       end
     end
   end

--- a/spec/scenarios/spending_minimum_spec.rb
+++ b/spec/scenarios/spending_minimum_spec.rb
@@ -72,7 +72,7 @@ describe 'Spending Minimum Scenarios', :scenarios, type: :request do
         }.to change { subscription.reload.status }.from('active').to('terminated')
           .and change { subscription.invoices.count }.from(2).to(3)
 
-        term_invoice = subscription.invoices.order(sequential_id: :desc).first
+        term_invoice = subscription.invoices.order(created_at: :desc).first
         expect(term_invoice).to be_draft
 
         expect(term_invoice.fees.count).to eq(2)
@@ -221,7 +221,7 @@ describe 'Spending Minimum Scenarios', :scenarios, type: :request do
         }.to change { subscription.reload.status }.from('active').to('terminated')
           .and change { subscription.invoices.count }.from(2).to(3)
 
-        term_invoice = subscription.invoices.order(sequential_id: :desc).first
+        term_invoice = subscription.invoices.order(created_at: :desc).first
         expect(term_invoice).to be_finalized
         expect(term_invoice.fees.count).to eq(3)
 


### PR DESCRIPTION
## Context

Currently invoice number is generated upon invoice generation. We should change this behaviour to generate invoice number upon changing invoice status to `finalized`.


## Description

This PR handles described case. New logic also ensures that all invoices that are in `draft` status before releasing the feature, keep already generated number and sequential ids.