### PR TITLE
feat(rbac): Add permissions to resolvers

### DIFF
--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -29,6 +29,7 @@ customers:
   update:
   delete:
 subscriptions:
+  view:
   create:
   update:
   delete:

--- a/app/graphql/resolvers/add_on_resolver.rb
+++ b/app/graphql/resolvers/add_on_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'addons:view'
+
     description 'Query a single add-on of an organization'
 
     argument :id, ID, required: true, description: 'Uniq ID of the add-on'

--- a/app/graphql/resolvers/add_ons_resolver.rb
+++ b/app/graphql/resolvers/add_ons_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'addons:view'
+
     description 'Query add-ons of an organization'
 
     argument :ids, [ID], required: false, description: 'List of add-ons IDs to fetch'

--- a/app/graphql/resolvers/billable_metric_resolver.rb
+++ b/app/graphql/resolvers/billable_metric_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'billable_metrics:view'
+
     description 'Query a single billable metric of an organization'
 
     argument :id, ID, required: true, description: 'Uniq ID of the billable metric'

--- a/app/graphql/resolvers/billable_metrics_resolver.rb
+++ b/app/graphql/resolvers/billable_metrics_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'billable_metrics:view'
+
     description 'Query billable metrics of an organization'
 
     argument :ids, [String], required: false, description: 'List of plan ID to fetch'

--- a/app/graphql/resolvers/coupon_resolver.rb
+++ b/app/graphql/resolvers/coupon_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'coupons:view'
+
     description 'Query a single coupon of an organization'
 
     argument :id, ID, required: true, description: 'Uniq ID of the coupon'

--- a/app/graphql/resolvers/coupons_resolver.rb
+++ b/app/graphql/resolvers/coupons_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'coupons:view'
+
     description 'Query coupons of an organization'
 
     argument :ids, [ID], required: false, description: 'List of coupon IDs to fetch'

--- a/app/graphql/resolvers/credit_note_resolver.rb
+++ b/app/graphql/resolvers/credit_note_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'credit_notes:view'
+
     description 'Query a single credit note'
 
     argument :id, ID, required: true, description: 'Uniq ID of the credit note'

--- a/app/graphql/resolvers/customer_credit_notes_resolver.rb
+++ b/app/graphql/resolvers/customer_credit_notes_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'customers:view'
+
     description "Query customer's credit note"
 
     argument :customer_id, ID, required: true, description: 'Uniq ID of the customer'

--- a/app/graphql/resolvers/customer_resolver.rb
+++ b/app/graphql/resolvers/customer_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'customers:view'
+
     description 'Query a single customer of an organization'
 
     argument :id, ID, required: true, description: 'Uniq ID of the customer'

--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -6,6 +6,8 @@ module Resolvers
       include AuthenticableApiUser
       include RequiredOrganization
 
+      REQUIRED_PERMISSION = 'invoices:view'
+
       description 'Query invoices of a customer'
 
       argument :customer_id, type: ID, required: true

--- a/app/graphql/resolvers/customers/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/customers/subscriptions_resolver.rb
@@ -3,6 +3,8 @@
 module Resolvers
   module Customers
     class SubscriptionsResolver < Resolvers::BaseResolver
+      REQUIRED_PERMISSION = 'customers:view'
+
       description 'Query subscriptions of a customer'
 
       argument :status, [Types::Subscriptions::StatusTypeEnum], required: false do

--- a/app/graphql/resolvers/customers/usage_resolver.rb
+++ b/app/graphql/resolvers/customers/usage_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     class UsageResolver < Resolvers::BaseResolver
       include AuthenticableApiUser
 
+      REQUIRED_PERMISSION = 'customers:view'
+
       description 'Query the usage of the customer on the current billing period'
 
       argument :customer_id, type: ID, required: false

--- a/app/graphql/resolvers/customers_resolver.rb
+++ b/app/graphql/resolvers/customers_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'customers:view'
+
     description 'Query customers of an organization'
 
     argument :ids, [String], required: false, description: 'List of customer Lago ID to fetch'

--- a/app/graphql/resolvers/integration_collection_mappings/netsuite_collection_mapping_resolver.rb
+++ b/app/graphql/resolvers/integration_collection_mappings/netsuite_collection_mapping_resolver.rb
@@ -6,6 +6,8 @@ module Resolvers
       include AuthenticableApiUser
       include RequiredOrganization
 
