### PR TITLE
feat(disputes): Add route, controller action and service for lost disputes

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -124,6 +124,17 @@ module Api
         end
       end
 
+      def lose_dispute
+        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
+
+        result = Invoices::LoseDisputeService.call(invoice:)
+        if result.success?
+          render_invoice(result.invoice)
+        else
+          render_error_response(result)
+        end
+      end
+
       def retry_payment
         invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
         return not_found_error(resource: 'invoice') unless invoice

--- a/app/services/invoices/lose_dispute_service.rb
+++ b/app/services/invoices/lose_dispute_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Invoices
+  class LoseDisputeService < BaseService
+    def initialize(invoice:)
+      @invoice = invoice
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'invoice') if invoice.nil?
+
+      result.invoice = invoice
+
+      invoice.mark_as_dispute_lost!
+
+      result
+    rescue ActiveRecord::RecordInvalid => _e
+      result.not_allowed_failure!(code: 'not_disputable')
+    end
+
+    private
+
+    attr_reader :invoice
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
       resources :invoices, only: %i[create update show index] do
         post :download, on: :member
         post :void, on: :member
+        post :lose_dispute, on: :member
         post :retry_payment, on: :member
         post :payment_url, on: :member
         put :refresh, on: :member

--- a/spec/services/invoices/lose_dispute_service_spec.rb
+++ b/spec/services/invoices/lose_dispute_service_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::LoseDisputeService, type: :service do
+  subject(:lose_dispute_service) { described_class.new(invoice:) }
+
+  describe '#call' do
+    context 'when invoice does not exist' do
+      let(:invoice) { nil }
+
+      it 'returns a failure' do
+        result = lose_dispute_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+
+          expect(result.error).to be_a(BaseService::NotFoundFailure)
+          expect(result.error.resource).to eq('invoice')
+        end
+      end
+    end
+
+    context 'when invoice exists' do
+      let(:invoice) { create(:invoice, status:) }
+
+      context 'when the invoice is voided' do
+        let(:status) { :voided }
+
+        it 'returns a failure' do
+          result = lose_dispute_service.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+            expect(result.error.code).to eq('not_disputable')
+          end
+        end
+      end
+
+      context 'when the invoice is draft' do
+        let(:status) { :draft }
+
+        it 'returns a failure' do
+          result = lose_dispute_service.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+            expect(result.error.code).to eq('not_disputable')
+          end
+        end
+      end
+
+      context 'when the invoice is finalized' do
+        let(:status) { :finalized }
+
+        it 'marks the dispute as lost' do
+          result = lose_dispute_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.invoice.payment_dispute_lost_at).to be_present
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/dispute-notification

## Context

PSP integration should listen to disputes and chargebacks to update payment_dispute_lost_at after a dispute is lost.

## Description

This PR adds route, controller action and `Invoices::LoseDisputeService` so that it's possible to mark invoice payment dispute as lost via the API:
`POST /api/v1/invoices/:id/lose_dispute`