### PR TITLE
feat(custom_agg): Base structure for custom aggregation

### DIFF
--- a/app/services/billable_metrics/aggregation_factory.rb
+++ b/app/services/billable_metrics/aggregation_factory.rb
@@ -58,6 +58,9 @@ module BillableMetrics
 
         BillableMetrics::Aggregations::WeightedSumService
 
+      when :custom_agg
+        BillableMetrics::Aggregations::CustomService
+
       else
         raise(NotImplementedError)
       end

--- a/app/services/billable_metrics/aggregations/custom_service.rb
+++ b/app/services/billable_metrics/aggregations/custom_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module BillableMetrics
+  module Aggregations
+    class CustomService < BillableMetrics::Aggregations::BaseService
+      def compute_aggregation(options: {})
+        # TODO(custom_agg): Implement custom aggregation logic
+        result.aggregation = 0
+        result.count = event_store.count
+        result.options = options
+        result
+      end
+
+      def compute_grouped_by_aggregation
+        # TODO(custom_agg): Implement custom aggregation logic
+        result.aggregations = []
+      end
+
+      def compute_per_event_aggregation
+        # TODO(custom_agg): Implement custom aggregation logic
+        []
+      end
+    end
+  end
+end

--- a/app/services/charges/charge_model_factory.rb
+++ b/app/services/charges/charge_model_factory.rb
@@ -28,6 +28,8 @@ module Charges
         Charges::ChargeModels::PercentageService
       when :volume
         Charges::ChargeModels::VolumeService
+      when :custom
+        Charges::ChargeModels::CustomService
       else
         raise(NotImplementedError)
       end

--- a/app/services/charges/charge_models/custom_service.rb
+++ b/app/services/charges/charge_models/custom_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Charges
+  module ChargeModels
+    class CustomService < Charges::ChargeModels::BaseService
+      protected
+
+      def compute_amount
+        # TODO(custom_agg): Implement custom aggregation logic
+        0
+      end
+
+      def unit_amount
+        total_units = aggregation_result.full_units_number || units
+        return 0 if total_units.zero?
+
+        result.amount / total_units
+      end
+    end
+  end
+end

--- a/spec/factories/billable_metrics.rb
+++ b/spec/factories/billable_metrics.rb
@@ -43,6 +43,6 @@ FactoryBot.define do
 
   factory :custom_billable_metric, parent: :billable_metric do
     aggregation_type { 'custom_agg' }
-    custom_aggreator { 'puts "foo bar"' }
+    custom_aggregator { 'puts "foo bar"' }
   end
 end

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -75,6 +75,13 @@ FactoryBot.define do
       end
     end
 
+    factory :custom_charge do
+      charge_model { 'custom' }
+      properties do
+        { custom_properties: { rate: '20' } }
+      end
+    end
+
     trait :pay_in_advance do
       pay_in_advance { true }
     end

--- a/spec/services/billable_metrics/aggregation_factory_spec.rb
+++ b/spec/services/billable_metrics/aggregation_factory_spec.rb
@@ -111,5 +111,11 @@ RSpec.describe BillableMetrics::AggregationFactory, type: :service do
         end
       end
     end
+
+    context 'with custom_agg aggregation' do
+      let(:billable_aggregation) { :custom_billable_metric }
+
+      it { expect(result).to be_a(BillableMetrics::Aggregations::CustomService) }
+    end
   end
 end

--- a/spec/services/billable_metrics/aggregations/custom_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/custom_service_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BillableMetrics::Aggregations::CustomService, type: :service do
+  subject(:custom_service) do
+    described_class.new(
+      event_store_class:,
+      charge:,
+      subscription:,
+      boundaries: {
+        from_datetime:,
+        to_datetime:,
+      },
+      filters:,
+    )
+  end
+
+  let(:event_store_class) { Events::Stores::PostgresStore }
+  let(:filters) { { group:, grouped_by: } }
+
+  let(:subscription) { create(:subscription) }
+  let(:organization) { subscription.organization }
+  let(:customer) { subscription.customer }
+
+  let(:group) { nil }
+  let(:grouped_by) { nil }
+
+  let(:billable_metric) do
+    create(:custom_billable_metric, organization:)
+  end
+
+  let(:charge) { create(:standard_charge, billable_metric:) }
+
+  let(:from_datetime) { (Time.current - 1.month).beginning_of_day }
+  let(:to_datetime) { Time.current.end_of_day }
+
+  it 'aggregates the events' do
+    result = custom_service.aggregate
+
+    expect(result.aggregation).to eq(0)
+    expect(result.count).to eq(0)
+  end
+end

