### PR TITLE
feat (accounting-integrations): add has_mappings_configured graphql field

### DIFF
--- a/app/graphql/types/integrations/netsuite.rb
+++ b/app/graphql/types/integrations/netsuite.rb
@@ -9,6 +9,7 @@ module Types
       field :client_id, String, null: true
       field :client_secret, String, null: true
       field :code, String, null: false
+      field :has_mappings_configured, Boolean
       field :id, ID, null: false
       field :name, String, null: false
       field :script_endpoint_url, String, null: true
@@ -21,6 +22,13 @@ module Types
       #       front end application. Instead we send an obfuscated value
       def client_secret
         "#{'•' * 8}…#{object.client_secret[-3..]}"
+      end
+
+      def has_mappings_configured
+        object.integration_collection_mappings
+          .where(type: 'IntegrationCollectionMappings::NetsuiteCollectionMapping')
+          .where(mapping_type: :fallback_item)
+          .any?
       end
     end
   end

--- a/app/models/integrations/base_integration.rb
+++ b/app/models/integrations/base_integration.rb
@@ -11,7 +11,8 @@ module Integrations
     belongs_to :organization
 
     has_many :integration_mappings, class_name: 'IntegrationMappings::BaseMapping', foreign_key: 'integration_id'
-    has_many :integration_collection_mappings, class_name: 'IntegrationCollectionMappings::BaseCollectionMapping',
+    has_many :integration_collection_mappings,
+             class_name: 'IntegrationCollectionMappings::BaseCollectionMapping',
              foreign_key: 'integration_id'
 
     validates :code, uniqueness: { scope: :organization_id }

--- a/app/models/integrations/base_integration.rb
+++ b/app/models/integrations/base_integration.rb
@@ -10,6 +10,10 @@ module Integrations
 
     belongs_to :organization
 
+    has_many :integration_mappings, class_name: 'IntegrationMappings::BaseMapping', foreign_key: 'integration_id'
+    has_many :integration_collection_mappings, class_name: 'IntegrationCollectionMappings::BaseCollectionMapping',
+             foreign_key: 'integration_id'
+
     validates :code, uniqueness: { scope: :organization_id }
     validates :name, presence: true
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4474,6 +4474,7 @@ type NetsuiteIntegration {
   clientId: String
   clientSecret: String
   code: String!
+  hasMappingsConfigured: Boolean
   id: ID!
   name: String!
   scriptEndpointUrl: String

--- a/schema.json
+++ b/schema.json
@@ -20217,6 +20217,20 @@
               ]
             },
             {
+              "name": "hasMappingsConfigured",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {

--- a/spec/graphql/types/integrations/netsuite_spec.rb
+++ b/spec/graphql/types/integrations/netsuite_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Types::Integrations::Netsuite do
   it { is_expected.to have_field(:client_id).of_type('String') }
   it { is_expected.to have_field(:client_secret).of_type('String') }
   it { is_expected.to have_field(:code).of_type('String!') }
+  it { is_expected.to have_field(:has_mappings_configured).of_type('Boolean') }
   it { is_expected.to have_field(:name).of_type('String!') }
   it { is_expected.to have_field(:script_endpoint_url).of_type('String') }
 


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR adds new graphql field which is needed on UI to display (or not) mapping alert
