### PR TITLE
misc: Preload filters allong with charges in billing process

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -101,7 +101,7 @@ module Invoices
       subscription
         .plan
         .charges
-        .includes(:billable_metric)
+        .includes(:billable_metric, filters: { values: :billable_metric_filter })
         .joins(:billable_metric)
         .where(invoiceable: true)
         .where

--- a/db/migrate/20240502075803_add_filters_missing_indexes.rb
+++ b/db/migrate/20240502075803_add_filters_missing_indexes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddFiltersMissingIndexes < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :charge_filters, :charge_id, where: 'deleted_at IS NULL', name: 'index_active_charge_filters'
+    add_index :charge_filter_values,
+              :charge_filter_id,
+              where: 'deleted_at IS NULL',
+              name: 'index_active_charge_filter_values'
+    add_index :billable_metric_filters,
+              :billable_metric_id,
+              where: 'deleted_at IS NULL',
+              name: 'index_active_metric_filters'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_30_133150) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_02_075803) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -135,6 +135,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_30_133150) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.index ["billable_metric_id"], name: "index_active_metric_filters", where: "(deleted_at IS NULL)"
     t.index ["billable_metric_id"], name: "index_billable_metric_filters_on_billable_metric_id"
     t.index ["deleted_at"], name: "index_billable_metric_filters_on_deleted_at"
   end
@@ -191,6 +192,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_30_133150) do
     t.datetime "deleted_at"
     t.string "values", default: [], null: false, array: true
     t.index ["billable_metric_filter_id"], name: "index_charge_filter_values_on_billable_metric_filter_id"
+    t.index ["charge_filter_id"], name: "index_active_charge_filter_values", where: "(deleted_at IS NULL)"
     t.index ["charge_filter_id"], name: "index_charge_filter_values_on_charge_filter_id"
     t.index ["deleted_at"], name: "index_charge_filter_values_on_deleted_at"
   end
@@ -202,6 +204,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_30_133150) do
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
     t.string "invoice_display_name"
+    t.index ["charge_id"], name: "index_active_charge_filters", where: "(deleted_at IS NULL)"
     t.index ["charge_id"], name: "index_charge_filters_on_charge_id"
     t.index ["deleted_at"], name: "index_charge_filters_on_deleted_at"
   end

--- a/db/seeds/invoices.rb
+++ b/db/seeds/invoices.rb
@@ -8,7 +8,7 @@ Subscription.all.find_each do |subscription|
     Invoices::SubscriptionService.call(
       subscriptions: [subscription],
       timestamp: Time.current - offset.months + 1.day,
-      recurring: true,
+      invoicing_reason: :subscription_periodic,
     )
   end
 end


### PR DESCRIPTION
## Context

Lago is facing some performance issues when it has to generate a lot of invoices on a single day.

## Description

This PR:
- Add 3 indexes
  - charge_filters#charge_id where deleted_at is null
  - charge_filter_values#charge_filter_id where deleted_at is null
  - billable_metric_filters#billable_metric_id where deleted_at is null
 
- Preload every `ChargeFilter`, `ChargeFilterValue` and `BillableMetricFilter` in the `Invoices#CalculateFeesService`