### PR TITLE
feat (accounting-integrations): add logic for fetching items from integration aggregator

### DIFF
--- a/app/jobs/integrations/aggregator/fetch_items_job.rb
+++ b/app/jobs/integrations/aggregator/fetch_items_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class FetchItemsJob < ApplicationJob
+      queue_as 'integrations'
+
+      retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
+
+      def perform(integration:)
+        result = Integrations::Aggregator::ItemsService.call(integration:)
+        result.raise_if_error!
+      end
+    end
+  end
+end

--- a/app/models/integration_item.rb
+++ b/app/models/integration_item.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class IntegrationItem < ApplicationRecord
+  include PaperTrailTraceable
+
+  belongs_to :integration, class_name: 'Integrations::BaseIntegration'
+
+  ITEM_TYPES = [
+    :standard,
+    :tax,
+  ].freeze
+
+  enum item_type: ITEM_TYPES
+
+  validates :external_id, presence: true
+end

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -21,6 +21,14 @@ module Integrations
 
       attr_reader :integration
 
+      # NOTE: Extend it with other providers if needed
+      def provider
+        case integration.type
+        when 'Integrations::NetsuiteIntegration'
+          'netsuite'
+        end
+      end
+
       def http_client
         LagoHttpClient::Client.new(endpoint_url)
       end

--- a/app/services/integrations/aggregator/items_service.rb
+++ b/app/services/integrations/aggregator/items_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class ItemsService < BaseService
+      LIMIT = 300
+      MAX_SUBSEQUENT_REQUESTS = 10
+
+      def action_path
+        "v1/#{provider}/items"
+      end
+
+      def call
+        @cursor = ''
+        @items = []
+
+        ActiveRecord::Base.transaction do
+          MAX_SUBSEQUENT_REQUESTS.times do |i|
+            response = http_client.get(headers:, params:)
+
+            handle_items(response['records'])
+            @cursor = response['next_cursor']
+
+            break if cursor.blank?
+          end
+        end
+        result.items = items
+
+        result
+      end
+
+      private
+
+      attr_reader :cursor, :items
+
+      def headers
+        {
+          'Connection-Id' => integration.connection_id,
+          'Authorization' => "Bearer #{secret_key}",
+          'Provider-Config-Key' => provider,
+        }
+      end
+
+      def handle_items(new_items)
+        @items = items.concat(new_items)
+
+        # TODO: Store items in DB
+      end
+
+      def params
+        {
+          limit: LIMIT,
+          cursor:,
+        }
+      end
+    end
+  end
+end

--- a/app/services/integrations/aggregator/items_service.rb
+++ b/app/services/integrations/aggregator/items_service.rb
@@ -15,7 +15,7 @@ module Integrations
         @items = []
 
         ActiveRecord::Base.transaction do
-          MAX_SUBSEQUENT_REQUESTS.times do |i|
+          MAX_SUBSEQUENT_REQUESTS.times do |_i|
             response = http_client.get(headers:, params:)
 
             handle_items(response['records'])

--- a/app/services/integrations/aggregator/items_service.rb
+++ b/app/services/integrations/aggregator/items_service.rb
@@ -44,7 +44,17 @@ module Integrations
       def handle_items(new_items)
         @items = items.concat(new_items)
 
-        # TODO: Store items in DB
+        new_items.each do |item|
+          integration_item = IntegrationItem.new(
+            integration:,
+            external_id: item['id'],
+            account_code: item['account_code'],
+            name: item['name'],
+            item_type: :standard,
+          )
+
+          integration_item.save!
+        end
       end
 
       def params

--- a/app/services/integrations/aggregator/sync_service.rb
+++ b/app/services/integrations/aggregator/sync_service.rb
@@ -22,14 +22,6 @@ module Integrations
       private
 
       # NOTE: Extend it with other providers if needed
-      def provider
-        case integration.type
-        when 'Integrations::NetsuiteIntegration'
-          'netsuite'
-        end
-      end
-
-      # NOTE: Extend it with other providers if needed
       def sync_items
         case integration.type
         when 'Integrations::NetsuiteIntegration'
@@ -38,6 +30,7 @@ module Integrations
             netsuite-items-sync
             netsuite-subsidiaries-sync
             netsuite-contacts-sync
+            netsuite-tax-items-sync
           ]
         end
       end

