### PR TITLE
fix(webhook): Fix webhook controller adyen params

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -56,6 +56,6 @@ class WebhooksController < ApplicationController
   end
 
   def adyen_params
-    params['notificationItems'].first&.dig('NotificationRequestItem')&.permit!
+    params['notificationItems']&.first&.dig('NotificationRequestItem')&.permit!
   end
 end


### PR DESCRIPTION
## Context

We're getting as error in webhooks controller when `params['notificationItems']` is `nil`.


## Description

This PR fixes `adyen_params` method by adding a safe navigation operator.