### PR TITLE
feat(integrations): Add models for integrations customers

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -28,6 +28,9 @@ class Customer < ApplicationRecord
            class_name: 'PaymentProviderCustomers::BaseCustomer',
            dependent: :destroy
   has_many :quantified_events
+  has_many :integration_customers,
+           class_name: 'IntegrationCustomers::BaseCustomer',
+           dependent: :destroy
 
   has_many :applied_taxes, class_name: 'Customer::AppliedTax', dependent: :destroy
   has_many :taxes, through: :applied_taxes
@@ -35,6 +38,7 @@ class Customer < ApplicationRecord
   has_one :stripe_customer, class_name: 'PaymentProviderCustomers::StripeCustomer'
   has_one :gocardless_customer, class_name: 'PaymentProviderCustomers::GocardlessCustomer'
   has_one :adyen_customer, class_name: 'PaymentProviderCustomers::AdyenCustomer'
+  has_one :netsuite_customer, class_name: 'IntegrationCustomers::NetsuiteCustomer'
 
   PAYMENT_PROVIDERS = %w[stripe gocardless adyen].freeze
 

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class BaseCustomer < ApplicationRecord
+    include PaperTrailTraceable
+    include SettingsStorable
+
+    self.table_name = 'integration_customers'
+
+    belongs_to :customer
+    belongs_to :integration, class_name: 'Integrations::BaseIntegration'
+
+    validates :customer_id, uniqueness: { scope: :type }
+
+    settings_accessors :sync_with_provider
+  end
+end

--- a/app/models/integration_customers/netsuite_customer.rb
+++ b/app/models/integration_customers/netsuite_customer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class NetsuiteCustomer < BaseCustomer
+    settings_accessors :subsidiary_id
+  end
+end

--- a/db/migrate/20240425082113_create_integration_customers.rb
+++ b/db/migrate/20240425082113_create_integration_customers.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateIntegrationCustomers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :integration_customers, id: :uuid do |t|
+      t.references :integration, null: false, foreign_key: true, type: :uuid
+      t.references :customer, null: false, foreign_key: true, type: :uuid
+      t.string :external_customer_id, null: false
+      t.string :type, null: false
+      t.jsonb 'settings', default: {}, null: false
+
+      t.index %i[customer_id type], unique: true
+      t.index :external_customer_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_24_110420) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_25_082113) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -555,6 +555,20 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_24_110420) do
     t.index ["mapping_type", "integration_id"], name: "index_int_collection_mappings_on_mapping_type_and_int_id", unique: true
   end
 
+  create_table "integration_customers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "integration_id", null: false
+    t.uuid "customer_id", null: false
+    t.string "external_customer_id", null: false
+    t.string "type", null: false
+    t.jsonb "settings", default: {}, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id", "type"], name: "index_integration_customers_on_customer_id_and_type", unique: true
+    t.index ["customer_id"], name: "index_integration_customers_on_customer_id"
+    t.index ["external_customer_id"], name: "index_integration_customers_on_external_customer_id"
+    t.index ["integration_id"], name: "index_integration_customers_on_integration_id"
+  end
+
   create_table "integration_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "integration_id", null: false
     t.integer "item_type", null: false
@@ -1051,6 +1065,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_24_110420) do
   add_foreign_key "groups", "billable_metrics", on_delete: :cascade
   add_foreign_key "groups", "groups", column: "parent_group_id"
   add_foreign_key "integration_collection_mappings", "integrations"
+  add_foreign_key "integration_customers", "customers"
+  add_foreign_key "integration_customers", "integrations"
   add_foreign_key "integration_items", "integrations"
   add_foreign_key "integration_mappings", "integrations"
   add_foreign_key "integrations", "organizations"

--- a/spec/factories/integration_customers.rb
+++ b/spec/factories/integration_customers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :netsuite_customer, class: 'IntegrationCustomers::NetsuiteCustomer' do
+    association :integration, factory: :netsuite_integration
+    customer
+    type { 'IntegrationCustomers::NetsuiteCustomer' }
+    external_customer_id { SecureRandom.uuid }
+
+    settings do
+      { sync_with_provider: true, subsidiary_id: Faker::Number.number(digits: 3) }
+    end
+  end
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe Customer, type: :model do
 
   it_behaves_like 'paper_trail traceable'
 
+  it { is_expected.to have_many(:integration_customers).dependent(:destroy) }
+  it { is_expected.to have_one(:netsuite_customer) }
+
   describe 'validations' do
     subject(:customer) do
       described_class.new(organization:, external_id:)

--- a/spec/models/integration_customers/base_customer_spec.rb
+++ b/spec/models/integration_customers/base_customer_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationCustomers::BaseCustomer, type: :model do
+  subject(:integration_customer) { described_class.new(integration:, customer:, type:, external_customer_id:) }
+
+  let(:integration) { create(:netsuite_integration) }
+  let(:type) { 'IntegrationCustomers::NetsuiteCustomer' }
+  let(:customer) { create(:customer) }
+  let(:external_customer_id) { '123' }
+
+  it { is_expected.to belong_to(:integration) }
+  it { is_expected.to belong_to(:customer) }
+
+  describe '#push_to_settings' do
+    it 'push the value into settings' do
+      integration_customer.push_to_settings(key: 'key1', value: 'val1')
+
+      expect(integration_customer.settings).to eq(
+        {
+          'key1' => 'val1',
+        },
+      )
+    end
+  end
+
+  describe '#get_from_settings' do
+    before { integration_customer.push_to_settings(key: 'key1', value: 'val1') }
+
+    it { expect(integration_customer.get_from_settings('key1')).to eq('val1') }
+
+    it { expect(integration_customer.get_from_settings(nil)).to be_nil }
+    it { expect(integration_customer.get_from_settings('foo')).to be_nil }
+  end
+
+  describe '#sync_with_provider' do
+    it 'assigns and retrieve a setting' do
+      integration_customer.sync_with_provider = true
+      expect(integration_customer.sync_with_provider).to eq(true)
+    end
+  end
+
+  describe 'validations' do
+    describe 'of customer id uniqueness' do
+      let(:errors) { another_integration_customer.errors }
+
+      context 'when it is unique in scope of type' do
+        subject(:another_integration_customer) do
+          described_class.new(integration: another_integration, customer:, type:, external_customer_id:)
+        end
+
+        let(:another_integration) { create(:netsuite_integration) }
+
+        before { another_integration_customer.valid? }
+
+        it 'does not add an error' do
+          expect(errors.where(:customer_id, :taken)).not_to be_present
+        end
+      end
+
+      context 'when it not is unique in scope of type' do
+        subject(:another_integration_customer) do
+          described_class.new(integration:, customer:, type:, external_customer_id:)
+        end
+
+        before do
+          described_class.create(integration:, customer:, type:, external_customer_id:)
+          another_integration_customer.valid?
+        end
+
+        it 'adds an error' do
+          expect(errors.where(:customer_id, :taken)).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/models/integration_customers/netsuite_customer_spec.rb
+++ b/spec/models/integration_customers/netsuite_customer_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationCustomers::NetsuiteCustomer, type: :model do
+  subject(:netsuite_customer) { build(:netsuite_customer) }
+
+  describe '#subsidiary_id' do
+    let(:subsidiary_id) { Faker::Number.number(digits: 3) }
+
+    it 'assigns and retrieve a setting' do
+      netsuite_customer.subsidiary_id = subsidiary_id
+      expect(netsuite_customer.subsidiary_id).to eq(subsidiary_id)
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR adds models for integration customers.