### PR TITLE
feat(integrations): Add netsuite_mappable to addons and billable metrics

### DIFF
--- a/app/graphql/types/add_ons/object.rb
+++ b/app/graphql/types/add_ons/object.rb
@@ -25,6 +25,8 @@ module Types
 
       field :taxes, [Types::Taxes::Object]
 
+      field :integration_mappings, [Types::IntegrationMappings::Netsuite::Object], null: true
+
       def customers_count
         object.applied_add_ons.select(:customer_id).distinct.count
       end

--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -30,6 +30,8 @@ module Types
       field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
+      field :integration_mappings, [Types::IntegrationMappings::Netsuite::Object], null: true
+
       def subscriptions_count
         object.plans.joins(:subscriptions).count
       end

--- a/app/models/integrations/base_integration.rb
+++ b/app/models/integrations/base_integration.rb
@@ -11,11 +11,14 @@ module Integrations
     belongs_to :organization
 
     has_many :integration_items, dependent: :destroy, foreign_key: :integration_id
-
-    has_many :integration_mappings, class_name: 'IntegrationMappings::BaseMapping', foreign_key: 'integration_id'
+    has_many :integration_mappings,
+             class_name: 'IntegrationMappings::BaseMapping',
+             foreign_key: :integration_id,
+             dependent: :destroy
     has_many :integration_collection_mappings,
              class_name: 'IntegrationCollectionMappings::BaseCollectionMapping',
-             foreign_key: 'integration_id'
+             foreign_key: :integration_id,
+             dependent: :destroy
 
     validates :code, uniqueness: { scope: :organization_id }
     validates :name, presence: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -62,6 +62,7 @@ type AddOn {
   deletedAt: ISO8601DateTime
   description: String
   id: ID!
+  integrationMappings: [NetsuiteMapping!]
   invoiceDisplayName: String
   name: String!
   organization: Organization
@@ -177,6 +178,7 @@ type BillableMetric {
   fieldName: String
   filters: [BillableMetricFilter!]
   id: ID!
+  integrationMappings: [NetsuiteMapping!]
   name: String!
   organization: Organization
   plansCount: Int!

--- a/schema.json
+++ b/schema.json
@@ -446,6 +446,28 @@
               ]
             },
             {
+              "name": "integrationMappings",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "NetsuiteMapping",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "invoiceDisplayName",
               "description": null,
               "type": {
@@ -1628,6 +1650,28 @@
                   "kind": "SCALAR",
                   "name": "ID",
                   "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "integrationMappings",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "NetsuiteMapping",
+                    "ofType": null
+                  }
                 }
               },
               "isDeprecated": false,

--- a/spec/graphql/types/add_ons/object_spec.rb
+++ b/spec/graphql/types/add_ons/object_spec.rb
@@ -19,4 +19,5 @@ RSpec.describe Types::AddOns::Object do
   it { is_expected.to have_field(:applied_add_ons_count).of_type('Int!') }
   it { is_expected.to have_field(:customers_count).of_type('Int!') }
   it { is_expected.to have_field(:taxes).of_type('[Tax!]') }
+  it { is_expected.to have_field(:integration_mappings).of_type('[NetsuiteMapping!]') }
 end

--- a/spec/graphql/types/billable_metrics/object_spec.rb
+++ b/spec/graphql/types/billable_metrics/object_spec.rb
@@ -22,4 +22,5 @@ RSpec.describe Types::BillableMetrics::Object do
   it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
   it { is_expected.to have_field(:deleted_at).of_type('ISO8601DateTime') }
   it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:integration_mappings).of_type('[NetsuiteMapping!]') }
 end

--- a/spec/models/integrations/base_integration_spec.rb
+++ b/spec/models/integrations/base_integration_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe Integrations::BaseIntegration, type: :model do
     { secrets: secrets.to_json }
   end
 
+  it { is_expected.to have_many(:integration_mappings).dependent(:destroy) }
+  it { is_expected.to have_many(:integration_collection_mappings).dependent(:destroy) }
+
   describe '.secrets_json' do
     it { expect(integration.secrets_json).to eq(secrets) }
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR adds `netsuite_mappable` to addons and billable metrics.