### PR TITLE
fix(trial): Ignore subscription if there is no free trial set

### DIFF
--- a/app/services/subscriptions/free_trial_billing_service.rb
+++ b/app/services/subscriptions/free_trial_billing_service.rb
@@ -59,6 +59,7 @@ module Subscriptions
           LEFT JOIN already_billed_today ON already_billed_today.subscription_id = subscriptions.id
         WHERE
           subscriptions.status = 1
+          AND plans.trial_period > 0
           AND subscriptions.trial_ended_at IS NULL
           AND #{trial_end_date + at_time_zone} <= '#{timestamp}'#{at_time_zone}
       SQL

--- a/spec/services/subscriptions/free_trial_billing_service_spec.rb
+++ b/spec/services/subscriptions/free_trial_billing_service_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe Subscriptions::FreeTrialBillingService, type: :service do
   describe '#call' do
     let(:plan) { create(:plan, trial_period: 10, pay_in_advance: true) }
 
+    context 'with a plan witout trial period' do
+      it 'does not set trial_ended_at' do
+        sub = create(:subscription, plan: create(:plan, trial_period: 0, pay_in_advance: true), started_at: 2.days.ago)
+        sub2 = create(:subscription, plan: create(:plan, pay_in_advance: true), started_at: 2.days.ago)
+        service.call
+        expect(sub.reload.trial_ended_at).to be_nil
+        expect(sub2.reload.trial_ended_at).to be_nil
+      end
+    end
+
     context 'without any ending trial subscriptions' do
       it 'does not set trial_ended_at', :aggregate_failures do
         sub1 = create(:subscription, plan:, started_at: 2.days.ago)


### PR DESCRIPTION
## Description

When a plan free trial has ended, we invoice the subscription, set `subscription.trial_ended_at` attribute and send the `subscription.trial_ended` webhook.

This fix will ensure we do this work *only* if the plan attached to the subscriptions has a free trial configured.

Note that in ruby, the `subscription.trial_ended_datetime` method already returns nil if there is no trial_period configured.