### PR TITLE
feat(wallet): Ability to create a voided wallet transaction

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -53,6 +53,7 @@ module Api
           :wallet_id,
           :paid_credits,
           :granted_credits,
+          :voided_credits,
         )
       end
     end

--- a/app/graphql/mutations/wallet_transactions/create.rb
+++ b/app/graphql/mutations/wallet_transactions/create.rb
@@ -11,9 +11,11 @@ module Mutations
       graphql_name 'CreateCustomerWalletTransaction'
       description 'Creates a new Customer Wallet Transaction'
 
-      argument :granted_credits, String, required: true
-      argument :paid_credits, String, required: true
       argument :wallet_id, ID, required: true
+
+      argument :granted_credits, String, required: false
+      argument :paid_credits, String, required: false
+      argument :voided_credits, String, required: false
 
       type Types::WalletTransactions::Object.collection_type
 

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -34,6 +34,7 @@ class SendWebhookJob < ApplicationJob
     'subscription.trial_ended' => Webhooks::Subscriptions::TrialEndedService,
     'wallet.depleted_ongoing_balance' => Webhooks::Wallets::DepletedOngoingBalanceService,
     'wallet_transaction.created' => Webhooks::WalletTransactions::CreatedService,
+    'wallet_transaction.updated' => Webhooks::WalletTransactions::UpdatedService,
   }.freeze
 
   def perform(webhook_type, object, options = {}, webhook_id = nil)

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -15,6 +15,7 @@ class WalletTransaction < ApplicationRecord
     :purchased,
     :granted,
     :voided,
+    :invoiced,
   ].freeze
 
   TRANSACTION_TYPES = [

--- a/app/services/credits/applied_prepaid_credit_service.rb
+++ b/app/services/credits/applied_prepaid_credit_service.rb
@@ -25,7 +25,7 @@ module Credits
           credit_amount:,
           status: :settled,
           settled_at: Time.current,
-          transaction_status: :purchased,
+          transaction_status: :invoiced,
         )
 
         result.wallet_transaction = wallet_transaction

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -29,6 +29,15 @@ module WalletTransactions
         wallet_transactions << transaction
       end
 
+      if params[:voided_credits]
+        void_result = WalletTransactions::VoidService.call(
+          wallet: result.current_wallet,
+          credits: params[:voided_credits],
+          from_source: source,
+        )
+        wallet_transactions << void_result.wallet_transaction
+      end
+
       transactions = wallet_transactions.compact
       if organization.webhook_endpoints.any?
         transactions.each { |wt| SendWebhookJob.perform_later('wallet_transaction.created', wt.reload) }

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -99,7 +99,10 @@ module WalletTransactions
     end
 
     def valid?
-      WalletTransactions::ValidateService.new(result, **params.merge(organization_id: organization.id)).valid?
+      WalletTransactions::ValidateService.new(
+        result,
+        **params.merge(organization_id: organization.id),
+      ).valid?
     end
   end
 end

--- a/app/services/wallet_transactions/settle_service.rb
+++ b/app/services/wallet_transactions/settle_service.rb
@@ -10,6 +10,7 @@ module WalletTransactions
 
     def call
       wallet_transaction.update!(status: :settled, settled_at: Time.current)
+      SendWebhookJob.perform_later('wallet_transaction.updated', wallet_transaction)
 
       result.wallet_transaction = wallet_transaction
       result

--- a/app/services/wallet_transactions/validate_service.rb
+++ b/app/services/wallet_transactions/validate_service.rb
@@ -6,6 +6,7 @@ module WalletTransactions
       valid_wallet?
       valid_paid_credits_amount? if args[:paid_credits]
       valid_granted_credits_amount? if args[:granted_credits]
+      valid_voided_credits_amount? if args[:voided_credits] && result.current_wallet
 
       if errors?
         result.validation_failure!(errors:)
@@ -38,6 +39,18 @@ module WalletTransactions
       return true if ::Validators::DecimalAmountService.new(args[:granted_credits]).valid_amount?
 
       add_error(field: :granted_credits, error_code: 'invalid_granted_credits')
+    end
+
+    def valid_voided_credits_amount?
+      unless ::Validators::DecimalAmountService.new(args[:voided_credits]).valid_amount?
+        return add_error(field: :voided_credits, error_code: 'invalid_voided_credits')
+      end
+
+      if BigDecimal(args[:voided_credits]) > result.current_wallet.credits_balance
+        return add_error(field: :voided_credits, error_code: 'insufficient_credits')
+      end
+
+      true
     end
   end
 end

