### PR TITLE
fix(prepaid-credit): Automatic topup without any usage

### DIFF
--- a/app/services/wallets/balance/decrease_ongoing_service.rb
+++ b/app/services/wallets/balance/decrease_ongoing_service.rb
@@ -34,7 +34,7 @@ module Wallets
         threshold_rule = wallet.recurring_transaction_rules.where(rule_type: :threshold).first
 
         return if threshold_rule.nil? || wallet.credits_ongoing_balance > threshold_rule.threshold_credits
-        return if ongoing_usage_balance_cents == amount_cents
+        return if amount_cents.positive? && ongoing_usage_balance_cents == amount_cents
 
         WalletTransactions::CreateJob.set(wait: 2.seconds).perform_later(
           organization_id: wallet.organization.id,

--- a/spec/services/wallets/balance/decrease_ongoing_service_spec.rb
+++ b/spec/services/wallets/balance/decrease_ongoing_service_spec.rb
@@ -49,6 +49,25 @@ RSpec.describe Wallets::Balance::DecreaseOngoingService, type: :service do
           expect { decrease_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
         end
       end
+
+      context 'without any usage' do
+        let(:wallet) do
+          create(
+            :wallet,
+            balance_cents: 200,
+            ongoing_balance_cents: 200,
+            ongoing_usage_balance_cents: 0,
+            credits_balance: 2.0,
+            credits_ongoing_balance: 2.0,
+            credits_ongoing_usage_balance: 0.0,
+          )
+        end
+        let(:credits_amount) { BigDecimal('0.0') }
+
+        it 'calls wallet transaction create job' do
+          expect { decrease_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The goal of this PR is to be able to handle automatic topup when usage is empty.