### PR TITLE
misc(gems): Fix warning with missing gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'scenic'
 gem 'with_advisory_lock'
 
 # Currencies, Countries, Timezones...
+gem 'bigdecimal'
 gem 'countries'
 gem 'money-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
@@ -54,8 +55,9 @@ gem 'analytics-ruby', '~> 2.4.0', require: 'segment/analytics'
 gem 'lograge'
 gem 'logstash-event'
 
-# Multipart support
+# HTTP and Multipart support
 gem 'multipart-post'
+gem 'mutex_m'
 
 # Monitoring
 gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,7 @@ GEM
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
+    bigdecimal (3.1.7)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -333,6 +334,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.3.0)
+    mutex_m (0.2.0)
     nenv (0.3.0)
     net-imap (0.4.10)
       date
@@ -830,6 +832,7 @@ DEPENDENCIES
   analytics-ruby (~> 2.4.0)
   aws-sdk-s3
   bcrypt
+  bigdecimal
   bootsnap
   bullet
   byebug
@@ -859,6 +862,7 @@ DEPENDENCIES
   logstash-event
   money-rails
   multipart-post
+  mutex_m
   newrelic_rpm
   oauth2
   opentelemetry-exporter-otlp


### PR DESCRIPTION
## Context

Since the update to ruby 3.3.0, to new warning appeared when starting the API containers:

```
/usr/local/bundle/gems/crack-0.4.5/lib/crack/xml.rb:9: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. Also contact author of crack-0.4.5 to add bigdecimal into its gemspec.
/usr/local/bundle/gems/httpclient-2.8.3/lib/httpclient/auth.rb:11: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec. Also contact author of httpclient-2.8.3 to add mutex_m into its gemspec.
```

## Description

This PR add `bigdecimal` and `mutex_m` in the Gemfile to fix the deprecation warning
