### PR TITLE
feat(filter): Handle adjusted fees and improve ignored filters

### DIFF
--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -43,7 +43,7 @@ module Types
         end
 
         def filters
-          return [] unless object.first.charge&.filters&.any?
+          return [] unless object.first.has_charge_filters?
 
           object.sort_by { |f| f.charge_filter&.display_name.to_s }
         end

--- a/app/graphql/types/customers/usage/charge.rb
+++ b/app/graphql/types/customers/usage/charge.rb
@@ -43,7 +43,9 @@ module Types
         end
 
         def filters
-          object.sort_by { |f| f&.charge_filter&.display_name.to_s }
+          return [] unless object.first.charge&.filters&.any?
+
+          object.sort_by { |f| f.charge_filter&.display_name.to_s }
         end
 
         def grouped_usage

--- a/app/graphql/types/customers/usage/grouped_usage.rb
+++ b/app/graphql/types/customers/usage/grouped_usage.rb
@@ -37,6 +37,8 @@ module Types
         end
 
         def filters
+          return [] unless object.first.charge&.filters&.any?
+
           object.sort_by { |f| f.charge_filter&.display_name }
         end
       end

--- a/app/graphql/types/customers/usage/grouped_usage.rb
+++ b/app/graphql/types/customers/usage/grouped_usage.rb
@@ -37,7 +37,7 @@ module Types
         end
 
         def filters
-          return [] unless object.first.charge&.filters&.any?
+          return [] unless object.first.has_charge_filters?
 
           object.sort_by { |f| f.charge_filter&.display_name }
         end

--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -6,6 +6,7 @@ class AdjustedFee < ApplicationRecord
   belongs_to :fee, optional: true
   belongs_to :charge, optional: true
   belongs_to :group, optional: true
+  belongs_to :charge_filter, optional: true
 
   ADJUSTED_FEE_TYPES = [
     :adjusted_units,

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -140,4 +140,8 @@ class Fee < ApplicationRecord
 
     @add_on = AddOn.with_discarded.find_by(id: applied_add_on.add_on_id)
   end
+
+  def has_charge_filters?
+    charge&.filters&.any?
+  end
 end

--- a/app/serializers/v1/customers/charge_usage_serializer.rb
+++ b/app/serializers/v1/customers/charge_usage_serializer.rb
@@ -48,6 +48,8 @@ module V1
       end
 
       def filters(fees)
+        return [] unless fees.first.charge&.filters&.any?
+
         fees.sort_by { |f| f.charge_filter&.display_name.to_s }.map do |f|
           {
             units: f.units,

--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -36,23 +36,18 @@ module ChargeFilters
       #           key2: [value3, value4]
       #         }
       #       ]
-      result.ignored_filters = children.each_with_object([]) do |child_filter, res|
-        child = child_filter.to_h_with_all_values
-        child_result = {}
+      result.ignored_filters = children.map do |child|
+        res = child.to_h_with_all_values
 
-        child.each do |key, values|
-          # NOTE: The parent filter does not have the key, so we ignore all values
-          next child_result[key] = values unless result.matching_filters[key]
-
-          # NOTE: The parent filter, has the same values for the key, so no need to filter them
-          next if values == result.matching_filters[key]
-
-          # NOTE: The parent filter has some values for the key, so we get only the parent ones
-          child_result[key] = values.select { result.matching_filters[key].include?(_1) }
+        if res.keys == result.matching_filters.keys
+          # NOTE: when child and filter have the same keys, we need to remove the filter value from the child
+          res.each do |key, values|
+            res[key] = values - result.matching_filters[key]
+          end
         end
 
-        res << child_result
-      end.uniq
+        res
+      end
 
       result
     end

--- a/app/services/charges/charge_model_factory.rb
+++ b/app/services/charges/charge_model_factory.rb
@@ -3,13 +3,13 @@
 module Charges
   class ChargeModelFactory
     def self.new_instance(charge:, aggregation_result:, properties:)
-      charge_model_class(charge:, aggregation_result:).new(charge:, aggregation_result:, properties:)
+      charge_model_class(charge:, aggregation_result:, properties:).new(charge:, aggregation_result:, properties:)
     end
 
-    def self.charge_model_class(charge:, aggregation_result:)
+    def self.charge_model_class(charge:, aggregation_result:, properties:)
       case charge.charge_model.to_sym
       when :standard
-        if charge.properties['grouped_by'].present? && !aggregation_result.aggregations.nil?
+        if properties['grouped_by'].present? && !aggregation_result.aggregations.nil?
           Charges::ChargeModels::GroupedStandardService
         else
           Charges::ChargeModels::StandardService

--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -48,8 +48,9 @@ module Charges
         event:,
       }
 
-      if charge.standard? && charge.properties['grouped_by'].present?
-        filters[:grouped_by_values] = charge.properties['grouped_by'].index_with do |grouped_by|
+      properties = charge_filter&.properties || charge.properties
+      if charge.standard? && properties['grouped_by'].present?
+        filters[:grouped_by_values] = properties['grouped_by'].index_with do |grouped_by|
           event.properties[grouped_by]
         end
       end

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -470,15 +470,15 @@ module Events
           scope = scope.where('events_raw.properties[?] IN ?', key.to_s, values)
         end
 
-        ignored_filters.each do |filters|
-          sql = filters.map do |key, values|
+        conditions = ignored_filters.map do |filters|
+          filters.map do |key, values|
             ActiveRecord::Base.sanitize_sql_for_conditions(
               ["(coalesce(events_raw.properties[?], '') IN (?))", key.to_s, values.map(&:to_s)],
             )
-          end.join(' OR ')
-
-          scope = scope.where.not(sql)
+          end.join(' AND ')
         end
+        sql = conditions.map { "(#{_1})" }.join(' OR ')
+        scope = scope.where.not(sql) if sql.present?
 
         scope
       end

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -340,15 +340,15 @@ module Events
           )
         end
 
