### PR TITLE
fix(filter): Render discarded charge filters when attached to fees

### DIFF
--- a/app/models/charge_filter.rb
+++ b/app/models/charge_filter.rb
@@ -5,7 +5,7 @@ class ChargeFilter < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
-  belongs_to :charge
+  belongs_to :charge, -> { with_discarded }
 
   has_many :values, class_name: 'ChargeFilterValue', dependent: :destroy
   has_many :billable_metric_filters, through: :values

--- a/app/models/charge_filter_value.rb
+++ b/app/models/charge_filter_value.rb
@@ -7,7 +7,7 @@ class ChargeFilterValue < ApplicationRecord
 
   ALL_FILTER_VALUES = '__ALL_FILTER_VALUES__'
 
-  belongs_to :charge_filter
+  belongs_to :charge_filter, -> { with_discarded }
   belongs_to :billable_metric_filter, -> { with_discarded }
 
   validates :values, presence: true

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -92,6 +92,7 @@ module Plans
       ).properties
 
       if args[:filters].present?
+        charge.save!
         ChargeFilters::CreateOrUpdateBatchService.call(
           charge:,
           filters_params: args[:filters].map(&:with_indifferent_access),

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -88,6 +88,7 @@ module Plans
       ).properties
 
       if params[:filters].present?
+        charge.save!
         ChargeFilters::CreateOrUpdateBatchService.call(
           charge:,
           filters_params: params[:filters].map(&:with_indifferent_access),
@@ -156,14 +157,6 @@ module Plans
             return group_result if group_result.error
           end
 
-          filters = payload_charge.delete(:filters)
-          unless filters.nil?
-            ChargeFilters::CreateOrUpdateBatchService.call(
-              charge:,
-              filters_params: filters.map(&:with_indifferent_access),
-            ).raise_if_error!
-          end
-
           properties = payload_charge.delete(:properties).presence || Charges::BuildDefaultPropertiesService.call(
             payload_charge[:charge_model],
           )
@@ -175,6 +168,14 @@ module Plans
               properties:,
             ).properties,
           )
+
+          filters = payload_charge.delete(:filters)
+          unless filters.nil?
+            ChargeFilters::CreateOrUpdateBatchService.call(
+              charge:,
+              filters_params: filters.map(&:with_indifferent_access),
+            ).raise_if_error!
+          end
 
           tax_codes = payload_charge.delete(:tax_codes)
           if tax_codes

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -156,20 +156,23 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
 
   context 'with a deleted billable metric' do
     let(:billable_metric) { create(:billable_metric, :deleted) }
-    let(:group) { create(:group, :deleted, billable_metric:) }
-    let(:fee) { create(:charge_fee, subscription:, invoice:, group:, charge:, amount_cents: 10) }
-
-    let(:group_property) do
-      build(
-        :group_property,
+    let(:billable_metric_filter) { create(:billable_metric_filter, :deleted, billable_metric:) }
+    let(:charge_filter) do
+      create(:charge_filter, :deleted, charge:, properties: { amount: '10' })
+    end
+    let(:charge_filter_value) do
+      create(
+        :charge_filter_value,
         :deleted,
-        group:,
-        values: { amount: '10', amount_currency: 'EUR' },
+        charge_filter:,
+        billable_metric_filter:,
+        values: [billable_metric_filter.values.first],
       )
     end
+    let(:fee) { create(:charge_fee, subscription:, invoice:, charge_filter:, charge:, amount_cents: 10) }
 
     let(:charge) do
-      create(:standard_charge, :deleted, billable_metric:, group_properties: [group_property])
+      create(:standard_charge, :deleted, billable_metric:)
     end
 
     it 'returns the invoice with the deleted resources' do

--- a/spec/services/invoices/generate_pdf_service_spec.rb
+++ b/spec/services/invoices/generate_pdf_service_spec.rb
@@ -86,20 +86,24 @@ RSpec.describe Invoices::GeneratePdfService, type: :service do
 
     context 'when a billable metric is deleted' do
       let(:billable_metric) { create(:billable_metric, :deleted) }
-      let(:group) { create(:group, :deleted, billable_metric:) }
-      let(:fees) { [create(:charge_fee, subscription:, invoice:, group:, charge:, amount_cents: 10)] }
-
-      let(:group_property) do
-        build(
-          :group_property,
+      let(:fees) { [create(:charge_fee, subscription:, invoice:, charge_filter:, charge:, amount_cents: 10)] }
+      let(:charge) { create(:standard_charge, :deleted, billable_metric:) }
+      let(:billable_metric_filter) { create(:billable_metric_filter, :deleted, billable_metric:) }
+      let(:charge_filter) do
+        create(:charge_filter, :deleted, charge_id: charge.id, properties: { amount: '10' })
+      end
+      let(:charge_filter_value) do
+        create(
+          :charge_filter_value,
           :deleted,
-          group:,
-          values: { amount: '10', amount_currency: 'EUR' },
+          charge_filter:,
+          billable_metric_filter:,
+          values: [billable_metric_filter.values.first],
         )
       end
 
-      let(:charge) do
-        create(:standard_charge, :deleted, billable_metric:, group_properties: [group_property])
+      before do
+        charge_filter_value
       end
 
       it 'generates the invoice synchronously' do


### PR DESCRIPTION
## Context

This PR follow the recent release of the filter feature.

## Description

It makes discarded charge filters attached to fees are returned:
- In the GraphQL API
- In the Rest API
- On the invoice  PDF