### PR TITLE
chore(tests): Fix flacky test

### DIFF
--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -145,9 +145,11 @@ RSpec.describe Subscriptions::TerminateService do
       end
 
       it 'creates a credit note for the remaining days' do
-        expect do
-          terminate_service.call
-        end.to change(CreditNote, :count)
+        travel_to(Time.current.end_of_month - 4.days) do
+          expect do
+            terminate_service.call
+          end.to change(CreditNote, :count).by(1)
+        end
       end
 
       context 'when invoice subscription is not generated' do


### PR DESCRIPTION
On the last day of the month, we don't create credit note because there is no days to refund.