### PR TITLE
feat(accounting-integrations): Send restlet endpoint to nango

### DIFF
--- a/app/jobs/integrations/aggregator/send_restlet_endpoint_job.rb
+++ b/app/jobs/integrations/aggregator/send_restlet_endpoint_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class SendRestletEndpointJob < ApplicationJob
+      queue_as 'integrations'
+
+      retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
+
+      def perform(integration:)
+        result = Integrations::Aggregator::SendRestletEndpointService.call(integration:)
+        result.raise_if_error!
+      end
+    end
+  end
+end

--- a/app/services/integrations/aggregator/send_restlet_endpoint_service.rb
+++ b/app/services/integrations/aggregator/send_restlet_endpoint_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class SendRestletEndpointService < BaseService
+      def action_path
+        "connection/#{integration.connection_id}/metadata"
+      end
+
+      def call
+        return unless integration.type == 'Integrations::NetsuiteIntegration'
+
+        payload = {
+          restletEndpoint: integration.script_endpoint_url,
+        }
+
+        response = http_client.post_with_response(payload, headers)
+        result.response = response
+
+        result
+      end
+
+      private
+
+      def headers
+        {
+          'Provider-Config-Key' => 'netsuite',
+          'Authorization' => "Bearer #{secret_key}",
+        }
+      end
+    end
+  end
+end

--- a/app/services/integrations/netsuite/create_service.rb
+++ b/app/services/integrations/netsuite/create_service.rb
@@ -28,7 +28,7 @@ module Integrations
 
         integration.save!
 
-        Integrations::Aggregator::PerformSyncJob.perform_later(integration:)
+        Integrations::Aggregator::SendRestletEndpointJob.perform_later(integration:)
 
         result.integration = integration
         result

--- a/app/services/integrations/netsuite/create_service.rb
+++ b/app/services/integrations/netsuite/create_service.rb
@@ -28,7 +28,9 @@ module Integrations
 
         integration.save!
 
-        Integrations::Aggregator::SendRestletEndpointJob.perform_later(integration:)
+        if integration.type == 'Integrations::NetsuiteIntegration'
+          Integrations::Aggregator::SendRestletEndpointJob.perform_later(integration:)
+        end
 
         result.integration = integration
         result

--- a/app/services/integrations/netsuite/update_service.rb
+++ b/app/services/integrations/netsuite/update_service.rb
@@ -29,7 +29,7 @@ module Integrations
 
         integration.save!
 
-        if integration.script_endpoint_url && integration.script_endpoint_url != old_script_url
+        if integration.type == 'Integrations::NetsuiteIntegration'  && integration.script_endpoint_url != old_script_url
           Integrations::Aggregator::SendRestletEndpointJob.perform_later(integration:)
         end
 

--- a/app/services/integrations/netsuite/update_service.rb
+++ b/app/services/integrations/netsuite/update_service.rb
@@ -29,7 +29,7 @@ module Integrations
 
         integration.save!
 
-        if integration.type == 'Integrations::NetsuiteIntegration'  && integration.script_endpoint_url != old_script_url
+        if integration.type == 'Integrations::NetsuiteIntegration' && integration.script_endpoint_url != old_script_url
           Integrations::Aggregator::SendRestletEndpointJob.perform_later(integration:)
         end
 

--- a/app/services/integrations/netsuite/update_service.rb
+++ b/app/services/integrations/netsuite/update_service.rb
@@ -17,6 +17,8 @@ module Integrations
           return result.not_allowed_failure!(code: 'premium_integration_missing')
         end
 
+        old_script_url = integration.script_endpoint_url
+
         integration.name = params[:name] if params.key?(:name)
         integration.code = params[:code] if params.key?(:code)
         integration.script_endpoint_url = params[:script_endpoint_url] if params.key?(:script_endpoint_url)
@@ -26,6 +28,10 @@ module Integrations
         integration.sync_sales_orders = params[:sync_sales_orders] if params.key?(:sync_sales_orders)
 
         integration.save!
+
+        if integration.script_endpoint_url && integration.script_endpoint_url != old_script_url
+          Integrations::Aggregator::SendRestletEndpointJob.perform_later(integration:)
+        end
 
         result.integration = integration
         result

--- a/spec/jobs/integrations/aggregator/send_restlet_endpoint_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/send_restlet_endpoint_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::SendRestletEndpointJob, type: :job do
+  subject(:send_endpoint_job) { described_class }
+
+  let(:send_endpoint_service) { instance_double(Integrations::Aggregator::SendRestletEndpointService) }
+  let(:integration) { create(:netsuite_integration) }
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(Integrations::Aggregator::SendRestletEndpointService).to receive(:new).and_return(send_endpoint_service)
+    allow(send_endpoint_service).to receive(:call).and_return(result)
+  end
+
+  it 'sends restlet url to the aggregator' do
+    described_class.perform_now(integration:)
+
+    expect(Integrations::Aggregator::SendRestletEndpointService).to have_received(:new)
+    expect(send_endpoint_service).to have_received(:call)
+  end
+end

