### PR TITLE
misc(guard): Add guard-rspec gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,7 @@ end
 
 group :test do
   gem 'database_cleaner-active_record'
+  gem 'guard-rspec', require: false
   gem 'rspec-graphql_matchers'
   gem 'shoulda-matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,7 @@ GEM
     clockwork-test (0.5.1)
       clockwork
       timecop
+    coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -215,6 +216,7 @@ GEM
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
     ffi (1.15.5)
+    formatador (1.1.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     gocardless_pro (2.34.0)
@@ -262,6 +264,20 @@ GEM
     graphql (2.0.11)
     graphql-pagination (2.0.1)
       graphql (~> 2.0)
+    guard (2.18.1)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.13.0)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
     hashdiff (1.0.1)
     hashie (5.0.0)
     highline (2.1.0)
@@ -290,6 +306,9 @@ GEM
       mini_portile2 (~> 2.6)
       rake (> 12)
     language_server-protocol (3.17.0.3)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.13.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -299,6 +318,7 @@ GEM
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    lumberjack (1.2.10)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -322,6 +342,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
+    nenv (0.3.0)
     net-imap (0.4.10)
       date
       net-protocol
@@ -341,6 +362,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
@@ -562,6 +586,9 @@ GEM
       racc
     pg (1.4.1)
     prism (0.24.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (5.0.1)
     puma (6.4.2)
       nio4r (~> 2.0)
@@ -608,6 +635,9 @@ GEM
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
+    rb-fsevent (0.11.2)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     redis (5.0.6)
       redis-client (>= 0.9.0)
     redis-client (0.17.0)
@@ -715,6 +745,7 @@ GEM
     sentry-sidekiq (5.12.0)
       sentry-ruby (~> 5.12.0)
       sidekiq (>= 3.0)
+    shellany (0.0.1)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     sidekiq (7.1.4)
@@ -826,6 +857,7 @@ DEPENDENCIES
   graphiql-rails!
   graphql
   graphql-pagination
+  guard-rspec
   i18n-tasks!
   jwt
   kaminari-activerecord

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+guard :rspec, cmd: 'bundle exec rspec' do
+  watch('spec/spec_helper.rb')                        { 'spec' }
+  watch('config/routes.rb')                           { 'spec/routing' }
+  watch('app/controllers/application_controller.rb')  { 'spec/requests' }
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^lib/(.+)\.rb$})                           { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch(%r{^app/controllers/(.+)_(controller)\.rb$}) do |m|
+    [
+      "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb",
+      "spec/requests/#{m[1]}_controller_spec.rb",
+    ]
+  end
+end


### PR DESCRIPTION
## Context

Guard::RSpec allows to automatically & intelligently launch specs when files are modified.

## Description

This PR adds `guard-rspec` gem.