### PR TITLE
feat(custom_agg): Add Ruby Sandbox to allow ruby execution in a safe environment

### DIFF
--- a/lib/lago_utils/lago_utils/ruby_sandbox.rb
+++ b/lib/lago_utils/lago_utils/ruby_sandbox.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'ruby_sandbox/runner'
+
+module LagoUtils
+  module RubySandbox
+    def self.run(code)
+      LagoUtils::RubySandbox::Runner.new(code).run
+    end
+  end
+end

--- a/lib/lago_utils/lago_utils/ruby_sandbox/runner.rb
+++ b/lib/lago_utils/lago_utils/ruby_sandbox/runner.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+require_relative 'sandbox_error'
+require_relative 'sanitizer'
+require_relative 'safe_environment'
+
+module LagoUtils
+  module RubySandbox
+    class Runner
+      def initialize(code)
+        @code = code
+      end
+
+      def run
+        result = nil
+        error = nil
+
+        temp_file = prepare_ruby_file
+
+        Open3.popen3("ruby #{temp_file.path}", chdir: '/tmp') do |_, stdout, stderr, _|
+          error = stderr.read
+          result = stdout.read
+        end
+
+        raise SandboxError.new(initial_error: error) if error.present?
+
+        parsed_result = JSON.parse(result)
+
+        if parsed_result.is_a?(Hash) && parsed_result['type'] == 'error'
+          raise SandboxError.new(
+            initial_error: parsed_result['error'],
+            backtrace: parsed_result['backtrace'],
+          )
+        end
+
+        parsed_result
+      ensure
+        temp_file.unlink
+      end
+
+      private
+
+      attr_reader :code
+
+      def sanitized_code
+        @sanitized_code ||= LagoUtils::RubySandbox::Sanitizer.new(code).sanitize
+      end
+
+      def prepare_ruby_file
+        file = Tempfile.new('lago-ruby-sandbox')
+        file.write(<<~STRING)
+          require 'json'
+          require 'bigdecimal'
+
+          #{LagoUtils::RubySandbox::SafeEnvironment::SAFE_ENV}
+
+          result = begin
+            #{sanitized_code}
+          rescue Exception => e
+            { type: 'error', error: e.message, backtrace: e.backtrace }
+          end
+
+          print JSON.dump(result)
+        STRING
+        file.rewind
+        file
+      end
+    end
+  end
+end

