### PR TITLE
feat(disputes): Add payment_dispute_lost_at to analytics queries

### DIFF
--- a/app/models/analytics/gross_revenue.rb
+++ b/app/models/analytics/gross_revenue.rb
@@ -57,6 +57,7 @@ module Analytics
             LEFT JOIN credit_notes cn ON cn.invoice_id = i.id
             WHERE i.organization_id = :organization_id
             AND i.status = 1
+            AND i.payment_dispute_lost_at IS NULL
             #{and_external_customer_id_sql}
             GROUP BY i.id, i.issuing_date, i.total_amount_cents, i.currency
             ORDER BY i.issuing_date ASC

--- a/app/models/analytics/invoice_collection.rb
+++ b/app/models/analytics/invoice_collection.rb
@@ -49,7 +49,8 @@ module Analytics
                 COALESCE(SUM(i.total_amount_cents::float), 0) AS amount_cents
             FROM invoices i
             WHERE i.organization_id = :organization_id
-                AND i.status = 1
+            AND i.status = 1
+            AND i.payment_dispute_lost_at IS NULL
             GROUP BY payment_status, month, currency
           )
           SELECT

--- a/app/models/analytics/invoiced_usage.rb
+++ b/app/models/analytics/invoiced_usage.rb
@@ -44,10 +44,12 @@ module Analytics
               f.amount_currency AS currency,
               f.created_at AS fee_created_at
             FROM fees f
+            LEFT JOIN invoices i ON f.invoice_id = i.id
             LEFT JOIN subscriptions s ON s.id = f.subscription_id
             LEFT JOIN customers c ON c.id = s.customer_id
             WHERE f.invoiceable_type = 'Charge'
             AND f.fee_type = 0
+            AND i.payment_dispute_lost_at IS NULL
             AND c.organization_id = :organization_id
           ),
           total_revenue_per_bm AS (

--- a/app/models/analytics/mrr.rb
+++ b/app/models/analytics/mrr.rb
@@ -64,6 +64,7 @@ module Analytics
             WHERE fee_type = 2
               AND c.organization_id = :organization_id
               AND i.status = 1
+              AND i.payment_dispute_lost_at IS NULL
             ORDER BY issuing_date ASC
           ),
           quarterly_advance AS (


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/dispute-notification

## Context

PSP integration should listen to disputes and chargebacks to update payment_dispute_lost_at after a dispute is lost.

## Description

This PR adds `payment_dispute_lost_at IS NULL` to analytics queries to exclude the invoices with lost payment dispute.