### PR TITLE
feat(custom_agg): Implement custom aggregator

### DIFF
--- a/app/services/billable_metrics/aggregations/custom_service.rb
+++ b/app/services/billable_metrics/aggregations/custom_service.rb
@@ -3,10 +3,16 @@
 module BillableMetrics
   module Aggregations
     class CustomService < BillableMetrics::Aggregations::BaseService
+      INITIAL_STATE = { total_units: BigDecimal('0'), amount: BigDecimal('0') }.freeze
+      BATCH_SIZE = 1000
+
       def compute_aggregation(options: {})
-        # TODO(custom_agg): Implement custom aggregation logic
-        result.aggregation = 0
         result.count = event_store.count
+
+        aggregation_result = perform_custom_aggregation
+
+        result.aggregation = aggregation_result[:total_units]
+        result.custom_aggregation = aggregation_result
         result.options = options
         result.pay_in_advance_aggregation = compute_pay_in_advance_aggregation
         result
@@ -18,8 +24,76 @@ module BillableMetrics
       end
 
       def compute_per_event_aggregation
-        # TODO(custom_agg): Implement custom aggregation logic
-        []
+        # TODO: Implement custom aggregation logic returning 1 value per event
+        event_store.events_properties
+      end
+
+      private
+
+      def custom_properties
+        charge.properties['custom_properties']
+      end
+
+      def current_state
+        # TODO: fecth state from the cached aggregation
+        INITIAL_STATE
+      end
+
+      def perform_custom_aggregation
+        total_batches = (result.count.to_f / BATCH_SIZE).ceil
+        state = current_state
+
+        # NOTE: Loop over events by batch
+        (1..total_batches).each do |batch|
+          events_properties = event_store.events.page(batch).per(BATCH_SIZE)
+            .map { |event| { timestamp: event.timestamp, properties: event.properties } }
+
+          sandboxed_result = LagoUtils::RubySandbox.run(aggregator(events_properties, state))
+
+          state = {
+            total_units: BigDecimal(sandboxed_result['total_units'].to_s),
+            amount: BigDecimal(sandboxed_result['amount']),
+          }
+        end
+
+        state
+      end
+
+      def aggregator(events_properties, current_state)
+        <<~RUBY
+          class EventValues
+            def initialize(timestamp:, properties:)
+              @timestamp = timestamp
+              @properties = properties
+            end
+
+            attr_reader :timestamp, :properties
+          end
+
+          initial_state = {
+            total_units: BigDecimal('#{current_state[:total_units]}'),
+            amount: BigDecimal('#{current_state[:amount]}')
+          }
+
+          aggregation_properties = JSON.parse('#{custom_properties.to_json}')
+
+          #{billable_metric.custom_aggregator}
+
+          events = [
+            #{events_properties.map do |event|
+              "EventValues.new(timestamp: Time.at(#{event[:timestamp].to_f}),properties: #{event[:properties].as_json})"
+            end.join(",\n")}
+          ]
+
+          result = events.each_with_object(initial_state.dup) do |event, agg|
+            res = aggregate(event, agg, aggregation_properties)
+
+            agg[:total_units] = res[:total_units]
+            agg[:amount] += res[:amount]
+          end
+
+          result
+        RUBY
       end
 
       def compute_pay_in_advance_aggregation

--- a/app/services/charges/charge_models/custom_service.rb
+++ b/app/services/charges/charge_models/custom_service.rb
@@ -6,8 +6,7 @@ module Charges
       protected
 
       def compute_amount
-        # TODO(custom_agg): Implement custom aggregation logic
-        0
+        aggregation_result.custom_aggregation&.[](:amount) || 0
       end
 
       def unit_amount

--- a/spec/factories/billable_metrics.rb
+++ b/spec/factories/billable_metrics.rb
@@ -43,6 +43,6 @@ FactoryBot.define do
 
   factory :custom_billable_metric, parent: :billable_metric do
     aggregation_type { 'custom_agg' }
