### PR TITLE
fix(tests): Better date definition for flacky test

### DIFF
--- a/spec/services/subscriptions/free_trial_billing_service_spec.rb
+++ b/spec/services/subscriptions/free_trial_billing_service_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Subscriptions::FreeTrialBillingService, type: :service do
       it 'sets trial_ended_at' do
         customer = create(:customer)
         attr = { customer:, plan:, external_id: 'abc123' }
-        sub = create(:subscription, started_at: 6.days.ago, **attr)
-        started_at = (10.days + 1.hour).ago
+        started_at = timestamp - 10.days - 1.hour
         create(:subscription, started_at:, terminated_at: 6.days.ago, status: :terminated, **attr)
+        sub = create(:subscription, started_at: 6.days.ago, **attr)
 
         expect { service.call }.to change { sub.reload.trial_ended_at }.from(nil).to(sub.trial_end_datetime)
       end


### PR DESCRIPTION
Test was [failing on main](https://github.com/getlago/lago-api/actions/runs/8702243995/job/23865887566).

```
Failures:

  1) Subscriptions::FreeTrialBillingService#call with trial ended due to previous subscription with the same external_id sets trial_ended_at
     Failure/Error: expect { service.call }.to change { sub.reload.trial_ended_at }.from(nil).to(sub.trial_end_datetime)
       expected `sub.reload.trial_ended_at` to have changed from nil to 2024-04-16 07:21:40.129012000 +0000, but did not change
     # ./spec/services/subscriptions/free_trial_billing_service_spec.rb:38:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:31:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:30:in `block (2 levels) in <top (required)>'

Finished in 5 minutes 2 seconds (files took 9.89 seconds to load)
4546 examples, 1 failure
```