### PR TITLE
poc: Add feature flags capability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem 'karafka'
 gem 'valvat', require: false
 
 # Feature flags
-gem 'flipper'
+gem 'flipper', '1.3.0'
 gem 'flipper-redis'
 
 group :development, :test, :staging do

--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,10 @@ gem 'karafka'
 # Taxes
 gem 'valvat', require: false
 
+# Feature flags
+gem 'flipper'
+gem 'flipper-redis'
+
 group :development, :test, :staging do
   gem 'factory_bot_rails'
   gem 'faker'

--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ gem 'valvat', require: false
 # Feature flags
 gem 'flipper'
 gem 'flipper-redis'
+gem 'flipper-ui'
 
 group :development, :test, :staging do
   gem 'factory_bot_rails'

--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,6 @@ gem 'valvat', require: false
 # Feature flags
 gem 'flipper'
 gem 'flipper-redis'
-gem 'flipper-ui'
 
 group :development, :test, :staging do
   gem 'factory_bot_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,11 @@ GEM
     faraday-retry (1.0.3)
     ffi (1.15.5)
     formatador (1.1.0)
+    flipper (1.2.2)
+      concurrent-ruby (< 2)
+    flipper-redis (1.2.2)
+      flipper (~> 1.2.2)
+      redis (>= 3.0, < 6)
     globalid (1.2.1)
       activesupport (>= 6.1)
     gocardless_pro (2.34.0)
@@ -851,6 +856,8 @@ DEPENDENCIES
   dotenv
   factory_bot_rails
   faker
+  flipper
+  flipper-redis
   gocardless_pro (~> 2.34)
   google-cloud-storage
   googleauth (~> 1.11.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,6 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    base64 (0.2.0)
     bcrypt (3.1.18)
     better_html (2.0.2)
       actionview (>= 6.0)
@@ -223,12 +222,6 @@ GEM
     flipper-redis (1.2.2)
       flipper (~> 1.2.2)
       redis (>= 3.0, < 6)
-    flipper-ui (1.2.2)
-      erubi (>= 1.0.0, < 2.0.0)
-      flipper (~> 1.2.2)
-      rack (>= 1.4, < 4)
-      rack-protection (>= 1.5.3, <= 4.0.0)
-      sanitize (< 7)
     globalid (1.2.1)
       activesupport (>= 6.1)
     gocardless_pro (2.34.0)
@@ -608,9 +601,6 @@ GEM
     rack (2.2.8.1)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-protection (3.2.0)
-      base64 (>= 0.1.0)
-      rack (~> 2.2, >= 2.2.4)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.8.1)
@@ -739,9 +729,6 @@ GEM
       sorbet-runtime (>= 0.5.9897)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    sanitize (6.1.0)
-      crass (~> 1.0.2)
-      nokogiri (>= 1.12.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -871,7 +858,6 @@ DEPENDENCIES
   faker
   flipper
   flipper-redis
-  flipper-ui
   gocardless_pro (~> 2.34)
   google-cloud-storage
   googleauth (~> 1.11.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,12 +216,12 @@ GEM
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
     ffi (1.15.5)
-    formatador (1.1.0)
-    flipper (1.2.2)
+    flipper (1.3.0)
       concurrent-ruby (< 2)
-    flipper-redis (1.2.2)
-      flipper (~> 1.2.2)
+    flipper-redis (1.3.0)
+      flipper (~> 1.3.0)
       redis (>= 3.0, < 6)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     gocardless_pro (2.34.0)
@@ -856,7 +856,7 @@ DEPENDENCIES
   dotenv
   factory_bot_rails
   faker
-  flipper
+  flipper (= 1.3.0)
   flipper-redis
   gocardless_pro (~> 2.34)
   google-cloud-storage
@@ -914,4 +914,4 @@ RUBY VERSION
    ruby 3.2.3p157
 
 BUNDLED WITH
-   2.5.5
+   2.5.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.2.0)
     bcrypt (3.1.18)
     better_html (2.0.2)
       actionview (>= 6.0)
@@ -222,6 +223,12 @@ GEM
     flipper-redis (1.2.2)
       flipper (~> 1.2.2)
       redis (>= 3.0, < 6)
+    flipper-ui (1.2.2)
+      erubi (>= 1.0.0, < 2.0.0)
+      flipper (~> 1.2.2)
+      rack (>= 1.4, < 4)
+      rack-protection (>= 1.5.3, <= 4.0.0)
+      sanitize (< 7)
     globalid (1.2.1)
       activesupport (>= 6.1)
     gocardless_pro (2.34.0)
@@ -601,6 +608,9 @@ GEM
     rack (2.2.8.1)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.8.1)
