### PR TITLE
feat (accounting-integrations): add logic for calling nango sync endpoint

### DIFF
--- a/app/jobs/integrations/aggregator/perform_sync_job.rb
+++ b/app/jobs/integrations/aggregator/perform_sync_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class PerformSyncJob < ApplicationJob
+      queue_as 'integrations'
+
+      retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
+
+      def perform(integration:)
+        result = Integrations::Aggregator::SyncService.call(integration:)
+        result.raise_if_error!
+      end
+    end
+  end
+end

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -5,7 +5,7 @@ require 'lago_http_client'
 module Integrations
   module Aggregator
     class BaseService < BaseService
-      BASE_URL = 'https://api.nango.dev/'.freeze
+      BASE_URL = 'https://api.nango.dev/'
 
       def initialize(integration:)
         @integration = integration

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'lago_http_client'
+
+module Integrations
+  module Aggregator
+    class BaseService < BaseService
+      BASE_URL = 'https://api.nango.dev/'.freeze
+
+      def initialize(integration:)
+        @integration = integration
+
+        super
+      end
+
+      def action_path
+        raise NotImplementedError
+      end
+
+      private
+
+      attr_reader :integration
+
+      def http_client
+        LagoHttpClient::Client.new(endpoint_url)
+      end
+
+      def endpoint_url
+        "#{BASE_URL}#{action_path}"
+      end
+
+      def generate_headers
+        {
+          'Connection-Id' => integration.connection_id,
+          'Authorization' => "Bearer #{secret_key}",
+        }
+      end
+
+      def secret_key
+        ENV['NANGO_SECRET_KEY']
+      end
+    end
+  end
+end

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -29,7 +29,7 @@ module Integrations
         "#{BASE_URL}#{action_path}"
       end
 
-      def generate_headers
+      def headers
         {
           'Connection-Id' => integration.connection_id,
           'Authorization' => "Bearer #{secret_key}",

--- a/app/services/integrations/aggregator/sync_service.rb
+++ b/app/services/integrations/aggregator/sync_service.rb
@@ -13,7 +13,7 @@ module Integrations
           syncs: sync_items,
         }
 
-        response = http_client.post_with_response(payload, generate_headers)
+        response = http_client.post_with_response(payload, headers)
         result.response = response
 
         result

--- a/app/services/integrations/aggregator/sync_service.rb
+++ b/app/services/integrations/aggregator/sync_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class SyncService < BaseService
+      def action_path
+        'sync/start'
+      end
+
+      def call
+        payload = {
+          provider_config_key: provider,
+          syncs: sync_items,
+        }
+
+        response = http_client.post_with_response(payload, generate_headers)
+        result.response = response
+
+        result
+      end
+
+      private
+
+      # NOTE: Extend it with other providers if needed
+      def provider
+        case integration.type
+        when 'Integrations::NetsuiteIntegration'
+          'netsuite'
+        end
+      end
+
+      # NOTE: Extend it with other providers if needed
+      def sync_items
+        case integration.type
+        when 'Integrations::NetsuiteIntegration'
+          %w[
+            netsuite-accounts-sync
+            netsuite-items-sync
+            netsuite-subsidiaries-sync
+            netsuite-contacts-sync
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/services/integrations/netsuite/create_service.rb
+++ b/app/services/integrations/netsuite/create_service.rb
@@ -28,6 +28,8 @@ module Integrations
 
         integration.save!
 
+        Integrations::Aggregator::PerformSyncJob.perform_later(integration:)
+
         result.integration = integration
         result
       rescue ActiveRecord::RecordInvalid => e

--- a/spec/jobs/integrations/aggregator/perform_sync_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/perform_sync_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::PerformSyncJob, type: :job do
+  subject(:perform_sync_job) { described_class }
+
+  let(:sync_service) { instance_double(Integrations::Aggregator::SyncService) }
+  let(:integration) { create(:netsuite_integration) }
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(Integrations::Aggregator::SyncService).to receive(:new).and_return(sync_service)
+    allow(sync_service).to receive(:call).and_return(result)
+  end
+
+  it 'calls the aggregator sync service' do
+    described_class.perform_now(integration:)
+
+    expect(Integrations::Aggregator::SyncService).to have_received(:new)
+    expect(sync_service).to have_received(:call)
+  end
+end

--- a/spec/services/integrations/aggregator/sync_service_spec.rb
+++ b/spec/services/integrations/aggregator/sync_service_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::SyncService do
+  subject(:sync_service) { described_class.new(integration:) }
+
+  let(:integration) { create(:netsuite_integration) }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:sync_endpoint) { 'https://api.nango.dev/sync/start' }
+    let(:syncs_list) do
+      %w[
+        netsuite-accounts-sync
+        netsuite-items-sync
+        netsuite-subsidiaries-sync
+        netsuite-contacts-sync
+      ]
+    end
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(sync_endpoint)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response)
+    end
+
+    it 'successfully calls sync endpoint' do
+      sync_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(sync_endpoint)
+      expect(lago_client).to have_received(:post_with_response) do |payload|
+        expect(payload[:provider_config_key]).to eq('netsuite')
+        expect(payload[:syncs]).to eq(syncs_list)
+      end
+    end
+  end
+end

--- a/spec/services/integrations/netsuite/create_service_spec.rb
+++ b/spec/services/integrations/netsuite/create_service_spec.rb
@@ -56,7 +56,10 @@ RSpec.describe Integrations::Netsuite::CreateService, type: :service do
       end
 
       context 'with netsuite premium integration present' do
-        before { organization.update!(premium_integrations: ['netsuite']) }
+        before do
+          organization.update!(premium_integrations: ['netsuite'])
+          allow(Integrations::Aggregator::PerformSyncJob).to receive(:perform_later)
+        end
 
         context 'without validation errors' do
           it 'creates an integration' do
@@ -65,6 +68,13 @@ RSpec.describe Integrations::Netsuite::CreateService, type: :service do
             integration = Integrations::NetsuiteIntegration.order(:created_at).last
             expect(integration.name).to eq(name)
             expect(integration.script_endpoint_url).to eq(script_endpoint_url)
+          end
+
+          it 'calls Integrations::Aggregator::PerformSyncJob' do
+            service_call
+
+            integration = Integrations::NetsuiteIntegration.order(:created_at).last
+            expect(Integrations::Aggregator::PerformSyncJob).to have_received(:perform_later).with(integration:)
           end
         end
 


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR adds base service for communicating with Lago's accounting integrations aggregator - Nango.

Also, the sync job is added. Lago needs to call Nango sync endpoint upon integration object creation. Sync is needed for Nango so that they can pull data from accounting provider.
Nango's enpoint structure will be the same for all other providers.
