### PR TITLE
feat(graphql): Rework GraphQl concerns

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -26,7 +26,9 @@ class GraphqlController < ApplicationController
       current_organization:,
       customer_portal_user:,
       request:,
-      permissions: current_user&.memberships&.find_by(organization: current_organization)&.permissions_hash || {},
+      permissions:
+        current_user&.memberships&.find_by(organization: current_organization)&.permissions_hash ||
+        Permission::EMPTY_PERMISSIONS_HASH,
     }
     result = LagoApiSchema.execute(query, variables:, context:, operation_name:)
     render(json: result)

--- a/app/graphql/concerns/can_require_permissions.rb
+++ b/app/graphql/concerns/can_require_permissions.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module CanRequirePermissions
+  extend ActiveSupport::Concern
+
+  private
+
+  def ready?(**args)
+    if defined? self.class::REQUIRED_PERMISSION
+      has_permission = context.dig(:permissions, self.class::REQUIRED_PERMISSION)
+      raise not_enough_permissions_error unless has_permission
+    end
+
+    super
+  end
+
+  def not_enough_permissions_error
+    extensions = {
+      status: :forbidden,
+      code: 'forbidden',
+      required_permissions: Array.wrap(self.class::REQUIRED_PERMISSION),
+    }
+
+    GraphQL::ExecutionError.new('Missing permissions', extensions:)
+  end
+end

--- a/app/graphql/concerns/required_organization.rb
+++ b/app/graphql/concerns/required_organization.rb
@@ -3,28 +3,17 @@
 module RequiredOrganization
   extend ActiveSupport::Concern
 
-  def self.included(base)
-    base.prepend(Module.new do
-      if base.method_defined?(:resolve)
-        define_method :resolve do |*args, **kwargs, &block|
-          validate_organization!
-          super(*args, **kwargs, &block)
-        end
-      end
-    end)
-  end
-    
   private
 
-  def current_organization
-    context[:current_organization]
-  end
-
-  def validate_organization!
+  def ready?(**args)
     raise organization_error('Missing organization id') unless current_organization
     raise organization_error('Not in organization') unless organization_member?
 
-    true
+    super
+  end
+
+  def current_organization
+    context[:current_organization]
   end
 
   def organization_error(message)

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -4,19 +4,11 @@
 module Mutations
   class BaseMutation < GraphQL::Schema::RelayClassicMutation
     include ExecutionErrorResponder
+    include CanRequirePermissions
+
     argument_class Types::BaseArgument
     field_class Types::BaseField
     input_object_class Types::BaseInputObject
     object_class Types::BaseObject
-
-    private
-
-    def ready?(**args)
-      if defined? self.class::REQUIRED_PERMISSION
-        context.dig(:permissions, self.class::REQUIRED_PERMISSION)
-      else
-        super
-      end
-    end
   end
 end

--- a/app/graphql/resolvers/add_ons_resolver.rb
+++ b/app/graphql/resolvers/add_ons_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  class AddOnsResolver < GraphQL::Schema::Resolver
+  class AddOnsResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
     include RequiredOrganization
 

--- a/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
+++ b/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
@@ -2,7 +2,7 @@
 
 module Resolvers
   module Analytics
-    class GrossRevenuesResolver < GraphQL::Schema::Resolver
+    class GrossRevenuesResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
       include RequiredOrganization
 

--- a/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
+++ b/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
@@ -6,6 +6,8 @@ module Resolvers
       include AuthenticableApiUser
       include RequiredOrganization
 
+      REQUIRED_PERMISSION = 'analytics:view'
+
       description 'Query gross revenue of an organization'
 
       argument :currency, Types::CurrencyEnum, required: false

--- a/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
+++ b/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
@@ -6,6 +6,8 @@ module Resolvers
       include AuthenticableApiUser
       include RequiredOrganization
 
+      REQUIRED_PERMISSION = 'analytics:view'
+
       description 'Query invoice collections of an organization'
 
       argument :currency, Types::CurrencyEnum, required: false

--- a/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
+++ b/app/graphql/resolvers/analytics/invoice_collections_resolver.rb
@@ -2,7 +2,7 @@
 
 module Resolvers
   module Analytics
-    class InvoiceCollectionsResolver < GraphQL::Schema::Resolver
+    class InvoiceCollectionsResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
       include RequiredOrganization
 

--- a/app/graphql/resolvers/analytics/invoiced_usages_resolver.rb
+++ b/app/graphql/resolvers/analytics/invoiced_usages_resolver.rb
@@ -6,6 +6,8 @@ module Resolvers
       include AuthenticableApiUser
       include RequiredOrganization
 
+      REQUIRED_PERMISSION = 'analytics:view'
+
       description 'Query invoiced usage of an organization'
 
       argument :currency, Types::CurrencyEnum, required: false

--- a/app/graphql/resolvers/analytics/invoiced_usages_resolver.rb
+++ b/app/graphql/resolvers/analytics/invoiced_usages_resolver.rb
@@ -2,7 +2,7 @@
 
 module Resolvers
   module Analytics
-    class InvoicedUsagesResolver < GraphQL::Schema::Resolver
+    class InvoicedUsagesResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
       include RequiredOrganization
 

--- a/app/graphql/resolvers/analytics/mrrs_resolver.rb
+++ b/app/graphql/resolvers/analytics/mrrs_resolver.rb
@@ -2,7 +2,7 @@
 
 module Resolvers
   module Analytics
-    class MrrsResolver < GraphQL::Schema::Resolver
+    class MrrsResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
       include RequiredOrganization
 

--- a/app/graphql/resolvers/analytics/mrrs_resolver.rb
+++ b/app/graphql/resolvers/analytics/mrrs_resolver.rb
@@ -6,6 +6,8 @@ module Resolvers
       include AuthenticableApiUser
       include RequiredOrganization
 
+      REQUIRED_PERMISSION = 'analytics:view'
+
       description 'Query MRR of an organization'
 
       argument :currency, Types::CurrencyEnum, required: false

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -3,5 +3,6 @@
 module Resolvers
   class BaseResolver < GraphQL::Schema::Resolver
     include ExecutionErrorResponder
+    include CanRequirePermissions
   end
 end

--- a/app/graphql/resolvers/billable_metrics_resolver.rb
+++ b/app/graphql/resolvers/billable_metrics_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  class BillableMetricsResolver < GraphQL::Schema::Resolver
+  class BillableMetricsResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
     include RequiredOrganization
 

--- a/app/graphql/resolvers/coupons_resolver.rb
+++ b/app/graphql/resolvers/coupons_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  class CouponsResolver < GraphQL::Schema::Resolver
+  class CouponsResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
     include RequiredOrganization
 
@@ -15,7 +15,7 @@ module Resolvers
 
     type Types::Coupons::Object.collection_type, null: false
 
