### PR TITLE
feat(custom_agg): Whitelist custom_properties in charge properties

### DIFF
--- a/app/graphql/types/charges/properties.rb
+++ b/app/graphql/types/charges/properties.rb
@@ -27,6 +27,9 @@ module Types
 
       # NOTE: Volume charge model
       field :volume_ranges, [Types::Charges::VolumeRange], null: true
+
+      # NOTE: properties for the custom aggregation
+      field :custom_properties, GraphQL::Types::JSON, null: true
     end
   end
 end

--- a/app/graphql/types/charges/properties_input.rb
+++ b/app/graphql/types/charges/properties_input.rb
@@ -27,6 +27,9 @@ module Types
 
       # NOTE: Volume charge model
       argument :volume_ranges, [Types::Charges::VolumeRangeInput], required: false
+
+      # NOTE: properties for the custom aggregation
+      argument :custom_properties, GraphQL::Types::JSON, required: false
     end
   end
 end

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -87,7 +87,7 @@ module Plans
 
       properties = args[:properties].presence || Charges::BuildDefaultPropertiesService.call(charge_model(args))
       charge.properties = Charges::FilterChargeModelPropertiesService.call(
-        charge_model: charge.charge_model,
+        charge:,
         properties:,
       ).properties
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -83,7 +83,7 @@ module Plans
 
       properties = params[:properties].presence || Charges::BuildDefaultPropertiesService.call(charge.charge_model)
       charge.properties = Charges::FilterChargeModelPropertiesService.call(
-        charge_model: charge.charge_model,
+        charge:,
         properties:,
       ).properties
 
@@ -171,7 +171,7 @@ module Plans
           charge.update!(
             invoice_display_name: payload_charge[:invoice_display_name],
             properties: Charges::FilterChargeModelPropertiesService.call(
-              charge_model: charge.charge_model,
+              charge:,
               properties:,
             ).properties,
           )
@@ -208,7 +208,7 @@ module Plans
     def sanitize_charges(plan, args_charges, created_charges_ids)
       args_charges_ids = args_charges.map { |c| c[:id] }.compact
       charges_ids = plan.charges.pluck(:id) - args_charges_ids - created_charges_ids
-      plan.charges.where(id: charges_ids).each { |charge| discard_charge!(charge) }
+      plan.charges.where(id: charges_ids).find_each { |charge| discard_charge!(charge) }
     end
 
     def discard_charge!(charge)

