### PR TITLE
feat(trial): Invoice subscription fee at the end of the trial period

### DIFF
--- a/app/jobs/bill_subscription_job.rb
+++ b/app/jobs/bill_subscription_job.rb
@@ -5,12 +5,13 @@ class BillSubscriptionJob < ApplicationJob
 
   retry_on Sequenced::SequenceError, ActiveJob::DeserializationError
 
-  def perform(subscriptions, timestamp, recurring: false, invoice: nil)
+  def perform(subscriptions, timestamp, recurring: false, invoice: nil, skip_charges: false)
     result = Invoices::SubscriptionService.call(
       subscriptions:,
       timestamp:,
       recurring:,
       invoice:,
+      skip_charges:,
     )
     return if result.success?
 
@@ -22,6 +23,7 @@ class BillSubscriptionJob < ApplicationJob
       timestamp,
       recurring:,
       invoice: result.invoice,
+      skip_charges:,
     )
   end
 end

--- a/app/jobs/clock/free_trial_subscriptions_biller_job.rb
+++ b/app/jobs/clock/free_trial_subscriptions_biller_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Clock
+  class FreeTrialSubscriptionsBillerJob < ApplicationJob
+    queue_as 'clock'
+
+    def perform
+      Subscriptions::FreeTrialBillingService.call
+    end
+  end
+end

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -31,6 +31,7 @@ class SendWebhookJob < ApplicationJob
     'subscription.terminated' => Webhooks::Subscriptions::TerminatedService,
     'subscription.started' => Webhooks::Subscriptions::StartedService,
     'subscription.termination_alert' => Webhooks::Subscriptions::TerminationAlertService,
+    'subscription.trial_ended' => Webhooks::Subscriptions::TrialEndedService,
   }.freeze
 
   def perform(webhook_type, object, options = {}, webhook_id = nil)

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -14,6 +14,7 @@ module V1
         billing_time: model.billing_time,
         subscription_at: model.subscription_at&.iso8601,
         started_at: model.started_at&.iso8601,
+        trial_ended_at: model.trial_ended_at&.iso8601,
         ending_at: model.ending_at&.iso8601,
         terminated_at: model.terminated_at&.iso8601,
         canceled_at: model.canceled_at&.iso8601,

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -2,7 +2,7 @@
 
 module Invoices
   class CalculateFeesService < BaseService
-    def initialize(invoice:, recurring: false, context: nil, skip_charges: false)
+    def initialize(invoice:, recurring: false, context: nil)
       @invoice = invoice
       @timestamp = invoice.invoice_subscriptions.first&.timestamp
 
@@ -11,7 +11,6 @@ module Invoices
       @recurring = recurring
 
       @context = context
-      @skip_charges = skip_charges
 
       super
     end
@@ -65,7 +64,7 @@ module Invoices
 
     private
 
-    attr_accessor :invoice, :subscriptions, :timestamp, :recurring, :context, :skip_charges
+    attr_accessor :invoice, :subscriptions, :timestamp, :recurring, :context
 
     delegate :customer, :currency, to: :invoice
 
@@ -194,7 +193,7 @@ module Invoices
     end
 
     def should_create_charge_fees?(subscription)
-      return false if skip_charges
+      return false if invoice.skip_charges
 
       # We should take a look at charges if subscription is created in the past and if it is not upgrade
       return true if subscription.plan.pay_in_advance? &&

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -197,9 +197,9 @@ module Invoices
       return false if skip_charges
 
       # We should take a look at charges if subscription is created in the past and if it is not upgrade
-      if subscription.plan.pay_in_advance? && subscription.started_in_past? && subscription.previous_subscription.nil?
-        return true
-      end
+      return true if subscription.plan.pay_in_advance? &&
+                     subscription.started_in_past? &&
+                     subscription.previous_subscription.nil?
 
       return false if subscription.plan.pay_in_advance? &&
                       subscription.started_at.to_date == timestamp.to_date

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -169,9 +169,10 @@ module Invoices
 
       return false if subscription.plan.pay_in_advance? && fee_exists
       return false unless should_create_yearly_subscription_fee?(subscription)
+      return false if subscription.in_trial_period? && !subscription.trial_end_datetime&.today?
 
       # NOTE: When a subscription is terminated we still need to charge the subscription
