### PR TITLE
feat(integrations-resolvers): Add resolvers and queries

### DIFF
--- a/app/graphql/resolvers/integration_collection_mappings/netsuite_collection_mapping_resolver.rb
+++ b/app/graphql/resolvers/integration_collection_mappings/netsuite_collection_mapping_resolver.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module IntegrationCollectionMappings
+    class NetsuiteCollectionMappingResolver < Resolvers::BaseResolver
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      description 'Query a single integration collection mapping'
+
+      argument :id, ID, required: true, description: 'Unique ID of the integration collection mappings'
+
+      type Types::IntegrationCollectionMappings::Netsuite::Object, null: true
+
+      def resolve(id: nil)
+        mapping = ::IntegrationCollectionMappings::NetsuiteCollectionMapping
+          .joins(:integration)
+          .where(id:, integration: { organization: current_organization }).first
+
+        return not_found_error(resource: 'integration_collection_mapping') unless mapping
+
+        mapping
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/integration_collection_mappings/netsuite_collection_mappings_resolver.rb
+++ b/app/graphql/resolvers/integration_collection_mappings/netsuite_collection_mappings_resolver.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module IntegrationCollectionMappings
+    class NetsuiteCollectionMappingsResolver < Resolvers::BaseResolver
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      description 'Query netsuite integration collection mappings'
+
+      argument :integration_id, ID, required: false
+      argument :limit, Integer, required: false
+      argument :mapping_type, String, required: false
+      argument :page, Integer, required: false
+
+      type Types::IntegrationCollectionMappings::Netsuite::Object.collection_type, null: true
+
+      def resolve(page: nil, limit: nil, integration_id: nil, mapping_type: nil)
+        result = ::IntegrationCollectionMappings::NetsuiteCollectionMappingsQuery.call(
+          organization: current_organization,
+          pagination: BaseQuery::Pagination.new(page:, limit:),
+          filters: BaseQuery::Filters.new({ integration_id:, mapping_type: }),
+        )
+
+        result.netsuite_collection_mappings
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/integration_mappings/netsuite_mapping_resolver.rb
+++ b/app/graphql/resolvers/integration_mappings/netsuite_mapping_resolver.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module IntegrationMappings
+    class NetsuiteMappingResolver < Resolvers::BaseResolver
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      description 'Query a single integration mapping'
+
+      argument :id, ID, required: true, description: 'Unique ID of the integration mappings'
+
+      type Types::IntegrationMappings::Netsuite::Object, null: true
+
+      def resolve(id: nil)
+        mapping = ::IntegrationMappings::NetsuiteMapping
+          .joins(:integration)
+          .where(id:, integration: { organization: current_organization }).first
+
+        return not_found_error(resource: 'integration_mapping') unless mapping
+
+        mapping
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/integration_mappings/netsuite_mappings_resolver.rb
+++ b/app/graphql/resolvers/integration_mappings/netsuite_mappings_resolver.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module IntegrationMappings
+    class NetsuiteMappingsResolver < Resolvers::BaseResolver
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      description 'Query netsuite integration mappings'
+
+      argument :integration_id, ID, required: false
+      argument :limit, Integer, required: false
+      argument :mappable_type, String, required: false
+      argument :page, Integer, required: false
+
+      type Types::IntegrationMappings::Netsuite::Object.collection_type, null: true
+
+      def resolve(page: nil, limit: nil, integration_id: nil, mappable_type: nil)
+        result = ::IntegrationMappings::NetsuiteMappingsQuery.call(
+          organization: current_organization,
+          pagination: BaseQuery::Pagination.new(page:, limit:),
+          filters: BaseQuery::Filters.new({ integration_id:, mappable_type: }),
+        )
+
+        result.netsuite_mappings
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -40,6 +40,12 @@ module Types
     field :invoices, resolver: Resolvers::InvoicesResolver
     field :memberships, resolver: Resolvers::MembershipsResolver
     field :mrrs, resolver: Resolvers::Analytics::MrrsResolver
