### PR TITLE
feat(disputes): Add payment_dispute_lost webhook

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -15,6 +15,7 @@ class SendWebhookJob < ApplicationJob
     'invoice.generated' => Webhooks::Invoices::GeneratedService,
     'invoice.drafted' => Webhooks::Invoices::DraftedService,
     'invoice.voided' => Webhooks::Invoices::VoidedService,
+    'invoice.payment_dispute_lost' => Webhooks::Invoices::PaymentDisputeLostService,
     'invoice.payment_status_updated' => Webhooks::Invoices::PaymentStatusUpdatedService,
     'invoice.payment_failure' => Webhooks::PaymentProviders::InvoicePaymentFailureService,
     'event.error' => Webhooks::Events::ErrorService,

--- a/app/serializers/v1/invoices/payment_dispute_lost_serializer.rb
+++ b/app/serializers/v1/invoices/payment_dispute_lost_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module V1
+  module Invoices
+    class PaymentDisputeLostSerializer < ModelSerializer
+      def serialize
+        result = { invoice: }
+        result[:provider_error] = options[:provider_error] if options[:provider_error].present?
+        result
+      end
+
+      private
+
+      def invoice
+        ::V1::InvoiceSerializer.new(model, includes: %i[customer]).serialize
+      end
+    end
+  end
+end

--- a/app/services/invoices/lose_dispute_service.rb
+++ b/app/services/invoices/lose_dispute_service.rb
@@ -14,6 +14,10 @@ module Invoices
 
       invoice.mark_as_dispute_lost!
 
+      if invoice.organization.webhook_endpoints.any?
+        SendWebhookJob.perform_later('invoice.payment_dispute_lost', result.invoice)
+      end
+
       result
     rescue ActiveRecord::RecordInvalid => _e
       result.not_allowed_failure!(code: 'not_disputable')

--- a/app/services/webhooks/invoices/payment_dispute_lost_service.rb
+++ b/app/services/webhooks/invoices/payment_dispute_lost_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Invoices
+    class PaymentDisputeLostService < Webhooks::BaseService
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::Invoices::PaymentDisputeLostSerializer.new(
+          object,
+          root_name: object_type,
+          provider_error: options[:provider_error],
+        )
+      end
+
+      def webhook_type
+        'invoice.payment_dispute_lost'
+      end
+
+      def object_type
+        'payment_dispute_lost'
+      end
+    end
+  end
+end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -19,5 +19,9 @@ FactoryBot.define do
     trait :credit do
       invoice_type { :credit }
     end
+
+    trait :dispute_lost do
+      payment_dispute_lost_at { DateTime.current - 1.day }
+    end
   end
 end

--- a/spec/serializers/v1/invoices/payment_dispute_lost_serializer_spec.rb
+++ b/spec/serializers/v1/invoices/payment_dispute_lost_serializer_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::Invoices::PaymentDisputeLostSerializer do
+  subject(:serializer) { described_class.new(invoice, options) }
+
+  let(:invoice) { create(:invoice, :dispute_lost) }
+
+  context 'when options are present' do
+    let(:options) do
+      {
+        'provider_error' => {
+          'error_message' => 'message',
+          'error_code' => 'code',
+        },
+      }.with_indifferent_access
+    end
+
+    it 'serializes the object' do
+      result = JSON.parse(serializer.to_json)
+
+      aggregate_failures do
+        expect(result['data']['invoice']['lago_id']).to eq(invoice.id)
+        expect(result['data']['provider_error']).to eq(options[:provider_error])
+      end
+    end
+  end
+
+  context 'when options are not present' do
+    let(:options) do
+      {}
+    end
+
+    it 'serializes the object' do
+      result = JSON.parse(serializer.to_json)
+
+      aggregate_failures do
+        expect(result['data']['invoice']['lago_id']).to eq(invoice.id)
+        expect(result['data'].key?('provider_error')).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/services/webhooks/invoices/payment_dispute_lost_service_spec.rb
+++ b/spec/services/webhooks/invoices/payment_dispute_lost_service_spec.rb
@@ -2,13 +2,13 @@
 
 require 'rails_helper'
 
-RSpec.describe Webhooks::Invoices::VoidedService do
-  subject(:webhook_invoice_service) { described_class.new(object: invoice) }
+RSpec.describe Webhooks::Invoices::PaymentDisputeLostService do
+  subject(:service) { described_class.new(object: invoice) }
 
   let(:organization) { create(:organization) }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, organization:) }
-  let(:invoice) { create(:invoice, customer:, organization:) }
+  let(:invoice) { create(:invoice, :dispute_lost, customer:, organization:) }
 
   before do
     create_list(:fee, 2, invoice:)
@@ -25,14 +25,14 @@ RSpec.describe Webhooks::Invoices::VoidedService do
       allow(lago_client).to receive(:post_with_response)
     end
 
-    it 'builds payload with invoice.voided webhook type' do
-      webhook_invoice_service.call
+    it 'builds payload with invoice.payment_dispute_lost webhook type' do
+      service.call
 
       expect(LagoHttpClient::Client).to have_received(:new)
         .with(organization.webhook_endpoints.first.webhook_url)
       expect(lago_client).to have_received(:post_with_response) do |payload|
-        expect(payload[:webhook_type]).to eq('invoice.voided')
-        expect(payload[:object_type]).to eq('invoice')
+        expect(payload[:webhook_type]).to eq('invoice.payment_dispute_lost')
+        expect(payload[:object_type]).to eq('payment_dispute_lost')
       end
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/dispute-notification

## Context

PSP integration should listen to disputes and chargebacks to update payment_dispute_lost_at after a dispute is lost.

## Description

This PR adds PaymentDisputeLostService webhook.