### PR TITLE
feat(integrations): Rename attributes

### DIFF
--- a/app/graphql/types/integration_collection_mappings/netsuite/create_input.rb
+++ b/app/graphql/types/integration_collection_mappings/netsuite/create_input.rb
@@ -6,11 +6,11 @@ module Types
       class CreateInput < Types::BaseInputObject
         graphql_name 'CreateNetsuiteIntegrationCollectionMappingInput'
 
+        argument :external_account_code, String, required: false
+        argument :external_id, String, required: true
+        argument :external_name, String, required: false
         argument :integration_id, ID, required: true
         argument :mapping_type, Types::IntegrationCollectionMappings::Netsuite::MappingTypeEnum, required: true
-        argument :netsuite_account_code, String, required: false
-        argument :netsuite_id, String, required: true
-        argument :netsuite_name, String, required: false
       end
     end
   end

--- a/app/graphql/types/integration_collection_mappings/netsuite/object.rb
+++ b/app/graphql/types/integration_collection_mappings/netsuite/object.rb
@@ -6,12 +6,12 @@ module Types
       class Object < Types::BaseObject
         graphql_name 'NetsuiteCollectionMapping'
 
+        field :external_account_code, String, null: true
+        field :external_id, String, null: false
+        field :external_name, String, null: true
         field :id, ID, null: false
         field :integration_id, ID, null: false
         field :mapping_type, Types::IntegrationCollectionMappings::Netsuite::MappingTypeEnum, null: false
-        field :netsuite_account_code, String, null: true
-        field :netsuite_id, String, null: false
-        field :netsuite_name, String, null: true
       end
     end
   end

--- a/app/graphql/types/integration_collection_mappings/netsuite/update_input.rb
+++ b/app/graphql/types/integration_collection_mappings/netsuite/update_input.rb
@@ -8,11 +8,11 @@ module Types
 
         argument :id, ID, required: true
 
+        argument :external_account_code, String, required: false
+        argument :external_id, String, required: false
+        argument :external_name, String, required: false
         argument :integration_id, ID, required: false
         argument :mapping_type, Types::IntegrationCollectionMappings::Netsuite::MappingTypeEnum, required: false
-        argument :netsuite_account_code, String, required: false
-        argument :netsuite_id, String, required: false
-        argument :netsuite_name, String, required: false
       end
     end
   end

--- a/app/graphql/types/integration_items/object.rb
+++ b/app/graphql/types/integration_items/object.rb
@@ -5,12 +5,12 @@ module Types
     class Object < Types::BaseObject
       graphql_name 'IntegrationItem'
 
-      field :account_code, String, null: true
+      field :external_account_code, String, null: true
       field :external_id, String, null: false
+      field :external_name, String, null: true
       field :id, ID, null: false
       field :integration_id, ID, null: false
       field :item_type, Types::IntegrationItems::ItemTypeEnum, null: false
-      field :name, String, null: true
     end
   end
 end

--- a/app/graphql/types/integration_mappings/netsuite/create_input.rb
+++ b/app/graphql/types/integration_mappings/netsuite/create_input.rb
@@ -6,12 +6,12 @@ module Types
       class CreateInput < Types::BaseInputObject
         graphql_name 'CreateNetsuiteIntegrationMappingInput'
 
+        argument :external_account_code, String, required: true
+        argument :external_id, String, required: true
+        argument :external_name, String, required: false
         argument :integration_id, ID, required: true
         argument :mappable_id, ID, required: true
         argument :mappable_type, Types::IntegrationMappings::Netsuite::MappableTypeEnum, required: true
-        argument :netsuite_account_code, String, required: true
-        argument :netsuite_id, String, required: true
-        argument :netsuite_name, String, required: false
       end
     end
   end

--- a/app/graphql/types/integration_mappings/netsuite/object.rb
+++ b/app/graphql/types/integration_mappings/netsuite/object.rb
@@ -6,13 +6,13 @@ module Types
       class Object < Types::BaseObject
         graphql_name 'NetsuiteMapping'
 
+        field :external_account_code, String, null: false
+        field :external_id, String, null: false
+        field :external_name, String, null: true
         field :id, ID, null: false
         field :integration_id, ID, null: false
         field :mappable_id, ID, null: false
         field :mappable_type, Types::IntegrationMappings::Netsuite::MappableTypeEnum, null: false
-        field :netsuite_account_code, String, null: false
-        field :netsuite_id, String, null: false
-        field :netsuite_name, String, null: true
       end
     end
   end

--- a/app/graphql/types/integration_mappings/netsuite/update_input.rb
+++ b/app/graphql/types/integration_mappings/netsuite/update_input.rb
@@ -6,13 +6,13 @@ module Types
       class UpdateInput < Types::BaseInputObject
         graphql_name 'UpdateNetsuiteIntegrationMappingInput'
 
+        argument :external_account_code, String, required: false
+        argument :external_id, String, required: false
+        argument :external_name, String, required: false
         argument :id, ID, required: true
         argument :integration_id, ID, required: false
         argument :mappable_id, ID, required: false
         argument :mappable_type, Types::IntegrationMappings::Netsuite::MappableTypeEnum, required: false
-        argument :netsuite_account_code, String, required: false
-        argument :netsuite_id, String, required: false
-        argument :netsuite_name, String, required: false
       end
     end
   end

--- a/app/models/integration_collection_mappings/netsuite_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/netsuite_collection_mapping.rb
@@ -2,6 +2,6 @@
 
 module IntegrationCollectionMappings
   class NetsuiteCollectionMapping < BaseCollectionMapping
-    settings_accessors :netsuite_id, :netsuite_account_code, :netsuite_name
+    settings_accessors :external_id, :external_account_code, :external_name
   end
 end

--- a/app/models/integration_item.rb
+++ b/app/models/integration_item.rb
@@ -15,6 +15,6 @@ class IntegrationItem < ApplicationRecord
   validates :external_id, presence: true
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[account_code external_id name]
+    %w[external_account_code external_id external_name]
   end
 end