--- a/db/migrate/20240419085012_create_integration_items.rb
+++ b/db/migrate/20240419085012_create_integration_items.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateIntegrationItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :integration_items, id: :uuid do |t|
+      t.references :integration, type: :uuid, foreign_key: true, null: false, index: true
+      t.integer :item_type, null: false
+      t.string :external_id, null: false
+      t.string :account_code
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_15_122310) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_19_085012) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -554,6 +554,17 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_15_122310) do
     t.index ["mapping_type", "integration_id"], name: "index_int_collection_mappings_on_mapping_type_and_int_id", unique: true
   end
 
+  create_table "integration_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "integration_id", null: false
+    t.integer "item_type", null: false
+    t.string "external_id", null: false
+    t.string "account_code"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["integration_id"], name: "index_integration_items_on_integration_id"
+  end
+
   create_table "integration_mappings", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "integration_id", null: false
     t.string "mappable_type", null: false
@@ -1038,6 +1049,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_15_122310) do
   add_foreign_key "groups", "billable_metrics", on_delete: :cascade
   add_foreign_key "groups", "groups", column: "parent_group_id"
   add_foreign_key "integration_collection_mappings", "integrations"
+  add_foreign_key "integration_items", "integrations"
   add_foreign_key "integration_mappings", "integrations"
   add_foreign_key "integrations", "organizations"
   add_foreign_key "invites", "memberships"

--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -70,8 +70,13 @@ module LagoHttpClient
       response
     end
 
-    def get
-      req = Net::HTTP::Get.new(uri.path)
+    def get(headers: {}, params: nil)
+      path = params ? "#{uri.path}?#{URI.encode_www_form(params)}" : uri.path
+      req = Net::HTTP::Get.new(path)
+
+      headers.keys.each do |key|
+        req[key] = headers[key]
+      end
 
       response = http_client.request(req)
 

--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -27,9 +27,9 @@ module LagoHttpClient
 
       raise_error(response) unless RESPONSE_SUCCESS_CODES.include?(response.code.to_i)
 
-      JSON.parse(response.body&.presence || '{}')
+      JSON.parse(response.body.presence || '{}')
     rescue JSON::ParserError
-      response.body&.presence || '{}'
+      response.body.presence || '{}'
     end
 
     def post_with_response(body, headers)
@@ -82,7 +82,7 @@ module LagoHttpClient
 
       raise_error(response) unless RESPONSE_SUCCESS_CODES.include?(response.code.to_i)
 
-      JSON.parse(response.body&.presence || '{}')
+      JSON.parse(response.body.presence || '{}')
     end
 
     private

--- a/spec/factories/integration_items.rb
+++ b/spec/factories/integration_items.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :integration_items do
+    integration
+    type { 'standard' }
+    name { 'test name' }
+    code { 'test_code' }
+  end
+end

--- a/spec/fixtures/integration_aggregator/items_response.json
+++ b/spec/fixtures/integration_aggregator/items_response.json
@@ -1,0 +1,65 @@
+{
+  "records": [
+    {
+      "id": "755",
+      "name": "Test-LeadConduit",
+      "account_code": "7691",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T12:10:02.430428+00:00",
+        "last_modified_at": "2024-04-17T12:10:02.430428+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMjoxMDowMi40MzA0MjgrMDA6MDB8fDAwNmZmYjJjLWQ1MjAtNWNiNy1hMjRhLTE5NzYzNzI1MDhlZQ=="
+      }
+    },
+    {
+      "id": "745",
+      "name": "Test-TrustedForm : TF Pings",
+      "account_code": "2428",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T12:10:02.430428+00:00",
+        "last_modified_at": "2024-04-17T12:10:02.430428+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMjoxMDowMi40MzA0MjgrMDA6MDB8fGY1ZDZiZmNiLTNlOGMtNWFlZS04OTU4LTQxMDBlMGNjMmYyMw=="
+      }
+    },
+    {
+      "id": "753",
+      "name": "Test-Anura",
+      "account_code": "1411",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T12:10:02.430428+00:00",
+        "last_modified_at": "2024-04-17T12:10:02.430428+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMjoxMDowMi40MzA0MjgrMDA6MDB8fGZiM2UwYjhiLTYyNjctNWEwNy1iNzhiLTk2ZDY1YjIwMTAzNA=="
+      }
+    },
+    {
+      "id": "484",
+      "name": "Test-Platform Subscription Annual",
+      "account_code": "9662",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T12:10:02.430428+00:00",
+        "last_modified_at": "2024-04-17T12:10:02.430428+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMjoxMDowMi40MzA0MjgrMDA6MDB8fGZlNWMwZjcxLTM0ZDktNTFiYy05ZGFiLTIxMGJkMTcyZmUyMw=="
+      }
+    },
+    {
+      "id": "828",
+      "name": "Test-LeadConduit : Add-Ons : CoreLogic Title Verification",
+      "account_code": "2904",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T12:10:02.430428+00:00",
+        "last_modified_at": "2024-04-17T12:10:02.430428+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMjoxMDowMi40MzA0MjgrMDA6MDB8fGZlYTRjNGQwLWYwZjctNTQwZi1iNjE5LWIyZGZlYzM5NGM0Zg=="
+      }
+    }
+  ],
+  "next_cursor": null
+}

