### PR TITLE
fix(pdf): Remove extra blank link in custom footer

### DIFF
--- a/app/views/helpers/line_break_helper.rb
+++ b/app/views/helpers/line_break_helper.rb
@@ -3,6 +3,6 @@
 class LineBreakHelper
   def self.break_lines(text)
     escaped_text = ERB::Util.html_escape(text.to_s)
-    escaped_text.gsub(/\n/, '<br/>').html_safe # rubocop:disable Rails/OutputSafety
+    escaped_text.split("\n").reject(&:blank?).join('<br/>').html_safe # rubocop:disable Rails/OutputSafety
   end
 end

--- a/spec/views/helpers/line_break_helper_spec.rb
+++ b/spec/views/helpers/line_break_helper_spec.rb
@@ -6,8 +6,20 @@ RSpec.describe LineBreakHelper do
   subject(:helper) { described_class }
 
   describe '.break_lines' do
-    it 'replaces \n with <br\>' do
+    it 'replaces \n with <br/>' do
       html = helper.break_lines("t\nt")
+
+      expect(html).to eq('t<br/>t')
+    end
+
+    it 'removes all \n at the beginning and the end' do
+      html = helper.break_lines("t\nt\n\n\n")
+
+      expect(html).to eq('t<br/>t')
+    end
+
+    it 'removes double extra \n' do
+      html = helper.break_lines("\n\n\nt\n\n\nt\n\n\n")
 
       expect(html).to eq('t<br/>t')
     end


### PR DESCRIPTION
## Context

An organisation can choose to display a custom text block on invoices.

## Description

With this change, we'll ensure the all the blank line before and after the last lines are removed. We'll also remove extra blank lines.

### Example

#### CONFIG

<img width="1021" alt="Screenshot 2024-04-08 at 14 05 30" src="https://github.com/getlago/lago-api/assets/1525636/e44acb32-fede-404b-9f69-5fe7e6704a2f">

#### BEFORE

<img width="851" alt="Screenshot 2024-04-08 at 13 58 00" src="https://github.com/getlago/lago-api/assets/1525636/890b58b4-735b-442b-b843-7efee1a6dff2">

#### AFTER

<img width="855" alt="Screenshot 2024-04-08 at 13 58 57" src="https://github.com/getlago/lago-api/assets/1525636/a19971ee-1013-42fc-9419-e1f1971bf188">

