### PR TITLE
feat(filter): Remove legacy group logic

### DIFF
--- a/app/services/adjusted_fees/create_service.rb
+++ b/app/services/adjusted_fees/create_service.rb
@@ -22,7 +22,6 @@ module AdjustedFees
         invoice: fee.invoice,
         subscription: fee.subscription,
         charge:,
-        group: fee.group,
         adjusted_units: params[:units].present? && params[:unit_amount_cents].blank?,
         adjusted_amount: params[:units].present? && params[:unit_amount_cents].present?,
         invoice_display_name: params[:invoice_display_name],

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -10,7 +10,6 @@ module BillableMetrics
         @subscription = subscription
 
         @filters = filters
-        @group = filters[:group]
         @charge_filter = filters[:charge_filter]
         @event = filters[:event]
         @grouped_by = filters[:grouped_by]
@@ -49,7 +48,6 @@ module BillableMetrics
                     :charge,
                     :subscription,
                     :filters,
-                    :group,
                     :charge_filter,
                     :event,
                     :boundaries,
@@ -125,7 +123,6 @@ module BillableMetrics
           .order(timestamp: :desc, created_at: :desc)
 
         query = query.where.not(event_id: event.id) if event.present?
-        query = query.where(group_id: group.id) if group
         query = query.where(charge_filter_id: charge_filter.id) if charge_filter
 
         query.first

--- a/app/services/billable_metrics/aggregations/weighted_sum_service.rb
+++ b/app/services/billable_metrics/aggregations/weighted_sum_service.rb
@@ -86,7 +86,6 @@ module BillableMetrics
           .where(grouped_by: {})
           .order(added_at: :desc)
 
-        quantified_events = quantified_events.where(group_id: group.id) if group
         quantified_events = quantified_events.where(charge_filter_id: charge_filter.id) if charge_filter
         quantified_event = quantified_events.first
 
@@ -130,7 +129,6 @@ module BillableMetrics
           quantified_events = quantified_events.where('grouped_by?:key', key:)
         end
 
-        quantified_events = quantified_events.where(group_id: group.id) if group
         quantified_events = quantified_events.where(charge_filter_id: charge_filter.id) if charge_filter
 
         if quantified_events.all.any?

--- a/app/services/billable_metrics/prorated_aggregations/base_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/base_service.rb
@@ -119,7 +119,7 @@ module BillableMetrics
         Fee.joins(:charge)
           .where(charge: { billable_metric_id: billable_metric.id })
           .where(charge: { prorated: true })
-          .where(subscription_id: subscription_ids, fee_type: :charge, group_id: group&.id)
+          .where(subscription_id: subscription_ids, fee_type: :charge, charge_filter_id: charge_filter&.id)
           .where("CAST(fees.properties->>'charges_to_datetime' AS timestamp) < ?", boundaries[:to_datetime])
           .order(created_at: :desc)
           .first

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -19,7 +19,6 @@ module Events
         scope = scope.where(numeric_condition) if numeric_property
 
         scope = with_grouped_by_values(scope) if grouped_by_values?
-        scope = group_scope(scope) if group.present?
         filters_scope(scope)
       end
 
@@ -456,13 +455,6 @@ module Events
             ],
           ),
         ).rows
-      end
-
-      def group_scope(scope)
-        scope = scope.where('events_raw.properties[?] = ?', group.key.to_s, group.value.to_s)
-        return scope unless group.parent
-
-        scope.where('events_raw.properties[?] = ?', group.parent.key.to_s, group.parent.value.to_s)
       end
 
       def filters_scope(scope)

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -18,7 +18,6 @@ module Events
         end
 
         scope = with_grouped_by_values(scope) if grouped_by_values?
-        scope = group_scope(scope) if group.present?
         filters_scope(scope)
       end
 
@@ -322,13 +321,6 @@ module Events
             ],
           ),
         ).rows