-    custom_aggregator { 'puts "foo bar"' }
+    custom_aggregator { 'puts "def aggregate(event, agg, aggregation_properties); agg; end' }
   end
 end

--- a/spec/scenarios/billable_metrics/custom_aggregation_spec.rb
+++ b/spec/scenarios/billable_metrics/custom_aggregation_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Aggregation - Custom Aggregation Scenarios', :scenarios, type: :request, transaction: false do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:plan) { create(:plan, organization:, amount_cents: 0) }
+  let(:billable_metric) { create(:custom_billable_metric, organization:, custom_aggregator:) }
+
+  let(:custom_aggregator) do
+    <<~RUBY
+      def aggregate(event, previous_state, aggregation_properties)
+        previous_units = previous_state[:total_units]
+        event_units = BigDecimal(event.properties['value'].to_s)
+        storage_zone = event.properties['storage_zone']
+        total_units = previous_units + event_units
+        ranges = aggregation_properties['ranges']
+
+        result_amount = ranges.each_with_object(0) do |range, amount|
+          # Range was already reached
+          next amount if range['to'] && previous_units > range['to']
+
+          zone_amount = BigDecimal(range[storage_zone] || '0')
+
+          if !range['to'] || total_units <= range['to']
+            # Last matching range is reached
+            units_to_use = if previous_units > range['from']
+              # All new units are in the current range
+              event_units
+            else
+              # Takes only the new units in the current range
+              total_units - range['from']
+            end
+            break amount += zone_amount * units_to_use
+
+          else
+            # Range is not the last one
+            units_to_use = if previous_units > range['from']
+              # All remaining units in the range
+              range['to'] - previous_units
+            else
+              # All units in the range
+              range['to'] - range['from']
+            end
+
+            amount += zone_amount * units_to_use
+          end
+
+          amount
+        end
+        { total_units: total_units, amount: result_amount }
+      end
+    RUBY
+  end
+
+  let(:standard_charge) do
+    create(
+      :standard_charge,
+      billable_metric:,
+      plan:,
+      properties: {
+        amount: '2',
+        custom_properties: {
+          ranges: [
+            { from: 0, to: 10, storage_eu: '0', storage_us: '0', storage_asia: '0' },
+            { from: 10, to: 20, storage_eu: '0.10', storage_us: '0.20', storage_asia: '0.30' },
+            { from: 20, to: nil, storage_eu: '0.20', storage_us: '0.30', storage_asia: '0.40' },
+          ],
+        },
+      },
+    )
+  end
+
+  let(:custom_charge) do
+    create(
+      :custom_charge,
+      billable_metric:,
+      plan:,
+      properties: {
+        custom_properties: {
+          ranges: [
+            { from: 0, to: 10, storage_eu: '0', storage_us: '0', storage_asia: '0' },
+            { from: 10, to: 20, storage_eu: '0.10', storage_us: '0.20', storage_asia: '0.30' },
+            { from: 20, to: nil, storage_eu: '0.20', storage_us: '0.30', storage_asia: '0.40' },
+          ],
+        },
+      },
+    )
+  end
+
+  before do
+    standard_charge
+    custom_charge
+  end
+
+  it 'create fees for each charges' do
+    travel_to(DateTime.new(2024, 2, 1)) do
+      create_subscription(
+        {
+          external_customer_id: customer.external_id,
+          external_id: customer.external_id,
+          plan_code: plan.code,
+        },
+      )
+    end
+
+    subscription = customer.subscriptions.first
+
+    travel_to(DateTime.new(2024, 2, 6, 1)) do
+      create_event(
+        {
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
+          properties: {
+            value: 1,
+            storage_zone: 'storage_eu',
+          },
+        },
+      )
+
+      fetch_current_usage(customer:)
+      expect(json[:customer_usage][:total_amount_cents]).to eq(200)
+      expect(json[:customer_usage][:charges_usage].count).to eq(2)
+
+      standard_usage = json[:customer_usage][:charges_usage].find do |cu|
+        cu[:charge][:charge_model] == 'standard'
+      end
+      expect(standard_usage[:units]).to eq('1.0')
+      expect(standard_usage[:amount_cents]).to eq(200)
+
+      custom_usage = json[:customer_usage][:charges_usage].find do |cu|
+        cu[:charge][:charge_model] == 'custom'
+      end
+      expect(custom_usage[:units]).to eq('1.0')
+      expect(custom_usage[:amount_cents]).to eq(0)
+    end
+
+    travel_to(DateTime.new(2024, 2, 6, 1)) do
+      create_event(
+        {
+          code: billable_metric.code,
+          transaction_id: SecureRandom.uuid,
+          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
+          properties: {
+            value: 10,
+            storage_zone: 'storage_asia',
+          },
+        },
+      )
+
+      fetch_current_usage(customer:)
+      expect(json[:customer_usage][:total_amount_cents]).to eq(2_230)
+      expect(json[:customer_usage][:charges_usage].count).to eq(2)
+
+      standard_usage = json[:customer_usage][:charges_usage].find do |cu|
+        cu[:charge][:charge_model] == 'standard'
+      end
+      expect(standard_usage[:units]).to eq('11.0')
+      expect(standard_usage[:amount_cents]).to eq(2_200)
+
+      custom_usage = json[:customer_usage][:charges_usage].find do |cu|
+        cu[:charge][:charge_model] == 'custom'
+      end
+      expect(custom_usage[:units]).to eq('11.0')
+      expect(custom_usage[:amount_cents]).to eq(30)
+    end
+  end
+end

