### PR TITLE
feat(integrations): Add provider code to integration customer error webhook

### DIFF
--- a/app/serializers/v1/integrations/customer_error_serializer.rb
+++ b/app/serializers/v1/integrations/customer_error_serializer.rb
@@ -8,6 +8,7 @@ module V1
           lago_customer_id: model.id,
           external_customer_id: model.external_id,
           accounting_provider: options[:provider],
+          accounting_provider_code: options[:provider_code],
           provider_error: options[:provider_error],
         }
       end

--- a/app/services/integrations/aggregator/contacts/base_service.rb
+++ b/app/services/integrations/aggregator/contacts/base_service.rb
@@ -30,6 +30,7 @@ module Integrations
             'customer.accounting_provider_error',
             customer,
             provider:,
+            provider_code: integration.code,
             provider_error: {
               message:,
               error_code: code,

--- a/app/services/webhooks/integrations/customer_error_service.rb
+++ b/app/services/webhooks/integrations/customer_error_service.rb
@@ -15,6 +15,7 @@ module Webhooks
           root_name: object_type,
           provider_error: options[:provider_error],
           provider: options[:provider],
+          provider_code: options[:provider_code],
         )
       end
 

--- a/spec/serializers/v1/integrations/customer_error_serializer_spec.rb
+++ b/spec/serializers/v1/integrations/customer_error_serializer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::Integrations::CustomerErrorSerializer do
+  subject(:serializer) { described_class.new(customer, options) }
+
+  let(:integration_customer) { create(:netsuite_customer) }
+  let(:customer) { integration_customer.customer }
+  let(:options) do
+    {
+      'provider_error' => {
+        'error_message' => 'message',
+        'error_code' => 'code',
+      },
+      'provider' => 'netsuite',
+      'provider_code' => integration_customer.integration.code,
+    }.with_indifferent_access
+  end
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['data']['lago_customer_id']).to eq(customer.id)
+      expect(result['data']['external_customer_id']).to eq(customer.external_id)
+      expect(result['data']['accounting_provider']).to eq(options[:provider])
+      expect(result['data']['accounting_provider_code']).to eq(integration_customer.integration.code)
+      expect(result['data']['provider_error']).to eq(options[:provider_error])
+    end
+  end
+end

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
             'customer.accounting_provider_error',
             customer,
             provider: 'netsuite',
+            provider_code: integration.code,
             provider_error: {
               message: 'submitFields: Missing a required argument: type',
               error_code: 'action_script_runtime_error',

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -95,6 +95,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
             'customer.accounting_provider_error',
             customer,
             provider: 'netsuite',
+            provider_code: integration.code,
             provider_error: {
               message: 'submitFields: Missing a required argument: type',
               error_code: 'action_script_runtime_error',


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

Integration customer error webhook now contains also `accounting_provider_code`