### PR TITLE
fix: allow display name edition for all types of fees in draft invoice

### DIFF
--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -15,9 +15,7 @@ module AdjustedFees
       return result.validation_failure!(errors: { adjusted_fee: ['already_exists'] }) if fee.adjusted_fee
 
       charge = fee.charge
-      if charge && params[:unit_amount_cents].blank? && (charge.percentage? || (charge.prorated? && charge.graduated?))
-        return result.validation_failure!(errors: { charge: ['invalid_charge_model'] })
-      end
+      return result.validation_failure!(errors: { charge: ['invalid_charge_model'] }) if disabled_charge_model?(charge)
 
       adjusted_fee = AdjustedFee.new(
         fee:,
@@ -51,5 +49,11 @@ module AdjustedFees
     private
 
     attr_reader :organization, :fee, :params
+
+    def disabled_charge_model?(charge)
+      unit_adjustment = params[:units].present? && params[:unit_amount_cents].blank?
+
+      charge && unit_adjustment && (charge.percentage? || (charge.prorated? && charge.graduated?))
+    end
   end
 end

--- a/spec/services/adjusted_fees/create_service_spec.rb
+++ b/spec/services/adjusted_fees/create_service_spec.rb
@@ -75,6 +75,23 @@ RSpec.describe AdjustedFees::CreateService, type: :service do
         end
       end
 
+      context 'when there is invalid charge model and display name is adjusted' do
+        let(:percentage_charge) { create(:percentage_charge) }
+        let(:params) do
+          {
+            invoice_display_name: 'new-dis-name',
+          }
+        end
+
+        before { fee.charge = percentage_charge }
+
+        it 'returns success response' do
+          result = create_service.call
+
+          expect(result).to be_success
+        end
+      end
+
       context 'when there is invalid charge model and units are adjusted' do
         let(:percentage_charge) { create(:percentage_charge) }
         let(:params) do


### PR DESCRIPTION
When editing draft invoice, we should raise validation failure for percentage and graduated prorated charge model only if user wants to edit units. In that case, having number of units as input is not sufficient for performing calculation.

If user wants to have amount adjustment or display name adjustment, we should allow it regardless of the charge model.