--- a/spec/services/charges/charge_models/custom_service_spec.rb
+++ b/spec/services/charges/charge_models/custom_service_spec.rb
@@ -14,7 +14,7 @@ Rspec.describe Charges::ChargeModels::CustomService, type: :service do
   let(:aggregation_result) { BaseService::Result.new }
   let(:aggregation) { 10 }
   let(:total_aggregated_units) { nil }
-  let(:full_units_number) { nil }
+  let(:full_units_number) { BigDecimal('10.0') }
 
   let(:charge) { create(:custom_charge, billable_metric:) }
   let(:billable_metric) { create(:custom_billable_metric) }
@@ -23,10 +23,11 @@ Rspec.describe Charges::ChargeModels::CustomService, type: :service do
     aggregation_result.aggregation = aggregation
     aggregation_result.total_aggregated_units = total_aggregated_units if total_aggregated_units
     aggregation_result.full_units_number = full_units_number if full_units_number
+    aggregation_result.custom_aggregation = { amount: 20, units: BigDecimal('10.0') }
   end
 
   it 'applies the charge model to the value' do
-    expect(apply_custom_service.amount).to eq(0)
-    expect(apply_custom_service.unit_amount).to eq(0)
+    expect(apply_custom_service.amount).to eq(20)
+    expect(apply_custom_service.unit_amount).to eq(2)
   end
 end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe Fees::ChargeService do
               aggregation_type:,
               field_name: 'foo_bar',
               weighted_interval: 'seconds',
-              custom_aggregator: 'puts "foo bar"',
+              custom_aggregator: 'def aggregate(event, agg, aggregation_properties); agg; end',
             )
           end
 
@@ -1771,7 +1771,7 @@ RSpec.describe Fees::ChargeService do
             aggregation_type:,
             field_name: 'foo_bar',
             weighted_interval: 'seconds',
-            custom_aggregator: 'puts "foo bar"',
+            custom_aggregator: 'def aggregate(event, agg, aggregation_properties); agg; end',
           )
 
           charge.update!(min_amount_cents: 1000)


### PR DESCRIPTION
## Context

Some of our customers have express a need for aggregation and charge models that does not fit into the current logic in place in Lago, like for example having a single aggregation for 2 different properties, but make the price per unit changing based on the position of the event.

This feature aims to propose a way to build custom aggregation logic for specific cases.

## Description

This PR implements the custom aggregation logic using the ruby Sandbox
