### PR TITLE
feat(model): Introduce Subscription.in_trial_period?

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -89,6 +89,13 @@ class Subscription < ApplicationRecord
     initial_started_at + plan.trial_period.days
   end
 
+  def in_trial_period?
+    return false unless active?
+    return false if initial_started_at.future?
+
+    trial_end_datetime.present? && trial_end_datetime.future?
+  end
+
   def started_in_past?
     started_at.to_date < created_at.to_date
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -182,6 +182,26 @@ RSpec.describe Subscription, type: :model do
     end
   end
 
+  describe '#in_trial_period?' do
+    context 'when plan has no trial' do
+      it { expect(subscription.in_trial_period?).to be false }
+    end
+
+    context 'when subscription is in trial' do
+      let(:subscription) { create(:subscription, plan:, started_at: 5.days.ago) }
+      let(:plan) { create(:plan, trial_period: 10) }
+
+      it { expect(subscription.in_trial_period?).to be true }
+    end
+
+    context 'when subscription trial has ended' do
+      let(:subscription) { create(:subscription, plan:, started_at: 5.days.ago) }
+      let(:plan) { create(:plan, trial_period: 2) }
+
+      it { expect(subscription.in_trial_period?).to be false }
+    end
+  end
+
   describe '#initial_started_at' do
     let(:customer) { create(:customer) }
     let(:subscription) do


### PR DESCRIPTION
## Context

We're working on some change with how the trial is billed. This is a very small function needed for these change. More PR are coming.

## Description

The `in_trial_period?` method will help us determine if a subscription is currently in trial (to know if they should be billed or not).