-        ignored_filters.each do |filters|
-          sql = filters.map do |key, values|
+        conditions = ignored_filters.map do |filters|
+          filters.map do |key, values|
             ActiveRecord::Base.sanitize_sql_for_conditions(
               ["(coalesce(events.properties ->> ?, '') IN (?))", key.to_s, values.map(&:to_s)],
             )
-          end.join(' OR ')
-
-          scope = scope.where.not(sql)
+          end.join(' AND ')
         end
+        sql = conditions.map { "(#{_1})" }.join(' OR ')
+        scope = scope.where.not(sql) if sql.present?
 
         scope
       end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -318,4 +318,24 @@ RSpec.describe Fee, type: :model do
       end
     end
   end
+
+  describe '.has_charge_filter?' do
+    subject(:fee) { create(:add_on_fee) }
+
+    it { expect(fee).not_to be_has_charge_filters }
+
+    context 'when fee is a charge fee' do
+      subject(:fee) { create(:charge_fee) }
+
+      it { expect(fee).not_to be_has_charge_filters }
+
+      context 'when charge has filters' do
+        let(:charge_filter) { create(:charge_filter, charge: fee.charge) }
+
+        before { charge_filter }
+
+        it { expect(fee).to be_has_charge_filters }
+      end
+    end
+  end
 end

