### PR TITLE
fix (integrations): add account id setter with needed transformations

### DIFF
--- a/app/models/integrations/netsuite_integration.rb
+++ b/app/models/integrations/netsuite_integration.rb
@@ -5,12 +5,19 @@ module Integrations
     validates :connection_id, :client_secret, :client_id, :account_id, presence: true
 
     settings_accessors :client_id,
-                       :account_id,
                        :sync_credit_notes,
                        :sync_invoices,
                        :sync_payments,
                        :sync_sales_orders,
                        :script_endpoint_url
     secrets_accessors :connection_id, :client_secret
+
+    def account_id=(value)
+      push_to_settings(key: 'account_id', value: value&.downcase&.strip&.split(' ')&.join('-'))
+    end
+
+    def account_id
+      get_from_settings('account_id')
+    end
   end
 end

--- a/spec/models/integrations/netsuite_integration_spec.rb
+++ b/spec/models/integrations/netsuite_integration_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe Integrations::NetsuiteIntegration, type: :model do
       netsuite_integration.account_id = 'account_id'
       expect(netsuite_integration.account_id).to eq('account_id')
     end
+
+    context 'when format is invalid' do
+      it 'assigns and retrieve a setting with correct format' do
+        netsuite_integration.account_id = '  THIS is    account  id  '
+        expect(netsuite_integration.account_id).to eq('this-is-account-id')
+      end
+    end
   end
 
   describe '.client_id' do


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR fixes storing account id. We need to store it with necessary string transformations
