### PR TITLE
feat (accounting-integrations): refactor logic for syncing resources

### DIFF
--- a/app/graphql/mutations/integration_items/fetch_items.rb
+++ b/app/graphql/mutations/integration_items/fetch_items.rb
@@ -18,7 +18,7 @@ module Mutations
       def resolve(**args)
         integration = current_organization.integrations.find_by(id: args[:integration_id])
 
-        ::Integrations::Aggregator::SyncService.call(integration:)
+        ::Integrations::Aggregator::SyncService.call(integration:, options: { only_items: true })
 
         result = ::Integrations::Aggregator::ItemsService.call(integration:)
 

--- a/app/graphql/mutations/integration_items/fetch_tax_items.rb
+++ b/app/graphql/mutations/integration_items/fetch_tax_items.rb
@@ -18,7 +18,7 @@ module Mutations
       def resolve(**args)
         integration = current_organization.integrations.find_by(id: args[:integration_id])
 
-        ::Integrations::Aggregator::SyncService.call(integration:)
+        ::Integrations::Aggregator::SyncService.call(integration:, options: { only_tax_items: true })
 
         result = ::Integrations::Aggregator::TaxItemsService.call(integration:)
 

--- a/app/jobs/integrations/aggregator/perform_sync_job.rb
+++ b/app/jobs/integrations/aggregator/perform_sync_job.rb
@@ -8,8 +8,14 @@ module Integrations
       retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
 
       def perform(integration:)
-        result = Integrations::Aggregator::SyncService.call(integration:)
-        result.raise_if_error!
+        sync_result = Integrations::Aggregator::SyncService.call(integration:)
+        sync_result.raise_if_error!
+
+        items_result = Integrations::Aggregator::ItemsService.call(integration:)
+        items_result.raise_if_error!
+
+        tax_items_result = Integrations::Aggregator::TaxItemsService.call(integration:)
+        tax_items_result.raise_if_error!
       end
     end
   end

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -7,8 +7,9 @@ module Integrations
     class BaseService < BaseService
       BASE_URL = 'https://api.nango.dev/'
 
-      def initialize(integration:)
+      def initialize(integration:, options: {})
         @integration = integration
+        @options = options
 
         super
       end
@@ -19,7 +20,7 @@ module Integrations
 
       private
 
-      attr_reader :integration
+      attr_reader :integration, :options
 
       # NOTE: Extend it with other providers if needed
       def provider

--- a/app/services/integrations/aggregator/sync_service.rb
+++ b/app/services/integrations/aggregator/sync_service.rb
@@ -10,7 +10,7 @@ module Integrations
       def call
         payload = {
           provider_config_key: provider,
-          syncs: sync_items,
+          syncs: sync_list,
         }
 
         response = http_client.post_with_response(payload, headers)
@@ -22,17 +22,22 @@ module Integrations
       private
 
       # NOTE: Extend it with other providers if needed
-      def sync_items
-        case integration.type
-        when 'Integrations::NetsuiteIntegration'
-          %w[
-            netsuite-accounts-sync
-            netsuite-items-sync
-            netsuite-subsidiaries-sync
-            netsuite-contacts-sync
-            netsuite-tax-items-sync
-          ]
+      def sync_list
+        list = case integration.type
+               when 'Integrations::NetsuiteIntegration'
+                 {
+                   accounts: 'netsuite-accounts-sync',
+                   items: 'netsuite-items-sync',
+                   subsidiaries: 'netsuite-subsidiaries-sync',
+                   contacts: 'netsuite-contacts-sync',
+                   tax_items: 'netsuite-tax-items-sync',
+                 }
         end
+
+        return [list[:items]] if options[:only_items]
+        return [list[:tax_items]] if options[:only_tax_items]
+
+        list.values
       end
     end
   end

--- a/app/services/integrations/netsuite/create_service.rb
+++ b/app/services/integrations/netsuite/create_service.rb
@@ -33,9 +33,6 @@ module Integrations
           Integrations::Aggregator::PerformSyncJob.set(wait: 2.seconds).perform_later(integration:)
         end
 
-        Integrations::Aggregator::FetchItemsJob.perform_later(integration:)
-        Integrations::Aggregator::FetchTaxItemsJob.perform_later(integration:)
-
         result.integration = integration
         result
       rescue ActiveRecord::RecordInvalid => e

