### PR TITLE
feat(gql): expose Memberships to UserType (to retrieve upcoming permissions)

### DIFF
--- a/app/graphql/resolvers/memberships_resolver.rb
+++ b/app/graphql/resolvers/memberships_resolver.rb
@@ -15,6 +15,7 @@ module Resolvers
     def resolve(page: nil, limit: nil)
       current_organization
         .memberships
+        .includes(:user)
         .active
         .page(page)
         .per(limit)

--- a/app/graphql/types/membership_type.rb
+++ b/app/graphql/types/membership_type.rb
@@ -2,13 +2,17 @@
 
 module Types
   class MembershipType < Types::BaseObject
-    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :id, ID, null: false
-    field :organization, Types::OrganizationType, null: false
-    field :revoked_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :role, String, null: true
-    field :status, Types::Memberships::StatusEnum, null: false
-    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+    field :organization, Types::SafeOrganizationType, null: false
     field :user, Types::UserType, null: false
+
+    # TODO: Add permissions here
+    field :role, Types::Memberships::RoleEnum, null: true
+    field :status, Types::Memberships::StatusEnum, null: false
+
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :revoked_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end
 end

--- a/app/graphql/types/memberships/role_enum.rb
+++ b/app/graphql/types/memberships/role_enum.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Memberships
+    class RoleEnum < Types::BaseEnum
+      graphql_name 'MembershipRole'
+
+      Membership::ROLES.keys.each do |role|
+        value role
+      end
+    end
+  end
+end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -2,17 +2,24 @@
 
 module Types
   class UserType < Types::BaseObject
-    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
-    field :email, String
     field :id, ID, null: false
+
+    field :email, String
     field :premium, Boolean, null: false
+
+    field :memberships, [Types::MembershipType], null: false
+    # TODO: keeping organization for backwards compatibility, remove once the frontend is updated
+    field :organizations, [Types::SafeOrganizationType], null: false
+
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
-    # Use SafeOrganizationType to prevent traversal attack. See SafeOrganizationType for more details.
-    field :organizations, [Types::SafeOrganizationType]
+    def memberships
+      object.memberships.active.includes(:organization)
+    end
 
     def organizations
-      object.memberships.active.map(&:organization)
+      memberships.map(&:organization)
     end
 
     def premium

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -11,8 +11,10 @@ class Membership < ApplicationRecord
     :revoked,
   ].freeze
 
+  ROLES = { admin: 0 }.freeze
+
   enum status: STATUSES
-  enum role: { admin: 0 }
+  enum role: ROLES
 
   validates :user_id, uniqueness: { conditions: -> { where(revoked_at: nil) }, scope: :organization_id }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -3694,9 +3694,9 @@ input LoseInvoiceDisputeInput {
 type Membership {
   createdAt: ISO8601DateTime!
   id: ID!
-  organization: Organization!
+  organization: SafeOrganization!
   revokedAt: ISO8601DateTime!
-  role: String
+  role: MembershipRole
   status: MembershipStatus!
   updatedAt: ISO8601DateTime!
   user: User!
@@ -3705,6 +3705,10 @@ type Membership {
 type MembershipCollection {
   collection: [Membership!]!
   metadata: CollectionMetadata!
+}
+
+enum MembershipRole {
+  admin
 }
 
 enum MembershipStatus {
@@ -6513,7 +6517,8 @@ type User {
   createdAt: ISO8601DateTime!
   email: String
   id: ID!
-  organizations: [SafeOrganization!]
+  memberships: [Membership!]!
+  organizations: [SafeOrganization!]!
   premium: Boolean!
   updatedAt: ISO8601DateTime!
 }

--- a/schema.json
+++ b/schema.json
@@ -17370,7 +17370,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "Organization",
+                  "name": "SafeOrganization",
                   "ofType": null
                 }
               },
@@ -17402,8 +17402,8 @@
               "name": "role",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "MembershipRole",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -17526,6 +17526,23 @@
           ],
           "inputFields": null,
           "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "MembershipRole",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "admin",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
         },
         {
           "kind": "ENUM",
@@ -30546,18 +30563,48 @@
               ]
             },
             {
+              "name": "memberships",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Membership",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "organizations",
               "description": null,
               "type": {
-                "kind": "LIST",
+                "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "NON_NULL",
+                  "kind": "LIST",
                   "name": null,
                   "ofType": {
-                    "kind": "OBJECT",
-                    "name": "SafeOrganization",
-                    "ofType": null
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SafeOrganization",
+                      "ofType": null
+                    }
                   }
                 }
               },


### PR DESCRIPTION
## Context

Role-based permissions are coming to Lago.

## Description

This PR introduces an proper RoleEnum for `membership.role` attribute. Today there is only admin but more roles are coming.

This is preliminary work to help the frontend retrieve permissions and role for the current user for each organization through memberships. The `organizations` relation is still available for backward compatibility reasons.

### Before

```gql
fragment CurrentUserInfos on User {
  id
  email
  premium
  organizations {
    id
    name
    logoUrl
  }
}
```

### After

```gql
fragment CurrentUserInfos on User {
  id
  email
  premium
  memberships {
    id
    role
    permissions.  <--- upcoming
    organization {
      id
      name
      logoUrl
    }
  }
}
```