### PR TITLE
feat(wallet): Set transaction status to wallet transaction

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -4,8 +4,7 @@ module Api
   module V1
     class WalletTransactionsController < Api::BaseController
       def create
-        service = WalletTransactions::CreateService.new
-        result = service.create(
+        result = WalletTransactions::CreateService.new.call(
           organization_id: current_organization.id,
           wallet_id: input_params[:wallet_id],
           paid_credits: input_params[:paid_credits],

--- a/app/graphql/mutations/wallet_transactions/create.rb
+++ b/app/graphql/mutations/wallet_transactions/create.rb
@@ -16,7 +16,7 @@ module Mutations
       type Types::WalletTransactions::Object.collection_type
 
       def resolve(**args)
-        result = ::WalletTransactions::CreateService.new.create(
+        result = ::WalletTransactions::CreateService.new(context[:current_user]).call(
           organization_id: current_organization.id,
           wallet_id: args[:wallet_id],
           paid_credits: args[:paid_credits],

--- a/app/graphql/types/wallet_transactions/object.rb
+++ b/app/graphql/types/wallet_transactions/object.rb
@@ -11,6 +11,7 @@ module Types
       field :amount, String, null: false
       field :credit_amount, String, null: false
       field :status, Types::WalletTransactions::StatusEnum, null: false
+      field :transaction_status, Types::WalletTransactions::TransactionStatusEnum, null: false
       field :transaction_type, Types::WalletTransactions::TransactionTypeEnum, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/wallet_transactions/transaction_status_enum.rb
+++ b/app/graphql/types/wallet_transactions/transaction_status_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module WalletTransactions
+    class TransactionStatusEnum < Types::BaseEnum
+      graphql_name 'WalletTransactionTransactionStatusEnum'
+
+      WalletTransaction::TRANSACTION_STATUSES.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/jobs/wallet_transactions/create_job.rb
+++ b/app/jobs/wallet_transactions/create_job.rb
@@ -5,7 +5,7 @@ module WalletTransactions
     queue_as 'wallets'
 
     def perform(organization_id:, wallet_id:, paid_credits:, granted_credits:, source:)
-      WalletTransactions::CreateService.new.create(
+      WalletTransactions::CreateService.new.call(
         organization_id:,
         wallet_id:,
         paid_credits:,

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -11,6 +11,12 @@ class WalletTransaction < ApplicationRecord
     :settled,
   ].freeze
 
+  TRANSACTION_STATUSES = [
+    :paid,
+    :offered,
+    :voided,
+  ].freeze
+
   TRANSACTION_TYPES = [
     :inbound,
     :outbound,
@@ -23,6 +29,7 @@ class WalletTransaction < ApplicationRecord
   ].freeze
 
   enum status: STATUSES
+  enum transaction_status: TRANSACTION_STATUSES
   enum transaction_type: TRANSACTION_TYPES
   enum source: SOURCES
 

--- a/app/serializers/v1/wallet_transaction_serializer.rb
+++ b/app/serializers/v1/wallet_transaction_serializer.rb
@@ -7,6 +7,7 @@ module V1
         lago_id: model.id,
         lago_wallet_id: model.wallet_id,
         status: model.status,
+        transaction_status: model.transaction_status,
         transaction_type: model.transaction_type,
         amount: model.amount,
         credit_amount: model.credit_amount,

--- a/app/serializers/v1/wallet_transaction_serializer.rb
+++ b/app/serializers/v1/wallet_transaction_serializer.rb
@@ -12,7 +12,7 @@ module V1
         amount: model.amount,
         credit_amount: model.credit_amount,
         settled_at: model.settled_at&.iso8601,
-        created_at: model.created_at&.iso8601,
+        created_at: model.created_at.iso8601,
       }
     end
   end

--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -25,6 +25,7 @@ module Credits
           credit_amount:,
           status: :settled,
           settled_at: Time.current,
+          transaction_status: :paid,
         )
 
         result.wallet_transaction = wallet_transaction

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -42,6 +42,7 @@ module WalletTransactions
         credit_amount: paid_credits_amount,
         status: :pending,
         source:,
+        transaction_status: :paid,
       )
       Wallets::Balance::IncreaseOngoingService.new(wallet:, credits_amount: paid_credits_amount).call
 
@@ -67,6 +68,7 @@ module WalletTransactions
           status: :settled,
           settled_at: Time.current,
           source:,
+          transaction_status: :offered,
         )
 
         Wallets::Balance::IncreaseService.new(

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -2,7 +2,7 @@
 
 module WalletTransactions
   class CreateService < BaseService
-    def create(**args)
+    def call(**args)
       return result unless valid?(**args)
 
       wallet_transactions = []

--- a/app/services/wallet_transactions/recredit_service.rb
+++ b/app/services/wallet_transactions/recredit_service.rb
@@ -15,7 +15,7 @@ module WalletTransactions
 
       return result.not_allowed_failure!(code: 'wallet_not_active') unless wallet.active?
 
-      transaction_result = WalletTransactions::CreateService.new.create(
+      transaction_result = WalletTransactions::CreateService.new.call(
         organization_id: customer.organization_id,
         wallet_id: wallet.id,
         granted_credits: wallet_transaction.credit_amount.to_s,

--- a/db/migrate/20240419071607_add_transaction_status_to_wallet_transactions.rb
+++ b/db/migrate/20240419071607_add_transaction_status_to_wallet_transactions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddTransactionStatusToWalletTransactions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :wallet_transactions, :transaction_status, :integer, null: false, default: 0
+
+    reversible do |dir|
+      dir.up do
+        # Set existing wallet transactions as offered if no invoices linked and status is settled.
+        execute <<-SQL
+          UPDATE wallet_transactions
+            SET transaction_status = 1 -- offered
+            WHERE invoice_id IS NULL
+            AND status = 1; -- settled
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -939,6 +939,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_19_085012) do
     t.datetime "updated_at", null: false
     t.uuid "invoice_id"
     t.integer "source", default: 0, null: false
+    t.integer "transaction_status", default: 0, null: false
     t.index ["invoice_id"], name: "index_wallet_transactions_on_invoice_id"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
   end

--- a/db/seeds/base.rb
+++ b/db/seeds/base.rb
@@ -220,6 +220,7 @@ Wallet.create!(
     amount: BigDecimal('10.00'),
     credit_amount: BigDecimal('10.00'),
     settled_at: Time.zone.now,
+    transaction_status: :paid,
   )
 end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -6543,6 +6543,7 @@ type WalletTransaction {
   id: ID!
   settledAt: ISO8601DateTime
   status: WalletTransactionStatusEnum!
+  transactionStatus: WalletTransactionTransactionStatusEnum!
   transactionType: WalletTransactionTransactionTypeEnum!
   updatedAt: ISO8601DateTime!
   wallet: Wallet
@@ -6556,6 +6557,12 @@ type WalletTransactionCollection {
 enum WalletTransactionStatusEnum {
   pending
   settled
+}
+
+enum WalletTransactionTransactionStatusEnum {
+  offered
+  paid
+  voided
 }
 
 enum WalletTransactionTransactionTypeEnum {

--- a/schema.json
+++ b/schema.json
@@ -31141,6 +31141,24 @@
               ]
             },
             {
+              "name": "transactionStatus",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "WalletTransactionTransactionStatusEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "transactionType",
               "description": null,
               "type": {
@@ -31268,6 +31286,35 @@
             },
             {
               "name": "settled",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "WalletTransactionTransactionStatusEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "paid",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "offered",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "voided",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/graphql/mutations/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/wallet_transactions/create_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
     wallet
   end
 
-  it 'create a wallet transaction' do
+  it 'creates a wallet transaction' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,

--- a/spec/graphql/types/wallet_transactions/object_spec.rb
+++ b/spec/graphql/types/wallet_transactions/object_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::WalletTransactions::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:wallet).of_type('Wallet') }
+
+  it { is_expected.to have_field(:amount).of_type('String!') }
+  it { is_expected.to have_field(:credit_amount).of_type('String!') }
+  it { is_expected.to have_field(:status).of_type('WalletTransactionStatusEnum!') }
+  it { is_expected.to have_field(:transaction_status).of_type('WalletTransactionTransactionStatusEnum!') }
+  it { is_expected.to have_field(:transaction_type).of_type('WalletTransactionTransactionTypeEnum!') }
+
+  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:settled_at).of_type('ISO8601DateTime') }
+  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+end

--- a/spec/jobs/wallet_transactions/create_job_spec.rb
+++ b/spec/jobs/wallet_transactions/create_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe WalletTransactions::CreateJob, type: :job do
   it 'calls the WalletTransactions::CreateService' do
     allow(WalletTransactions::CreateService).to receive(:new)
       .and_return(wallet_transaction_create_service)
-    allow(wallet_transaction_create_service).to receive(:create)
+    allow(wallet_transaction_create_service).to receive(:call)
 
     described_class.perform_now(
       organization_id: '123456',
@@ -20,7 +20,7 @@ RSpec.describe WalletTransactions::CreateJob, type: :job do
       source: 'manual',
     )
 
-    expect(wallet_transaction_create_service).to have_received(:create).with(
+    expect(wallet_transaction_create_service).to have_received(:call).with(
       organization_id: '123456',
       wallet_id: '123456',
       paid_credits: '1.00',

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ::V1::WalletTransactionSerializer do
         'amount' => wallet_transaction.amount.to_s,
         'credit_amount' => wallet_transaction.credit_amount.to_s,
         'settled_at' => wallet_transaction.settled_at&.iso8601,
-        'created_at' => wallet_transaction.created_at&.iso8601,
+        'created_at' => wallet_transaction.created_at.iso8601,
       )
     end
   end

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::WalletTransactionSerializer do
+  subject(:serializer) do
+    described_class.new(wallet_transaction, root_name: 'wallet_transaction')
+  end
+
+  let(:wallet_transaction) { create(:wallet_transaction) }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['wallet_transaction']).to include(
+        'lago_id' => wallet_transaction.id,
+        'lago_wallet_id' => wallet_transaction.wallet_id,
+        'status' => wallet_transaction.status,
+        'transaction_status' => wallet_transaction.transaction_status,
+        'transaction_type' => wallet_transaction.transaction_type,
+        'amount' => wallet_transaction.amount.to_s,
+        'credit_amount' => wallet_transaction.credit_amount.to_s,
+        'settled_at' => wallet_transaction.settled_at&.iso8601,
+        'created_at' => wallet_transaction.created_at&.iso8601,
+      )
+    end
+  end
+end

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
 
   before { subscription }
 
-  describe 'call' do
+  describe '#call' do
     it 'calculates prepaid credit' do
       result = credit_service.call
 
@@ -35,6 +35,7 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
       expect(result).to be_success
       expect(result.wallet_transaction).to be_present
       expect(result.wallet_transaction.amount).to eq(1.0)
+      expect(result.wallet_transaction).to be_paid
     end
 
     it 'updates wallet balance' do

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
     subscription
   end
 
-  describe '.create' do
+  describe '#create' do
     let(:paid_credits) { '10.00' }
     let(:granted_credits) { '15.00' }
     let(:create_args) do
@@ -40,6 +40,16 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
     it 'creates a wallet transactions' do
       expect { create_service.create(**create_args) }
         .to change(WalletTransaction, :count).by(2)
+    end
+
+    it 'sets expected transaction status', :aggregate_failures do
+      create_service.create(**create_args)
+
+      paid_transaction = WalletTransaction.where(wallet_id: wallet.id).paid.first
+      offered_transaction = WalletTransaction.where(wallet_id: wallet.id).offered.first
+
+      expect(paid_transaction.credit_amount).to eq(10)
+      expect(offered_transaction.credit_amount).to eq(15)
     end
 
     it 'sets correct source' do


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to add a `transaction_status` field for wallet transactions.
This field can be set to `paid`, `offered`, or `voided` (not used yet).