--- a/spec/scenarios/invoices/filters_and_grouped_by_spec.rb
+++ b/spec/scenarios/invoices/filters_and_grouped_by_spec.rb
@@ -1,0 +1,186 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Invoices for charges with filters and grouped by', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
+
+  let(:customer) { create(:customer, organization:) }
+
+  let(:billable_metric) { create(:sum_billable_metric, organization:, field_name: 'value') }
+  let(:billable_metric_filter1) do
+    create(:billable_metric_filter, billable_metric:, key: 'cloud', values: %w[aws gcp azure])
+  end
+  let(:billable_metric_filter2) do
+    create(:billable_metric_filter, billable_metric:, key: 'region', values: %w[us europe asia])
+  end
+
+  let(:plan) { create(:plan, organization:, amount_cents: 0, interval: 'monthly', pay_in_advance: false) }
+  let(:charge) do
+    create(:standard_charge, plan:, billable_metric:, properties: { amount: '10' })
+  end
+
+  let(:charge_filter) { create(:charge_filter, charge:, properties: { amount: '12', grouped_by: %w[country] }) }
+  let(:charge_filter_value1) do
+    create(:charge_filter_value, charge_filter:, billable_metric_filter: billable_metric_filter1, values: %w[aws])
+  end
+  let(:charge_filter_value2) do
+    create(
+      :charge_filter_value,
+      charge_filter:,
+      billable_metric_filter: billable_metric_filter2,
+      values: [ChargeFilterValue::ALL_FILTER_VALUES],
+    )
+  end
+
+  before do
+    charge_filter_value1
+    charge_filter_value2
+  end
+
+  it 'creates a new invoice for charges with filters and grouped by' do
+    # Create a subscription
+    travel_to(Time.zone.parse('2024-02-25T10:00:00')) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time: 'anniversary',
+        },
+      )
+    end
+
+    subscription = customer.subscriptions.first
+
+    # Send an event matching a filter and a group
+    travel_to(Time.zone.parse('2024-02-28T10:00:00')) do
+      create_event(
+        {
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          properties: { cloud: 'aws', region: 'us', country: 'us', value: 10 },
+        },
+      )
+    end
+
+    travel_to(Time.zone.parse('2024-03-01T10:00:00')) do
+      create_event(
+        {
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          properties: { cloud: 'aws', region: 'europe', country: 'france', value: 10 },
+        },
+      )
+    end
+
+    travel_to(Time.zone.parse('2024-03-02T10:00:00')) do
+      create_event(
+        {
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          properties: { cloud: 'aws', region: 'asia', value: 10 },
+        },
+      )
+    end
+
+    travel_to(Time.zone.parse('2024-03-03T10:00:00')) do
+      create_event(
+        {
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_subscription_id: subscription.external_id,
+          properties: { cloud: 'gcp', region: 'asia', country: 'china', value: 10 },
+        },
+      )
+    end
+
+    # Fetch the current usage
+    travel_to(Time.zone.parse('2024-03-04T10:00:00')) do
+      fetch_current_usage(customer:)
+
+      expect(json[:customer_usage][:total_amount_cents]).to eq(46_000)
+
+      expect(json[:customer_usage][:charges_usage].count).to eq(1)
+      charge_usage = json[:customer_usage][:charges_usage].first
+      expect(charge_usage[:units]).to eq('40.0')
+      expect(charge_usage[:events_count]).to eq(4)
+      expect(charge_usage[:amount_cents]).to eq(46_000)
+
+      expect(charge_usage[:grouped_usage].count).to eq(4)
+      us_group = charge_usage[:grouped_usage].find { |group| group[:grouped_by][:country] == 'us' }
+      expect(us_group[:amount_cents]).to eq(12_000)
+      expect(us_group[:events_count]).to eq(1)
+      expect(us_group[:units]).to eq('10.0')
+      expect(us_group[:filters].count).to eq(1)
+      expect(us_group[:filters].first[:units]).to eq('10.0')
+      expect(us_group[:filters].first[:values]).to eq(cloud: %w[aws], region: [ChargeFilterValue::ALL_FILTER_VALUES])
+
+      france_group = charge_usage[:grouped_usage].find { |group| group[:grouped_by][:country] == 'france' }
+      expect(france_group[:amount_cents]).to eq(12_000)
+      expect(france_group[:events_count]).to eq(1)
+      expect(france_group[:units]).to eq('10.0')
+      expect(france_group[:filters].count).to eq(1)
+      expect(france_group[:filters].first[:units]).to eq('10.0')
+      expect(france_group[:filters].first[:values]).to eq(
+        cloud: %w[aws],
+        region: [ChargeFilterValue::ALL_FILTER_VALUES],
+      )
+
+      empty_group = charge_usage[:grouped_usage].find { |group| group[:grouped_by][:country].nil? }
+      expect(empty_group[:amount_cents]).to eq(12_000)
+      expect(empty_group[:events_count]).to eq(1)
+      expect(empty_group[:units]).to eq('10.0')
+      expect(empty_group[:filters].count).to eq(1)
+
+      aws_filter = empty_group[:filters].find do |filter|
+        filter[:values] == { cloud: ['aws'], region: [ChargeFilterValue::ALL_FILTER_VALUES] }
+      end
+      expect(aws_filter[:units]).to eq('10.0')
+      expect(aws_filter[:values]).to eq(cloud: %w[aws], region: [ChargeFilterValue::ALL_FILTER_VALUES])
+
+      empty_filter = charge_usage[:filters].find { |filter| filter[:values].nil? }
+      expect(empty_filter[:amount_cents]).to eq(10_000)
+      expect(empty_filter[:events_count]).to eq(1)
+      expect(empty_filter[:units]).to eq('10.0')
+      expect(empty_filter[:values]).to be_nil
+    end
+
+    # Run the billing job
+    travel_to(Time.zone.parse('2024-03-25T10:00:00')) do
+      Subscriptions::BillingService.new.call
+      expect { perform_all_enqueued_jobs }.to change { subscription.reload.invoices.count }.by(1)
+
+      invoice = subscription.invoices.last
+      expect(invoice.total_amount_cents).to eq(46_000)
+
+      expect(invoice.fees.charge.count).to eq(4)
+      us_fee = invoice.fees.charge.find { |fee| fee.grouped_by['country'] == 'us' }
+      expect(us_fee.amount_cents).to eq(12_000)
+      expect(us_fee.events_count).to eq(1)
+      expect(us_fee.units).to eq(10.0)
+      expect(us_fee.charge_filter).to eq(charge_filter)
+
+      france_fee = invoice.fees.charge.find { |fee| fee.grouped_by['country'] == 'france' }
+      expect(france_fee.amount_cents).to eq(12_000)
+      expect(france_fee.events_count).to eq(1)
+      expect(france_fee.units).to eq(10.0)
+      expect(france_fee.charge_filter).to eq(charge_filter)
+
+      ungrouped_fee = invoice.fees.charge.find { |fee| fee.grouped_by['country'].nil? }
+      expect(ungrouped_fee.amount_cents).to eq(12_000)
+      expect(ungrouped_fee.events_count).to eq(1)
+      expect(ungrouped_fee.units).to eq(10.0)
+      expect(ungrouped_fee.charge_filter).to eq(charge_filter)
+
+      empty_filter = invoice.fees.charge.find { |fee| fee.charge_filter_id.nil? }
+      expect(empty_filter.amount_cents).to eq(10_000)
+      expect(empty_filter.events_count).to eq(1)
+      expect(empty_filter.units).to eq(10)
+      expect(empty_filter.charge_filter).to be_nil
+    end
+  end
+end

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -48,15 +48,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
           'code' => billable_metric.code,
           'aggregation_type' => billable_metric.aggregation_type,
         },
