### PR TITLE
feat(accounting-integrations): add support for integrations graphql queries

### DIFF
--- a/app/graphql/resolvers/integration_resolver.rb
+++ b/app/graphql/resolvers/integration_resolver.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class IntegrationResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description 'Query a single integration'
+
+    argument :id, ID, required: false, description: 'Uniq ID of the integration'
+
+    type Types::Integrations::Object, null: true
+
+    def resolve(id: nil)
+      validate_organization!
+
+      current_organization.integrations.find(id)
+    rescue ActiveRecord::RecordNotFound
+      not_found_error(resource: 'integration')
+    end
+  end
+end

--- a/app/graphql/resolvers/integrations_resolver.rb
+++ b/app/graphql/resolvers/integrations_resolver.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class IntegrationsResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description "Query organization's integrations"
+
+    argument :limit, Integer, required: false
+    argument :page, Integer, required: false
+    argument :type, Types::Integrations::IntegrationTypeEnum, required: false
+
+    type Types::Integrations::Object.collection_type, null: true
+
+    def resolve(type: nil, page: nil, limit: nil)
+      validate_organization!
+
+      scope = current_organization.integrations.page(page).per(limit)
+      scope = scope.where(type: integration_type(type)) if type.present?
+      scope
+    end
+
+    private
+
+    def integration_type(type)
+      case type
+      when 'netsuite'
+        'Integrations::NetsuiteIntegration'
+      else
+        raise(NotImplementedError)
+      end
+    end
+  end
+end

--- a/app/graphql/types/integrations/integration_type_enum.rb
+++ b/app/graphql/types/integrations/integration_type_enum.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module Integrations
+    class IntegrationTypeEnum < Types::BaseEnum
+      Organization::INTEGRATIONS.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/integrations/netsuite.rb
+++ b/app/graphql/types/integrations/netsuite.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Types
+  module Integrations
+    class Netsuite < Types::BaseObject
+      graphql_name 'NetsuiteIntegration'
+
+      field :code, String, null: false
+      field :id, ID, null: false
+      field :name, String, null: false
+      field :account_id, String, null: true
+      field :client_id, String, null: true
+      field :client_secret, String, null: true
+
+      # NOTE: Client secret is a sensitive information. It should not be sent back to the
+      #       front end application. Instead we send an obfuscated value
+      def client_secret
+        "#{'•' * 8}…#{object.secret_key[-3..]}"
+      end
+    end
+  end
+end

--- a/app/graphql/types/integrations/netsuite.rb
+++ b/app/graphql/types/integrations/netsuite.rb
@@ -5,12 +5,12 @@ module Types
     class Netsuite < Types::BaseObject
       graphql_name 'NetsuiteIntegration'
 
-      field :code, String, null: false
-      field :id, ID, null: false
-      field :name, String, null: false
       field :account_id, String, null: true
       field :client_id, String, null: true
       field :client_secret, String, null: true
+      field :code, String, null: false
+      field :id, ID, null: false
+      field :name, String, null: false
 
       # NOTE: Client secret is a sensitive information. It should not be sent back to the
       #       front end application. Instead we send an obfuscated value

--- a/app/graphql/types/integrations/object.rb
+++ b/app/graphql/types/integrations/object.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Types
+  module Integrations
+    class Object < Types::BaseUnion
+      graphql_name 'Integration'
+
+      possible_types Types::Integrations::Netsuite
+
+      def self.resolve_type(object, _context)
+        case object.class.to_s
+        when 'Integrations::NetsuiteIntegration'
+          Types::Integrations::Netsuite
+        else
+          raise "Unexpected integration type: #{object.inspect}"
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -32,6 +32,8 @@ module Types
 
     field :eu_tax_management, Boolean, null: false
 
+    # TODO: Also check if Nango ENV var is set in order to lock/unlock this feature
+    #       This would enable us to use premium add_on logic on OSS version
     field :premium_integrations, [Types::Integrations::IntegrationTypeEnum], null: false
 
     field :billing_configuration, Types::Organizations::BillingConfiguration, null: true
