### PR TITLE
fix(grace-period): Avoid multiple finalize call when grace period is the same

### DIFF
--- a/spec/services/customers/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/customers/update_invoice_grace_period_service_spec.rb
@@ -66,5 +66,27 @@ RSpec.describe Customers::UpdateInvoiceGracePeriodService, type: :service do
         end
       end
     end
+
+    context 'when grace period is the same' do
+      let(:grace_period) { customer.invoice_grace_period }
+
+      it 'does not finalize any draft invoices' do
+        current_date = DateTime.parse('22 Jun 2022')
+
+        travel_to(current_date) do
+          update_service.call
+
+          expect(Invoices::FinalizeService).not_to have_received(:call)
+        end
+      end
+
+      it 'does not update issuing_date on draft invoices' do
+        current_date = DateTime.parse('22 Jun 2022')
+
+        travel_to(current_date) do
+          expect { update_service.call }.not_to change { invoice_to_not_be_finalized.reload.issuing_date }
+        end
+      end
+    end
   end
 end

--- a/spec/services/organizations/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/organizations/update_invoice_grace_period_service_spec.rb
@@ -66,5 +66,27 @@ RSpec.describe Organizations::UpdateInvoiceGracePeriodService, type: :service do
         end
       end
     end
+
+    context 'when grace_period is the same as the current one' do
+      let(:grace_period) { organization.invoice_grace_period }
+
+      it 'does not finalize any draft invoices' do
+        current_date = DateTime.parse('22 Jun 2022')
+
+        travel_to(current_date) do
+          update_service.call
+
+          expect(Invoices::FinalizeService).not_to have_received(:call)
+        end
+      end
+
+      it 'does not update issuing_date on draft invoices' do
+        current_date = DateTime.parse('22 Jun 2022')
+
+        travel_to(current_date) do
+          expect { update_service.call }.not_to change { invoice_to_not_be_finalized.reload.issuing_date }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

- Some users update the grace period to 0 to finalize all draft invoices. Sometimes this call is done twice and it finalize each invoice twice. No major bug linked to this but we send the email twice to customers.

## Description

- Do not trigger invoice finalization if the grace period is the same, on both `organizations` and `customers`