+      REQUIRED_PERMISSION = 'organization:integrations:view'
+
       description 'Query a single integration collection mapping'
 
       argument :id, ID, required: true, description: 'Unique ID of the integration collection mappings'

--- a/app/graphql/resolvers/integration_collection_mappings/netsuite_collection_mappings_resolver.rb
+++ b/app/graphql/resolvers/integration_collection_mappings/netsuite_collection_mappings_resolver.rb
@@ -6,6 +6,8 @@ module Resolvers
       include AuthenticableApiUser
       include RequiredOrganization
 
+      REQUIRED_PERMISSION = 'organization:integrations:view'
+
       description 'Query netsuite integration collection mappings'
 
       argument :integration_id, ID, required: false

--- a/app/graphql/resolvers/integration_items_resolver.rb
+++ b/app/graphql/resolvers/integration_items_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'organization:integrations:view'
+
     description 'Query integration items of an integration'
 
     argument :integration_id, ID, required: true

--- a/app/graphql/resolvers/integration_mappings/netsuite_mapping_resolver.rb
+++ b/app/graphql/resolvers/integration_mappings/netsuite_mapping_resolver.rb
@@ -6,6 +6,8 @@ module Resolvers
       include AuthenticableApiUser
       include RequiredOrganization
 
+      REQUIRED_PERMISSION = 'organization:integrations:view'
+
       description 'Query a single integration mapping'
 
       argument :id, ID, required: true, description: 'Unique ID of the integration mappings'

--- a/app/graphql/resolvers/integration_mappings/netsuite_mappings_resolver.rb
+++ b/app/graphql/resolvers/integration_mappings/netsuite_mappings_resolver.rb
@@ -6,6 +6,8 @@ module Resolvers
       include AuthenticableApiUser
       include RequiredOrganization
 
+      REQUIRED_PERMISSION = 'organization:integrations:view'
+
       description 'Query netsuite integration mappings'
 
       argument :integration_id, ID, required: false

--- a/app/graphql/resolvers/integration_resolver.rb
+++ b/app/graphql/resolvers/integration_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'organization:integrations:view'
+
     description 'Query a single integration'
 
     argument :id, ID, required: false, description: 'Uniq ID of the integration'

--- a/app/graphql/resolvers/integrations/subsidiaries_resolver.rb
+++ b/app/graphql/resolvers/integrations/subsidiaries_resolver.rb
@@ -6,6 +6,8 @@ module Resolvers
       include AuthenticableApiUser
       include RequiredOrganization
 
+      REQUIRED_PERMISSION = 'organization:integrations:view'
+
       description 'Query integration subsidiaries'
 
       argument :integration_id, ID, required: false

--- a/app/graphql/resolvers/integrations_resolver.rb
+++ b/app/graphql/resolvers/integrations_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'organization:integrations:view'
+
     description "Query organization's integrations"
 
     argument :limit, Integer, required: false

--- a/app/graphql/resolvers/invoice_credit_notes_resolver.rb
+++ b/app/graphql/resolvers/invoice_credit_notes_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'credit_notes:view'
+
     description "Query invoice's credit note"
 
     argument :invoice_id, ID, required: true, description: 'Uniq ID of the invoice'

--- a/app/graphql/resolvers/invoice_resolver.rb
+++ b/app/graphql/resolvers/invoice_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'invoices:view'
+
     description 'Query a single Invoice of an organization'
 
     argument :id, ID, required: true, description: 'Uniq ID of the invoice'

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'invoices:view'
+
     description 'Query invoices'
 
     argument :ids, [ID], required: false, description: 'List of invoice IDs to fetch'

--- a/app/graphql/resolvers/payment_provider_resolver.rb
+++ b/app/graphql/resolvers/payment_provider_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'organization:integrations:view'
+
     description 'Query a single payment provider'
 
     argument :code, String, required: false, description: 'Code of the payment provider'

--- a/app/graphql/resolvers/payment_providers_resolver.rb
+++ b/app/graphql/resolvers/payment_providers_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'organization:integrations:view'
+
     description "Query organization's payment providers"
 
     argument :limit, Integer, required: false

