### PR TITLE
misc: Prevent duplications of at_time_zone methods

### DIFF
--- a/app/jobs/clock/terminate_ended_subscriptions_job.rb
+++ b/app/jobs/clock/terminate_ended_subscriptions_job.rb
@@ -8,8 +8,11 @@ module Clock
       Subscription
         .joins(customer: :organization)
         .active
-        .where("DATE(subscriptions.ending_at#{Utils::TimezoneService.at_time_zone}) = "\
-               "DATE(?#{Utils::TimezoneService.at_time_zone})", Time.current)
+        .where(
+          "DATE(subscriptions.ending_at#{Utils::Timezone.at_time_zone_sql}) = " \
+          "DATE(?#{Utils::Timezone.at_time_zone_sql})",
+          Time.current,
+        )
         .find_each do |subscription|
           Subscriptions::TerminateService.call(subscription:)
         end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -191,7 +191,7 @@ class Invoice < ApplicationRecord
 
     return {} unless event
 
-    number_of_days = Utils::DatetimeService.date_diff_with_timezone(
+    number_of_days = Utils::Datetime.date_diff_with_timezone(
       event.timestamp,
       date_service.charges_to_datetime,
       customer.applicable_timezone,

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -146,7 +146,7 @@ class Subscription < ApplicationRecord
   # When upgrade, we want to bill one day less since date of the upgrade will be
   # included in the first invoice for the new plan
   def date_diff_with_timezone(from_datetime, to_datetime)
-    number_od_days = Utils::DatetimeService.date_diff_with_timezone(
+    number_od_days = Utils::Datetime.date_diff_with_timezone(
       from_datetime,
       to_datetime,
       customer.applicable_timezone,

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -169,4 +169,10 @@ class BaseService
   def graphql_context?
     source&.to_sym == :graphql
   end
+
+  def at_time_zone(customer: 'customers', organization: 'organizations')
+    <<-SQL
+      ::timestamptz AT TIME ZONE COALESCE(#{customer}.timezone, #{organization}.timezone, 'UTC')
+    SQL
+  end
 end

--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -171,8 +171,6 @@ class BaseService
   end
 
   def at_time_zone(customer: 'customers', organization: 'organizations')
-    <<-SQL
-      ::timestamptz AT TIME ZONE COALESCE(#{customer}.timezone, #{organization}.timezone, 'UTC')
-    SQL
+    Utils::Timezone.at_time_zone_sql(customer:, organization:)
   end
 end

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -13,7 +13,7 @@ module BillableMetrics
 
         # In order to get proration coefficient we have to divide number of seconds with number
         # of seconds in one day (86400). That way we will get number of days when the service was used.
-        proration_coefficient = Utils::DatetimeService.date_diff_with_timezone(
+        proration_coefficient = Utils::Datetime.date_diff_with_timezone(
           event.timestamp,
           to_datetime,
           customer.applicable_timezone,

--- a/app/services/commitments/calculate_prorated_coefficient_service.rb
+++ b/app/services/commitments/calculate_prorated_coefficient_service.rb
@@ -40,13 +40,13 @@ module Commitments
           ),
         )
 
-      days = Utils::DatetimeService.date_diff_with_timezone(
+      days = Utils::Datetime.date_diff_with_timezone(
         all_invoice_subscriptions.first.from_datetime,
         subscription.terminated? ? subscription.terminated_at : invoice_subscription.to_datetime,
         subscription.customer.applicable_timezone,
       )
 
-      days_total = Utils::DatetimeService.date_diff_with_timezone(
+      days_total = Utils::Datetime.date_diff_with_timezone(
         dates_service.previous_beginning_of_period,
         dates_service.end_of_period,
         subscription.customer.applicable_timezone,

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -246,7 +246,7 @@ module Events
       end
 
       def sum_date_breakdown
-        date_field = Utils::TimezoneService.date_in_customer_timezone_sql(customer, 'events.timestamp')
+        date_field = Utils::Timezone.date_in_customer_timezone_sql(customer, 'events.timestamp')
 
         events.group(Arel.sql("DATE(#{date_field})"))
           .reorder(Arel.sql("DATE(#{date_field}) ASC"))
@@ -383,8 +383,8 @@ module Events
       # NOTE: Compute pro-rata of the duration in days between the datetimes over the duration of the billing period
       #       Dates are in customer timezone to make sure the duration is good
       def duration_ratio_sql(from, to, duration)
-        from_in_timezone = Utils::TimezoneService.date_in_customer_timezone_sql(customer, from)
-        to_in_timezone = Utils::TimezoneService.date_in_customer_timezone_sql(customer, to)
+        from_in_timezone = Utils::Timezone.date_in_customer_timezone_sql(customer, from)
+        to_in_timezone = Utils::Timezone.date_in_customer_timezone_sql(customer, to)
 
         "((DATE(#{to_in_timezone}) - DATE(#{from_in_timezone}))::numeric + 1) / #{duration}::numeric"
       end

--- a/app/services/fees/subscription_service.rb
+++ b/app/services/fees/subscription_service.rb
@@ -152,7 +152,7 @@ module Fees
       end
 
       # NOTE: Number of days of the first period since subscription creation
-      days_to_bill = Utils::DatetimeService.date_diff_with_timezone(
+      days_to_bill = Utils::Datetime.date_diff_with_timezone(
         from_datetime,
         to_datetime,
         customer.applicable_timezone,
@@ -209,7 +209,7 @@ module Fees
       end
 
       # NOTE: number of days between the upgrade and the end of the period
-      number_of_day_to_bill = Utils::DatetimeService.date_diff_with_timezone(
+      number_of_day_to_bill = Utils::Datetime.date_diff_with_timezone(
         from_datetime,
         to_datetime,
         customer.applicable_timezone,
@@ -238,7 +238,7 @@ module Fees
         #       for this case, we should not apply the full period amount
         #       but the prorata between the trial end date end the invoice to_date
         if (subscription.trial_end_datetime > from_datetime) && (subscription.trial_end_datetime < to_datetime)
-          number_of_day_to_bill = Utils::DatetimeService.date_diff_with_timezone(
+          number_of_day_to_bill = Utils::Datetime.date_diff_with_timezone(
             subscription.trial_end_datetime,
             to_datetime,
             customer.applicable_timezone,

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -13,8 +13,11 @@ module Subscriptions
         .joins(customer: :organization)
         .pending
         .where(previous_subscription: nil)
-        .where("DATE(subscriptions.subscription_at#{Utils::TimezoneService.at_time_zone}) <= "\
-               "DATE(?#{Utils::TimezoneService.at_time_zone})", Time.zone.at(timestamp))
+        .where(
+          "DATE(subscriptions.subscription_at#{Utils::Timezone.at_time_zone_sql}) <= " \
+          "DATE(?#{Utils::Timezone.at_time_zone_sql})",
+          Time.zone.at(timestamp),
+        )
         .find_each do |subscription|
           subscription.mark_as_active!(Time.zone.at(timestamp))
 

--- a/app/services/subscriptions/billing_service.rb
+++ b/app/services/subscriptions/billing_service.rb
@@ -280,12 +280,6 @@ module Subscriptions
       )
     end
 
-    def at_time_zone(customer: 'customers', organization: 'organizations')
-      <<-SQL
-      ::timestamptz AT TIME ZONE COALESCE(#{customer}.timezone, #{organization}.timezone, 'UTC')
-      SQL
-    end
-
     def end_of_month
       <<-SQL
         (DATE_TRUNC('month', :today#{at_time_zone}) + INTERVAL '1 month - 1 day')::date

--- a/app/services/subscriptions/validate_service.rb
+++ b/app/services/subscriptions/validate_service.rb
@@ -36,7 +36,7 @@ module Subscriptions
     end
 
     def valid_subscription_at?
-      return true if Utils::DatetimeService.valid_format?(args[:subscription_at])
+      return true if Utils::Datetime.valid_format?(args[:subscription_at])
 
       add_error(field: :subscription_at, error_code: 'invalid_date')
 
@@ -46,8 +46,8 @@ module Subscriptions
     def valid_ending_at?
       return true if args[:ending_at].blank?
 
-      if Utils::DatetimeService.valid_format?(args[:ending_at]) &&
-         Utils::DatetimeService.valid_format?(args[:subscription_at]) &&
+      if Utils::Datetime.valid_format?(args[:ending_at]) &&
+         Utils::Datetime.valid_format?(args[:subscription_at]) &&
          ending_at.to_date > Time.current.to_date &&
          ending_at.to_date > subscription_at.to_date
         return true

--- a/app/services/utils/datetime.rb
+++ b/app/services/utils/datetime.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Utils
-  class DatetimeService < BaseService
+  class Datetime
     def self.valid_format?(datetime)
       datetime.respond_to?(:strftime) || datetime.is_a?(String) && DateTime._strptime(datetime).present?
     end

--- a/app/services/utils/timezone.rb
+++ b/app/services/utils/timezone.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Utils
-  class TimezoneService < BaseService
+  class Timezone
     def self.date_in_customer_timezone_sql(customer, value)
       sanitized_field_name = if value.is_a?(String)
         ActiveRecord::Base.sanitize_sql_for_conditions(value)
@@ -13,9 +13,9 @@ module Utils
       "(#{sanitized_field_name})::timestamptz AT TIME ZONE '#{sanitized_timezone}'"
     end
 
-    def self.at_time_zone
+    def self.at_time_zone_sql(customer: 'customers', organization: 'organizations')
       <<-SQL
-        ::timestamptz AT TIME ZONE COALESCE(customers.timezone, organizations.timezone, 'UTC')
+        ::timestamptz AT TIME ZONE COALESCE(#{customer}.timezone, #{organization}.timezone, 'UTC')
       SQL
     end
   end

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -171,12 +171,6 @@ module Wallets
       )
     end
 
-    def at_time_zone(customer: 'customers', organization: 'organizations')
-      <<-SQL
-      ::timestamptz AT TIME ZONE COALESCE(#{customer}.timezone, #{organization}.timezone, 'UTC')
-      SQL
-    end
-
     def end_of_month
       <<-SQL
         (DATE_TRUNC('month', :today#{at_time_zone}) + INTERVAL '1 month - 1 day')::date

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -33,7 +33,7 @@ module Wallets
     def valid_expiration_at?(expiration_at:)
       return true if expiration_at.blank?
 
-      if Utils::DatetimeService.valid_format?(expiration_at)
+      if Utils::Datetime.valid_format?(expiration_at)
         parsed_expiration_at = if expiration_at.is_a?(String)
           DateTime.strptime(expiration_at)
         else

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -49,10 +49,8 @@ module Wallets
     def valid_expiration_at?
       return true if args[:expiration_at].blank?
 
-      if Utils::DatetimeService.valid_format?(args[:expiration_at]) && expiration_at.to_date > Time.current.to_date
-
-        return true
-      end
+      future = Utils::Datetime.valid_format?(args[:expiration_at]) && expiration_at.to_date > Time.current.to_date
+      return true if future
 
       add_error(field: :expiration_at, error_code: 'invalid_date')
 

--- a/spec/services/utils/datetime_spec.rb
+++ b/spec/services/utils/datetime_spec.rb
@@ -2,23 +2,23 @@
 
 require 'rails_helper'
 
-RSpec.describe Utils::DatetimeService, type: :service do
-  subject(:datetime_service) { described_class }
+RSpec.describe Utils::Datetime, type: :service do
+  subject(:datetime) { described_class }
 
   describe '.valid_format?' do
     it 'returns false for invalid format' do
-      expect(datetime_service.valid_format?('aaa')).to be_falsey
+      expect(datetime).not_to be_valid_format('aaa')
     end
 
     context 'when parameter is string and is valid' do
       it 'returns true' do
-        expect(datetime_service.valid_format?('2022-12-13T12:00:00Z')).to be_truthy
+        expect(datetime).to be_valid_format('2022-12-13T12:00:00Z')
       end
     end
 
     context 'when parameter is datetime object' do
       it 'returns true' do
-        expect(datetime_service.valid_format?(Time.current)).to be_truthy
+        expect(datetime).to be_valid_format(Time.current)
       end
     end
   end
@@ -29,7 +29,7 @@ RSpec.describe Utils::DatetimeService, type: :service do
     let(:timezone) { 'Europe/Paris' }
 
     let(:result) do
-      datetime_service.date_diff_with_timezone(
+      datetime.date_diff_with_timezone(
         from_datetime,
         to_datetime,
         timezone,


### PR DESCRIPTION
The goal of this PR is to:
- avoid duplications of `at_time_zone` methods 
- rename `Utils::DatetimeService` to `Utils::Datetime`
- rename `Utils::TimezoneService` to `Utils::Timezone`