### PR TITLE
fix(invoices): Fix boundaries when in advance anniversary

### DIFF
--- a/app/services/subscriptions/dates/monthly_service.rb
+++ b/app/services/subscriptions/dates/monthly_service.rb
@@ -104,9 +104,9 @@ module Subscriptions
         year = nil
         month = nil
 
-        # NOTE: in anniversary mode if both subscription date and current date are
-        #       the last day of month, anniversary day is on the current day
-        day = if subscription.anniversary? && last_day_of_month?(date) && last_day_of_month?(subscription_at)
+        # NOTE: if subscription anniversary day is higher than the current last day of the month,
+        #       anniversary day is on the current day
+        day = if subscription.anniversary? && last_day_of_month?(date) && (date.day < subscription_at.day)
           date.day
         else
           subscription_at.day

--- a/app/services/subscriptions/dates/quarterly_service.rb
+++ b/app/services/subscriptions/dates/quarterly_service.rb
@@ -105,9 +105,9 @@ module Subscriptions
         year = nil
         month = nil
 
-        # NOTE: in anniversary mode if both subscription date and current date are
-        #       the last day of month, anniversary day is on the current day
-        day = if subscription.anniversary? && last_day_of_month?(date) && last_day_of_month?(subscription_at)
+        # NOTE: if subscription anniversary day is higher than the current last day of the month,
+        #       anniversary day is on the current day
+        day = if subscription.anniversary? && last_day_of_month?(date) && (date.day < subscription_at.day)
           date.day
         else
           subscription_at.day