@@ -729,6 +739,9 @@ GEM
       sorbet-runtime (>= 0.5.9897)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    sanitize (6.1.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -858,6 +871,7 @@ DEPENDENCIES
   faker
   flipper
   flipper-redis
+  flipper-ui
   gocardless_pro (~> 2.34)
   google-cloud-storage
   googleauth (~> 1.11.0)

--- a/app/graphql/resolvers/feature_flags_resolver.rb
+++ b/app/graphql/resolvers/feature_flags_resolver.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class FeatureFlagsResolver < GraphQL::Schema::Resolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    description 'Feature flags enabled for the current organization'
+
+    type Types::Invites::Object.collection_type, null: false
+
+    def resolve
+      FeatureFlag::FEATURES.keys.index_with { |name| FeatureFlag.enabled?(name, actor: current_organization) }
+    end
+  end
+end

--- a/app/graphql/types/feature_flag_type.rb
+++ b/app/graphql/types/feature_flag_type.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  class FeatureFlagType < Types::BaseObject
+    description 'Feature Flag Type'
+
+    FeatureFlag::FEATURES.each do |feature, attr|
+      field feature, Boolean, attr[:description], null: false
+    end
+  end
+end

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -4,7 +4,6 @@ class FeatureFlag
   FEATURES = {
     feature1: {
       description: 'Feature 1 description',
-      owner: 'Julien Bourdeau',
     },
   }.with_indifferent_access.freeze
 

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class FeatureFlag
+  FEATURES = {
+    feature1: {
+      description: 'Feature 1 description',
+      owner: 'Julien Bourdeau',
+    },
+  }.with_indifferent_access.freeze
+
+  class << self
+    def enabled?(feature_name, actor: nil)
+      ensure_feature_flag_exists!(feature_name)
+      Flipper.enabled?(feature_name, actor)
+    end
+
+    def disabled?(feature_name, actor: nil)
+      !enabled?(feature_name, actor:)
+    end
+
+    def enable(feature_name, actor: nil)
+      ensure_feature_flag_exists!(feature_name)
+      Flipper.enable(feature_name, actor)
+    end
+
+    def disable(feature_name, actor: nil)
+      ensure_feature_flag_exists!(feature_name)
+      Flipper.disable(feature_name, actor)
+    end
+
+    def sync!
+      found = Flipper.features.inject([]) { |memo, feature| memo << feature.key.to_sym }
+      defined = FEATURES.keys
+
+      (found - defined).each { |name| Flipper.remove(name) }
+      (defined - found).each { |name| Flipper.add(name) }
+    end
+
+    private
+
+    def ensure_feature_flag_exists!(name)
+      return if Rails.env.production?
+
+      raise "Unknown feature flag: #{name}" unless FEATURES.key?(name)
+    end
+  end
+end

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -4,6 +4,7 @@ class FeatureFlag
   FEATURES = {
     feature1: {
       description: 'Feature 1 description',
+      owner: 'Julien Bourdeau',
     },
   }.with_indifferent_access.freeze
 

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'flipper/adapters/redis'
+
+Flipper.configure do |config|
+  config.adapter { Flipper::Adapters::Redis.new(Redis.new(db: 8)) }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,9 @@
 Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq' if defined? Sidekiq::Web
 
+  # The goal is to load this production but we need a good way to restrict access
+  mount Flipper::UI.app(Flipper) => '/flipper' if Rails.env.development?
+
   mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql' if Rails.env.development?
 
   post '/graphql', to: 'graphql#execute'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,6 @@
 Rails.application.routes.draw do
   mount Sidekiq::Web => '/sidekiq' if defined? Sidekiq::Web
 
-  # The goal is to load this production but we need a good way to restrict access
-  mount Flipper::UI.app(Flipper) => '/flipper' if Rails.env.development?
-
   mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql' if Rails.env.development?
 
   post '/graphql', to: 'graphql#execute'

--- a/spec/graphql/types/feature_flag_type_spec.rb
+++ b/spec/graphql/types/feature_flag_type_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::FeatureFlagType do
+  subject(:ff_type) { described_class }
+
+  it { expect(ff_type.fields.keys).to match_array(FeatureFlag::FEATURES.keys) }
+end


### PR DESCRIPTION
## Introduction

This PR adds the ability to use [Feature Flag](https://launchdarkly.com/blog/what-are-feature-flags/). It's been discussed in the team that we will need it at some point. This PR is a POC for discussion. I wanted to show what it takes to add Flipper and what it looks like. I'm open to other solutions if the team doesn't like it.

It adds the [Flipper gem](https://www.flippercloud.io/docs/introduction) to the project with the Redis driver. It doesn't rely on any external services.

Feature flags can be enabled globally or for specific organizations.

### Feature flags, not plan flags

There are really (at least) two kind of "feature flags":

* Feature flags that are temporary to release a feature temporarily. They are enabled progressively but should ultimately be removed. They are managed by admins, the user cannot turn on and off these flags (except if you want to, like for a beta).

* Feature flags that depends on the plan. You can upgrade to high plans to enabled new feature that are gated in lower plans. The users can usually enabled/disable them by changing plan themselves.  In Lago it's `org.premium?` for now.

Note that this is also different from permissions!

In the future we could have things like the following.

```ruby
def can_use_feature_x?(org, user)
  License.premium? && FeatureFlag.enabled?(:x, actor: org) && user.can?('view:x')
end
```

## How to use


In your code, you can check if a flag is enabled for an actor. You can also use the console to enable it.

```ruby
FeatureFlag.enabled? :feature1
# => false

FeatureFlag.disabled? :feature1
# => true

FeatureFlag.enabled? :feature1, actor: organization1
# => true

FeatureFlag.enabled? :feature1, actor: another_org
# => false
```

### In Redis

![CleanShot 2024-04-16 at 10 57 41@2x](https://github.com/getlago/lago-api/assets/1525636/db1a9a48-9445-49b7-9460-6a9bcdd80403)


### Frontend

In GraphQL, you can retrieve an object with all the feature flags and whether they are enabled or not for the current organization.

```js
{
  feature1: true,
  feature2: false
}
```

In a typical SAAS app, we could filter out the disabled flags to keep them secret and not leak them to the frontend but Lago is open source, there is nothing to hide.

## Notes

### Using a hash to define all the feature flags.

Flipper can create feature flags on the fly but I didn't really like it workin with it before, that's why I used a defined hardcoded list and `ensure_feature_flag_exists!` in dev mode.
This allows us to easily type the object in GraphQL and can be added to the documentation.

### `FeatureFlag.sync!`

This method removed or add the flags from Redis based on the definition hash. It should run after deploys, just like `rails db:migrate`.

### Going Further: Add the UI (not part of the POC)

There is a UI where you can add flag to an actor or enable/disable. Today, we don't have a good way to load protected admin tools so the UI is not part of this POC.

We could rely on Rack and basic auth, but I'd rather discuss this seperately.

```ruby
flipper_app = Flipper::UI.app do |builder|
  builder.use Rack::Auth::Basic do |username, password|
    username == ENV['ADMIN_USER'] && password == ENV['ADMIN_PASSWORD']
  end
end
mount flipper_app, at: '/feature-flags'
```

![CleanShot 2024-04-16 at 09 24 32@2x](https://github.com/getlago/lago-api/assets/1525636/31351a9b-0590-4bc4-9f3e-fdbf6c1f3a10)

![CleanShot 2024-04-16 at 09 24 19@2x](https://github.com/getlago/lago-api/assets/1525636/e38d7bf0-b9ef-4467-b671-7ade28aab281)