--- a/app/services/wallet_transactions/void_service.rb
+++ b/app/services/wallet_transactions/void_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module WalletTransactions
+  class VoidService < BaseService
+    def initialize(wallet:, credits:, from_source: :manual)
+      @wallet = wallet
+      @credits = credits
+      @from_source = from_source
+
+      super
+    end
+
+    def call
+      return if credits_amount.zero?
+
+      ActiveRecord::Base.transaction do
+        wallet_transaction = wallet.wallet_transactions.create!(
+          transaction_type: :outbound,
+          amount: wallet.rate_amount * credits_amount,
+          credit_amount: credits_amount,
+          status: :settled,
+          settled_at: Time.current,
+          source: from_source,
+          transaction_status: :voided,
+        )
+        Wallets::Balance::DecreaseService.new(wallet:, credits_amount:).call
+        result.wallet_transaction = wallet_transaction
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :wallet, :credits, :from_source
+
+    def credits_amount
+      @credits_amount ||= BigDecimal(credits)
+    end
+  end
+end

--- a/app/services/webhooks/invoices/payment_status_updated_service.rb
+++ b/app/services/webhooks/invoices/payment_status_updated_service.rb
@@ -11,7 +11,7 @@ module Webhooks
         ::V1::InvoiceSerializer.new(
           object,
           root_name: 'invoice',
-          includes: %i[customer],
+          includes: %i[customer fees],
         )
       end
 

--- a/app/services/webhooks/wallet_transactions/updated_service.rb
+++ b/app/services/webhooks/wallet_transactions/updated_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module WalletTransactions
+    class UpdatedService < Webhooks::BaseService
+      private
+
+      def current_organization
+        @current_organization ||= object.wallet.organization
+      end
+
+      def object_serializer
+        ::V1::WalletTransactionSerializer.new(object, root_name: 'wallet_transaction')
+      end
+
+      def webhook_type
+        'wallet_transaction.updated'
+      end
+
+      def object_type
+        'wallet_transaction'
+      end
+    end
+  end
+end

--- a/db/migrate/20240430133150_add_invoiced_to_transaction_status.rb
+++ b/db/migrate/20240430133150_add_invoiced_to_transaction_status.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddInvoicedToTransactionStatus < ActiveRecord::Migration[7.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Set existing wallet transactions as invoiced when transaction_type is outbound.
+        execute <<-SQL
+          UPDATE wallet_transactions
+            SET transaction_status = 3 -- invoiced
+            WHERE transaction_type = 1; -- outbound
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_29_141108) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_30_133150) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/seeds/base.rb
+++ b/db/seeds/base.rb
@@ -220,7 +220,7 @@ Wallet.create!(
     amount: BigDecimal('10.00'),
     credit_amount: BigDecimal('10.00'),
     settled_at: Time.zone.now,
-    transaction_status: :purchased,
+    transaction_status: :invoiced,
   )
 end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -6953,6 +6953,7 @@ enum WalletTransactionStatusEnum {
 
 enum WalletTransactionTransactionStatusEnum {
   granted
+  invoiced
   purchased
   voided
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -1811,8 +1811,9 @@ input CreateCustomerWalletTransactionInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  grantedCredits: String!
-  paidCredits: String!
+  grantedCredits: String
+  paidCredits: String
+  voidedCredits: String
   walletId: ID!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -6712,38 +6712,6 @@
               "deprecationReason": null
             },
             {
-              "name": "grantedCredits",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "paidCredits",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "walletId",
               "description": null,
               "type": {
@@ -6754,6 +6722,42 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "grantedCredits",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paidCredits",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "voidedCredits",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -34148,6 +34148,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "invoiced",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/graphql/mutations/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/wallet_transactions/create_spec.rb
@@ -44,11 +44,7 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
     )
 
     result_data = result['data']['createCustomerWalletTransaction']
-
-    aggregate_failures do
-      expect(result_data['collection'].count).to eq(2)
-      expect(result_data['collection'].first['status']).to eq('pending')
-      expect(result_data['collection'].last['status']).to eq('settled')
-    end
+    expect(result_data['collection'].map { |wt| wt['status'] })
+      .to contain_exactly('pending', 'settled')
   end
 end

--- a/spec/services/credits/applied_prepaid_credit_service_spec.rb
+++ b/spec/services/credits/applied_prepaid_credit_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Credits::AppliedPrepaidCreditService do
       expect(result).to be_success
       expect(result.wallet_transaction).to be_present
       expect(result.wallet_transaction.amount).to eq(1.0)
-      expect(result.wallet_transaction).to be_purchased
+      expect(result.wallet_transaction).to be_invoiced
     end
 
     it 'updates wallet balance' do

--- a/spec/services/wallet_transactions/settle_service_spec.rb
+++ b/spec/services/wallet_transactions/settle_service_spec.rb
@@ -14,5 +14,11 @@ RSpec.describe WalletTransactions::SettleService, type: :service do
       }.to change { wallet_transaction.reload.status }.from('pending').to('settled')
         .and change(wallet_transaction, :settled_at).from(nil)
     end
+
+    it 'enqueues a SendWebhookJob for each wallet transaction' do
+      expect do
+        service.call
+      end.to have_enqueued_job(SendWebhookJob).with('wallet_transaction.updated', WalletTransaction)
+    end
   end
 end

--- a/spec/services/wallet_transactions/validate_service_spec.rb
+++ b/spec/services/wallet_transactions/validate_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
   let(:wallet_id) { wallet.id }
   let(:paid_credits) { '1.00' }
   let(:granted_credits) { '0.00' }
+  let(:voided_credits) { '0.00' }
   let(:args) do
     {
       wallet_id:,
@@ -21,6 +22,7 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
       organization_id: organization.id,
       paid_credits:,
       granted_credits:,
+      voided_credits:,
     }
   end
 
@@ -55,6 +57,24 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
         expect(result.error.messages[:granted_credits]).to eq(['invalid_granted_credits'])
+      end
+    end
+
+    context 'with invalid voided_credits' do
+      let(:voided_credits) { 'foobar' }
+
+      it 'returns false and result has errors' do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:voided_credits]).to eq(['invalid_voided_credits'])
+      end
+    end
+
+    context 'with valid voided_credits but insufficient credits' do
+      let(:voided_credits) { '1.00' }
+
+      it 'returns false and result has errors' do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:voided_credits]).to eq(['insufficient_credits'])
       end
     end
   end

