### PR TITLE
misc: Make group migrations non transactional

### DIFF
--- a/db/migrate/20240314165306_migrate_groups_to_filters.rb
+++ b/db/migrate/20240314165306_migrate_groups_to_filters.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class MigrateGroupsToFilters < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
   class BillableMetricFilter < ApplicationRecord
     belongs_to :billable_metric
   end

--- a/db/migrate/20240314170211_add_charge_filter_id_to_quantified_events.rb
+++ b/db/migrate/20240314170211_add_charge_filter_id_to_quantified_events.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AddChargeFilterIdToQuantifiedEvents < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
   class BillableMetricFilter < ApplicationRecord
   end
 

--- a/db/migrate/20240314172008_link_filters_to_cached_aggregation.rb
+++ b/db/migrate/20240314172008_link_filters_to_cached_aggregation.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class LinkFiltersToCachedAggregation < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
   class BillableMetricFilter < ApplicationRecord
   end
 
@@ -46,16 +48,20 @@ class LinkFiltersToCachedAggregation < ActiveRecord::Migration[7.0]
 
   def up
     # NOTE: Associate cached aggregations with charge filters
+    puts 'Migrate cached aggregations' # rubocop:disable Rails/Output
+
     CachedAggregation.where.associated(:group).where(charge_filter_id: nil).find_each do |agg|
       link_charge_filter(agg)
     end
 
     # NOTE: Associate fees with charge filters
+    puts 'Migrate fees' # rubocop:disable Rails/Output
     Fee.where.associated(:group).where(charge_filter_id: nil).find_each do |fee|
       link_charge_filter(fee)
     end
 
     # NOTE: Associate adjusted fees with charge filters
+    puts 'Migrate adjusted fees' # rubocop:disable Rails/Output
     AdjustedFee.where.associated(:group).where(charge_filter_id: nil).find_each do |fee|
       link_charge_filter(fee)
     end


### PR DESCRIPTION
Disable database transaction for migration from groups into filters as the migration are fully re-playable and should be visible for the customer as fast as possible