### PR TITLE
feat(disputes): Add payment dispute stripe and adyen service

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -127,7 +127,7 @@ module Api
       def lose_dispute
         invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
 
-        result = Invoices::LoseDisputeService.call(invoice:)
+        result = Invoices::LoseDisputeService.call(invoice:, payment_dispute_lost_at: DateTime.current)
         if result.success?
           render_invoice(result.invoice)
         else

--- a/app/graphql/mutations/invoices/lose_dispute.rb
+++ b/app/graphql/mutations/invoices/lose_dispute.rb
@@ -16,6 +16,7 @@ module Mutations
       def resolve(**args)
         result = ::Invoices::LoseDisputeService.call(
           invoice: current_organization.invoices.not_generating.find_by(id: args[:id]),
+          payment_dispute_lost_at: DateTime.current,
         )
         result.success? ? result.invoice : result_error(result)
       end

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -10,6 +10,7 @@ module Resolvers
     argument :ids, [ID], required: false, description: 'List of invoice IDs to fetch'
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
+    argument :payment_dispute_lost, Boolean, required: false
     argument :payment_status, [Types::Invoices::PaymentStatusTypeEnum], required: false
     argument :search_term, String, required: false
     argument :status, Types::Invoices::StatusTypeEnum, required: false
@@ -22,7 +23,8 @@ module Resolvers
       limit: nil,
       payment_status: nil,
       status: nil,
-      search_term: nil
+      search_term: nil,
+      payment_dispute_lost: nil
     )
       query = InvoicesQuery.new(organization: current_organization)
       result = query.call(
@@ -30,6 +32,7 @@ module Resolvers
         page:,
         limit:,
         payment_status:,
+        payment_dispute_lost:,
         status:,
         filters: {
           ids:,

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class InvoicesQuery < BaseQuery
-  def call(search_term:, status:, page:, limit:, filters: {}, customer_id: nil, payment_status: nil) # rubocop:disable Metrics/ParameterLists
+  def call(search_term:, status:, page:, limit:, filters: {}, customer_id: nil, payment_status: nil, payment_dispute_lost: nil) # rubocop:disable Metrics/ParameterLists, Layout/LineLength
     @search_term = search_term
     @customer_id = customer_id
 
@@ -10,6 +10,7 @@ class InvoicesQuery < BaseQuery
     invoices = invoices.where(customer_id:) if customer_id.present?
     invoices = invoices.where(status:) if status.present?
     invoices = invoices.where(payment_status:) if payment_status.present?
+    invoices = invoices.where.not(payment_dispute_lost_at: nil) unless payment_dispute_lost.nil?
     invoices = invoices.order(issuing_date: :desc, created_at: :desc).page(page).per(limit)
 
     result.invoices = invoices

--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -73,8 +73,7 @@ module CreditNotes
       end
 
       def should_process_refund?
-        return false unless credit_note.refunded?
-        return false if credit_note.succeeded?
+        return false if !credit_note.refunded? || credit_note.succeeded? || invoice.payment_dispute_lost_at?
 
         payment.present?
       end

--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -69,8 +69,7 @@ module CreditNotes
       delegate :organization, :customer, :invoice, to: :credit_note
 
       def should_process_refund?
-        return false unless credit_note.refunded?
-        return false if credit_note.succeeded?
+        return false if !credit_note.refunded? || credit_note.succeeded? || invoice.payment_dispute_lost_at?
 
         payment.present?
       end

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -65,8 +65,7 @@ module CreditNotes
       delegate :organization, :customer, :invoice, to: :credit_note
 
       def should_process_refund?
-        return false unless credit_note.refunded?
-        return false if credit_note.succeeded?
+        return false if !credit_note.refunded? || credit_note.succeeded? || invoice.payment_dispute_lost_at?
 
         payment.present?
       end

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -11,6 +11,7 @@ module PaymentProviders
       'charge.refund.updated',
       'customer.updated',
       'charge.succeeded',
+      'charge.dispute.closed',
     ].freeze
 
     def create_or_update(**args)
@@ -168,6 +169,11 @@ module PaymentProviders
             status: 'succeeded',
             metadata: event.data.object.metadata.to_h.symbolize_keys,
           )
+      when 'charge.dispute.closed'
+        PaymentProviders::Webhooks::Stripe::ChargeDisputeClosedService.call(
+          organization_id: organization.id,
+          event_json:,
+        )
       when 'payment_intent.payment_failed', 'payment_intent.succeeded'
         status = (event.type == 'payment_intent.succeeded') ? 'succeeded' : 'failed'
 

