### PR TITLE
feat (accounting-integrations): add logic and graphql support for fetching subsidiaries list

### DIFF
--- a/app/graphql/resolvers/integrations/subsidiaries_resolver.rb
+++ b/app/graphql/resolvers/integrations/subsidiaries_resolver.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module Integrations
+    class SubsidiariesResolver < Resolvers::BaseResolver
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      description 'Query integration subsidiaries'
+
+      argument :integration_id, ID, required: false
+
+      type Types::Integrations::Subsidiaries::Object.collection_type, null: true
+
+      def resolve(integration_id: nil)
+        integration = current_organization.integrations.find(integration_id)
+
+        result = ::Integrations::Aggregator::SubsidiariesService.call(integration:)
+
+        result.subsidiaries
+      end
+    end
+  end
+end

--- a/app/graphql/types/integrations/subsidiaries/object.rb
+++ b/app/graphql/types/integrations/subsidiaries/object.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Types
+  module Integrations
+    module Subsidiaries
+      class Object < Types::BaseObject
+        graphql_name 'Subsidiary'
+
+        field :external_id, String, null: false
+        field :external_name, String, null: true
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -31,6 +31,7 @@ module Types
     field :gross_revenues, resolver: Resolvers::Analytics::GrossRevenuesResolver
     field :integration, resolver: Resolvers::IntegrationResolver
     field :integration_items, resolver: Resolvers::IntegrationItemsResolver
+    field :integration_subsidiaries, resolver: Resolvers::Integrations::SubsidiariesResolver
     field :integrations, resolver: Resolvers::IntegrationsResolver
     field :invite, resolver: Resolvers::InviteResolver
     field :invites, resolver: Resolvers::InvitesResolver

--- a/app/services/integrations/aggregator/subsidiaries_service.rb
+++ b/app/services/integrations/aggregator/subsidiaries_service.rb
@@ -3,7 +3,6 @@
 module Integrations
   module Aggregator
     class SubsidiariesService < BaseService
-
       def action_path
         "v1/#{provider}/subsidiaries"
       end

--- a/app/services/integrations/aggregator/subsidiaries_service.rb
+++ b/app/services/integrations/aggregator/subsidiaries_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    class SubsidiariesService < BaseService
+
+      def action_path
+        "v1/#{provider}/subsidiaries"
+      end
+
+      def call
+        response = http_client.get(headers:)
+
+        result.subsidiaries = handle_subsidiaries(response['records'])
+
+        result
+      end
+
+      private
+
+      def headers
+        {
+          'Connection-Id' => integration.connection_id,
+          'Authorization' => "Bearer #{secret_key}",
+          'Provider-Config-Key' => provider,
+        }
+      end
+
+      def handle_subsidiaries(subsidiaries)
+        subsidiaries.map do |subsidiary|
+          OpenStruct.new(external_id: subsidiary['id'], external_name: subsidiary['name'])
+        end
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -5163,6 +5163,11 @@ type Query {
   integrationItems(integrationId: ID!, itemType: IntegrationItemTypeEnum, limit: Int, page: Int, searchTerm: String): IntegrationItemCollection!
 
   """
+  Query integration subsidiaries
+  """
+  integrationSubsidiaries(integrationId: ID): SubsidiaryCollection
+
+  """
   Query organization's integrations
   """
   integrations(limit: Int, page: Int, type: IntegrationTypeEnum): IntegrationCollection
@@ -5615,6 +5620,16 @@ type Subscription {
 
 type SubscriptionCollection {
   collection: [Subscription!]!
+  metadata: CollectionMetadata!
+}
+
+type Subsidiary {
+  externalId: String!
+  externalName: String
+}
+
+type SubsidiaryCollection {
+  collection: [Subsidiary!]!
   metadata: CollectionMetadata!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -25723,6 +25723,31 @@
               ]
             },
             {
+              "name": "integrationSubsidiaries",
+              "description": "Query integration subsidiaries",
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubsidiaryCollection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "integrationId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "integrations",
               "description": "Query organization's integrations",
               "type": {
@@ -28421,6 +28446,108 @@
                     "ofType": {
                       "kind": "OBJECT",
                       "name": "Subscription",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Subsidiary",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "externalId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "externalName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SubsidiaryCollection",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Subsidiary",
                       "ofType": null
                     }
                   }

--- a/spec/fixtures/integration_aggregator/subsidiaries_response.json
+++ b/spec/fixtures/integration_aggregator/subsidiaries_response.json
@@ -1,0 +1,49 @@
+{
+  "records": [
+    {
+      "id": "1",
+      "name": "Holo, Inc.",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T12:10:02.341285+00:00",
+        "last_modified_at": "2024-04-17T12:10:02.341285+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMjoxMDowMi4zNDEyODUrMDA6MDB8fDAwYTM5NzdmLWYxYjctNTU2ZS04ZDRhLTJkYTRmY2UyODkwMg=="
+      }
+    },
+    {
+      "id": "3",
+      "name": "Holo, Inc. : Elimination Subsidiary",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T12:10:02.341285+00:00",
+        "last_modified_at": "2024-04-17T12:10:02.341285+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMjoxMDowMi4zNDEyODUrMDA6MDB8fDYwOWNmYzg5LTdhMGItNTYxNy1iYWEyLWU3ODczNzE3NzJlYQ=="
+      }
+    },
+    {
+      "id": "4",
+      "name": "Holo, Inc. : Te Inc",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T12:10:02.341285+00:00",
+        "last_modified_at": "2024-04-17T12:10:02.341285+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMjoxMDowMi4zNDEyODUrMDA6MDB8fDhjNzY3NDg1LTQyOTgtNWU1YS1hOWI0LTIyMTZhOTYwMTk0ZQ=="
+      }
+    },
+    {
+      "id": "2",
+      "name": "Holo, Inc. : Te SRL",
+      "_nango_metadata": {
+        "first_seen_at": "2024-04-17T12:10:02.341285+00:00",
+        "last_modified_at": "2024-04-17T12:10:02.341285+00:00",
+        "last_action": "ADDED",
+        "deleted_at": null,
+        "cursor": "MjAyNC0wNC0xN1QxMjoxMDowMi4zNDEyODUrMDA6MDB8fGI5MzYyMTkxLWU0NzItNTU1Zi1hYTA0LTQzZmFhOTg1NjU5OA=="
+      }
+    }
+  ],
+  "next_cursor": null
+}