--- a/spec/services/charges/charge_model_factory_spec.rb
+++ b/spec/services/charges/charge_model_factory_spec.rb
@@ -58,5 +58,11 @@ RSpec.describe Charges::ChargeModelFactory, type: :service do
 
       it { expect(result).to be_a(Charges::ChargeModels::VolumeService) }
     end
+
+    context 'with custom charge model' do
+      let(:charge) { build(:custom_charge) }
+
+      it { expect(result).to be_a(Charges::ChargeModels::CustomService) }
+    end
   end
 end

--- a/spec/services/charges/charge_models/custom_service_spec.rb
+++ b/spec/services/charges/charge_models/custom_service_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+Rspec.describe Charges::ChargeModels::CustomService, type: :service do
+  subject(:apply_custom_service) do
+    described_class.apply(
+      charge:,
+      aggregation_result:,
+      properties: charge.properties,
+    )
+  end
+
+  let(:aggregation_result) { BaseService::Result.new }
+  let(:aggregation) { 10 }
+  let(:total_aggregated_units) { nil }
+  let(:full_units_number) { nil }
+
+  let(:charge) { create(:custom_charge, billable_metric:) }
+  let(:billable_metric) { create(:custom_billable_metric) }
+
+  before do
+    aggregation_result.aggregation = aggregation
+    aggregation_result.total_aggregated_units = total_aggregated_units if total_aggregated_units
+    aggregation_result.full_units_number = full_units_number if full_units_number
+  end
+
+  it 'applies the charge model to the value' do
+    expect(apply_custom_service.amount).to eq(0)
+    expect(apply_custom_service.unit_amount).to eq(0)
+  end
+end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -353,10 +353,13 @@ RSpec.describe Fees::ChargeService do
 
       context 'with all types of aggregation' do
         BillableMetric::AGGREGATION_TYPES.keys.each do |aggregation_type|
-          next if aggregation_type.to_sym == :custom_agg # TODO(custom_agg): will be implemented in a next PR
-
           before do
-            billable_metric.update!(aggregation_type:, field_name: 'foo_bar', weighted_interval: 'seconds')
+            billable_metric.update!(
+              aggregation_type:,
+              field_name: 'foo_bar',
+              weighted_interval: 'seconds',
+              custom_aggregator: 'puts "foo bar"',
+            )
           end
 
           it 'creates fees' do
@@ -1747,13 +1750,12 @@ RSpec.describe Fees::ChargeService do
   describe '.current_usage' do
     context 'with all types of aggregation' do
       BillableMetric::AGGREGATION_TYPES.keys.each do |aggregation_type|
-        next if aggregation_type.to_sym == :custom_agg # TODO(custom_agg): will be implemented in a next PR
-
         before do
           billable_metric.update!(
             aggregation_type:,
             field_name: 'foo_bar',
             weighted_interval: 'seconds',
+            custom_aggregator: 'puts "foo bar"',
           )
 
           charge.update!(min_amount_cents: 1000)


### PR DESCRIPTION
## Context

Some of our customers have express a need for aggregation and charge models that does not fit into the current logic in place in Lago, like for example having a single aggregation for 2 different properties, but make the price per unit changing based on the position of the event.

This feature aims to propose a way to build custom aggregation logic for specific cases.

## Description

This PR adds the base logic for `BillableMetrics::Aggregations::CustomService` and `Charges::ChargeModels::CustomService`

Note: the aggregation logic itself will come in a next PR(s)