--- a/app/graphql/resolvers/plan_resolver.rb
+++ b/app/graphql/resolvers/plan_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'plans:view'
+
     description 'Query a single plan of an organization'
 
     argument :id, ID, required: true, description: 'Uniq ID of the plan'

--- a/app/graphql/resolvers/plans_resolver.rb
+++ b/app/graphql/resolvers/plans_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'plans:view'
+
     description 'Query plans of an organization'
 
     argument :ids, [String], required: false, description: 'List of plan ID to fetch'

--- a/app/graphql/resolvers/subscription_resolver.rb
+++ b/app/graphql/resolvers/subscription_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'subscriptions:view'
+
     description 'Query a single subscription of an organization'
 
     argument :id, ID, required: true, description: 'Uniq ID of the subscription'

--- a/app/graphql/resolvers/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/subscriptions_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'subscriptions:view'
+
     description 'Query subscriptions of an organization'
 
     argument :limit, Integer, required: false

--- a/app/graphql/resolvers/webhook_endpoint_resolver.rb
+++ b/app/graphql/resolvers/webhook_endpoint_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'developers:manage'
+
     description 'Query a single webhook endpoint'
 
     argument :id, ID, required: true, description: 'Uniq ID of the webhook endpoint'

--- a/app/graphql/resolvers/webhook_endpoints_resolver.rb
+++ b/app/graphql/resolvers/webhook_endpoints_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'developers:manage'
+
     description 'Query webhook endpoints of an organization'
 
     argument :ids, [ID], required: false, description: 'List of webhook endpoint IDs to fetch'

--- a/app/graphql/resolvers/webhooks_resolver.rb
+++ b/app/graphql/resolvers/webhooks_resolver.rb
@@ -5,6 +5,8 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
+    REQUIRED_PERMISSION = 'developers:manage'
+
     description 'Query Webhooks'
 
     argument :limit, Integer, required: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -4885,6 +4885,7 @@ type Permissions {
   subscriptionsCreate: Boolean!
   subscriptionsDelete: Boolean!
   subscriptionsUpdate: Boolean!
+  subscriptionsView: Boolean!
   walletsCreate: Boolean!
   walletsTerminate: Boolean!
   walletsTopUp: Boolean!

--- a/schema.json
+++ b/schema.json
@@ -23489,6 +23489,24 @@
               ]
             },
             {
+              "name": "subscriptionsView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "walletsCreate",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/add_on_resolver_spec.rb
+++ b/spec/graphql/resolvers/add_on_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::AddOnResolver, type: :graphql do
+  let(:required_permission) { 'addons:view' }
   let(:query) do
     <<~GQL
       query($addOnId: ID!) {
@@ -32,10 +33,15 @@ RSpec.describe Resolvers::AddOnResolver, type: :graphql do
     end
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'addons:view'
+
   it 'returns a single add-on' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
       variables: { addOnId: add_on.id },
     )
@@ -50,23 +56,12 @@ RSpec.describe Resolvers::AddOnResolver, type: :graphql do
     end
   end
 
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query:,
-        variables: { addOnId: add_on.id },
-      )
-
-      expect_graphql_error(result:, message: 'Missing organization id')
-    end
-  end
-
   context 'when add-on is not found' do
     it 'returns an error' do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
         variables: { addOnId: 'invalid' },
       )

--- a/spec/graphql/resolvers/coupons_resolver_spec.rb
+++ b/spec/graphql/resolvers/coupons_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::CouponsResolver, type: :graphql do
+  let(:required_permission) { 'coupons:view' }
   let(:query) do
     <<~GQL
       query {
@@ -24,10 +25,15 @@ RSpec.describe Resolvers::CouponsResolver, type: :graphql do
     create(:coupon, organization:, status: :terminated)
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'coupons:view'
+
   it 'returns a list of coupons' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
     )
 
@@ -39,32 +45,6 @@ RSpec.describe Resolvers::CouponsResolver, type: :graphql do
 
       expect(coupons_response['metadata']['currentPage']).to eq(1)
       expect(coupons_response['metadata']['totalCount']).to eq(1)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(current_user: membership.user, query:)
