### PR TITLE
chore(env): define ActiveRecord encryption config

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -23,9 +23,6 @@ jobs:
       DATABASE_URL: "postgres://lago:lago@localhost:5432/lago"
       RAILS_MASTER_KEY: ${{ secrets.RAILS_TEST_KEY }}
       SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
-      ENCRYPTION_PRIMARY_KEY: 5I9mjfzry2P787x4S5ZuDdJwXNgYEwqo
-      ENCRYPTION_DETERMINISTIC_KEY: SGiZzmh18EjBF9gSW8LCNk7pelauWVr4
-      ENCRYPTION_KEY_DERIVATION_SALT: q3pkMw34ZkRPFSf2LmtWe705yw532Pf7
       LAGO_API_URL: https://api.lago.dev
       LAGO_PDF_URL: https://pdf.lago.dev
       SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,12 +19,17 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = false
   config.action_controller.allow_forgery_protection = false
   config.active_storage.service = :test
+
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :test
+
+  config.active_record.encryption.primary_key = 'test'
+  config.active_record.encryption.deterministic_key = 'test'
+  config.active_record.encryption.key_derivation_salt = 'test'
+
   config.active_support.deprecation = :stderr
   config.active_support.disallowed_deprecation = :raise
   config.active_support.disallowed_deprecation_warnings = []
-  config.action_mailer.delivery_method = :test
 
   Dotenv.load
 


### PR DESCRIPTION
## Description

Defining configuration here rather than in env vars makes it easier to run tests outside Docker.

When running tests, do we need actual encryption value? We could put the values from `.github/workflows/spec.yml` inside the config if they matter but I don't think they do.