--- a/app/models/integration_mappings/netsuite_mapping.rb
+++ b/app/models/integration_mappings/netsuite_mapping.rb
@@ -2,6 +2,6 @@
 
 module IntegrationMappings
   class NetsuiteMapping < BaseMapping
-    settings_accessors :netsuite_id, :netsuite_account_code, :netsuite_name
+    settings_accessors :external_id, :external_account_code, :external_name
   end
 end

--- a/app/queries/integration_items_query.rb
+++ b/app/queries/integration_items_query.rb
@@ -8,7 +8,7 @@ class IntegrationItemsQuery < BaseQuery
     integration_items = base_scope.result
     integration_items = integration_items.where(integration_id:) if integration_id.present?
     integration_items = integration_items.where(item_type: filters[:item_type]) unless filters[:item_type].nil?
-    integration_items = integration_items.order(name: :asc).page(page).per(limit)
+    integration_items = integration_items.order(external_name: :asc).page(page).per(limit)
 
     result.integration_items = integration_items
     result
@@ -27,9 +27,9 @@ class IntegrationItemsQuery < BaseQuery
 
     {
       m: 'or',
-      name_cont: search_term,
+      external_name_cont: search_term,
       external_id_cont: search_term,
-      account_code_cont: search_term,
+      external_account_code_cont: search_term,
     }
   end
 end

--- a/app/services/integration_collection_mappings/netsuite/create_service.rb
+++ b/app/services/integration_collection_mappings/netsuite/create_service.rb
@@ -9,11 +9,11 @@ module IntegrationCollectionMappings
           mapping_type: args[:mapping_type],
         )
 
-        integration_collection_mapping.netsuite_id = args[:netsuite_id] if args.key?(:netsuite_id)
-        if args.key?(:netsuite_account_code)
-          integration_collection_mapping.netsuite_account_code = args[:netsuite_account_code]
+        integration_collection_mapping.external_id = args[:external_id] if args.key?(:external_id)
+        if args.key?(:external_account_code)
+          integration_collection_mapping.external_account_code = args[:external_account_code]
         end
-        integration_collection_mapping.netsuite_name = args[:netsuite_name] if args.key?(:netsuite_name)
+        integration_collection_mapping.external_name = args[:external_name] if args.key?(:external_name)
 
         integration_collection_mapping.save!
 

--- a/app/services/integration_collection_mappings/netsuite/update_service.rb
+++ b/app/services/integration_collection_mappings/netsuite/update_service.rb
@@ -17,11 +17,11 @@ module IntegrationCollectionMappings
 
         integration_collection_mapping.integration_id = params[:integration_id] if params.key?(:integration_id)
         integration_collection_mapping.mapping_type = params[:mapping_type] if params.key?(:mapping_type)
-        integration_collection_mapping.netsuite_id = params[:netsuite_id] if params.key?(:netsuite_id)
-        if params.key?(:netsuite_account_code)
-          integration_collection_mapping.netsuite_account_code = params[:netsuite_account_code]
+        integration_collection_mapping.external_id = params[:external_id] if params.key?(:external_id)
+        if params.key?(:external_account_code)
+          integration_collection_mapping.external_account_code = params[:external_account_code]
         end
-        integration_collection_mapping.netsuite_name = params[:netsuite_name] if params.key?(:netsuite_name)
+        integration_collection_mapping.external_name = params[:external_name] if params.key?(:external_name)
 
         integration_collection_mapping.save!
 

--- a/app/services/integration_mappings/netsuite/create_service.rb
+++ b/app/services/integration_mappings/netsuite/create_service.rb
@@ -10,9 +10,9 @@ module IntegrationMappings
           mappable_type: args[:mappable_type],
         )
 
-        integration_mapping.netsuite_id = args[:netsuite_id] if args.key?(:netsuite_id)
-        integration_mapping.netsuite_account_code = args[:netsuite_account_code] if args.key?(:netsuite_account_code)
-        integration_mapping.netsuite_name = args[:netsuite_name] if args.key?(:netsuite_name)
+        integration_mapping.external_id = args[:external_id] if args.key?(:external_id)
+        integration_mapping.external_account_code = args[:external_account_code] if args.key?(:external_account_code)
+        integration_mapping.external_name = args[:external_name] if args.key?(:external_name)
 
         integration_mapping.save!
 

--- a/app/services/integration_mappings/netsuite/update_service.rb
+++ b/app/services/integration_mappings/netsuite/update_service.rb
@@ -16,11 +16,11 @@ module IntegrationMappings
         integration_mapping.integration_id = params[:integration_id] if params.key?(:integration_id)
         integration_mapping.mappable_id = params[:mappable_id] if params.key?(:mappable_id)
         integration_mapping.mappable_type = params[:mappable_type] if params.key?(:mappable_type)
-        integration_mapping.netsuite_id = params[:netsuite_id] if params.key?(:netsuite_id)
-        if params.key?(:netsuite_account_code)
-          integration_mapping.netsuite_account_code = params[:netsuite_account_code]
+        integration_mapping.external_id = params[:external_id] if params.key?(:external_id)
+        if params.key?(:external_account_code)
+          integration_mapping.external_account_code = params[:external_account_code]
         end
-        integration_mapping.netsuite_name = params[:netsuite_name] if params.key?(:netsuite_name)
+        integration_mapping.external_name = params[:external_name] if params.key?(:external_name)
 
         integration_mapping.save!
 

--- a/app/services/integrations/aggregator/items_service.rb
+++ b/app/services/integrations/aggregator/items_service.rb
@@ -46,8 +46,8 @@ module Integrations
           integration_item = IntegrationItem.new(
             integration:,
             external_id: item['id'],
-            account_code: item['account_code'],
-            name: item['name'],
+            external_account_code: item['account_code'],
+            external_name: item['name'],
             item_type: :standard,
           )
 