-    def resolve(ids: nil, page: nil, limit: nil, status: nil, search_term: nil)      
+    def resolve(ids: nil, page: nil, limit: nil, status: nil, search_term: nil)
       query = CouponsQuery.new(organization: current_organization)
       result = query.call(
         search_term:,

--- a/app/graphql/resolvers/current_user_resolver.rb
+++ b/app/graphql/resolvers/current_user_resolver.rb
@@ -2,7 +2,7 @@
 
 module Resolvers
   # MeResolver resolves current user field
-  class CurrentUserResolver < GraphQL::Schema::Resolver
+  class CurrentUserResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
 
     description 'Retrieves currently connected user'

--- a/app/graphql/resolvers/customers_resolver.rb
+++ b/app/graphql/resolvers/customers_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  class CustomersResolver < GraphQL::Schema::Resolver
+  class CustomersResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
     include RequiredOrganization
 

--- a/app/graphql/resolvers/events_resolver.rb
+++ b/app/graphql/resolvers/events_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  class EventsResolver < GraphQL::Schema::Resolver
+  class EventsResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
     include RequiredOrganization
 

--- a/app/graphql/resolvers/integration_items_resolver.rb
+++ b/app/graphql/resolvers/integration_items_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  class IntegrationItemsResolver < GraphQL::Schema::Resolver
+  class IntegrationItemsResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
     include RequiredOrganization
 

--- a/app/graphql/resolvers/invites_resolver.rb
+++ b/app/graphql/resolvers/invites_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  class InvitesResolver < GraphQL::Schema::Resolver
+  class InvitesResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
     include RequiredOrganization
 

--- a/app/graphql/resolvers/memberships_resolver.rb
+++ b/app/graphql/resolvers/memberships_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  class MembershipsResolver < GraphQL::Schema::Resolver
+  class MembershipsResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
     include RequiredOrganization
 

--- a/app/graphql/resolvers/plans_resolver.rb
+++ b/app/graphql/resolvers/plans_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  class PlansResolver < GraphQL::Schema::Resolver
+  class PlansResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
     include RequiredOrganization
 

--- a/app/graphql/resolvers/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/subscriptions_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  class SubscriptionsResolver < GraphQL::Schema::Resolver
+  class SubscriptionsResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
     include RequiredOrganization
 

--- a/app/graphql/resolvers/taxes_resolver.rb
+++ b/app/graphql/resolvers/taxes_resolver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Resolvers
-  class TaxesResolver < GraphQL::Schema::Resolver
+  class TaxesResolver < Resolvers::BaseResolver
     include AuthenticableApiUser
     include RequiredOrganization
 

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -7,6 +7,8 @@ class Permission
   end
 
   # rubocop:disable Layout/ClassStructure
+  EMPTY_PERMISSIONS_HASH = {}.freeze
+
   DEFAULT_PERMISSIONS_HASH = yaml_to_hash('definition.yml').freeze
 
   ADMIN_PERMISSIONS_HASH = DEFAULT_PERMISSIONS_HASH.transform_values { true }.freeze

--- a/spec/graphql/concerns/authenticable_api_user_spec.rb
+++ b/spec/graphql/concerns/authenticable_api_user_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module AuthenticableApiUserSpec
+  class ThingType < Types::BaseObject
+    field :name, String, null: false
+    field :count, Integer
+  end
+
+  class RenameThingMutation < Mutations::BaseMutation
+    include AuthenticableApiUser
+
+    graphql_name 'RenameThing'
+    argument :new_name, String, required: true
+    type ThingType
+
+    def resolve(**args)
+      {name: args[:new_name], count: 1}
+    end
+  end
+
+  class ThingsMutationType < Types::BaseObject
+    field :renameThing, mutation: RenameThingMutation
+  end
+
+  class TestApiSchema < LagoApiSchema
+    mutation(ThingsMutationType)
+  end
+end
+
+RSpec.describe AuthenticableApiUser, type: :graphql do
+  let(:mutation) do
+    <<-GQL
+      mutation($input: RenameThingInput!) {
+        renameThing(input: $input) {
+          name
+        }
+      }
+    GQL
+  end
+
+  context 'with a current user' do
+    it 'renames the thing' do
+      membership = create(:membership)
+
+      result = AuthenticableApiUserSpec::TestApiSchema.execute(
+        mutation,
+        variables: { input: { newName: 'new name' } },
+        context: { current_user: membership.user },
+      )
+
+      expect(result['data']['renameThing']['name']).to eq 'new name'
+    end
+  end
+
+  context 'without a current user' do
+    it 'returns an error' do
+      result = AuthenticableApiUserSpec::TestApiSchema.execute(
+        mutation,
+        variables: { input: { newName: 'new name' } },
+        context: { current_user: nil },
+      )
+
+      partial_error = {
+        'message' => 'unauthorized',
+        'extensions' => { 'status' => :unauthorized, 'code' => 'unauthorized' },
+      }
+
+      expect(result['errors']).to include hash_including(partial_error)
+    end
+  end
+end

--- a/spec/graphql/concerns/authenticable_api_user_spec.rb
+++ b/spec/graphql/concerns/authenticable_api_user_spec.rb
@@ -16,7 +16,7 @@ module AuthenticableApiUserSpec
     type ThingType
 
     def resolve(**args)
-      {name: args[:new_name], count: 1}
+      { name: args[:new_name], count: 1 }
     end
   end
 

--- a/spec/graphql/concerns/can_require_permissions_spec.rb
+++ b/spec/graphql/concerns/can_require_permissions_spec.rb
@@ -18,7 +18,7 @@ module CanRequirePermissionsSpec
     type ThingType
 
     def resolve(**args)
-      {name: args[:new_name], count: 1}
+      { name: args[:new_name], count: 1 }
     end
   end
 

--- a/spec/graphql/concerns/can_require_permissions_spec.rb
+++ b/spec/graphql/concerns/can_require_permissions_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module CanRequirePermissionsSpec
+  class ThingType < Types::BaseObject
+    field :name, String, null: false
+    field :count, Integer
+  end
+
+  class RenameThingMutation < Mutations::BaseMutation
+    include CanRequirePermissions
+
+    REQUIRED_PERMISSION = 'things:rename'
+
+    graphql_name 'RenameThing'
+    argument :new_name, String, required: true
+    type ThingType
+
+    def resolve(**args)
+      {name: args[:new_name], count: 1}
+    end
+  end
+
+  class ThingsMutationType < Types::BaseObject
+    field :renameThing, mutation: RenameThingMutation
+  end
+
+  class TestApiSchema < LagoApiSchema
+    mutation(ThingsMutationType)
+  end
+end
+
+RSpec.describe CanRequirePermissions, type: :graphql do
+  let(:mutation) do
+    <<-GQL
+      mutation($input: RenameThingInput!) {
+        renameThing(input: $input) {
+          name
+        }
+      }
+    GQL
+  end
+
+  context 'with a the correct permissions' do
+    it 'renames the thing' do
+      result = CanRequirePermissionsSpec::TestApiSchema.execute(
+        mutation,
+        variables: { input: { newName: 'new name' } },
+        context: { permissions: { 'things:rename' => true } },
+      )
+
+      expect(result['data']['renameThing']['name']).to eq 'new name'
+    end
+  end
+
+  context 'without a current user' do
+    it 'returns an error' do
+      result = CanRequirePermissionsSpec::TestApiSchema.execute(
+        mutation,
+        variables: { input: { newName: 'new name' } },
+        context: { permissions: Permission::EMPTY_PERMISSIONS_HASH },
+      )
+
+      partial_error = {
+        'message' => 'Missing permissions',
+        'extensions' => { 'status' => :forbidden, 'code' => 'forbidden', 'required_permissions' => ['things:rename'] },
+      }
+
+      expect(result['errors']).to include hash_including(partial_error)
+    end
+  end
+end

--- a/spec/graphql/concerns/required_organization_spec.rb
+++ b/spec/graphql/concerns/required_organization_spec.rb
@@ -16,7 +16,7 @@ module RequiredOrganizationSpec
     type ThingType
 
     def resolve(**args)
-      {name: args[:new_name], count: 1}
+      { name: args[:new_name], count: 1 }
     end
   end
 

--- a/spec/graphql/concerns/required_organization_spec.rb
+++ b/spec/graphql/concerns/required_organization_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module RequiredOrganizationSpec
+  class ThingType < Types::BaseObject
+    field :name, String, null: false
+    field :count, Integer
+  end
+
+  class RenameThingMutation < Mutations::BaseMutation
+    include RequiredOrganization
+
+    graphql_name 'RenameThing'
+    argument :new_name, String, required: true
+    type ThingType
+
+    def resolve(**args)
+      {name: args[:new_name], count: 1}
+    end
+  end
+
+  class ThingsMutationType < Types::BaseObject
+    field :renameThing, mutation: RenameThingMutation
+  end
+
+  class TestApiSchema < LagoApiSchema
+    mutation(ThingsMutationType)
+  end
+end
+
+RSpec.describe RequiredOrganization, type: :graphql do
+  let(:mutation) do
+    <<-GQL
+      mutation($input: RenameThingInput!) {
+        renameThing(input: $input) {
+          name
+        }
+      }
+    GQL
+  end
+
+  context 'with a current organization and a member' do
+    it 'renames the thing' do
+      membership = create(:membership)
+
+      result = RequiredOrganizationSpec::TestApiSchema.execute(
+        mutation,
+        variables: { input: { newName: 'new name' } },
+        context: { current_user: membership.user, current_organization: membership.organization },
+      )
+
+      expect(result['data']['renameThing']['name']).to eq 'new name'
+    end
+  end
+
+  context 'without a current organization' do
+    it 'returns an error' do
+      result = RequiredOrganizationSpec::TestApiSchema.execute(
+        mutation,
+        variables: { input: { newName: 'new name' } },
+        context: { current_user: create(:user), permissions: Permission::ADMIN_PERMISSIONS_HASH },
+      )
+
+      partial_error = {
+        'message' => 'Missing organization id',
+        'extensions' => { 'status' => :forbidden, 'code' => 'forbidden' },
+      }
+
+      expect(result['errors']).to include hash_including(partial_error)
+    end
+  end
+
+  context 'without a current organization but the current is not a member' do
+    it 'returns an error' do
+      result = RequiredOrganizationSpec::TestApiSchema.execute(
+        mutation,
+        variables: { input: { newName: 'new name' } },
+        context: { current_user: create(:user), current_organization: create(:organization) },
+      )
+
+      partial_error = {
+        'message' => 'Not in organization',
+        'extensions' => { 'status' => :forbidden, 'code' => 'forbidden' },
+      }
+
+      expect(result['errors']).to include hash_including(partial_error)
+    end
+  end
+end

--- a/spec/graphql/mutations/add_ons/create_spec.rb
+++ b/spec/graphql/mutations/add_ons/create_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Mutations::AddOns::Create, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'addons:create'
 
   it 'creates an add-on' do
@@ -56,46 +58,6 @@ RSpec.describe Mutations::AddOns::Create, type: :graphql do
       expect(result_data['amountCents']).to eq('5000')
       expect(result_data['amountCurrency']).to eq('EUR')
       expect(result_data['taxes'].map { |t| t['code'] }).to contain_exactly(tax.code)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        permissions: required_permission,
-        variables: {
-          input: {
-            name: 'Test Add-on',
-            code: 'free-beer-for-us',
-            amountCents: 5000,
-            amountCurrency: 'EUR',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query: mutation,
-        permissions: required_permission,
-        variables: {
-          input: {
-            name: 'Test Add-on',
-            code: 'free-beer-for-us',
-            amountCents: 5000,
-            amountCurrency: 'EUR',
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/add_ons/destroy_spec.rb
+++ b/spec/graphql/mutations/add_ons/destroy_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Mutations::AddOns::Destroy, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'addons:delete'
 
   it 'deletes an add-on' do
@@ -30,18 +31,5 @@ RSpec.describe Mutations::AddOns::Destroy, type: :graphql do
 
     data = result['data']['destroyAddOn']
     expect(data['id']).to eq(add_on.id)
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: { id: add_on.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/add_ons/update_spec.rb
+++ b/spec/graphql/mutations/add_ons/update_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Mutations::AddOns::Update, type: :graphql do
 
   before { create(:add_on_applied_tax, add_on:, tax:) }
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'addons:update'
 
   it 'updates an add-on' do
@@ -59,25 +60,6 @@ RSpec.describe Mutations::AddOns::Update, type: :graphql do
       expect(result_data['amountCents']).to eq('123')
       expect(result_data['amountCurrency']).to eq('USD')
       expect(result_data['taxes'].map { |t| t['code'] }).to contain_exactly(tax2.code)
-    end
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: {
-            id: add_on.id,
-            name: 'New name',
-            code: 'new_code',
-            amountCents: 123,
-            amountCurrency: 'USD',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/adjusted_fees/create_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/create_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe Mutations::AdjustedFees::Create, type: :graphql do
 
   around { |test| lago_premium!(&test) }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'invoices:update'
 
   it 'creates an adjusted fee' do
@@ -52,31 +54,6 @@ RSpec.describe Mutations::AdjustedFees::Create, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: membership.organization,
-        permissions: required_permission,
-        query: mutation,
-        variables: { input: },
-      )
-
-      expect_forbidden_error(result)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: { input: },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
         permissions: required_permission,
         query: mutation,
         variables: { input: },

--- a/spec/graphql/mutations/adjusted_fees/destroy_spec.rb
+++ b/spec/graphql/mutations/adjusted_fees/destroy_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Mutations::AdjustedFees::Destroy, type: :graphql do
 
   before { adjusted_fee }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'invoices:update'
 
   it 'destroys an adjusted fee' do
@@ -32,30 +34,5 @@ RSpec.describe Mutations::AdjustedFees::Destroy, type: :graphql do
         variables: { input: { id: fee.id } },
       )
     end.to change(AdjustedFee, :count).by(-1)
-  end
-
-  context 'without current_organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: { input: { id: fee.id } },
-      )
-
-      expect_forbidden_error(result)
-    end
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: { input: { id: fee.id } },
-      )
-
-      expect_unauthorized_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/applied_coupons/create_spec.rb
+++ b/spec/graphql/mutations/applied_coupons/create_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe Mutations::AppliedCoupons::Create, type: :graphql do
     create(:subscription, customer:)
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'coupons:attach'
 
   it 'assigns a coupon to the customer' do
@@ -54,45 +56,6 @@ RSpec.describe Mutations::AppliedCoupons::Create, type: :graphql do
       expect(result_data['amountCents']).to eq('123')
       expect(result_data['amountCurrency']).to eq('EUR')
       expect(result_data['createdAt']).to be_present
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: organization,
-        query: mutation,
-        variables: {
-          input: {
-            couponId: coupon.id,
-            customerId: customer.id,
-            amountCents: 123,
-            amountCurrency: 'EUR',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            couponId: coupon.id,
-            customerId: customer.id,
-            amountCents: 123,
-            amountCurrency: 'EUR',
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/applied_coupons/terminate_spec.rb
+++ b/spec/graphql/mutations/applied_coupons/terminate_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Mutations::AppliedCoupons::Terminate, type: :graphql do
 
   before { applied_coupon }
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'coupons:detach'
 
   it 'terminates an applied coupon' do

--- a/spec/graphql/mutations/billable_metrics/create_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/create_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Mutations::BillableMetrics::Create, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'billable_metrics:create'
 
   it 'creates a billable metric' do
@@ -58,45 +60,6 @@ RSpec.describe Mutations::BillableMetrics::Create, type: :graphql do
       expect(result_data['recurring']).to eq(false)
       expect(result_data['weightedInterval']).to be_nil
       expect(result_data['filters'].count).to eq(1)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            name: 'New Metric',
-            code: 'new_metric',
-            description: 'New metric description',
-            aggregationType: 'count_agg',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            name: 'New Metric',
-            code: 'new_metric',
-            description: 'New metric description',
-            aggregationType: 'count_agg',
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/billable_metrics/destroy_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/destroy_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Mutations::BillableMetrics::Destroy, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'billable_metrics:delete'
 
   it 'deletes a billable metric' do
@@ -30,16 +31,5 @@ RSpec.describe Mutations::BillableMetrics::Destroy, type: :graphql do
 
     data = result['data']['destroyBillableMetric']
     expect(data['id']).to eq(billable_metric.id)
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: { input: { id: billable_metric.id } },
-      )
-
-      expect_unauthorized_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/billable_metrics/update_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/update_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Mutations::BillableMetrics::Update, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'billable_metrics:update'
 
   it 'updates a billable metric' do
@@ -60,25 +61,6 @@ RSpec.describe Mutations::BillableMetrics::Update, type: :graphql do
       expect(result_data['weightedInterval']).to eq('seconds')
       expect(result_data['recurring']).to eq(false)
       expect(result_data['filters'].count).to eq(1)
-    end
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: {
-            id: billable_metric.id,
-            name: 'New Metric',
-            code: 'new_metric',
-            description: 'New metric description',
-            aggregationType: 'count_agg',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/coupons/create_spec.rb
+++ b/spec/graphql/mutations/coupons/create_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'coupons:create'
 
   it 'creates a coupon' do
@@ -174,53 +176,6 @@ RSpec.describe Mutations::Coupons::Create, type: :graphql do
         expect(result_data['expirationAt']).to eq(expiration_at.iso8601)
         expect(result_data['status']).to eq('active')
       end
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            name: 'Super Coupon',
-            code: 'free-beer',
-            couponType: 'fixed_amount',
-            frequency: 'once',
-            amountCents: 5000,
-            amountCurrency: 'EUR',
-            expiration: 'time_limit',
-            expirationAt: (Time.current + 3.days).iso8601,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            name: 'Super Coupon',
-            code: 'free-beer',
-            couponType: 'fixed_amount',
-            frequency: 'once',
-            amountCents: 5000,
-            amountCurrency: 'EUR',
-            expiration: 'time_limit',
-            expirationAt: (Time.current + 3.days).iso8601,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/coupons/destroy_spec.rb
+++ b/spec/graphql/mutations/coupons/destroy_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Mutations::Coupons::Destroy, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'coupons:delete'
 
   it 'deletes a coupon' do
@@ -30,18 +31,5 @@ RSpec.describe Mutations::Coupons::Destroy, type: :graphql do
 
     data = result['data']['destroyCoupon']
     expect(data['id']).to eq(coupon.id)
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: { id: coupon.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/coupons/terminate_spec.rb
+++ b/spec/graphql/mutations/coupons/terminate_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Mutations::Coupons::Terminate, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'coupons:update'
 
   it 'terminates a coupon' do
@@ -35,18 +36,5 @@ RSpec.describe Mutations::Coupons::Terminate, type: :graphql do
     expect(data['name']).to eq(coupon.name)
     expect(data['status']).to eq('terminated')
     expect(data['terminatedAt']).to be_present
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: { id: coupon.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/coupons/update_spec.rb
+++ b/spec/graphql/mutations/coupons/update_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Mutations::Coupons::Update, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'coupons:update'
 
   it 'updates a coupon' do
@@ -137,29 +138,6 @@ RSpec.describe Mutations::Coupons::Update, type: :graphql do
         expect(result_data['limitedBillableMetrics']).to eq(true)
         expect(result_data['billableMetrics'].first['id']).to eq(billable_metric.id)
       end
-    end
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: {
-            id: coupon.id,
-            name: 'New name',
-            code: 'new_code',
-            couponType: 'fixed_amount',
-            frequency: 'once',
-            amountCents: 123,
-            amountCurrency: 'USD',
-            expiration: 'time_limit',
-            expirationAt: (Time.current + 33.days).iso8601,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
 
   around { |test| lago_premium!(&test) }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'credit_notes:create'
 
   it 'creates a credit note' do
@@ -130,57 +132,6 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
       )
 
       expect_not_found(result)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: organization,
-        query: mutation,
-        variables: {
-          input: {
-            reason: 'duplicated_charge',
-            invoiceId: invoice.id,
-            creditAmountCents: 10,
-            refundAmountCents: 5,
-            items: [
-              {
-                feeId: fee1.id,
-                amountCents: 15,
-              },
-            ],
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            reason: 'duplicated_charge',
-            invoiceId: invoice.id,
-            creditAmountCents: 10,
-            refundAmountCents: 5,
-            items: [
-              {
-                feeId: fee1.id,
-                amountCents: 15,
-              },
-            ],
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/credit_notes/download_spec.rb
+++ b/spec/graphql/mutations/credit_notes/download_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Mutations::CreditNotes::Download, type: :graphql do
       .to_return(body: pdf_response, status: 200)
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'credit_notes:view'
 
   it 'generates the credit note PDF' do

--- a/spec/graphql/mutations/credit_notes/update_spec.rb
+++ b/spec/graphql/mutations/credit_notes/update_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Mutations::CreditNotes::Update, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'credit_notes:update'
 
   it 'updates the credit note' do
@@ -59,22 +60,6 @@ RSpec.describe Mutations::CreditNotes::Update, type: :graphql do
       )
 
       expect_not_found(result)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: {
-            id: credit_note.id,
-            refundStatus: 'succeeded',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/credit_notes/void_spec.rb
+++ b/spec/graphql/mutations/credit_notes/void_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Mutations::CreditNotes::Void, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'credit_notes:void'
 
   it 'voids the credit note' do
@@ -58,21 +59,6 @@ RSpec.describe Mutations::CreditNotes::Void, type: :graphql do
       )
 
       expect_not_found(result)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: {
-            id: credit_note.id,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/customer_portal/generate_url_spec.rb
+++ b/spec/graphql/mutations/customer_portal/generate_url_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe Mutations::CustomerPortal::GenerateUrl, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+
   context 'when licence is premium' do
     around { |test| lago_premium!(&test) }
 
@@ -33,34 +36,6 @@ RSpec.describe Mutations::CustomerPortal::GenerateUrl, type: :graphql do
       data = result['data']['generateCustomerPortalUrl']
 
       expect(data['url']).to include('/customer-portal/')
-    end
-
-    context 'without current user' do
-      it 'returns an error' do
-        result = execute_graphql(
-          current_organization: organization,
-          query: mutation,
-          variables: {
-            input: { id: customer.id },
-          },
-        )
-
-        expect_unauthorized_error(result)
-      end
-    end
-
-    context 'without current organization' do
-      it 'returns an error' do
-        result = execute_graphql(
-          current_user: user,
-          query: mutation,
-          variables: {
-            input: { id: customer.id },
-          },
-        )
-
-        expect_forbidden_error(result)
-      end
     end
   end
 end

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
       .to_return(status: 200, body: body.to_json, headers: {})
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'customers:create'
 
   it 'creates a customer' do
@@ -141,41 +143,6 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
         expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
         expect(result_data['invoiceGracePeriod']).to be_nil
       end
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            name: 'John Doe',
-            externalId: 'john_doe_2',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permissions,
-        query: mutation,
-        variables: {
-          input: {
-            name: 'John Doe',
-            externalId: 'john_doe_2',
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 

--- a/spec/graphql/mutations/customers/destroy_spec.rb
+++ b/spec/graphql/mutations/customers/destroy_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Mutations::Customers::Destroy, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'customers:delete'
 
   it 'deletes a customer' do
@@ -32,18 +33,5 @@ RSpec.describe Mutations::Customers::Destroy, type: :graphql do
 
     data = result['data']['destroyCustomer']
     expect(data['id']).to eq(customer.id)
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: { id: customer.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/customers/update_invoice_grace_period_spec.rb
+++ b/spec/graphql/mutations/customers/update_invoice_grace_period_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Mutations::Customers::UpdateInvoiceGracePeriod, type: :graphql do
 
   around { |test| lago_premium!(&test) }
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'customers:update'
 
   it 'updates a customer' do
@@ -43,22 +44,6 @@ RSpec.describe Mutations::Customers::UpdateInvoiceGracePeriod, type: :graphql do
     aggregate_failures do
       expect(result_data['id']).to be_present
       expect(result_data['invoiceGracePeriod']).to eq(12)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: {
-            id: customer.id,
-            invoiceGracePeriod: 12,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
     allow(Stripe::Customer).to receive(:update).and_return(BaseService::Result.new)
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'customers:update'
 
   it 'updates a customer' do
@@ -132,23 +133,6 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
         expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
         expect(result_data['invoiceGracePeriod']).to eq(2)
       end
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: {
-            id: customer.id,
-            name: 'Updated customer',
-            externalId: SecureRandom.uuid,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/integration_collection_mappings/destroy_spec.rb
+++ b/spec/graphql/mutations/integration_collection_mappings/destroy_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Destroy, type: :graphql
 
   before { integration_collection_mapping }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'deletes an integration collection mapping' do
@@ -48,35 +50,6 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Destroy, type: :graphql
       )
 
       expect_not_found(result)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: { id: integration_collection_mapping.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: { id: integration_collection_mapping.id },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/integration_collection_mappings/netsuite/create_spec.rb
+++ b/spec/graphql/mutations/integration_collection_mappings/netsuite/create_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Create, type:
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'creates a netsuite integration collection mapping' do
@@ -55,47 +57,6 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Create, type:
       expect(result_data['externalAccountCode']).to eq(external_account_code)
       expect(result_data['externalId']).to eq(external_id)
       expect(result_data['externalName']).to eq(external_name)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            integrationId: integration.id,
-            mappingType: mapping_type,
-            externalAccountCode: external_account_code,
-            externalId: external_id,
-            externalName: external_name,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            integrationId: integration.id,
-            mappingType: mapping_type,
-            externalAccountCode: external_account_code,
-            externalId: external_id,
-            externalName: external_name,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/integration_collection_mappings/netsuite/update_spec.rb
+++ b/spec/graphql/mutations/integration_collection_mappings/netsuite/update_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Update, type:
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'updates a netsuite integration' do
@@ -56,49 +58,6 @@ RSpec.describe Mutations::IntegrationCollectionMappings::Netsuite::Update, type:
       expect(result_data['externalAccountCode']).to eq(external_account_code)
       expect(result_data['externalId']).to eq(external_id)
       expect(result_data['externalName']).to eq(external_name)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            id: integration_collection_mapping.id,
-            integrationId: integration_collection_mapping.id,
-            mappingType: mapping_type,
-            externalAccountCode: external_account_code,
-            externalId: external_id,
-            externalName: external_name,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            id: integration_collection_mapping.id,
-            integrationId: integration_collection_mapping.id,
-            mappingType: mapping_type,
-            externalAccountCode: external_account_code,
-            externalId: external_id,
-            externalName: external_name,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/integration_items/fetch_items_spec.rb
+++ b/spec/graphql/mutations/integration_items/fetch_items_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe Mutations::IntegrationItems::FetchItems, type: :graphql do
     IntegrationItem.destroy_all
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'fetches the integration items' do
@@ -51,34 +53,5 @@ RSpec.describe Mutations::IntegrationItems::FetchItems, type: :graphql do
     invoice_ids = result_data['collection'].map { |value| value['externalId'] }
 
     expect(invoice_ids).to eq(%w[755 745 753 484 828])
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: { integrationId: integration.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: { integrationId: integration.id },
-        },
-      )
-
-      expect_forbidden_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/integration_items/fetch_tax_items_spec.rb
+++ b/spec/graphql/mutations/integration_items/fetch_tax_items_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe Mutations::IntegrationItems::FetchTaxItems, type: :graphql do
     IntegrationItem.destroy_all
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'fetches the integration tax items' do
@@ -51,34 +53,5 @@ RSpec.describe Mutations::IntegrationItems::FetchTaxItems, type: :graphql do
     invoice_ids = result_data['collection'].map { |value| value['externalId'] }
 
     expect(invoice_ids).to eq(%w[-3557 -3879 -4692 -5307])
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: { integrationId: integration.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: { integrationId: integration.id },
-        },
-      )
-
-      expect_forbidden_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/integration_mappings/destroy_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/destroy_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe Mutations::IntegrationMappings::Destroy, type: :graphql do
     end.to change(::IntegrationMappings::BaseMapping, :count).by(-1)
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   context 'when integration mapping is not found' do
@@ -48,35 +50,6 @@ RSpec.describe Mutations::IntegrationMappings::Destroy, type: :graphql do
       )
 
       expect_not_found(result)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: { id: integration_mapping.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: { id: integration_mapping.id },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/integration_mappings/netsuite/create_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/netsuite/create_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Create, type: :graphql 
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'creates a netsuite integration mapping' do
@@ -58,49 +60,6 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Create, type: :graphql 
       expect(result_data['externalAccountCode']).to eq(external_account_code)
       expect(result_data['externalId']).to eq(external_id)
       expect(result_data['externalName']).to eq(external_name)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            integrationId: integration.id,
-            mappableId: mappable.id,
-            mappableType: 'AddOn',
-            externalAccountCode: external_account_code,
-            externalId: external_id,
-            externalName: external_name,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            integrationId: integration.id,
-            mappableId: mappable.id,
-            mappableType: 'AddOn',
-            externalAccountCode: external_account_code,
-            externalId: external_id,
-            externalName: external_name,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/integration_mappings/netsuite/update_spec.rb
+++ b/spec/graphql/mutations/integration_mappings/netsuite/update_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Update, type: :graphql 
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'updates a netsuite integration' do
@@ -59,51 +61,6 @@ RSpec.describe Mutations::IntegrationMappings::Netsuite::Update, type: :graphql 
       expect(result_data['externalAccountCode']).to eq(external_account_code)
       expect(result_data['externalId']).to eq(external_id)
       expect(result_data['externalName']).to eq(external_name)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            id: integration_mapping.id,
-            integrationId: integration_mapping.id,
-            mappableId: mappable.id,
-            mappableType: 'AddOn',
-            externalAccountCode: external_account_code,
-            externalId: external_id,
-            externalName: external_name,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            id: integration_mapping.id,
-            integrationId: integration_mapping.id,
-            mappableId: mappable.id,
-            mappableType: 'AddOn',
-            externalAccountCode: external_account_code,
-            externalId: external_id,
-            externalName: external_name,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/integrations/destroy_spec.rb
+++ b/spec/graphql/mutations/integrations/destroy_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe Mutations::Integrations::Destroy, type: :graphql do
 
   before { integration }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'organization:integrations:delete'
+
   it 'deletes an integration' do
     expect do
       execute_graphql(
@@ -30,36 +34,5 @@ RSpec.describe Mutations::Integrations::Destroy, type: :graphql do
         },
       )
     end.to change(::Integrations::BaseIntegration, :count).by(-1)
-  end
-
-  it_behaves_like 'requires permission', 'organization:integrations:delete'
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: { id: integration.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: { id: integration.id },
-        },
-      )
-
-      expect_forbidden_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/integrations/netsuite/create_spec.rb
+++ b/spec/graphql/mutations/integrations/netsuite/create_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe Mutations::Integrations::Netsuite::Create, type: :graphql do
 
   before { membership.organization.update!(premium_integrations: ['netsuite']) }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:create'
 
   it 'creates a netsuite integration' do
@@ -60,49 +62,6 @@ RSpec.describe Mutations::Integrations::Netsuite::Create, type: :graphql do
       expect(result_data['code']).to eq(code)
       expect(result_data['name']).to eq(name)
       expect(result_data['scriptEndpointUrl']).to eq(script_endpoint_url)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            code:,
-            name:,
-            accountId: '012',
-            clientId: '123',
-            clientSecret: '456',
-            connectionId: 'this-is-random-uuid',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            code:,
-            name:,
-            accountId: '012',
-            clientId: '123',
-            clientSecret: '456',
-            connectionId: 'this-is-random-uuid',
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/integrations/netsuite/update_spec.rb
+++ b/spec/graphql/mutations/integrations/netsuite/update_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe Mutations::Integrations::Netsuite::Update, type: :graphql do
     membership.organization.update!(premium_integrations: ['netsuite'])
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'updates a netsuite integration' do
@@ -61,43 +63,6 @@ RSpec.describe Mutations::Integrations::Netsuite::Update, type: :graphql do
       expect(result_data['name']).to eq(name)
       expect(result_data['code']).to eq(code)
       expect(result_data['scriptEndpointUrl']).to eq(script_endpoint_url)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            id: integration.id,
-            code:,
-            name:,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            id: integration.id,
-            code:,
-            name:,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/integrations/okta/create_spec.rb
+++ b/spec/graphql/mutations/integrations/okta/create_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Mutations::Integrations::Okta::Create, type: :graphql do
 
   before { membership.organization.update!(premium_integrations: ['okta']) }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:create'
 
   it 'creates an okta integration' do
@@ -49,45 +51,6 @@ RSpec.describe Mutations::Integrations::Okta::Create, type: :graphql do
       expect(result_data['id']).to be_present
       expect(result_data['code']).to eq('okta')
       expect(result_data['name']).to eq('Okta Integration')
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            clientId: '123',
-            clientSecret: '456',
-            domain: 'foo.bar',
-            organizationName: 'Foobar',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            clientId: '123',
-            clientSecret: '456',
-            domain: 'foo.bar',
-            organizationName: 'Foobar',
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/integrations/okta/update_spec.rb
+++ b/spec/graphql/mutations/integrations/okta/update_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe Mutations::Integrations::Okta::Update, type: :graphql do
     membership.organization.update!(premium_integrations: ['okta'])
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'updates an okta integration' do
@@ -53,43 +55,6 @@ RSpec.describe Mutations::Integrations::Okta::Update, type: :graphql do
     aggregate_failures do
       expect(result_data['domain']).to eq('foo.bar')
       expect(result_data['organizationName']).to eq('Footest')
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            id: integration.id,
-            domain: 'foo.bar',
-            organizationName: 'Footest',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            id: integration.id,
-            domain: 'foo.bar',
-            organizationName: 'Footest',
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/invites/create_spec.rb
+++ b/spec/graphql/mutations/invites/create_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe Mutations::Invites::Create, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:members:create'
 
   it 'creates an invite for a new user' do

--- a/spec/graphql/mutations/invites/revoke_spec.rb
+++ b/spec/graphql/mutations/invites/revoke_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Mutations::Invites::Revoke, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:members:delete'
 
   describe 'Invite revoke mutation' do

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
 
   before { tax }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'invoices:create'
 
   it 'creates one-off invoice' do
@@ -82,43 +84,6 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
         { 'units' => 2.0, 'preciseUnitAmount' => 12.0 },
         { 'units' => 1.0, 'preciseUnitAmount' => 4.0 },
       )
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: organization,
-        query: mutation,
-        variables: {
-          input: {
-            customerId: customer.id,
-            currency:,
-            fees:,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            customerId: customer.id,
-            currency:,
-            fees:,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/invoices/download_spec.rb
+++ b/spec/graphql/mutations/invoices/download_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Mutations::Invoices::Download, type: :graphql do
       .and_return(pdf_response)
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'invoices:view'
 
   it 'generates the PDF for the given invoice' do
@@ -55,35 +57,6 @@ RSpec.describe Mutations::Invoices::Download, type: :graphql do
       aggregate_failures do
         expect(result_data['id']).to be_present
       end
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/invoices/finalize_spec.rb
+++ b/spec/graphql/mutations/invoices/finalize_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Mutations::Invoices::Finalize, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'invoices:update'
 
   it 'finalizes the given invoice' do
@@ -40,35 +42,6 @@ RSpec.describe Mutations::Invoices::Finalize, type: :graphql do
         expect(result_data['id']).to be_present
         expect(result_data['status']).to eq('finalized')
       end
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/invoices/lose_dispute_spec.rb
+++ b/spec/graphql/mutations/invoices/lose_dispute_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Mutations::Invoices::LoseDispute, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'invoices:update'
 
   it 'marks payment dispute lost to true' do
@@ -40,35 +42,6 @@ RSpec.describe Mutations::Invoices::LoseDispute, type: :graphql do
         expect(result_data['id']).to be_present
         expect(result_data['paymentDisputeLostAt']).to be_present
       end
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/invoices/refresh_spec.rb
+++ b/spec/graphql/mutations/invoices/refresh_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Mutations::Invoices::Refresh, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'invoices:update'
 
   it 'refreshes the given invoice' do
@@ -40,35 +42,6 @@ RSpec.describe Mutations::Invoices::Refresh, type: :graphql do
         expect(result_data['id']).to be_present
         expect(result_data['updatedAt']).to eq(Time.current.iso8601)
       end
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/invoices/retry_all_payments_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_all_payments_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Mutations::Invoices::RetryAllPayments, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'invoices:update'
 
   context 'with valid preconditions' do
@@ -70,35 +72,6 @@ RSpec.describe Mutations::Invoices::RetryAllPayments, type: :graphql do
 
       expect(invoice_ids).to include(invoice_first.id)
       expect(invoice_ids).to include(invoice_second.id)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: organization,
-        query: mutation,
-        variables: {
-          input: {},
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {},
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/invoices/retry_payment_spec.rb
+++ b/spec/graphql/mutations/invoices/retry_payment_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Mutations::Invoices::RetryPayment, type: :graphql do
     gocardless_customer
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'invoices:update'
 
   context 'with valid preconditions' do
@@ -53,35 +55,6 @@ RSpec.describe Mutations::Invoices::RetryPayment, type: :graphql do
       data = result['data']['retryInvoicePayment']
 
       expect(data['id']).to eq(invoice.id)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: organization,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/invoices/update_spec.rb
+++ b/spec/graphql/mutations/invoices/update_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Mutations::Invoices::Update, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'invoices:update'
 
   it 'updates a invoice' do
@@ -69,23 +70,6 @@ RSpec.describe Mutations::Invoices::Update, type: :graphql do
         result:,
         message: 'Resource not found',
       )
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        current_organization: organization,
-        variables: {
-          input: {
-            id: invoice.id,
-            paymentStatus: 'succeeded',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/invoices/void_spec.rb
+++ b/spec/graphql/mutations/invoices/void_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe Mutations::Invoices::Void, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'invoices:void'
 
   it 'voids the given invoice' do
@@ -40,35 +42,6 @@ RSpec.describe Mutations::Invoices::Void, type: :graphql do
         expect(result_data['id']).to be_present
         expect(result_data['status']).to eq('voided')
       end
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: { id: invoice.id },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/memberships/revoke_spec.rb
+++ b/spec/graphql/mutations/memberships/revoke_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Mutations::Memberships::Revoke, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'organization:members:update'
 
   it 'Revokes a membership' do

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -36,6 +36,9 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+
   it 'updates an organization' do
     result = execute_graphql(
       current_user: membership.user,
@@ -149,38 +152,6 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           expect(result_data['billingConfiguration']['invoiceGracePeriod']).to eq(3)
         end
       end
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            webhookUrl: 'http://foo.bar',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query: mutation,
-        variables: {
-          input: {
-            webhookUrl: 'http://foo.bar',
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/payment_providers/adyen/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/adyen/create_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe Mutations::PaymentProviders::Adyen::Create, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:create'
 
   it 'creates an adyen provider' do
@@ -62,45 +64,6 @@ RSpec.describe Mutations::PaymentProviders::Adyen::Create, type: :graphql do
       expect(result_data['livePrefix']).to eq(live_prefix)
       expect(result_data['merchantAccount']).to eq(merchant_account)
       expect(result_data['successRedirectUrl']).to eq(success_redirect_url)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            apiKey: api_key,
-            code:,
-            name:,
-            merchantAccount: merchant_account,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            apiKey: api_key,
-            code:,
-            name:,
-            merchantAccount: merchant_account,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/payment_providers/adyen/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/adyen/update_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Mutations::PaymentProviders::Adyen::Update, type: :graphql do
 
   before { adyen_provider }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'updates an adyen provider' do
@@ -60,41 +62,6 @@ RSpec.describe Mutations::PaymentProviders::Adyen::Update, type: :graphql do
       result_data = result['data']['updateAdyenPaymentProvider']
 
       expect(result_data['successRedirectUrl']).to eq(nil)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            id: adyen_provider.id,
-            successRedirectUrl: success_redirect_url,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            id: adyen_provider.id,
-            successRedirectUrl: success_redirect_url,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/payment_providers/destroy_spec.rb
+++ b/spec/graphql/mutations/payment_providers/destroy_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Mutations::PaymentProviders::Destroy, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'organization:integrations:delete'
 
   it 'deletes a payment provider' do

--- a/spec/graphql/mutations/payment_providers/gocardless/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/gocardless/create_spec.rb
@@ -38,6 +38,8 @@ RSpec.describe Mutations::PaymentProviders::Gocardless::Create, type: :graphql d
       .and_return('access_token_554')
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:create'
 
   it 'creates a gocardless provider' do
@@ -64,43 +66,6 @@ RSpec.describe Mutations::PaymentProviders::Gocardless::Create, type: :graphql d
       expect(result_data['code']).to eq(code)
       expect(result_data['name']).to eq(name)
       expect(result_data['successRedirectUrl']).to eq(success_redirect_url)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            accessCode: access_code,
-            code:,
-            name:,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            accessCode: access_code,
-            code:,
-            name:,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/payment_providers/gocardless/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/gocardless/update_spec.rb
@@ -35,6 +35,8 @@ RSpec.describe Mutations::PaymentProviders::Gocardless::Update, type: :graphql d
     gocardless_provider
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'updates an gocardless provider' do
@@ -74,41 +76,6 @@ RSpec.describe Mutations::PaymentProviders::Gocardless::Update, type: :graphql d
       result_data = result['data']['updateGocardlessPaymentProvider']
 
       expect(result_data['successRedirectUrl']).to eq(nil)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            id: gocardless_provider.id,
-            successRedirectUrl: success_redirect_url,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            id: gocardless_provider.id,
-            successRedirectUrl: success_redirect_url,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/payment_providers/stripe/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/stripe/create_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Create, type: :graphql do
   let(:secret_key) { 'sk_12345678901234567890' }
   let(:success_redirect_url) { Faker::Internet.url }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:create'
 
   it 'creates a stripe provider' do
@@ -51,43 +53,6 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Create, type: :graphql do
       expect(result_data['code']).to eq(code)
       expect(result_data['name']).to eq(name)
       expect(result_data['successRedirectUrl']).to eq(success_redirect_url)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            secretKey: secret_key,
-            code:,
-            name:,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            secretKey: secret_key,
-            code:,
-            name:,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/payment_providers/stripe/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/stripe/update_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Update, type: :graphql do
 
   before { stripe_provider }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'organization:integrations:update'
 
   it 'updates an stripe provider' do
@@ -60,41 +62,6 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Update, type: :graphql do
       result_data = result['data']['updateStripePaymentProvider']
 
       expect(result_data['successRedirectUrl']).to eq(nil)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            id: stripe_provider.id,
-            successRedirectUrl: success_redirect_url,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            id: stripe_provider.id,
-            successRedirectUrl: success_redirect_url,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -78,6 +78,8 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
 
   around { |test| lago_premium!(&test) }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'plans:create'
 
   it 'creates a plan' do
@@ -257,51 +259,6 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
         'amountCents' => minimum_commitment_amount_cents.to_s,
       )
       expect(result_data['minimumCommitment']['taxes'].count).to eq(1)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            name: 'New Plan',
-            code: 'new_plan',
-            interval: 'monthly',
-            payInAdvance: false,
-            amountCents: 200,
-            amountCurrency: 'EUR',
-            charges: [],
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            name: 'New Plan',
-            code: 'new_plan',
-            interval: 'monthly',
-            payInAdvance: false,
-            amountCents: 200,
-            amountCurrency: 'EUR',
-            charges: [],
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/plans/destroy_spec.rb
+++ b/spec/graphql/mutations/plans/destroy_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Mutations::Plans::Destroy, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'plans:delete'
 
   it 'marks plan as pending_deletion' do
@@ -36,16 +37,5 @@ RSpec.describe Mutations::Plans::Destroy, type: :graphql do
   it 'returns the deleted plan' do
     data = graphql_request['data']['destroyPlan']
     expect(data['id']).to eq(plan.id)
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: { input: { id: plan.id } },
-      )
-
-      expect_unauthorized_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -169,6 +169,7 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
 
   before { minimum_commitment }
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'plans:update'
 
   context 'with premium license' do
@@ -302,28 +303,6 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
           'amountCents' => minimum_commitment.amount_cents.to_s,
         )
       end
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: {
-            id: plan.id,
-            name: 'Updated plan',
-            code: 'new_plan',
-            interval: 'monthly',
-            payInAdvance: false,
-            amountCents: 200,
-            amountCurrency: 'EUR',
-            charges: [],
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -36,6 +36,8 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
 
   around { |test| lago_premium!(&test) }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'subscriptions:create'
 
   it 'creates a subscription', :aggregate_failures do
@@ -82,42 +84,5 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
       'id' => String,
       'amountCents' => '100',
     )
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            customerId: customer.id,
-            planId: plan.id,
-            billingTime: 'anniversary',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            customerId: customer.id,
-            planId: plan.id,
-            billingTime: 'anniversary',
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/subscriptions/terminate_spec.rb
+++ b/spec/graphql/mutations/subscriptions/terminate_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Mutations::Subscriptions::Terminate, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'subscriptions:update'
 
   it 'terminates a subscription' do
@@ -39,39 +41,6 @@ RSpec.describe Mutations::Subscriptions::Terminate, type: :graphql do
       expect(result_data['id']).to eq(subscription.id)
       expect(result_data['status']).to eq('terminated')
       expect(result_data['terminatedAt']).to be_present
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            id: subscription.id,
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            id: subscription.id,
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/subscriptions/update_spec.rb
+++ b/spec/graphql/mutations/subscriptions/update_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
   it_behaves_like 'requires permission', 'subscriptions:update'
 
   it 'updates an subscription' do
@@ -45,22 +46,6 @@ RSpec.describe Mutations::Subscriptions::Update, type: :graphql do
 
     aggregate_failures do
       expect(result_data['name']).to eq('New name')
-    end
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: {
-            id: subscription.id,
-            name: 'New name',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/taxes/create_spec.rb
+++ b/spec/graphql/mutations/taxes/create_spec.rb
@@ -39,28 +39,4 @@ RSpec.describe Mutations::Taxes::Create, type: :graphql do
       'rate' => 15.0,
     )
   end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: { input: },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query: mutation,
-        variables: { input: },
-      )
-
-      expect_forbidden_error(result)
-    end
-  end
 end

--- a/spec/graphql/mutations/taxes/destroy_spec.rb
+++ b/spec/graphql/mutations/taxes/destroy_spec.rb
@@ -27,28 +27,4 @@ RSpec.describe Mutations::Taxes::Destroy, type: :graphql do
       )
     end.to change(Tax, :count).by(-1)
   end
-
-  context 'without current_organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query: mutation,
-        variables: { input: { id: tax.id } },
-      )
-
-      expect_forbidden_error(result)
-    end
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: { input: { id: tax.id } },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
 end

--- a/spec/graphql/mutations/taxes/update_spec.rb
+++ b/spec/graphql/mutations/taxes/update_spec.rb
@@ -43,28 +43,4 @@ RSpec.describe Mutations::Taxes::Update, type: :graphql do
       'appliedToOrganization' => false,
     )
   end
-
-  context 'without current_organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query: mutation,
-        variables: { input: },
-      )
-
-      expect_forbidden_error(result)
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: { input: },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
 end

--- a/spec/graphql/mutations/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/wallet_transactions/create_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
     wallet
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'wallets:top_up'
 
   it 'creates a wallet transaction' do
@@ -47,43 +49,6 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
       expect(result_data['collection'].count).to eq(2)
       expect(result_data['collection'].first['status']).to eq('pending')
       expect(result_data['collection'].last['status']).to eq('settled')
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            walletId: wallet.id,
-            paidCredits: '5.00',
-            grantedCredits: '5.00',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            walletId: wallet.id,
-            paidCredits: '5.00',
-            grantedCredits: '5.00',
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
 
   around { |test| lago_premium!(&test) }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'wallets:create'
 
   it 'create a wallet' do
@@ -94,51 +96,6 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
         expect(result_data['id']).to be_present
         expect(result_data['name']).to be_nil
       end
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: {
-          input: {
-            customerId: customer.id,
-            name: 'First Wallet',
-            rateAmount: '1',
-            paidCredits: '0.00',
-            grantedCredits: '0.00',
-            expirationAt: (Time.zone.now + 1.year).iso8601,
-            currency: 'EUR',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: {
-          input: {
-            customerId: customer.id,
-            name: 'First Wallet',
-            rateAmount: '1',
-            paidCredits: '0.00',
-            grantedCredits: '0.00',
-            expirationAt: (Time.zone.now + 1.year).iso8601,
-            currency: 'EUR',
-          },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/wallets/terminate_spec.rb
+++ b/spec/graphql/mutations/wallets/terminate_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Mutations::Wallets::Terminate, type: :graphql do
 
   before { subscription }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'wallets:terminate'
 
   it 'terminates a wallet' do
@@ -41,18 +43,5 @@ RSpec.describe Mutations::Wallets::Terminate, type: :graphql do
     expect(data['name']).to eq(wallet.name)
     expect(data['status']).to eq('terminated')
     expect(data['terminatedAt']).to be_present
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: { id: wallet.id },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
 
   around { |test| lago_premium!(&test) }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'wallets:update'
 
   it 'updates a wallet' do
@@ -71,22 +73,6 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
       expect(result_data['recurringTransactionRules'][0]['interval']).to eq('weekly')
       expect(result_data['recurringTransactionRules'][0]['paidCredits']).to eq('22.2')
       expect(result_data['recurringTransactionRules'][0]['grantedCredits']).to eq('22.2')
-    end
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        query: mutation,
-        variables: {
-          input: {
-            id: wallet.id,
-            name: 'New name',
-          },
-        },
-      )
-
-      expect_unauthorized_error(result)
     end
   end
 end

--- a/spec/graphql/mutations/webhook_endpoints/create_spec.rb
+++ b/spec/graphql/mutations/webhook_endpoints/create_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Mutations::WebhookEndpoints::Create, type: :graphql do
     GQL
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'developers:manage'
 
   it 'creates a webhook_endpoint' do
@@ -42,30 +44,5 @@ RSpec.describe Mutations::WebhookEndpoints::Create, type: :graphql do
       'webhookUrl' => webhook_url,
       'signatureAlgo' => 'hmac',
     )
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: { input: },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: { input: },
-      )
-
-      expect_forbidden_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/webhook_endpoints/destroy_spec.rb
+++ b/spec/graphql/mutations/webhook_endpoints/destroy_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Mutations::WebhookEndpoints::Destroy, type: :graphql do
 
   before { webhook_endpoint }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'developers:manage'
 
   it 'destroys a webhook_endpoint' do
@@ -30,30 +32,5 @@ RSpec.describe Mutations::WebhookEndpoints::Destroy, type: :graphql do
         variables: { input: { id: webhook_endpoint.id } },
       )
     end.to change(WebhookEndpoint, :count).by(-1)
-  end
-
-  context 'without current_organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: { input: { id: webhook_endpoint.id } },
-      )
-
-      expect_forbidden_error(result)
-    end
-  end
-
-  context 'without current_user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: { input: { id: webhook_endpoint.id } },
-      )
-
-      expect_unauthorized_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/webhook_endpoints/update_spec.rb
+++ b/spec/graphql/mutations/webhook_endpoints/update_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe Mutations::WebhookEndpoints::Update, type: :graphql do
 
   before { webhook_endpoint }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'developers:manage'
 
   it 'updates a webhook_endpoint' do
@@ -46,30 +48,5 @@ RSpec.describe Mutations::WebhookEndpoints::Update, type: :graphql do
       'webhookUrl' => webhook_url,
       'signatureAlgo' => 'hmac',
     )
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query: mutation,
-        variables: { input: },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        permissions: required_permission,
-        query: mutation,
-        variables: { input: },
-      )
-
-      expect_forbidden_error(result)
-    end
   end
 end

--- a/spec/graphql/mutations/webhooks/retry_spec.rb
+++ b/spec/graphql/mutations/webhooks/retry_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Mutations::Webhooks::Retry, type: :graphql do
 
   before { webhook }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'developers:manage'
 
   it 'retries a webhook' do

--- a/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver, type: :graphql do
+  let(:required_permission) { 'analytics:view' }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum) {
@@ -21,11 +22,14 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver, type: :graphql 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
+  it_behaves_like 'requires permission', 'analytics:view'
+
   context 'without premium feature' do
     it 'returns an error' do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
       )
 
@@ -43,6 +47,7 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver, type: :graphql 
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
       )
 
@@ -58,7 +63,7 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver, type: :graphql 
 
     context 'without current organization' do
       it 'returns an error' do
-        result = execute_graphql(current_user: membership.user, query:)
+        result = execute_graphql(current_user: membership.user, permissions: required_permission, query:)
 
         expect_graphql_error(
           result:,
@@ -72,6 +77,7 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver, type: :graphql 
         result = execute_graphql(
           current_user: membership.user,
           current_organization: create(:organization),
+          permissions: Permission::EMPTY_PERMISSIONS_HASH,
           query:,
         )
 

--- a/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoice_collections_resolver_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver, type: :graphql 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'analytics:view'
 
   context 'without premium feature' do
@@ -61,33 +63,6 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver, type: :graphql 
       end
     end
 
-    context 'without current organization' do
-      it 'returns an error' do
-        result = execute_graphql(current_user: membership.user, permissions: required_permission, query:)
-
-        expect_graphql_error(
-          result:,
-          message: 'Missing organization id',
-        )
-      end
-    end
-
-    context 'when not member of the organization' do
-      it 'returns an error' do
-        result = execute_graphql(
-          current_user: membership.user,
-          current_organization: create(:organization),
-          permissions: Permission::EMPTY_PERMISSIONS_HASH,
-          query:,
-        )
-
-        expect_graphql_error(
-          result:,
-          message: 'Not in organization',
-        )
-      end
-    end
-
     describe '#resolve' do
       subject(:resolve) { resolver.resolve }
 
@@ -97,7 +72,6 @@ RSpec.describe Resolvers::Analytics::InvoiceCollectionsResolver, type: :graphql 
       before do
         allow(Analytics::InvoiceCollection).to receive(:find_all_by).and_return([])
         allow(resolver).to receive(:current_organization).and_return(current_organization)
-        allow(resolver).to receive(:validate_organization!).and_return(true)
 
         resolve
       end

--- a/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'analytics:view'
 
   context 'without premium feature' do
@@ -53,33 +55,6 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver, type: :graphql do
       expect(result['data']['invoicedUsages']['collection']).to eq([])
     end
 
-    context 'without current organization' do
-      it 'returns an error' do
-        result = execute_graphql(current_user: membership.user, permissions: required_permission, query:)
-
-        expect_graphql_error(
-          result:,
-          message: 'Missing organization id',
-        )
-      end
-    end
-
-    context 'when not member of the organization' do
-      it 'returns an error' do
-        result = execute_graphql(
-          current_user: membership.user,
-          current_organization: create(:organization),
-          permissions: Permission::EMPTY_PERMISSIONS_HASH,
-          query:,
-        )
-
-        expect_graphql_error(
-          result:,
-          message: 'Not in organization',
-        )
-      end
-    end
-
     describe '#resolve' do
       subject(:resolve) { resolver.resolve }
 
@@ -89,7 +64,6 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver, type: :graphql do
       before do
         allow(Analytics::InvoicedUsage).to receive(:find_all_by).and_return([])
         allow(resolver).to receive(:current_organization).and_return(current_organization)
-        allow(resolver).to receive(:validate_organization!).and_return(true)
 
         resolve
       end

--- a/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/invoiced_usages_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver, type: :graphql do
+  let(:required_permission) { 'analytics:view' }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum) {
@@ -20,11 +21,14 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
+  it_behaves_like 'requires permission', 'analytics:view'
+
   context 'without premium feature' do
     it 'returns an error' do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
       )
 
@@ -42,6 +46,7 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
       )
 