+    field :netsuite_collection_mapping,
+          resolver: Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappingResolver
+    field :netsuite_collection_mappings,
+          resolver: Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappingsResolver
+    field :netsuite_mapping, resolver: Resolvers::IntegrationMappings::NetsuiteMappingResolver
+    field :netsuite_mappings, resolver: Resolvers::IntegrationMappings::NetsuiteMappingsResolver
     field :organization, resolver: Resolvers::OrganizationResolver
     field :password_reset, resolver: Resolvers::PasswordResetResolver
     field :payment_provider, resolver: Resolvers::PaymentProviderResolver

--- a/app/queries/integration_collection_mappings/netsuite_collection_mappings_query.rb
+++ b/app/queries/integration_collection_mappings/netsuite_collection_mappings_query.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module IntegrationCollectionMappings
+  class NetsuiteCollectionMappingsQuery < BaseQuery
+    def call
+      netsuite_collection_mappings = paginate(base_scope)
+      netsuite_collection_mappings = netsuite_collection_mappings.order(created_at: :desc)
+
+      netsuite_collection_mappings = with_integration_id(netsuite_collection_mappings) if filters.integration_id
+      netsuite_collection_mappings = with_mapping_type(netsuite_collection_mappings) if filters.mapping_type
+
+      result.netsuite_collection_mappings = netsuite_collection_mappings
+      result
+    end
+
+    private
+
+    def base_scope
+      ::IntegrationCollectionMappings::NetsuiteCollectionMapping
+        .joins(:integration).where(integration: { organization: })
+    end
+
+    def with_integration_id(scope)
+      scope.where(integration_id: filters.integration_id)
+    end
+
+    def with_mapping_type(scope)
+      scope.where(mapping_type: filters.mapping_type)
+    end
+  end
+end

--- a/app/queries/integration_mappings/netsuite_mappings_query.rb
+++ b/app/queries/integration_mappings/netsuite_mappings_query.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module IntegrationMappings
+  class NetsuiteMappingsQuery < BaseQuery
+    def call
+      netsuite_mappings = paginate(base_scope)
+      netsuite_mappings = netsuite_mappings.order(created_at: :desc)
+
+      netsuite_mappings = with_integration_id(netsuite_mappings) if filters.integration_id
+      netsuite_mappings = with_mappable_type(netsuite_mappings) if filters.mappable_type
+
+      result.netsuite_mappings = netsuite_mappings
+      result
+    end
+
+    private
+
+    def base_scope
+      ::IntegrationMappings::NetsuiteMapping.joins(:integration).where(integration: { organization: })
+    end
+
+    def with_integration_id(scope)
+      scope.where(integration_id: filters.integration_id)
+    end
+
+    def with_mappable_type(scope)
+      scope.where(mappable_type: filters.mappable_type)
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4455,6 +4455,20 @@ type Mutation {
   ): Invoice
 }
 
