### PR TITLE
feat(rbac): Introduce permission system

### DIFF
--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -1,0 +1,84 @@
+---
+analytics:
+  view:
+billable_metrics:
+  view:
+  create:
+  update:
+  delete:
+plans:
+  view: true
+  create:
+  update:
+  delete:
+addons:
+  view: true
+  create:
+  update:
+  delete:
+coupons:
+  view: true
+  create:
+  update:
+  delete:
+  attach:
+  detach:
+customers:
+  view: true
+  create:
+  update:
+  delete:
+subscriptions:
+  create:
+  update:
+  delete:
+wallets:
+  create:
+  update:
+  top_up:
+  terminate:
+invoices:
+  view: true
+  send: true
+  update: true
+  void: true
+  create:
+draft_invoices:
+  update: true
+credit_notes:
+  view: true
+  create: true
+  void: true
+customer_settings:
+  view: true
+  edit:
+    tax_rates: true
+    payment_terms: true
+    grace_period: true
+    lang: true
+developers:
+  view:
+  keys:
+    view:
+organization:
+  view:
+  edit:
+  invoices:
+    view:
+    edit:
+  taxes:
+    view:
+    edit:
+  emails:
+    view:
+    edit:
+  integrations:
+    view:
+    create:
+    update:
+    delete:
+  members:
+    view:
+    create:
+    update:
+    delete:

--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -1,0 +1,64 @@
+
+---
+analytics:
+  view: true
+billable_metrics:
+  view: false
+  create: false
+  update: false
+  delete: false
+plans:
+  create: false
+  update: false
+  delete: false
+addons:
+  create: false
+  update: false
+  delete: false
+coupons:
+  create: false
+  update: false
+  delete: false
+  attach: false
+  detach: false
+customers:
+  create: false
+  update: false
+  delete: false
+subscriptions:
+  create: false
+  update: false
+  delete: false
+wallets:
+  create: false
+  update: false
+  top_up: false
+  terminate: false
+invoices:
+  create: false
+developers:
+  view: false
+  keys:
+    view: false
+organization:
+  view: true
+  edit: true
+  invoices:
+    view: true
+    edit: true
+  taxes:
+    view: false
+    edit: false
+  emails:
+    view: false
+    edit: false
+  integrations:
+    view: true
+    create: true
+    update: true
+    delete: true
+  members:
+    view: false
+    create: false
+    update: false
+    delete: false

--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -1,0 +1,63 @@
+---
+analytics:
+  view: false
+billable_metrics:
+  view: false
+  create: false
+  update: false
+  delete: false
+plans:
+  create: false
+  update: false
+  delete: false
+addons:
+  create: false
+  update: false
+  delete: false
+coupons:
+  create: false
+  update: false
+  delete: false
+  attach: true
+  detach: true
+customers:
+  create: true
+  update: true
+  delete: true
+subscriptions:
+  create: true
+  update: true
+  delete: true
+wallets:
+  create: true
+  update: true
+  top_up: true
+  terminate: true
+invoices:
+  create: true
+developers:
+  view: false
+  keys:
+    view: false
+organization:
+  view: false
+  edit: false
+  invoices:
+    view: false
+    edit: false
+  taxes:
+    view: false
+    edit: false
+  emails:
+    view: false
+    edit: false
+  integrations:
+    view: false
+    create: false
+    update: false
+    delete: false
+  members:
+    view: false
+    create: false
+    update: false
+    delete: false

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -26,6 +26,7 @@ class GraphqlController < ApplicationController
       current_organization:,
       customer_portal_user:,
       request:,
+      permissions: current_user&.memberships&.find_by(organization: current_organization)&.permissions_hash || {},
     }
     result = LagoApiSchema.execute(query, variables:, context:, operation_name:)
     render(json: result)
@@ -59,11 +60,11 @@ class GraphqlController < ApplicationController
     end
   end
 
-  def handle_error_in_development(e)
-    logger.error(e.message)
-    logger.error(e.backtrace.join("\n"))
+  def handle_error_in_development(error)
+    logger.error(error.message)
+    logger.error(error.backtrace.join("\n"))
 
