### PR TITLE
feat(custom_agg): Finalize aggregregation logic

### DIFF
--- a/app/models/cached_aggregation.rb
+++ b/app/models/cached_aggregation.rb
@@ -11,20 +11,4 @@ class CachedAggregation < ApplicationRecord
 
   scope :from_datetime, ->(from_datetime) { where('cached_aggregations.timestamp::timestamp(0) >= ?', from_datetime) }
   scope :to_datetime, ->(to_datetime) { where('cached_aggregations.timestamp::timestamp(0) <= ?', to_datetime) }
-
-  def current_aggregation_decimal
-    BigDecimal(current_aggregation.to_s)
-  end
-
-  def max_aggregation_decimal
-    BigDecimal(max_aggregation.to_s)
-  end
-
-  def units_applied_decimal
-    BigDecimal(units_applied.to_s)
-  end
-
-  def current_amount_decimal
-    BigDecimal(current_amount.to_s)
-  end
 end

--- a/app/models/cached_aggregation.rb
+++ b/app/models/cached_aggregation.rb
@@ -11,4 +11,20 @@ class CachedAggregation < ApplicationRecord
 
   scope :from_datetime, ->(from_datetime) { where('cached_aggregations.timestamp::timestamp(0) >= ?', from_datetime) }
   scope :to_datetime, ->(to_datetime) { where('cached_aggregations.timestamp::timestamp(0) <= ?', to_datetime) }
+
+  def current_aggregation_decimal
+    BigDecimal(current_aggregation.to_s)
+  end
+
+  def max_aggregation_decimal
+    BigDecimal(max_aggregation.to_s)
+  end
+
+  def units_applied_decimal
+    BigDecimal(units_applied.to_s)
+  end
+
+  def current_amount_decimal
+    BigDecimal(current_amount.to_s)
+  end
 end

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -45,6 +45,8 @@ module Charges
                           Charges::ChargeModels::PackageService
                         when :percentage
                           Charges::ChargeModels::PercentageService
+                        when :custom
+                          Charges::ChargeModels::CustomService
                         else
                           raise(NotImplementedError)
       end

--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -98,7 +98,10 @@ module Events
       end
 
       # NOTE: ensure event is processable
-      return if !billable_metric.count_agg? && event.properties[billable_metric.field_name].nil?
+      processable_event = billable_metric.count_agg? ||
+                          billable_metric.custom_agg? ||
+                          event.properties[billable_metric.field_name].present?
+      return unless processable_event
 
       charges.where(invoiceable: true).find_each do |charge|
         Invoices::CreatePayInAdvanceChargeJob.perform_later(charge:, event:, timestamp: event.timestamp)

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -140,6 +140,7 @@ module Fees
         charge_id: charge.id,
         charge_filter_id: charge_filter&.id,
         current_aggregation: aggregation_result.current_aggregation,
+        current_amount: aggregation_result.current_amount,
         max_aggregation: aggregation_result.max_aggregation,
         max_aggregation_with_proration: aggregation_result.max_aggregation_with_proration,
         grouped_by: format_grouped_by,

--- a/spec/scenarios/billable_metrics/custom_aggregation_spec.rb
+++ b/spec/scenarios/billable_metrics/custom_aggregation_spec.rb
@@ -55,11 +55,14 @@ RSpec.describe 'Aggregation - Custom Aggregation Scenarios', :scenarios, type: :
     RUBY
   end
 
