### PR TITLE
fix(filter): Fix email template with fee display name

### DIFF
--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -429,13 +429,13 @@ html
                 - pay_in_advance_range = charge_pay_in_advance_proration_range(fee, invoice_subscription(fee.subscription.id).timestamp)
                 td
                   .body-1
-                    = fee.invoice_name + FeeDisplayHelper.grouped_by_display(self)
+                    = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
                     - if fee.charge_filter_id?
                       = ' • ' + fee.filter_display_name(separator: ' • ')
                   .body-3 = I18n.t('invoice.breakdown_for_days', breakdown_duration: pay_in_advance_range[:number_of_days], breakdown_total_duration: pay_in_advance_range[:period_duration])
               - else
                 td.body-1
-                  = fee.invoice_name + FeeDisplayHelper.grouped_by_display(self)
+                  = fee.invoice_name + FeeDisplayHelper.grouped_by_display(fee)
                   - if fee.charge_filter_id?
                     = ' • ' + fee.filter_display_name(separator: ' • ')
               td.body-2 = fee.units


### PR DESCRIPTION
## Description

This PR is a fix for the following error in InvoiceMailer:

```
undefined method `charge?' for #<Invoice id: "<GUID>", created_at: "<DATETIME>", updated_at: "<DATETIME>", issuing_date: "<DATE>", taxes_amount_cents: 0, total_amount_cents: 0, invoice_type: "subscription", payment_status: "succeeded", number: "SOR-D491-348-140", sequential_id: 140, file: nil, customer_id: "<GUID>", taxes_rate: 0.0, status: "finalized", timezone: "UTC", payment_attempts: 0, ready_for_payment_processing: true, organization_id: "<GUID>", version_number: 4, currency: "USD", fees_amount_cents: 0, coupons_amount_cents: 0, credit_notes_amount_cents: 0, prepaid_credit_amount_cents: 0, sub_total_excluding_taxes_amount_cents: 0, sub_total_including_taxes_amount_cents: 0, payment_due_date: "<DATE>", net_payment_term: 0, voided_at: nil, organization_sequential_id: 0, ready_to_be_refreshed: false, payment_dispute_lost_at: nil, skip_charges: false>
```