-      #       fee if the plan is in pay in arrear, otherwise this fee will never
+      #       fee if the plan is in pay in arrears, otherwise this fee will never
       #       be created.
       subscription.active? ||
         (subscription.terminated? && subscription.plan.pay_in_arrear?) ||

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -2,7 +2,7 @@
 
 module Invoices
   class CalculateFeesService < BaseService
-    def initialize(invoice:, recurring: false, context: nil)
+    def initialize(invoice:, recurring: false, context: nil, skip_charges: false)
       @invoice = invoice
       @timestamp = invoice.invoice_subscriptions.first&.timestamp
 
@@ -11,6 +11,7 @@ module Invoices
       @recurring = recurring
 
       @context = context
+      @skip_charges = skip_charges
 
       super
     end
@@ -64,7 +65,7 @@ module Invoices
 
     private
 
-    attr_accessor :invoice, :subscriptions, :timestamp, :recurring, :context
+    attr_accessor :invoice, :subscriptions, :timestamp, :recurring, :context, :skip_charges
 
     delegate :customer, :currency, to: :invoice
 
@@ -193,6 +194,8 @@ module Invoices
     end
 
     def should_create_charge_fees?(subscription)
+      return false if skip_charges
+
       # We should take a look at charges if subscription is created in the past and if it is not upgrade
       if subscription.plan.pay_in_advance? && subscription.started_in_past? && subscription.previous_subscription.nil?
         return true

--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -2,12 +2,13 @@
 
 module Invoices
   class CreateGeneratingService < BaseService
-    def initialize(customer:, invoice_type:, datetime:, currency:, charge_in_advance: false)
+    def initialize(customer:, invoice_type:, datetime:, currency:, charge_in_advance: false, skip_charges: false) # rubocop:disable Metrics/ParameterLists
       @customer = customer
       @invoice_type = invoice_type
       @currency = currency
       @datetime = datetime
       @charge_in_advance = charge_in_advance
+      @skip_charges = skip_charges
 
       super
     end
@@ -24,6 +25,7 @@ module Invoices
           issuing_date:,
           payment_due_date:,
           net_payment_term: customer.applicable_net_payment_term,
+          skip_charges:,
         )
         result.invoice = invoice
 
@@ -35,7 +37,7 @@ module Invoices
 
     private
 
-    attr_accessor :customer, :invoice_type, :currency, :datetime, :charge_in_advance
+    attr_accessor :customer, :invoice_type, :currency, :datetime, :charge_in_advance, :skip_charges
 
     delegate :organization, to: :customer
 

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -31,8 +31,6 @@ module Invoices
 
         timestamp = fetch_timestamp
 
-        skip_charges = invoice.fees.charge_kind.none?
-
         invoice.fees.destroy_all
 
         invoice.invoice_subscriptions.destroy_all
@@ -50,7 +48,6 @@ module Invoices
           invoice: invoice.reload,
           recurring:,
           context:,
-          skip_charges:,
         )
 
         invoice.credit_notes.each do |credit_note|

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -31,6 +31,8 @@ module Invoices
 
         timestamp = fetch_timestamp
 
+        skip_charges = invoice.fees.charge_kind.none?
+
         invoice.fees.destroy_all
 
         invoice.invoice_subscriptions.destroy_all
@@ -48,6 +50,7 @@ module Invoices
           invoice: invoice.reload,
           recurring:,
           context:,
+          skip_charges:,
         )
 
         invoice.credit_notes.each do |credit_note|

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -35,7 +35,6 @@ module Invoices
         fee_result = Invoices::CalculateFeesService.call(
           invoice:,
           recurring:,
-          skip_charges:,
         )
 
         fee_result.raise_if_error!
@@ -74,6 +73,7 @@ module Invoices
         invoice_type: :subscription,
         currency:,
         datetime: Time.zone.at(timestamp),
+        skip_charges:,
       ) do |invoice|
         Invoices::CreateInvoiceSubscriptionService
           .call(invoice:, subscriptions:, timestamp:, recurring:)

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -2,7 +2,7 @@
 
 module Invoices
   class SubscriptionService < BaseService