-      end
-
-      def group_scope(scope)
-        scope = scope.where('events.properties @> ?', { group.key.to_s => group.value }.to_json)
-        return scope unless group.parent
-
-        scope.where('events.properties @> ?', { group.parent.key.to_s => group.parent.value }.to_json)
       end
 
       def filters_scope(scope)

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -17,13 +17,16 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:filters) { { group:, event: pay_in_advance_event, grouped_by: } }
+  let(:filters) do
+    { event: pay_in_advance_event, grouped_by:, matching_filters:, ignored_filters: }
+  end
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
-  let(:group) { nil }
   let(:grouped_by) { nil }
+  let(:matching_filters) { {} }
+  let(:ignored_filters) { [] }
 
   let(:billable_metric) do
     create(
@@ -77,20 +80,8 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
     end
   end
 
-  context 'when group_id is given' do
-    let(:parent_group) do
-      create(:group, billable_metric_id: billable_metric.id, key: 'cloud', value: 'AWS')
-    end
-
-    let(:group) do
-      create(
-        :group,
-        billable_metric_id: billable_metric.id,
-        key: 'region',
-        value: 'europe',
-        parent_group_id: parent_group.id,
-      )
-    end
+  context 'when filters are given' do
+    let(:matching_filters) { { cloud: ['AWS'], region: ['europe'] } }
 
     let(:event_list) do
       [

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -17,13 +17,14 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:filters) { { group:, grouped_by: } }
+  let(:filters) { { grouped_by:, matching_filters:, ignored_filters: } }
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
-  let(:group) { nil }
   let(:grouped_by) { nil }
+  let(:matching_filters) { {} }
+  let(:ignored_filters) { [] }
 
   let(:billable_metric) do
     create(
@@ -176,10 +177,8 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
     end
   end
 
-  context 'when group_id is given' do
-    let(:group) do
-      create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
-    end
+  context 'when filters are given' do
+    let(:matching_filters) { { region: ['europe'] } }
 
     let(:events) do
       [

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -17,13 +17,14 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:filters) { { group:, grouped_by: } }
+  let(:filters) { { grouped_by:, matching_filters:, ignored_filters: } }
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
-  let(:group) { nil }
   let(:grouped_by) { nil }
+  let(:matching_filters) { {} }
+  let(:ignored_filters) { [] }
 
   let(:billable_metric) do
     create(
@@ -181,10 +182,8 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
     end
   end
 
-  context 'when group_id is given' do
-    let(:group) do
-      create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
-    end
+  context 'when filters are given' do
+    let(:matching_filters) { { region: ['europe'] } }
 
     let(:events) do
       [

--- a/spec/services/billable_metrics/aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/sum_service_spec.rb
@@ -18,13 +18,12 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
 
   let(:event_store_class) { Events::Stores::PostgresStore }
   let(:filters) do
-    { group:, event: pay_in_advance_event, grouped_by:, charge_filter:, matching_filters:, ignored_filters: }
+    { event: pay_in_advance_event, grouped_by:, charge_filter:, matching_filters:, ignored_filters: }
   end
 
   let(:subscription) { create(:subscription, started_at: Time.current.beginning_of_month - 6.months) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
-  let(:group) { nil }
   let(:grouped_by) { nil }
   let(:charge_filter) { nil }
   let(:matching_filters) { nil }
@@ -295,10 +294,8 @@ RSpec.describe BillableMetrics::Aggregations::SumService, type: :service, transa
     end
   end
 
-  context 'when group_id is given' do
-    let(:group) do
-      create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
-    end
+  context 'when filters are given' do
+    let(:matching_filters) { { region: ['europe'] } }
 
     before do
       create(

--- a/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/unique_count_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
 
   let(:event_store_class) { Events::Stores::PostgresStore }
   let(:filters) do
-    { group:, event: pay_in_advance_event, grouped_by:, charge_filter:, matching_filters:, ignored_filters: }
+    { event: pay_in_advance_event, grouped_by:, charge_filter:, matching_filters:, ignored_filters: }
   end
 
   let(:subscription) do
@@ -35,7 +35,6 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
   let(:started_at) { subscription_at }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
-  let(:group) { nil }
   let(:grouped_by) { nil }
   let(:charge_filter) { nil }
   let(:matching_filters) { nil }
@@ -366,20 +365,6 @@ RSpec.describe BillableMetrics::Aggregations::UniqueCountService, type: :service
         result = count_service.aggregate
 
         expect(result.pay_in_advance_aggregation).to eq(0)
-      end
-
-      context 'when dimensions are used' do
-        let(:properties) { { unique_id: '111', region: 'europe' } }
-
-        let(:group) do
-          create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
-        end
-
-        it 'assigns an pay_in_advance aggregation' do
-          result = count_service.aggregate
-
-          expect(result.pay_in_advance_aggregation).to eq(1)
-        end
       end
 
       context 'when charge filter is used' do

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -18,13 +18,14 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:filters) { { group:, grouped_by: } }
+  let(:filters) { { grouped_by:, matching_filters:, ignored_filters: } }
 
   let(:subscription) { create(:subscription, started_at: DateTime.parse('2023-04-01 22:22:22')) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
-  let(:group) { nil }
   let(:grouped_by) { nil }
+  let(:matching_filters) { nil }
+  let(:ignored_filters) { nil }
 
   let(:billable_metric) { create(:weighted_sum_billable_metric, organization:) }
 
@@ -236,8 +237,8 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
     end
   end
 
-  context 'with group' do
-    let(:group) { create(:group, billable_metric:, key: 'region', value: 'europe') }
+  context 'with filters' do
+    let(:matching_filters) { { region: ['europe'] } }
 
     let(:events_values) do
       [
@@ -491,8 +492,8 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
       end
     end
 
-    context 'with group' do
-      let(:group) { create(:group, billable_metric:, key: 'region', value: 'europe') }
+    context 'with filters' do
+      let(:matching_filters) { { region: ['europe'] } }
 
       let(:events_values) do
         [

--- a/spec/services/billable_metrics/breakdown/sum_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/sum_service_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
         to_datetime:,
       },
       filters: {
-        group:,
+        matching_filters:,
+        ignored_filters:,
       },
     )
   end
@@ -33,7 +34,8 @@ RSpec.describe BillableMetrics::Breakdown::SumService, type: :service, transacti
   let(:started_at) { subscription_at }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
-  let(:group) { nil }
+  let(:matching_filters) { nil }
+  let(:ignored_filters) { nil }
 
   let(:billable_metric) do
     create(

--- a/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/breakdown/unique_count_service_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
         charges_duration: (to_datetime - from_datetime).fdiv(1.day).round,
       },
       filters: {
-        group:,
+        matching_filters:,
+        ignored_filters:,
       },
     )
   end
@@ -61,7 +62,8 @@ RSpec.describe BillableMetrics::Breakdown::UniqueCountService, type: :service do
 
   let(:subscription_at) { Time.zone.parse('2022-06-09') }
   let(:started_at) { subscription_at }
-  let(:group) { nil }
+  let(:matching_filters) { nil }
+  let(:ignored_filters) { nil }
 
   let(:from_datetime) { Time.zone.parse('2022-07-09 00:00:00 UTC') }
   let(:to_datetime) { Time.zone.parse('2022-08-08 23:59:59 UTC') }

--- a/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/sum_service_spec.rb
@@ -17,13 +17,14 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:filters) { { group:, event: pay_in_advance_event, grouped_by: } }
+  let(:filters) { { event: pay_in_advance_event, grouped_by:, matching_filters:, ignored_filters: } }
 
   let(:subscription) { create(:subscription, started_at: Time.zone.parse('2022-12-01 00:00:00')) }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
-  let(:group) { nil }
   let(:grouped_by) { nil }
+  let(:matching_filters) { {} }
+  let(:ignored_filters) { [] }
 
   let(:billable_metric) do
     create(
@@ -314,10 +315,8 @@ RSpec.describe BillableMetrics::ProratedAggregations::SumService, type: :service
     end
   end
 
-  context 'when group_id is given' do
-    let(:group) do
-      create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
-    end
+  context 'when filters are given' do
+    let(:matching_filters) { { region: ['europe'] } }
 
     before do
       create(

--- a/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
+++ b/spec/services/billable_metrics/prorated_aggregations/unique_count_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:filters) { { group:, event: pay_in_advance_event, grouped_by: } }
+  let(:filters) { { event: pay_in_advance_event, grouped_by:, matching_filters:, ignored_filters: } }
 
   let(:subscription) do
     create(
@@ -35,8 +35,9 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
   let(:started_at) { subscription_at }
   let(:organization) { subscription.organization }
   let(:customer) { subscription.customer }
-  let(:group) { nil }
   let(:grouped_by) { nil }
+  let(:matching_filters) { nil }
+  let(:ignored_filters) { nil }
 
   let(:billable_metric) do
     create(
@@ -155,7 +156,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
         end
       end
 
-      context 'when dimensions are used' do
+      context 'when filters are used' do
         let(:event) do
           create(
             :event,
@@ -167,9 +168,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
           )
         end
 
-        let(:group) do
-          create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
-        end
+        let(:matching_filters) { { region: ['europe'] } }
 
         it 'returns the number of persisted metric' do
           expect(result.aggregation).to eq(1)
@@ -508,7 +507,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
         end
       end
 
-      context 'when dimensions are used' do
+      context 'when filters are used' do
         let(:events) do
           agent_names.each do |agent_name|
             create(
@@ -522,9 +521,7 @@ RSpec.describe BillableMetrics::ProratedAggregations::UniqueCountService, type: 
           end
         end
 
-        let(:group) do
-          create(:group, billable_metric_id: billable_metric.id, key: 'region', value: 'europe')
-        end
+        let(:matching_filters) { { region: ['europe'] } }
 
         it 'returns the number of persisted metric' do
           expect(result.aggregations.count).to eq(2)

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
       subscription:,
       boundaries:,
       filters: {
-        group:,
         grouped_by:,
         grouped_by_values:,
         matching_filters:,
@@ -35,7 +34,6 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     }
   end
 
-  let(:group) { nil }
   let(:grouped_by) { nil }
   let(:grouped_by_values) { nil }
   let(:matching_filters) { {} }
@@ -48,7 +46,6 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
       properties = { billable_metric.field_name => i + 1 }
 
       if i.even?
-        properties[group.key.to_s] = group.value.to_s if group
         matching_filters.each { |key, values| properties[key] = values.first }
 
         if grouped_by_values.present?
@@ -95,14 +92,6 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
   describe '.events' do
     it 'returns a list of events' do
       expect(event_store.events.count).to eq(5)
-    end
-
-    context 'with group' do
-      let(:group) { create(:group, billable_metric:) }
-
-      it 'returns a list of events' do
-        expect(event_store.events.count).to eq(3)
-      end
     end
 
     context 'with grouped_by_values' do
@@ -967,12 +956,12 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
       end
     end
 
-    context 'with group' do
-      let(:group) { create(:group, billable_metric:, key: 'region', value: 'europe') }
+    context 'with filters' do
+      let(:matching_filters) { { region: ['europe'] } }
 
       let(:events_values) do
         [
-          { timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 1000, region: group.value },
+          { timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 1000, region: 'europe' },
         ]
       end
 

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       subscription:,
       boundaries:,
       filters: {
-        group:,
         grouped_by:,
         grouped_by_values:,
         matching_filters:,
@@ -35,7 +34,6 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     }
   end
 
-  let(:group) { nil }
   let(:grouped_by) { nil }
   let(:grouped_by_values) { nil }
   let(:matching_filters) { {} }
@@ -58,7 +56,6 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       )
 
       if i.even?
-        event.properties[group.key] = group.value if group
         matching_filters.each { |key, values| event.properties[key] = values.first }
 
         if grouped_by_values.present?
@@ -89,14 +86,6 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
   describe '#events' do
     it 'returns a list of events' do
       expect(event_store.events.count).to eq(5)
-    end
-
-    context 'with group' do
-      let(:group) { create(:group, billable_metric:) }
-
-      it 'returns a list of events' do
-        expect(event_store.events.count).to eq(3)
-      end
     end
 
     context 'with grouped_by_values' do
@@ -973,7 +962,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     end
 
     context 'with group' do
-      let(:group) { create(:group, billable_metric:, key: 'region', value: 'europe') }
+      let(:matching_filters) { { region: ['europe'] } }
 
       let(:events_values) do
         [


### PR DESCRIPTION
## Context

This PR follow the recent release of the filter feature.

## Description

This PR removes reference to groups in Billable Metric Aggregators and Event Stores