### PR TITLE
feat(disputes): Add dispute columns to invoices

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -96,7 +96,7 @@ class Invoice < ApplicationRecord
   validates :issuing_date, :currency, presence: true
   validates :timezone, timezone: true, allow_nil: true
   validates :total_amount_cents, numericality: { greater_than_or_equal_to: 0 }
-  validates :payment_dispute_lost_at, absence: true, if: :voided?
+  validates :payment_dispute_lost_at, absence: true, unless: :payment_dispute_losable?
 
   def self.ransackable_attributes(_ = nil)
     %w[id number]
@@ -247,6 +247,10 @@ class Invoice < ApplicationRecord
              credits.where(before_taxes: false).sum(:amount_cents) -
              prepaid_credit_amount_cents
     amount.negative? ? 0 : amount
+  end
+
+  def payment_dispute_losable?
+    finalized?
   end
 
   def voidable?

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -13,7 +13,6 @@ module V1
         invoice_type: model.invoice_type,
         status: model.status,
         payment_status: model.payment_status,
-        payment_disputed: model.payment_disputed,
         payment_dispute_lost_at: model.payment_dispute_lost_at,
         currency: model.currency,
         fees_amount_cents: model.fees_amount_cents,

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -13,6 +13,8 @@ module V1
         invoice_type: model.invoice_type,
         status: model.status,
         payment_status: model.payment_status,
+        payment_disputed: model.payment_disputed,
+        payment_dispute_lost_at: model.payment_dispute_lost_at,
         currency: model.currency,
         fees_amount_cents: model.fees_amount_cents,
         taxes_amount_cents: model.taxes_amount_cents,

--- a/db/migrate/20240327071539_add_payment_disputed_to_invoices.rb
+++ b/db/migrate/20240327071539_add_payment_disputed_to_invoices.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddPaymentDisputedToInvoices < ActiveRecord::Migration[7.0]
+  def change
+    change_table :invoices, bulk: true do |t|
+      t.boolean :payment_disputed, null: false, default: false
+      t.datetime :payment_dispute_lost_at, default: nil
+    end
+  end
+end

--- a/db/migrate/20240327071539_add_payment_disputed_to_invoices.rb
+++ b/db/migrate/20240327071539_add_payment_disputed_to_invoices.rb
@@ -3,7 +3,6 @@
 class AddPaymentDisputedToInvoices < ActiveRecord::Migration[7.0]
   def change
     change_table :invoices, bulk: true do |t|
-      t.boolean :payment_disputed, null: false, default: false
       t.datetime :payment_dispute_lost_at, default: nil
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_14_163426) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_27_071539) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -481,8 +481,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_14_163426) do
     t.bigint "unit_amount_cents", default: 0, null: false
     t.boolean "pay_in_advance", default: false, null: false
     t.decimal "precise_coupons_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
-    t.decimal "total_aggregated_units"
     t.string "invoice_display_name"
+    t.decimal "total_aggregated_units"
     t.decimal "precise_unit_amount", precision: 30, scale: 15, default: "0.0", null: false
     t.jsonb "amount_details", default: {}, null: false
     t.uuid "charge_filter_id"
@@ -615,6 +615,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_14_163426) do
     t.datetime "voided_at"
     t.integer "organization_sequential_id", default: 0, null: false
     t.boolean "ready_to_be_refreshed", default: false, null: false
+    t.boolean "payment_disputed", default: false, null: false
+    t.datetime "payment_dispute_lost_at"
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
@@ -676,9 +678,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_14_163426) do
     t.string "tax_identification_number"
     t.integer "net_payment_term", default: 0, null: false
     t.string "default_currency", default: "USD", null: false
+    t.boolean "eu_tax_management", default: false
     t.integer "document_numbering", default: 0, null: false
     t.string "document_number_prefix"
-    t.boolean "eu_tax_management", default: false
     t.boolean "clickhouse_aggregation", default: false, null: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -481,8 +481,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_27_071539) do
     t.bigint "unit_amount_cents", default: 0, null: false
     t.boolean "pay_in_advance", default: false, null: false
     t.decimal "precise_coupons_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
