### PR TITLE
misc: Extract pending subscription factory into a trait

### DIFF
--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     external_id { SecureRandom.uuid }
     started_at { 1.day.ago }
 
-    factory :pending_subscription do
+    trait :pending do
       status { :pending }
     end
 

--- a/spec/graphql/resolvers/customer_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_resolver_spec.rb
@@ -101,8 +101,8 @@ RSpec.describe Resolvers::CustomerResolver, type: :graphql do
   end
 
   context 'when active and pending subscriptions are requested' do
-    let(:second_subscription) { create(:pending_subscription, customer:) }
-    let(:third_subscription) { create(:pending_subscription, customer:, previous_subscription: subscription) }
+    let(:second_subscription) { create(:subscription, :pending, customer:) }
+    let(:third_subscription) { create(:subscription, :pending, customer:, previous_subscription: subscription) }
 
     let(:query) do
       <<~GQL

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe Subscription, type: :model do
     end
 
     context 'when subscription is pending and starting in the future' do
-      let(:subscription) { create(:pending_subscription) }
+      let(:subscription) { create(:subscription, :pending) }
 
       it 'returns true' do
         expect(subscription.starting_in_the_future?).to be true
@@ -347,7 +347,7 @@ RSpec.describe Subscription, type: :model do
 
     context 'when subscription is pending and downgraded' do
       let(:old_subscription) { create(:subscription) }
-      let(:subscription) { create(:pending_subscription, previous_subscription: old_subscription) }
+      let(:subscription) { create(:subscription, :pending, previous_subscription: old_subscription) }
 
       it 'returns false' do
         expect(subscription.starting_in_the_future?).to be false

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe SubscriptionsQuery, type: :query do
       let(:query_filters) { { status: [:active, :pending] } }
 
       it 'returns correct subscriptions' do
-        create(:pending_subscription, customer:, plan:)
+        create(:subscription, :pending, customer:, plan:)
         create(:subscription, customer:, plan:, status: :canceled)
         create(:subscription, customer:, plan:, status: :terminated)
         result = subscriptions_query.call
@@ -92,7 +92,7 @@ RSpec.describe SubscriptionsQuery, type: :query do
       let(:query_filters) { { status: [:pending] } }
 
       it 'returns only pending subscriptions' do
-        create(:pending_subscription, customer:, plan:)
+        create(:subscription, :pending, customer:, plan:)
         create(:subscription, customer:, plan:, status: :canceled)
         create(:subscription, customer:, plan:, status: :terminated)
 
@@ -113,7 +113,7 @@ RSpec.describe SubscriptionsQuery, type: :query do
       let(:query_filters) { { status: [:canceled] } }
 
       it 'returns only pending subscriptions' do
-        create(:pending_subscription, customer:, plan:)
+        create(:subscription, :pending, customer:, plan:)
         create(:subscription, customer:, plan:, status: :canceled)
         create(:subscription, customer:, plan:, status: :terminated)
 
@@ -134,7 +134,7 @@ RSpec.describe SubscriptionsQuery, type: :query do
       let(:query_filters) { { status: [:terminated] } }
 
       it 'returns only pending subscriptions' do
-        create(:pending_subscription, customer:, plan:)
+        create(:subscription, :pending, customer:, plan:)
         create(:subscription, customer:, plan:, status: :canceled)
         create(:subscription, customer:, plan:, status: :terminated)
 
@@ -153,7 +153,7 @@ RSpec.describe SubscriptionsQuery, type: :query do
 
     context 'with no status filter' do
       it 'returns only active subscriptions' do
-        create(:pending_subscription, customer:, plan:)
+        create(:subscription, :pending, customer:, plan:)
 
         result = subscriptions_query.call
 

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
   end
 
   describe 'update' do
-    let(:subscription) { create(:pending_subscription, customer:, plan:) }
+    let(:subscription) { create(:subscription, :pending, customer:, plan:) }
     let(:update_params) do
       {
         name: 'subscription name new',

--- a/spec/scenarios/create_event_spec.rb
+++ b/spec/scenarios/create_event_spec.rb
@@ -304,7 +304,8 @@ describe 'Create Event Scenarios', :scenarios, type: :request do
   context 'with external_subscription_id but multiple subscriptions' do
     let(:subscription2) do
       create(
-        :pending_subscription,
+        :subscription,
+        :pending,
         customer:,
         external_id: subscription.external_id,
       )

--- a/spec/services/customers/terminate_relations_service_spec.rb
+++ b/spec/services/customers/terminate_relations_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Customers::TerminateRelationsService, type: :service do
   end
 
   context 'with a pending subscription' do
-    let(:subscription) { create(:pending_subscription, customer:) }
+    let(:subscription) { create(:subscription, :pending, customer:) }
 
     before { subscription }
 

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Plans::DestroyService, type: :service do
     end
 
     context 'with pending subscriptions' do
-      let(:subscriptions) { create_list(:pending_subscription, 2, plan:) }
+      let(:subscriptions) { create_list(:subscription, 2, :pending, plan:) }
 
       before { subscriptions }
 

--- a/spec/services/subscriptions/activate_service_spec.rb
+++ b/spec/services/subscriptions/activate_service_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Subscriptions::ActivateService, type: :service do
 
   describe 'activate_all_expired' do
     let(:active_subscription) { create(:subscription) }
-    let(:pending_subscriptions) { create_list(:pending_subscription, 3, subscription_at: timestamp) }
+    let(:pending_subscriptions) { create_list(:subscription, 3, :pending, subscription_at: timestamp) }
 
     let(:future_pending_subscriptions) do
-      create_list(:pending_subscription, 2, subscription_at: (timestamp + 10.days))
+      create_list(:subscription, 2, :pending, subscription_at: (timestamp + 10.days))
     end
 
     before do

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Subscriptions::TerminateService do
     end
 
     context 'when subscription is starting in the future' do
-      let(:subscription) { create(:pending_subscription) }
+      let(:subscription) { create(:subscription, :pending) }
 
       it 'does not enqueue a BillSubscriptionJob' do
         expect do
@@ -41,7 +41,7 @@ RSpec.describe Subscriptions::TerminateService do
     end
 
     context 'when downgrade subscription is pending' do
-      let(:subscription) { create(:pending_subscription, previous_subscription: create(:subscription)) }
+      let(:subscription) { create(:subscription, :pending, previous_subscription: create(:subscription)) }
 
       it 'does cancel it' do
         result = terminate_service.call

--- a/spec/services/subscriptions/update_service_spec.rb
+++ b/spec/services/subscriptions/update_service_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Subscriptions::UpdateService, type: :service do
     end
 
     context 'when subscription is starting in the future' do
-      let(:subscription) { create(:pending_subscription) }
+      let(:subscription) { create(:subscription, :pending) }
 
       it 'updates the subscription_at as well' do
         result = update_service.call


### PR DESCRIPTION
The goal of this PR is to extract the `pending_subscription` factory into a trait, to be consistent with the other traits (ie. terminated).