-    def initialize(subscriptions:, timestamp:, recurring:, invoice: nil)
+    def initialize(subscriptions:, timestamp:, recurring:, invoice: nil, skip_charges: false)
       @subscriptions = subscriptions
       @timestamp = timestamp
 
@@ -17,6 +17,7 @@ module Invoices
       #       and if the generating invoice was persisted,
       #       the process can be retried without creating a new invoice
       @invoice = invoice
+      @skip_charges = skip_charges
 
       super
     end
@@ -34,6 +35,7 @@ module Invoices
         fee_result = Invoices::CalculateFeesService.call(
           invoice:,
           recurring:,
+          skip_charges:,
         )
 
         fee_result.raise_if_error!
@@ -60,7 +62,7 @@ module Invoices
 
     private
 
-    attr_accessor :subscriptions, :timestamp, :recurring, :customer, :currency, :invoice
+    attr_accessor :subscriptions, :timestamp, :recurring, :customer, :currency, :invoice, :skip_charges
 
     def active_subscriptions
       @active_subscriptions ||= subscriptions.select(&:active?)

--- a/app/services/subscriptions/free_trial_billing_service.rb
+++ b/app/services/subscriptions/free_trial_billing_service.rb
@@ -11,7 +11,7 @@ module Subscriptions
     def call
       ending_trial_subscriptions.each do |subscription|
         if subscription.plan_pay_in_advance && !already_billed?(subscription)
-          BillSubscriptionJob.perform_later([subscription], timestamp)
+          BillSubscriptionJob.perform_later([subscription], timestamp, skip_charges: true)
         end
 
         subscription.update!(trial_ended_at: timestamp)

--- a/app/services/webhooks/subscriptions/trial_ended_service.rb
+++ b/app/services/webhooks/subscriptions/trial_ended_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Subscriptions
+    class TrialEndedService < Webhooks::BaseService
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::SubscriptionSerializer.new(
+          object,
+          root_name: 'subscription',
+          includes: %i[plan customer],
+        )
+      end
+
+      def webhook_type
+        'subscription.trial_ended'
+      end
+
+      def object_type
+        'subscription'
+      end
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -46,6 +46,10 @@ module Clockwork
     Clock::TerminateCouponsJob.perform_later
   end
 
+  every(1.hour, 'schedule:bill_ended_trial_subscriptions', at: '*:35') do
+    Clock::FreeTrialSubscriptionsBillerJob.perform_later
+  end
+
   every(1.hour, 'schedule:terminate_wallets', at: '*:45') do
     Clock::TerminateWalletsJob.perform_later
   end

--- a/db/migrate/20240329112415_fill_subscriptions_trial_ended_at.rb
+++ b/db/migrate/20240329112415_fill_subscriptions_trial_ended_at.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class FillSubscriptionsTrialEndedAt < ActiveRecord::Migration[7.0]
+  class Subscription < ApplicationRecord
+    belongs_to :customer
+    belongs_to :plan
+
+    # NOTE: We reimplement the logic from Subscription#initial_started_at  differently to avoid N+1 queries
+    #       eager loading subscription.customer.subscriptions is not enough.
+    def initial_started_at
+      customer.subscriptions.select do |s|
+        s.external_id == external_id && s.started_at.present?
+      end.min_by(&:started_at)&.started_at || subscription_at
+    end
+  end
+
+  class Customer < ApplicationRecord
+    has_many :subscriptions
+  end
+
+  class Plan < ApplicationRecord
+    has_many :subscriptions
+  end
+
+  def up
+    Subscription
+      .joins(:plan)
+      .where(trial_ended_at: nil)
+      .where.not(plans: { trial_period: nil })
+      .includes(:plan, customer: :subscriptions)
+      .find_each do |subscription|
+        trial_ended_at = subscription.initial_started_at + subscription.plan.trial_period.days
+
+        next if trial_ended_at.to_date >= Time.zone.today
+
+        subscription.update(trial_ended_at:)
+      end
+  end
+
+  def down; end
+end

--- a/db/migrate/20240404123257_add_skip_charges_bool_in_invoices.rb
+++ b/db/migrate/20240404123257_add_skip_charges_bool_in_invoices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSkipChargesBoolInInvoices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invoices, :skip_charges, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_03_084644) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_04_123257) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -629,6 +629,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_03_084644) do
     t.integer "organization_sequential_id", default: 0, null: false
     t.boolean "ready_to_be_refreshed", default: false, null: false
     t.datetime "payment_dispute_lost_at"
