### PR TITLE
fix(invoice): Prevent duplicated non-recurring invoices

### DIFF
--- a/app/jobs/bill_subscription_job.rb
+++ b/app/jobs/bill_subscription_job.rb
@@ -5,11 +5,11 @@ class BillSubscriptionJob < ApplicationJob
 
   retry_on Sequenced::SequenceError, ActiveJob::DeserializationError
 
-  def perform(subscriptions, timestamp, recurring: false, invoice: nil, skip_charges: false)
+  def perform(subscriptions, timestamp, invoicing_reason:, invoice: nil, skip_charges: false)
     result = Invoices::SubscriptionService.call(
       subscriptions:,
       timestamp:,
-      recurring:,
+      invoicing_reason:,
       invoice:,
       skip_charges:,
     )
@@ -21,7 +21,7 @@ class BillSubscriptionJob < ApplicationJob
     self.class.set(wait: 3.seconds).perform_later(
       subscriptions,
       timestamp,
-      recurring:,
+      invoicing_reason:,
       invoice: result.invoice,
       skip_charges:,
     )

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -13,6 +13,15 @@ class InvoiceSubscription < ApplicationRecord
   monetize :subscription_amount_cents, disable_validation: true, allow_nil: true
   monetize :total_amount_cents, disable_validation: true, allow_nil: true
 
+  INVOICING_REASONS = {
+    subscription_starting: 'subscription_starting',
+    subscription_periodic: 'subscription_periodic',
+    subscription_terminating: 'subscription_terminating',
+    in_advance_charge: 'in_advance_charge',
+  }.freeze
+
+  enum invoicing_reason: INVOICING_REASONS
+
   scope :order_by_charges_to_datetime,
         lambda {
           condition = <<-SQL

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -67,7 +67,7 @@ module Invoices
         charge_in_advance: true,
       ) do |invoice|
         Invoices::CreateInvoiceSubscriptionService
-          .call(invoice:, subscriptions: [subscription], timestamp:, recurring: false)
+          .call(invoice:, subscriptions: [subscription], timestamp:, invoicing_reason: :in_advance_charge)
           .raise_if_error!
       end
       invoice_result.raise_if_error!

--- a/app/services/subscriptions/activate_service.rb
+++ b/app/services/subscriptions/activate_service.rb
@@ -24,7 +24,7 @@ module Subscriptions
           SendWebhookJob.perform_later('subscription.started', subscription)
 
           if subscription.plan.pay_in_advance? && !subscription.in_trial_period?
-            BillSubscriptionJob.perform_later([subscription], timestamp)
+            BillSubscriptionJob.perform_later([subscription], timestamp, invoicing_reason: :subscription_starting)
           end
         end
     end

--- a/app/services/subscriptions/billing_service.rb
+++ b/app/services/subscriptions/billing_service.rb
@@ -18,7 +18,11 @@ module Subscriptions
           end
         end
 
-        BillSubscriptionJob.perform_later(billing_subscriptions, billing_timestamp, recurring: true)
+        BillSubscriptionJob.perform_later(
+          billing_subscriptions,
+          billing_timestamp,
+          invoicing_reason: :subscription_periodic,
+        )
       end
     end
 

--- a/app/services/subscriptions/free_trial_billing_service.rb
+++ b/app/services/subscriptions/free_trial_billing_service.rb
@@ -13,7 +13,12 @@ module Subscriptions
         if subscription.plan_pay_in_advance &&
            !subscription.was_already_billed_today &&
            !already_billed_on_day_one?(subscription)
-          BillSubscriptionJob.perform_later([subscription], timestamp, recurring: false, skip_charges: true)
+          BillSubscriptionJob.perform_later(
+            [subscription],
+            timestamp,
+            invoicing_reason: :subscription_starting,
+            skip_charges: true,
+          )
         end
 
         subscription.update!(trial_ended_at: subscription.trial_end_utc_date_from_query)

--- a/app/services/subscriptions/update_service.rb
+++ b/app/services/subscriptions/update_service.rb
@@ -57,7 +57,7 @@ module Subscriptions
 
       return unless subscription.plan.pay_in_advance? && subscription.subscription_at.today?
 
-      BillSubscriptionJob.perform_later([subscription], Time.current.to_i)
+      BillSubscriptionJob.perform_later([subscription], Time.current.to_i, invoicing_reason: :subscription_starting)
     end
 
     def handle_plan_override