@@ -50,7 +55,7 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver, type: :graphql do
 
     context 'without current organization' do
       it 'returns an error' do
-        result = execute_graphql(current_user: membership.user, query:)
+        result = execute_graphql(current_user: membership.user, permissions: required_permission, query:)
 
         expect_graphql_error(
           result:,
@@ -64,6 +69,7 @@ RSpec.describe Resolvers::Analytics::InvoicedUsagesResolver, type: :graphql do
         result = execute_graphql(
           current_user: membership.user,
           current_organization: create(:organization),
+          permissions: Permission::EMPTY_PERMISSIONS_HASH,
           query:,
         )
 

--- a/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::Analytics::MrrsResolver, type: :graphql do
+  let(:required_permission) { 'analytics:view' }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum) {
@@ -20,11 +21,14 @@ RSpec.describe Resolvers::Analytics::MrrsResolver, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
+  it_behaves_like 'requires permission', 'analytics:view'
+
   context 'without premium feature' do
     it 'returns an error' do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
       )
 
@@ -42,6 +46,7 @@ RSpec.describe Resolvers::Analytics::MrrsResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
       )
 
@@ -57,7 +62,7 @@ RSpec.describe Resolvers::Analytics::MrrsResolver, type: :graphql do
 
     context 'without current organization' do
       it 'returns an error' do
