### PR TITLE
feat(trial): Introduce Subscriptions::FreeTrialBillingService

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -90,6 +90,7 @@ class Subscription < ApplicationRecord
   end
 
   def in_trial_period?
+    return false if trial_ended_at
     return false unless active?
     return false if initial_started_at.future?
 

--- a/app/services/subscriptions/free_trial_billing_service.rb
+++ b/app/services/subscriptions/free_trial_billing_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Subscriptions
+  class FreeTrialBillingService < BaseService
+    def initialize(timestamp: Time.current)
+      @timestamp = timestamp
+
+      super
+    end
+
+    def call
+      ending_trial_subscriptions.each do |subscription|
+        # if subscription.plan_pay_in_advance
+        #   BillSubscriptionJob.perform_later([subscription], timestamp)
+        # end
+
+        # TODO: Send webhook
+        subscription.update!(trial_ended_at: timestamp)
+      end
+    end
+
+    private
+
+    attr_reader :timestamp
+
+    def ending_trial_subscriptions
+      sql = <<-SQL
+        WITH
+          initial_started_at AS (#{initial_started_at})
+        SELECT DISTINCT
+          plans.pay_in_advance AS plan_pay_in_advance,
+          subscriptions.*
+        FROM
+          subscriptions
+          INNER JOIN plans ON subscriptions.plan_id = plans.id
+          INNER JOIN initial_started_at ON initial_started_at.external_id = subscriptions.external_id
+          INNER JOIN customers ON subscriptions.customer_id = customers.id
+          INNER JOIN organizations ON customers.organization_id = organizations.id
+        WHERE
+          subscriptions.status = 1
+          AND subscriptions.trial_ended_at IS NULL
+          AND DATE(initial_started_at#{at_time_zone} + plans.trial_period * INTERVAL '1 day') = DATE('#{timestamp}'#{at_time_zone})
+      SQL
+
+      Subscription.find_by_sql([sql, { timestamp: }])
+    end
+
+    def initial_started_at
+      <<-SQL
+        SELECT
+          external_id,
+          FIRST_VALUE(started_at) OVER (PARTITION BY external_id ORDER BY started_at) AS initial_started_at
+        FROM
+          subscriptions
+      SQL
+    end
+  end
+end

--- a/db/migrate/20240328075919_add_trial_ended_at_to_subscriptions.rb
+++ b/db/migrate/20240328075919_add_trial_ended_at_to_subscriptions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTrialEndedAtToSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :subscriptions, :trial_ended_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_27_071539) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_28_075919) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -838,6 +838,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_27_071539) do
     t.integer "billing_time", default: 0, null: false
     t.datetime "subscription_at"
     t.datetime "ending_at"
+    t.datetime "trial_ended_at"
     t.index ["customer_id"], name: "index_subscriptions_on_customer_id"
     t.index ["external_id"], name: "index_subscriptions_on_external_id"
     t.index ["plan_id"], name: "index_subscriptions_on_plan_id"

--- a/spec/services/subscriptions/free_trial_billing_service_spec.rb
+++ b/spec/services/subscriptions/free_trial_billing_service_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Subscriptions::FreeTrialBillingService, type: :service do
+  subject(:service) { described_class.new(timestamp:) }
+
+  describe '#call' do
+    let(:timestamp) { Time.current.change(usec: 0) }
+    let(:plan) { create(:plan, trial_period: 10, pay_in_advance: true) }
+
+    context 'without any ending trial subscriptions' do
+      it 'does not set trial_ended_at', :aggregate_failures do
+        sub1 = create(:subscription, plan:, started_at: 2.days.ago)
+        sub2 = create(:subscription, plan:, started_at: 15.days.ago)
+
+        expect { service.call }.not_to change { sub1.reload.trial_ended_at }.from(nil)
+        expect { service.call }.not_to change { sub2.reload.trial_ended_at }.from(nil)
+      end
+    end
+
+    context 'with ending trial subscriptions' do
+      it 'sets trial_ended_at to current time' do
+        sub = create(:subscription, plan:, started_at: 10.days.ago)
+        expect { service.call }.to change { sub.reload.trial_ended_at }.from(nil).to(timestamp)
+      end
+    end
+
+    context 'with trial ended due to previous subscription with the same external_id' do
+      it 'sets trial_ended_at' do
+        customer = create(:customer)
+        attr = { customer:, plan:, external_id: 'abc123' }
+        sub = create(:subscription, started_at: 6.days.ago, **attr)
+        create(:subscription, started_at: 10.days.ago, terminated_at: 6.days.ago, status: :terminated, **attr)
+
+        expect { service.call }.to change { sub.reload.trial_ended_at }.from(nil).to(timestamp)
+      end
+    end
+
+    context 'with customer timezone' do
+      let(:timestamp) { DateTime.parse('2024-03-12 01:00:00 UTC') }
+
+      it 'sets trial_ended_at to the expected subscription', :aggregate_failures do
+        started_at = DateTime.parse('2024-03-01 12:00:00 UTC')
+        customer = create(:customer, timezone: 'America/Los_Angeles')
+        sub = create(:subscription, plan:, customer:, started_at:)
+        utc_sub = create(:subscription, plan:, started_at:)
+
+        expect { service.call }.to change { sub.reload.trial_ended_at }.from(nil).to(timestamp)
+        expect { service.call }.not_to change { utc_sub.reload.trial_ended_at }.from(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Following https://github.com/getlago/lago-api/pull/1820, we need a job find all subscriptions which has a trial which just ended.

## Description

This introduce a new service to find all subscription with a trial period ending today. The job will run every hour to follow customer timezones. 

We introduce a new timestamp in subscriptions to know if the trial has ended. This ensure we only run the job once. Without this flag, we would retrieve the same subscription 24 times and dispatch the webhook 24 times. The invoice can't be used to know if the job was run because we only change plans with `pay_in_advance = true`.

This adds the fourth definition of the `at_time_zone` method. I'm hoping to refactor this later.

**Note that the job doesn't run yet**. The following PR will add it to the scheduler and generate invoice and send the webhooks.

### Migration

The data is migrated for all subscriptions with a trial that has already ended. This is done to ensure a minimum of consistency in the data.

The logic for `initial_started_at` is implemented to avoid the N+1 queries triggered by the original method.

I didn't reuse the SQL query from the service because `find_by_sql` returns an array, not a collection so you can't load the data in batch (like with `find_each`). We'd have to load ALL subscription in the array 🙈

Alternatively, we can probably write an SQL query that update all data at once, without using the model. It would be fun but I'm not sure it's worth the effort.