--- a/db/migrate/20240412133335_add_invoice_type_to_invoice_subscriptions.rb
+++ b/db/migrate/20240412133335_add_invoice_type_to_invoice_subscriptions.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AddInvoiceTypeToInvoiceSubscriptions < ActiveRecord::Migration[7.0]
+  def change
+    create_enum :subscription_invoicing_reason,
+                %w[
+                  subscription_starting
+                  subscription_periodic
+                  subscription_terminating
+                  in_advance_charge
+                ]
+
+    change_table :invoice_subscriptions do |t|
+      t.enum :invoicing_reason, enum_type: 'subscription_invoicing_reason', null: true
+
+      t.index %w[subscription_id invoicing_reason],
+              unique: true,
+              where: "invoicing_reason = 'subscription_starting'",
+              name: 'index_unique_starting_subscription_invoice'
+      t.index %w[subscription_id invoicing_reason],
+              unique: true,
+              where: "invoicing_reason = 'subscription_terminating'",
+              name: 'index_unique_terminating_subscription_invoice'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_19_085012) do
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "billable_metric_weighted_interval", ["seconds"]
+  create_enum "subscription_invoicing_reason", ["subscription_starting", "subscription_periodic", "subscription_terminating", "in_advance_charge"]
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
@@ -626,9 +627,12 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_19_085012) do
     t.datetime "to_datetime"
     t.datetime "charges_from_datetime"
     t.datetime "charges_to_datetime"
+    t.enum "invoicing_reason", enum_type: "subscription_invoicing_reason"
     t.index ["invoice_id", "subscription_id"], name: "index_invoice_subscriptions_on_invoice_id_and_subscription_id", unique: true, where: "(created_at >= '2023-11-23 00:00:00'::timestamp without time zone)"
     t.index ["invoice_id"], name: "index_invoice_subscriptions_on_invoice_id"
     t.index ["subscription_id", "charges_from_datetime", "charges_to_datetime"], name: "index_invoice_subscriptions_on_charges_from_and_to_datetime", unique: true, where: "((created_at >= '2023-06-09 00:00:00'::timestamp without time zone) AND (recurring IS TRUE))"
+    t.index ["subscription_id", "invoicing_reason"], name: "index_unique_starting_subscription_invoice", unique: true, where: "(invoicing_reason = 'subscription_starting'::subscription_invoicing_reason)"
+    t.index ["subscription_id", "invoicing_reason"], name: "index_unique_terminating_subscription_invoice", unique: true, where: "(invoicing_reason = 'subscription_terminating'::subscription_invoicing_reason)"
     t.index ["subscription_id"], name: "index_invoice_subscriptions_on_subscription_id"
   end
 

--- a/spec/scenarios/subscriptions/free_trial_billing_spec.rb
+++ b/spec/scenarios/subscriptions/free_trial_billing_spec.rb
@@ -89,7 +89,7 @@ describe 'Free Trial Billing Subscriptions Scenario', :scenarios, type: :request
         expect(customer.reload.invoices.count).to eq(0)
 
         plan.update! trial_period: 0 # disable trial to force billing
-        BillSubscriptionJob.perform_now(customer.subscriptions, Time.current)
+        BillSubscriptionJob.perform_now(customer.subscriptions, Time.current, invoicing_reason: :subscription_starting)
 
         expect(customer.reload.invoices.count).to eq(1)
 

--- a/spec/services/customers/terminate_relations_service_spec.rb
+++ b/spec/services/customers/terminate_relations_service_spec.rb
@@ -40,9 +40,8 @@ RSpec.describe Customers::TerminateRelationsService, type: :service do
     let(:invoices) { create_list(:invoice, 2, :draft, customer:) }
 
     before do
-      invoices.each do |invoice|
-        create(:invoice_subscription, invoice:, subscription:)
-      end
+      create(:invoice_subscription, invoice: invoices.first, subscription:, invoicing_reason: :subscription_starting)
+      create(:invoice_subscription, invoice: invoices.last, subscription:, invoicing_reason: :subscription_periodic)
     end
 
     it 'finalizes draft invoices' do

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
     described_class.new(
       subscriptions:,
       timestamp: timestamp.to_i,
-      recurring: true,
+      invoicing_reason: :subscription_periodic,
     )
   end
 
@@ -114,7 +114,7 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
       end.not_to have_enqueued_job(SendEmailJob)
     end
 
-    context 'when recurring but no active subscriptions' do
+    context 'when periodic but no active subscriptions' do
       it 'does not create any invoices' do
         subscription.terminated!
         expect { invoice_service.call }.not_to change(Invoice, :count)

--- a/spec/services/plans/destroy_service_spec.rb
+++ b/spec/services/plans/destroy_service_spec.rb
@@ -103,9 +103,8 @@ RSpec.describe Plans::DestroyService, type: :service do
       let(:invoices) { create_list(:invoice, 2, :draft) }
 
       before do