@@ -55,13 +57,6 @@ module Types
 
     def webhook_url
       object.webhook_endpoints.map(&:webhook_url).first
-    end
-
-    def premium_integrations
-      # TODO: Also check if Nango ENV var is set in order to lock/unlock this feature
-      #       This would enable us to use premium add_on logic on OSS version
-
-      object.premium_integrations
     end
   end
 end

--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -32,6 +32,8 @@ module Types
 
     field :eu_tax_management, Boolean, null: false
 
+    field :premium_integrations, [Types::Integrations::IntegrationTypeEnum], null: false
+
     field :billing_configuration, Types::Organizations::BillingConfiguration, null: true
     field :email_settings, [Types::Organizations::EmailSettingsEnum], null: true
     field :taxes, [Types::Taxes::Object], null: true, resolver: Resolvers::TaxesResolver
@@ -53,6 +55,13 @@ module Types
 
     def webhook_url
       object.webhook_endpoints.map(&:webhook_url).first
+    end
+
+    def premium_integrations
+      # TODO: Also check if Nango ENV var is set in order to lock/unlock this feature
+      #       This would enable us to use premium add_on logic on OSS version
+
+      object.premium_integrations
     end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -29,6 +29,8 @@ module Types
     field :events, resolver: Resolvers::EventsResolver
     field :google_auth_url, resolver: Resolvers::Auth::Google::AuthUrlResolver
     field :gross_revenues, resolver: Resolvers::Analytics::GrossRevenuesResolver
+    field :integration, resolver: Resolvers::IntegrationResolver
+    field :integrations, resolver: Resolvers::IntegrationsResolver
     field :invite, resolver: Resolvers::InviteResolver
     field :invites, resolver: Resolvers::InvitesResolver
     field :invoice, resolver: Resolvers::InvoiceResolver

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -46,6 +46,8 @@ class Organization < ApplicationRecord
     :per_organization,
   ].freeze
 
+  INTEGRATIONS = %w[netsuite].freeze
+
   enum document_numbering: DOCUMENT_NUMBERINGS
 
   before_create :generate_api_key

--- a/schema.graphql
+++ b/schema.graphql
@@ -3410,6 +3410,17 @@ An ISO 8601-encoded datetime
 """
 scalar ISO8601DateTime
 
+union Integration = NetsuiteIntegration
+
+type IntegrationCollection {
+  collection: [Integration!]!
+  metadata: CollectionMetadata!
+}
+
+enum IntegrationTypeEnum {
+  netsuite
+}
+
 type Invite {
   acceptedAt: ISO8601DateTime!
   email: String!
@@ -4334,6 +4345,15 @@ type Mutation {
   ): Invoice
 }
 
+type NetsuiteIntegration {
+  accountId: String
+  clientId: String
+  clientSecret: String
+  code: String!
+  id: ID!
+  name: String!
+}
+
 """
 Organization Type
 """
@@ -4359,6 +4379,7 @@ type Organization {
   logoUrl: String
   name: String!
   netPaymentTerm: Int!
+  premiumIntegrations: [IntegrationTypeEnum!]!
   state: String
   stripePaymentProviders: [StripeProvider!]
   taxIdentificationNumber: String
@@ -4701,6 +4722,21 @@ type Query {
   Query gross revenue of an organization
   """
   grossRevenues(currency: CurrencyEnum, externalCustomerId: String): GrossRevenueCollection!
