### PR TITLE
chore(config): Move Sidekiq config to initializer

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -12,6 +12,12 @@ if ENV['REDIS_PASSWORD'].present? && !ENV['REDIS_PASSWORD'].empty?
   redis_config = redis_config.merge({ password: ENV['REDIS_PASSWORD'] })
 end
 
+if ENV['LAGO_SIDEKIQ_WEB'] == 'true'
+  require 'sidekiq/web'
+  Sidekiq::Web.use(ActionDispatch::Cookies)
+  Sidekiq::Web.use(ActionDispatch::Session::CookieStore, key: '_interslice_session')
+end
+
 Sidekiq.configure_server do |config|
   config.redis = redis_config
   config.logger = Sidekiq::Logger.new($stdout)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-require 'sidekiq/web'
-
-# NOTE: Configure Sidekiq Web session middleware
-Sidekiq::Web.use(ActionDispatch::Cookies)
-Sidekiq::Web.use(ActionDispatch::Session::CookieStore, key: '_interslice_session')
-
 Rails.application.routes.draw do
-  mount Sidekiq::Web => '/sidekiq' if ENV['LAGO_SIDEKIQ_WEB'] == 'true'
+  mount Sidekiq::Web => '/sidekiq' if defined? Sidekiq::Web
 
   mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql' if Rails.env.development?
 


### PR DESCRIPTION
## Description

Very small improvements:

* Move sidekiq session config to initializer rather than `routes.rb`.
* Only `require 'sidekiq/web'` if we're going to mount it

See https://github.com/getlago/lago-api/pull/1071/