--- a/schema.graphql
+++ b/schema.graphql
@@ -4637,6 +4637,7 @@ input PlanOverridesInput {
 
 type Properties {
   amount: String
+  customProperties: JSON
   fixedAmount: String
   freeUnits: BigInt
   freeUnitsPerEvents: BigInt
@@ -4653,6 +4654,7 @@ type Properties {
 
 input PropertiesInput {
   amount: String
+  customProperties: JSON
   fixedAmount: String
   freeUnits: BigInt
   freeUnitsPerEvents: BigInt

--- a/schema.json
+++ b/schema.json
@@ -21984,6 +21984,20 @@
               ]
             },
             {
+              "name": "customProperties",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "fixedAmount",
               "description": null,
               "type": {
@@ -22378,6 +22392,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customProperties",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/types/charges/properties_input_spec.rb
+++ b/spec/graphql/types/charges/properties_input_spec.rb
@@ -23,4 +23,6 @@ RSpec.describe Types::Charges::PropertiesInput do
   it { is_expected.to accept_argument(:rate).of_type('String') }
 
   it { is_expected.to accept_argument(:volume_ranges).of_type('[VolumeRangeInput!]') }
+
+  it { is_expected.to accept_argument(:custom_properties).of_type('JSON') }
 end

--- a/spec/graphql/types/charges/properties_spec.rb
+++ b/spec/graphql/types/charges/properties_spec.rb
@@ -23,4 +23,6 @@ RSpec.describe Types::Charges::Properties do
   it { is_expected.to have_field(:rate).of_type('String') }
 
   it { is_expected.to have_field(:volume_ranges).of_type('[VolumeRange!]') }
+
+  it { is_expected.to have_field(:custom_properties).of_type('JSON') }
 end

--- a/spec/services/charges/filter_charge_model_properties_service_spec.rb
+++ b/spec/services/charges/filter_charge_model_properties_service_spec.rb
@@ -3,9 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe Charges::FilterChargeModelPropertiesService, type: :service do
-  subject(:filter_servier) { described_class.new(charge_model:, properties:) }
+  subject(:filter_service) { described_class.new(charge:, properties:) }
 
   let(:charge_model) { nil }
+  let(:billable_metric) { build(:billable_metric) }
+  let(:charge) { build(:charge, charge_model:, billable_metric:) }
+
   let(:properties) do
     {
       amount: 100,
@@ -21,51 +24,52 @@ RSpec.describe Charges::FilterChargeModelPropertiesService, type: :service do
       per_transaction_max_amount: 100,
       per_transaction_min_amount: 10,
       volume_ranges: [{ from_value: 0, to_value: 100, per_unit_amount: '2', flat_amount: '1' }],
+      custom_properties: { rate: '20' },
     }
   end
 
   describe '#call' do
     context 'without charge_model' do
       it 'returns empty hash' do
-        expect(filter_servier.call.properties).to eq({})
+        expect(filter_service.call.properties).to eq({})
       end
     end
 
     context 'with standard charge_model' do
       let(:charge_model) { 'standard' }
 
-      it { expect(filter_servier.call.properties.keys).to include('amount', 'grouped_by') }
+      it { expect(filter_service.call.properties.keys).to include('amount', 'grouped_by') }
 
       context 'when grouped_by contains empty string' do
         let(:properties) { { amount: 100, grouped_by: ['', ''] } }
 
-        it { expect(filter_servier.call.properties[:grouped_by]).to be_empty }
+        it { expect(filter_service.call.properties[:grouped_by]).to be_empty }
       end
     end
 
     context 'with graduated charge_model' do
       let(:charge_model) { 'graduated' }
 
-      it { expect(filter_servier.call.properties.keys).to include('graduated_ranges') }
+      it { expect(filter_service.call.properties.keys).to include('graduated_ranges') }
     end
 
     context 'with graduated_percentage charge_model' do
       let(:charge_model) { 'graduated_percentage' }
 
-      it { expect(filter_servier.call.properties.keys).to include('graduated_percentage_ranges') }
+      it { expect(filter_service.call.properties.keys).to include('graduated_percentage_ranges') }
     end
 
     context 'with package charge_model' do
       let(:charge_model) { 'package' }
 
-      it { expect(filter_servier.call.properties.keys).to include('amount', 'free_units', 'package_size') }
+      it { expect(filter_service.call.properties.keys).to include('amount', 'free_units', 'package_size') }
     end
 
     context 'with percentage charge_model' do
       let(:charge_model) { 'percentage' }
 
       it do
-        expect(filter_servier.call.properties.keys).to include(
+        expect(filter_service.call.properties.keys).to include(
           'rate',
           'fixed_amount',
           'free_units_per_events',
@@ -79,7 +83,13 @@ RSpec.describe Charges::FilterChargeModelPropertiesService, type: :service do
     context 'with volume charge_model' do
       let(:charge_model) { 'volume' }
 
-      it { expect(filter_servier.call.properties.keys).to include('volume_ranges') }
+      it { expect(filter_service.call.properties.keys).to include('volume_ranges') }
+    end
+
+    context 'with custom billable metric' do
+      let(:billable_metric) { build(:custom_billable_metric) }
+
+      it { expect(filter_service.call.properties.keys).to include('custom_properties') }
     end
   end
 end


### PR DESCRIPTION
## Context

Some of our customers have express a need for aggregation and charge models that does not fit into the current logic in place in Lago, like for example having a single aggregation for 2 different properties, but make the price per unit changing based on the position of the event.

This feature aims to propose a way to build custom aggregation logic for specific cases.

## Description

This PR adds the whitelisting logic for `custom_properties` in the `charge#properties` object and updates the GraphQL type to expose this field

