### PR TITLE
add new integrations queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,6 +10,7 @@ queues:
   - webhook
   - invoices
   - wallets
+  - integrations
 
 production:
   concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 10) %>


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR adds `integrations` queue in sidekiq definition