### PR TITLE
poc(billing): Refactor first invoice when pay plan.in_advance

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -192,8 +192,6 @@ module Invoices
     end
 
     def should_create_charge_fees?(subscription)
-      return true if subscription.terminated?
-
       # We should take a look at charges if subscription is created in the past and if it is not upgrade
       if subscription.plan.pay_in_advance? && subscription.started_in_past? && subscription.previous_subscription.nil?
         return true

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -192,14 +192,15 @@ module Invoices
     end
 
     def should_create_charge_fees?(subscription)
+      return true if subscription.terminated?
+
       # We should take a look at charges if subscription is created in the past and if it is not upgrade
       if subscription.plan.pay_in_advance? && subscription.started_in_past? && subscription.previous_subscription.nil?
         return true
       end
 
-      # NOTE: Charges should not be billed in advance when we are just upgrading to a new
-      #       pay_in_advance subscription
-      return false if subscription.plan.pay_in_advance? && subscription.invoices.created_before(invoice).count.zero?
+      return false if subscription.plan.pay_in_advance? &&
+                      subscription.started_at.to_date == timestamp.to_date
 
       true
     end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -679,7 +679,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               expect(invoice.subscriptions.first).to eq(subscription)
               expect(invoice.payment_status).to eq('pending')
               expect(invoice.fees.subscription_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.count).to eq(0)
+              expect(invoice.fees.charge_kind.count).to eq(1)
+              expect(invoice.fees.charge_kind.first.amount_cents).to eq(0) # because there is no usage
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
@@ -713,7 +714,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               expect(invoice.subscriptions.first).to eq(subscription)
               expect(invoice.payment_status).to eq('pending')
               expect(invoice.fees.subscription_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.count).to eq(0)
+              expect(invoice.fees.charge_kind.count).to eq(1)
+              expect(invoice.fees.charge_kind.first.amount_cents).to eq(0) # because there is no usage
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
@@ -807,7 +809,9 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         end
       end
 
-      context 'when subscription started on creation day' do
+      context 'when subscription is billed on started_at day' do
+        let(:timestamp) { created_at + 10.minutes }
+
         it 'does not create any charge fees' do
           result = invoice_service.call
 
@@ -856,7 +860,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               expect(invoice).to be_pending
               expect(invoice.fees.subscription_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.count).to eq(0)
+              expect(invoice.fees.charge_kind.count).to eq(1)
+              expect(invoice.fees.charge_kind.first.amount_cents).to eq(0) # because there is no usage
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
@@ -890,7 +895,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               expect(invoice).to be_pending
               expect(invoice.fees.subscription_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.count).to eq(0)
+              expect(invoice.fees.charge_kind.count).to eq(1)
+              expect(invoice.fees.charge_kind.first.amount_cents).to eq(0) # because there is no usage
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
@@ -1069,7 +1075,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               expect(invoice.subscriptions.first).to eq(subscription)
               expect(invoice.fees.subscription_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.count).to eq(0)
+              expect(invoice.fees.charge_kind.count).to eq(1)
+              expect(invoice.fees.charge_kind.first.amount_cents).to eq(0) # because there is no usage
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(


### PR DESCRIPTION
When creating an invoice, the fees are determined by `Invoices::CalculateFeesService`. 

If the subscription is set to `pay_in_advance`, the first invoice should not include the usage-based charges because they are billed in arrears and you just got started.

Before, we used to only check if there was a previous invoice to guess of the charge fees should be added. It's worked because pay in advance plan were always billed on day one.

### Enter trial changes

We're changing how the trial works and we're now **charging the subscription fee only at then end of trial**. Now, we cannot assume there was an invoice created on day 1.

## The problem 

Let's look at a subscription with a plan billed monthly, on the first day of the month, with **a trial period of 20 days**.

### Before this PR, before trial change

- 2023-03-20 
  - subscription started
  - one invoice created, subscription fee is 0
- 2023-04-01
  - It's billing day, we charge the usage from March 20th to April 1st, one invoice is created
  - we change a subscription without the 10 days left of FREE trial
  - It works because `subscription.invoices.created_before(invoice).count.zero?` is false, there is already an invoice
- 2023-04-10
  - end of trial. Nothing happens.
- 2023-05-01
  - invoice for full subscription fee in May
  - and all charges for usage in April

### Before this PR, with trial change

- 2023-03-20 
  - subscription started
  - no invoice created
- 2023-04-01
  - It's billing day, we  should charge the usage from March 20th to April 1st
  - we shouldn't invoice subscription fee yet because we're in trial
  - ❌ No invoice is created because `Invoices::CalculateFeesService` won't invoice charges unless there is an existing invoice. `subscription.invoices.created_before(invoice).count.zero?` is true.
- 2023-04-10
  - one invoice is created with the subscription fee remaining for the period
  - no usage fee should be added
- 2023-05-01
  - invoice for full subscription fee in May
  - and all charges for usage in April

### With this PR, with trial change

- 2023-03-20 
  - subscription started
  - no invoice created
- 2023-04-01
  - It's billing day, we charge the usage from March 20th to April 1st because we're not on subscription day 1
  - we don't charge subscription fee yet because we're in trial
- 2023-04-10
  - one invoice is created with the subscription fee remaining for the period
  - no usage fee should be added
- 2023-05-01
  - invoice for full subscription fee in May
  - and all charges for usage in April