### PR TITLE
feat(filter): Convert group input payload into filters

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -6,10 +6,10 @@ module Api
       def create
         service = ::BillableMetrics::CreateService.new
         result = service.create(
-          **input_params
-            .merge(organization_id: current_organization.id)
-            .to_h
-            .symbolize_keys,
+          BillableMetricInput.new(
+            current_organization,
+            input_params.merge(organization_id: current_organization.id).to_h.deep_symbolize_keys,
+          ).create_input,
         )
 
         if result.success?
@@ -30,7 +30,13 @@ module Api
           organization_id: current_organization.id,
         )
 
-        result = ::BillableMetrics::UpdateService.call(billable_metric:, params: input_params.to_h)
+        result = ::BillableMetrics::UpdateService.call(
+          billable_metric:,
+          params: BillableMetricInput.new(
+            current_organization,
+            input_params.to_h.deep_symbolize_keys,
+          ).update_input,
+        )
 
         if result.success?
           render(

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -6,10 +6,13 @@ module Api
       def create
         service = ::Plans::CreateService.new
         result = service.create(
-          **input_params
-            .merge(organization_id: current_organization.id)
-            .to_h
-            .deep_symbolize_keys,
+          PlanLegacyInput.new(
+            current_organization,
+            input_params
+              .merge(organization_id: current_organization.id)
+              .to_h
+              .deep_symbolize_keys,
+          ).create_input,
         )
 
         if result.success?
@@ -21,7 +24,13 @@ module Api
 
       def update
         plan = current_organization.plans.parents.find_by(code: params[:code])
-        result = ::Plans::UpdateService.call(plan:, params: input_params.to_h.deep_symbolize_keys)
+        result = ::Plans::UpdateService.call(
+          plan:,
+          params: PlanLegacyInput.new(
+            current_organization,
+            input_params.to_h.deep_symbolize_keys,
+          ).update_input,
+        )
 
         if result.success?
           render_plan(result.plan)

--- a/app/legacy_inputs/billable_metric_input.rb
+++ b/app/legacy_inputs/billable_metric_input.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class BillableMetricInput < BaseLegacyInput
+  def create_input
+    if args[:group].present? && args[:filters].blank?
+      return args unless group_args[:key].present? && group_args[:values].present?
+
+      if one_dimension?
+        args[:filters] = [
+          {
+            key: group_args[:key],
+            values: group_args[:values],
+          },
+        ]
+      else
+        args[:filters] = [
+          {
+            key: group_args[:key],
+            values: group_args[:values].map { |v| v[:name] },
+          },
+        ]
+
+        group_args[:values].each do |group|
+          existing_result = args[:filters].find { |r| r[:key] == group[:key] }
+
+          if existing_result
+            existing_result[:values] = (existing_result[:values] + group[:values]).uniq
+          else
+            args[:filters] << {
+              key: group[:key],
+              values: group[:values],
+            }
+          end
+        end
+      end
+    elsif args[:filters].present?
+      args[:group] = {}
+    end
+
+    args
+  end
+
+  alias update_input create_input
+
+  private
+
+  def group_args
+    @group_args ||= args[:group]
+  end
+
+  def one_dimension?
+    # ie: { key: "region", values: ["USA", "EUROPE"] }
+    group_args[:key].is_a?(String) && group_args[:values]&.all?(String)
+  end
+end

--- a/app/legacy_inputs/plan_legacy_input.rb
+++ b/app/legacy_inputs/plan_legacy_input.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class PlanLegacyInput < BaseLegacyInput
+  def create_input
+    return args unless args[:charges].is_a?(Array)
+    return args unless args[:charges].any? { |c| c[:group_properties].present? }
+
+    args[:charges].each do |charge|
+      next if charge[:group_properties].blank?
+      next charge[:group] = [] if charge[:filters].present?
+
+      billable_metric = organization.billable_metrics.find_by(id: charge[:billable_metric_id])
+      next unless billable_metric
+
+      charge[:filters] = charge[:group_properties].map do |properties|
+        group = billable_metric.groups.find_by(id: properties[:group_id])
+        next unless group
+
+        values = { group.key => [group.value] }
+        values[group.parent.key] = [group.parent.value] if group.parent
+
+        {
+          invoice_display_name: properties[:invoice_display_name],
+          properties: properties[:values],
+          values:,
+        }
+      end
+
+      # NOTE: create default filter to keep compatibility with old charges
+      group_ids = charge[:group_properties].map { |p| p[:group_id] }
+
+      billable_metric.groups.where.not(id: group_ids).includes(:children).find_each do |group|
+        next if group.children.any?
+
+        values = { group.key => [group.value] }
+        values[group.parent.key] = [group.parent.value] if group.parent
+
+        charge[:filters] << {
+          invoice_display_name: charge[:invoice_display_name],
+          properties: charge[:properties],
+          values:,
+        }
+      end
+    end
+
+    args
+  end
+
+  alias update_input create_input
+end

--- a/app/legacy_inputs/subscription_legacy_input.rb
+++ b/app/legacy_inputs/subscription_legacy_input.rb
@@ -6,6 +6,9 @@ class SubscriptionLegacyInput < BaseLegacyInput
       args[:subscription_at] ||= date_in_organization_timezone(args[:subscription_date], end_of_day: false)
     end
 
+    return args if args[:plan_overrides].blank?
+
+    args[:plan_overrides] = PlanLegacyInput.new(organization, args[:plan_overrides]).create_input
     args
   end
   alias update_input create_input

--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -2,9 +2,10 @@
 
 module BillableMetricFilters
   class CreateOrUpdateBatchService < BaseService
-    def initialize(billable_metric:, filters_params:)
+    def initialize(billable_metric:, filters_params:, legacy_group_params: nil)
       @billable_metric = billable_metric
       @filters_params = filters_params
+      @legacy_group_params = legacy_group_params
 
       super
     end
@@ -42,14 +43,19 @@ module BillableMetricFilters
         billable_metric.filters.where.not(id: result.filters.map(&:id)).find_each do
           discard_filter(_1)
         end
+
+        # NOTE: keep compatibility with old group structure by creating the default group properties (as filters)
+        handle_charge_group_properties if legacy_group_params.present?
       end
+
+      refresh_draft_invoices
 
       result
     end
 
     private
 
-    attr_reader :billable_metric, :filters_params
+    attr_reader :billable_metric, :filters_params, :legacy_group_params
 
     def discard_all
       ActiveRecord::Base.transaction do
@@ -67,6 +73,60 @@ module BillableMetricFilters
       return if filter_value.charge_filter.values.where.not(id: filter_value.id).exists?
 
       filter_value.charge_filter.discard!
+    end
+
+    def refresh_draft_invoices
+      draft_invoices = Invoice.draft.joins(plans: [:billable_metrics])
+        .where(billable_metrics: { id: billable_metric.id })
+        .distinct
+
+      draft_invoices.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    def handle_charge_group_properties
+      billable_metric.groups.find_each do |group|
+        next if group.children.any?
+
+        group_values = group_values(group)
+
+        charges_missing_group(group_values).each do |charge|
+          filter = charge.filters.create!(
+            invoice_display_name: nil,
+            properties: charge[:properties],
+          )
+
+          group_values.each do |key, filter_values|
+            billable_metric_filter = billable_metric.filters.find_by(key:)
+
+            filter.values.create!(
+              billable_metric_filter_id: billable_metric_filter&.id,
+              values: filter_values,
+            )
+          end
+        end
+      end
+    end
+
+    def group_values(group)
+      values = { group.key => [group.value] }
+      values[group.parent.key] = [group.parent.value] if group.parent
+      values
+    end
+
+    def charges_missing_group(group_values)
+      billable_metric.charges.all.select do |charge|
+        filters = charge.filters.includes(values: :billable_metric_filter)
+
+        filter = filters.find do |f|
+          next unless f.to_h.sort == group_values.sort
+
+          f.values.all? do |value|
+            group_values[value.key].sort == value.values.sort
+          end
+        end
+
+        filter.nil?
+      end
     end
   end
 end

--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -2,7 +2,7 @@
 
 module BillableMetrics
   class CreateService < BaseService
-    def create(**args)
+    def create(args)
       ActiveRecord::Base.transaction do
         metric = BillableMetric.create!(
           organization_id: args[:organization_id],

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -25,6 +25,7 @@ module BillableMetrics
           BillableMetricFilters::CreateOrUpdateBatchService.call(
             billable_metric:,
             filters_params: params[:filters].map { |f| f.to_h.with_indifferent_access },
+            legacy_group_params: params[:group],
           ).raise_if_error!
         end
       end

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -55,7 +55,7 @@ module Fees
     def init_fees
       result.fees = []
 
-      if billable_metric.selectable_groups.any?
+      if billable_metric.selectable_groups.any? && charge.filters.none? # NOTE: ignore migrated groups
         # NOTE: Create a fee for each groups defined on the charge.
         charge.group_properties.each do |group_properties|
           group = billable_metric.selectable_groups.find_by(id: group_properties.group_id)
@@ -63,7 +63,7 @@ module Fees
         end
 
         # NOTE: Create a fee for groups not defined (with default properties).
-        billable_metric.selectable_groups.where.not(id: charge.group_properties.pluck(:group_id)).each do |group|
+        billable_metric.selectable_groups.where.not(id: charge.group_properties.pluck(:group_id)).find_each do |group|
           init_charge_fees(properties: charge.properties, group:)
         end
       else

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -14,10 +14,10 @@ module Fees
       fees = []
 
       ActiveRecord::Base.transaction do
-        if charge.billable_metric.selectable_groups.any?
-          fees += create_group_properties_fees
-        elsif charge.filters.any?
+        if charge.filters.any?
           fees << create_charge_filter_fee
+        elsif charge.billable_metric.selectable_groups.any?
+          fees += create_group_properties_fees
         else
           fees << create_fee(properties: charge.properties)
         end
@@ -93,7 +93,7 @@ module Fees
         end
 
         # NOTE: Create a fee for groups not defined (with default properties).
-        billable_metric.selectable_groups.where.not(id: charge.group_properties.pluck(:group_id)).each do |group|
+        billable_metric.selectable_groups.where.not(id: charge.group_properties.pluck(:group_id)).find_each do |group|
           next unless event_linked_to?(group:)
 
           group_fees << create_fee(properties: charge.properties, group:)

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -2,7 +2,7 @@
 
 module Plans
   class CreateService < BaseService
-    def create(**args)
+    def create(args)
       plan = Plan.new(
         organization_id: args[:organization_id],
         name: args[:name],

--- a/spec/requests/api/v1/billable_metrics_controller_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_controller_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
         )
 
         expect(json[:billable_metric][:group]).to eq(group)
+        expect(json[:billable_metric][:filters].count).to eq(2)
       end
     end
 
@@ -132,6 +133,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
         )
 
         expect(json[:billable_metric][:group]).to eq(group)
+        expect(json[:billable_metric][:filters].count).to eq(2)
       end
     end
 

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -124,6 +124,9 @@ RSpec.describe Api::V1::PlansController, type: :request do
 
     context 'with group properties on charges' do
       let(:group) { create(:group, billable_metric:) }
+      let(:billable_metric_filter) do
+        create(:billable_metric_filter, billable_metric:, key: group.key, values: [group.value])
+      end
       let(:create_params) do
         {
           name: 'P1',
@@ -150,6 +153,8 @@ RSpec.describe Api::V1::PlansController, type: :request do
         }
       end
 
+      before { billable_metric_filter }
+
       it 'creates a plan' do
         post_with_token(organization, '/api/v1/plans', { plan: create_params })
 
@@ -163,6 +168,16 @@ RSpec.describe Api::V1::PlansController, type: :request do
               group_id: group.id,
               invoice_display_name: 'Europe',
               values: { amount: '0.22' },
+            },
+          ],
+        )
+
+        expect(json[:plan][:charges].first[:filters]).to eq(
+          [
+            {
+              invoice_display_name: 'Europe',
+              properties: { amount: '0.22' },
+              values: { group.key.to_sym => [group.value] },
             },
           ],
         )