+type NetsuiteCollectionMapping {
+  id: ID!
+  integrationId: ID!
+  mappingType: NetsuiteMappingTypeEnum!
+  netsuiteAccountCode: String!
+  netsuiteId: String!
+  netsuiteName: String
+}
+
+type NetsuiteCollectionMappingCollection {
+  collection: [NetsuiteCollectionMapping!]!
+  metadata: CollectionMetadata!
+}
+
 type NetsuiteIntegration {
   accountId: String
   clientId: String
@@ -4467,6 +4481,35 @@ type NetsuiteIntegration {
   syncInvoices: Boolean
   syncPayments: Boolean
   syncSalesOrders: Boolean
+}
+
+enum NetsuiteMappableTypeEnum {
+  AddOn
+  BillableMetric
+}
+
+type NetsuiteMapping {
+  id: ID!
+  integrationId: ID!
+  mappableId: ID!
+  mappableType: NetsuiteMappableTypeEnum!
+  netsuiteAccountCode: String!
+  netsuiteId: String!
+  netsuiteName: String
+}
+
+type NetsuiteMappingCollection {
+  collection: [NetsuiteMapping!]!
+  metadata: CollectionMetadata!
+}
+
+enum NetsuiteMappingTypeEnum {
+  coupon
+  fallback_item
+  minimum_commitment
+  prepaid_credit
+  subscription_fee
+  tax
 }
 
 type OktaIntegration {
@@ -4935,6 +4978,36 @@ type Query {
   Query MRR of an organization
   """
   mrrs(currency: CurrencyEnum): MrrCollection!
+
+  """
+  Query a single integration collection mapping
+  """
+  netsuiteCollectionMapping(
+    """
+    Unique ID of the integration collection mappings
+    """
+    id: ID!
+  ): NetsuiteCollectionMapping
+
+  """
+  Query netsuite integration collection mappings
+  """
+  netsuiteCollectionMappings(integrationId: ID, limit: Int, mappingType: String, page: Int): NetsuiteCollectionMappingCollection
+
+  """
+  Query a single integration mapping
+  """
+  netsuiteMapping(
+    """
+    Unique ID of the integration mappings
+    """
+    id: ID!
+  ): NetsuiteMapping
+
+  """
+  Query netsuite integration mappings
+  """
+  netsuiteMappings(integrationId: ID, limit: Int, mappableType: String, page: Int): NetsuiteMappingCollection
 
   """
   Query the current organization

--- a/schema.json
+++ b/schema.json
@@ -19975,6 +19975,180 @@
         },
         {
           "kind": "OBJECT",
+          "name": "NetsuiteCollectionMapping",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "integrationId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "mappingType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "NetsuiteMappingTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "netsuiteAccountCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "netsuiteId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "netsuiteName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "NetsuiteCollectionMappingCollection",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "NetsuiteCollectionMapping",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "NetsuiteIntegration",
           "description": null,
           "interfaces": [
@@ -20151,6 +20325,268 @@
           ],
           "inputFields": null,
           "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "NetsuiteMappableTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "AddOn",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BillableMetric",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "NetsuiteMapping",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "integrationId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "mappableId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "mappableType",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "NetsuiteMappableTypeEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "netsuiteAccountCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "netsuiteId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "netsuiteName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "NetsuiteMappingCollection",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "NetsuiteMapping",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "NetsuiteMappingTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "fallback_item",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "coupon",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscription_fee",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minimum_commitment",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tax",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "prepaid_credit",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
         },
         {
           "kind": "OBJECT",
@@ -23842,6 +24278,186 @@
                   "type": {
                     "kind": "ENUM",
                     "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "netsuiteCollectionMapping",
+              "description": "Query a single integration collection mapping",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NetsuiteCollectionMapping",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Unique ID of the integration collection mappings",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "netsuiteCollectionMappings",
+              "description": "Query netsuite integration collection mappings",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NetsuiteCollectionMappingCollection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "integrationId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "mappingType",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "netsuiteMapping",
+              "description": "Query a single integration mapping",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NetsuiteMapping",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Unique ID of the integration mappings",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "netsuiteMappings",
+              "description": "Query netsuite integration mappings",
+              "type": {
+                "kind": "OBJECT",
+                "name": "NetsuiteMappingCollection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "integrationId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "mappableType",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/spec/graphql/resolvers/integration_collection_mappings/netsuite_collection_mapping_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_collection_mappings/netsuite_collection_mapping_resolver_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappingResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($netsuiteCollectionMappingId: ID!) {
+        netsuiteCollectionMapping(id: $netsuiteCollectionMappingId) {
+          id
+          mappingType
+          netsuiteId
+          netsuiteAccountCode
+          netsuiteName
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:netsuite_collection_mapping) { create(:netsuite_collection_mapping, integration:) }
+
+  before do
+    netsuite_collection_mapping
+  end
+
+  it 'returns a single integration collection mapping' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+      variables: { netsuiteCollectionMappingId: netsuite_collection_mapping.id },
+    )
+
+    integration_mapping_response = result['data']['netsuiteCollectionMapping']
+
+    aggregate_failures do
+      expect(integration_mapping_response['id']).to eq(netsuite_collection_mapping.id)
+      expect(integration_mapping_response['mappingType']).to eq(netsuite_collection_mapping.mapping_type)
+      expect(integration_mapping_response['netsuiteId']).to eq(netsuite_collection_mapping.netsuite_id)
+      expect(integration_mapping_response['netsuiteName']).to eq(netsuite_collection_mapping.netsuite_name)
+      expect(integration_mapping_response['netsuiteAccountCode'])
+        .to eq(netsuite_collection_mapping.netsuite_account_code)
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query:,
+        variables: { netsuiteCollectionMappingId: netsuite_collection_mapping.id },
+      )
+
+      expect_graphql_error(
+        result:,
+        message: 'Missing organization id',
+      )
+    end
+  end
+
+  context 'when integration mapping is not found' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: { netsuiteCollectionMappingId: '123456' },
+      )
+
+      expect_graphql_error(
+        result:,
+        message: 'Resource not found',
+      )
+    end
+  end
+end

--- a/spec/graphql/resolvers/integration_collection_mappings/netsuite_collection_mappings_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_collection_mappings/netsuite_collection_mappings_resolver_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappingsResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query {
+        netsuiteCollectionMappings(limit: 5) {
+          collection { id }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:netsuite_collection_mapping) { create(:netsuite_collection_mapping, integration:) }
+
+  before { netsuite_collection_mapping }
+
+  it 'returns a list of netsuite mappings' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+    )
+
+    netsuite_collection_mappings_response = result['data']['netsuiteCollectionMappings']
+
+    aggregate_failures do
+      expect(netsuite_collection_mappings_response['collection'].count).to eq(1)
+      expect(netsuite_collection_mappings_response['collection'].first['id']).to eq(netsuite_collection_mapping.id)
+
+      expect(netsuite_collection_mappings_response['metadata']['currentPage']).to eq(1)
+      expect(netsuite_collection_mappings_response['metadata']['totalCount']).to eq(1)
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query:,
+      )
+
+      expect_graphql_error(
+        result:,
+        message: 'Missing organization id',
+      )
+    end
+  end
+end

--- a/spec/graphql/resolvers/integration_mappings/netsuite_mapping_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_mappings/netsuite_mapping_resolver_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::IntegrationMappings::NetsuiteMappingResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($netsuiteMappingId: ID!) {
+        netsuiteMapping(id: $netsuiteMappingId) {
+          id
+          mappableId
+          mappableType
+          netsuiteId
+          netsuiteAccountCode
+          netsuiteName
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:netsuite_mapping) { create(:netsuite_mapping, integration:) }
+
+  before do
+    netsuite_mapping
+  end
+
+  it 'returns a single integration mapping' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+      variables: { netsuiteMappingId: netsuite_mapping.id },
+    )
+
+    integration_mapping_response = result['data']['netsuiteMapping']
+
+    aggregate_failures do
+      expect(integration_mapping_response['id']).to eq(netsuite_mapping.id)
+      expect(integration_mapping_response['mappableId']).to eq(netsuite_mapping.mappable_id)
+      expect(integration_mapping_response['mappableType']).to eq(netsuite_mapping.mappable_type)
+      expect(integration_mapping_response['netsuiteId']).to eq(netsuite_mapping.netsuite_id)
+      expect(integration_mapping_response['netsuiteName']).to eq(netsuite_mapping.netsuite_name)
+      expect(integration_mapping_response['netsuiteAccountCode'])
+        .to eq(netsuite_mapping.netsuite_account_code)
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query:,
+        variables: { netsuiteMappingId: netsuite_mapping.id },
+      )
+
+      expect_graphql_error(
+        result:,
+        message: 'Missing organization id',
+      )
+    end
+  end
+
+  context 'when integration mapping is not found' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        query:,
+        variables: { netsuiteMappingId: '123456' },
+      )
+
+      expect_graphql_error(
+        result:,
+        message: 'Resource not found',
+      )
+    end
+  end
+end