+  let(:pay_in_advance) { false }
+
   let(:standard_charge) do
     create(
       :standard_charge,
       billable_metric:,
       plan:,
+      pay_in_advance:,
       properties: {
         amount: '2',
         custom_properties: {
@@ -78,6 +81,7 @@ RSpec.describe 'Aggregation - Custom Aggregation Scenarios', :scenarios, type: :
       :custom_charge,
       billable_metric:,
       plan:,
+      pay_in_advance:,
       properties: {
         custom_properties: {
           ranges: [
@@ -95,79 +99,203 @@ RSpec.describe 'Aggregation - Custom Aggregation Scenarios', :scenarios, type: :
     custom_charge
   end
 
-  it 'create fees for each charges' do
-    travel_to(DateTime.new(2024, 2, 1)) do
-      create_subscription(
-        {
-          external_customer_id: customer.external_id,
-          external_id: customer.external_id,
-          plan_code: plan.code,
-        },
-      )
-    end
-
-    subscription = customer.subscriptions.first
-
-    travel_to(DateTime.new(2024, 2, 6, 1)) do
-      create_event(
-        {
-          code: billable_metric.code,
-          transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
-          external_subscription_id: subscription.external_id,
-          properties: {
-            value: 1,
-            storage_zone: 'storage_eu',
+  context 'when in arrears aggregation' do
+    it 'create fees for each charges' do
+      travel_to(DateTime.new(2024, 2, 1)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
           },
-        },
-      )
-
-      fetch_current_usage(customer:)
-      expect(json[:customer_usage][:total_amount_cents]).to eq(200)
-      expect(json[:customer_usage][:charges_usage].count).to eq(2)
-
-      standard_usage = json[:customer_usage][:charges_usage].find do |cu|
-        cu[:charge][:charge_model] == 'standard'
+        )
       end
-      expect(standard_usage[:units]).to eq('1.0')
-      expect(standard_usage[:amount_cents]).to eq(200)
 
-      custom_usage = json[:customer_usage][:charges_usage].find do |cu|
-        cu[:charge][:charge_model] == 'custom'
-      end
-      expect(custom_usage[:units]).to eq('1.0')
-      expect(custom_usage[:amount_cents]).to eq(0)
-    end
+      subscription = customer.subscriptions.first
 
-    travel_to(DateTime.new(2024, 2, 6, 1)) do
-      create_event(
-        {
-          code: billable_metric.code,
-          transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
-          external_subscription_id: subscription.external_id,
-          properties: {
-            value: 10,
-            storage_zone: 'storage_asia',
+      travel_to(DateTime.new(2024, 2, 6, 1)) do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: {
+              value: 1,
+              storage_zone: 'storage_eu',
+            },
           },
-        },
-      )
+        )
 
-      fetch_current_usage(customer:)
-      expect(json[:customer_usage][:total_amount_cents]).to eq(2_230)
-      expect(json[:customer_usage][:charges_usage].count).to eq(2)
+        fetch_current_usage(customer:)
+        expect(json[:customer_usage][:total_amount_cents]).to eq(200)
+        expect(json[:customer_usage][:charges_usage].count).to eq(2)
 
-      standard_usage = json[:customer_usage][:charges_usage].find do |cu|
-        cu[:charge][:charge_model] == 'standard'
+        standard_usage = json[:customer_usage][:charges_usage].find do |cu|
+          cu[:charge][:charge_model] == 'standard'
+        end
+        expect(standard_usage[:units]).to eq('1.0')
+        expect(standard_usage[:amount_cents]).to eq(200)
+
+        custom_usage = json[:customer_usage][:charges_usage].find do |cu|
+          cu[:charge][:charge_model] == 'custom'
+        end
+        expect(custom_usage[:units]).to eq('1.0')
+        expect(custom_usage[:amount_cents]).to eq(0)
       end
-      expect(standard_usage[:units]).to eq('11.0')
-      expect(standard_usage[:amount_cents]).to eq(2_200)
 
-      custom_usage = json[:customer_usage][:charges_usage].find do |cu|
-        cu[:charge][:charge_model] == 'custom'
+      travel_to(DateTime.new(2024, 2, 6, 2)) do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: {
+              value: 10,
+              storage_zone: 'storage_asia',
+            },
+          },
+        )
+
+        fetch_current_usage(customer:)
+        expect(json[:customer_usage][:total_amount_cents]).to eq(2_230)
+        expect(json[:customer_usage][:charges_usage].count).to eq(2)
+
+        standard_usage = json[:customer_usage][:charges_usage].find do |cu|
+          cu[:charge][:charge_model] == 'standard'
+        end
+        expect(standard_usage[:units]).to eq('11.0')
+        expect(standard_usage[:amount_cents]).to eq(2_200)
+
+        custom_usage = json[:customer_usage][:charges_usage].find do |cu|
+          cu[:charge][:charge_model] == 'custom'
+        end
+        expect(custom_usage[:units]).to eq('11.0')
+        expect(custom_usage[:amount_cents]).to eq(30)
       end
-      expect(custom_usage[:units]).to eq('11.0')
-      expect(custom_usage[:amount_cents]).to eq(30)
+    end
+  end
+
+  context 'when in advance aggregation' do
+    let(:pay_in_advance) { true }
+
+    it 'creates a fee per events' do
+      travel_to(DateTime.new(2024, 2, 1)) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: customer.external_id,
+            plan_code: plan.code,
+          },
+        )
+      end
+
+      subscription = customer.subscriptions.first
+
+      travel_to(DateTime.new(2024, 2, 6, 1)) do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: {
+              value: 1,
+              storage_zone: 'storage_eu',
+            },
+          },
+        )
+
+        perform_all_enqueued_jobs
+
+        expect(subscription.fees.count).to eq(2)
+        expect(CachedAggregation.where(organization_id: organization.id).count).to eq(2)
+
+        standard_fee = subscription.fees.find_by(charge: standard_charge)
+        expect(standard_fee.amount_cents).to eq(200)
+        expect(standard_fee.events_count).to eq(1)
+        expect(standard_fee.units).to eq(1)
+
+        custom_fee = subscription.fees.find_by(charge: custom_charge)
+        expect(custom_fee.amount_cents).to eq(0)
+        expect(custom_fee.events_count).to eq(1)
+        expect(custom_fee.units).to eq(1)
+      end
+
+      travel_to(DateTime.new(2024, 2, 6, 2)) do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: {
+              value: 10,
+              storage_zone: 'storage_asia',
+            },
+          },
+        )
+
+        expect(subscription.fees.count).to eq(4)
+        expect(CachedAggregation.where(organization_id: organization.id).count).to eq(4)
+
+        standard_fee = subscription.fees.order(created_at: :desc).where(charge: standard_charge).first
+        expect(standard_fee.amount_cents).to eq(2000)
+        expect(standard_fee.events_count).to eq(1)
+        expect(standard_fee.units).to eq(10)
+
+        custom_fee = subscription.fees.order(created_at: :desc).where(charge: custom_charge).first
+        expect(custom_fee.amount_cents).to eq(30)
+        expect(custom_fee.events_count).to eq(1)
+        expect(custom_fee.units).to eq(10)
+      end
+
+      travel_to(DateTime.new(2024, 2, 6, 3)) do
+        create_event(
+          {
+            code: billable_metric.code,
+            transaction_id: SecureRandom.uuid,
+            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
+            properties: {
+              value: 20,
+              storage_zone: 'storage_us',
+            },
+          },
+        )
+
+        expect(subscription.fees.count).to eq(6)
+        expect(CachedAggregation.where(organization_id: organization.id).count).to eq(6)
+
+        standard_fee = subscription.fees.order(created_at: :desc).where(charge: standard_charge).first
+        expect(standard_fee.amount_cents).to eq(4000)
+        expect(standard_fee.events_count).to eq(1)
+        expect(standard_fee.units).to eq(20)
+
+        custom_fee = subscription.fees.order(created_at: :desc).where(charge: custom_charge).first
+        expect(custom_fee.amount_cents).to eq(330)
+        expect(custom_fee.events_count).to eq(1)
+        expect(custom_fee.units).to eq(20)
+      end
+
+      travel_to(DateTime.new(2024, 2, 6, 4)) do
+        fetch_current_usage(customer:)
+        expect(json[:customer_usage][:total_amount_cents]).to eq(6_560)
+        expect(json[:customer_usage][:charges_usage].count).to eq(2)
+
+        standard_usage = json[:customer_usage][:charges_usage].find do |cu|
+          cu[:charge][:charge_model] == 'standard'
+        end
+        expect(standard_usage[:units]).to eq('31.0')
+        expect(standard_usage[:amount_cents]).to eq(6_200)
+
+        custom_usage = json[:customer_usage][:charges_usage].find do |cu|
+          cu[:charge][:charge_model] == 'custom'
+        end
+        expect(custom_usage[:units]).to eq('31.0')
+        expect(custom_usage[:amount_cents]).to eq(360)
+      end
     end
   end
 end