-
-      expect_graphql_error(
-        result:,
-        message: 'Missing organization id',
-      )
-    end
-  end
-
-  context 'when not member of the organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: create(:organization),
-        query:,
-      )
-
-      expect_graphql_error(
-        result:,
-        message: 'Not in organization',
-      )
     end
   end
 end

--- a/spec/graphql/resolvers/credit_note_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_note_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::CreditNoteResolver, type: :graphql do
+  let(:required_permission) { 'credit_notes:view' }
   let(:query) do
     <<-GQL
       query($creditNoteId: ID!) {
@@ -51,10 +52,15 @@ RSpec.describe Resolvers::CreditNoteResolver, type: :graphql do
   let(:invoice) { create(:invoice, organization: membership.organization, customer:) }
   let(:credit_note) { create(:credit_note, customer:, invoice:) }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'credit_notes:view'
+
   it 'returns a single credit note' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: customer.organization,
+      permissions: required_permission,
       query:,
       variables: {
         creditNoteId: credit_note.id,

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
+  let(:required_permission) { 'customers:view' }
   let(:query) do
     <<~GQL
       query($customerId: ID!, $subscriptionId: ID!) {
@@ -121,10 +122,14 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
     )
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires permission', 'customers:view'
+
   it 'returns the usage for the customer' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
       variables: {
         customerId: customer.id,
@@ -230,6 +235,7 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
         variables: {
           customerId: customer.id,

--- a/spec/graphql/resolvers/customers_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::CustomersResolver, type: :graphql do
+  let(:required_permission) { 'customers:view' }
   let(:query) do
     <<~GQL
       query {
@@ -17,12 +18,17 @@ RSpec.describe Resolvers::CustomersResolver, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'customers:view'
+
   it 'returns a list of customers' do
     customer = create(:customer, organization:)
 
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
     )
 

--- a/spec/graphql/resolvers/integration_collection_mappings/netsuite_collection_mapping_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_collection_mappings/netsuite_collection_mapping_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappingResolver, type: :graphql do
+  let(:required_permission) { 'organization:integrations:view' }
   let(:query) do
     <<~GQL
       query($netsuiteCollectionMappingId: ID!) {
@@ -26,10 +27,15 @@ RSpec.describe Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappi
     netsuite_collection_mapping
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'organization:integrations:view'
+
   it 'returns a single integration collection mapping' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
       variables: { netsuiteCollectionMappingId: netsuite_collection_mapping.id },
     )
@@ -46,26 +52,12 @@ RSpec.describe Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappi
     end
   end
 
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query:,
-        variables: { netsuiteCollectionMappingId: netsuite_collection_mapping.id },
-      )
-
-      expect_graphql_error(
-        result:,
-        message: 'Missing organization id',
-      )
-    end
-  end
-
   context 'when integration mapping is not found' do
     it 'returns an error' do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
         variables: { netsuiteCollectionMappingId: '123456' },
       )

--- a/spec/graphql/resolvers/integration_collection_mappings/netsuite_collection_mappings_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_collection_mappings/netsuite_collection_mappings_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappingsResolver, type: :graphql do
+  let(:required_permission) { 'organization:integrations:view' }
   let(:query) do
     <<~GQL
       query {
@@ -21,10 +22,15 @@ RSpec.describe Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappi
 
   before { netsuite_collection_mapping }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'organization:integrations:view'
+
   it 'returns a list of netsuite mappings' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
     )
 
@@ -36,20 +42,6 @@ RSpec.describe Resolvers::IntegrationCollectionMappings::NetsuiteCollectionMappi
 
       expect(netsuite_collection_mappings_response['metadata']['currentPage']).to eq(1)
       expect(netsuite_collection_mappings_response['metadata']['totalCount']).to eq(1)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query:,
-      )
-
-      expect_graphql_error(
-        result:,
-        message: 'Missing organization id',
-      )
     end
   end
 end

--- a/spec/graphql/resolvers/integration_mappings/netsuite_mapping_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_mappings/netsuite_mapping_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::IntegrationMappings::NetsuiteMappingResolver, type: :graphql do
+  let(:required_permission) { 'organization:integrations:view' }
   let(:query) do
     <<~GQL
       query($netsuiteMappingId: ID!) {
@@ -27,10 +28,15 @@ RSpec.describe Resolvers::IntegrationMappings::NetsuiteMappingResolver, type: :g
     netsuite_mapping
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'organization:integrations:view'
+
   it 'returns a single integration mapping' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
       variables: { netsuiteMappingId: netsuite_mapping.id },
     )
@@ -48,26 +54,12 @@ RSpec.describe Resolvers::IntegrationMappings::NetsuiteMappingResolver, type: :g
     end
   end
 
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query:,
-        variables: { netsuiteMappingId: netsuite_mapping.id },
-      )
-
-      expect_graphql_error(
-        result:,
-        message: 'Missing organization id',
-      )
-    end
-  end
-
   context 'when integration mapping is not found' do
     it 'returns an error' do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
         variables: { netsuiteMappingId: '123456' },
       )