-        result = execute_graphql(current_user: membership.user, query:)
+        result = execute_graphql(current_user: membership.user, permissions: required_permission, query:)
 
         expect_graphql_error(
           result:,
@@ -71,6 +76,7 @@ RSpec.describe Resolvers::Analytics::MrrsResolver, type: :graphql do
         result = execute_graphql(
           current_user: membership.user,
           current_organization: create(:organization),
+          permissions: Permission::EMPTY_PERMISSIONS_HASH,
           query:,
         )
 

--- a/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/mrrs_resolver_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Resolvers::Analytics::MrrsResolver, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'analytics:view'
 
   context 'without premium feature' do
@@ -60,33 +62,6 @@ RSpec.describe Resolvers::Analytics::MrrsResolver, type: :graphql do
       end
     end
 
-    context 'without current organization' do
-      it 'returns an error' do
-        result = execute_graphql(current_user: membership.user, permissions: required_permission, query:)
-
-        expect_graphql_error(
-          result:,
-          message: 'Missing organization id',
-        )
-      end
-    end
-
-    context 'when not member of the organization' do
-      it 'returns an error' do
-        result = execute_graphql(
-          current_user: membership.user,
-          current_organization: create(:organization),
-          permissions: Permission::EMPTY_PERMISSIONS_HASH,
-          query:,
-        )
-
-        expect_graphql_error(
-          result:,
-          message: 'Not in organization',
-        )
-      end
-    end
-
     describe '#resolve' do
       subject(:resolve) { resolver.resolve }
 
@@ -96,7 +71,6 @@ RSpec.describe Resolvers::Analytics::MrrsResolver, type: :graphql do
       before do
         allow(Analytics::Mrr).to receive(:find_all_by).and_return([])
         allow(resolver).to receive(:current_organization).and_return(current_organization)
-        allow(resolver).to receive(:validate_organization!).and_return(true)
 
         resolve
       end

--- a/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes/estimate_resolver_spec.rb
@@ -55,6 +55,9 @@ RSpec.describe Resolvers::CreditNotes::EstimateResolver, type: :graphql do
 
   before { credit }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+
   it 'returns the estimate for the credit note creation' do
     result = execute_graphql(
       current_user: membership.user,
@@ -77,36 +80,6 @@ RSpec.describe Resolvers::CreditNotes::EstimateResolver, type: :graphql do
       expect(estimate_response['couponsAdjustmentAmountCents']).to eq('50')
       expect(estimate_response['items'].first['amountCents']).to eq('50')
       expect(estimate_response['appliedTaxes']).to be_blank
-    end
-  end
-
-  context 'without current user' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_organization: membership.organization,
-        query:,
-        variables: {
-          invoiceId: invoice.id,
-          items: fees.map { |f| { feeId: f.id, amountCents: 50 } },
-        },
-      )
-
-      expect_unauthorized_error(result)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query:,
-        variables: {
-          invoiceId: invoice.id,
-          items: fees.map { |f| { feeId: f.id, amountCents: 50 } },
-        },
-      )
-
-      expect_forbidden_error(result)
     end
   end
 