--- a/spec/jobs/integrations/aggregator/fetch_items_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/fetch_items_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::FetchItemsJob, type: :job do
+  subject(:fetch_items_job) { described_class }
+
+  let(:items_service) { instance_double(Integrations::Aggregator::ItemsService) }
+  let(:integration) { create(:netsuite_integration) }
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(Integrations::Aggregator::ItemsService).to receive(:new).and_return(items_service)
+    allow(items_service).to receive(:call).and_return(result)
+  end
+
+  it 'calls the items service' do
+    described_class.perform_now(integration:)
+
+    expect(Integrations::Aggregator::ItemsService).to have_received(:new)
+    expect(items_service).to have_received(:call)
+  end
+end

--- a/spec/models/integration_item_spec.rb
+++ b/spec/models/integration_item_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationItem, type: :model do
+  it { is_expected.to belong_to(:integration) }
+
+  it { is_expected.to validate_presence_of(:external_id) }
+end

--- a/spec/services/integrations/aggregator/items_service_spec.rb
+++ b/spec/services/integrations/aggregator/items_service_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Integrations::Aggregator::ItemsService do
       allow(lago_client).to receive(:get)
         .with(headers:, params:)
         .and_return(aggregator_response)
+
+      IntegrationItem.destroy_all
     end
 
     it 'successfully fetches items' do
@@ -45,6 +47,7 @@ RSpec.describe Integrations::Aggregator::ItemsService do
         expect(LagoHttpClient::Client).to have_received(:new).with(items_endpoint)
         expect(lago_client).to have_received(:get)
         expect(result.items.pluck('id')).to eq(%w[755 745 753 484 828])
+        expect(IntegrationItem.count).to eq(5)
       end
     end
   end

--- a/spec/services/integrations/aggregator/items_service_spec.rb
+++ b/spec/services/integrations/aggregator/items_service_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::ItemsService do
+  subject(:items_service) { described_class.new(integration:) }
+
+  let(:integration) { create(:netsuite_integration) }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:items_endpoint) { 'https://api.nango.dev/v1/netsuite/items' }
+    let(:headers) do
+      {
+        'Connection-Id' => integration.connection_id,
+        'Authorization' => "Bearer ",
+        'Provider-Config-Key' => 'netsuite',
+      }
+    end
+    let(:params) do
+      {
+        limit: 300,
+        cursor: '',
+      }
+    end
+
+    let(:aggregator_response) do
+      path = Rails.root.join('spec/fixtures/integration_aggregator/items_response.json')
+      JSON.parse(File.read(path))
+    end
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(items_endpoint)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:get)
+        .with(headers:, params:)
+        .and_return(aggregator_response)
+    end
+
+    it 'successfully fetches items' do
+      result = items_service.call
+
+      aggregate_failures do
+        expect(LagoHttpClient::Client).to have_received(:new).with(items_endpoint)
+        expect(lago_client).to have_received(:get)
+        expect(result.items.pluck('id')).to eq(%w[755 745 753 484 828])
+      end
+    end
+  end
+end

--- a/spec/services/integrations/aggregator/items_service_spec.rb
+++ b/spec/services/integrations/aggregator/items_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Integrations::Aggregator::ItemsService do
     let(:headers) do
       {
         'Connection-Id' => integration.connection_id,
-        'Authorization' => "Bearer ",
+        'Authorization' => 'Bearer ',
         'Provider-Config-Key' => 'netsuite',
       }
     end

--- a/spec/services/integrations/aggregator/sync_service_spec.rb
+++ b/spec/services/integrations/aggregator/sync_service_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Integrations::Aggregator::SyncService do
         netsuite-items-sync
         netsuite-subsidiaries-sync
         netsuite-contacts-sync
+        netsuite-tax-items-sync
       ]
     end
 


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR adds logic for fetching items from Nango (Lago's integration aggregator).

These items are basically objects that are used for mapping. We decided to store it on our side in order to make it searchable and more efficient since the same list need to be returned to the UI for various mappable objects.