--- a/spec/jobs/integrations/aggregator/perform_sync_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/perform_sync_job_spec.rb
@@ -6,18 +6,34 @@ RSpec.describe Integrations::Aggregator::PerformSyncJob, type: :job do
   subject(:perform_sync_job) { described_class }
 
   let(:sync_service) { instance_double(Integrations::Aggregator::SyncService) }
+  let(:items_service) { instance_double(Integrations::Aggregator::ItemsService) }
+  let(:tax_items_service) { instance_double(Integrations::Aggregator::TaxItemsService) }
   let(:integration) { create(:netsuite_integration) }
   let(:result) { BaseService::Result.new }
 
   before do
     allow(Integrations::Aggregator::SyncService).to receive(:new).and_return(sync_service)
     allow(sync_service).to receive(:call).and_return(result)
+
+    allow(Integrations::Aggregator::ItemsService).to receive(:new).and_return(items_service)
+    allow(items_service).to receive(:call).and_return(result)
+
+    allow(Integrations::Aggregator::TaxItemsService).to receive(:new).and_return(tax_items_service)
+    allow(tax_items_service).to receive(:call).and_return(result)
   end
 
   it 'calls the aggregator sync service' do
     described_class.perform_now(integration:)
 
-    expect(Integrations::Aggregator::SyncService).to have_received(:new)
-    expect(sync_service).to have_received(:call)
+    aggregate_failures do
+      expect(Integrations::Aggregator::SyncService).to have_received(:new)
+      expect(sync_service).to have_received(:call)
+
+      expect(Integrations::Aggregator::ItemsService).to have_received(:new)
+      expect(items_service).to have_received(:call)
+
+      expect(Integrations::Aggregator::TaxItemsService).to have_received(:new)
+      expect(tax_items_service).to have_received(:call)
+    end
   end
 end

--- a/spec/services/integrations/aggregator/sync_service_spec.rb
+++ b/spec/services/integrations/aggregator/sync_service_spec.rb
@@ -37,5 +37,18 @@ RSpec.describe Integrations::Aggregator::SyncService do
         expect(payload[:syncs]).to eq(syncs_list)
       end
     end
+
+    context 'when only items should be synced' do
+      it 'successfully performs sync' do
+        described_class.new(integration:, options: { only_items: true }).call
+
+        expect(LagoHttpClient::Client).to have_received(:new)
+          .with(sync_endpoint)
+        expect(lago_client).to have_received(:post_with_response) do |payload|
+          expect(payload[:provider_config_key]).to eq('netsuite')
+          expect(payload[:syncs]).to eq(%w[netsuite-items-sync])
+        end
+      end
+    end
   end
 end

--- a/spec/services/integrations/netsuite/create_service_spec.rb
+++ b/spec/services/integrations/netsuite/create_service_spec.rb
@@ -89,20 +89,6 @@ RSpec.describe Integrations::Netsuite::CreateService, type: :service do
           it 'calls Integrations::Aggregator::PerformSyncJob' do
             expect { service_call }.to have_enqueued_job(Integrations::Aggregator::PerformSyncJob)
           end
-
-          it 'calls Integrations::Aggregator::FetchItemsJob' do
-            service_call
-
-            integration = Integrations::NetsuiteIntegration.order(:created_at).last
-            expect(Integrations::Aggregator::FetchItemsJob).to have_received(:perform_later).with(integration:)
-          end
-
-          it 'calls Integrations::Aggregator::FetchTaxItemsJob' do
-            service_call
-
-            integration = Integrations::NetsuiteIntegration.order(:created_at).last
-            expect(Integrations::Aggregator::FetchTaxItemsJob).to have_received(:perform_later).with(integration:)
-          end
         end
 
         context 'with validation error' do


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR handles following issues:

1. When connection is created or updated we are triggering sync of all resources between our aggregator and Netsuite. After we receive the success response we want to start the services for importing items and tax items from aggregator. That being said, from now on, the jobs for importing items should be part of sync service since it can take a lot of time to be handled in the service.
2. When Re-fetch button is pressed in items dropdown (GRAPHQL MUTATION) , following actions should be performed: sync should be started between aggregator and Netsuite, we should import items / tax items. For this case it does not make sense to trigger sync of all resources. Instead, we should just trigger sync for the resource we are trying to import
