### PR TITLE
chore(ci): Update pronto actions/checkout to v4

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -8,7 +8,7 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - run: |
           git fetch --no-tags --prune --depth=10 origin +refs/heads/*:refs/remotes/origin/*
       - name: Setup Ruby

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
## Description

I'm seeing deprecation notices in the pronto actions. Updating to latest `actions/checkout@v4` should fix them.

https://github.com/getlago/lago-api/actions/runs/8599754635

<img width="1235" alt="Screenshot 2024-04-08 at 14 18 29" src="https://github.com/getlago/lago-api/assets/1525636/b7a6ec86-8b6a-4532-82a7-61115c84765c">