--- a/app/services/integrations/aggregator/tax_items_service.rb
+++ b/app/services/integrations/aggregator/tax_items_service.rb
@@ -46,7 +46,7 @@ module Integrations
           integration_item = IntegrationItem.new(
             integration:,
             external_id: item['id'],
-            name: item['name'],
+            external_name: item['name'],
             item_type: :tax,
           )
 

--- a/db/migrate/20240424110420_rename_integration_items_columns.rb
+++ b/db/migrate/20240424110420_rename_integration_items_columns.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RenameIntegrationItemsColumns < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :integration_items, :name, :external_name
+    rename_column :integration_items, :account_code, :external_account_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_23_155113) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_24_110420) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -559,8 +559,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_23_155113) do
     t.uuid "integration_id", null: false
     t.integer "item_type", null: false
     t.string "external_id", null: false
-    t.string "account_code"
-    t.string "name"
+    t.string "external_account_code"
+    t.string "external_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["integration_id"], name: "index_integration_items_on_integration_id"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1844,11 +1844,11 @@ input CreateNetsuiteIntegrationCollectionMappingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  externalAccountCode: String
+  externalId: String!
+  externalName: String
   integrationId: ID!
   mappingType: NetsuiteMappingTypeEnum!
-  netsuiteAccountCode: String
-  netsuiteId: String!
-  netsuiteName: String
 }
 
 """
@@ -1881,12 +1881,12 @@ input CreateNetsuiteIntegrationMappingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  externalAccountCode: String!
+  externalId: String!
+  externalName: String
   integrationId: ID!
   mappableId: ID!
   mappableType: NetsuiteMappableTypeEnum!
-  netsuiteAccountCode: String!
-  netsuiteId: String!
-  netsuiteName: String
 }
 
 """