-    t.string "invoice_display_name"
     t.decimal "total_aggregated_units"
+    t.string "invoice_display_name"
     t.decimal "precise_unit_amount", precision: 30, scale: 15, default: "0.0", null: false
     t.jsonb "amount_details", default: {}, null: false
     t.uuid "charge_filter_id"
@@ -615,7 +615,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_27_071539) do
     t.datetime "voided_at"
     t.integer "organization_sequential_id", default: 0, null: false
     t.boolean "ready_to_be_refreshed", default: false, null: false
-    t.boolean "payment_disputed", default: false, null: false
     t.datetime "payment_dispute_lost_at"
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
@@ -678,9 +677,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_27_071539) do
     t.string "tax_identification_number"
     t.integer "net_payment_term", default: 0, null: false
     t.string "default_currency", default: "USD", null: false
-    t.boolean "eu_tax_management", default: false
     t.integer "document_numbering", default: 0, null: false
     t.string "document_number_prefix"
+    t.boolean "eu_tax_management", default: false
     t.boolean "clickhouse_aggregation", default: false, null: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -459,34 +459,6 @@ RSpec.describe Invoice, type: :model do
 
         before { create(:credit_note, credit_status: :voided, invoice:) }
 
-        context 'when invoice is not finalized' do
-          let(:status) { :draft }
-
-          context 'when invoice is pending' do
-            let(:payment_status) { :pending }
-
-            it 'returns false' do
-              expect(voidable).to be false
-            end
-          end
-
-          context 'when invoice is failed' do
-            let(:payment_status) { :failed }
-
-            it 'returns false' do
-              expect(voidable).to be false
-            end
-          end
-
-          context 'when invoice is succeeded' do
-            let(:payment_status) { :succeeded }
-
-            it 'returns false' do
-              expect(voidable).to be false
-            end
-          end
-        end
-
         context 'when invoice is finalized' do
           let(:status) { :finalized }
 
@@ -520,34 +492,6 @@ RSpec.describe Invoice, type: :model do
         let(:invoice) { create(:invoice, status:, payment_status:, payment_dispute_lost_at:) }
 
         before { create(:credit_note, invoice:) }
-
-        context 'when invoice is not finalized' do
-          let(:status) { :draft }
-
-          context 'when invoice is pending' do
-            let(:payment_status) { :pending }
-
-            it 'returns false' do
-              expect(voidable).to be false
-            end
-          end
-
-          context 'when invoice is failed' do
-            let(:payment_status) { :failed }
-
-            it 'returns false' do
-              expect(voidable).to be false
-            end
-          end
-
-          context 'when invoice is succeeded' do
-            let(:payment_status) { :succeeded }
-
-            it 'returns false' do
-              expect(voidable).to be false
-            end
-          end
-        end
 
         context 'when invoice is finalized' do
           let(:status) { :finalized }

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe ::V1::InvoiceSerializer do
         'invoice_type' => invoice.invoice_type,
         'status' => invoice.status,
         'payment_status' => invoice.payment_status,
+        'payment_disputed' => invoice.payment_disputed,
+        'payment_dispute_lost_at' => invoice.payment_dispute_lost_at,
         'currency' => invoice.currency,
         'fees_amount_cents' => invoice.fees_amount_cents,
         'coupons_amount_cents' => invoice.coupons_amount_cents,

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe ::V1::InvoiceSerializer do
         'invoice_type' => invoice.invoice_type,
         'status' => invoice.status,
         'payment_status' => invoice.payment_status,
-        'payment_disputed' => invoice.payment_disputed,
         'payment_dispute_lost_at' => invoice.payment_dispute_lost_at,
         'currency' => invoice.currency,
         'fees_amount_cents' => invoice.fees_amount_cents,


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/dispute-notification

## Context

PSP integration should listen to disputes and chargebacks to update payment status.

## Description

This PR adds a migration that adds `payment_dispute_lost_at` column to `invoices` table.
It also handles validations in `Invoice` model with and model specs as well.
It adds this field to `InvoiceSerializer`.