-    render(json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500)
+    render(json: { errors: [{ message: error.message, backtrace: error.backtrace }], data: {} }, status: 500)
   end
 
   def render_graphql_error(code:, status:, message: nil)

--- a/app/graphql/concerns/authenticable_api_user.rb
+++ b/app/graphql/concerns/authenticable_api_user.rb
@@ -5,10 +5,10 @@ module AuthenticableApiUser
 
   private
 
-  def ready?(*)
-    return true if context[:current_user]
+  def ready?(**args)
+    raise unauthorized_error unless context[:current_user]
 
-    raise unauthorized_error
+    super
   end
 
   def unauthorized_error

--- a/app/graphql/extensions/field_authorization_extension.rb
+++ b/app/graphql/extensions/field_authorization_extension.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Extensions
+  class FieldAuthorizationExtension < GraphQL::Schema::FieldExtension
+    def resolve(object:, arguments:, context:)
+      super if field.permissions.any? { |p| context.dig(:permissions, p) }
+    end
+  end
+end

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -8,5 +8,15 @@ module Mutations
     field_class Types::BaseField
     input_object_class Types::BaseInputObject
     object_class Types::BaseObject
+
+    private
+
+    def ready?(**args)
+      if defined? self.class::REQUIRED_PERMISSION
+        context.dig(:permissions, self.class::REQUIRED_PERMISSION)
+      else
+        super
+      end
+    end
   end
 end

--- a/app/graphql/types/base_argument.rb
+++ b/app/graphql/types/base_argument.rb
@@ -2,5 +2,11 @@
 
 module Types
   class BaseArgument < GraphQL::Schema::Argument
+    attr_reader :permission
+
+    def initialize(*args, permission: nil, **kwargs, &block)
+      @permission = permission
+      super(*args, **kwargs, &block)
+    end
   end
 end

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -3,5 +3,21 @@
 module Types
   class BaseField < GraphQL::Schema::Field
     argument_class Types::BaseArgument
+
+    attr_reader :permissions
+
+    def initialize(*args, permission: nil, permissions: nil, **kwargs, &block)
+      if permission
+        @permissions = [permission.to_s]
+      elsif permissions
+        @permissions = Array.wrap(permissions).map(&:to_s)
+      end
+
+      kwargs[:null] = true if @permissions
+
+      super(*args, **kwargs, &block)
+
+      extension(Extensions::FieldAuthorizationExtension) if @permissions
+    end
   end
 end

--- a/app/graphql/types/base_input_object.rb
+++ b/app/graphql/types/base_input_object.rb
@@ -3,5 +3,20 @@
 module Types
   class BaseInputObject < GraphQL::Schema::InputObject
     argument_class Types::BaseArgument
+
+    # NOTE: This is how you can remove fields from the input object based on permissions
+    def initialize(arguments, ruby_kwargs:, context:, defaults_used:)
+      cleaned_arguments = arguments.argument_values.dup
+      cleaned_kwargs = ruby_kwargs.dup
+
+      self.class.arguments(context).each_value do |arg_defn|
+        if arg_defn.permission && !context.dig(:permissions, arg_defn.permission)
+          cleaned_arguments.delete(arg_defn.keyword)
+          cleaned_kwargs.delete(arg_defn.keyword)
+        end
+      end
+
+      super(cleaned_arguments, ruby_kwargs: cleaned_kwargs, context:, defaults_used:)
+    end
   end
 end

--- a/app/graphql/types/membership_type.rb
+++ b/app/graphql/types/membership_type.rb
@@ -7,7 +7,7 @@ module Types
     field :organization, Types::OrganizationType, null: false
     field :user, Types::UserType, null: false
 
-    # TODO: Add permissions here
+    field :permissions, Types::PermissionsType, null: false
     field :role, Types::Memberships::RoleEnum, null: true
     field :status, Types::Memberships::StatusEnum, null: false
 

