### PR TITLE
fix: Ruby sandbox support for ruby 3.3.0

### DIFF
--- a/lib/lago_utils/lago_utils/ruby_sandbox/safe_environment.rb
+++ b/lib/lago_utils/lago_utils/ruby_sandbox/safe_environment.rb
@@ -141,9 +141,7 @@ module LagoUtils
         all_symbols
       ].freeze
 
-      STRING_S_METHODS = %w[
-        new
-      ].freeze
+      STRING_S_METHODS = %w[].freeze
 
       KERNEL_METHODS = %w[
         ==


### PR DESCRIPTION
## Description

This PR fixes the RubySandbox issue with Ruby 3.3.0

```
`undef_method': undefined method `new' for class `String' (NameError)
```
