### PR TITLE
feat(filter): last mergeable changes before release

### DIFF
--- a/app/graphql/types/customers/usage/charge_filter.rb
+++ b/app/graphql/types/customers/usage/charge_filter.rb
@@ -17,6 +17,10 @@ module Types
         def values
           object.charge_filter&.to_h || {} # rubocop:disable Lint/RedundantSafeNavigation
         end
+
+        def invoice_display_name
+          object.charge_filter&.invoice_display_name
+        end
       end
     end
   end

--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -15,8 +15,12 @@ class ChargeFilter < ApplicationRecord
 
   default_scope -> { kept }
 
-  def display_name
-    invoice_display_name.presence || values.map(&:values).flatten.join(', ')
+  def display_name(separator: ', ')
+    invoice_display_name.presence || (values.order(updated_at: :asc).map do |value|
+      next value.billable_metric_filter.key if value.values == [ChargeFilterValue::ALL_FILTER_VALUES]
+
+      value.values
+    end).flatten.join(separator)
   end
 
   def to_h

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -103,8 +103,8 @@ class Fee < ApplicationRecord
     charge&.group_properties&.find_by(group:)&.invoice_display_name || group&.name
   end
 
-  def filter_display_name
-    charge_filter&.display_name
+  def filter_display_name(separator: ', ')
+    charge_filter&.display_name(separator:)
   end
 
   def invoice_sorting_clause

--- a/app/services/charge_filters/matching_and_ignored_service.rb
+++ b/app/services/charge_filters/matching_and_ignored_service.rb
@@ -42,12 +42,14 @@ module ChargeFilters
         if res.keys == result.matching_filters.keys
           # NOTE: when child and filter have the same keys, we need to remove the filter value from the child
           res.each do |key, values|
+            next if filter.to_h[key] == [ChargeFilterValue::ALL_FILTER_VALUES]
+
             res[key] = values - result.matching_filters[key]
           end
         end
 
         res
-      end
+      end.compact
 
       result
     end

--- a/app/services/fees/init_from_adjusted_charge_fee_service.rb
+++ b/app/services/fees/init_from_adjusted_charge_fee_service.rb
@@ -22,7 +22,7 @@ module Fees
 
     attr_reader :adjusted_fee, :boundaries, :properties
 
-    delegate :group, :charge, :invoice, :subscription, to: :adjusted_fee
+    delegate :group, :charge, :charge_filter, :invoice, :subscription, to: :adjusted_fee
 
     def compute_amount
       adjusted_fee_result = BaseService::Result.new
@@ -78,6 +78,7 @@ module Fees
         amount_details:,
         invoice_display_name: adjusted_fee.invoice_display_name,
         grouped_by: adjusted_fee.grouped_by,
+        charge_filter_id: charge_filter&.id,
       )
     end
   end

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -322,15 +322,21 @@ RSpec.describe ChargeFilter, type: :model do
   end
 
   describe '#display_name' do
-    subject(:charge_filter) { build(:charge_filter, invoice_display_name:, values:) }
+    subject(:charge_filter) { create(:charge_filter, charge:, invoice_display_name:) }
+
+    let(:charge) { create(:standard_charge) }
+    let(:method_filter) { create(:billable_metric_filter, key: 'card', values: %w[card apple_pay]) }
+    let(:scheme_filter) { create(:billable_metric_filter, key: 'card', values: %w[visa mastercard]) }
 
     let(:invoice_display_name) { Faker::Fantasy::Tolkien.character }
     let(:values) do
       [
-        build(:charge_filter_value, values: ['card']),
-        build(:charge_filter_value, values: ['visa']),
+        create(:charge_filter_value, values: ['card'], charge_filter:, billable_metric_filter: method_filter),
+        create(:charge_filter_value, values: ['visa'], charge_filter:, billable_metric_filter: scheme_filter),
       ]
     end
+
+    before { values }
 
     it 'returns the invoice display name' do
       expect(charge_filter.display_name).to eq(invoice_display_name)


### PR DESCRIPTION
## Context

Lago is not currently supporting more than 2 levels of event grouping (parent → children)

The goal of this feature is to allow more flexibility of event grouping by allowing an unlimited level of grouping and making it easier to define default charge properties for events based on their properties.

## Description

This PR adds all remaining parts than can be merged without impacting the production.