--- a/lib/lago_utils/lago_utils/ruby_sandbox/safe_environment.rb
+++ b/lib/lago_utils/lago_utils/ruby_sandbox/safe_environment.rb
@@ -1,0 +1,425 @@
+# frozen_string_literal: true
+
+module LagoUtils
+  module RubySandbox
+    module SafeEnvironment
+      ALLOWED_CONSTANTS = [
+        :Object,
+        :Module,
+        :Class,
+        :BasicObject,
+        :Kernel,
+        :NilClass,
+        :NIL,
+        :Data,
+        :TrueClass,
+        :TRUE,
+        :FalseClass,
+        :FALSE,
+        :Encoding,
+        :Comparable,
+        :Enumerable,
+        :String,
+        :Symbol,
+        :Exception,
+        :SystemExit,
+        :SignalException,
+        :Interrupt,
+        :StandardError,
+        :TypeError,
+        :ArgumentError,
+        :IndexError,
+        :KeyError,
+        :RangeError,
+        :ScriptError,
+        :SyntaxError,
+        :LoadError,
+        :NotImplementedError,
+        :NameError,
+        :NoMethodError,
+        :RuntimeError,
+        :SecurityError,
+        :NoMemoryError,
+        :EncodingError,
+        :SystemCallError,
+        :Errno,
+        :ZeroDivisionError,
+        :FloatDomainError,
+        :Numeric,
+        :Integer,
+        :Fixnum,
+        :Float,
+        :Bignum,
+        :BigDecimal,
+        :Array,
+        :Hash,
+        :Struct,
+        :RegexpError,
+        :Regexp,
+        :MatchData,
+        :Range,
+        :IOError,
+        :EOFError,
+        :STDIN,
+        :STDOUT,
+        :STDERR,
+        :Time,
+        :Random,
+        :Signal,
+        :Proc,
+        :LocalJumpError,
+        :SystemStackError,
+        :Method,
+        :UnboundMethod,
+        :Math,
+        :Enumerator,
+        :StopIteration,
+        :TOPLEVEL_BINDING,
+        :Rational,
+        :Complex,
+        :RUBY_VERSION,
+        :RUBY_RELEASE_DATE,
+        :RUBY_PLATFORM,
+        :RUBY_PATCHLEVEL,
+        :RUBY_REVISION,
+        :RUBY_DESCRIPTION,
+        :RUBY_COPYRIGHT,
+        :RUBY_ENGINE,
+        :TracePoint,
+        :ARGV,
+        :Gem,
+        :RbConfig,
+        :Config,
+        :CROSS_COMPILING,
+        :Date,
+        :ConditionVariable,
+        :Queue,
+        :SizedQueue,
+        :MonitorMixin,
+        :Monitor,
+        :Exception2MessageMapper,
+        :RubyToken,
+        :RubyLex,
+        :RUBYGEMS_ACTIVATION_MONITOR,
+        :JSON,
+      ].freeze
+
+      KERNEL_S_METHODS = %w[
+        Array
+        binding
+        block_given?
+        catch
+        chomp
+        chomp!
+        chop
+        chop!
+        eval
+        fail
+        Float
+        format
+        global_variables
+        gsub
+        gsub!
+        Integer
+        iterator?
+        lambda
+        local_variables
+        loop
+        method_missing
+        proc
+        raise
+        scan
+        split
+        sprintf
+        String
+        sub
+        sub!
+        throw
+      ].freeze
+
+      SYMBOL_S_METHODS = %w[
+        all_symbols
+      ].freeze
+
+      STRING_S_METHODS = %w[
+        new
+      ].freeze
+
+      KERNEL_METHODS = %w[
+        ==
+
+        ray
+        nding
+        ock_given?
+        tch
+        omp
+        omp!
+        op
+        op!
+        ass
+        clone
+        dup
+        eql?
+        equal?
+        eval
+        fail
+        Float
+        format
+        freeze
+        frozen?
+        global_variables
+        gsub
+        gsub!
+        hash
+        id
+        initialize_copy
+        inspect
+        instance_eval
+        instance_of?
+        instance_variables
+        instance_variable_get
+        instance_variable_set
+        instance_variable_defined?
+        Integer
+        is_a?
+        iterator?
+        kind_of?
+        lambda
+        local_variables
+        loop
+        methods
+        method_missing
+        nil?
+        private_methods
+        print
+        proc
+        protected_methods
+        public_methods
+        raise
+        remove_instance_variable
+        respond_to?
+        respond_to_missing?
+        scan
+        send
+        singleton_methods
+        singleton_method_added
+        singleton_method_removed
+        singleton_method_undefined
+        split
+        sprintf
+        String
+        sub
+        sub!
+        taint
+        tainted?
+        throw
+        to_a
+        to_s
+        type
+        untaint
+        __send__
+      ].freeze
+
+      NILCLASS_METHODS = %w[
+        &
+        inspect
+        nil?
+        to_a
+        to_f
+        to_i
+        to_s
+        ^
+        |
+      ].freeze
+
+      SYMBOL_METHODS = %w[
+        ===
+        id2name
+        inspect
+        to_i
+        to_int
+        to_s
+        to_sym
+      ].freeze
+
+      TRUECLASS_METHODS = %w[
+        &
+        to_s
+        ^
+        |
+      ].freeze
+
+      FALSECLASS_METHODS = %w[
+        &
+        to_s
+        ^
+        |
+      ].freeze
+
+      ENUMERABLE_METHODS = %w[
+        all?
+        any?
+        collect
+        detect
+        each_with_index
+        entries
+        find
+        find_all
+        grep
+        include?
+        inject
+        map
+        max
+        member?
+        min
+        partition
+        reject
+        select
+        sort
+        sort_by
+        to_a
+        zip
+      ].freeze
+
+      STRING_METHODS = %w[
+        %
+        *
+        +
+        <<
+        <=>
+        ==
+        =~
+        capitalize
+        capitalize!
+        casecmp
+        center
+        chomp
+        chomp!
+        chop
+        chop!
+        concat
+        count
+        crypt
+        delete
+        delete!
+        downcase
+        downcase!
+        dump
+        each
+        each_byte
+        each_line
+        empty?
+        eql?
+        gsub
+        gsub!
+        hash
+        hex
+        include?
+        index
+        initialize
+        initialize_copy
+        insert
+        inspect
+        intern
+        length
+        ljust
+        lines
+        lstrip
+        lstrip!
+        match
+        next
+        next!
+        oct
+        replace
+        reverse
+        reverse!
+        rindex
+        rjust
+        rstrip
+        rstrip!
+        scan
+        size
+        slice
+        slice!
+        split
+        squeeze
+        squeeze!
+        strip
+        strip!
+        start_with?
+        sub
+        sub!
+        succ
+        succ!
+        sum
+        swapcase
+        swapcase!
+        to_f
+        to_i
+        to_s
+        to_str
+        to_sym
+        tr
+        tr!
+        tr_s
+        tr_s!
+        upcase
+        upcase!
+        upto
+        []
+        []=
+      ].freeze
+
+      SAFE_ENV = <<~STRING.freeze
+        def keep_singleton_methods(klass, singleton_methods)
+          klass = Object.const_get(klass)
+          singleton_methods = singleton_methods.map(&:to_sym)
+          undef_methods = (klass.singleton_methods - singleton_methods)
+
+          undef_methods.each do |method|
+            klass.singleton_class.send(:undef_method, method)
+          end
+
+        end
+
+        def keep_methods(klass, methods)
+          klass = Object.const_get(klass)
+          methods = methods.map(&:to_sym)
+          undef_methods = (klass.methods(false) - methods)
+          undef_methods.each do |method|
+            klass.send(:undef_method, method)
+          end
+        end
+
+        def clean_constants
+          (Object.constants - #{ALLOWED_CONSTANTS}).each do |const|
+            Object.send(:remove_const, const) if defined?(const)
+          end
+        end
+
+        keep_singleton_methods(:Kernel, #{KERNEL_S_METHODS})
+        keep_singleton_methods(:Symbol, #{SYMBOL_S_METHODS})
+        keep_singleton_methods(:String, #{STRING_S_METHODS})
+
+        keep_methods(:Kernel, #{KERNEL_METHODS})
+        keep_methods(:NilClass, #{NILCLASS_METHODS})
+        keep_methods(:TrueClass, #{TRUECLASS_METHODS})
+        keep_methods(:FalseClass, #{FALSECLASS_METHODS})
+        keep_methods(:Enumerable, #{ENUMERABLE_METHODS})
+        keep_methods(:String, #{STRING_METHODS})
+
+        Kernel.class_eval do
+          def `(*args)
+            raise NoMethodError, "` is unavailable"
+          end
+
+          def system(*args)
+            raise NoMethodError, "system is unavailable"
+          end
+        end
+
+        clean_constants
+      STRING
+    end
+  end
+end

--- a/lib/lago_utils/lago_utils/ruby_sandbox/sandbox_error.rb
+++ b/lib/lago_utils/lago_utils/ruby_sandbox/sandbox_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module LagoUtils
+  module RubySandbox
+    class SandboxError < StandardError
+      def initialize(initial_error:, backtrace: nil)
+        @initial_error = initial_error
+        @backtrace = backtrace
+        super
+      end
+
+      attr_reader :initial_error, :backtrace
+    end
+  end
+end

--- a/lib/lago_utils/lago_utils/ruby_sandbox/sanitizer.rb
+++ b/lib/lago_utils/lago_utils/ruby_sandbox/sanitizer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module LagoUtils
+  module RubySandbox
+    class Sanitizer
+      def initialize(code)
+        @code = code || ''
+      end
+
+      def sanitize
+        code.gsub(/require\s/, 'raise NoMethodError, "require is not allowed";')
+      end
+
+      private
+
+      attr_reader :code
+    end
+  end
+end

--- a/spec/lib/lago_utils/ruby_sandbox_spec.rb
+++ b/spec/lib/lago_utils/ruby_sandbox_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LagoUtils::RubySandbox do
+  let(:code) { <<~RUBY }
+    input = { 'a' => 1, 'b' => 2 }
+
+    input.values.sum
+  RUBY
+
+  it 'runs the code' do
+    expect(described_class.run(code)).to eq(3)
+  end
+
+  context 'with method definition' do
+    let(:code) { <<~RUBY }
+      def sum(a, b)
+        a + b
+      end
+
+      sum(1, 2)
+    RUBY
+
+    it 'runs the code' do
+      expect(described_class.run(code)).to eq(3)
+    end
+  end
+
+  context 'when code requires a library' do
+    let(:code) { <<~RUBY }
+      require 'json'
+
+      { 'a' => 1, 'b' => 2 }.to_json
+    RUBY
+
+    it 'raises an error' do
+      expect { described_class.run(code) }.to raise_error(LagoUtils::RubySandbox::SandboxError)
+    end
+  end
+
+  context 'when code is calling a blacklisted method' do
+    let(:code) { <<~RUBY }
+      Kernel.exit
+    RUBY
+
+    it 'raises an error' do
+      expect { described_class.run(code) }.to raise_error(LagoUtils::RubySandbox::SandboxError)
+    end
+  end
+
+  context 'when code is executing an external script' do
+    let(:code) { <<~RUBY }
+      `rm -rf /tmp`
+    RUBY
+
+    it 'raises an error' do
+      expect { described_class.run(code) }.to raise_error(LagoUtils::RubySandbox::SandboxError)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Some of our customers have express a need for aggregation and charge models that does not fit into the current logic in place in Lago, like for example having a single aggregation for 2 different properties, but make the price per unit changing based on the position of the event.

This feature aims to propose a way to build custom aggregation logic for specific cases.

## Description

This PR adds the Ruby Sandbox that will be used to execute the custom aggregation method in a next PR
