### PR TITLE
feat(custom_agg): Add flag to enable the feature

### DIFF
--- a/app/services/billable_metrics/create_service.rb
+++ b/app/services/billable_metrics/create_service.rb
@@ -3,9 +3,15 @@
 module BillableMetrics
   class CreateService < BaseService
     def create(args)
+      organization = Organization.find_by(id: args[:organization_id])
+
+      if args[:aggregation_type]&.to_sym == :custom_agg && !organization&.custom_aggregation
+        return result.forbidden_failure!
+      end
+
       ActiveRecord::Base.transaction do
         metric = BillableMetric.create!(
-          organization_id: args[:organization_id],
+          organization_id: organization&.id,
           name: args[:name],
           code: args[:code],
           description: args[:description],

--- a/app/services/billable_metrics/update_service.rb
+++ b/app/services/billable_metrics/update_service.rb
@@ -12,6 +12,12 @@ module BillableMetrics
     def call
       return result.not_found_failure!(resource: 'billable_metric') unless billable_metric
 
+      if params.key?(:aggregation_type) &&
+         params[:aggregation_type]&.to_sym == :custom_agg &&
+         !organization&.custom_aggregation
+        return result.forbidden_failure!
+      end
+
       billable_metric.name = params[:name] if params.key?(:name)
       billable_metric.description = params[:description] if params.key?(:description)
 
@@ -52,6 +58,8 @@ module BillableMetrics
     private
 
     attr_reader :billable_metric, :params
+
+    delegate :organization, to: :billable_metric
 
     def update_groups(metric, group_params)
       Groups::CreateOrUpdateBatchService.call(

--- a/db/migrate/20240429141108_add_custom_aggregation_to_organizations.rb
+++ b/db/migrate/20240429141108_add_custom_aggregation_to_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCustomAggregationToOrganizations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :organizations, :custom_aggregation, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_26_143059) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_29_141108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -752,6 +752,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_26_143059) do
     t.boolean "eu_tax_management", default: false
     t.boolean "clickhouse_aggregation", default: false, null: false
     t.string "premium_integrations", default: [], null: false, array: true
+    t.boolean "custom_aggregation", default: false
     t.index ["api_key"], name: "index_organizations_on_api_key", unique: true
     t.check_constraint "invoice_grace_period >= 0", name: "check_organizations_on_invoice_grace_period"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -132,5 +132,25 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
         end
       end
     end
+
+    context 'with custom aggregation' do
+      let(:create_args) do
+        {
+          name: 'New Metric',
+          code: 'new_metric',
+          description: 'New metric description',
+          organization_id: organization.id,
+          aggregation_type: 'custom_agg',
+          recurring: false,
+        }
+      end
+
+      it 'returns a forbidden failure' do
+        result = create_service.create(**create_args)
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+      end
+    end
   end
 end

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -129,6 +129,17 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
       end
     end
 
+    context 'with custom aggregation' do
+      let(:params) { { aggregation_type: 'custom_agg' } }
+
+      it 'returns a forbidden failure' do
+        result = update_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ForbiddenFailure)
+      end
+    end
+
     context 'when billable metric is linked to plan' do
       let(:plan) { create(:plan, organization:) }
       let(:charge) { create(:standard_charge, billable_metric:, plan:) }


### PR DESCRIPTION
## Context

Some of our customers have express a need for aggregation and charge models that does not fit into the current logic in place in Lago, like for example having a single aggregation for 2 different properties, but make the price per unit changing based on the position of the event.

This feature aims to propose a way to build custom aggregation logic for specific cases.

## Description

This PR adds a new flag to the `organizations` table, name `custom_aggregation`, to enable the custom aggregation feature.

This flag is then used to enforce both billable metric creation and update permissions with `custom_agg` aggregation type

**NOTE: A flag feature might soon replace the current logic**.
See https://github.com/getlago/lago-api/pull/1872