### PR TITLE
feat (accounting-integrations): start sync upon connection create and update

### DIFF
--- a/app/services/integrations/netsuite/create_service.rb
+++ b/app/services/integrations/netsuite/create_service.rb
@@ -30,6 +30,7 @@ module Integrations
 
         if integration.type == 'Integrations::NetsuiteIntegration'
           Integrations::Aggregator::SendRestletEndpointJob.perform_later(integration:)
+          Integrations::Aggregator::PerformSyncJob.set(wait: 2.seconds).perform_later(integration:)
         end
 
         Integrations::Aggregator::FetchItemsJob.perform_later(integration:)

--- a/app/services/integrations/netsuite/update_service.rb
+++ b/app/services/integrations/netsuite/update_service.rb
@@ -31,6 +31,7 @@ module Integrations
 
         if integration.type == 'Integrations::NetsuiteIntegration' && integration.script_endpoint_url != old_script_url
           Integrations::Aggregator::SendRestletEndpointJob.perform_later(integration:)
+          Integrations::Aggregator::PerformSyncJob.set(wait: 2.seconds).perform_later(integration:)
         end
 
         result.integration = integration

--- a/spec/services/integrations/netsuite/create_service_spec.rb
+++ b/spec/services/integrations/netsuite/create_service_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Integrations::Netsuite::CreateService, type: :service do
         before do
           organization.update!(premium_integrations: ['netsuite'])
           allow(Integrations::Aggregator::SendRestletEndpointJob).to receive(:perform_later)
+          allow(Integrations::Aggregator::PerformSyncJob).to receive(:perform_later)
           allow(Integrations::Aggregator::FetchItemsJob).to receive(:perform_later)
           allow(Integrations::Aggregator::FetchTaxItemsJob).to receive(:perform_later)
         end
@@ -77,6 +78,13 @@ RSpec.describe Integrations::Netsuite::CreateService, type: :service do
 
             integration = Integrations::NetsuiteIntegration.order(:created_at).last
             expect(Integrations::Aggregator::SendRestletEndpointJob).to have_received(:perform_later).with(integration:)
+          end
+
+          it 'calls Integrations::Aggregator::PerformSyncJob' do
+            service_call
+
+            integration = Integrations::NetsuiteIntegration.order(:created_at).last
+            expect(Integrations::Aggregator::PerformSyncJob).to have_received(:perform_later).with(integration:)
           end
 
           it 'calls Integrations::Aggregator::FetchItemsJob' do

--- a/spec/services/integrations/netsuite/create_service_spec.rb
+++ b/spec/services/integrations/netsuite/create_service_spec.rb
@@ -81,10 +81,7 @@ RSpec.describe Integrations::Netsuite::CreateService, type: :service do
           end
 
           it 'calls Integrations::Aggregator::PerformSyncJob' do
-            service_call
-
-            integration = Integrations::NetsuiteIntegration.order(:created_at).last
-            expect(Integrations::Aggregator::PerformSyncJob).to have_received(:perform_later).with(integration:)
+            expect { service_call }.to have_enqueued_job(Integrations::Aggregator::PerformSyncJob)
           end
 
           it 'calls Integrations::Aggregator::FetchItemsJob' do

--- a/spec/services/integrations/netsuite/update_service_spec.rb
+++ b/spec/services/integrations/netsuite/update_service_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe Integrations::Netsuite::UpdateService, type: :service do
         before do
           organization.update!(premium_integrations: ['netsuite'])
           allow(Integrations::Aggregator::SendRestletEndpointJob).to receive(:perform_later)
+          allow(Integrations::Aggregator::PerformSyncJob).to receive(:perform_later)
         end
 
         context 'without validation errors' do
@@ -67,6 +68,12 @@ RSpec.describe Integrations::Netsuite::UpdateService, type: :service do
             service_call
 
             expect(Integrations::Aggregator::SendRestletEndpointJob).to have_received(:perform_later).with(integration:)
+          end
+
+          it 'calls Integrations::Aggregator::PerformSyncJob' do
+            service_call
+
+            expect(Integrations::Aggregator::PerformSyncJob).to have_received(:perform_later).with(integration:)
           end
         end
 

--- a/spec/services/integrations/netsuite/update_service_spec.rb
+++ b/spec/services/integrations/netsuite/update_service_spec.rb
@@ -71,9 +71,7 @@ RSpec.describe Integrations::Netsuite::UpdateService, type: :service do
           end
 
           it 'calls Integrations::Aggregator::PerformSyncJob' do
-            service_call
-
-            expect(Integrations::Aggregator::PerformSyncJob).to have_received(:perform_later).with(integration:)
+            expect { service_call }.to have_enqueued_job(Integrations::Aggregator::PerformSyncJob)
           end
         end
 


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR triggers Nango (accounting aggregator) sync when we create or update connection. Sync is needed only when restlet url is set because without restlet url sync will fail.