--- a/spec/graphql/resolvers/integration_mappings/netsuite_mappings_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_mappings/netsuite_mappings_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::IntegrationMappings::NetsuiteMappingsResolver, type: :graphql do
+  let(:required_permission) { 'organization:integrations:view' }
   let(:query) do
     <<~GQL
       query {
@@ -21,10 +22,15 @@ RSpec.describe Resolvers::IntegrationMappings::NetsuiteMappingsResolver, type: :
 
   before { netsuite_mapping }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'organization:integrations:view'
+
   it 'returns a list of netsuite mappings' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
     )
 
@@ -36,20 +42,6 @@ RSpec.describe Resolvers::IntegrationMappings::NetsuiteMappingsResolver, type: :
 
       expect(netsuite_mappings_response['metadata']['currentPage']).to eq(1)
       expect(netsuite_mappings_response['metadata']['totalCount']).to eq(1)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query:,
-      )
-
-      expect_graphql_error(
-        result:,
-        message: 'Missing organization id',
-      )
     end
   end
 end

--- a/spec/graphql/resolvers/integration_resolver_spec.rb
+++ b/spec/graphql/resolvers/integration_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::IntegrationResolver, type: :graphql do
+  let(:required_permission) { 'organization:integrations:view' }
   let(:query) do
     <<~GQL
       query($integrationId: ID!) {
@@ -29,10 +30,15 @@ RSpec.describe Resolvers::IntegrationResolver, type: :graphql do
     netsuite_integration
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'organization:integrations:view'
+
   it 'returns a single integration' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
       variables: { integrationId: netsuite_integration.id },
     )
@@ -47,26 +53,12 @@ RSpec.describe Resolvers::IntegrationResolver, type: :graphql do
     end
   end
 
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query:,
-        variables: { integrationId: netsuite_integration.id },
-      )
-
-      expect_graphql_error(
-        result:,
-        message: 'Missing organization id',
-      )
-    end
-  end
-
   context 'when integration is not found' do
     it 'returns an error' do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
         variables: { integrationId: 'foo' },
       )