@@ -414,6 +429,9 @@ RSpec.describe Api::V1::PlansController, type: :request do
 
     context 'with group properties on charges' do
       let(:group) { create(:group, billable_metric:) }
+      let(:billable_metric_filter) do
+        create(:billable_metric_filter, billable_metric:, key: group.key, values: [group.value])
+      end
       let(:update_params) do
         {
           name: 'P1',
@@ -440,6 +458,8 @@ RSpec.describe Api::V1::PlansController, type: :request do
         }
       end
 
+      before { billable_metric_filter }
+
       it 'creates a plan' do
         put_with_token(organization, "/api/v1/plans/#{plan.code}", { plan: update_params })
 
@@ -453,6 +473,16 @@ RSpec.describe Api::V1::PlansController, type: :request do
               group_id: group.id,
               invoice_display_name: 'Europe',
               values: { amount: '0.22' },
+            },
+          ],
+        )
+
+        expect(json[:plan][:charges].first[:filters]).to eq(
+          [
+            {
+              invoice_display_name: 'Europe',
+              properties: { amount: '0.22' },
+              values: { group.key.to_sym => [group.value] },
             },
           ],
         )

--- a/spec/scenarios/update_groups_spec.rb
+++ b/spec/scenarios/update_groups_spec.rb
@@ -208,17 +208,18 @@ describe 'Update Groups Scenarios', :scenarios, type: :request do
           group: {
             key: 'cloud',
             values: [
-              { name: 'aws', key: 'country', values: %w[usa france] },
+              { name: 'azure', key: 'country', values: %w[usa france] },
               { name: 'google', key: 'country', values: ['usa'] },
             ],
           },
         )
         perform_invoices_refresh
 
-        expect(cards.groups.parents.pluck(:value)).to contain_exactly('aws', 'google')
+        expect(cards.groups.parents.pluck(:value)).to contain_exactly('azure', 'google')
         expect(cards.groups.children.pluck(:value)).to contain_exactly('usa', 'france', 'usa')
         expect(cards.charges.first.group_properties.count).to eq(0)
-        expect(invoice.reload.total_amount_cents).to eq(13_000)
+        expect(cards.charges.first.filters.count).to eq(5)
+        expect(invoice.reload.total_amount_cents).to eq(19_000)
       end
     end
   end


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR ensure that the creation of billable metrics and plans keeps accepting group as legacy input, by converting them into filters