### PR TITLE
feat(filter): Remove groups from in advance aggregations

### DIFF
--- a/app/services/charges/pay_in_advance_aggregation_service.rb
+++ b/app/services/charges/pay_in_advance_aggregation_service.rb
@@ -2,13 +2,12 @@
 
 module Charges
   class PayInAdvanceAggregationService < BaseService
-    def initialize(charge:, boundaries:, properties:, event:, group: nil, charge_filter: nil) # rubocop:disable Metrics/ParameterLists
+    def initialize(charge:, boundaries:, properties:, event:, charge_filter: nil)
       @charge = charge
       @boundaries = boundaries
       @properties = properties
       @event = event
       @charge_filter = charge_filter
-      @group = group
 
       super
     end
@@ -30,7 +29,7 @@ module Charges
 
     private
 
-    attr_reader :charge, :boundaries, :group, :properties, :event, :charge_filter
+    attr_reader :charge, :boundaries, :properties, :event, :charge_filter
 
     delegate :subscription, to: :event
     delegate :billable_metric, to: :charge
@@ -43,10 +42,7 @@ module Charges
     end
 
     def aggregation_filters
-      filters = {
-        group:,
-        event:,
-      }
+      filters = { event: }
 
       properties = charge_filter&.properties || charge.properties
       if charge.standard? && properties['grouped_by'].present?

--- a/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
+++ b/spec/services/charges/pay_in_advance_aggregation_service_spec.rb
@@ -4,13 +4,12 @@ require 'rails_helper'
 
 RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
   subject(:agg_service) do
-    described_class.new(charge:, boundaries:, group:, properties:, event:, charge_filter:)
+    described_class.new(charge:, boundaries:, properties:, event:, charge_filter:)
   end
 
   let(:organization) { create(:organization) }
   let(:billable_metric) { create(:billable_metric, organization:, aggregation_type:, field_name: 'item_id') }
   let(:charge) { create(:standard_charge, billable_metric:, pay_in_advance: true) }
-  let(:group) { create(:group) }
   let(:charge_filter) { nil }
   let(:aggregation_type) { 'count_agg' }
   let(:event) { create(:event, organization:, external_subscription_id: subscription.external_id) }
@@ -51,7 +50,6 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               charges_duration: boundaries[:charges_duration],
             },
             filters: {
-              group:,
               event:,
             },
           )
@@ -96,7 +94,6 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
                 charges_duration: boundaries[:charges_duration],
               },
               filters: {
-                group:,
                 event:,
                 grouped_by_values: { 'operator' => 'foo' },
               },
@@ -139,7 +136,6 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
                 charges_duration: boundaries[:charges_duration],
               },
               filters: {
-                group:,
                 event:,
                 charge_filter:,
                 matching_filters: charge_filter.to_h,
@@ -177,7 +173,6 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               charges_duration: boundaries[:charges_duration],
             },
             filters: {
-              group:,
               event:,
             },
           )
@@ -210,7 +205,6 @@ RSpec.describe Charges::PayInAdvanceAggregationService, type: :service do
               charges_duration: boundaries[:charges_duration],
             },
             filters: {
-              group:,
               event:,
             },
           )

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
   let(:plan) { create(:plan, organization:) }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:charge) { create(:standard_charge, :pay_in_advance, billable_metric:, plan:) }
-  let(:group) { nil }
+  let(:charge_filter) { nil }
 
   let(:invoice) { nil }
 
@@ -51,7 +51,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
 
     before do
       allow(Charges::PayInAdvanceAggregationService).to receive(:call)
-        .with(charge:, boundaries: Hash, group:, properties: Hash, event:, charge_filter: nil)
+        .with(charge:, boundaries: Hash, properties: Hash, event:, charge_filter:)
         .and_return(aggregation_result)
 
       allow(Charges::ApplyPayInAdvanceChargeModelService).to receive(:call)
@@ -88,7 +88,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
           units: 9,
           properties: Hash,
           events_count: 1,
-          group: nil,
+          charge_filter: nil,
           pay_in_advance_event_id: event.id,
           payment_status: 'pending',
           unit_amount_cents: 1,
@@ -233,7 +233,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
           units: 9,
           properties: Hash,
           events_count: 1,
-          group: nil,
+          charge_filter: nil,
           pay_in_advance_event_id: event.id,
           payment_status: 'pending',
           unit_amount_cents: 1,


### PR DESCRIPTION
## Context

This PR follow the recent release of the filter feature.

## Description

This PR is cleaning up the groups from pay in advance logic for fees and invoices