--- a/app/graphql/types/permissions_type.rb
+++ b/app/graphql/types/permissions_type.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  class PermissionsType < Types::BaseObject
+    description 'Permissions Type'
+
+    # NOTE: GraphQL field names cannot contain colons, so we convert them to underscores
+    #       `billing_metrics:view` becomes `billing_metrics_view` which becomes `billingMetricsView`
+    #       https://spec.graphql.org/October2021/#sec-Punctuators
+    #       https://spec.graphql.org/October2021/#sec-Names
+    Permission::DEFAULT_PERMISSIONS_HASH.keys.each do |permissions|
+      field permissions.tr(':', '_'), Boolean, null: false
+    end
+  end
+end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -11,7 +11,11 @@ class Membership < ApplicationRecord
     :revoked,
   ].freeze
 
-  ROLES = { admin: 0 }.freeze
+  ROLES = {
+    admin: 0,
+    manager: 1,
+    finance: 2,
+  }.freeze
 
   enum status: STATUSES
   enum role: ROLES
@@ -21,5 +25,22 @@ class Membership < ApplicationRecord
   def mark_as_revoked!(timestamp = Time.current)
     self.revoked_at ||= timestamp
     revoked!
+  end
+
+  def can?(permission)
+    permissions_hash[permission.to_s]
+  end
+
+  def permissions_hash
+    case role
+    when 'admin'
+      Permission::ADMIN_PERMISSIONS_HASH
+    when 'manager'
+      Permission::MANAGER_PERMISSIONS_HASH
+    when 'finance'
+      Permission::FINANCE_PERMISSIONS_HASH
+    else
+      {}
+    end
   end
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Permission
+  def self.yaml_to_hash(filename)
+    h = YAML.parse_file(Rails.root.join('app/config/permissions', filename)).to_ruby
+    DottedHash.new(h, separator: ':').transform_values(&:present?)
+  end
+
+  # rubocop:disable Layout/ClassStructure
+  DEFAULT_PERMISSIONS_HASH = yaml_to_hash('definition.yml').freeze
+
+  ADMIN_PERMISSIONS_HASH = DEFAULT_PERMISSIONS_HASH.transform_values { true }.freeze
+
+  MANAGER_PERMISSIONS_HASH = DEFAULT_PERMISSIONS_HASH.merge(yaml_to_hash('role-manager.yml')).freeze
+
+  FINANCE_PERMISSIONS_HASH = DEFAULT_PERMISSIONS_HASH.merge(yaml_to_hash('role-finance.yml')).freeze
+  # rubocop:enable Layout/ClassStructure
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,8 @@ class User < ApplicationRecord
 
   validates :email, presence: true
   validates :password, presence: true
+
+  def can?(permission, organization:)
+    memberships.find { |m| m.organization_id == organization.id }&.can?(permission)
+  end
 end

--- a/app/support/dotted_hash.rb
+++ b/app/support/dotted_hash.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class DottedHash < Hash
+  attr_reader :separator
+
+  def initialize(hash = {}, separator: '.')
+    super()
+    @separator = separator
+    to_dotted_hash(hash, recursive_key: '')
+  end
+
+  private
+
+  def to_dotted_hash(hash, recursive_key: '')
+    hash.each do |k, v|
+      key = recursive_key + k.to_s
+      if v.is_a?(Hash)
+        to_dotted_hash(v, recursive_key: key + separator)
+      else
+        self[key] = v
+      end
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,7 @@ module LagoApi
       #{config.root}/lib/lago_utils
       #{config.root}/lib/lago_eu_vat
       #{config.root}/app/views/helpers
+      #{config.root}/app/support
     ]
     config.api_only = true
     config.active_job.queue_adapter = :sidekiq

