### PR TITLE
misc(settings-and-secrets): Add settings and secrets accessors to payment providers and customers

### DIFF
--- a/app/models/payment_provider_customers/adyen_customer.rb
+++ b/app/models/payment_provider_customers/adyen_customer.rb
@@ -2,12 +2,6 @@
 
 module PaymentProviderCustomers
   class AdyenCustomer < BaseCustomer
-    def payment_method_id
-      get_from_settings('payment_method_id')
-    end
-
-    def payment_method_id=(payment_method_id)
-      push_to_settings(key: 'payment_method_id', value: payment_method_id)
-    end
+    settings_accessors :payment_method_id
   end
 end

--- a/app/models/payment_provider_customers/base_customer.rb
+++ b/app/models/payment_provider_customers/base_customer.rb
@@ -3,6 +3,7 @@
 module PaymentProviderCustomers
   class BaseCustomer < ApplicationRecord
     include PaperTrailTraceable
+    include SettingsStorable
 
     self.table_name = 'payment_provider_customers'
 
@@ -14,33 +15,10 @@ module PaymentProviderCustomers
 
     validates :customer_id, uniqueness: { scope: :type }
 
-    def push_to_settings(key:, value:)
-      self.settings ||= {}
-      settings[key] = value
-    end
-
-    def get_from_settings(key)
-      (settings || {})[key]
-    end
-
-    def provider_mandate_id
-      get_from_settings('provider_mandate_id')
-    end
-
-    def provider_mandate_id=(provider_mandate_id)
-      push_to_settings(key: 'provider_mandate_id', value: provider_mandate_id)
-    end
+    settings_accessors :provider_mandate_id, :sync_with_provider
 
     def provider_payment_methods
       nil
-    end
-
-    def sync_with_provider
-      get_from_settings('sync_with_provider')
-    end
-
-    def sync_with_provider=(sync_with_provider)
-      push_to_settings(key: 'sync_with_provider', value: sync_with_provider)
     end
   end
 end

--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -7,13 +7,7 @@ module PaymentProviderCustomers
     validates :provider_payment_methods, presence: true
     validate :allowed_provider_payment_methods
 
-    def payment_method_id
-      get_from_settings('payment_method_id')
-    end
-
-    def payment_method_id=(payment_method_id)
-      push_to_settings(key: 'payment_method_id', value: payment_method_id)
-    end
+    settings_accessors :payment_method_id
 
     def provider_payment_methods
       get_from_settings('provider_payment_methods')

--- a/app/models/payment_providers/adyen_provider.rb
+++ b/app/models/payment_providers/adyen_provider.rb
@@ -7,44 +7,15 @@ module PaymentProviders
     validates :api_key, :merchant_account, presence: true
     validates :success_redirect_url, adyen_url: true, allow_nil: true, length: { maximum: 1024 }
 
+    settings_accessors :live_prefix, :merchant_account
+    secrets_accessors :api_key, :hmac_key
+
     def environment
       if Rails.env.production? && live_prefix.present?
         :live
       else
         :test
       end
-    end
-
-    def api_key=(value)
-      push_to_secrets(key: 'api_key', value:)
-    end
-
-    def api_key
-      get_from_secrets('api_key')
-    end
-
-    def hmac_key=(value)
-      push_to_secrets(key: 'hmac_key', value:)
-    end
-
-    def hmac_key
-      get_from_secrets('hmac_key')
-    end
-
-    def live_prefix=(value)
-      push_to_settings(key: 'live_prefix', value:)
-    end
-
-    def live_prefix
-      get_from_settings('live_prefix')
-    end
-
-    def merchant_account=(value)
-      push_to_settings(key: 'merchant_account', value:)
-    end
-
-    def merchant_account
-      get_from_settings('merchant_account')
     end
   end
 end

--- a/app/models/payment_providers/base_provider.rb
+++ b/app/models/payment_providers/base_provider.rb
@@ -21,20 +21,6 @@ module PaymentProviders
     validates :code, uniqueness: { scope: :organization_id }
     validates :name, presence: true
 
-    def webhook_secret=(value)
-      push_to_settings(key: 'webhook_secret', value:)
-    end
-
-    def webhook_secret
-      get_from_settings('webhook_secret')
-    end
-
-    def success_redirect_url=(value)
-      push_to_settings(key: 'success_redirect_url', value:)
-    end
-
-    def success_redirect_url
-      get_from_settings('success_redirect_url')
-    end
+    settings_accessors :webhook_secret, :success_redirect_url
   end
 end

--- a/app/models/payment_providers/gocardless_provider.rb
+++ b/app/models/payment_providers/gocardless_provider.rb
@@ -7,6 +7,8 @@ module PaymentProviders
     validates :access_token, presence: true
     validates :success_redirect_url, url: true, allow_nil: true, length: { maximum: 1024 }
 
+    secrets_accessors :access_token
+
     def self.auth_site
       if Rails.env.production?
         'https://connect.gocardless.com'
@@ -21,14 +23,6 @@ module PaymentProviders
       else
         :sandbox
       end
-    end
-
-    def access_token=(access_token)
-      push_to_secrets(key: 'access_token', value: access_token)
-    end
-
-    def access_token
-      get_from_secrets('access_token')
     end
   end
 end

--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -7,20 +7,7 @@ module PaymentProviders
     validates :secret_key, presence: true
     validates :success_redirect_url, url: true, allow_nil: true, length: { maximum: 1024 }
 
-    def secret_key=(secret_key)
-      push_to_secrets(key: 'secret_key', value: secret_key)
-    end
-
-    def secret_key
-      get_from_secrets('secret_key')
-    end
-
-    def webhook_id=(value)
-      push_to_settings(key: 'webhook_id', value:)
-    end
-
-    def webhook_id
-      get_from_settings('webhook_id')
-    end
+    settings_accessors :webhook_id
+    secrets_accessors :secret_key
   end
 end


### PR DESCRIPTION
## Context

Since we have `SecretsStorable` and `SettingsStorable` we can call methods like `settings_accessors :webhook_secret, :success_redirect_url` in the models so that we don't have to implement each getter and setter.

## Description

This PR includes `SecretsStorable` and `SettingsStorable` to payment providers and payment provider customers base models and then calls `settings_accessors` and `secret_accessors` when needed.