### PR TITLE
fix(invoice): Remove charges if charge boundaries are invalid

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -90,7 +90,14 @@ module Invoices
       fee_result.raise_if_error!
     end
 
+    def charge_boundaries_valid?(boundaries)
+      # TODO: Investigate why invalid boundaries are even possible
+      boundaries[:charges_from_datetime] < boundaries[:charges_to_datetime]
+    end
+
     def create_charges_fees(subscription, boundaries)
+      return unless charge_boundaries_valid?(boundaries)
+
       subscription
         .plan
         .charges

--- a/spec/support/matchers/have_empty_charge_fees.rb
+++ b/spec/support/matchers/have_empty_charge_fees.rb
@@ -2,7 +2,12 @@
 
 RSpec::Matchers.define :have_empty_charge_fees do
   match do |invoice|
-    invoice.fees.charge.all? { |fee| fee.total_amount_cents.zero? }
+    invoice.fees.charge.all? do |fee|
+      from = Time.zone.parse(fee.properties['charges_from_datetime'])
+      to = Time.zone.parse(fee.properties['charges_to_datetime'])
+
+      fee.total_amount_cents.zero? && from.before?(to)
+    end
   end
 
   failure_message do |invoice|


### PR DESCRIPTION
https://linear.app/getlago/issue/DLVRY-262

## Context

Subscriptions fees are now invoiced at the end of the trial instead of at the beginning of the subscription. We made a change were we don't always skip charge fees if it's the first invoice anymore. See https://github.com/getlago/lago-api/pull/1836

## Description

In some cases, the system might create invalid charge boundaries. This is not new but those cases always happened on the first invoice, and previously, we were skipping charges in this case so it was never visible.

With this PR, we'll ensure a charge is only created if the boundaries are valid. Next, we'll need to look into *why* the boundaries are invalid in the first place but it's important to merge this fix in the meantime.

### Example of invalid boundaries on upgrade

![CleanShot 2024-04-17 at 10 41 01@2x](https://github.com/getlago/lago-api/assets/1525636/2ae49ab7-7fff-497c-8290-608c91b47e87)