-        invoices.each do |invoice|
-          create(:invoice_subscription, invoice:, subscription:)
-        end
+        create(:invoice_subscription, invoice: invoices.first, subscription:, invoicing_reason: :subscription_starting)
+        create(:invoice_subscription, invoice: invoices.second, subscription:, invoicing_reason: :subscription_periodic)
       end
 
       it 'finalizes draft invoices' do

--- a/spec/services/subscriptions/billing_service_spec.rb
+++ b/spec/services/subscriptions/billing_service_spec.rb
@@ -69,10 +69,14 @@ RSpec.describe Subscriptions::BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with(contain_exactly(subscription1, subscription2), current_date.to_i, recurring: true)
+            .with(
+              contain_exactly(subscription1, subscription2),
+              current_date.to_i,
+              invoicing_reason: :subscription_periodic,
+            )
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription3], current_date.to_i, recurring: true)
+            .with([subscription3], current_date.to_i, invoicing_reason: :subscription_periodic)
         end
       end
 
@@ -96,7 +100,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, recurring: true)
+            .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
         end
       end
 
@@ -126,7 +130,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).not_to have_been_enqueued
-              .with([subscription], billing_date.to_i, recurring: true)
+              .with([subscription], billing_date.to_i, invoicing_reason: :subscription_periodic)
           end
         end
       end
@@ -143,7 +147,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, recurring: true)
+            .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
         end
       end
 
@@ -154,7 +158,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).not_to have_been_enqueued
-            .with([subscription], current_date.to_i, recurring: true)
+            .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
         end
       end
     end
@@ -170,7 +174,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, recurring: true)
+            .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
         end
       end
 
@@ -192,7 +196,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with([subscription], current_date.to_i, recurring: true)
+              .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
           end
         end
       end
@@ -211,7 +215,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, recurring: true)
+            .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
         end
       end
 
@@ -232,7 +236,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, recurring: true)
+            .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
         end
       end
 
@@ -251,7 +255,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with([subscription], current_date.to_i, recurring: true)
+              .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
           end
         end
       end
@@ -267,7 +271,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, recurring: true)
+            .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
         end
       end
 
@@ -286,7 +290,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with([subscription], current_date.to_i, recurring: true)
+              .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
           end
         end
       end
@@ -300,7 +304,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with([subscription], current_date.to_i, recurring: true)
+              .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
           end
         end
       end
@@ -317,7 +321,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
           billing_service.call
 
           expect(BillSubscriptionJob).to have_been_enqueued
-            .with([subscription], current_date.to_i, recurring: true)
+            .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
         end
       end
 
@@ -336,7 +340,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with([subscription], current_date.to_i, recurring: true)
+              .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
           end
         end
       end
@@ -350,7 +354,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
             billing_service.call
 
             expect(BillSubscriptionJob).to have_been_enqueued
-              .with([subscription], current_date.next_month.to_i, recurring: true)
+              .with([subscription], current_date.next_month.to_i, invoicing_reason: :subscription_periodic)
           end
         end
 
@@ -363,7 +367,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
               billing_service.call
 
               expect(BillSubscriptionJob).to have_been_enqueued
-                .with([subscription], current_date.to_i, recurring: true)
+                .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
             end
           end
         end
@@ -450,8 +454,9 @@ RSpec.describe Subscriptions::BillingService, type: :service do
         create(
           :invoice_subscription,
           subscription:,
-          recurring: true,
+          invoicing_reason: :subscription_periodic,
           timestamp: subscription_at - 1.hour,
+          recurring: true,
         )
       end
 

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Subscriptions::TerminateService do
         terminate_service.terminate_and_start_next(timestamp:)
 
         expect(BillSubscriptionJob).to have_been_enqueued
-          .with([subscription, next_subscription], timestamp)
+          .with([subscription, next_subscription], timestamp, invoicing_reason: :upgrading)
       end
     end
   end


### PR DESCRIPTION
## Context

In some cases, due to race conditions, duplicated non-recurring invoices are created by the system, (for example when the clock job stars a subscription)

Today, only recurring invoices are protected against the duplication via a unique index on `recurring`, `charges_from_datetime` and `charges_to_datetime` columns of the `invoice_subscriptions` table

## Description

This PR tries to address the problem by
- Adding a new `invoicing_reason` on the `invoice_subscriptions` table as an enum accepting `subscription_started`, `subscription_terminated`, `in_advance_charge` and `subscription_periodic` values
  - It will replace the `recurring` column in the future
- Adding two new unique indexes on the `invoice_subscriptions` table
  - subscription_id, invoice_type where invoice_type = 'started'
  - subscription_id, invoice_type where invoice_type = 'terminated'
- Populating these fields depending of the context