### PR TITLE
chore(ci): update pronto from Actions to Checks

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -2,27 +2,15 @@ name: Pronto
 on: [pull_request]
 
 jobs:
-  linters:
-    name: Linters
+  run:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - run: |
           git fetch --no-tags --prune --depth=10 origin +refs/heads/*:refs/remotes/origin/*
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-      - name: Setup pronto
-        run: |
-          gem install rugged -v 1.6.3
-          gem install pronto
-          gem install pronto-rubocop
-          gem install rubocop -v 1.44.1
-          gem install rubocop-rspec
-          gem install rubocop-performance
-          gem install rubocop-rails
-          gem install rubocop-thread_safety
-          gem install rubocop-graphql
-      - name: Run Pronto
-        run: PRONTO_PULL_REQUEST_ID="${{ github.event.pull_request.number }}" PRONTO_GITHUB_ACCESS_TOKEN="${{ secrets.GH_TOKEN }}" pronto run -f github_status github_pr -c origin/${{ github.base_ref }}
+      - uses: adwerx/pronto-ruby@main # use a tag version here
+        with:
+          target: origin/${{ github.base_ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-performance
   - rubocop-rails
   - rubocop-thread_safety
-  - rubocop-graphql
+#  - rubocop-graphql
 
 AllCops:
   NewCops: disable
@@ -298,14 +298,14 @@ Style/HashTransformKeys:
 Style/HashTransformValues:
   Enabled: false
 
-GraphQL/ArgumentDescription:
-  Enabled: false
-
-GraphQL/FieldDescription:
-  Enabled: false
-
-GraphQL/ObjectDescription:
-  Enabled: false
-
-GraphQL/ExtractType:
-  Enabled: false
+#GraphQL/ArgumentDescription:
+#  Enabled: false
+#
+#GraphQL/FieldDescription:
+#  Enabled: false
+#
+#GraphQL/ObjectDescription:
+#  Enabled: false
+#
+#GraphQL/ExtractType:
+#  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -108,6 +108,7 @@ group :development do
   gem 'coffee-rails'
   gem 'graphiql-rails', git: 'https://github.com/rmosolgo/graphiql-rails.git'
 
+  gem 'rubocop', require: false
   gem 'rubocop-graphql', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -847,6 +847,7 @@ DEPENDENCIES
   ransack (~> 4.0.0)
   rspec-graphql_matchers
   rspec-rails
+  rubocop
   rubocop-graphql
   rubocop-performance
   rubocop-rails
@@ -875,4 +876,4 @@ RUBY VERSION
    ruby 3.2.3p157
 
 BUNDLED WITH
-   2.5.5
+   2.5.6


### PR DESCRIPTION
Migrated our pronto actions to github checks with https://github.com/marketplace/actions/pronto-ruby

Started this because of this new error: https://github.com/getlago/lago-api/actions/runs/8600901566/job/23566843917?pr=1854