### PR TITLE
feat(wallet): Send wallet.depleted_ongoing_balance webhook

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -32,6 +32,7 @@ class SendWebhookJob < ApplicationJob
     'subscription.started' => Webhooks::Subscriptions::StartedService,
     'subscription.termination_alert' => Webhooks::Subscriptions::TerminationAlertService,
     'subscription.trial_ended' => Webhooks::Subscriptions::TrialEndedService,
+    'wallet.depleted_ongoing_balance' => Webhooks::Wallets::DepletedOngoingBalanceService,
     'wallet_transaction.created' => Webhooks::WalletTransactions::CreatedService,
   }.freeze
 

--- a/app/services/webhooks/wallets/depleted_ongoing_balance_service.rb
+++ b/app/services/webhooks/wallets/depleted_ongoing_balance_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Wallets
+    class DepletedOngoingBalanceService < Webhooks::BaseService
+      private
+
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::WalletSerializer.new(object, root_name: 'wallet')
+      end
+
+      def webhook_type
+        'wallet.depleted_ongoing_balance'
+      end
+
+      def object_type
+        'wallet'
+      end
+    end
+  end
+end

--- a/db/migrate/20240424124802_add_depleted_ongoing_balance_to_wallets.rb
+++ b/db/migrate/20240424124802_add_depleted_ongoing_balance_to_wallets.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDepletedOngoingBalanceToWallets < ActiveRecord::Migration[7.0]
+  def change
+    add_column :wallets, :depleted_ongoing_balance, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -981,6 +981,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_25_131701) do
     t.bigint "ongoing_usage_balance_cents", default: 0, null: false
     t.decimal "credits_ongoing_balance", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "credits_ongoing_usage_balance", precision: 30, scale: 5, default: "0.0", null: false
+    t.boolean "depleted_ongoing_balance", default: false, null: false
     t.index ["customer_id"], name: "index_wallets_on_customer_id"
   end
 

--- a/spec/services/webhooks/wallets/depleted_ongoing_balance_service_spec.rb
+++ b/spec/services/webhooks/wallets/depleted_ongoing_balance_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Wallets::DepletedOngoingBalanceService do
+  subject(:webhook_service) { described_class.new(object: wallet) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:wallet) { create(:wallet, customer:) }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response)
+    end
+
+    it 'builds payload with wallet.depleted_ongoing_balance webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+
+      expect(lago_client).to have_received(:post_with_response) do |payload|
+        expect(payload[:webhook_type]).to eq('wallet.depleted_ongoing_balance')
+        expect(payload[:object_type]).to eq('wallet')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to add a new webhook when the ongoing balance is < or = 0.00.