### PR TITLE
misc: Enable YJIT

### DIFF
--- a/config/initializers/enable_yjit.rb
+++ b/config/initializers/enable_yjit.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+if defined? RubyVM::YJIT.enable
+  Rails.application.config.after_initialize do
+    RubyVM::YJIT.enable
+  end
+end


### PR DESCRIPTION
## Context

Following the recent update of Ruby to version 3.3.0, we can now enable Ruby YJIT

## Description

This PR simply adds an initializer to enable YJIT.

For more details, see:
- https://github.com/Shopify/yjit?tab=readme-ov-file
- https://github.com/ruby/ruby/blob/master/doc/yjit/yjit.md
- https://github.com/rails/rails/pull/49947