--- a/spec/scenarios/subscriptions/billing_boundaries_spec.rb
+++ b/spec/scenarios/subscriptions/billing_boundaries_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Billing Boundaries Scenario', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+
+  let(:timezone) { 'UTC' }
+  let(:customer) { create(:customer, organization:, timezone:) }
+
+  let(:plan_interval) { :monthly }
+  let(:plan_monthly_charges) { false }
+  let(:plan_in_advance) { false }
+
+  let(:billing_time) { 'anniversary' }
+
+  let(:plan) do
+    create(
+      :plan,
+      organization:,
+      interval: plan_interval,
+      pay_in_advance: plan_in_advance,
+      bill_charges_monthly: plan_monthly_charges,
+    )
+  end
+
+  it 'creates invoices' do
+    travel_to(Time.zone.parse('2024-01-31T01:00:00Z')) do
+      create_subscription(
+        external_customer_id: customer.external_id,
+        external_id: customer.external_id,
+        plan_code: plan.code,
+        billing_time:,
+      )
+    end
+
+    subscription = customer.subscriptions.first
+
+    # February billing
+    travel_to(Time.zone.parse('2024-02-29T02:00:00Z')) do
+      expect { perform_billing }.to change { subscription.reload.invoices.count }.by(1)
+    end
+
+    invoice = subscription.invoices.order(created_at: :desc).first
+    invoice_subscription = invoice.invoice_subscriptions.first
+
+    expect(invoice_subscription.from_datetime).to match_datetime('2024-01-31T00:00:00Z')
+    expect(invoice_subscription.to_datetime).to match_datetime('2024-02-28T23:59:59Z')
+    expect(invoice_subscription.charges_from_datetime).to match_datetime('2024-01-31T01:00:00Z')
+    expect(invoice_subscription.charges_to_datetime).to match_datetime('2024-02-28T23:59:59Z')
+
+    # March billing
+    travel_to(Time.zone.parse('2024-03-31T02:00:00Z')) do
+      expect { perform_billing }.to change { subscription.reload.invoices.count }.by(1)
+    end
+
+    invoice = subscription.invoices.order(created_at: :desc).first
+    invoice_subscription = invoice.invoice_subscriptions.first
+
+    expect(invoice_subscription.from_datetime).to match_datetime('2024-02-29T00:00:00Z')
+    expect(invoice_subscription.to_datetime).to match_datetime('2024-03-30T23:59:59Z')
+    expect(invoice_subscription.charges_from_datetime).to match_datetime('2024-02-29T00:00:00Z')
+    expect(invoice_subscription.charges_to_datetime).to match_datetime('2024-03-30T23:59:59Z')
+
+    # April billing
+    travel_to(Time.zone.parse('2024-04-30T02:00:00Z')) do
+      expect { perform_billing }.to change { subscription.reload.invoices.count }.by(1)
+    end
+
+    invoice = subscription.invoices.order(created_at: :desc).first
+    invoice_subscription = invoice.invoice_subscriptions.first
+
+    expect(invoice_subscription.from_datetime).to match_datetime('2024-03-31T00:00:00Z')
+    expect(invoice_subscription.to_datetime).to match_datetime('2024-04-29T23:59:59Z')
+    expect(invoice_subscription.charges_from_datetime).to match_datetime('2024-03-31T00:00:00Z')
+    expect(invoice_subscription.charges_to_datetime).to match_datetime('2024-04-29T23:59:59Z')
+  end
+
+  context 'with plans in advance' do
+    let(:plan_in_advance) { true }
+
+    it 'creates invoices' do
+      travel_to(Time.zone.parse('2024-01-30T00:00:00Z')) do
+        create_subscription(
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+          billing_time:,
+        )
+      end
+
+      subscription = customer.subscriptions.first
+      expect(subscription.invoices.count).to eq(1)
+
+      invoice = subscription.invoices.order(created_at: :desc).first
+      invoice_subscription = invoice.invoice_subscriptions.first
+
+      expect(invoice_subscription.from_datetime).to match_datetime('2024-01-30T00:00:00Z')
+      expect(invoice_subscription.to_datetime).to match_datetime('2024-02-28T23:59:59Z')
+
+      # February billing
+      travel_to(Time.zone.parse('2024-02-29T02:00:00Z')) do
+        expect { perform_billing }.to change { subscription.reload.invoices.count }.by(1)
+      end
+
+      invoice = subscription.invoices.order(created_at: :desc).first
+      invoice_subscription = invoice.invoice_subscriptions.first
+
+      expect(invoice_subscription.from_datetime).to match_datetime('2024-02-29T00:00:00Z')
+      expect(invoice_subscription.to_datetime).to match_datetime('2024-03-29T23:59:59Z')
+      expect(invoice_subscription.charges_from_datetime).to match_datetime('2024-01-30T00:00:00Z')
+      expect(invoice_subscription.charges_to_datetime).to match_datetime('2024-02-28T23:59:59Z')
+
+      # March billing
+      travel_to(Time.zone.parse('2024-03-30T02:00:00Z')) do
+        expect { perform_billing }.to change { subscription.reload.invoices.count }.by(1)
+      end
+
+      invoice = subscription.invoices.order(created_at: :desc).first
+      invoice_subscription = invoice.invoice_subscriptions.first
+
+      expect(invoice_subscription.from_datetime).to match_datetime('2024-03-30T00:00:00Z')
+      expect(invoice_subscription.to_datetime).to match_datetime('2024-04-29T23:59:59Z')
+      expect(invoice_subscription.charges_from_datetime).to match_datetime('2024-02-29T00:00:00Z')
+      expect(invoice_subscription.charges_to_datetime).to match_datetime('2024-03-29T23:59:59Z')
+
+      # April billing
+      travel_to(Time.zone.parse('2024-04-30T02:00:00Z')) do
+        expect { perform_billing }.to change { subscription.reload.invoices.count }.by(1)
+      end
+
+      invoice = subscription.invoices.order(created_at: :desc).first
+      invoice_subscription = invoice.invoice_subscriptions.first
+
+      expect(invoice_subscription.from_datetime).to match_datetime('2024-04-30T00:00:00Z')
+      expect(invoice_subscription.to_datetime).to match_datetime('2024-05-29T23:59:59Z')
+      expect(invoice_subscription.charges_from_datetime).to match_datetime('2024-03-30T00:00:00Z')
+      expect(invoice_subscription.charges_to_datetime).to match_datetime('2024-04-29T23:59:59Z')
+    end
+  end
+end

--- a/spec/support/matchers/datetime_matcher.rb
+++ b/spec/support/matchers/datetime_matcher.rb
@@ -2,8 +2,8 @@
 
 RSpec::Matchers.define :match_datetime do |expectation|
   match do |subject|
-    subject = subject.to_datetime.change(usec: 0) if subject.is_a?(String)
-    expectation = DateTime.parse(expectation) if expectation.is_a?(String)
+    subject = Time.zone.parse(subject).change(usec: 0) if subject.is_a?(String)
+    expectation = Time.zone.parse(expectation) if expectation.is_a?(String)
 
     subject.change(usec: 0) == expectation.change(usec: 0)
   end


### PR DESCRIPTION
## Context

An issue have been identified when a subscription is billed in advance on a monthly basis if the subscription starts on a 30 and the billing month is shorter than the subscription month

Subscription_at = 30th of January, billed on an anniversary basis
Plan: Monthly, billed in advance

On the billing day of February 29th, the following boundaries were returned: 
- From datetime: 2024-01-30 00:00:00.000000000
- To datetime: 2024-02-28T59:59.999999000 UTC +00:00

The expected boundaries are:
- From datetime: 2024-02-29 00:00:00.000000000
- To datetime: 2024-03-29T59:59.999999000 UTC +00:00

## Description

This PR ensure that the boundaries are correct
