### PR TITLE
chore: update gems for :development and :test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,12 +8,11 @@ GIT
 
 GIT
   remote: https://github.com/glebm/i18n-tasks.git
-  revision: 249f0dd61b4e2a07befad96bed8e1f89b7527d3e
+  revision: 3bfe80cec5f8c83fabd3d4932b4eff590f45c6d6
   specs:
-    i18n-tasks (1.0.12)
+    i18n-tasks (1.0.13)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
-      better_html (>= 1.0, < 3.0)
       erubi
       highline (>= 2.0.0)
       i18n
@@ -24,11 +23,10 @@ GIT
 
 GIT
   remote: https://github.com/rmosolgo/graphiql-rails.git
-  revision: 6b34eb17bf13262eef6edf9a069cfc69b5db9708
+  revision: 8d3c96190cbe2004be99b23c28d28d96962bb8d0
   specs:
-    graphiql-rails (1.8.0)
+    graphiql-rails (1.10.0)
       railties
-      sprockets-rails
 
 GEM
   remote: https://rubygems.org/
@@ -132,17 +130,10 @@ GEM
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
-    better_html (2.0.2)
-      actionview (>= 6.0)
-      activesupport (>= 6.0)
-      ast (~> 2.0)
-      erubi (~> 1.4)
-      parser (>= 2.4)
-      smart_properties
     bootsnap (1.12.0)
       msgpack (~> 1.2)
     builder (3.2.4)
-    bullet (7.1.4)
+    bullet (7.1.6)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
@@ -172,7 +163,7 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     date (3.3.4)
-    debug (1.6.2)
+    debug (1.6.3)
       irb (>= 1.3.6)
       reline (>= 0.3.1)
     declarative (0.0.20)
@@ -182,7 +173,7 @@ GEM
     discard (1.3.0)
       activerecord (>= 4.2, < 8)
     docile (1.4.0)
-    dotenv (2.8.1)
+    dotenv (3.1.0)
     erubi (1.12.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
@@ -190,7 +181,7 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faker (2.23.0)
+    faker (3.3.1)
       i18n (>= 1.8.11, < 2)
     faraday (1.10.3)
       faraday-em_http (~> 1.0)
@@ -670,7 +661,7 @@ GEM
     rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (6.0.3)
+    rspec-rails (6.1.1)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)
@@ -696,7 +687,7 @@ GEM
       rubocop (~> 1.41)
     rubocop-factory_bot (2.25.1)
       rubocop (~> 1.41)
-    rubocop-graphql (1.5.0)
+    rubocop-graphql (1.5.1)
       rubocop (>= 0.90, < 2)
     rubocop-performance (1.20.2)
       rubocop (>= 1.48.1, < 2.0)
@@ -706,10 +697,13 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
-    rubocop-rspec (2.26.1)
+    rubocop-rspec (2.29.1)
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
+      rubocop-rspec_rails (~> 2.28)
+    rubocop-rspec_rails (2.28.3)
+      rubocop (~> 1.40)
     rubocop-thread_safety (0.5.1)
       rubocop (>= 0.90.0)
     ruby-lsp (0.14.1)
@@ -746,7 +740,7 @@ GEM
       sentry-ruby (~> 5.12.0)
       sidekiq (>= 3.0)
     shellany (0.0.1)
-    shoulda-matchers (5.3.0)
+    shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
     sidekiq (7.1.4)
       concurrent-ruby (< 2)
@@ -772,7 +766,6 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 6.0, != 5.0.0)
-    smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -790,7 +783,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.1)
     tilt (2.0.10)
-    timecop (0.9.5)
+    timecop (0.9.8)
     timeout (0.4.1)
     trailblazer-option (0.1.2)
     tzinfo (2.0.6)
@@ -806,7 +799,7 @@ GEM
     waterdrop (2.6.10)
       karafka-core (>= 2.2.3, < 3.0.0)
       zeitwerk (~> 2.3)
-    webmock (3.14.0)
+    webmock (3.23.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)


### PR DESCRIPTION
```sh
bundle update --conservative --group test development
```
The result

```
Fetching https://github.com/rmosolgo/graphiql-rails.git
Fetching https://github.com/glebm/i18n-tasks.git
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Fetching timecop 0.9.8 (was 0.9.5)
Fetching dotenv 3.1.0 (was 2.8.1)
Using webmock 3.23.0 (was 3.14.0)
Fetching faker 3.3.1 (was 2.23.0)
Fetching bullet 7.1.6 (was 7.1.4)
Fetching debug 1.6.3 (was 1.6.2)
Fetching shoulda-matchers 6.2.0 (was 5.3.0)
Fetching rubocop-graphql 1.5.1 (was 1.5.0)
Fetching rubocop-rspec_rails 2.28.3
Using graphiql-rails 1.10.0 (was 1.8.0) from https://github.com/rmosolgo/graphiql-rails.git (at master@8d3c961)
Fetching rspec-rails 6.1.1 (was 6.0.3)
Using i18n-tasks 1.0.13 (was 1.0.12) from https://github.com/glebm/i18n-tasks.git (at main@3bfe80c)
Installing timecop 0.9.8 (was 0.9.5)
Installing dotenv 3.1.0 (was 2.8.1)
Installing faker 3.3.1 (was 2.23.0)
Installing bullet 7.1.6 (was 7.1.4)
Installing debug 1.6.3 (was 1.6.2) with native extensions
Installing shoulda-matchers 6.2.0 (was 5.3.0)
Installing rubocop-graphql 1.5.1 (was 1.5.0)
Installing rubocop-rspec_rails 2.28.3
Fetching rubocop-rspec 2.29.1 (was 2.26.1)
Installing rspec-rails 6.1.1 (was 6.0.3)
Installing rubocop-rspec 2.29.1 (was 2.26.1)
Bundler attempted to update factory_bot_rails but its version stayed the same
Bundler attempted to update byebug but its version stayed the same
Bundler attempted to update clockwork-test but its version stayed the same
Bundler attempted to update simplecov but its version stayed the same
Bundler attempted to update database_cleaner-active_record but its version stayed the same
Bundler attempted to update guard-rspec but its version stayed the same
Bundler attempted to update rspec-graphql_matchers but its version stayed the same
Bundler attempted to update coffee-rails but its version stayed the same
Bundler attempted to update rubocop-performance but its version stayed the same
Bundler attempted to update rubocop-rails but its version stayed the same
Bundler attempted to update rubocop-thread_safety but its version stayed the same
Bundler attempted to update sass-rails but its version stayed the same
Bundler attempted to update uglifier but its version stayed the same
Bundler attempted to update ruby-lsp-rails but its version stayed the same
Bundle updated!
Post-install message from i18n-tasks:
# Install default configuration:
cp $(bundle exec i18n-tasks gem-path)/templates/config/i18n-tasks.yml config/
# Add an RSpec for missing and unused keys:
cp $(bundle exec i18n-tasks gem-path)/templates/rspec/i18n_spec.rb spec/
# Or for minitest:
cp $(bundle exec i18n-tasks gem-path)/templates/minitest/i18n_test.rb test/
2 installed gems you directly depend on are looking for funding.
  Run `bundle fund` for details
