### PR TITLE
feat(filter): GraphQL and BillableMetricFilter improvements

### DIFF
--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -42,6 +42,11 @@ module Types
         scope = scope.with_discarded if object.discarded?
         scope.includes(:group).sort_by { |gp| gp.group&.name }
       end
+
+      def filters
+        # NOTE: Ensure filters are keeping the initial ordering
+        object.filters.order(updated_at: :asc)
+      end
     end
   end
 end

--- a/app/graphql/types/customers/usage/charge_filter.rb
+++ b/app/graphql/types/customers/usage/charge_filter.rb
@@ -6,7 +6,7 @@ module Types
       class ChargeFilter < Types::BaseObject
         graphql_name 'ChargeFilterUsage'
 
-        field :id, ID, null: false, method: :charge_filter_id
+        field :id, ID, null: true, method: :charge_filter_id
 
         field :amount_cents, GraphQL::Types::BigInt, null: false
         field :events_count, Integer, null: false
@@ -16,10 +16,6 @@ module Types
 
         def values
           object.charge_filter&.to_h || {} # rubocop:disable Lint/RedundantSafeNavigation
-        end
-
-        def invoice_display_name
-          object.charge_filter&.display_name
         end
       end
     end

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -20,7 +20,8 @@ class ChargeFilter < ApplicationRecord
   end
 
   def to_h
-    values.each_with_object({}) do |filter_value, result|
+    # NOTE: Ensure filters are keeping the initial ordering
+    values.order(updated_at: :asc).each_with_object({}) do |filter_value, result|
       result[filter_value.billable_metric_filter.key] = filter_value.values
     end
   end

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -103,14 +103,18 @@ class Fee < ApplicationRecord
     charge&.group_properties&.find_by(group:)&.invoice_display_name || group&.name
   end
 
+  def filter_display_name
+    charge_filter&.display_name
+  end
+
   def invoice_sorting_clause
-    base_clause = "#{invoice_name} #{group_name}".downcase
+    base_clause = "#{invoice_name} #{group_name} #{filter_display_name}".downcase
 
     return base_clause unless charge?
     return base_clause unless charge.standard?
     return base_clause if charge.properties['grouped_by'].blank?
 
-    "#{invoice_name} #{grouped_by.values.join} #{group_name}".downcase
+    "#{invoice_name} #{grouped_by.values.join} #{group_name} #{filter_display_name}".downcase
   end
 
   def currency

--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -33,6 +33,7 @@ module AdjustedFees
         units: params[:units].presence || 0,
         unit_amount_cents: params[:unit_amount_cents].presence || 0,
         grouped_by: fee.grouped_by,
+        charge_filter: fee.charge_filter,
       )
 
       adjusted_fee.save!

--- a/schema.graphql
+++ b/schema.graphql
@@ -250,7 +250,7 @@ input ChargeFilterInput {
 type ChargeFilterUsage {
   amountCents: BigInt!
   eventsCount: Int!
-  id: ID!
+  id: ID
   invoiceDisplayName: String
   units: Float!
   values: ChargeFilterValues!

--- a/schema.json
+++ b/schema.json
@@ -2441,13 +2441,9 @@
               "name": "id",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/types/customers/usage/charge_filter_spec.rb
+++ b/spec/graphql/types/customers/usage/charge_filter_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Types::Customers::Usage::ChargeFilter do
   subject { described_class }
 
-  it { is_expected.to have_field(:id).of_type('ID!') }
+  it { is_expected.to have_field(:id).of_type('ID') }
   it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:events_count).of_type('Int!') }
   it { is_expected.to have_field(:invoice_display_name).of_type('String') }

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -346,16 +346,18 @@ RSpec.describe ChargeFilter, type: :model do
   end
 
   describe '#to_h' do
-    subject(:charge_filter) { build(:charge_filter, values:) }
+    subject(:charge_filter) { create(:charge_filter) }
 
-    let(:card) { create(:billable_metric_filter, key: 'card') }
-    let(:scheme) { create(:billable_metric_filter, key: 'scheme') }
+    let(:card) { create(:billable_metric_filter, key: 'card', values: %w[credit debit]) }
+    let(:scheme) { create(:billable_metric_filter, key: 'scheme', values: %w[visa mastercard]) }
     let(:values) do
       [
-        build(:charge_filter_value, values: ['credit'], billable_metric_filter: card),
-        build(:charge_filter_value, values: ['visa'], billable_metric_filter: scheme),
+        create(:charge_filter_value, charge_filter:, values: ['credit'], billable_metric_filter: card),
+        create(:charge_filter_value, charge_filter:, values: ['visa'], billable_metric_filter: scheme),
       ]
     end