--- a/schema.graphql
+++ b/schema.graphql
@@ -3822,6 +3822,7 @@ type Membership {
   createdAt: ISO8601DateTime!
   id: ID!
   organization: Organization!
+  permissions: Permissions!
   revokedAt: ISO8601DateTime!
   role: MembershipRole
   status: MembershipStatus!
@@ -3836,6 +3837,8 @@ type MembershipCollection {
 
 enum MembershipRole {
   admin
+  finance
+  manager
 }
 
 enum MembershipStatus {
@@ -4776,6 +4779,74 @@ union PaymentProvider = AdyenProvider | GocardlessProvider | StripeProvider
 type PaymentProviderCollection {
   collection: [PaymentProvider!]!
   metadata: CollectionMetadata!
+}
+
+"""
+Permissions Type
+"""
+type Permissions {
+  addonsCreate: Boolean!
+  addonsDelete: Boolean!
+  addonsUpdate: Boolean!
+  addonsView: Boolean!
+  analyticsView: Boolean!
+  billableMetricsCreate: Boolean!
+  billableMetricsDelete: Boolean!
+  billableMetricsUpdate: Boolean!
+  billableMetricsView: Boolean!
+  couponsAttach: Boolean!
+  couponsCreate: Boolean!
+  couponsDelete: Boolean!
+  couponsDetach: Boolean!
+  couponsUpdate: Boolean!
+  couponsView: Boolean!
+  creditNotesCreate: Boolean!
+  creditNotesView: Boolean!
+  creditNotesVoid: Boolean!
+  customerSettingsEditGracePeriod: Boolean!
+  customerSettingsEditLang: Boolean!
+  customerSettingsEditPaymentTerms: Boolean!
+  customerSettingsEditTaxRates: Boolean!
+  customerSettingsView: Boolean!
+  customersCreate: Boolean!
+  customersDelete: Boolean!
+  customersUpdate: Boolean!
+  customersView: Boolean!
+  developersKeysView: Boolean!
+  developersView: Boolean!
+  draftInvoicesUpdate: Boolean!
+  invoicesCreate: Boolean!
+  invoicesSend: Boolean!
+  invoicesUpdate: Boolean!
+  invoicesView: Boolean!
+  invoicesVoid: Boolean!
+  organizationEdit: Boolean!
+  organizationEmailsEdit: Boolean!
+  organizationEmailsView: Boolean!
+  organizationIntegrationsCreate: Boolean!
+  organizationIntegrationsDelete: Boolean!
+  organizationIntegrationsUpdate: Boolean!
+  organizationIntegrationsView: Boolean!
+  organizationInvoicesEdit: Boolean!
+  organizationInvoicesView: Boolean!
+  organizationMembersCreate: Boolean!
+  organizationMembersDelete: Boolean!
+  organizationMembersUpdate: Boolean!
+  organizationMembersView: Boolean!
+  organizationTaxesEdit: Boolean!
+  organizationTaxesView: Boolean!
+  organizationView: Boolean!
+  plansCreate: Boolean!
+  plansDelete: Boolean!
+  plansUpdate: Boolean!
+  plansView: Boolean!
+  subscriptionsCreate: Boolean!
+  subscriptionsDelete: Boolean!
+  subscriptionsUpdate: Boolean!
+  walletsCreate: Boolean!
+  walletsTerminate: Boolean!
+  walletsTopUp: Boolean!
+  walletsUpdate: Boolean!
 }
 
 type Plan {

--- a/schema.json
+++ b/schema.json
@@ -18367,6 +18367,24 @@
               ]
             },
             {
+              "name": "permissions",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Permissions",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "revokedAt",
               "description": null,
               "type": {
@@ -18524,6 +18542,18 @@
           "enumValues": [
             {
               "name": "admin",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "manager",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "finance",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -22159,6 +22189,1135 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Permissions",
+          "description": "Permissions Type",
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "addonsCreate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "addonsDelete",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "addonsUpdate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "addonsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "analyticsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "billableMetricsCreate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "billableMetricsDelete",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "billableMetricsUpdate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "billableMetricsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "couponsAttach",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "couponsCreate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "couponsDelete",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "couponsDetach",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "couponsUpdate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "couponsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditNotesCreate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditNotesView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "creditNotesVoid",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customerSettingsEditGracePeriod",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customerSettingsEditLang",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customerSettingsEditPaymentTerms",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customerSettingsEditTaxRates",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customerSettingsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customersCreate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customersDelete",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customersUpdate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customersView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "developersKeysView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "developersView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "draftInvoicesUpdate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoicesCreate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoicesSend",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoicesUpdate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoicesView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoicesVoid",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationEdit",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationEmailsEdit",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationEmailsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationIntegrationsCreate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationIntegrationsDelete",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationIntegrationsUpdate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationIntegrationsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationInvoicesEdit",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationInvoicesView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationMembersCreate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationMembersDelete",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationMembersUpdate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationMembersView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationTaxesEdit",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationTaxesView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "organizationView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "plansCreate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "plansDelete",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "plansUpdate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "plansView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "subscriptionsCreate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "subscriptionsDelete",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "subscriptionsUpdate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "walletsCreate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "walletsTerminate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "walletsTopUp",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "walletsUpdate",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
               },

--- a/spec/graphql/types/permissions_type_spec.rb
+++ b/spec/graphql/types/permissions_type_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::PermissionsType do
+  it 'matches the list of default permissions' do
+    all_boolean = described_class.fields.values.all? do |f|
+      f.type.to_type_signature == 'Boolean!'
+    end
+    expect(all_boolean).to be_truthy
+
+    gql_field_names = described_class.fields.keys.map(&:underscore)
+    rails_field_names = Permission::DEFAULT_PERMISSIONS_HASH.keys.map { |k| k.tr(':', '_') }
+    expect(gql_field_names).to match_array(rails_field_names)
+  end
+end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Permission, type: :model do
+  it 'defines permission hashes' do
+    names = %w[DEFAULT_PERMISSIONS_HASH ADMIN_PERMISSIONS_HASH MANAGER_PERMISSIONS_HASH FINANCE_PERMISSIONS_HASH]
+
+    names.each do |name|
+      expect(described_class).to be_const_defined(name)
+
+      hash = described_class.const_get(name)
+      expect(hash).to be_a(Hash) # transform_values returns a Hash, not a DottedHash
+      expect(hash).to be_frozen
+      expect(hash.values).to all(be_in([true, false]))
+      expect(hash.keys).to all(be_a(String))
+    end
+
+    %w[ADMIN_PERMISSIONS_HASH MANAGER_PERMISSIONS_HASH FINANCE_PERMISSIONS_HASH].each do |name|
+      expect(described_class::DEFAULT_PERMISSIONS_HASH.keys).to match_array(described_class.const_get(name).keys)
+    end
+  end
+end

--- a/spec/support/graphql_helper.rb
+++ b/spec/support/graphql_helper.rb
@@ -7,9 +7,9 @@ module GraphQLHelper
     end
   end
 
-  # rubocop:disable Metrics/ParameterLists, Layout/LineLength
-  def execute_graphql(current_user: nil, query: nil, current_organization: nil, customer_portal_user: nil, request: nil, **kwargs)
-    # rubocop:enable Metrics/ParameterLists, Layout/LineLength
+  def execute_graphql(current_user: nil, query: nil, current_organization: nil, customer_portal_user: nil, request: nil, permissions: nil, **kwargs) # rubocop:disable Metrics/ParameterLists, Layout/LineLength
+    permissions = permissions.index_with { true } if permissions.is_a? Array
+
     args = kwargs.merge(
       context: {
         controller:,
@@ -17,6 +17,7 @@ module GraphQLHelper
         current_organization:,
         customer_portal_user:,
         request:,
+        permissions:,
       },
     )
 

--- a/spec/support/matchers/graphql_field_permissions_matcher.rb
+++ b/spec/support/matchers/graphql_field_permissions_matcher.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Usage:
+#  it { is_expected.to have_a_field(:api_key).with_permissions('developers:view') }
+#
+module RSpec
+  module GraphqlMatchers
+    class HaveAField < BaseMatcher
+      def with_permissions(expected_permissions)
+        @expectations << HaveAFieldMatchers::WithPermissions.new(expected_permissions)
+        self
+      end
+      alias with_permission with_permissions
+    end
+
+    module HaveAFieldMatchers
+      class WithPermissions
+        def initialize(expected_permissions)
+          @expected_permissions = Array.wrap(expected_permissions)
+        end
+
+        def description
+          "with permissions `#{@expected_permissions}`"
+        end
+
+        def matches?(actual_field)
+          @actual_permissions = actual_field.permissions
+          @actual_permissions.sort == @expected_permissions.sort
+        end
+
+        def failure_message
+          "#{description}, but it was `#{@actual_permissions}`"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, all Lago users are admin. They can perform all actions and access every piece of data.

This PR introduces the base needed to add permissions all over the codebase.

## Overview

- **users** have roles per **organization**, hence **membership** have `roles`
- **roles** have `permissions`
- app always checks for `permissions` (as much as possible), not `roles`

### 3 roles, no custom roles

Lago defines 3 roles by default

* Admin
* Account Manager
* Finance & Analyst

These roles exist for every organization. It's not possible to create custom roles. It's not possible to customize the permissions of these roles.

### Examples

```ruby
# ❌ Bad
user.has_role? :admin, organization
user.admin? organization
user.manager? organization

# ✅ Good
user.has_permission? "organization:info:edit", organization
user.can? "organization:info:edit", organization
```

## Implementation

* The role and their perimissions are defined in yaml (`app/config/permissions/`)
  * `definition.yml` defines ALL permissions and their default value
  * `role-finance.yml` and `role-manager.yml` overrides the default permissions for their respective roles

Each roles has a list of permission associated stored in a hash. The hash is instantiated and frozen when the app is booted. Checking permission is simply checking the value in a flat hash.

```ruby
# Checking `addons:create` for account manager.
MANAGER_PERMISSIONS_HASH['addons:create']
```

Permissions are *per user per organization*, hence they are part of the Membership model. Usually, it's called directly from users. If you're in a loop, you can eager load `user.memberships`.

```ruby
user.can? 'addons:create', organization: org
```

### GraphQL

The permissions **of the current user on the current organization** are passed in the GraphQL context. We don't need to call `user.can?`, we can directly check the `context['permissions']` hash.

⚠️ If there is no current organization, the permissions hash will be empty.

## Usage

In this step, the permissions are only added to the GraphQL. The REST API will come late when we introduce api key scopes.

### Protecting a Type field when retrieving data

Every used can retrieve the current organization but some fields will require a some permissions. **If you request a field you don't have access to, you'll simply get a null value, not an error.**

```diff
module Types
  class CurrentOrganizationType < Types::BaseObject
    description 'Current Organization Type'

    field :id, ID, null: false
    field :name, String, null: false

    ...

-    field :api_key, String
+    field :api_key, String, permission: 'developer:view'

-    field :webhook_url, String
+    field :webhook_url, String, permissions: ['developer:view', 'something:else']

    ...
  end
end
```

### Protecting a mutation

If the entire mutation requires a role to be executed, you can define the required permission in a constant.

```diff
module Mutations
  module AddOns
    class Create < BaseMutation
      include AuthenticableApiUser
      include RequiredOrganization

+      REQUIRED_PERMISSION = 'addons:create'

      graphql_name 'CreateAddOn'
      description 'Creates a new add-on'

      input_object_class Types::AddOns::CreateInput
      type Types::AddOns::Object

      def resolve(**args)
        ...
      end
    end
  end
end
```

### Protecting only a field

In some situation, a user can update some fields of a type but not all of them. They must be able to access the mutation so the previous solution doesn't work. In this case, we rely on the input object to restrict the list of arguments.

In this case, the app will loop over the arguments and remove the arguments doesn't have the required permission.


```diff
module Types
  module AddOns
    class UpdateInput < Types::BaseInputObject
      graphql_name 'UpdateAddOnInput'

      argument :id, ID, required: true
      argument :description, String, required: false
      ... 
-     argument :tax_codes, [String], required: false
+     argument :tax_codes, [String], required: false, permission: 'addons:update:tax'
    end
  end
end
```



