### PR TITLE
misc(wallet): Refactor WalletTransaction create service

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -4,11 +4,9 @@ module Api
   module V1
     class WalletTransactionsController < Api::BaseController
       def create
-        result = WalletTransactions::CreateService.new.call(
-          organization_id: current_organization.id,
-          wallet_id: input_params[:wallet_id],
-          paid_credits: input_params[:paid_credits],
-          granted_credits: input_params[:granted_credits],
+        result = WalletTransactions::CreateService.call(
+          organization: current_organization,
+          params: input_params,
         )
 
         if result.success?

--- a/app/graphql/mutations/wallet_transactions/create.rb
+++ b/app/graphql/mutations/wallet_transactions/create.rb
@@ -16,12 +16,7 @@ module Mutations
       type Types::WalletTransactions::Object.collection_type
 
       def resolve(**args)
-        result = ::WalletTransactions::CreateService.new(context[:current_user]).call(
-          organization_id: current_organization.id,
-          wallet_id: args[:wallet_id],
-          paid_credits: args[:paid_credits],
-          granted_credits: args[:granted_credits],
-        )
+        result = ::WalletTransactions::CreateService.call(organization: current_organization, params: args)
 
         result.success? ? result.wallet_transactions : result_error(result)
       end

--- a/app/jobs/wallet_transactions/create_job.rb
+++ b/app/jobs/wallet_transactions/create_job.rb
@@ -4,14 +4,9 @@ module WalletTransactions
   class CreateJob < ApplicationJob
     queue_as 'wallets'
 
-    def perform(organization_id:, wallet_id:, paid_credits:, granted_credits:, source:)
-      WalletTransactions::CreateService.new.call(
-        organization_id:,
-        wallet_id:,
-        paid_credits:,
-        granted_credits:,
-        source:,
-      )
+    def perform(organization_id:, params:)
+      organization = Organization.find(organization_id)
+      WalletTransactions::CreateService.call(organization:, params:)
     end
   end
 end

--- a/app/services/base_validator.rb
+++ b/app/services/base_validator.rb
@@ -3,7 +3,7 @@
 class BaseValidator
   def initialize(result, **args)
     @result = result
-    @args = args
+    @args = args.to_h.with_indifferent_access
 
     @errors = {}
   end

--- a/app/services/wallet_transactions/recredit_service.rb
+++ b/app/services/wallet_transactions/recredit_service.rb
@@ -15,11 +15,13 @@ module WalletTransactions
 
       return result.not_allowed_failure!(code: 'wallet_not_active') unless wallet.active?
 
-      transaction_result = WalletTransactions::CreateService.new.call(
-        organization_id: customer.organization_id,
-        wallet_id: wallet.id,
-        granted_credits: wallet_transaction.credit_amount.to_s,
-        reset_consumed_credits: true,
+      transaction_result = WalletTransactions::CreateService.call(
+        organization: customer.organization,
+        params: {
+          wallet_id: wallet.id,
+          granted_credits: wallet_transaction.credit_amount.to_s,
+          reset_consumed_credits: true,
+        },
       )
 
       return transaction_result unless transaction_result.success?

--- a/app/services/wallets/balance/decrease_ongoing_service.rb
+++ b/app/services/wallets/balance/decrease_ongoing_service.rb
@@ -38,10 +38,12 @@ module Wallets
 
         WalletTransactions::CreateJob.set(wait: 2.seconds).perform_later(
           organization_id: wallet.organization.id,
-          wallet_id: wallet.id,
-          paid_credits: threshold_rule.paid_credits.to_s,
-          granted_credits: threshold_rule.granted_credits.to_s,
-          source: :threshold,
+          params: {
+            wallet_id: wallet.id,
+            paid_credits: threshold_rule.paid_credits.to_s,
+            granted_credits: threshold_rule.granted_credits.to_s,
+            source: :threshold,
+          },
         )
       end
 

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -8,10 +8,12 @@ module Wallets
 
         WalletTransactions::CreateJob.perform_later(
           organization_id: wallet.organization.id,
-          wallet_id: wallet.id,
-          paid_credits: recurring_transaction_rule.paid_credits.to_s,
-          granted_credits: recurring_transaction_rule.granted_credits.to_s,
-          source: :interval,
+          params: {
+            wallet_id: wallet.id,
+            paid_credits: recurring_transaction_rule.paid_credits.to_s,
+            granted_credits: recurring_transaction_rule.granted_credits.to_s,
+            source: :interval,
+          },
         )
       end
     end
@@ -102,7 +104,6 @@ module Wallets
     end
 
     # NOTE: Billed quarterly on anniversary date
-    # rubocop:disable Layout/LineLength
     def quarterly_anniversary
       billing_day = <<-SQL
         DATE_PART('day', (wallets.created_at#{at_time_zone})) = ANY (
@@ -139,7 +140,6 @@ module Wallets
         conditions: [billing_month, billing_day],
       )
     end
-    # rubocop:enable Layout/LineLength
 
     def yearly_anniversary
       billing_month = <<-SQL

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -37,10 +37,12 @@ module Wallets
 
       WalletTransactions::CreateJob.perform_later(
         organization_id: args[:organization_id],
-        wallet_id: wallet.id,
-        paid_credits: args[:paid_credits],
-        granted_credits: args[:granted_credits],
-        source: :manual,
+        params: {
+          wallet_id: wallet.id,
+          paid_credits: args[:paid_credits],
+          granted_credits: args[:granted_credits],
+          source: :manual,
+        },
       )
 
       result

--- a/spec/jobs/wallet_transactions/create_job_spec.rb
+++ b/spec/jobs/wallet_transactions/create_job_spec.rb
@@ -5,27 +5,30 @@ require 'rails_helper'
 RSpec.describe WalletTransactions::CreateJob, type: :job do
   subject(:create_job) { described_class }
 
+  let(:organization) { create(:organization) }
   let(:wallet_transaction_create_service) { instance_double(WalletTransactions::CreateService) }
 
   it 'calls the WalletTransactions::CreateService' do
-    allow(WalletTransactions::CreateService).to receive(:new)
-      .and_return(wallet_transaction_create_service)
-    allow(wallet_transaction_create_service).to receive(:call)
+    allow(WalletTransactions::CreateService).to receive(:call)
 
     described_class.perform_now(
-      organization_id: '123456',
-      wallet_id: '123456',
-      paid_credits: '1.00',
-      granted_credits: '1.00',
-      source: 'manual',
+      organization_id: organization.id,
+      params: {
+        wallet_id: '123456',
+        paid_credits: '1.00',
+        granted_credits: '1.00',
+        source: 'manual',
+      },
     )
 
-    expect(wallet_transaction_create_service).to have_received(:call).with(
-      organization_id: '123456',
-      wallet_id: '123456',
-      paid_credits: '1.00',
-      granted_credits: '1.00',
-      source: 'manual',
+    expect(WalletTransactions::CreateService).to have_received(:call).with(
+      organization:,
+      params: {
+        wallet_id: '123456',
+        paid_credits: '1.00',
+        granted_credits: '1.00',
+        source: 'manual',
+      },
     )
   end
 end

--- a/spec/requests/api/v1/wallet_transactions_controller_spec.rb
+++ b/spec/requests/api/v1/wallet_transactions_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
   end
 
   describe 'create' do
-    let(:create_params) do
+    let(:params) do
       {
         wallet_id:,
         paid_credits: '10',
@@ -24,7 +24,7 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
     end
 
     it 'creates a wallet transactions' do
-      post_with_token(organization, '/api/v1/wallet_transactions', { wallet_transaction: create_params })
+      post_with_token(organization, '/api/v1/wallet_transactions', { wallet_transaction: params })
 
       expect(response).to have_http_status(:success)
 
@@ -41,7 +41,7 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
       let(:wallet_id) { "#{wallet.id}123" }
 
       it 'returns unprocessable_entity error' do
-        post_with_token(organization, '/api/v1/wallet_transactions', { wallet_transaction: create_params })
+        post_with_token(organization, '/api/v1/wallet_transactions', { wallet_transaction: params })
 
         expect(response).to have_http_status(:unprocessable_entity)
       end

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe WalletTransactions::CreateService, type: :service do
-  subject(:create_service) { described_class.new(membership.user) }
+  subject(:create_service) { described_class.call(organization:, params:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
@@ -27,10 +27,9 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
   describe '#call' do
     let(:paid_credits) { '10.00' }
     let(:granted_credits) { '15.00' }
-    let(:create_args) do
+    let(:params) do
       {
         wallet_id: wallet.id,
-        organization_id: organization.id,
         paid_credits:,
         granted_credits:,
         source: :manual,
@@ -38,13 +37,11 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
     end
 
     it 'creates a wallet transactions' do
-      expect { create_service.call(**create_args) }
-        .to change(WalletTransaction, :count).by(2)
+      expect { create_service }.to change(WalletTransaction, :count).by(2)
     end
 
     it 'sets expected transaction status', :aggregate_failures do
-      create_service.call(**create_args)
-
+      create_service
       paid_transaction = WalletTransaction.where(wallet_id: wallet.id).paid.first
       offered_transaction = WalletTransaction.where(wallet_id: wallet.id).offered.first
 
@@ -53,8 +50,7 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
     end
 
     it 'sets correct source' do
-      create_service.call(**create_args)
-
+      create_service
       wallet_transactions = WalletTransaction.where(wallet_id: wallet.id).order(created_at: :desc)
 
       aggregate_failures do
@@ -64,19 +60,18 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
     end
 
     it 'enqueues the BillPaidCreditJob' do
-      expect { create_service.call(**create_args) }
-        .to have_enqueued_job(BillPaidCreditJob)
+      expect { create_service }.to have_enqueued_job(BillPaidCreditJob)
     end
 
     it 'updates wallet balance only with granted credits' do
-      create_service.call(**create_args)
+      create_service
 
       expect(wallet.reload.balance_cents).to eq(2500)
       expect(wallet.reload.credits_balance).to eq(25.0)
     end
 
     it 'updates wallet ongoing balance with granted and paid credits' do
-      create_service.call(**create_args)
+      create_service
 
       expect(wallet.reload.ongoing_balance_cents).to eq(3500)
       expect(wallet.reload.credits_ongoing_balance).to eq(35.0)
@@ -86,7 +81,7 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
       let(:paid_credits) { '-15.00' }
 
       it 'returns an error' do
-        result = create_service.call(**create_args)
+        result = create_service
 
         expect(result).not_to be_success
         expect(result.error.messages[:paid_credits]).to eq(['invalid_paid_credits'])

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -36,10 +36,12 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
           expect(WalletTransactions::CreateJob).to have_been_enqueued
             .with(
               organization_id: customer.organization_id,
-              wallet_id: wallet.id,
-              paid_credits: recurring_transaction_rule.paid_credits.to_s,
-              granted_credits: recurring_transaction_rule.granted_credits.to_s,
-              source: :interval,
+              params: {
+                wallet_id: wallet.id,
+                paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                granted_credits: recurring_transaction_rule.granted_credits.to_s,
+                source: :interval,
+              },
             )
         end
       end
@@ -62,10 +64,12 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
           expect(WalletTransactions::CreateJob).to have_been_enqueued
             .with(
               organization_id: customer.organization_id,
-              wallet_id: wallet.id,
-              paid_credits: recurring_transaction_rule.paid_credits.to_s,
-              granted_credits: recurring_transaction_rule.granted_credits.to_s,
-              source: :interval,
+              params: {
+                wallet_id: wallet.id,
+                paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                granted_credits: recurring_transaction_rule.granted_credits.to_s,
+                source: :interval,
+              },
             )
         end
       end
@@ -87,10 +91,12 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
             expect(WalletTransactions::CreateJob).to have_been_enqueued
               .with(
                 organization_id: customer.organization_id,
-                wallet_id: wallet.id,
-                paid_credits: recurring_transaction_rule.paid_credits.to_s,
-                granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                source: :interval,
+                params: {
+                  wallet_id: wallet.id,
+                  paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                  granted_credits: recurring_transaction_rule.granted_credits.to_s,
+                  source: :interval,
+                },
               )
           end
         end
@@ -108,10 +114,12 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
           expect(WalletTransactions::CreateJob).to have_been_enqueued
             .with(
               organization_id: customer.organization_id,
-              wallet_id: wallet.id,
-              paid_credits: recurring_transaction_rule.paid_credits.to_s,
-              granted_credits: recurring_transaction_rule.granted_credits.to_s,
-              source: :interval,
+              params: {
+                wallet_id: wallet.id,
+                paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                granted_credits: recurring_transaction_rule.granted_credits.to_s,
+                source: :interval,
+              },
             )
         end
       end
@@ -133,10 +141,12 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
             expect(WalletTransactions::CreateJob).to have_been_enqueued
               .with(
                 organization_id: customer.organization_id,
-                wallet_id: wallet.id,
-                paid_credits: recurring_transaction_rule.paid_credits.to_s,
-                granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                source: :interval,
+                params: {
+                  wallet_id: wallet.id,
+                  paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                  granted_credits: recurring_transaction_rule.granted_credits.to_s,
+                  source: :interval,
+                },
               )
           end
         end
@@ -153,10 +163,12 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
             expect(WalletTransactions::CreateJob).to have_been_enqueued
               .with(
                 organization_id: customer.organization_id,
-                wallet_id: wallet.id,
-                paid_credits: recurring_transaction_rule.paid_credits.to_s,
-                granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                source: :interval,
+                params: {
+                  wallet_id: wallet.id,
+                  paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                  granted_credits: recurring_transaction_rule.granted_credits.to_s,
+                  source: :interval,
+                },
               )
           end
         end
@@ -174,10 +186,12 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
           expect(WalletTransactions::CreateJob).to have_been_enqueued
             .with(
               organization_id: customer.organization_id,
-              wallet_id: wallet.id,
-              paid_credits: recurring_transaction_rule.paid_credits.to_s,
-              granted_credits: recurring_transaction_rule.granted_credits.to_s,
-              source: :interval,
+              params: {
+                wallet_id: wallet.id,
+                paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                granted_credits: recurring_transaction_rule.granted_credits.to_s,
+                source: :interval,
+              },
             )
         end
       end
@@ -199,10 +213,12 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
             expect(WalletTransactions::CreateJob).to have_been_enqueued
               .with(
                 organization_id: customer.organization_id,
-                wallet_id: wallet.id,
-                paid_credits: recurring_transaction_rule.paid_credits.to_s,
-                granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                source: :interval,
+                params: {
+                  wallet_id: wallet.id,
+                  paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                  granted_credits: recurring_transaction_rule.granted_credits.to_s,
+                  source: :interval,
+                },
               )
           end
         end


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to refactor `WalletTransactions::CreateService` to use the common `call` method.