### PR TITLE
feat(wallet): Reload wallet transaction before sending webhook

### DIFF
--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -31,7 +31,7 @@ module WalletTransactions
 
       transactions = wallet_transactions.compact
       if organization.webhook_endpoints.any?
-        transactions.each { |wt| SendWebhookJob.perform_later('wallet_transaction.created', wt) }
+        transactions.each { |wt| SendWebhookJob.perform_later('wallet_transaction.created', wt.reload) }
       end
 
       result.wallet_transactions = transactions


### PR DESCRIPTION
The goal of this PR is to send a webhook with up-to-date values for the wallet transaction, because sometimes, it can be outdated