--- a/spec/graphql/resolvers/invoice_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoice_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
+  let(:required_permission) { 'invoices:view' }
   let(:query) do
     <<~GQL
       query($id: ID!) {
@@ -96,10 +97,15 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
 
   before { fee and invoice }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'invoices:view'
+
   it 'returns a single invoice' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
       variables: {
         id: invoice.id,
@@ -131,6 +137,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
       variables: { id: invoice.id },
     )
@@ -144,6 +151,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: invoice.organization,
+        permissions: required_permission,
         query:,
         variables: {
           id: 'foo',
@@ -179,6 +187,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
         variables: {
           id: invoice.id,
@@ -210,6 +219,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
         variables: {
           id: invoice.id,
@@ -239,6 +249,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
         result = execute_graphql(
           current_user: membership.user,
           current_organization: organization,
+          permissions: required_permission,
           query:,
           variables: {
             id: invoice.id,
@@ -271,6 +282,7 @@ RSpec.describe Resolvers::InvoiceResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
         variables: {
           id: invoice.id,

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
+  let(:required_permission) { 'invoices:view' }
   let(:query) do
     <<~GQL
       query {
@@ -30,10 +31,15 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
     invoice_second
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'invoices:view'
+
   it 'returns all invoices' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
     )
 
@@ -66,6 +72,7 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
       )
 
@@ -102,6 +109,7 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
       )
 
@@ -157,6 +165,7 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: organization,
+        permissions: required_permission,
         query:,
       )
 
@@ -169,35 +178,6 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
         expect(invoices_response['metadata']['currentPage']).to eq(1)
         expect(invoices_response['metadata']['totalCount']).to eq(1)
       end
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        query:,
-      )
-
-      expect_graphql_error(
-        result:,
-        message: 'Missing organization id',
-      )
-    end
-  end
-
-  context 'when not member of the organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: create(:organization),
-        query:,
-      )
-
-      expect_graphql_error(
-        result:,
-        message: 'Not in organization',
-      )
     end
   end
 end

--- a/spec/graphql/resolvers/memberships_resolver_spec.rb
+++ b/spec/graphql/resolvers/memberships_resolver_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe Resolvers::MembershipsResolver, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+
   it 'returns a list of memberships' do
     result = execute_graphql(
       current_user: membership.user,

--- a/spec/graphql/resolvers/plans_resolver_spec.rb
+++ b/spec/graphql/resolvers/plans_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::PlansResolver, type: :graphql do
+  let(:required_permission) { 'plans:view' }
   let(:query) do
     <<~GQL
       query {
@@ -28,10 +29,15 @@ RSpec.describe Resolvers::PlansResolver, type: :graphql do
     end
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'plans:view'
+
   it 'returns a list of plans' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
     )
 
@@ -44,26 +50,6 @@ RSpec.describe Resolvers::PlansResolver, type: :graphql do
 
       expect(plans_response['metadata']['currentPage']).to eq(1)
       expect(plans_response['metadata']['totalCount']).to eq(1)
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(current_user: membership.user, query:)
-
-      expect_graphql_error(result:, message: 'Missing organization id')
-    end
-  end
-
-  context 'when not member of the organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: create(:organization),
-        query:,
-      )
-
-      expect_graphql_error(result:, message: 'Not in organization')
     end
   end
 end

--- a/spec/graphql/resolvers/webhook_endpoint_resolver_spec.rb
+++ b/spec/graphql/resolvers/webhook_endpoint_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::WebhookEndpointResolver, type: :graphql do
+  let(:required_permission) { 'developers:manage' }
   let(:query) do
     <<-GQL
       query($webhookEndpointId: ID!) {
@@ -25,10 +26,15 @@ RSpec.describe Resolvers::WebhookEndpointResolver, type: :graphql do
     organization.webhook_endpoints << webhook_endpoint
   end
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'developers:manage'
+
   it 'returns a single credit note' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
       variables: {
         webhookEndpointId: webhook_endpoint.id,

--- a/spec/graphql/resolvers/webhook_endpoints_resolver_spec.rb
+++ b/spec/graphql/resolvers/webhook_endpoints_resolver_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::WebhookEndpointsResolver, type: :graphql do
+  let(:required_permission) { 'developers:manage' }
   let(:query) do
     <<~GQL
       query {
@@ -17,10 +18,15 @@ RSpec.describe Resolvers::WebhookEndpointsResolver, type: :graphql do
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
 
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'developers:manage'
+
   it 'returns a list of webhook endpoints' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
+      permissions: required_permission,
       query:,
     )
 
@@ -36,26 +42,6 @@ RSpec.describe Resolvers::WebhookEndpointsResolver, type: :graphql do
         'currentPage' => 1,
         'totalCount' => 1,
       )
-    end
-  end
-
-  context 'without current organization' do
-    it 'returns an error' do
-      result = execute_graphql(current_user: membership.user, query:)
-
-      expect_graphql_error(result:, message: 'Missing organization id')
-    end
-  end
-
-  context 'when not member of the organization' do
-    it 'returns an error' do
-      result = execute_graphql(
-        current_user: membership.user,
-        current_organization: create(:organization),
-        query:,
-      )
-
-      expect_graphql_error(result:, message: 'Not in organization')
     end
   end
 end


### PR DESCRIPTION
## Context

Granular permissions are being added to Lago

## Description

Following #1926,  #1941 and #1952, this PR adds permissions to Resolvers.

Like in mutation, I have ignored the Organization resolver, it will be done separately because it will be using permissions per field.
