### PR TITLE
feat(wallet): Rename transaction statuses for wallet

### DIFF
--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -12,8 +12,8 @@ class WalletTransaction < ApplicationRecord
   ].freeze
 
   TRANSACTION_STATUSES = [
-    :paid,
-    :offered,
+    :purchased,
+    :granted,
     :voided,
   ].freeze
 

--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -25,7 +25,7 @@ module Credits
           credit_amount:,
           status: :settled,
           settled_at: Time.current,
-          transaction_status: :paid,
+          transaction_status: :purchased,
         )
 
         result.wallet_transaction = wallet_transaction

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -54,7 +54,7 @@ module WalletTransactions
         credit_amount: paid_credits_amount,
         status: :pending,
         source:,
-        transaction_status: :paid,
+        transaction_status: :purchased,
       )
 
       BillPaidCreditJob.perform_later(wallet_transaction, Time.current.to_i)
@@ -76,7 +76,7 @@ module WalletTransactions
           status: :settled,
           settled_at: Time.current,
           source:,
-          transaction_status: :offered,
+          transaction_status: :granted,
         )
 
         Wallets::Balance::IncreaseService.new(

--- a/db/migrate/20240419071607_add_transaction_status_to_wallet_transactions.rb
+++ b/db/migrate/20240419071607_add_transaction_status_to_wallet_transactions.rb
@@ -6,10 +6,10 @@ class AddTransactionStatusToWalletTransactions < ActiveRecord::Migration[7.0]
 
     reversible do |dir|
       dir.up do
-        # Set existing wallet transactions as offered if no invoices linked and status is settled.
+        # Set existing wallet transactions as granted if no invoices linked and status is settled.
         execute <<-SQL
           UPDATE wallet_transactions
-            SET transaction_status = 1 -- offered
+            SET transaction_status = 1 -- granted
             WHERE invoice_id IS NULL
             AND status = 1; -- settled
         SQL

--- a/db/seeds/base.rb
+++ b/db/seeds/base.rb
@@ -220,7 +220,7 @@ Wallet.create!(
     amount: BigDecimal('10.00'),
     credit_amount: BigDecimal('10.00'),
     settled_at: Time.zone.now,
-    transaction_status: :paid,
+    transaction_status: :purchased,
   )
 end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -6899,8 +6899,8 @@ enum WalletTransactionStatusEnum {
 }
 
 enum WalletTransactionTransactionStatusEnum {
-  offered
-  paid
+  granted
+  purchased
   voided
 }
 

--- a/schema.json
+++ b/schema.json
@@ -33809,13 +33809,13 @@
           "inputFields": null,
           "enumValues": [
             {
-              "name": "paid",
+              "name": "purchased",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "offered",
+              "name": "granted",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
       expect(result).to be_success
       expect(result.wallet_transaction).to be_present
       expect(result.wallet_transaction.amount).to eq(1.0)
-      expect(result.wallet_transaction).to be_paid
+      expect(result.wallet_transaction).to be_purchased
     end
 
     it 'updates wallet balance' do

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
 
     it 'sets expected transaction status', :aggregate_failures do
       create_service
-      paid_transaction = WalletTransaction.where(wallet_id: wallet.id).paid.first
-      offered_transaction = WalletTransaction.where(wallet_id: wallet.id).offered.first
+      purchased_transaction = WalletTransaction.where(wallet_id: wallet.id).purchased.first
+      granted_transaction = WalletTransaction.where(wallet_id: wallet.id).granted.first
 
-      expect(paid_transaction.credit_amount).to eq(10)
-      expect(offered_transaction.credit_amount).to eq(15)
+      expect(purchased_transaction.credit_amount).to eq(10)
+      expect(granted_transaction.credit_amount).to eq(15)
     end
 
     it 'sets correct source' do


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to rename:

- `paid` to `purchased`
- `offered` to `granted`

for the `transaction_status` field for Wallet.
