### PR TITLE
fix(postgres-store): Fix empty conditions sql error

### DIFF
--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -347,7 +347,7 @@ module Events
             )
           end.join(' AND ')
         end
-        sql = conditions.map { "(#{_1})" }.join(' OR ')
+        sql = conditions.compact_blank.map { "(#{_1})" }.join(' OR ')
         scope = scope.where.not(sql) if sql.present?
 
         scope


### PR DESCRIPTION
## Context

We're getting SQL syntax errors when some of the conditions are blank: 

```
aggregation_failure: PG::SyntaxError: ERROR:  syntax error at or near ")" (BaseService::ServiceFailure)
LINE 1: ...ies->>'core_hours' ~ '^-?\d+(\.\d+)?$') AND NOT (() OR () OR...
                                                             ^
```

## Description

In this PR we're adding `conditions.compact_blank` to remove the blank ones.