### PR TITLE
feat(wallet): Send webhook message when wallet transaction is created

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -32,6 +32,7 @@ class SendWebhookJob < ApplicationJob
     'subscription.started' => Webhooks::Subscriptions::StartedService,
     'subscription.termination_alert' => Webhooks::Subscriptions::TerminationAlertService,
     'subscription.trial_ended' => Webhooks::Subscriptions::TrialEndedService,
+    'wallet_transaction.created' => Webhooks::WalletTransactions::CreatedService,
   }.freeze
 
   def perform(webhook_type, object, options = {}, webhook_id = nil)

--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -35,6 +35,8 @@ module Credits
         invoice.prepaid_credit_amount_cents += amount_cents
       end
 
+      SendWebhookJob.perform_later('wallet_transaction.created', result.wallet_transaction)
+
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/webhooks/wallet_transactions/created_service.rb
+++ b/app/services/webhooks/wallet_transactions/created_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module WalletTransactions
+    class CreatedService < Webhooks::BaseService
+      private
+
+      def current_organization
+        @current_organization ||= object.wallet.organization
+      end
+
+      def object_serializer
+        ::V1::WalletTransactionSerializer.new(object, root_name: 'wallet_transaction')
+      end
+
+      def webhook_type
+        'wallet_transaction.created'
+      end
+
+      def object_type
+        'wallet_transaction'
+      end
+    end
+  end
+end

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -46,6 +46,11 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
       expect(wallet.credits_balance).to eq(9.0)
     end
 
+    it 'enqueues a SendWebhookJob' do
+      expect { credit_service.call }.to have_enqueued_job(SendWebhookJob)
+        .with('wallet_transaction.created', WalletTransaction)
+    end
+
     context 'when wallet credits are less than invoice amount' do
       let(:amount_cents) { 1500 }
 

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -77,6 +77,12 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
       expect(wallet.reload.credits_ongoing_balance).to eq(35.0)
     end
 
+    it 'enqueues a SendWebhookJob for each wallet transaction' do
+      expect do
+        create_service.call
+      end.to have_enqueued_job(SendWebhookJob).twice.with('wallet_transaction.created', WalletTransaction)
+    end
+
     context 'with validation error' do
       let(:paid_credits) { '-15.00' }
 

--- a/spec/services/webhooks/wallet_transactions/created_service_spec.rb
+++ b/spec/services/webhooks/wallet_transactions/created_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::WalletTransactions::CreatedService do
+  subject(:webhook_service) { described_class.new(object: wallet_transaction) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:wallet) { create(:wallet, customer:) }
+  let(:wallet_transaction) { create(:wallet_transaction, wallet:) }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response)
+    end
+
+    it 'builds payload with wallet_transaction.created webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+
+      expect(lago_client).to have_received(:post_with_response) do |payload|
+        expect(payload[:webhook_type]).to eq('wallet_transaction.created')
+        expect(payload[:object_type]).to eq('wallet_transaction')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to send a webhook `wallet_transaction.created` each time a wallet transaction is created (inbound or outbound).