@@ -3544,12 +3544,12 @@ type IntegrationCollection {
 }
 
 type IntegrationItem {
-  accountCode: String
+  externalAccountCode: String
   externalId: String!
+  externalName: String
   id: ID!
   integrationId: ID!
   itemType: IntegrationItemTypeEnum!
-  name: String
 }
 
 type IntegrationItemCollection {
@@ -4625,12 +4625,12 @@ type Mutation {
 }
 
 type NetsuiteCollectionMapping {
+  externalAccountCode: String
+  externalId: String!
+  externalName: String
   id: ID!
   integrationId: ID!
   mappingType: NetsuiteMappingTypeEnum!
-  netsuiteAccountCode: String
-  netsuiteId: String!
-  netsuiteName: String
 }
 
 type NetsuiteCollectionMappingCollection {
@@ -4660,13 +4660,13 @@ enum NetsuiteMappableTypeEnum {
 }
 
 type NetsuiteMapping {
+  externalAccountCode: String!
+  externalId: String!
+  externalName: String
   id: ID!
   integrationId: ID!
   mappableId: ID!
   mappableType: NetsuiteMappableTypeEnum!
-  netsuiteAccountCode: String!
-  netsuiteId: String!
-  netsuiteName: String
 }
 
 type NetsuiteMappingCollection {
@@ -6524,12 +6524,12 @@ input UpdateNetsuiteIntegrationCollectionMappingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  externalAccountCode: String
+  externalId: String
+  externalName: String
   id: ID!
   integrationId: ID
   mappingType: NetsuiteMappingTypeEnum
-  netsuiteAccountCode: String
-  netsuiteId: String
-  netsuiteName: String
 }
 
 """
@@ -6563,13 +6563,13 @@ input UpdateNetsuiteIntegrationMappingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  externalAccountCode: String
+  externalId: String
+  externalName: String
   id: ID!
   integrationId: ID
   mappableId: ID
   mappableType: NetsuiteMappableTypeEnum
-  netsuiteAccountCode: String
-  netsuiteId: String
-  netsuiteName: String
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -6854,6 +6854,46 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "externalAccountCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "integrationId",
               "description": null,
               "type": {
@@ -6880,46 +6920,6 @@
                   "name": "NetsuiteMappingTypeEnum",
                   "ofType": null
                 }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteAccountCode",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteId",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteName",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -7128,6 +7128,50 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "externalAccountCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "integrationId",
               "description": null,
               "type": {
@@ -7170,50 +7214,6 @@
                   "name": "NetsuiteMappableTypeEnum",
                   "ofType": null
                 }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteAccountCode",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteId",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteName",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -15360,7 +15360,7 @@
           "possibleTypes": null,
           "fields": [
             {
-              "name": "accountCode",
+              "name": "externalAccountCode",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -15384,6 +15384,20 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "externalName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -15438,20 +15452,6 @@
                   "name": "IntegrationItemTypeEnum",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "name",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -20462,6 +20462,52 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "externalAccountCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "externalId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "externalName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -20508,52 +20554,6 @@
                   "name": "NetsuiteMappingTypeEnum",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "netsuiteAccountCode",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "netsuiteId",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "netsuiteName",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -20866,6 +20866,56 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "externalAccountCode",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "externalId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "externalName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -20930,56 +20980,6 @@
                   "name": "NetsuiteMappableTypeEnum",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "netsuiteAccountCode",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "netsuiteId",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "netsuiteName",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -30075,6 +30075,42 @@
               "deprecationReason": null
             },
             {
+              "name": "externalAccountCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "integrationId",
               "description": null,
               "type": {
@@ -30092,42 +30128,6 @@
               "type": {
                 "kind": "ENUM",
                 "name": "NetsuiteMappingTypeEnum",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteAccountCode",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteName",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               },
               "defaultValue": null,
@@ -30325,6 +30325,42 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "externalAccountCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "type": {
@@ -30370,42 +30406,6 @@
               "type": {
                 "kind": "ENUM",
                 "name": "NetsuiteMappableTypeEnum",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteAccountCode",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "netsuiteName",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/factories/integration_collection_mappings.rb
+++ b/spec/factories/integration_collection_mappings.rb
@@ -7,9 +7,9 @@ FactoryBot.define do
 
     settings do
       {
-        netsuite_id: 'netsuite-123',
-        netsuite_account_code: 'netsuite-code-1',
-        netsuite_name: 'Credits and Discounts',
+        external_id: 'netsuite-123',
+        external_account_code: 'netsuite-code-1',
+        external_name: 'Credits and Discounts',
       }
     end
   end

--- a/spec/factories/integration_items.rb
+++ b/spec/factories/integration_items.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
   factory :integration_item do
     association :integration, factory: :netsuite_integration
     item_type { 'standard' }
-    name { 'test name' }
-    account_code { 'test_code' }
+    external_name { 'test name' }
+    external_account_code { 'test_code' }
     external_id { SecureRandom.uuid }
   end
 end

--- a/spec/factories/integration_mappings.rb
+++ b/spec/factories/integration_mappings.rb
@@ -7,9 +7,9 @@ FactoryBot.define do
 
     settings do
       {
-        netsuite_id: 'netsuite-123',
-        netsuite_account_code: 'netsuite-code-1',
-        netsuite_name: 'Credits and Discounts',
+        external_id: 'netsuite-123',
+        external_account_code: 'netsuite-code-1',
+        external_name: 'Credits and Discounts',
       }
     end
   end

--- a/spec/graphql/mutations/integration_collection_mappings/netsuite/create_spec.rb
+++ b/spec/graphql/mutations/integration_collection_mappings/netsuite/create_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Create, type:
   let(:mapping_type) { %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit].sample.to_s }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
-  let(:netsuite_account_code) { Faker::Barcode.ean }
-  let(:netsuite_id) { SecureRandom.uuid }
-  let(:netsuite_name) { Faker::Commerce.department }
+  let(:external_account_code) { Faker::Barcode.ean }
+  let(:external_id) { SecureRandom.uuid }
+  let(:external_name) { Faker::Commerce.department }
 
   let(:mutation) do
     <<-GQL
@@ -18,9 +18,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Create, type:
           id,
           integrationId,
           mappingType,
-          netsuiteAccountCode,
-          netsuiteId,
-          netsuiteName
+          externalAccountCode,
+          externalId,
+          externalName
         }
       }
     GQL
@@ -35,9 +35,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Create, type:
         input: {
           integrationId: integration.id,
           mappingType: mapping_type,
-          netsuiteAccountCode: netsuite_account_code,
-          netsuiteId: netsuite_id,
-          netsuiteName: netsuite_name,
+          externalAccountCode: external_account_code,
+          externalId: external_id,
+          externalName: external_name,
         },
       },
     )
@@ -48,9 +48,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Create, type:
       expect(result_data['id']).to be_present
       expect(result_data['integrationId']).to eq(integration.id)
       expect(result_data['mappingType']).to eq(mapping_type)
-      expect(result_data['netsuiteAccountCode']).to eq(netsuite_account_code)
-      expect(result_data['netsuiteId']).to eq(netsuite_id)
-      expect(result_data['netsuiteName']).to eq(netsuite_name)
+      expect(result_data['externalAccountCode']).to eq(external_account_code)
+      expect(result_data['externalId']).to eq(external_id)
+      expect(result_data['externalName']).to eq(external_name)
     end
   end
 
@@ -63,9 +63,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Create, type:
           input: {
             integrationId: integration.id,
             mappingType: mapping_type,
-            netsuiteAccountCode: netsuite_account_code,
-            netsuiteId: netsuite_id,
-            netsuiteName: netsuite_name,
+            externalAccountCode: external_account_code,
+            externalId: external_id,
+            externalName: external_name,
           },
         },
       )
@@ -83,9 +83,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Create, type:
           input: {
             integrationId: integration.id,
             mappingType: mapping_type,
-            netsuiteAccountCode: netsuite_account_code,
-            netsuiteId: netsuite_id,
-            netsuiteName: netsuite_name,
+            externalAccountCode: external_account_code,
+            externalId: external_id,
+            externalName: external_name,
           },
         },
       )

--- a/spec/graphql/mutations/integration_collection_mappings/netsuite/update_spec.rb
+++ b/spec/graphql/mutations/integration_collection_mappings/netsuite/update_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Update, type:
   let(:mapping_type) { %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit].sample.to_s }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
-  let(:netsuite_account_code) { Faker::Barcode.ean }
-  let(:netsuite_id) { SecureRandom.uuid }
-  let(:netsuite_name) { Faker::Commerce.department }
+  let(:external_account_code) { Faker::Barcode.ean }
+  let(:external_id) { SecureRandom.uuid }
+  let(:external_name) { Faker::Commerce.department }
 
   let(:mutation) do
     <<-GQL
@@ -19,9 +19,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Update, type:
           id,
           integrationId,
           mappingType,
-          netsuiteAccountCode,
-          netsuiteId,
-          netsuiteName
+          externalAccountCode,
+          externalId,
+          externalName
         }
       }
     GQL
@@ -37,9 +37,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Update, type:
           id: integration_collection_mapping.id,
           integrationId: integration.id,
           mappingType: mapping_type,
-          netsuiteAccountCode: netsuite_account_code,
-          netsuiteId: netsuite_id,
-          netsuiteName: netsuite_name,
+          externalAccountCode: external_account_code,
+          externalId: external_id,
+          externalName: external_name,
         },
       },
     )
@@ -49,9 +49,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Update, type:
     aggregate_failures do
       expect(result_data['integrationId']).to eq(integration.id)
       expect(result_data['mappingType']).to eq(mapping_type)
-      expect(result_data['netsuiteAccountCode']).to eq(netsuite_account_code)
-      expect(result_data['netsuiteId']).to eq(netsuite_id)
-      expect(result_data['netsuiteName']).to eq(netsuite_name)
+      expect(result_data['externalAccountCode']).to eq(external_account_code)
+      expect(result_data['externalId']).to eq(external_id)
+      expect(result_data['externalName']).to eq(external_name)
     end
   end
 
@@ -65,9 +65,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Update, type:
             id: integration_collection_mapping.id,
             integrationId: integration_collection_mapping.id,
             mappingType: mapping_type,
-            netsuiteAccountCode: netsuite_account_code,
-            netsuiteId: netsuite_id,
-            netsuiteName: netsuite_name,
+            externalAccountCode: external_account_code,
+            externalId: external_id,
+            externalName: external_name,
           },
         },
       )
@@ -86,9 +86,9 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Update, type:
             id: integration_collection_mapping.id,
             integrationId: integration_collection_mapping.id,
             mappingType: mapping_type,
-            netsuiteAccountCode: netsuite_account_code,
-            netsuiteId: netsuite_id,
-            netsuiteName: netsuite_name,
+            externalAccountCode: external_account_code,
+            externalId: external_id,
+            externalName: external_name,
           },
         },
       )

--- a/spec/graphql/mutations/integration_items/fetch_items_spec.rb
+++ b/spec/graphql/mutations/integration_items/fetch_items_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Mutations::IntegrationItems::FetchItems, type: :graphql do
     <<~GQL
       mutation($input: FetchIntegrationItemsInput!) {
         fetchIntegrationItems(input: $input) {
-          collection { name, accountCode, externalId }
+          collection { externalName, externalAccountCode, externalId }
         }
       }
     GQL

--- a/spec/graphql/mutations/integration_items/fetch_tax_items_spec.rb
+++ b/spec/graphql/mutations/integration_items/fetch_tax_items_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Mutations::IntegrationItems::FetchTaxItems, type: :graphql do
     <<~GQL
       mutation($input: FetchIntegrationTaxItemsInput!) {
         fetchIntegrationTaxItems(input: $input) {
-          collection { name, externalId }
+          collection { externalName, externalId }
         }
       }
     GQL

--- a/spec/graphql/mutations/integration_mappings/netsuite/create_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/netsuite/create_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Create, type: :graphql 
   let(:mappable) { create(:add_on, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
-  let(:netsuite_account_code) { Faker::Barcode.ean }
-  let(:netsuite_id) { SecureRandom.uuid }
-  let(:netsuite_name) { Faker::Commerce.department }
+  let(:external_account_code) { Faker::Barcode.ean }
+  let(:external_id) { SecureRandom.uuid }
+  let(:external_name) { Faker::Commerce.department }
 
   let(:mutation) do
     <<-GQL
@@ -19,9 +19,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Create, type: :graphql 
           integrationId,
           mappableId,
           mappableType,
-          netsuiteAccountCode,
-          netsuiteId,
-          netsuiteName
+          externalAccountCode,
+          externalId,
+          externalName
         }
       }
     GQL
@@ -37,9 +37,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Create, type: :graphql 
           integrationId: integration.id,
           mappableId: mappable.id,
           mappableType: 'AddOn',
-          netsuiteAccountCode: netsuite_account_code,
-          netsuiteId: netsuite_id,
-          netsuiteName: netsuite_name,
+          externalAccountCode: external_account_code,
+          externalId: external_id,
+          externalName: external_name,
         },
       },
     )
@@ -51,9 +51,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Create, type: :graphql 
       expect(result_data['integrationId']).to eq(integration.id)
       expect(result_data['mappableId']).to eq(mappable.id)
       expect(result_data['mappableType']).to eq('AddOn')
-      expect(result_data['netsuiteAccountCode']).to eq(netsuite_account_code)
-      expect(result_data['netsuiteId']).to eq(netsuite_id)
-      expect(result_data['netsuiteName']).to eq(netsuite_name)
+      expect(result_data['externalAccountCode']).to eq(external_account_code)
+      expect(result_data['externalId']).to eq(external_id)
+      expect(result_data['externalName']).to eq(external_name)
     end
   end
 
@@ -67,9 +67,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Create, type: :graphql 
             integrationId: integration.id,
             mappableId: mappable.id,
             mappableType: 'AddOn',
-            netsuiteAccountCode: netsuite_account_code,
-            netsuiteId: netsuite_id,
-            netsuiteName: netsuite_name,
+            externalAccountCode: external_account_code,
+            externalId: external_id,
+            externalName: external_name,
           },
         },
       )
@@ -88,9 +88,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Create, type: :graphql 
             integrationId: integration.id,
             mappableId: mappable.id,
             mappableType: 'AddOn',
-            netsuiteAccountCode: netsuite_account_code,
-            netsuiteId: netsuite_id,
-            netsuiteName: netsuite_name,
+            externalAccountCode: external_account_code,
+            externalId: external_id,
+            externalName: external_name,
           },
         },
       )

--- a/spec/graphql/mutations/integration_mappings/netsuite/update_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/netsuite/update_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Update, type: :graphql 
   let(:mappable) { create(:add_on, organization:) }
   let(:organization) { membership.organization }
   let(:membership) { create(:membership) }
-  let(:netsuite_account_code) { Faker::Barcode.ean }
-  let(:netsuite_id) { SecureRandom.uuid }
-  let(:netsuite_name) { Faker::Commerce.department }
+  let(:external_account_code) { Faker::Barcode.ean }
+  let(:external_id) { SecureRandom.uuid }
+  let(:external_name) { Faker::Commerce.department }
 
   let(:mutation) do
     <<-GQL
@@ -20,9 +20,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Update, type: :graphql 
           integrationId,
           mappableId,
           mappableType,
-          netsuiteAccountCode,
-          netsuiteId,
-          netsuiteName
+          externalAccountCode,
+          externalId,
+          externalName
         }
       }
     GQL
@@ -39,9 +39,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Update, type: :graphql 
           integrationId: integration.id,
           mappableId: mappable.id,
           mappableType: 'AddOn',
-          netsuiteAccountCode: netsuite_account_code,
-          netsuiteId: netsuite_id,
-          netsuiteName: netsuite_name,
+          externalAccountCode: external_account_code,
+          externalId: external_id,
+          externalName: external_name,
         },
       },
     )
@@ -52,9 +52,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Update, type: :graphql 
       expect(result_data['integrationId']).to eq(integration.id)
       expect(result_data['mappableId']).to eq(mappable.id)
       expect(result_data['mappableType']).to eq('AddOn')
-      expect(result_data['netsuiteAccountCode']).to eq(netsuite_account_code)
-      expect(result_data['netsuiteId']).to eq(netsuite_id)
-      expect(result_data['netsuiteName']).to eq(netsuite_name)
+      expect(result_data['externalAccountCode']).to eq(external_account_code)
+      expect(result_data['externalId']).to eq(external_id)
+      expect(result_data['externalName']).to eq(external_name)
     end
   end
 
@@ -69,9 +69,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Update, type: :graphql 
             integrationId: integration_mapping.id,
             mappableId: mappable.id,
             mappableType: 'AddOn',
-            netsuiteAccountCode: netsuite_account_code,
-            netsuiteId: netsuite_id,
-            netsuiteName: netsuite_name,
+            externalAccountCode: external_account_code,
+            externalId: external_id,
+            externalName: external_name,
           },
         },
       )
@@ -91,9 +91,9 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Update, type: :graphql 
             integrationId: integration_mapping.id,
             mappableId: mappable.id,
             mappableType: 'AddOn',
-            netsuiteAccountCode: netsuite_account_code,
-            netsuiteId: netsuite_id,
-            netsuiteName: netsuite_name,
+            externalAccountCode: external_account_code,
+            externalId: external_id,
+            externalName: external_name,
           },
         },
       )

--- a/spec/graphql/resolvers/integration_collection_mappings/netsuite_collection_mapping_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_collection_mappings/netsuite_collection_mapping_resolver_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappi
         netsuiteCollectionMapping(id: $netsuiteCollectionMappingId) {
           id
           mappingType
-          netsuiteId
-          netsuiteAccountCode
-          netsuiteName
+          externalId
+          externalAccountCode
+          externalName
         }
       }
     GQL
@@ -39,10 +39,10 @@ RSpec.describe Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappi
     aggregate_failures do
       expect(integration_mapping_response['id']).to eq(netsuite_collection_mapping.id)
       expect(integration_mapping_response['mappingType']).to eq(netsuite_collection_mapping.mapping_type)
-      expect(integration_mapping_response['netsuiteId']).to eq(netsuite_collection_mapping.netsuite_id)
-      expect(integration_mapping_response['netsuiteName']).to eq(netsuite_collection_mapping.netsuite_name)
-      expect(integration_mapping_response['netsuiteAccountCode'])
-        .to eq(netsuite_collection_mapping.netsuite_account_code)
+      expect(integration_mapping_response['externalId']).to eq(netsuite_collection_mapping.external_id)
+      expect(integration_mapping_response['externalName']).to eq(netsuite_collection_mapping.external_name)
+      expect(integration_mapping_response['externalAccountCode'])
+        .to eq(netsuite_collection_mapping.external_account_code)
     end
   end
 

--- a/spec/graphql/resolvers/integration_items_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_items_resolver_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Resolvers::IntegrationItemsResolver, type: :graphql do
     <<~GQL
       query($integrationId: ID!, $itemType: IntegrationItemTypeEnum) {
         integrationItems(integrationId: $integrationId, itemType: $itemType, limit: 5) {
-          collection { id externalId itemType name }
+          collection { id externalId itemType externalName }
           metadata { currentPage, totalCount }
         }
       }

--- a/spec/graphql/resolvers/integration_mappings/netsuite_mapping_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_mappings/netsuite_mapping_resolver_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Resolvers::IntegrationMappings::NetsuiteMappingResolver, type: :g
           id
           mappableId
           mappableType
-          netsuiteId
-          netsuiteAccountCode
-          netsuiteName
+          externalId
+          externalAccountCode
+          externalName
         }
       }
     GQL
@@ -41,10 +41,10 @@ RSpec.describe Resolvers::IntegrationMappings::NetsuiteMappingResolver, type: :g
       expect(integration_mapping_response['id']).to eq(netsuite_mapping.id)
       expect(integration_mapping_response['mappableId']).to eq(netsuite_mapping.mappable_id)
       expect(integration_mapping_response['mappableType']).to eq(netsuite_mapping.mappable_type)
-      expect(integration_mapping_response['netsuiteId']).to eq(netsuite_mapping.netsuite_id)
-      expect(integration_mapping_response['netsuiteName']).to eq(netsuite_mapping.netsuite_name)
-      expect(integration_mapping_response['netsuiteAccountCode'])
-        .to eq(netsuite_mapping.netsuite_account_code)
+      expect(integration_mapping_response['externalId']).to eq(netsuite_mapping.external_id)
+      expect(integration_mapping_response['externalName']).to eq(netsuite_mapping.external_name)
+      expect(integration_mapping_response['externalAccountCode'])
+        .to eq(netsuite_mapping.external_account_code)
     end
   end
 

--- a/spec/graphql/types/integration_collection_mappings/netsuite/create_input_spec.rb
+++ b/spec/graphql/types/integration_collection_mappings/netsuite/create_input_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Types::IntegrationCollectionMappings::Netsuite::CreateInput do
 
   it { is_expected.to accept_argument(:integration_id).of_type('ID!') }
   it { is_expected.to accept_argument(:mapping_type).of_type('NetsuiteMappingTypeEnum!') }
-  it { is_expected.to accept_argument(:netsuite_account_code).of_type('String') }
-  it { is_expected.to accept_argument(:netsuite_id).of_type('String!') }
-  it { is_expected.to accept_argument(:netsuite_name).of_type('String') }
+  it { is_expected.to accept_argument(:external_account_code).of_type('String') }
+  it { is_expected.to accept_argument(:external_id).of_type('String!') }
+  it { is_expected.to accept_argument(:external_name).of_type('String') }
 end

--- a/spec/graphql/types/integration_collection_mappings/netsuite/object_spec.rb
+++ b/spec/graphql/types/integration_collection_mappings/netsuite/object_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Types::IntegrationCollectionMappings::Netsuite::Object do
   it { is_expected.to have_field(:id).of_type('ID!') }
   it { is_expected.to have_field(:integration_id).of_type('ID!') }
   it { is_expected.to have_field(:mapping_type).of_type('NetsuiteMappingTypeEnum!') }
-  it { is_expected.to have_field(:netsuite_account_code).of_type('String') }
-  it { is_expected.to have_field(:netsuite_id).of_type('String!') }
-  it { is_expected.to have_field(:netsuite_name).of_type('String') }
+  it { is_expected.to have_field(:external_account_code).of_type('String') }
+  it { is_expected.to have_field(:external_id).of_type('String!') }
+  it { is_expected.to have_field(:external_name).of_type('String') }
 end

--- a/spec/graphql/types/integration_collection_mappings/netsuite/update_input_spec.rb
+++ b/spec/graphql/types/integration_collection_mappings/netsuite/update_input_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Types::IntegrationCollectionMappings::Netsuite::UpdateInput do
   it { is_expected.to accept_argument(:id).of_type('ID!') }
   it { is_expected.to accept_argument(:integration_id).of_type('ID') }
   it { is_expected.to accept_argument(:mapping_type).of_type('NetsuiteMappingTypeEnum') }
-  it { is_expected.to accept_argument(:netsuite_account_code).of_type('String') }
-  it { is_expected.to accept_argument(:netsuite_id).of_type('String') }
-  it { is_expected.to accept_argument(:netsuite_name).of_type('String') }
+  it { is_expected.to accept_argument(:external_account_code).of_type('String') }
+  it { is_expected.to accept_argument(:external_id).of_type('String') }
+  it { is_expected.to accept_argument(:external_name).of_type('String') }
 end

--- a/spec/graphql/types/integration_items/object_spec.rb
+++ b/spec/graphql/types/integration_items/object_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationItems::Object do
   subject { described_class }
 
-  it { is_expected.to have_field(:account_code).of_type('String') }
+  it { is_expected.to have_field(:external_account_code).of_type('String') }
   it { is_expected.to have_field(:external_id).of_type('String!') }
   it { is_expected.to have_field(:id).of_type('ID!') }
   it { is_expected.to have_field(:integration_id).of_type('ID!') }
   it { is_expected.to have_field(:item_type).of_type('IntegrationItemTypeEnum!') }
-  it { is_expected.to have_field(:name).of_type('String') }
+  it { is_expected.to have_field(:external_name).of_type('String') }
 end

--- a/spec/graphql/types/integration_mappings/netsuite/create_input_spec.rb
+++ b/spec/graphql/types/integration_mappings/netsuite/create_input_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Types::IntegrationMappings::Netsuite::CreateInput do
   it { is_expected.to accept_argument(:integration_id).of_type('ID!') }
   it { is_expected.to accept_argument(:mappable_id).of_type('ID!') }
   it { is_expected.to accept_argument(:mappable_type).of_type('NetsuiteMappableTypeEnum!') }
-  it { is_expected.to accept_argument(:netsuite_account_code).of_type('String!') }
-  it { is_expected.to accept_argument(:netsuite_id).of_type('String!') }
-  it { is_expected.to accept_argument(:netsuite_name).of_type('String') }
+  it { is_expected.to accept_argument(:external_account_code).of_type('String!') }
+  it { is_expected.to accept_argument(:external_id).of_type('String!') }
+  it { is_expected.to accept_argument(:external_name).of_type('String') }
 end

--- a/spec/graphql/types/integration_mappings/netsuite/object_spec.rb
+++ b/spec/graphql/types/integration_mappings/netsuite/object_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Types::IntegrationMappings::Netsuite::Object do
   it { is_expected.to have_field(:integration_id).of_type('ID!') }
   it { is_expected.to have_field(:mappable_id).of_type('ID!') }
   it { is_expected.to have_field(:mappable_type).of_type('NetsuiteMappableTypeEnum!') }
-  it { is_expected.to have_field(:netsuite_account_code).of_type('String!') }
-  it { is_expected.to have_field(:netsuite_id).of_type('String!') }
-  it { is_expected.to have_field(:netsuite_name).of_type('String') }
+  it { is_expected.to have_field(:external_account_code).of_type('String!') }
+  it { is_expected.to have_field(:external_id).of_type('String!') }
+  it { is_expected.to have_field(:external_name).of_type('String') }
 end

--- a/spec/graphql/types/integration_mappings/netsuite/update_input_spec.rb
+++ b/spec/graphql/types/integration_mappings/netsuite/update_input_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Types::IntegrationMappings::Netsuite::UpdateInput do
   it { is_expected.to accept_argument(:integration_id).of_type('ID') }
   it { is_expected.to accept_argument(:mappable_id).of_type('ID') }
   it { is_expected.to accept_argument(:mappable_type).of_type('NetsuiteMappableTypeEnum') }
-  it { is_expected.to accept_argument(:netsuite_account_code).of_type('String') }
-  it { is_expected.to accept_argument(:netsuite_id).of_type('String') }
-  it { is_expected.to accept_argument(:netsuite_name).of_type('String') }
+  it { is_expected.to accept_argument(:external_account_code).of_type('String') }
+  it { is_expected.to accept_argument(:external_id).of_type('String') }
+  it { is_expected.to accept_argument(:external_name).of_type('String') }
 end

--- a/spec/models/integration_collection_mappings/netsuite_collection_mapping_spec.rb
+++ b/spec/models/integration_collection_mappings/netsuite_collection_mapping_spec.rb
@@ -11,30 +11,30 @@ RSpec.describe IntegrationCollectionMappings::NetsuiteCollectionMapping, type: :
 
   it { is_expected.to define_enum_for(:mapping_type).with_values(mapping_types) }
 
-  describe '#netsuite_id' do
-    let(:netsuite_id) { SecureRandom.uuid }
+  describe '#external_id' do
+    let(:external_id) { SecureRandom.uuid }
 
     it 'assigns and retrieve a setting' do
-      mapping.netsuite_id = netsuite_id
-      expect(mapping.netsuite_id).to eq(netsuite_id)
+      mapping.external_id = external_id
+      expect(mapping.external_id).to eq(external_id)
     end
   end
 
-  describe '#netsuite_account_code' do
-    let(:netsuite_account_code) { 'netsuite-code-1' }
+  describe '#external_account_code' do
+    let(:external_account_code) { 'netsuite-code-1' }
 
     it 'assigns and retrieve a setting' do
-      mapping.netsuite_account_code = netsuite_account_code
-      expect(mapping.netsuite_account_code).to eq(netsuite_account_code)
+      mapping.external_account_code = external_account_code
+      expect(mapping.external_account_code).to eq(external_account_code)
     end
   end
 
-  describe '#netsuite_name' do
-    let(:netsuite_name) { 'Credits and Discounts' }
+  describe '#external_name' do
+    let(:external_name) { 'Credits and Discounts' }
 
     it 'assigns and retrieve a setting' do
-      mapping.netsuite_name = netsuite_name
-      expect(mapping.netsuite_name).to eq(netsuite_name)
+      mapping.external_name = external_name
+      expect(mapping.external_name).to eq(external_name)
     end
   end
 end

--- a/spec/models/integration_mappings/netsuite_mapping_spec.rb
+++ b/spec/models/integration_mappings/netsuite_mapping_spec.rb
@@ -5,30 +5,30 @@ require 'rails_helper'
 RSpec.describe IntegrationMappings::NetsuiteMapping, type: :model do
   subject(:mapping) { build(:netsuite_mapping) }
 
-  describe '#netsuite_id' do
-    let(:netsuite_id) { SecureRandom.uuid }
+  describe '#external_id' do
+    let(:external_id) { SecureRandom.uuid }
 
     it 'assigns and retrieve a setting' do
-      mapping.netsuite_id = netsuite_id
-      expect(mapping.netsuite_id).to eq(netsuite_id)
+      mapping.external_id = external_id
+      expect(mapping.external_id).to eq(external_id)
     end
   end
 
-  describe '#netsuite_account_code' do
-    let(:netsuite_account_code) { 'netsuite-code-1' }
+  describe '#external_account_code' do
+    let(:external_account_code) { 'netsuite-code-1' }
 
     it 'assigns and retrieve a setting' do
-      mapping.netsuite_account_code = netsuite_account_code
-      expect(mapping.netsuite_account_code).to eq(netsuite_account_code)
+      mapping.external_account_code = external_account_code
+      expect(mapping.external_account_code).to eq(external_account_code)
     end
   end
 
-  describe '#netsuite_name' do
-    let(:netsuite_name) { 'Credits and Discounts' }
+  describe '#external_name' do
+    let(:external_name) { 'Credits and Discounts' }
 
     it 'assigns and retrieve a setting' do
-      mapping.netsuite_name = netsuite_name
-      expect(mapping.netsuite_name).to eq(netsuite_name)
+      mapping.external_name = external_name
+      expect(mapping.external_name).to eq(external_name)
     end
   end
 end

--- a/spec/queries/integration_items_query_spec.rb
+++ b/spec/queries/integration_items_query_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe IntegrationItemsQuery, type: :query do
   let(:integration_item_first) { create(:integration_item, item_type: 'tax', integration:) }
   let(:integration_item_second) { create(:integration_item, integration: integration_second) }
   let(:integration_item_third) { create(:integration_item, integration: integration_third) }
-  let(:integration_item_fourth) { create(:integration_item, name: 'Findme', integration:) }
+  let(:integration_item_fourth) { create(:integration_item, external_name: 'Findme', integration:) }
 
   let(:service_call) do
     integration_items_query.call(integration_id: integration.id, search_term:, page: 1, limit: 10, filters:)

--- a/spec/services/integration_collection_mappings/netsuite/update_service_spec.rb
+++ b/spec/services/integration_collection_mappings/netsuite/update_service_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe IntegrationCollectionMappings::Netsuite::UpdateService, type: :se
 
     let(:update_args) do
       {
-        netsuite_id: '456',
-        netsuite_name: 'Name1',
-        netsuite_account_code: 'code-2',
+        external_id: '456',
+        external_name: 'Name1',
+        external_account_code: 'code-2',
       }
     end
 
@@ -29,9 +29,9 @@ RSpec.describe IntegrationCollectionMappings::Netsuite::UpdateService, type: :se
           IntegrationCollectionMappings::NetsuiteCollectionMapping.order(:updated_at).last
 
         aggregate_failures do
-          expect(integration_collection_mapping.netsuite_id).to eq('456')
-          expect(integration_collection_mapping.netsuite_name).to eq('Name1')
-          expect(integration_collection_mapping.netsuite_account_code).to eq('code-2')
+          expect(integration_collection_mapping.external_id).to eq('456')
+          expect(integration_collection_mapping.external_name).to eq('Name1')
+          expect(integration_collection_mapping.external_account_code).to eq('code-2')
         end
       end
 

--- a/spec/services/integration_mappings/netsuite/update_service_spec.rb
+++ b/spec/services/integration_mappings/netsuite/update_service_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe IntegrationMappings::Netsuite::UpdateService, type: :service do
 
     let(:update_args) do
       {
-        netsuite_id: '456',
-        netsuite_name: 'Name1',
-        netsuite_account_code: 'code-2',
+        external_id: '456',
+        external_name: 'Name1',
+        external_account_code: 'code-2',
       }
     end
 
@@ -28,9 +28,9 @@ RSpec.describe IntegrationMappings::Netsuite::UpdateService, type: :service do
         integration_mapping = IntegrationMappings::NetsuiteMapping.order(:updated_at).last
 
         aggregate_failures do
-          expect(integration_mapping.netsuite_id).to eq('456')
-          expect(integration_mapping.netsuite_name).to eq('Name1')
-          expect(integration_mapping.netsuite_account_code).to eq('code-2')
+          expect(integration_mapping.external_id).to eq('456')
+          expect(integration_mapping.external_name).to eq('Name1')
+          expect(integration_mapping.external_account_code).to eq('code-2')
         end
       end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR renames `account_code` and `name` attributes of integration mapping-related resources to `integration_account_code` and `integration_name`.