### PR TITLE
fix(wallet): Prevent creation of several recurring topup

### DIFF
--- a/app/services/wallets/balance/update_ongoing_service.rb
+++ b/app/services/wallets/balance/update_ongoing_service.rb
@@ -51,6 +51,7 @@ module Wallets
 
         return if threshold_rule.nil? || wallet.credits_ongoing_balance > threshold_rule.threshold_credits
         return if usage_amount_cents.positive? && ongoing_usage_balance_cents == usage_amount_cents
+        return if (pending_transactions_amount + credits_ongoing_balance) > threshold_rule.threshold_credits
 
         WalletTransactions::CreateJob.set(wait: 2.seconds).perform_later(
           organization_id: wallet.organization.id,
@@ -77,6 +78,10 @@ module Wallets
 
       def credits_ongoing_balance
         wallet.credits_balance - usage_credits_amount
+      end
+
+      def pending_transactions_amount
+        wallet.wallet_transactions.pending.sum(:amount)
       end
     end
   end

--- a/spec/services/wallets/balance/update_ongoing_service_spec.rb
+++ b/spec/services/wallets/balance/update_ongoing_service_spec.rb
@@ -78,6 +78,13 @@ RSpec.describe Wallets::Balance::UpdateOngoingService, type: :service do
         end
       end
 
+      context 'with pending transactions' do
+        it 'does not call wallet transaction create job' do
+          create(:wallet_transaction, wallet:, amount: 1.0, credit_amount: 1.0, status: 'pending')
+          expect { update_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
+        end
+      end
+
       context 'without any usage' do
         let(:wallet) do
           create(


### PR DESCRIPTION
The goal of this PR is to fix an issue we recently introduced by accepting negative values for the ongoing balance of a wallet.

For the recurring topup, we want to take into consideration pending transactions, to avoid pending topup every 5 minutes.