### PR TITLE
Revert "chore(ci): Migrate DB before test instead of running a dedicated job"

### DIFF
--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -1,4 +1,4 @@
-name: Run Spec
+name: Run rails migrations
 on:
   push:
     branches:
@@ -6,8 +6,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:
-  run-spec:
-    name: Run Spec
+  run-migrations:
+    name: Run migrations
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -23,6 +23,9 @@ jobs:
       DATABASE_URL: "postgres://lago:lago@localhost:5432/lago"
       RAILS_MASTER_KEY: ${{ secrets.RAILS_TEST_KEY }}
       SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+      ENCRYPTION_PRIMARY_KEY: 5I9mjfzry2P787x4S5ZuDdJwXNgYEwqo
+      ENCRYPTION_DETERMINISTIC_KEY: SGiZzmh18EjBF9gSW8LCNk7pelauWVr4
+      ENCRYPTION_KEY_DERIVATION_SALT: q3pkMw34ZkRPFSf2LmtWe705yw532Pf7
       LAGO_API_URL: https://api.lago.dev
       LAGO_PDF_URL: https://pdf.lago.dev
       SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
@@ -32,6 +35,7 @@ jobs:
       LAGO_CLICKHOUSE_DATABASE: default
       LAGO_CLICKHOUSE_USERNAME: ""
       LAGO_CLICKHOUSE_PASSWORD: ""
+      LAGO_DISABLE_SCHEMA_DUMP: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,11 +50,7 @@ jobs:
         shell: bash
       - name: Generate RSA keys
         run: ./scripts/generate.rsa.sh
-      - name: Set up Postgres database schema
-        run: bin/rails db:schema:load:primary
-      - name: Set up Clickhouse database schema
+      - name: Perform Postgres database migrations
+        run: bin/rails db:migrate:primary
+      - name: Perform Clickhouse database migrations
         run: bin/rails db:migrate:clickhouse
-      - name: Set up Clickhouse database schema
-        run: bin/rails db:schema:dump:clickhouse
-      - name: Run tests
-        run: bundle exec rspec


### PR DESCRIPTION
Reverts getlago/lago-api#1888

For some reasons `AddNewIndexToGroups` stays stuck for a very long time and running specs takes forever. Let's revert back.

https://github.com/getlago/lago-api/actions/runs/8801237466/job/24154104088?pr=1912

![CleanShot 2024-04-23 at 15 41 20@2x](https://github.com/getlago/lago-api/assets/1525636/af90cf1d-c0bf-4b11-a082-6e091b1f3ddb)