+    t.boolean "skip_charges", default: false, null: false
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"

--- a/spec/jobs/bill_subscription_job_spec.rb
+++ b/spec/jobs/bill_subscription_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BillSubscriptionJob, type: :job do
 
   before do
     allow(Invoices::SubscriptionService).to receive(:call)
-      .with(subscriptions:, timestamp:, recurring:, invoice:)
+      .with(subscriptions:, timestamp:, recurring:, invoice:, skip_charges: false)
       .and_return(result)
   end
 
@@ -58,7 +58,7 @@ RSpec.describe BillSubscriptionJob, type: :job do
         expect(Invoices::SubscriptionService).to have_received(:call)
 
         expect(described_class).to have_been_enqueued
-          .with(subscriptions, timestamp, recurring: false, invoice: result_invoice)
+          .with(subscriptions, timestamp, recurring: false, invoice: result_invoice, skip_charges: false)
       end
     end
 

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -38,14 +38,14 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       subscription = customer.subscriptions.first
       expect(subscription.invoices.count).to eq(0)
 
-      travel_to(DateTime.new(2024, 3, 11, 3)) do
+      travel_to(DateTime.new(2024, 3, 11, 22)) do
         perform_billing
       end
 
       invoice = subscription.invoices.first
       expect(invoice.total_amount_cents).to eq(2371) # (31 - 3 - 7) * 35 / 31
 
-      travel_to(DateTime.new(2024, 3, 11, 6)) do
+      travel_to(DateTime.new(2024, 3, 11, 23)) do
         terminate_subscription(subscription)
       end
 
@@ -55,7 +55,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       expect(invoice.reload.credit_notes.count).to eq(1)
       expect(invoice.credit_notes.first.total_amount_cents).to eq(2371)
 