--- a/spec/services/billable_metrics/aggregations/custom_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/custom_service_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe BillableMetrics::Aggregations::CustomService, type: :service do
   end
 
   let(:event_store_class) { Events::Stores::PostgresStore }
-  let(:filters) { { grouped_by:, matching_filters:, ignored_filters: } }
+  let(:filters) { { grouped_by:, matching_filters:, ignored_filters:, event: } }
 
   let(:subscription) { create(:subscription) }
   let(:organization) { subscription.organization }
@@ -26,6 +26,7 @@ RSpec.describe BillableMetrics::Aggregations::CustomService, type: :service do
   let(:grouped_by) { nil }
   let(:matching_filters) { nil }
   let(:ignored_filters) { nil }
+  let(:event) { nil }
 
   let(:billable_metric) do
     create(:custom_billable_metric, organization:, custom_aggregator:)
@@ -148,6 +149,70 @@ RSpec.describe BillableMetrics::Aggregations::CustomService, type: :service do
       expect(result.count).to eq(0)
       expect(result.options).to eq({})
       expect(result.custom_aggregation).to eq({ total_units: 0, amount: 0 })
+    end
+  end
+
+  context 'when the charge is payed in advance' do
+    let(:charge) { create(:standard_charge, billable_metric:, properties: charge_properties, pay_in_advance: true) }
+
+    let(:event_list) do
+      [
+        create(
+          :event,
+          organization_id: organization.id,
+          code: billable_metric.code,
+          subscription:,
+          customer:,
+          timestamp: Time.zone.now - 4.days,
+          properties: { value: 11, storage_zone: 'storage_eu' },
+        ),
+      ]
+    end
+    let(:event) { event_list.first }
+
+    it 'aggregates the events', :aggregate_failures do
+      result = custom_service.aggregate
+
+      expect(result.aggregation).to eq(11)
+      expect(result.count).to eq(1)
+      expect(result.options).to eq({})
+      expect(result.custom_aggregation).to eq({ total_units: 11.0, amount: 0.1 })
+
+      expect(result.pay_in_advance_aggregation).to eq(11)
+      expect(result.current_aggregation).to eq(11.0)
+      expect(result.max_aggregation).to eq(11.0)
+      expect(result.units_applied).to eq(11.0)
+      expect(result.current_amount).to eq(0.1)
+    end
+
+    context 'with a cached aggregation' do
+      before do
+        create(
+          :cached_aggregation,
+          organization:,
+          charge:,
+          external_subscription_id: subscription.external_id,
+          timestamp: Time.zone.now - 4.days,
+          current_aggregation: 11.0,
+          max_aggregation: 11.0,
+          current_amount: 0.1,
+        )
+      end
+
+      it 'aggregates the events with the cached aggregation', :aggregate_failures do
+        result = custom_service.aggregate
+
+        expect(result.aggregation).to eq(11)
+        expect(result.count).to eq(1)
+        expect(result.options).to eq({})
+        expect(result.custom_aggregation).to eq({ total_units: 11.0, amount: 0.4 })
+
+        expect(result.pay_in_advance_aggregation).to eq(11)
+        expect(result.current_aggregation).to eq(22.0)
+        expect(result.max_aggregation).to eq(22.0)
+        expect(result.units_applied).to eq(11.0)
+        expect(result.current_amount).to eq(0.5)
+      end
     end
   end
 end

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -242,6 +242,20 @@ RSpec.describe Fees::ChargeService do
               expect(result.quantified_events.count).to eq(2)
             end
           end