-        'filters' => [
-          {
-            'amount_cents' => 100,
-            'events_count' => 12,
-            'invoice_display_name' => nil,
-            'units' => 10,
-            'values' => nil,
-          },
-        ],
+        'filters' => [],
         'groups' => [],
         'grouped_usage' => [
           {
@@ -64,15 +56,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
             'events_count' => 12,
             'units' => '10.0',
             'grouped_by' => { 'card_type' => 'visa' },
-            'filters' => [
-              {
-                'amount_cents' => 100,
-                'events_count' => 12,
-                'invoice_display_name' => nil,
-                'units' => 10,
-                'values' => nil,
-              },
-            ],
+            'filters' => [],
             'groups' => [],
           },
         ],
@@ -140,7 +124,8 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
   end
 
   describe '#filters' do
-    let(:charge_filter) { create(:charge_filter) }
+    let(:billable_metric_filter) { create(:billable_metric_filter, billable_metric:) }
+    let(:charge_filter) { create(:charge_filter, charge:, invoice_display_name: nil) }
 
     let(:usage) do
       [

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -56,7 +56,14 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     )
 
     expect(service.ignored_filters).to eq(
-      [{ 'card_type' => ['credit'] }],
+      [
+        {
+          'card_location' => ['domestic'],
+          'card_type' => ['credit'],
+          'payment_method' => ['card'],
+          'scheme' => %w[visa mastercard],
+        },
+      ],
     )
   end
 


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR:
- Adds the logic to handle `AdjustedFee` with filters
- Fixes the behavior with filters and `grouped_by`
- Improve the handling of `ignored_filters` with `ALL_VALUES`