-      travel_to(DateTime.new(2024, 3, 11, 22)) do
+      travel_to(DateTime.new(2024, 3, 11, 23, 5)) do
         create_subscription(
           {
             external_customer_id: customer.external_id,

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -36,10 +36,16 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       end
 
       subscription = customer.subscriptions.first
+      expect(subscription.invoices.count).to eq(0)
+
+      travel_to(DateTime.new(2024, 3, 11, 3)) do
+        perform_billing
+      end
+
       invoice = subscription.invoices.first
       expect(invoice.total_amount_cents).to eq(2371) # (31 - 3 - 7) * 35 / 31
 
-      travel_to(DateTime.new(2024, 3, 5, 3)) do
+      travel_to(DateTime.new(2024, 3, 11, 6)) do
         terminate_subscription(subscription)
       end
 
@@ -49,7 +55,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
       expect(invoice.reload.credit_notes.count).to eq(1)
       expect(invoice.credit_notes.first.total_amount_cents).to eq(2371)
 
-      travel_to(DateTime.new(2024, 3, 5, 4)) do
+      travel_to(DateTime.new(2024, 3, 11, 22)) do
         create_subscription(
           {
             external_customer_id: customer.external_id,

--- a/spec/scenarios/subscriptions/free_trial_billing_spec.rb
+++ b/spec/scenarios/subscriptions/free_trial_billing_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Free Trial Billing Subscriptions Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      trial_period:,
+      amount_cents: 5_000_000,
+      pay_in_advance: true,
+    )
+  end
+
+  context 'without free trial' do
+    let(:trial_period) { 0 }
+
+    it 'bills the customer at the beginning of the subscription' do
+      travel_to(Time.zone.parse('2024-03-05T12:12:00')) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+
+        expect(customer.reload.invoices.count).to eq(1)
+        expect(customer.invoices.first.fees.subscription).to exist
+      end
+    end
+  end
+
+  context 'with free trial' do
+    let(:trial_period) { 10 }
+
+    it 'bills the customer at the end of the free trial' do
+      travel_to(Time.zone.parse('2024-03-05T12:12:00')) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+
+        expect(customer.reload.invoices.count).to eq(0)
+      end
+
+      # Ensure nothing happened
+      travel_to(Time.zone.parse('2024-03-10T12:12:00')) do
+        perform_billing
+        expect(customer.reload.invoices.count).to eq(0)
+      end
+
+      travel_to(Time.zone.parse('2024-03-15T15:00:00')) do
+        perform_billing
+        expect(customer.reload.invoices.count).to eq(1)
+      end
+    end
+
+    # NOTE: This only happens if the customer was billed at the beginning of the free trial
+    #       BEFORE the feature to bill at the end of the free trial was implemented
+    it 'does not bill the customer if it was already billed at the beginning of the trial' do
+      travel_to(Time.zone.parse('2024-03-05T12:12:00')) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+
+        expect(customer.reload.invoices.count).to eq(0)
+
+        plan.update! trial_period: 0 # disable trial to force billing
+        BillSubscriptionJob.perform_now(customer.subscriptions, Time.current)
+
+        expect(customer.reload.invoices.count).to eq(1)
+
+        plan.update! trial_period: 10
+      end
+
+      # Ensure nothing happened
+      travel_to(Time.zone.parse('2024-03-10T12:12:00')) do
+        perform_billing
+        expect(customer.reload.invoices.count).to eq(1)
+      end
+
+      travel_to(Time.zone.parse('2024-03-15T15:00:00')) do
+        perform_billing
+        expect(customer.reload.invoices.count).to eq(1)
+      end
+
+      travel_to(Time.zone.parse('2024-03-20T12:12:00')) do
+        perform_billing
+        expect(customer.reload.invoices.count).to eq(1)
+      end
+    end
+  end
+
+  context 'with free trial > billing period' do
+    let(:trial_period) { 45 }
+    let(:billable_metric) { create(:billable_metric, organization:) }
+
+    it 'bills subscription at the end of the free trial' do
+      travel_to(Time.zone.parse('2024-03-05T12:12:00')) do
+        create(:standard_charge, plan:, billable_metric:, properties: { amount: '10' })
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+
+        expect(customer.reload.invoices.count).to eq(0)
+      end
+
+      travel_to(Time.zone.parse('2024-03-10')) do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+          },
+        )
+      end
+
+      travel_to(Time.zone.parse('2024-04-01')) do
+        perform_billing
+        expect(customer.reload.invoices.count).to eq(1)
+      end
+
+      invoice = customer.invoices.first
+      expect(invoice.fees.subscription).not_to exist
+      expect(invoice.fees.charge.first.amount_cents).to eq(1000)
+
+      travel_to(Time.zone.parse('2024-04-19')) do
+        perform_billing
+        expect(customer.reload.invoices.count).to eq(2)
+      end
+
+      free_trial_invoice = customer.invoices.order(created_at: :desc).first
+      expect(free_trial_invoice.fees.subscription.first.amount_cents).to eq(2_000_000) # 5_000_000 * 12 / 30
+      expect(free_trial_invoice.fees.charge).not_to exist
+    end
+  end
+
+  context 'with free trial ending on billing day' do
+    let(:trial_period) { 10 }
+    let(:billable_metric) { create(:billable_metric, organization:) }
+
+    it 'bills subscription and usage-based charges' do
+      travel_to(Time.zone.parse('2024-03-22T12:12:00')) do
+        create(:standard_charge, plan:, billable_metric:, properties: { amount: '10' })
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+
+        expect(customer.reload.invoices.count).to eq(0)
+      end
+
+      travel_to(Time.zone.parse('2024-03-23')) do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+          },
+        )
+      end
+
+      expect(customer.reload.invoices.count).to eq(0)
+
+      travel_to(Time.zone.parse('2024-04-01')) do
+        expect { Clock::SubscriptionsBillerJob.perform_now }.to change { customer.reload.invoices.count }.from(0).to(1)
+
+        expect { Clock::FreeTrialSubscriptionsBillerJob.perform_now }.not_to change { customer.reload.invoices.count }
+      end
+
+      invoice = customer.invoices.order(created_at: :desc).first
+      expect(invoice.fees.subscription.first.amount_cents).to eq(5_000_000) # full fee, trial is over
+      expect(invoice.fees.charge.first.amount_cents).to eq(1000)
+    end
+  end
+end

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ::V1::SubscriptionSerializer do
           'billing_time' => subscription.billing_time,
           'created_at' => subscription.created_at.iso8601,
           'ending_at' => subscription.ending_at.iso8601,
