### PR TITLE
feat(rbac): Add role to user invitation GQL endpoints and services

### DIFF
--- a/app/graphql/mutations/invites/create.rb
+++ b/app/graphql/mutations/invites/create.rb
@@ -12,6 +12,7 @@ module Mutations
       description 'Creates a new Invite'
 
       argument :email, String, required: true
+      argument :role, Types::Memberships::RoleEnum, required: true
 
       type Types::Invites::Object
 

--- a/app/graphql/types/invites/object.rb
+++ b/app/graphql/types/invites/object.rb
@@ -11,6 +11,7 @@ module Types
       field :id, ID, null: false
 
       field :email, String, null: false
+      field :role, Types::Memberships::RoleEnum, null: false
       field :status, Types::Invites::StatusTypeEnum, null: false
       field :token, String, null: false
 

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -13,6 +13,7 @@ class Invite < ApplicationRecord
   ].freeze
 
   enum status: INVITE_STATUS
+  enum role: Membership::ROLES
 
   validates :email, email: true
   validates :token, uniqueness: true

--- a/app/services/invites/accept_service.rb
+++ b/app/services/invites/accept_service.rb
@@ -7,11 +7,7 @@ module Invites
       return result.not_found_failure!(resource: 'invite') unless invite
 
       ActiveRecord::Base.transaction do
-        result = UsersService.new.register_from_invite(
-          args[:email],
-          args[:password],
-          invite.organization_id,
-        )
+        result = UsersService.new.register_from_invite(invite, args[:password])
 
         invite.recipient = result.membership
 

--- a/app/services/invites/create_service.rb
+++ b/app/services/invites/create_service.rb
@@ -9,6 +9,7 @@ module Invites
         organization_id: args[:current_organization].id,
         email: args[:email],
         token: generate_token,
+        role: args[:role],
       )
 
       result

--- a/app/services/invites/validate_service.rb
+++ b/app/services/invites/validate_service.rb
@@ -5,6 +5,7 @@ module Invites
     def valid?
       valid_invite?
       valid_user?
+      valid_role?
 
       if errors?
         result.validation_failure!(errors:)
@@ -30,6 +31,12 @@ module Invites
         .exists?
 
       add_error(field: :email, error_code: 'email_already_used')
+    end
+
+    def valid_role?
+      return true if args[:role].present? && Membership::ROLES[args[:role].to_sym].present?
+
+      add_error(field: :role, error_code: 'invalid_role')
     end
   end
 end

--- a/db/migrate/20240430100120_add_role_to_invite.rb
+++ b/db/migrate/20240430100120_add_role_to_invite.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRoleToInvite < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invites, :role, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -618,6 +618,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_30_133150) do
     t.datetime "revoked_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "role", default: 0, null: false
     t.index ["membership_id"], name: "index_invites_on_membership_id"
     t.index ["organization_id"], name: "index_invites_on_organization_id"
     t.index ["token"], name: "index_invites_on_token", unique: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -1828,6 +1828,7 @@ input CreateInviteInput {
   """
   clientMutationId: String
   email: String!
+  role: MembershipRole!
 }
 
 """
@@ -3634,6 +3635,7 @@ type Invite {
   organization: Organization!
   recipient: Membership!
   revokedAt: ISO8601DateTime!
+  role: MembershipRole!
   status: InviteStatusTypeEnum!
   token: String!
 }

--- a/schema.json
+++ b/schema.json
@@ -6845,6 +6845,22 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "role",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "MembershipRole",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "enumValues": null
@@ -16393,6 +16409,24 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "role",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "MembershipRole",
                   "ofType": null
                 }
               },

--- a/spec/graphql/mutations/invites/create_spec.rb
+++ b/spec/graphql/mutations/invites/create_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Mutations::Invites::Create, type: :graphql do
   end
   let(:organization) { membership.organization }
   let(:email) { Faker::Internet.email }
+  let(:role) { 'finance' }
 
   let(:mutation) do
     <<~GQL
@@ -22,6 +23,7 @@ RSpec.describe Mutations::Invites::Create, type: :graphql do
           id
           token
           email
+          role
         }
       }
     GQL
@@ -40,6 +42,7 @@ RSpec.describe Mutations::Invites::Create, type: :graphql do
       variables: {
         input: {
           email:,
+          role:,
         },
       },
     )
@@ -47,6 +50,7 @@ RSpec.describe Mutations::Invites::Create, type: :graphql do
     data = result['data']['createInvite']
 
     expect(data['email']).to eq(email)
+    expect(data['role']).to eq(role)
     expect(data['token']).to be_present
   end
 
@@ -59,6 +63,7 @@ RSpec.describe Mutations::Invites::Create, type: :graphql do
       variables: {
         input: {
           email: revoked_membership.user.email,
+          role:,
         },
       },
     )
@@ -80,6 +85,7 @@ RSpec.describe Mutations::Invites::Create, type: :graphql do
       variables: {
         input: {
           email:,
+          role:,
         },
       },
     )
@@ -98,6 +104,7 @@ RSpec.describe Mutations::Invites::Create, type: :graphql do
       variables: {
         input: {
           email: membership.user.email,
+          role:,
         },
       },
     )

--- a/spec/services/invites/accept_service_spec.rb
+++ b/spec/services/invites/accept_service_spec.rb
@@ -11,9 +11,8 @@ RSpec.describe Invites::AcceptService, type: :service do
   let(:invite) { create(:invite, organization:, email: user.email) }
   let(:accept_args) do
     {
-      email: invite.email,
-      password: 'ILoveLago!',
       token: invite.token,
+      password: 'ILoveLago!',
     }
   end
 