--- a/app/services/payment_providers/webhooks/adyen/chargeback_service.rb
+++ b/app/services/payment_providers/webhooks/adyen/chargeback_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Webhooks
+    module Adyen
+      class ChargebackService < BaseService
+        def call
+          status = event['additionalData']['disputeStatus']
+          reason = event['reason']
+          provider_payment_id = event['pspReference']
+
+          payment = Payment.find_by(provider_payment_id:)
+          return result.not_found_failure!(resource: 'adyen_payment') unless payment
+
+          if status == 'Lost' && event['success'] == 'true'
+            return Invoices::LoseDisputeService.call(invoice: payment.invoice, payment_dispute_lost_at:, reason:)
+          end
+
+          result
+        end
+
+        private
+
+        def event
+          @event ||= JSON.parse(event_json)['notificationItems'].first&.dig('NotificationRequestItem')
+        end
+
+        def payment_dispute_lost_at
+          Time.zone.parse(event['eventDate'])
+        end
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/webhooks/base_service.rb
+++ b/app/services/payment_providers/webhooks/base_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Webhooks
+    class BaseService < BaseService
+      def initialize(organization_id:, event_json:)
+        @organization = Organization.find(organization_id)
+        @event_json = event_json
+
+        super
+      end
+
+      private
+
+      attr_reader :organization, :event_json
+    end
+  end
+end

