### PR TITLE
fix(invoice): Bill usage-based charges if subscription is terminated on day one

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -197,6 +197,8 @@ module Invoices
         return true
       end
 
+      # NOTE: Charges should not be billed in advance when we are just upgrading to a new
+      #       pay_in_advance subscription
       return false if subscription.plan.pay_in_advance? && subscription.invoices.created_before(invoice).count.zero?
 
       true

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -99,7 +99,7 @@ module Invoices
         .where(invoiceable: true)
         .where
         .not(pay_in_advance: true, billable_metric: { recurring: false })
-        .each do |charge|
+        .find_each do |charge|
           next if should_not_create_charge_fee?(charge, subscription)
 
           fee_result = Fees::ChargeService.new(invoice:, charge:, subscription:, boundaries:).create
@@ -197,8 +197,7 @@ module Invoices
         return true
       end
 
-      return false if subscription.plan.pay_in_advance? &&
-                      subscription.started_at.to_date == timestamp.to_date
+      return false if subscription.plan.pay_in_advance? && subscription.invoices.created_before(invoice).count.zero?
 
       true
     end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -679,8 +679,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               expect(invoice.subscriptions.first).to eq(subscription)
               expect(invoice.payment_status).to eq('pending')
               expect(invoice.fees.subscription_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.first.amount_cents).to eq(0) # because there is no usage
+              expect(invoice.fees.charge_kind.count).to eq(0)
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
@@ -714,8 +713,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               expect(invoice.subscriptions.first).to eq(subscription)
               expect(invoice.payment_status).to eq('pending')
               expect(invoice.fees.subscription_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.first.amount_cents).to eq(0) # because there is no usage
+              expect(invoice.fees.charge_kind.count).to eq(0)
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
@@ -809,9 +807,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         end
       end
 
-      context 'when subscription is billed on started_at day' do
-        let(:timestamp) { created_at + 10.minutes }
-
+      context 'when subscription started on creation day' do
         it 'does not create any charge fees' do
           result = invoice_service.call
 
@@ -860,8 +856,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               expect(invoice).to be_pending
               expect(invoice.fees.subscription_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.first.amount_cents).to eq(0) # because there is no usage
+              expect(invoice.fees.charge_kind.count).to eq(0)
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
@@ -895,8 +890,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               expect(invoice).to be_pending
               expect(invoice.fees.subscription_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.first.amount_cents).to eq(0) # because there is no usage
+              expect(invoice.fees.charge_kind.count).to eq(0)
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(
@@ -1075,8 +1069,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
               expect(invoice.subscriptions.first).to eq(subscription)
               expect(invoice.fees.subscription_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.count).to eq(1)
-              expect(invoice.fees.charge_kind.first.amount_cents).to eq(0) # because there is no usage
+              expect(invoice.fees.charge_kind.count).to eq(0)
 
               invoice_subscription = invoice.invoice_subscriptions.first
               expect(invoice_subscription).to have_attributes(


### PR DESCRIPTION
Broken by this PR https://github.com/getlago/lago-api/pull/1836

On the same day
* Create a pay_in_advance subscription
* The invoice is generated for the subscription fee
* Send events
* Terminate subscription
* A credit note is created to refund all subscription fee by one day
* A charge is created to bill you the usage-based charges ⬅️ This part was broken