### PR TITLE
refactor: check validate_organization! on graphql resolve when RequiredOrganization included

### DIFF
--- a/app/graphql/concerns/required_organization.rb
+++ b/app/graphql/concerns/required_organization.rb
@@ -3,6 +3,19 @@
 module RequiredOrganization
   extend ActiveSupport::Concern
 
+  def self.included(base)
+    base.prepend(Module.new do
+      if base.method_defined?(:resolve)
+        define_method :resolve do |*args, **kwargs, &block|
+          validate_organization!
+          super(*args, **kwargs, &block)
+        end
+      end
+    end)
+  end
+    
+  private
+
   def current_organization
     context[:current_organization]
   end

--- a/app/graphql/mutations/add_ons/create.rb
+++ b/app/graphql/mutations/add_ons/create.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::AddOns::Object
 
       def resolve(**args)
-        validate_organization!
-
         result = ::AddOns::CreateService
           .new(context[:current_user])
           .create(**args.merge(organization_id: current_organization.id))

--- a/app/graphql/mutations/adjusted_fees/create.rb
+++ b/app/graphql/mutations/adjusted_fees/create.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::Fees::Object
 
       def resolve(**args)
-        validate_organization!
-
         fee = Fee.find_by(id: args[:fee_id])
 
         result = ::AdjustedFees::CreateService.call(

--- a/app/graphql/mutations/adjusted_fees/destroy.rb
+++ b/app/graphql/mutations/adjusted_fees/destroy.rb
@@ -14,8 +14,6 @@ module Mutations
       field :id, ID, null: true
 
       def resolve(id:)
-        validate_organization!
-
         organization_draft_invoices = current_organization.invoices.draft.pluck(:id)
         fee = Fee.where(invoice_id: organization_draft_invoices).find_by(id:)
 

--- a/app/graphql/mutations/applied_coupons/create.rb
+++ b/app/graphql/mutations/applied_coupons/create.rb
@@ -21,8 +21,6 @@ module Mutations
       type Types::AppliedCoupons::Object
 
       def resolve(**args)
-        validate_organization!
-
         customer = Customer.find_by(
           id: args[:customer_id],
           organization_id: current_organization.id,

--- a/app/graphql/mutations/billable_metrics/create.rb
+++ b/app/graphql/mutations/billable_metrics/create.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::BillableMetrics::Object
 
       def resolve(**args)
-        validate_organization!
-
         result = ::BillableMetrics::CreateService
           .new(context[:current_user])
           .create(**args.merge(organization_id: current_organization.id))

--- a/app/graphql/mutations/coupons/create.rb
+++ b/app/graphql/mutations/coupons/create.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::Coupons::Object
 
       def resolve(**args)
-        validate_organization!
-
         result = ::Coupons::CreateService
           .new(context[:current_user])
           .create(args.merge(organization_id: current_organization.id))

--- a/app/graphql/mutations/credit_notes/create.rb
+++ b/app/graphql/mutations/credit_notes/create.rb
@@ -21,7 +21,6 @@ module Mutations
       type Types::CreditNotes::Object
 
       def resolve(**args)
-        validate_organization!
         args[:items].map!(&:to_h)
 
         result = ::CreditNotes::CreateService

--- a/app/graphql/mutations/credit_notes/download.rb
+++ b/app/graphql/mutations/credit_notes/download.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::CreditNotes::Object
 
       def resolve(**args)
-        validate_organization!
-
         result = ::CreditNotes::GenerateService.new(
           credit_note: context[:current_user].credit_notes.find_by(id: args[:id]),
         ).call

--- a/app/graphql/mutations/customer_portal/generate_url.rb
+++ b/app/graphql/mutations/customer_portal/generate_url.rb
@@ -14,8 +14,6 @@ module Mutations
       field :url, String, null: false
 
       def resolve(id:)
-        validate_organization!
-
         customer = current_organization.customers.find_by(id:)
         result = ::CustomerPortal::GenerateUrlService.call(customer:)
 

--- a/app/graphql/mutations/customers/create.rb
+++ b/app/graphql/mutations/customers/create.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::Customers::Object
 
       def resolve(**args)
-        validate_organization!
-
         result = ::Customers::CreateService
           .new(context[:current_user])
           .create(**args.merge(organization_id: current_organization.id))

--- a/app/graphql/mutations/invites/create.rb
+++ b/app/graphql/mutations/invites/create.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::Invites::Object
 
       def resolve(**args)
-        validate_organization!
-
         result = ::Invites::CreateService
           .new(context[:current_user])
           .call(**args.merge(current_organization:))

--- a/app/graphql/mutations/invoices/create.rb
+++ b/app/graphql/mutations/invoices/create.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(**args)
-        validate_organization!
-
         customer = Customer.find_by(
           id: args[:customer_id],
           organization_id: current_organization.id,

--- a/app/graphql/mutations/invoices/download.rb
+++ b/app/graphql/mutations/invoices/download.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(id:)
-        validate_organization!
-
         invoice = Invoice.not_generating.find_by(id:, organization_id: current_organization.id)
         result = ::Invoices::GeneratePdfService.call(invoice:)
         result.success? ? result.invoice : result_error(result)

--- a/app/graphql/mutations/invoices/finalize.rb
+++ b/app/graphql/mutations/invoices/finalize.rb
@@ -14,7 +14,6 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(**args)
-        validate_organization!
         result = ::Invoices::FinalizeService.call(
           invoice: current_organization.invoices.draft.find_by(id: args[:id]),
         )

--- a/app/graphql/mutations/invoices/lose_dispute.rb
+++ b/app/graphql/mutations/invoices/lose_dispute.rb
@@ -14,7 +14,6 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(**args)
-        validate_organization!
         result = ::Invoices::LoseDisputeService.call(
           invoice: current_organization.invoices.not_generating.find_by(id: args[:id]),
         )

--- a/app/graphql/mutations/invoices/refresh.rb
+++ b/app/graphql/mutations/invoices/refresh.rb
@@ -14,7 +14,6 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(**args)
-        validate_organization!
         result = ::Invoices::RefreshDraftService.call(
           invoice: current_organization.invoices.not_generating.find_by(id: args[:id]),
         )

--- a/app/graphql/mutations/invoices/retry_all_payments.rb
+++ b/app/graphql/mutations/invoices/retry_all_payments.rb
@@ -12,8 +12,6 @@ module Mutations
       type Types::Invoices::Object.collection_type
 
       def resolve
-        validate_organization!
-
         result = ::Invoices::Payments::RetryBatchService.new(organization_id: current_organization.id).call_later
 
         result.success? ? result.invoices : result_error(result)

--- a/app/graphql/mutations/invoices/retry_payment.rb
+++ b/app/graphql/mutations/invoices/retry_payment.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(**args)
-        validate_organization!
-
         invoice = current_organization.invoices.not_generating.find_by(id: args[:id])
         result = ::Invoices::Payments::RetryService.new(invoice:).call
 

--- a/app/graphql/mutations/invoices/void.rb
+++ b/app/graphql/mutations/invoices/void.rb
@@ -14,7 +14,6 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(**args)
-        validate_organization!
         result = ::Invoices::VoidService.call(
           invoice: current_organization.invoices.not_generating.find_by(id: args[:id]),
         )

--- a/app/graphql/mutations/organizations/update.rb
+++ b/app/graphql/mutations/organizations/update.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::OrganizationType
 
       def resolve(**args)
-        validate_organization!
-
         result = ::Organizations::UpdateService.call(organization: current_organization, params: args)
         result.success? ? result.organization : result_error(result)
       end

--- a/app/graphql/mutations/payment_providers/adyen/base.rb
+++ b/app/graphql/mutations/payment_providers/adyen/base.rb
@@ -8,8 +8,6 @@ module Mutations
         include RequiredOrganization
 
         def resolve(**args)
-          validate_organization!
-
           result = ::PaymentProviders::AdyenService
             .new(context[:current_user])
             .create_or_update(**args.merge(organization: current_organization))

--- a/app/graphql/mutations/payment_providers/gocardless/base.rb
+++ b/app/graphql/mutations/payment_providers/gocardless/base.rb
@@ -8,8 +8,6 @@ module Mutations
         include RequiredOrganization
 
         def resolve(**args)
-          validate_organization!
-
           result = ::PaymentProviders::GocardlessService
             .new(context[:current_user])
             .create_or_update(**args.merge(organization: current_organization))

--- a/app/graphql/mutations/payment_providers/stripe/base.rb
+++ b/app/graphql/mutations/payment_providers/stripe/base.rb
@@ -8,8 +8,6 @@ module Mutations
         include RequiredOrganization
 
         def resolve(**args)
-          validate_organization!
-
           result = ::PaymentProviders::StripeService
             .new(context[:current_user])
             .create_or_update(**args.merge(organization_id: current_organization.id))

--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -27,7 +27,6 @@ module Mutations
       type Types::Plans::Object
 
       def resolve(**args)
-        validate_organization!
         args[:charges].map!(&:to_h)
 
         result = ::Plans::CreateService

--- a/app/graphql/mutations/subscriptions/create.rb
+++ b/app/graphql/mutations/subscriptions/create.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::Subscriptions::Object
 
       def resolve(**args)
-        validate_organization!
-
         customer = Customer.find_by(
           id: args[:customer_id],
           organization_id: current_organization.id,

--- a/app/graphql/mutations/subscriptions/terminate.rb
+++ b/app/graphql/mutations/subscriptions/terminate.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::Subscriptions::Object
 
       def resolve(**args)
-        validate_organization!
-
         subscription = current_organization.subscriptions.find_by(id: args[:id])
         result = ::Subscriptions::TerminateService.call(subscription:)
 

--- a/app/graphql/mutations/taxes/create.rb
+++ b/app/graphql/mutations/taxes/create.rb
@@ -13,8 +13,6 @@ module Mutations
       type Types::Taxes::Object
 
       def resolve(**args)
-        validate_organization!
-
         result = ::Taxes::CreateService.call(organization: current_organization, params: args)
         result.success? ? result.tax : result_error(result)
       end

--- a/app/graphql/mutations/taxes/destroy.rb
+++ b/app/graphql/mutations/taxes/destroy.rb
@@ -14,8 +14,6 @@ module Mutations
       field :id, ID, null: true
 
       def resolve(id:)
-        validate_organization!
-
         tax = current_organization.taxes.find_by(id:)
         result = ::Taxes::DestroyService.call(tax:)
 

--- a/app/graphql/mutations/taxes/update.rb
+++ b/app/graphql/mutations/taxes/update.rb
@@ -13,8 +13,6 @@ module Mutations
       type Types::Taxes::Object
 
       def resolve(**args)
-        validate_organization!
-
         tax = current_organization.taxes.find_by(id: args[:id])
         result = ::Taxes::UpdateService.call(tax:, params: args)
 

--- a/app/graphql/mutations/wallet_transactions/create.rb
+++ b/app/graphql/mutations/wallet_transactions/create.rb
@@ -16,8 +16,6 @@ module Mutations
       type Types::WalletTransactions::Object.collection_type
 
       def resolve(**args)
-        validate_organization!
-
         result = ::WalletTransactions::CreateService.new.create(
           organization_id: current_organization.id,
           wallet_id: args[:wallet_id],

--- a/app/graphql/mutations/wallets/create.rb
+++ b/app/graphql/mutations/wallets/create.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::Wallets::Object
 
       def resolve(**args)
-        validate_organization!
-
         result = ::Wallets::CreateService
           .new(context[:current_user])
           .create(

--- a/app/graphql/mutations/webhook_endpoints/create.rb
+++ b/app/graphql/mutations/webhook_endpoints/create.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::WebhookEndpoints::Object
 
       def resolve(**args)
-        validate_organization!
-
         result = ::WebhookEndpoints::CreateService.call(
           organization: current_organization,
           params: args,

--- a/app/graphql/mutations/webhook_endpoints/destroy.rb
+++ b/app/graphql/mutations/webhook_endpoints/destroy.rb
@@ -14,8 +14,6 @@ module Mutations
       field :id, ID, null: true
 
       def resolve(id:)
-        validate_organization!
-
         webhook_endpoint = current_organization.webhook_endpoints.find_by(id:)
         result = ::WebhookEndpoints::DestroyService.call(webhook_endpoint:)
 

--- a/app/graphql/mutations/webhook_endpoints/update.rb
+++ b/app/graphql/mutations/webhook_endpoints/update.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::WebhookEndpoints::Object
 
       def resolve(**args)
-        validate_organization!
-
         result = ::WebhookEndpoints::UpdateService.call(
           id: args[:id],
           organization: current_organization,

--- a/app/graphql/mutations/webhooks/retry.rb
+++ b/app/graphql/mutations/webhooks/retry.rb
@@ -14,8 +14,6 @@ module Mutations
       type Types::Webhooks::Object
 
       def resolve(id:)
-        validate_organization!
-
         webhook = current_organization.webhooks.find_by(id:)
         result = ::Webhooks::RetryService.call(webhook:)
 

--- a/app/graphql/resolvers/add_on_resolver.rb
+++ b/app/graphql/resolvers/add_on_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::AddOns::Object, null: true
 
     def resolve(id: nil)
-      validate_organization!
-
       current_organization.add_ons.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'add_on')

--- a/app/graphql/resolvers/add_ons_resolver.rb
+++ b/app/graphql/resolvers/add_ons_resolver.rb
@@ -15,8 +15,6 @@ module Resolvers
     type Types::AddOns::Object.collection_type, null: false
 
     def resolve(ids: nil, page: nil, limit: nil, search_term: nil)
-      validate_organization!
-
       query = ::AddOnsQuery.new(organization: current_organization)
       result = query.call(
         search_term:,

--- a/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
+++ b/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
@@ -14,8 +14,6 @@ module Resolvers
       type Types::Analytics::GrossRevenues::Object.collection_type, null: false
 
       def resolve(**args)
-        validate_organization!
-
         ::Analytics::GrossRevenue.find_all_by(current_organization.id, **args.merge(months: 12))
       end
     end

--- a/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
+++ b/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
@@ -13,8 +13,6 @@ module Resolvers
       type Types::Analytics::InvoiceCollections::Object.collection_type, null: false
 
       def resolve(**args)
-        validate_organization!
-
         raise unauthorized_error unless License.premium?
 
         ::Analytics::InvoiceCollection.find_all_by(current_organization.id, **args.merge(months: 12))

--- a/app/graphql/resolvers/analytics/invoiced_usages_resolver.rb
+++ b/app/graphql/resolvers/analytics/invoiced_usages_resolver.rb
@@ -13,8 +13,6 @@ module Resolvers
       type Types::Analytics::InvoicedUsages::Object.collection_type, null: false
 
       def resolve(**args)
-        validate_organization!
-
         raise unauthorized_error unless License.premium?
 
         ::Analytics::InvoicedUsage.find_all_by(current_organization.id, **args.merge({ months: 12 }))

--- a/app/graphql/resolvers/analytics/mrrs_resolver.rb
+++ b/app/graphql/resolvers/analytics/mrrs_resolver.rb
@@ -13,8 +13,6 @@ module Resolvers
       type Types::Analytics::Mrrs::Object.collection_type, null: false
 
       def resolve(**args)
-        validate_organization!
-
         raise unauthorized_error unless License.premium?
 
         ::Analytics::Mrr.find_all_by(current_organization.id, **args.merge({ months: 12 }))

--- a/app/graphql/resolvers/billable_metric_resolver.rb
+++ b/app/graphql/resolvers/billable_metric_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::BillableMetrics::Object, null: true
 
     def resolve(id: nil)
-      validate_organization!
-
       current_organization.billable_metrics.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'billable_metric')

--- a/app/graphql/resolvers/billable_metrics_resolver.rb
+++ b/app/graphql/resolvers/billable_metrics_resolver.rb
@@ -18,8 +18,6 @@ module Resolvers
     type Types::BillableMetrics::Object.collection_type, null: false
 
     def resolve(**args)
-      validate_organization!
-
       result = ::BillableMetricsQuery.new(organization: current_organization).call(
         search_term: args[:search_term],
         page: args[:page],

--- a/app/graphql/resolvers/coupon_resolver.rb
+++ b/app/graphql/resolvers/coupon_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::Coupons::Object, null: true
 
     def resolve(id: nil)
-      validate_organization!
-
       current_organization.coupons.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'coupon')

--- a/app/graphql/resolvers/coupons_resolver.rb
+++ b/app/graphql/resolvers/coupons_resolver.rb
@@ -15,9 +15,7 @@ module Resolvers
 
     type Types::Coupons::Object.collection_type, null: false
 
-    def resolve(ids: nil, page: nil, limit: nil, status: nil, search_term: nil)
-      validate_organization!
-
+    def resolve(ids: nil, page: nil, limit: nil, status: nil, search_term: nil)      
       query = CouponsQuery.new(organization: current_organization)
       result = query.call(
         search_term:,

--- a/app/graphql/resolvers/credit_note_resolver.rb
+++ b/app/graphql/resolvers/credit_note_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::CreditNotes::Object, null: true
 
     def resolve(id: nil)
-      validate_organization!
-
       current_organization.credit_notes.finalized.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'credit_note')

--- a/app/graphql/resolvers/credit_notes/estimate_resolver.rb
+++ b/app/graphql/resolvers/credit_notes/estimate_resolver.rb
@@ -14,8 +14,6 @@ module Resolvers
       type Types::CreditNotes::Estimate, null: false
 
       def resolve(invoice_id:, items:)
-        validate_organization!
-
         result = ::CreditNotes::EstimateService.call(
           invoice: current_organization.invoices.not_generating.find_by(id: invoice_id),
           items:,

--- a/app/graphql/resolvers/customer_credit_notes_resolver.rb
+++ b/app/graphql/resolvers/customer_credit_notes_resolver.rb
@@ -16,8 +16,6 @@ module Resolvers
     type Types::CreditNotes::Object.collection_type, null: true
 
     def resolve(customer_id: nil, ids: nil, page: nil, limit: nil, search_term: nil)
-      validate_organization!
-
       query = CustomerCreditNotesQuery.new(organization: current_organization)
       result = query.call(
         search_term:,

--- a/app/graphql/resolvers/customer_resolver.rb
+++ b/app/graphql/resolvers/customer_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::Customers::Object, null: true
 
     def resolve(id: nil)
-      validate_organization!
-
       current_organization.customers.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'customer')

--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -17,8 +17,6 @@ module Resolvers
       type Types::Invoices::Object.collection_type, null: false
 
       def resolve(customer_id: nil, status: nil, page: nil, limit: nil, search_term: nil)
-        validate_organization!
-
         query = InvoicesQuery.new(organization: current_organization)
         result = query.call(
           search_term:,

--- a/app/graphql/resolvers/customers_resolver.rb
+++ b/app/graphql/resolvers/customers_resolver.rb
@@ -15,8 +15,6 @@ module Resolvers
     type Types::Customers::Object.collection_type, null: false
 
     def resolve(ids: nil, page: nil, limit: nil, search_term: nil)
-      validate_organization!
-
       query = CustomersQuery.new(organization: current_organization)
       result = query.call(
         search_term:,

--- a/app/graphql/resolvers/events_resolver.rb
+++ b/app/graphql/resolvers/events_resolver.rb
@@ -13,8 +13,6 @@ module Resolvers
     type Types::Events::Object.collection_type, null: true
 
     def resolve(page: nil, limit: nil)
-      validate_organization!
-
       Event.where(organization_id: current_organization.id)
         .order(timestamp: :desc)
         .page(page)

--- a/app/graphql/resolvers/integration_resolver.rb
+++ b/app/graphql/resolvers/integration_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::Integrations::Object, null: true
 
     def resolve(id: nil)
-      validate_organization!
-
       current_organization.integrations.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'integration')

--- a/app/graphql/resolvers/integrations_resolver.rb
+++ b/app/graphql/resolvers/integrations_resolver.rb
@@ -14,8 +14,6 @@ module Resolvers
     type Types::Integrations::Object.collection_type, null: true
 
     def resolve(type: nil, page: nil, limit: nil)
-      validate_organization!
-
       scope = current_organization.integrations.page(page).per(limit)
       scope = scope.where(type: integration_type(type)) if type.present?
       scope

--- a/app/graphql/resolvers/invites_resolver.rb
+++ b/app/graphql/resolvers/invites_resolver.rb
@@ -13,8 +13,6 @@ module Resolvers
     type Types::Invites::Object.collection_type, null: false
 
     def resolve(page: nil, limit: nil)
-      validate_organization!
-
       current_organization
         .invites
         .pending

--- a/app/graphql/resolvers/invoice_credit_notes_resolver.rb
+++ b/app/graphql/resolvers/invoice_credit_notes_resolver.rb
@@ -14,8 +14,6 @@ module Resolvers
     type Types::CreditNotes::Object.collection_type, null: true
 
     def resolve(invoice_id: nil, page: nil, limit: nil)
-      validate_organization!
-
       Invoice.find(invoice_id)
         .credit_notes
         .finalized

--- a/app/graphql/resolvers/invoice_resolver.rb
+++ b/app/graphql/resolvers/invoice_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::Invoices::Object, null: true
 
     def resolve(id:)
-      validate_organization!
-
       current_organization.invoices.not_generating.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'invoice')

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -24,8 +24,6 @@ module Resolvers
       status: nil,
       search_term: nil
     )
-      validate_organization!
-
       query = InvoicesQuery.new(organization: current_organization)
       result = query.call(
         search_term:,

--- a/app/graphql/resolvers/memberships_resolver.rb
+++ b/app/graphql/resolvers/memberships_resolver.rb
@@ -13,8 +13,6 @@ module Resolvers
     type Types::MembershipType.collection_type, null: false
 
     def resolve(page: nil, limit: nil)
-      validate_organization!
-
       current_organization
         .memberships
         .active

--- a/app/graphql/resolvers/organization_resolver.rb
+++ b/app/graphql/resolvers/organization_resolver.rb
@@ -10,7 +10,6 @@ module Resolvers
     type Types::OrganizationType, null: true
 
     def resolve
-      validate_organization!
       current_organization
     end
   end

--- a/app/graphql/resolvers/payment_provider_resolver.rb
+++ b/app/graphql/resolvers/payment_provider_resolver.rb
@@ -13,8 +13,6 @@ module Resolvers
     type Types::PaymentProviders::Object, null: true
 
     def resolve(id: nil, code: nil)
-      validate_organization!
-
       if id.present?
         current_organization.payment_providers.find(id)
       else

--- a/app/graphql/resolvers/payment_providers_resolver.rb
+++ b/app/graphql/resolvers/payment_providers_resolver.rb
@@ -14,8 +14,6 @@ module Resolvers
     type Types::PaymentProviders::Object.collection_type, null: true
 
     def resolve(type: nil, page: nil, limit: nil)
-      validate_organization!
-
       scope = current_organization.payment_providers.page(page).per(limit)
       scope = scope.where(type: provider_type(type)) if type.present?
       scope

--- a/app/graphql/resolvers/plan_resolver.rb
+++ b/app/graphql/resolvers/plan_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::Plans::Object, null: true
 
     def resolve(id: nil)
-      validate_organization!
-
       current_organization.plans.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'plan')

--- a/app/graphql/resolvers/plans_resolver.rb
+++ b/app/graphql/resolvers/plans_resolver.rb
@@ -15,8 +15,6 @@ module Resolvers
     type Types::Plans::Object.collection_type, null: false
 
     def resolve(ids: nil, page: nil, limit: nil, search_term: nil)
-      validate_organization!
-
       query = PlansQuery.new(organization: current_organization)
       result = query.call(
         search_term:,

--- a/app/graphql/resolvers/subscription_resolver.rb
+++ b/app/graphql/resolvers/subscription_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::Subscriptions::Object, null: true
 
     def resolve(id: nil)
-      validate_organization!
-
       current_organization.subscriptions.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'subscription')

--- a/app/graphql/resolvers/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/subscriptions_resolver.rb
@@ -15,8 +15,6 @@ module Resolvers
     type Types::Subscriptions::Object.collection_type, null: false
 
     def resolve(page: nil, limit: nil, plan_code: nil, status: nil)
-      validate_organization!
-
       result = SubscriptionsQuery.call(
         organization: current_organization,
         pagination: BaseQuery::Pagination.new(page:, limit:),

--- a/app/graphql/resolvers/tax_resolver.rb
+++ b/app/graphql/resolvers/tax_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::Taxes::Object, null: true
 
     def resolve(id: nil)
-      validate_organization!
-
       current_organization.taxes.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'tax')

--- a/app/graphql/resolvers/taxes_resolver.rb
+++ b/app/graphql/resolvers/taxes_resolver.rb
@@ -26,8 +26,6 @@ module Resolvers
       limit: nil,
       search_term: nil
     )
-      validate_organization!
-
       query = ::TaxesQuery.new(organization: current_organization)
       result = query.call(
         search_term:,

--- a/app/graphql/resolvers/wallet_resolver.rb
+++ b/app/graphql/resolvers/wallet_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::Wallets::Object, null: true
 
     def resolve(id:)
-      validate_organization!
-
       current_organization.wallets.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'wallet')

--- a/app/graphql/resolvers/wallet_transactions_resolver.rb
+++ b/app/graphql/resolvers/wallet_transactions_resolver.rb
@@ -24,8 +24,6 @@ module Resolvers
       status: nil,
       transaction_type: nil
     )
-      validate_organization!
-
       query = WalletTransactionsQuery.new(organization: current_organization)
       result = query.call(
         wallet_id:,

--- a/app/graphql/resolvers/wallets_resolver.rb
+++ b/app/graphql/resolvers/wallets_resolver.rb
@@ -16,8 +16,6 @@ module Resolvers
     type Types::Wallets::Object.collection_type, null: false
 
     def resolve(customer_id: nil, ids: nil, page: nil, limit: nil, status: nil)
-      validate_organization!
-
       current_customer = Customer.find(customer_id)
 
       wallets = current_customer

--- a/app/graphql/resolvers/webhook_endpoint_resolver.rb
+++ b/app/graphql/resolvers/webhook_endpoint_resolver.rb
@@ -12,8 +12,6 @@ module Resolvers
     type Types::WebhookEndpoints::Object, null: true
 
     def resolve(id:)
-      validate_organization!
-
       current_organization.webhook_endpoints.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'webhook_endpoint')

--- a/app/graphql/resolvers/webhook_endpoints_resolver.rb
+++ b/app/graphql/resolvers/webhook_endpoints_resolver.rb
@@ -15,8 +15,6 @@ module Resolvers
     type Types::WebhookEndpoints::Object.collection_type, null: false
 
     def resolve(ids: nil, page: nil, limit: nil, search_term: nil)
-      validate_organization!
-
       query = ::WebhookEndpointsQuery.new(organization: current_organization)
       result = query.call(
         search_term:,

--- a/app/graphql/resolvers/webhooks_resolver.rb
+++ b/app/graphql/resolvers/webhooks_resolver.rb
@@ -16,8 +16,6 @@ module Resolvers
     type Types::Webhooks::Object.collection_type, null: false
 
     def resolve(webhook_endpoint_id:, page: nil, limit: nil, status: nil, search_term: nil)
-      validate_organization!
-
       webhook_endpoint = WebhookEndpoint.find(webhook_endpoint_id)
 
       query = WebhooksQuery.new(webhook_endpoint:)

--- a/spec/graphql/mutations/invites/revoke_spec.rb
+++ b/spec/graphql/mutations/invites/revoke_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe Mutations::Invites::Revoke, type: :graphql do
-  let(:organization) { create(:organization) }
-  let(:user) { create(:user) }
+  let(:membership) { create(:membership)}
+  let(:organization) { membership.organization }
+  let(:user) { membership.user }
 
   let(:mutation) do
     <<-GQL

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
 
   it 'updates a wallet' do
     result = execute_graphql(
+      current_organization: organization,
       current_user: membership.user,
       query: mutation,
       variables: {
@@ -59,7 +60,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
     aggregate_failures do
       expect(result_data['name']).to eq('New name')
       expect(result_data['status']).to eq('active')
-      expect(result_data['expirationAt']).to eq((Time.zone.now + 1.year).iso8601)
+      expect(result_data['expirationAt']).to eq(expiration_at.iso8601)
       expect(result_data['recurringTransactionRules'].count).to eq(1)
       expect(result_data['recurringTransactionRules'][0]['lagoId']).to eq(recurring_transaction_rule.id)
       expect(result_data['recurringTransactionRules'][0]['ruleType']).to eq('interval')


### PR DESCRIPTION
## Context

Following the convention over configuration and DRY (Don't Repeat Yourself) principles of Ruby on Rails design paradigm, this PR implements automatic validation of `validate_organization!` when including the `RequiredOrganization` concern on GraphQL query/mutation resolvers

## Description

- Automatically triggers `validate_organization!` for `resolve` when `RequiredOrganization` is included.
- Updates the spec for `Mutations::Invites::Revoke` to use a user within the organization.
- Enhances the spec for `Mutations::Wallets::Update` to include the current organization in the GraphQL mutation.
- Additionally, updates the `expirationAt` check to prevent false positives when tests run for more than 1 second.