--- a/spec/graphql/resolvers/integration_mappings/netsuite_mappings_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_mappings/netsuite_mappings_resolver_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::IntegrationMappings::NetsuiteMappingsResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query {
+        netsuiteMappings(limit: 5) {
+          collection { id }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:netsuite_mapping) { create(:netsuite_mapping, integration:) }
+
+  before { netsuite_mapping }
+
+  it 'returns a list of netsuite mappings' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+    )
+
+    netsuite_mappings_response = result['data']['netsuiteMappings']
+
+    aggregate_failures do
+      expect(netsuite_mappings_response['collection'].count).to eq(1)
+      expect(netsuite_mappings_response['collection'].first['id']).to eq(netsuite_mapping.id)
+
+      expect(netsuite_mappings_response['metadata']['currentPage']).to eq(1)
+      expect(netsuite_mappings_response['metadata']['totalCount']).to eq(1)
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query:,
+      )
+
+      expect_graphql_error(
+        result:,
+        message: 'Missing organization id',
+      )
+    end
+  end
+end

--- a/spec/queries/integration_collection_mappings/netsuite_collection_mappings_query_spec.rb
+++ b/spec/queries/integration_collection_mappings/netsuite_collection_mappings_query_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationCollectionMappings::NetsuiteCollectionMappingsQuery, type: :query do
+  subject(:netsuite_collection_mappings_query) { described_class.new(organization:, pagination:, filters:) }
+
+  let(:pagination) { BaseQuery::Pagination.new }
+  let(:filters) { BaseQuery::Filters.new(query_filters) }
+  let(:query_filters) { {} }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:integration_second) { create(:netsuite_integration, organization:) }
+  let(:integration_third) { create(:netsuite_integration) }
+
+  let(:netsuite_collection_mapping_first) do
+    create(:netsuite_collection_mapping, integration:, mapping_type: :fallback_item)
+  end
+
+  let(:netsuite_collection_mapping_second) { create(:netsuite_collection_mapping, integration:, mapping_type: :coupon) }
+
+  let(:netsuite_collection_mapping_third) do
+    create(:netsuite_collection_mapping, integration: integration_second, mapping_type: :subscription_fee)
+  end
+
+  let(:netsuite_collection_mapping_fourth) do
+    create(:netsuite_collection_mapping, integration: integration_third, mapping_type: :minimum_commitment)
+  end
+
+  before do
+    netsuite_collection_mapping_first
+    netsuite_collection_mapping_second
+    netsuite_collection_mapping_third
+    netsuite_collection_mapping_fourth
+  end
+
+  context 'when filters are empty' do
+    it 'returns all netsuite mappings' do
+      result = netsuite_collection_mappings_query.call
+
+      returned_ids = result.netsuite_collection_mappings.pluck(:id)
+
+      aggregate_failures do
+        expect(result.netsuite_collection_mappings.count).to eq(3)
+        expect(returned_ids).to include(netsuite_collection_mapping_first.id)
+        expect(returned_ids).to include(netsuite_collection_mapping_second.id)
+        expect(returned_ids).to include(netsuite_collection_mapping_third.id)
+        expect(returned_ids).not_to include(netsuite_collection_mapping_fourth.id)
+      end
+    end
+  end
+
+  context 'when filtering by integration id' do
+    let(:query_filters) { { integration_id: integration.id } }
+
+    it 'returns two netsuite mappings' do
+      result = netsuite_collection_mappings_query.call
+
+      returned_ids = result.netsuite_collection_mappings.pluck(:id)
+
+      aggregate_failures do
+        expect(result.netsuite_collection_mappings.count).to eq(2)
+        expect(returned_ids).to include(netsuite_collection_mapping_first.id)
+        expect(returned_ids).to include(netsuite_collection_mapping_second.id)
+        expect(returned_ids).not_to include(netsuite_collection_mapping_third.id)
+        expect(returned_ids).not_to include(netsuite_collection_mapping_fourth.id)
+      end
+    end
+  end
+
+  context 'when filtering by mapping type' do
+    let(:query_filters) { { mapping_type: 'fallback_item' } }
+
+    it 'returns one netsuite mappings' do
+      result = netsuite_collection_mappings_query.call
+
+      returned_ids = result.netsuite_collection_mappings.pluck(:id)
+
+      aggregate_failures do
+        expect(result.netsuite_collection_mappings.count).to eq(1)
+        expect(returned_ids).to include(netsuite_collection_mapping_first.id)
+        expect(returned_ids).not_to include(netsuite_collection_mapping_second.id)
+        expect(returned_ids).not_to include(netsuite_collection_mapping_third.id)
+        expect(returned_ids).not_to include(netsuite_collection_mapping_fourth.id)
+      end
+    end
+  end
+end