--- a/spec/support/shared_examples/graphql_requirements.rb
+++ b/spec/support/shared_examples/graphql_requirements.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'requires current user' do
+  it 'requires a current user' do
+    expect(described_class.ancestors).to include(AuthenticableApiUser)
+  end
+end
+
+RSpec.shared_examples 'requires current organization' do
+  it 'requires a current organization' do
+    expect(described_class.ancestors).to include(RequiredOrganization)
+  end
+end
+
+RSpec.shared_examples 'requires permission' do |permission|
+  it "requires #{permission} permission" do
+    expect(described_class::REQUIRED_PERMISSION).to eq(permission)
+  end
+end

--- a/spec/support/shared_examples/requires_permission.rb
+++ b/spec/support/shared_examples/requires_permission.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.shared_examples 'requires permission' do |permission|
-  it "requires #{permission} permission" do
-    expect(described_class::REQUIRED_PERMISSION).to eq(permission)
-  end
-end


### PR DESCRIPTION
## Context

Granular permissions are being added to Lago

## Description

A first PR added all the permission system foundations to Lago (https://github.com/getlago/lago-api/pull/1926). A second PR added permissions to all GraphQL mutations (https://github.com/getlago/lago-api/pull/1941).


- As I'm working on adding it to Resolvers, I realized I needed the exact the thing as mutations so I extracted some logic into `CanRequirePermissions` concern.
- Not all resolvers were extending our custom BaseResolvers, now they do.
- As I was testing my new concern, I added tests to `AuthenticableApiUser` and `RequiredOrganization` concerns

When I was editing tests for mutations, I add to edit MANY tests re-testing _"without current user"_ and _"without current organization"_. I believe those tests are redundant and we can now simply tests of the Mutation/Resolver includes the correct concern. The behavior is tested once in the concern. See e48109da for single example.

Recently @josemoyab introduced [a great refactor](https://github.com/getlago/lago-api/pull/1853) of `RequiredOrganization` to avoid calling `validate_organization!` in every `resolve` method. I'm taking this one step further by removing the meta programming and using the `ready?` method to be consistent with other concerns.

I'll deal with `AuthenticableCustomerPortalUser` concern separately as this PR is already huge and it doesn't affect my work on RBAC.

### About execution order

Each `ready?` method will be executed in order, starting by the last concern added, all the way to the first concern added.

```ruby
class CreateThing < BaseMutation
    include AuthenticableApiUser
    include RequiredOrganization

    ...
end
```

In the above snippet, we'll call `RequiredOrganization#ready?` first, then `AuthenticableApiUser#ready?`. In this case, you'll never get to the `AuthenticableApiUser` error because `RequiredOrganization#ready?` also checks that the current_user is part of the current_organization. Without a current_user, this check will never pass.

**This is the reason why I had to edit all mutation tests in the PR**. Previously, the `AuthenticableApiUser#ready?` would run first, then `resolve` would automatically call `current_organization!`.

### Nota Bene

We don't need to add dedicated tests case for current_user and curent_organization in every new mutation or resolver.