+
+  """
+  Query a single integration
+  """
+  integration(
+    """
+    Uniq ID of the integration
+    """
+    id: ID
+  ): Integration
+
+  """
+  Query organization's integrations
+  """
+  integrations(limit: Int, page: Int, type: IntegrationTypeEnum): IntegrationCollection
 
   """
   Query a single Invite

--- a/schema.json
+++ b/schema.json
@@ -14907,6 +14907,96 @@
           "enumValues": null
         },
         {
+          "kind": "UNION",
+          "name": "Integration",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "NetsuiteIntegration",
+              "ofType": null
+            }
+          ],
+          "fields": null,
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "IntegrationCollection",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "UNION",
+                      "name": "Integration",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "IntegrationTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "netsuite",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
           "kind": "OBJECT",
           "name": "Invite",
           "description": null,
@@ -19398,6 +19488,115 @@
         },
         {
           "kind": "OBJECT",
+          "name": "NetsuiteIntegration",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "accountId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "clientId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "clientSecret",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Organization",
           "description": "Organization Type",
           "interfaces": [
@@ -19751,6 +19950,32 @@
                   "kind": "SCALAR",
                   "name": "Int",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "premiumIntegrations",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "IntegrationTypeEnum",
+                      "ofType": null
+                    }
+                  }
                 }
               },
               "isDeprecated": false,
@@ -22462,6 +22687,80 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "integration",
+              "description": "Query a single integration",
+              "type": {
+                "kind": "UNION",
+                "name": "Integration",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Uniq ID of the integration",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "integrations",
+              "description": "Query organization's integrations",
+              "type": {
+                "kind": "OBJECT",
+                "name": "IntegrationCollection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "type",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "IntegrationTypeEnum",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/spec/graphql/resolvers/integration_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_resolver_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::IntegrationResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($integrationId: ID!) {
+        integration(id: $integrationId) {
+          ... on NetsuiteIntegration {
+            id
+            code
+            name
+            __typename
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:netsuite_integration) { create(:netsuite_integration, organization:) }
+
+  before do
+    customer
+    netsuite_integration
+  end
+
+  it 'returns a single integration' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+      variables: { integrationId: netsuite_integration.id },
+    )
+
+    integration_response = result['data']['integration']
+
+    aggregate_failures do
+      expect(integration_response['id']).to eq(netsuite_integration.id)
+      expect(integration_response['code']).to eq(netsuite_integration.code)
+      expect(integration_response['name']).to eq(netsuite_integration.name)
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query:,
+        variables: { integrationId: netsuite_integration.id },
+      )
+
+      expect_graphql_error(
+        result:,
+        message: 'Missing organization id',
+      )
+    end
+  end
+
+  context 'when integration is not found' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: { integrationId: 'foo' },
+      )
+
+      expect_graphql_error(
+        result:,
+        message: 'Resource not found',
+      )
+    end
+  end
+end

--- a/spec/graphql/resolvers/integrations_resolver_spec.rb
+++ b/spec/graphql/resolvers/integrations_resolver_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::IntegrationsResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query {
+        integrations(limit: 5) {
+          collection {
+            ... on NetsuiteIntegration {
+              id
+              code
+              __typename
+            }
+          }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:netsuite_integration) { create(:netsuite_integration, organization:) }
+
+  before { netsuite_integration }
+
+  context 'when type is present' do
+    let(:query) do
+      <<~GQL
+        query {
+          integrations(limit: 5, type: netsuite) {
+            collection {
+              ... on NetsuiteIntegration {
+                id
+                code
+                __typename
+              }
+            }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    it 'returns a list of integrations' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+      )
+
+      integrations_response = result['data']['integrations']
+
+      aggregate_failures do
+        expect(integrations_response['collection'].count).to eq(1)
+        expect(integrations_response['collection'].first['id']).to eq(netsuite_integration.id)
+
+        expect(integrations_response['metadata']['currentPage']).to eq(1)
+        expect(integrations_response['metadata']['totalCount']).to eq(1)
+      end
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(current_user: membership.user, query:)
+
+      expect_graphql_error(result:, message: 'Missing organization id')
+    end
+  end
+
+  context 'when not member of the organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: create(:organization),
+        query:,
+      )
+
+      expect_graphql_error(result:, message: 'Not in organization')
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR adds support for graphql queries related to integrations models
