### PR TITLE
misc(filter): re-enable an ignored test case

### DIFF
--- a/spec/scenarios/plans/create_and_update_filters_spec.rb
+++ b/spec/scenarios/plans/create_and_update_filters_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Create and edit plans with charge filters', :scenarios, type: :r
     model_name_bm_filter
   end
 
-  xit 'allows the creation and update of plans with charge filters' do
+  it 'allows the creation and update of plans with charge filters' do
     # Create a plan with a charge and filters
     travel_to(Time.zone.parse('2024-03-27T12:00:00')) do
       create_plan(


### PR DESCRIPTION
## Description

This PR is re-enabling a spec that was ignored due to a flaky behavior that has been fixed