--- a/spec/graphql/resolvers/integrations/subsidiaries_resolver_spec.rb
+++ b/spec/graphql/resolvers/integrations/subsidiaries_resolver_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::Integrations::SubsidiariesResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query($integrationId: ID!) {
+        integrationSubsidiaries(integrationId: $integrationId) {
+           collection { externalId externalName }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:lago_client) { instance_double(LagoHttpClient::Client) }
+  let(:subsidiaries_endpoint) { 'https://api.nango.dev/v1/netsuite/subsidiaries' }
+
+  let(:headers) do
+    {
+      'Connection-Id' => integration.connection_id,
+      'Authorization' => 'Bearer ',
+      'Provider-Config-Key' => 'netsuite',
+    }
+  end
+
+  let(:aggregator_response) do
+    path = Rails.root.join('spec/fixtures/integration_aggregator/subsidiaries_response.json')
+    JSON.parse(File.read(path))
+  end
+
+  before do
+    allow(LagoHttpClient::Client).to receive(:new)
+      .with(subsidiaries_endpoint)
+      .and_return(lago_client)
+    allow(lago_client).to receive(:get)
+      .with(headers:)
+      .and_return(aggregator_response)
+  end
+
+  it 'returns a list of subsidiaries' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+      variables: { integrationId: integration.id },
+    )
+
+    subsidiaries = result['data']['integrationSubsidiaries']
+
+    aggregate_failures do
+      expect(subsidiaries['collection'].count).to eq(4)
+      expect(subsidiaries['collection'].first['externalId']).to eq('1')
+    end
+  end
+
+  context 'without current organization' do
+    it 'returns an error' do
+      result = execute_graphql(
+        current_user: membership.user,
+        query:,
+        variables: { integrationId: integration.id },
+      )
+
+      expect_graphql_error(
+        result:,
+        message: 'Missing organization id',
+      )
+    end
+  end
+end

--- a/spec/services/integrations/aggregator/subsidiaries_service_spec.rb
+++ b/spec/services/integrations/aggregator/subsidiaries_service_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::SubsidiariesService do
+  subject(:subsidiaries_service) { described_class.new(integration:) }
+
+  let(:integration) { create(:netsuite_integration) }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:subsidiaries_endpoint) { 'https://api.nango.dev/v1/netsuite/subsidiaries' }
+    let(:headers) do
+      {
+        'Connection-Id' => integration.connection_id,
+        'Authorization' => 'Bearer ',
+        'Provider-Config-Key' => 'netsuite',
+      }
+    end
+
+    let(:aggregator_response) do
+      path = Rails.root.join('spec/fixtures/integration_aggregator/subsidiaries_response.json')
+      JSON.parse(File.read(path))
+    end
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(subsidiaries_endpoint)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:get)
+        .with(headers:)
+        .and_return(aggregator_response)
+    end
+
+    it 'successfully fetches subsidiaries' do
+      result = subsidiaries_service.call
+
+      aggregate_failures do
+        expect(LagoHttpClient::Client).to have_received(:new).with(subsidiaries_endpoint)
+        expect(lago_client).to have_received(:get)
+        expect(result.subsidiaries.count).to eq(4)
+        expect(result.subsidiaries.first.external_id).to eq('1')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR covers fetching subsidiaries from Lago's integration aggregator.

List of subsidiaries is needed on the UI in order to allow user to select customer's subsidiary. Subsidiary is required field in customer create and update actions.

There is small amount of subsidiaries (and it is used only on one place in the UI) so we will return it to the UI on the fly from accounting aggregator.