--- a/spec/services/wallet_transactions/void_service_spec.rb
+++ b/spec/services/wallet_transactions/void_service_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe WalletTransactions::VoidService, type: :service do
+  subject(:void_service) { described_class.call(wallet:, credits:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, customer:) }
+  let(:wallet) do
+    create(
+      :wallet,
+      customer:,
+      balance_cents: 1000,
+      credits_balance: 10.0,
+      ongoing_balance_cents: 1000,
+      credits_ongoing_balance: 10.0,
+    )
+  end
+  let(:credits) { '10.00' }
+
+  before do
+    subscription
+  end
+
+  describe '#call' do
+    context 'when credits amount is zero' do
+      let(:credits) { '0.00' }
+
+      it 'does not create a wallet transaction' do
+        expect { void_service }.not_to change(WalletTransaction, :count)
+      end
+    end
+
+    it 'creates a wallet transaction' do
+      expect { void_service }.to change(WalletTransaction, :count).by(1)
+    end
+
+    it 'sets expected attributes' do
+      freeze_time do
+        result = void_service
+        expect(result.wallet_transaction).to have_attributes(
+          amount: 10,
+          credit_amount: 10,
+          transaction_type: 'outbound',
+          status: 'settled',
+          source: 'manual',
+          transaction_status: 'voided',
+          settled_at: Time.current,
+        )
+      end
+    end
+
+    it 'updates wallet balance' do
+      result = void_service
+      wallet = result.wallet_transaction.wallet
+
+      expect(wallet.balance_cents).to eq(0)
+      expect(wallet.credits_balance).to eq(0.0)
+    end
+  end
+end

--- a/spec/services/webhooks/wallet_transactions/updated_service_spec.rb
+++ b/spec/services/webhooks/wallet_transactions/updated_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::WalletTransactions::UpdatedService do
+  subject(:webhook_service) { described_class.new(object: wallet_transaction) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:wallet) { create(:wallet, customer:) }
+  let(:wallet_transaction) { create(:wallet_transaction, wallet:) }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response)
+    end
+
+    it 'builds payload with wallet_transaction.updated webhook type' do
+      webhook_service.call
+
+      expect(LagoHttpClient::Client).to have_received(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+
+      expect(lago_client).to have_received(:post_with_response) do |payload|
+        expect(payload[:webhook_type]).to eq('wallet_transaction.updated')
+        expect(payload[:object_type]).to eq('wallet_transaction')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to create a voided wallet transaction.