--- a/spec/services/integrations/aggregator/send_restlet_endpoint_service_spec.rb
+++ b/spec/services/integrations/aggregator/send_restlet_endpoint_service_spec.rb
@@ -21,13 +21,15 @@ RSpec.describe Integrations::Aggregator::SendRestletEndpointService do
       integration.save!
     end
 
-    it 'successfully calls sync endpoint' do
+    it 'successfully sends restlet endpoint' do
       send_restlet_endpoint_service.call
 
-      expect(LagoHttpClient::Client).to have_received(:new)
-        .with(endpoint)
-      expect(lago_client).to have_received(:post_with_response) do |payload|
-        expect(payload[:restletEndpoint]).to eq('https://example.com')
+      aggregate_failures do
+        expect(LagoHttpClient::Client).to have_received(:new)
+          .with(endpoint)
+        expect(lago_client).to have_received(:post_with_response) do |payload|
+          expect(payload[:restletEndpoint]).to eq('https://example.com')
+        end
       end
     end
   end

--- a/spec/services/integrations/aggregator/send_restlet_endpoint_service_spec.rb
+++ b/spec/services/integrations/aggregator/send_restlet_endpoint_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::SendRestletEndpointService do
+  subject(:send_restlet_endpoint_service) { described_class.new(integration:) }
+
+  let(:integration) { create(:netsuite_integration) }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { "https://api.nango.dev/connection/#{integration.connection_id}/metadata" }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(endpoint)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response)
+
+      integration.script_endpoint_url = 'https://example.com'
+      integration.save!
+    end
+
+    it 'successfully calls sync endpoint' do
+      send_restlet_endpoint_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(endpoint)
+      expect(lago_client).to have_received(:post_with_response) do |payload|
+        expect(payload[:restletEndpoint]).to eq('https://example.com')
+      end
+    end
+  end
+end

--- a/spec/services/integrations/netsuite/create_service_spec.rb
+++ b/spec/services/integrations/netsuite/create_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Integrations::Netsuite::CreateService, type: :service do
       context 'with netsuite premium integration present' do
         before do
           organization.update!(premium_integrations: ['netsuite'])
-          allow(Integrations::Aggregator::PerformSyncJob).to receive(:perform_later)
+          allow(Integrations::Aggregator::SendRestletEndpointJob).to receive(:perform_later)
         end
 
         context 'without validation errors' do

--- a/spec/services/integrations/netsuite/create_service_spec.rb
+++ b/spec/services/integrations/netsuite/create_service_spec.rb
@@ -70,11 +70,11 @@ RSpec.describe Integrations::Netsuite::CreateService, type: :service do
             expect(integration.script_endpoint_url).to eq(script_endpoint_url)
           end
 
-          it 'calls Integrations::Aggregator::PerformSyncJob' do
+          it 'calls Integrations::Aggregator::SendRestletEndpointJob' do
             service_call
 
             integration = Integrations::NetsuiteIntegration.order(:created_at).last
-            expect(Integrations::Aggregator::PerformSyncJob).to have_received(:perform_later).with(integration:)
+            expect(Integrations::Aggregator::SendRestletEndpointJob).to have_received(:perform_later).with(integration:)
           end
         end
 

--- a/spec/services/integrations/netsuite/update_service_spec.rb
+++ b/spec/services/integrations/netsuite/update_service_spec.rb
@@ -59,6 +59,12 @@ RSpec.describe Integrations::Netsuite::UpdateService, type: :service do
             expect(integration.name).to eq(name)
             expect(integration.script_endpoint_url).to eq(script_endpoint_url)
           end
+
+          it 'calls Integrations::Aggregator::SendRestletEndpointJob' do
+            service_call
+
+            expect(Integrations::Aggregator::SendRestletEndpointJob).to have_received(:perform_later).with(integration:)
+          end
         end
 
         context 'with validation error' do

--- a/spec/services/integrations/netsuite/update_service_spec.rb
+++ b/spec/services/integrations/netsuite/update_service_spec.rb
@@ -49,7 +49,10 @@ RSpec.describe Integrations::Netsuite::UpdateService, type: :service do
       end
 
       context 'with netsuite premium integration present' do
-        before { organization.update!(premium_integrations: ['netsuite']) }
+        before do
+          organization.update!(premium_integrations: ['netsuite'])
+          allow(Integrations::Aggregator::SendRestletEndpointJob).to receive(:perform_later)
+        end
 
         context 'without validation errors' do
           it 'updates an integration' do


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR handles following cases:
- When connection is created or updated Lago needs to send restlet endpoint URL to aggregator (Nango)
- Also, this PR removes job that triggers Nango sync upon connection creation. We realised that it can be done automatically by providing extra configuration in Nango. However, until the whole integration is done, we will leave related code in the codebase, just in case.