+
+          context 'with custom aggregation' do
+            let(:billable_metric) do
+              create(:custom_aggregation_billable_metric, organization:)
+
+              it 'creates a fee and a cached aggregation' do
+                result = charge_subscription_service.create
+                expect(result).to be_success
+
+                expect(result.fees.count).to eq(2)
+                expect(result.cached_aggregation.count).to eq(2)
+              end
+            end
+          end
         end
       end
 

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -353,6 +353,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
           expect(cached_aggregation.external_subscription_id).to eq(event.external_subscription_id)
           expect(cached_aggregation.charge_filter_id).to be_nil
           expect(cached_aggregation.current_aggregation).to eq(9)
+          expect(cached_aggregation.current_amount).to be_nil
           expect(cached_aggregation.max_aggregation).to eq(9)
           expect(cached_aggregation.max_aggregation_with_proration).to be_nil
           expect(cached_aggregation.grouped_by).to eq({})


### PR DESCRIPTION
## Context

Some of our customers have express a need for aggregation and charge models that does not fit into the current logic in place in Lago, like for example having a single aggregation for 2 different properties, but make the price per unit changing based on the position of the event.

This feature aims to propose a way to build custom aggregation logic for specific cases.

## Description

This PR adds the aggregation logic for recurring, current usage and pay in advance flows
