### PR TITLE
feat: Add missing fields in Wallet and CreditNote responses

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -109,7 +109,7 @@ module Api
             ::V1::CreditNoteSerializer,
             collection_name: 'credit_notes',
             meta: pagination_metadata(credit_notes),
-            includes: %i[applied_taxes],
+            includes: %i[items applied_taxes],
           ),
         )
       end

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -73,6 +73,7 @@ module Api
             ::V1::WalletSerializer,
             collection_name: 'wallets',
             meta: pagination_metadata(wallets),
+            includes: %i[recurring_transaction_rules],
           ),
         )
       end

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
         expect(response).to have_http_status(:success)
         expect(json[:credit_notes].count).to eq(2)
         expect(json[:credit_notes].first[:lago_id]).to eq(second_credit_note.id)
+        expect(json[:credit_notes].first[:items]).to be_empty
         expect(json[:credit_notes].last[:lago_id]).to eq(credit_note.id)
       end
     end

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -272,6 +272,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
       expect(json[:wallets].count).to eq(1)
       expect(json[:wallets].first[:lago_id]).to eq(wallet.id)
       expect(json[:wallets].first[:name]).to eq(wallet.name)
+      expect(json[:wallets].first[:recurring_transaction_rules]).to be_empty
     end
 
     context 'with pagination' do


### PR DESCRIPTION
The goal of this PR is to add:
- `items` to `CreditNotesController#index`
- `recurring_transaction_rules` to `WalletsController#index`