### PR TITLE
feat (accounting-integrations): add logic for fetching tax items

### DIFF
--- a/app/jobs/integrations/aggregator/fetch_tax_items_job.rb
+++ b/app/jobs/integrations/aggregator/fetch_tax_items_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class FetchTaxItemsJob < ApplicationJob
+      queue_as 'integrations'
+
+      retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
+
+      def perform(integration:)
+        result = Integrations::Aggregator::TaxItemsService.call(integration:)
+        result.raise_if_error!
+      end
+    end
+  end
+end

--- a/app/services/integrations/aggregator/tax_items_service.rb
+++ b/app/services/integrations/aggregator/tax_items_service.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class TaxItemsService < BaseService
+      LIMIT = 300
+      MAX_SUBSEQUENT_REQUESTS = 10
+
+      def action_path
+        "v1/#{provider}/taxitems"
+      end
+
+      def call
+        @cursor = ''
+        @items = []
+
+        ActiveRecord::Base.transaction do
+          MAX_SUBSEQUENT_REQUESTS.times do |_i|
+            response = http_client.get(headers:, params:)
+
+            handle_tax_items(response['records'])
+            @cursor = response['next_cursor']
+
+            break if cursor.blank?
+          end
+        end
+        result.tax_items = items
+
+        result
+      end
+
+      private
+
+      attr_reader :cursor, :items
+
+      def headers
+        {
+          'Connection-Id' => integration.connection_id,
+          'Authorization' => "Bearer #{secret_key}",
+          'Provider-Config-Key' => provider,
+        }
+      end
+
+      def handle_tax_items(new_items)
+        @items = items.concat(new_items)
+
+        new_items.each do |item|
+          integration_item = IntegrationItem.new(
+            integration:,
+            external_id: item['id'],
+            name: item['name'],
+            item_type: :tax,
+          )
+
+          integration_item.save!
+        end
+      end
+
+      def params
+        {
+          limit: LIMIT,
+          cursor:,
+        }
+      end
+    end
+  end
+end

--- a/spec/fixtures/integration_aggregator/tax_items_response.json
+++ b/spec/fixtures/integration_aggregator/tax_items_response.json
@@ -1,0 +1,49 @@
+{
+  "records": [
+    {
+      "id": "-3557",
+      "name": "CA_PLPL",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T13:04:48.699947+00:00",
+        "last_modified_at": "2024-04-17T13:04:48.699947+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMzowNDo0OC42OTk5NDcrMDA6MDB8fDAwMDU4MWQ1LThkNGMtNTk0Yi1hMDJkLWYyOTU3YzFiZTNjMA=="
+      }
+    },
+    {
+      "id": "-3879",
+      "name": "CA_ARROWHED FARM",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T13:04:48.699947+00:00",
+        "last_modified_at": "2024-04-17T13:04:48.699947+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMzowNDo0OC42OTk5NDcrMDA6MDB8fDAwMmVlYjA2LTRlMjktNTc0ZC04NWJhLTIwMzU4NWM5NGM2MA=="
+      }
+    },
+    {
+      "id": "-4692",
+      "name": "GA_STEWART",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T13:04:48.699947+00:00",
+        "last_modified_at": "2024-04-17T13:04:48.699947+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMzowNDo0OC42OTk5NDcrMDA6MDB8fDAwOGEzYmFmLTY5MmItNTllNC1hYmYyLWJmMDY1YWVmM2JlNg=="
+      }
+    },
+    {
+      "id": "-5307",
+      "name": "IL_FRANKLIN PARK",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T13:04:48.699947+00:00",
+        "last_modified_at": "2024-04-17T13:04:48.699947+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMzowNDo0OC42OTk5NDcrMDA6MDB8fDAwYTEwZDllLTk2NjUtNWNlYy1iZDAwLWJlMjA3ZTk2ODJmMw=="
+      }
+    }
+  ],
+  "next_cursor": null
+}

--- a/spec/jobs/integrations/aggregator/fetch_tax_items_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/fetch_tax_items_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::FetchTaxItemsJob, type: :job do
+  subject(:fetch_tax_items_job) { described_class }
+
+  let(:tax_items_service) { instance_double(Integrations::Aggregator::TaxItemsService) }
+  let(:integration) { create(:netsuite_integration) }
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(Integrations::Aggregator::TaxItemsService).to receive(:new).and_return(tax_items_service)
+    allow(tax_items_service).to receive(:call).and_return(result)
+  end
+
+  it 'calls the tax items service' do
+    described_class.perform_now(integration:)
+
+    expect(Integrations::Aggregator::TaxItemsService).to have_received(:new)
+    expect(tax_items_service).to have_received(:call)
+  end
+end

--- a/spec/services/integrations/aggregator/tax_items_service_spec.rb
+++ b/spec/services/integrations/aggregator/tax_items_service_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::TaxItemsService do
+  subject(:tax_items_service) { described_class.new(integration:) }
+
+  let(:integration) { create(:netsuite_integration) }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:tax_items_endpoint) { 'https://api.nango.dev/v1/netsuite/taxitems' }
+    let(:headers) do
+      {
+        'Connection-Id' => integration.connection_id,
+        'Authorization' => 'Bearer ',
+        'Provider-Config-Key' => 'netsuite',
+      }
+    end
+    let(:params) do
+      {
+        limit: 300,
+        cursor: '',
+      }
+    end
+
+    let(:aggregator_response) do
+      path = Rails.root.join('spec/fixtures/integration_aggregator/tax_items_response.json')
+      JSON.parse(File.read(path))
+    end
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(tax_items_endpoint)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:get)
+        .with(headers:, params:)
+        .and_return(aggregator_response)
+
+      IntegrationItem.destroy_all
+    end
+
+    it 'successfully fetches tax items' do
+      result = tax_items_service.call
+
+      aggregate_failures do
+        expect(LagoHttpClient::Client).to have_received(:new).with(tax_items_endpoint)
+        expect(lago_client).to have_received(:get)
+        expect(result.tax_items.pluck('id')).to eq(%w[-3557 -3879 -4692 -5307])
+        expect(IntegrationItem.count).to eq(4)
+        expect(IntegrationItem.first.item_type).to eq('tax')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently, Lago does not support accounting integrations.

## Description

This PR handles fetching tax items from netsuite and storing it on Lago side.

This will allow users to perform mapping between Lago taxes and Netsuite tax items which is needed for the sync of invoices, fees and other objects