--- a/spec/queries/integration_mappings/netsuite_mappings_query_spec.rb
+++ b/spec/queries/integration_mappings/netsuite_mappings_query_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationMappings::NetsuiteMappingsQuery, type: :query do
+  subject(:netsuite_mappings_query) { described_class.new(organization:, pagination:, filters:) }
+
+  let(:pagination) { BaseQuery::Pagination.new }
+  let(:filters) { BaseQuery::Filters.new(query_filters) }
+  let(:query_filters) { {} }
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:integration_second) { create(:netsuite_integration, organization:) }
+  let(:integration_third) { create(:netsuite_integration) }
+
+  let(:netsuite_mapping_first) { create(:netsuite_mapping, integration:) }
+  let(:netsuite_mapping_second) { create(:netsuite_mapping, integration:, mappable:) }
+  let(:netsuite_mapping_third) { create(:netsuite_mapping, integration: integration_second) }
+  let(:netsuite_mapping_fourth) { create(:netsuite_mapping, integration: integration_third) }
+
+  let(:mappable) { create(:billable_metric, organization:) }
+
+  before do
+    netsuite_mapping_first
+    netsuite_mapping_second
+    netsuite_mapping_third
+    netsuite_mapping_fourth
+  end
+
+  context 'when filters are empty' do
+    it 'returns all netsuite mappings' do
+      result = netsuite_mappings_query.call
+
+      returned_ids = result.netsuite_mappings.pluck(:id)
+
+      aggregate_failures do
+        expect(result.netsuite_mappings.count).to eq(3)
+        expect(returned_ids).to include(netsuite_mapping_first.id)
+        expect(returned_ids).to include(netsuite_mapping_second.id)
+        expect(returned_ids).to include(netsuite_mapping_third.id)
+        expect(returned_ids).not_to include(netsuite_mapping_fourth.id)
+      end
+    end
+  end
+
+  context 'when filtering by integration id' do
+    let(:query_filters) { { integration_id: integration.id } }
+
+    it 'returns two netsuite mappings' do
+      result = netsuite_mappings_query.call
+
+      returned_ids = result.netsuite_mappings.pluck(:id)
+
+      aggregate_failures do
+        expect(result.netsuite_mappings.count).to eq(2)
+        expect(returned_ids).to include(netsuite_mapping_first.id)
+        expect(returned_ids).to include(netsuite_mapping_second.id)
+        expect(returned_ids).not_to include(netsuite_mapping_third.id)
+        expect(returned_ids).not_to include(netsuite_mapping_fourth.id)
+      end
+    end
+  end
+
+  context 'when filtering by mappable type' do
+    let(:query_filters) { { mappable_type: 'BillableMetric' } }
+
+    it 'returns one netsuite mappings' do
+      result = netsuite_mappings_query.call
+
+      returned_ids = result.netsuite_mappings.pluck(:id)
+
+      aggregate_failures do
+        expect(result.netsuite_mappings.count).to eq(1)
+        expect(returned_ids).not_to include(netsuite_mapping_first.id)
+        expect(returned_ids).to include(netsuite_mapping_second.id)
+        expect(returned_ids).not_to include(netsuite_mapping_third.id)
+        expect(returned_ids).not_to include(netsuite_mapping_fourth.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations.

## Description

This Pull request adds queries and GraphQL resolvers needed for Netsuite integration mappings.