@@ -49,7 +48,6 @@ RSpec.describe Invites::AcceptService, type: :service do
 
       it 'sets user, membership and organization' do
         result = accept_service.call(
-          email: revoked_membership.user.email,
           password: accept_args[:password],
           token: new_invite[:token],
         )
@@ -67,7 +65,6 @@ RSpec.describe Invites::AcceptService, type: :service do
 
       it 'returns invite_not_found error' do
         result = accept_service.call(
-          email: accepted_invite[:email],
           password: accept_args[:password],
           token: accepted_invite[:token],
         )
@@ -82,7 +79,6 @@ RSpec.describe Invites::AcceptService, type: :service do
 
       it 'returns invite_not_found error' do
         result = accept_service.call(
-          email: revoked_invite[:email],
           password: accept_args[:password],
           token: revoked_invite[:token],
         )
@@ -92,19 +88,11 @@ RSpec.describe Invites::AcceptService, type: :service do
       end
     end
 
-    context 'without email' do
-      it 'returns an error' do
-        result = accept_service.call(email: nil, password: accept_args[:password], token: accept_args[:token])
-
-        expect(result).not_to be_success
-        expect(result.error).to be_a(BaseService::ValidationFailure)
-        expect(result.error.messages[:email]).to eq(['value_is_mandatory'])
-      end
-    end
-
     context 'without password' do
+      let(:invite) { create(:invite, organization:, email: Faker::Internet.email) }
+
       it 'returns an error' do
-        result = accept_service.call(email: accept_args[:email], password: nil, token: accept_args[:token])
+        result = accept_service.call(password: nil, token: accept_args[:token])
 
         expect(result).not_to be_success
         expect(result.error).to be_a(BaseService::ValidationFailure)
@@ -113,7 +101,7 @@ RSpec.describe Invites::AcceptService, type: :service do
 
       context 'without token' do
         it 'returns invite_not_found error' do
-          result = accept_service.call(email: accept_args[:email], password: accept_args[:password], token: nil)
+          result = accept_service.call(password: accept_args[:password], token: nil)
 
           expect(result.error).to be_a(BaseService::NotFoundFailure)
           expect(result.error.message).to eq('invite_not_found')

--- a/spec/services/invites/create_service_spec.rb
+++ b/spec/services/invites/create_service_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Invites::CreateService, type: :service do
       {
         email: Faker::Internet.email,
         current_organization: organization,
+        role: 'admin',
       }
     end
 
@@ -23,12 +24,24 @@ RSpec.describe Invites::CreateService, type: :service do
 
     context 'with validation error' do
       it 'returns an error' do
-        result = create_service.call(current_organization: organization)
+        result = create_service.call(current_organization: organization, role: 'admin')
 
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ValidationFailure)
           expect(result.error.messages[:email]).to eq(['invalid_email_format'])
+        end
+      end
+    end
+
+    context 'with missing role' do
+      it 'returns an error' do
+        result = create_service.call(current_organization: organization, email: Faker::Internet.email)
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:role]).to eq(['invalid_role'])
         end
       end
     end

--- a/spec/services/invites/validate_service_spec.rb
+++ b/spec/services/invites/validate_service_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Invites::ValidateService, type: :service do
     {
       current_organization: organization,
       email: Faker::Internet.email,
+      role: :admin,
     }
   end
 
@@ -27,6 +28,7 @@ RSpec.describe Invites::ValidateService, type: :service do
         {
           current_organization: organization,
           email: user.email,
+          role: :admin,
         }
       end
 
@@ -41,12 +43,28 @@ RSpec.describe Invites::ValidateService, type: :service do
         {
           current_organization: organization,
           email: user.email,
+          role: :admin,
         }
       end
 
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
         expect(result.error.messages[:email]).to eq(['email_already_used'])
+      end
+    end
+
+    context 'when role is invalid' do
+      let(:args) do
+        {
+          current_organization: organization,
+          email: Faker::Internet.email,
+          role: 'super_admin',
+        }
+      end
+
+      it 'returns false and result has errors' do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:role]).to eq(['invalid_role'])
       end
     end
   end

--- a/spec/services/users_service_spec.rb
+++ b/spec/services/users_service_spec.rb
@@ -77,12 +77,35 @@ RSpec.describe UsersService, type: :service do
   end
 
   describe 'register_from_invite' do
-    it 'creates an organization, user and membership' do
-      result = user_service.register('email', 'password', 'organization_name')
-      expect(result.user).to be_present
-      expect(result.membership).to be_present
-      expect(result.organization).to be_present
-      expect(result.token).to be_present
+    let(:email) { Faker::Internet.email }
+
+    context 'when user already exists' do
+      it 'creates user and membership if user doesn\'t exist' do
+        create(:user, email:)
+        invite = create(:invite, email:)
+
+        result = user_service.register_from_invite(invite, nil)
+
+        expect(result.user).to be_persisted
+        expect(result.user.email).to eq email
+        expect(result.membership).to be_persisted
+        expect(result.organization).to eq invite.organization
+        expect(result.token).to be_present
+      end
+    end
+
+    context 'when user doesn\'t exist' do
+      it 'creates user and membership if user doesn\'t exist' do
+        invite = create(:invite, email:)
+
+        result = user_service.register_from_invite(invite, 'password')
+
+        expect(result.user).to be_persisted
+        expect(result.user.email).to eq email
+        expect(result.membership).to be_present
+        expect(result.organization).to eq invite.organization
+        expect(result.token).to be_present
+      end
     end
   end
 


### PR DESCRIPTION
## Context

Granular permissions are being added to Lago.

## Description

When inviting a user to an app, you must assign them a role. This PR adds role to user invitation endpoints (create and accept) and related services.

`Invite.role` attribute is added and on par with `Membership.role`.

I removed the email param when possible, instead of using the email passed to graphql, we use the email from the invite we retrive via the token.