+
+    before { values }
 
     it 'returns the values as a hash' do
       expect(charge_filter.to_h).to eq(

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -302,7 +302,9 @@ RSpec.describe Fee, type: :model do
     context 'when it is standard charge fee with grouped_by property' do
       it 'returns valid response' do
         expect(fee.invoice_sorting_clause)
-          .to eq("#{fee.invoice_name} #{fee.grouped_by.values.join} #{fee.group_name}".downcase)
+          .to eq(
+            "#{fee.invoice_name} #{fee.grouped_by.values.join} #{fee.group_name} #{fee.filter_display_name}".downcase,
+          )
       end
     end
 
@@ -314,7 +316,9 @@ RSpec.describe Fee, type: :model do
       end
 
       it 'returns valid response' do
-        expect(fee.invoice_sorting_clause).to eq("#{fee.invoice_name} #{fee.group_name}".downcase)
+        expect(
+          fee.invoice_sorting_clause,
+        ).to eq("#{fee.invoice_name} #{fee.group_name} #{fee.filter_display_name}".downcase)
       end
     end
   end

--- a/spec/scenarios/plans/create_and_update_filters_spec.rb
+++ b/spec/scenarios/plans/create_and_update_filters_spec.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Create and edit plans with charge filters', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:billable_metric) { create(:sum_billable_metric, organization:, field_name: 'value') }
+
+  let(:steps_bm_filter) do
+    create(:billable_metric_filter, billable_metric:, key: 'steps', values: %w[0-25 26-50 51-100])
+  end
+  let(:image_size_bm_filter) do
+    create(:billable_metric_filter, billable_metric:, key: 'image_size', values: %w[1024x1024 512x152])
+  end
+  let(:model_name_bm_filter) do
+    create(:billable_metric_filter, billable_metric:, key: 'model_name', values: %w[llama-1 llama-2 llama-3])
+  end
+
+  before do
+    steps_bm_filter
+    image_size_bm_filter
+    model_name_bm_filter
+  end
+
+  it 'allows the creation and update of plans with charge filters' do
+    # Create a plan with a charge and filters
+    travel_to(Time.zone.parse('2024-03-27T12:00:00')) do
+      create_plan(
+        name: 'Filtered Plan',
+        code: 'filtered_plan',
+        interval: 'monthly',
+        amount_cents: 10_000,
+        amount_currency: 'EUR',
+        pay_in_advance: false,
+        charges: [
+          {
+            billable_metric_id: billable_metric.id,
+            charge_model: 'standard',
+            properties: { amount: '0' },
+            filters: [
+              {
+                invoice_display_name: 'f1',
+                properties: { amount: '10' },
+                values: { image_size: ['512x152'], steps: ['0-25'], model_name: ['llama-2'] },
+              },
+              {
+                invoice_display_name: 'f2',
+                properties: { amount: '5' },
+                values: { image_size: ['512x152'], steps: ['0-25'] },
+              },
+              {
+                invoice_display_name: 'f3',
+                properties: { amount: '5' },
+                values: {
+                  image_size: [ChargeFilterValue::ALL_FILTER_VALUES],
+                  steps: [ChargeFilterValue::ALL_FILTER_VALUES],
+                },
+              },
+              {
+                invoice_display_name: 'f4',
+                properties: { amount: '2.5' },
+                values: {
+                  image_size: [ChargeFilterValue::ALL_FILTER_VALUES],
+                },
+              },
+            ],
+          },
+        ],
+      )
+    end
+
+    plan = organization.plans.find_by(code: 'filtered_plan')
+    expect(plan.charges.count).to eq(1)
+
+    charge = plan.charges.first
+    expect(charge.filters.count).to eq(4)
+
+    # Update the typo on the charge filter values
+    travel_to(Time.zone.parse('2024-03-27T14:00:00')) do
+      update_metric(
+        billable_metric,
+        filters: [
+          { key: 'image_size', values: %w[1024x1024 512x512] },
+          { key: 'steps', values: %w[0-25 26-50 51-100] },
+          { key: 'model_name', values: %w[llama-1 llama-2 llama-3] },
+        ],
+      )
+    end
+
+    charge.reload
+    f1 = charge.filters.find_by(invoice_display_name: 'f1')
+    expect(f1.to_h.keys).to eq(%w[steps model_name])
+
+    f2 = charge.filters.find_by(invoice_display_name: 'f2')
+    expect(f2.to_h.keys).to eq(%w[steps])
+
+    f3 = charge.filters.find_by(invoice_display_name: 'f3')
+    expect(f3.to_h.keys).to eq(%w[image_size steps])
+
+    f4 = charge.filters.find_by(invoice_display_name: 'f4')
+    expect(f4.to_h.keys).to eq(%w[image_size])
+
+    # Update the plan to fix the filters
+    travel_to(Time.zone.parse('2024-03-27T16:00:00')) do
+      update_plan(
+        plan,
+        name: 'Filtered Plan',
+        code: 'filtered_plan',
+        interval: 'monthly',
+        amount_cents: 10_000,
+        amount_currency: 'EUR',
+        pay_in_advance: false,
+        charges: [
+          {
+            billable_metric_id: billable_metric.id,
+            id: charge.id,
+            charge_model: 'standard',
+            properties: { amount: '0' },
+            filters: [
+              {
+                invoice_display_name: 'f2',
+                properties: { amount: '5' },
+                values: { image_size: ['512x512'], steps: ['0-25'] },
+              },
+              {
+                invoice_display_name: 'f3',
+                properties: { amount: '5' },
+                values: {
+                  image_size: [ChargeFilterValue::ALL_FILTER_VALUES],
+                  steps: [ChargeFilterValue::ALL_FILTER_VALUES],
+                },
+              },
+              {
+                invoice_display_name: 'f4',
+                properties: { amount: '2.5' },
+                values: {
+                  image_size: [ChargeFilterValue::ALL_FILTER_VALUES],
+                },
+              },
+              {
+                invoice_display_name: 'f1',
+                properties: { amount: '10' },
+                values: { image_size: ['512x512'], steps: ['0-25'], model_name: ['llama-2'] },
+              },
+              {
+                invoice_display_name: 'f5',
+                properties: { amount: '1' },
+                values: { image_size: ['1024x1024'] },
+              },
+            ],
+          },
+        ],
+      )
+
+      plan.reload
+      charge = plan.charges.first
+      expect(charge.filters.count).to eq(5)
+    end
+
+    # TODO: send events to check the filters are working
+    travel_to(Time.zone.parse('2024-03-28T12:00:00')) do
+      create_subscription(
+        external_customer_id: customer.external_id,
+        external_id: customer.external_id,
+        plan_code: plan.code,
+        billing_time: 'anniversary',
+      )
+    end
+
+    subscription = organization.subscriptions.find_by(external_id: customer.external_id)
+    expect(subscription).to be_present
+
+    travel_to(Time.zone.parse('2024-03-29T12:00:00')) do
+      # Send an event with more values than the filters
+      create_event(
+        code: billable_metric.code,
+        transaction_id: SecureRandom.uuid,
+        external_subscription_id: customer.external_id,
+        properties: {
+          value: 10,
+          image_size: '512x512',
+          steps: '0-25',
+          model: 'llama-3',
+        },
+      )
+
+      create_event(
+        code: billable_metric.code,
+        transaction_id: SecureRandom.uuid,
+        external_subscription_id: customer.external_id,
+        properties: {
+          value: 10,
+          image: '512x512',
+          step: '0-25',
+          model: 'llama-3',
+        },
+      )
+
+      fetch_current_usage(customer:)
+      expect(json[:customer_usage][:total_amount_cents]).to eq(5000)
+      expect(json[:customer_usage][:charges_usage].count).to eq(1)
+
+      charges_usage = json[:customer_usage][:charges_usage].first
+      expect(charges_usage[:filters].count).to eq(6)
+
+      f2_filter = charges_usage[:filters].find { _1[:invoice_display_name] == 'f2' }
+      expect(f2_filter[:amount_cents]).to eq(5000)
+      expect(f2_filter[:units]).to eq('10.0')
+      expect(f2_filter[:events_count]).to eq(1)
+      expect(f2_filter[:invoice_display_name]).to eq('f2')
+
+      charges_usage[:filters].reject { [nil, 'f2'].include?(_1[:invoice_display_name]) }.each do |filter|
+        expect(filter[:amount_cents]).to eq(0)
+        expect(filter[:units]).to eq('0.0')
+        expect(filter[:events_count]).to eq(0)
+      end
+
+      default_filter = charges_usage[:filters].find { _1[:invoice_display_name].nil? }
+      expect(default_filter[:amount_cents]).to eq(0)
+      expect(default_filter[:units]).to eq('10.0')
+      expect(default_filter[:events_count]).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR:
- Improve the GraphQl API for billable metric and charge filter
- Makes sure that the edited ChargeFilter and ChargeFilterValue keeps their order after edition