+          'trial_ended_at' => nil,
         )
 
         expect(result['subscription']['customer']['lago_id']).to be_present

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -69,10 +69,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
   let(:terminated_at) { nil }
   let(:status) { :active }
 
-  let(:plan) { create(:plan, organization:, interval:, pay_in_advance:) }
+  let(:plan) { create(:plan, organization:, interval:, pay_in_advance:, trial_period:) }
   let(:pay_in_advance) { false }
   let(:billing_time) { :calendar }
   let(:interval) { 'monthly' }
+  let(:trial_period) { 0 }
 
   let(:charge) { create(:standard_charge, plan: subscription.plan, charge_model: 'standard') }
 
@@ -733,6 +734,22 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               expect(invoice.fees.commitment_kind.count).to eq(0)
             end
+          end
+        end
+      end
+
+      context 'when plan is in trial period' do
+        let(:trial_period) { 45 }
+        let(:started_at) { 40.days.ago }
+
+        it 'does not create a subscription fee' do
+          subscription.created_at
+          result = invoice_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(invoice.fees.subscription_kind.count).to eq(0)
           end
         end
       end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -227,6 +227,14 @@ RSpec.describe Subscriptions::CreateService, type: :service do
       end
     end
 
+    context 'when plan is pay_in_advance and subscription_at is current date but there is a trial period' do
+      let(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true, trial_period: 10) }
+
+      it 'does not enqueue a job to bill the subscription' do
+        expect { create_service.call }.not_to have_enqueued_job(BillSubscriptionJob)
+      end
+    end
+
     context 'when customer is missing' do
       let(:customer) { nil }
       let(:external_customer_id) { nil }

--- a/spec/services/webhooks/subscriptions/trial_ended_service_spec.rb
+++ b/spec/services/webhooks/subscriptions/trial_ended_service_spec.rb
@@ -2,10 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe Webhooks::Subscriptions::TerminatedService do
+RSpec.describe Webhooks::Subscriptions::TrialEndedService do
   subject(:webhook_service) { described_class.new(object: subscription) }
 
-  let(:subscription) { create(:subscription, status: :terminated) }
+  let(:subscription) { create(:subscription, plan: create(:plan, trial_period: 1)) }
   let(:organization) { subscription.organization }
 
   describe '.call' do
@@ -18,13 +18,13 @@ RSpec.describe Webhooks::Subscriptions::TerminatedService do
       allow(lago_client).to receive(:post_with_response)
     end
 
-    it 'builds payload with subscription.terminated webhook type' do
+    it 'builds payload with subscription.trial_ended webhook type' do
       webhook_service.call
 
       expect(LagoHttpClient::Client).to have_received(:new)
         .with(organization.webhook_endpoints.first.webhook_url)
       expect(lago_client).to have_received(:post_with_response) do |payload|
-        expect(payload[:webhook_type]).to eq('subscription.terminated')
+        expect(payload[:webhook_type]).to eq('subscription.trial_ended')
         expect(payload[:object_type]).to eq('subscription')
       end
     end

--- a/spec/support/scenarios_helper.rb
+++ b/spec/support/scenarios_helper.rb
@@ -121,6 +121,7 @@ module ScenariosHelper
 
   def perform_billing
     Clock::SubscriptionsBillerJob.perform_later
+    Clock::FreeTrialSubscriptionsBillerJob.perform_later
     perform_all_enqueued_jobs
   end
 


### PR DESCRIPTION
## Context

When a subscription has a trial period, we want to invoice the customer at the end of the trial, not at the beginning.

Following #1820 and #1821

## Description

* Disable billing when creating a new subscription if there is a trial
* Disable billing when activating a pending subscription if there is a trial
* Run the `Subscriptions::FreeTrialBillingService` introduced in #1821 every hour
* Migrate data for existing subscription with trial already ended
* Ensure we don't bill customers if an invoice was created when the subscription started (for sub created before this feature)

## Note

* Introduction of `skip_charge`
* Refactor of charge fees for first invoice, see: https://github.com/getlago/lago-api/pull/1836
* Handle grace_period
* Handle minimum_commitment