### PR TITLE
feat(metric): Add custom_agg type and custom_aggregator to BM

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -24,6 +24,7 @@ class BillableMetric < ApplicationRecord
     # NOTE: deleted aggregation type, recurring_count_agg: 4,
     weighted_sum_agg: 5,
     latest_agg: 6,
+    custom_agg: 7,
   }.freeze
 
   WEIGHTED_INTERVAL = { seconds: 'seconds' }.freeze
@@ -42,6 +43,7 @@ class BillableMetric < ApplicationRecord
   validates :weighted_interval,
             inclusion: { in: WEIGHTED_INTERVAL.values },
             if: :weighted_sum_agg?
+  validates :custom_aggregator, presence: true, if: :custom_agg?
 
   default_scope -> { kept }
 
@@ -94,7 +96,7 @@ class BillableMetric < ApplicationRecord
   private
 
   def should_have_field_name?
-    !count_agg?
+    !count_agg? && !custom_agg?
   end
 
   def validate_recurring

--- a/db/migrate/20240415122310_add_custom_aggregator_to_billable_metrics.rb
+++ b/db/migrate/20240415122310_add_custom_aggregator_to_billable_metrics.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCustomAggregatorToBillableMetrics < ActiveRecord::Migration[7.0]
+  def change
+    add_column :billable_metrics, :custom_aggregator, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_12_085450) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_15_122310) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -151,6 +151,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_12_085450) do
     t.datetime "deleted_at"
     t.boolean "recurring", default: false, null: false
     t.enum "weighted_interval", enum_type: "billable_metric_weighted_interval"
+    t.text "custom_aggregator"
     t.index ["deleted_at"], name: "index_billable_metrics_on_deleted_at"
     t.index ["organization_id", "code"], name: "index_billable_metrics_on_organization_id_and_code", unique: true, where: "(deleted_at IS NULL)"
     t.index ["organization_id"], name: "index_billable_metrics_on_organization_id"
@@ -481,8 +482,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_12_085450) do
     t.bigint "unit_amount_cents", default: 0, null: false
     t.boolean "pay_in_advance", default: false, null: false
     t.decimal "precise_coupons_amount_cents", precision: 30, scale: 5, default: "0.0", null: false
-    t.string "invoice_display_name"
     t.decimal "total_aggregated_units"
+    t.string "invoice_display_name"
     t.decimal "precise_unit_amount", precision: 30, scale: 15, default: "0.0", null: false
     t.jsonb "amount_details", default: {}, null: false
     t.uuid "charge_filter_id"
@@ -714,9 +715,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_12_085450) do
     t.string "tax_identification_number"
     t.integer "net_payment_term", default: 0, null: false
     t.string "default_currency", default: "USD", null: false
-    t.boolean "eu_tax_management", default: false
     t.integer "document_numbering", default: 0, null: false
     t.string "document_number_prefix"
+    t.boolean "eu_tax_management", default: false
     t.boolean "clickhouse_aggregation", default: false, null: false
     t.string "premium_integrations", default: [], null: false, array: true
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -106,6 +106,7 @@ type AdyenProvider {
 
 enum AggregationTypeEnum {
   count_agg
+  custom_agg
   latest_agg
   max_agg
   sum_agg

--- a/schema.graphql
+++ b/schema.graphql
@@ -275,6 +275,7 @@ input ChargeInput {
 }
 
 enum ChargeModelEnum {
+  custom
   graduated
   graduated_percentage
   package

--- a/schema.json
+++ b/schema.json
@@ -2752,6 +2752,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "custom",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/schema.json
+++ b/schema.json
@@ -879,6 +879,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "custom_agg",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/factories/billable_metrics.rb
+++ b/spec/factories/billable_metrics.rb
@@ -40,4 +40,9 @@ FactoryBot.define do
     aggregation_type { 'unique_count_agg' }
     field_name { 'item_id' }
   end
+
+  factory :custom_billable_metric, parent: :billable_metric do
+    aggregation_type { 'custom_agg' }
+    custom_aggreator { 'puts "foo bar"' }
+  end
 end

--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe BillableMetric, type: :model do
   it { is_expected.to have_many(:filters).dependent(:delete_all) }
   it { is_expected.to have_many(:netsuite_mappings).dependent(:destroy) }
 
+  it { validate_presence_of(:field_name) }
+  it { validate_presence_of(:custom_aggregator) }
+
   describe '#aggregation_type=' do
     let(:billable_metric) { described_class.new }
 

--- a/spec/models/charge_spec.rb
+++ b/spec/models/charge_spec.rb
@@ -511,4 +511,17 @@ RSpec.describe Charge, type: :model do
       end
     end
   end
+
+  describe '#validate_custom_model' do
+    subject(:charge) { build(:charge, billable_metric:, charge_model: 'custom') }
+
+    let(:billable_metric) { create(:billable_metric, aggregation_type: :count_agg) }
+
+    it 'returns an error for invalid metric type' do
+      aggregate_failures do
+        expect(charge).not_to be_valid
+        expect(charge.errors.messages[:charge_model]).to include('invalid_aggregation_type_or_charge_model')
+      end
+    end
+  end
 end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -353,6 +353,8 @@ RSpec.describe Fees::ChargeService do
 
       context 'with all types of aggregation' do
         BillableMetric::AGGREGATION_TYPES.keys.each do |aggregation_type|
+          next if aggregation_type.to_sym == :custom_agg # TODO(custom_agg): will be implemented in a next PR
+
           before do
             billable_metric.update!(aggregation_type:, field_name: 'foo_bar', weighted_interval: 'seconds')
           end
@@ -1745,8 +1747,14 @@ RSpec.describe Fees::ChargeService do
   describe '.current_usage' do
     context 'with all types of aggregation' do
       BillableMetric::AGGREGATION_TYPES.keys.each do |aggregation_type|
+        next if aggregation_type.to_sym == :custom_agg # TODO(custom_agg): will be implemented in a next PR
+
         before do
-          billable_metric.update!(aggregation_type:, field_name: 'foo_bar', weighted_interval: 'seconds')
+          billable_metric.update!(
+            aggregation_type:,
+            field_name: 'foo_bar',
+            weighted_interval: 'seconds',
+          )
 
           charge.update!(min_amount_cents: 1000)
         end


### PR DESCRIPTION
## Context

Some of our customers have express a need for aggregation and charge models that does not fit into the current logic in place in Lago, like for example having a single aggregation for 2 different properties, but make the price per unit changing based on the position of the event.

This feature aims to propose a way to build custom aggregation logic for specific cases.

## Description

This PR updates 
- The billable metric model to add:
  - The `custom_agg` aggregation type
  - A new `custom_aggregator` database column
- The charge model to add
  - The `custom` charge model