--- a/app/services/payment_providers/webhooks/stripe/charge_dispute_closed_service.rb
+++ b/app/services/payment_providers/webhooks/stripe/charge_dispute_closed_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Webhooks
+    module Stripe
+      class ChargeDisputeClosedService < BaseService
+        def call
+          status = event.data.object.status
+          reason = event.data.object.reason
+          provider_payment_id = event.data.object.payment_intent
+
+          payment = Payment.find_by(provider_payment_id:)
+          return result.not_found_failure!(resource: 'stripe_payment') unless payment
+
+          if status == 'lost'
+            return Invoices::LoseDisputeService.call(invoice: payment.invoice, payment_dispute_lost_at:, reason:)
+          end
+
+          result
+        end
+
+        private
+
+        def event
+          @event ||= ::Stripe::Event.construct_from(JSON.parse(event_json))
+        end
+
+        def payment_dispute_lost_at
+          Time.zone.at(event.created)
+        end
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4918,6 +4918,7 @@ type Query {
     ids: [ID!]
     limit: Int
     page: Int
+    paymentDisputeLost: Boolean
     paymentStatus: [InvoicePaymentStatusTypeEnum!]
     searchTerm: String
     status: InvoiceStatusTypeEnum

--- a/schema.json
+++ b/schema.json
@@ -23711,6 +23711,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "paymentDisputeLost",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "paymentStatus",
                   "description": null,
                   "type": {

--- a/spec/fixtures/adyen/chargeback_lost_event.json
+++ b/spec/fixtures/adyen/chargeback_lost_event.json
@@ -1,0 +1,28 @@
+{
+  "live" : "true",
+  "notificationItems" : [
+    {
+       "NotificationRequestItem" : {
+          "additionalData" : {
+             "chargebackReasonCode" : "13.1",
+             "modificationMerchantReferences" : "",
+             "chargebackSchemeCode" : "visa",
+             "disputeStatus" : "Lost"
+          },
+          "amount" : {
+             "currency" : "GBP",
+             "value" : 10000
+          },
+          "eventCode" : "CHARGEBACK",
+          "eventDate" : "2020-03-13T11:35:42+01:00",
+          "merchantAccountCode" : "YOUR_MERCHANT_ACCOUNT",
+          "merchantReference" : "YOUR_REFERENCE",
+          "originalReference":"9913333333333333",
+          "paymentMethod" : "visa",
+          "pspReference" : "9915555555555555",
+          "reason" : "Merchandise/Services Not Received",
+          "success" : "true"
+       }
+    }
+  ]
+}

--- a/spec/fixtures/adyen/chargeback_won_event.json
+++ b/spec/fixtures/adyen/chargeback_won_event.json
@@ -1,0 +1,30 @@
+{
+  "live":"true",
+  "notificationItems":[
+     {
+        "NotificationRequestItem":{
+           "additionalData":{
+              "chargebackReasonCode":"10.4",
+              "modificationMerchantReferences":"",
+              "chargebackSchemeCode":"visa",
+              "defensePeriodEndsAt":"2021-05-24T22:09:50+02:00",
+              "defendable" : "true",
+              "disputeStatus" : "Won"
+           },
+           "amount":{
+              "currency":"EUR",
+              "value":1000
+           },
+           "eventCode":"CHARGEBACK",
+           "eventDate":"2021-05-06T22:09:50+02:00",
+           "merchantAccountCode":"YOUR_MERCHANT_ACCOUNT",
+           "merchantReference":"YOUR_REFERENCE",
+           "originalReference":"9913333333333333",
+           "paymentMethod":"visa",
+           "pspReference":"9915555555555555",
+           "reason":"Other Fraud-Card Absent Environment",
+           "success":"true"
+        }
+     }
+  ]
+}

--- a/spec/fixtures/stripe/charge_dispute_lost_event.json
+++ b/spec/fixtures/stripe/charge_dispute_lost_event.json
@@ -1,0 +1,103 @@
+{
+  "id": "evt_3OzgpDH4tiDZlIUa09cnGOsO",
+  "object": "event",
+  "api_version": "2020-08-27",
+  "created": 1711724294,
+  "data": {
+    "object": {
+      "id": "dp_1OzgpEH4tiDZlIUaZ8iWQMsb",
+      "object": "dispute",
+      "amount": 4516,
+      "balance_transaction": "txn_1OzgpEH4tiDZlIUaXu3PFSnM",
+      "balance_transactions": [
+        {
+          "id": "txn_1OzgpEH4tiDZlIUaXu3PFSnM",
+          "object": "balance_transaction",
+          "amount": -4516,
+          "available_on": 1712275200,
+          "created": 1711724076,
+          "currency": "usd",
+          "description": "Chargeback withdrawal for ch_3OzgpDH4tiDZlIUa0M7QchGT",
+          "exchange_rate": null,
+          "fee": 2000,
+          "fee_details": [
+            {
+              "amount": 2000,
+              "application": null,
+              "currency": "usd",
+              "description": "Dispute fee",
+              "type": "stripe_fee"
+            }
+          ],
+          "net": -6516,
+          "reporting_category": "dispute",
+          "source": "dp_1OzgpEH4tiDZlIUaZ8iWQMsb",
+          "status": "pending",
+          "type": "adjustment"
+        }
+      ],
+      "charge": "ch_3OzgpDH4tiDZlIUa0M7QchGT",
+      "created": 1711724076,
+      "currency": "usd",
+      "evidence": {
+        "access_activity_log": null,
+        "billing_address": null,
+        "cancellation_policy": null,
+        "cancellation_policy_disclosure": null,
+        "cancellation_rebuttal": null,
+        "customer_communication": null,
+        "customer_email_address": null,
+        "customer_name": "i_stripe_3",
+        "customer_purchase_ip": null,
+        "customer_signature": null,
+        "duplicate_charge_documentation": null,
+        "duplicate_charge_explanation": null,
+        "duplicate_charge_id": null,
+        "product_description": null,
+        "receipt": null,
+        "refund_policy": null,
+        "refund_policy_disclosure": null,
+        "refund_refusal_explanation": null,
+        "service_date": null,
+        "service_documentation": null,
+        "shipping_address": null,
+        "shipping_carrier": null,
+        "shipping_date": null,
+        "shipping_documentation": null,
+        "shipping_tracking_number": null,
+        "uncategorized_file": null,
+        "uncategorized_text": null
+      },
+      "evidence_details": {
+        "due_by": 1712534399,
+        "has_evidence": false,
+        "past_due": false,
+        "submission_count": 0
+      },
+      "is_charge_refundable": false,
+      "livemode": false,
+      "metadata": {},
+      "payment_intent": "pi_3OzgpDH4tiDZlIUa0Ezzggtg",
+      "payment_method_details": {
+        "card": {
+          "brand": "visa",
+          "network_reason_code": "83"
+        },
+        "type": "card"
+      },
+      "reason": "fraudulent",
+      "status": "lost"
+    },
+    "previous_attributes": {
+      "status": "needs_response"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 2,
+  "request": {
+    "id": "req_Lb7Yp8XdgG2n7N",
+    "idempotency_key": "[FILTERED]"
+  },
+  "type": "charge.dispute.closed",
+  "organization_id": "57e0597e-3cc5-4496-a46b-ac29b9439ab9"
+}

--- a/spec/fixtures/stripe/charge_dispute_won_event.json
+++ b/spec/fixtures/stripe/charge_dispute_won_event.json
@@ -1,0 +1,103 @@
+{
+  "id": "evt_3OzgpDH4tiDZlIUa09cnGOsO",
+  "object": "event",
+  "api_version": "2020-08-27",
+  "created": 1711724294,
+  "data": {
+    "object": {
+      "id": "dp_1OzgpEH4tiDZlIUaZ8iWQMsb",
+      "object": "dispute",
+      "amount": 4516,
+      "balance_transaction": "txn_1OzgpEH4tiDZlIUaXu3PFSnM",
+      "balance_transactions": [
+        {
+          "id": "txn_1OzgpEH4tiDZlIUaXu3PFSnM",
+          "object": "balance_transaction",
+          "amount": -4516,
+          "available_on": 1712275200,
+          "created": 1711724076,
+          "currency": "usd",
+          "description": "Chargeback withdrawal for ch_3OzgpDH4tiDZlIUa0M7QchGT",
+          "exchange_rate": null,
+          "fee": 2000,
+          "fee_details": [
+            {
+              "amount": 2000,
+              "application": null,
+              "currency": "usd",
+              "description": "Dispute fee",
+              "type": "stripe_fee"
+            }
+          ],
+          "net": -6516,
+          "reporting_category": "dispute",
+          "source": "dp_1OzgpEH4tiDZlIUaZ8iWQMsb",
+          "status": "pending",
+          "type": "adjustment"
+        }
+      ],
+      "charge": "ch_3OzgpDH4tiDZlIUa0M7QchGT",
+      "created": 1711724076,
+      "currency": "usd",
+      "evidence": {
+        "access_activity_log": null,
+        "billing_address": null,
+        "cancellation_policy": null,
+        "cancellation_policy_disclosure": null,
+        "cancellation_rebuttal": null,
+        "customer_communication": null,
+        "customer_email_address": null,
+        "customer_name": "i_stripe_3",
+        "customer_purchase_ip": null,
+        "customer_signature": null,
+        "duplicate_charge_documentation": null,
+        "duplicate_charge_explanation": null,
+        "duplicate_charge_id": null,
+        "product_description": null,
+        "receipt": null,
+        "refund_policy": null,
+        "refund_policy_disclosure": null,
+        "refund_refusal_explanation": null,
+        "service_date": null,
+        "service_documentation": null,
+        "shipping_address": null,
+        "shipping_carrier": null,
+        "shipping_date": null,
+        "shipping_documentation": null,
+        "shipping_tracking_number": null,
+        "uncategorized_file": null,
+        "uncategorized_text": null
+      },
+      "evidence_details": {
+        "due_by": 1712534399,
+        "has_evidence": false,
+        "past_due": false,
+        "submission_count": 0
+      },
+      "is_charge_refundable": false,
+      "livemode": false,
+      "metadata": {},
+      "payment_intent": "pi_3OzgpDH4tiDZlIUa0Ezzggtg",
+      "payment_method_details": {
+        "card": {
+          "brand": "visa",
+          "network_reason_code": "83"
+        },
+        "type": "card"
+      },
+      "reason": "...",
+      "status": "won"
+    },
+    "previous_attributes": {
+      "status": "needs_response"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 2,
+  "request": {
+    "id": "req_Lb7Yp8XdgG2n7N",
+    "idempotency_key": "[FILTERED]"
+  },
+  "type": "charge.dispute.closed",
+  "organization_id": "57e0597e-3cc5-4496-a46b-ac29b9439ab9"
+}

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -117,6 +117,61 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
     end
   end
 
+  context 'when filtering by payment dispute lost' do
+    let(:invoice_third) do
+      create(
+        :invoice,
+        customer: customer_second,
+        status: :draft,
+        organization:,
+      )
+    end
+
+    let(:invoice_fourth) do
+      create(
+        :invoice,
+        :dispute_lost,
+        customer: customer_second,
+        status: :finalized,
+        organization:,
+      )
+    end
+
+    let(:query) do
+      <<~GQL
+        query {
+          invoices(limit: 5, paymentDisputeLost: true) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    before do
+      invoice_third
+      invoice_fourth
+    end
+
+    it 'returns all invoices with payment dispute lost' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+      )
+
+      invoices_response = result['data']['invoices']
+
+      aggregate_failures do
+        expect(invoices_response['collection'].count).to eq(1)
+        expect(invoices_response['collection'].first['id']).to eq(invoice_fourth.id)
+
+        expect(invoices_response['metadata']['currentPage']).to eq(1)
+        expect(invoices_response['metadata']['totalCount']).to eq(1)
+      end
+    end
+  end
+
   context 'without current organization' do
     it 'returns an error' do
       result = execute_graphql(

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -61,6 +61,16 @@ RSpec.describe InvoicesQuery, type: :query do
       number: '5555555555',
     )
   end
+  let(:invoice_sixth) do
+    create(
+      :invoice,
+      :dispute_lost,
+      organization:,
+      payment_status: 'pending',
+      customer: customer_first,
+      number: '6666666666',
+    )
+  end
 
   before do
     invoice_first
@@ -68,6 +78,7 @@ RSpec.describe InvoicesQuery, type: :query do
     invoice_third
     invoice_fourth
     invoice_fifth
+    invoice_sixth
   end
 
   it 'returns all invoices' do
@@ -82,12 +93,13 @@ RSpec.describe InvoicesQuery, type: :query do
     returned_ids = result.invoices.pluck(:id)
 
     aggregate_failures do
-      expect(result.invoices.count).to eq(5)
+      expect(result.invoices.count).to eq(6)
       expect(returned_ids).to include(invoice_first.id)
       expect(returned_ids).to include(invoice_second.id)
       expect(returned_ids).to include(invoice_third.id)
       expect(returned_ids).to include(invoice_fourth.id)
       expect(returned_ids).to include(invoice_fifth.id)
+      expect(returned_ids).to include(invoice_sixth.id)
     end
   end
 
@@ -159,6 +171,30 @@ RSpec.describe InvoicesQuery, type: :query do
         expect(returned_ids).to include(invoice_third.id)
         expect(returned_ids).not_to include(invoice_fourth.id)
         expect(returned_ids).not_to include(invoice_fifth.id)
+      end
+    end
+  end
+
+  context 'when filtering by payment dispute lost' do
+    it 'returns 1 invoices' do
+      result = invoice_query.call(
+        search_term: nil,
+        status: nil,
+        payment_dispute_lost: true,
+        page: 1,
+        limit: 10,
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(result.invoices.count).to eq(1)
+        expect(returned_ids).not_to include(invoice_first.id)
+        expect(returned_ids).not_to include(invoice_second.id)
+        expect(returned_ids).not_to include(invoice_third.id)
+        expect(returned_ids).not_to include(invoice_fourth.id)
+        expect(returned_ids).not_to include(invoice_fifth.id)
+        expect(returned_ids).to include(invoice_sixth.id)
       end
     end
   end
@@ -245,12 +281,13 @@ RSpec.describe InvoicesQuery, type: :query do
       returned_ids = result.invoices.pluck(:id)
 
       aggregate_failures do
-        expect(result.invoices.count).to eq(3)
+        expect(result.invoices.count).to eq(4)
         expect(returned_ids).to include(invoice_first.id)
         expect(returned_ids).not_to include(invoice_second.id)
         expect(returned_ids).to include(invoice_third.id)
         expect(returned_ids).not_to include(invoice_fourth.id)
         expect(returned_ids).to include(invoice_fifth.id)
+        expect(returned_ids).to include(invoice_sixth.id)
       end
     end
   end

--- a/spec/services/credit_notes/refunds/adyen_service_spec.rb
+++ b/spec/services/credit_notes/refunds/adyen_service_spec.rb
@@ -151,6 +151,23 @@ RSpec.describe CreditNotes::Refunds::AdyenService, type: :service do
         end
       end
     end
+
+    context 'when dispute was lost' do
+      let(:invoice) { create(:invoice, :dispute_lost, customer:, organization:) }
+
+      it 'does not create a refund' do
+        result = adyen_service.create
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.credit_note).to eq(credit_note)
+          expect(result.refund).to be_nil
+
+          expect(modifications_api).not_to have_received(:refund_captured_payment)
+        end
+      end
+    end
   end
 
   describe '#update_status' do

--- a/spec/services/credit_notes/refunds/gocardless_service_spec.rb
+++ b/spec/services/credit_notes/refunds/gocardless_service_spec.rb
@@ -151,6 +151,23 @@ RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
         end
       end
     end
+
+    context 'when dispute was lost' do
+      let(:invoice) { create(:invoice, :dispute_lost, customer:, organization:) }
+
+      it 'does not create a refund' do
+        result = gocardless_service.create
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.credit_note).to eq(credit_note)
+          expect(result.refund).to be_nil
+
+          expect(gocardless_refunds_service).not_to have_received(:create)
+        end
+      end
+    end
   end
 
   describe '#update_status' do

--- a/spec/services/credit_notes/refunds/stripe_service_spec.rb
+++ b/spec/services/credit_notes/refunds/stripe_service_spec.rb
@@ -148,6 +148,23 @@ RSpec.describe CreditNotes::Refunds::StripeService, type: :service do
         end
       end
     end
+
+    context 'when dispute was lost' do
+      let(:invoice) { create(:invoice, :dispute_lost, customer:, organization:) }
+
+      it 'does not create a refund' do
+        result = stripe_service.create
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.credit_note).to eq(credit_note)
+          expect(result.refund).to be_nil
+
+          expect(Stripe::Refund).not_to have_received(:create)
+        end
+      end
+    end
   end
 
   describe '#update_status' do

--- a/spec/services/invoices/lose_dispute_service_spec.rb
+++ b/spec/services/invoices/lose_dispute_service_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Invoices::LoseDisputeService, type: :service do
         it 'enqueues a send webhook job for the invoice' do
           expect do
             lose_dispute_service.call
-          end.to have_enqueued_job(SendWebhookJob).with('invoice.payment_dispute_lost', Invoice)
+          end.to have_enqueued_job(SendWebhookJob).with('invoice.payment_dispute_lost', invoice, provider_error: nil)
         end
       end
     end

--- a/spec/services/payment_providers/webhooks/adyen/chargeback_service_spec.rb
+++ b/spec/services/payment_providers/webhooks/adyen/chargeback_service_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentProviders::Webhooks::Adyen::ChargebackService, type: :service do
+  subject(:service) { described_class.new(organization_id:, event_json:) }
+
+  let(:organization_id) { organization.id }
+  let(:organization) { create(:organization) }
+  let(:membership) { create(:membership, organization:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:payment) { create(:payment, invoice:, provider_payment_id: '9915555555555555') }
+  let(:lose_dispute_service) { Invoices::LoseDisputeService.new(invoice:) }
+  let(:invoice) { create(:invoice, customer:, organization:, status:, payment_status: 'succeeded') }
+
+  describe '#call' do
+    before { payment }
+
+    context 'when dispute is lost' do
+      let(:event_json) do
+        path = Rails.root.join('spec/fixtures/adyen/chargeback_lost_event.json')
+        File.read(path)
+      end
+
+      context 'when invoice is draft' do
+        let(:status) { 'draft' }
+
+        it 'does not updates invoice payment dispute lost' do
+          expect do
+            service.call
+            payment.invoice.reload
+          end.not_to change(payment.invoice.reload, :payment_dispute_lost_at).from(nil)
+        end
+
+        it 'does not deliver webhook' do
+          expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+        end
+      end
+
+      context 'when invoice is finalized' do
+        let(:status) { 'finalized' }
+
+        it 'updates invoice payment dispute lost' do
+          expect do
+            service.call
+            payment.invoice.reload
+          end.to change(payment.invoice, :payment_dispute_lost_at).from(nil)
+        end
+
+        it 'delivers a webhook' do
+          expect do
+            service.call
+            payment.invoice.reload
+          end.to have_enqueued_job(SendWebhookJob).with(
+            'invoice.payment_dispute_lost',
+            payment.invoice,
+            provider_error: 'Merchandise/Services Not Received',
+          )
+        end
+      end
+    end
+
+    context 'when dispute is won' do
+      let(:event_json) do
+        path = Rails.root.join('spec/fixtures/adyen/chargeback_won_event.json')
+        File.read(path)
+      end
+
+      context 'when invoice is draft' do
+        let(:status) { 'draft' }
+
+        it 'does not updates invoice payment dispute lost' do
+          expect do
+            service.call
+            payment.invoice.reload
+          end.not_to change(payment.invoice.reload, :payment_dispute_lost_at).from(nil)
+        end
+
+        it 'does not deliver webhook' do
+          expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+        end
+      end
+
+      context 'when invoice is finalized' do
+        let(:status) { 'finalized' }
+
+        it 'does not updates invoice payment dispute lost' do
+          expect do
+            service.call
+            payment.invoice.reload
+          end.not_to change(payment.invoice.reload, :payment_dispute_lost_at).from(nil)
+        end
+
+        it 'does not deliver webhook' do
+          expect { service.call }.not_to have_enqueued_job(SendWebhookJob)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/dispute-notification

## Context

PSP integration should listen to disputes and chargebacks to update payment_dispute_lost_at after a dispute is lost.

## Description

This PR adds `PaymentProviders::Webhooks::Stripe::ChargeDisputeClosedService` and `PaymentProviders::Webhooks::Adyen::ChargebackService`