### PR TITLE
feat(rbac): Add premissions on Organization (resolver and mutation)

### DIFF
--- a/app/graphql/types/base_argument.rb
+++ b/app/graphql/types/base_argument.rb
@@ -2,10 +2,10 @@
 
 module Types
   class BaseArgument < GraphQL::Schema::Argument
-    attr_reader :permission
+    attr_reader :permissions
 
     def initialize(*args, permission: nil, **kwargs, &block)
-      @permission = permission
+      @permissions = [permission].compact
       super(*args, **kwargs, &block)
     end
   end

--- a/app/graphql/types/base_input_object.rb
+++ b/app/graphql/types/base_input_object.rb
@@ -10,7 +10,9 @@ module Types
       cleaned_kwargs = ruby_kwargs.dup
 
       self.class.arguments(context).each_value do |arg_defn|
-        if arg_defn.permission && !context.dig(:permissions, arg_defn.permission)
+        next if arg_defn.permissions.blank?
+
+        if arg_defn.permissions.none? { |p| context.dig(:permissions, p) }
           cleaned_arguments.delete(arg_defn.keyword)
           cleaned_kwargs.delete(arg_defn.keyword)
         end

--- a/app/graphql/types/current_organization_type.rb
+++ b/app/graphql/types/current_organization_type.rb
@@ -7,25 +7,25 @@ module Types
     field :id, ID, null: false
     field :logo_url, String
     field :name, String, null: false
-    field :timezone, Types::TimezoneEnum, null: true
+    field :timezone, Types::TimezoneEnum
 
     field :default_currency, Types::CurrencyEnum, null: false
     field :email, String
 
     field :legal_name, String
     field :legal_number, String
-    field :tax_identification_number, String, null: true
+    field :tax_identification_number, String, permission: 'organization:taxes:view'
 
     field :address_line1, String
     field :address_line2, String
     field :city, String
-    field :country, Types::CountryCodeEnum, null: true
+    field :country, Types::CountryCodeEnum
     field :net_payment_term, Integer, null: false
     field :state, String
     field :zipcode, String
 
-    field :api_key, String, null: false
-    field :webhook_url, String
+    field :api_key, String, permission: 'developers:keys:manage'
+    field :webhook_url, String, permission: 'developers:manage'
 
     field :document_number_prefix, String, null: false
     field :document_numbering, Types::Organizations::DocumentNumberingEnum, null: false
@@ -39,13 +39,13 @@ module Types
     #       This would enable us to use premium add_on logic on OSS version
     field :premium_integrations, [Types::Integrations::IntegrationTypeEnum], null: false
 
-    field :billing_configuration, Types::Organizations::BillingConfiguration, null: true
-    field :email_settings, [Types::Organizations::EmailSettingsEnum], null: true
-    field :taxes, [Types::Taxes::Object], null: true, resolver: Resolvers::TaxesResolver
+    field :billing_configuration, Types::Organizations::BillingConfiguration, permission: 'organization:invoices:view'
+    field :email_settings, [Types::Organizations::EmailSettingsEnum], permission: 'organization:emails:view'
+    field :taxes, [Types::Taxes::Object], resolver: Resolvers::TaxesResolver, permission: 'organization:taxes:view'
 
-    field :adyen_payment_providers, [Types::PaymentProviders::Adyen], null: true
-    field :gocardless_payment_providers, [Types::PaymentProviders::Gocardless], null: true
-    field :stripe_payment_providers, [Types::PaymentProviders::Stripe], null: true
+    field :adyen_payment_providers, [Types::PaymentProviders::Adyen], permission: 'organization:integrations:view'
+    field :gocardless_payment_providers, [Types::PaymentProviders::Gocardless], permission: 'organization:integrations:view' # rubocop:disable Layout/LineLength
+    field :stripe_payment_providers, [Types::PaymentProviders::Stripe], permission: 'organization:integrations:view'
 
     def billing_configuration
       {

--- a/app/graphql/types/organizations/update_organization_input.rb
+++ b/app/graphql/types/organizations/update_organization_input.rb
@@ -10,7 +10,7 @@ module Types
       argument :legal_name, String, required: false
       argument :legal_number, String, required: false
       argument :logo, String, required: false
-      argument :tax_identification_number, String, required: false
+      argument :tax_identification_number, String, required: false, permission: 'organization:taxes:view'
 
       argument :address_line1, String, required: false
       argument :address_line2, String, required: false
@@ -20,7 +20,7 @@ module Types
       argument :state, String, required: false
       argument :zipcode, String, required: false
 
-      argument :webhook_url, String, required: false
+      argument :webhook_url, String, required: false, permission: 'developers:manage'
 
       argument :timezone, Types::TimezoneEnum, required: false
 
@@ -29,8 +29,8 @@ module Types
       argument :document_number_prefix, String, required: false
       argument :document_numbering, Types::Organizations::DocumentNumberingEnum, required: false
 
-      argument :billing_configuration, Types::Organizations::BillingConfigurationInput, required: false
-      argument :email_settings, [Types::Organizations::EmailSettingsEnum], required: false
+      argument :billing_configuration, Types::Organizations::BillingConfigurationInput, required: false, permission: 'organization:invoices:view' # rubocop:disable Layout/LineLength
+      argument :email_settings, [Types::Organizations::EmailSettingsEnum], required: false, permission: 'organization:emails:view' # rubocop:disable Layout/LineLength
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -2801,7 +2801,7 @@ type CurrentOrganization {
   addressLine1: String
   addressLine2: String
   adyenPaymentProviders: [AdyenProvider!]
-  apiKey: String!
+  apiKey: String
   billingConfiguration: OrganizationBillingConfiguration
   city: String
   country: CountryCode

--- a/schema.json
+++ b/schema.json
@@ -10121,13 +10121,9 @@
               "name": "apiKey",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/types/current_organization_type_spec.rb
+++ b/spec/graphql/types/current_organization_type_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-
 RSpec.describe Types::CurrentOrganizationType do
   subject { described_class }
 
   it { is_expected.to have_field(:id).of_type('ID!') }
 
+  # rubocop:disable Layout/LineLength
   it { is_expected.to have_field(:default_currency).of_type('CurrencyEnum!') }
   it { is_expected.to have_field(:email).of_type('String') }
   it { is_expected.to have_field(:legal_name).of_type('String') }
   it { is_expected.to have_field(:legal_number).of_type('String') }
   it { is_expected.to have_field(:logo_url).of_type('String') }
   it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:tax_identification_number).of_type('String') }
+  it { is_expected.to have_field(:tax_identification_number).of_type('String').with_permission('organization:taxes:view') }
 
   it { is_expected.to have_field(:address_line1).of_type('String') }
   it { is_expected.to have_field(:address_line2).of_type('String') }
@@ -23,19 +23,20 @@ RSpec.describe Types::CurrentOrganizationType do
   it { is_expected.to have_field(:state).of_type('String') }
   it { is_expected.to have_field(:zipcode).of_type('String') }
 
-  it { is_expected.to have_field(:api_key).of_type('String!') }
-  it { is_expected.to have_field(:webhook_url).of_type('String') }
+  it { is_expected.to have_field(:api_key).of_type('String').with_permission('developers:keys:manage') }
+  it { is_expected.to have_field(:webhook_url).of_type('String').with_permission('developers:manage') }
 
   it { is_expected.to have_field(:timezone).of_type('TimezoneEnum') }
 
   it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
   it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
 
-  it { is_expected.to have_field(:billing_configuration).of_type('OrganizationBillingConfiguration') }
-  it { is_expected.to have_field(:email_settings).of_type('[EmailSettingsEnum!]') }
-  it { is_expected.to have_field(:taxes).of_type('[Tax!]') }
+  it { is_expected.to have_field(:billing_configuration).of_type('OrganizationBillingConfiguration').with_permission('organization:invoices:view') }
+  it { is_expected.to have_field(:email_settings).of_type('[EmailSettingsEnum!]').with_permission('organization:emails:view') }
+  it { is_expected.to have_field(:taxes).of_type('[Tax!]').with_permission('organization:taxes:view') }
 
-  it { is_expected.to have_field(:adyen_payment_providers).of_type('[AdyenProvider!]') }
-  it { is_expected.to have_field(:gocardless_payment_providers).of_type('[GocardlessProvider!]') }
-  it { is_expected.to have_field(:stripe_payment_providers).of_type('[StripeProvider!]') }
+  it { is_expected.to have_field(:adyen_payment_providers).of_type('[AdyenProvider!]').with_permission('organization:integrations:view') }
+  it { is_expected.to have_field(:gocardless_payment_providers).of_type('[GocardlessProvider!]').with_permission('organization:integrations:view') }
+  it { is_expected.to have_field(:stripe_payment_providers).of_type('[StripeProvider!]').with_permission('organization:integrations:view') }
+  # rubocop:enable Layout/LineLength
 end

--- a/spec/graphql/types/organizations/update_organization_input_spec.rb
+++ b/spec/graphql/types/organizations/update_organization_input_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# rubocop:disable Layout/LineLength
 RSpec.describe Types::Organizations::UpdateOrganizationInput do
   subject { described_class }
 
@@ -10,7 +11,7 @@ RSpec.describe Types::Organizations::UpdateOrganizationInput do
   it { is_expected.to accept_argument(:legal_name).of_type('String') }
   it { is_expected.to accept_argument(:legal_number).of_type('String') }
   it { is_expected.to accept_argument(:logo).of_type('String') }
-  it { is_expected.to accept_argument(:tax_identification_number).of_type('String') }
+  it { is_expected.to accept_argument(:tax_identification_number).of_type('String').with_permission('organization:taxes:view') }
 
   it { is_expected.to accept_argument(:address_line1).of_type('String') }
   it { is_expected.to accept_argument(:address_line2).of_type('String') }
@@ -23,10 +24,11 @@ RSpec.describe Types::Organizations::UpdateOrganizationInput do
   it { is_expected.to accept_argument(:document_numbering).of_type('DocumentNumberingEnum') }
   it { is_expected.to accept_argument(:document_number_prefix).of_type('String') }
 
-  it { is_expected.to accept_argument(:webhook_url).of_type('String') }
+  it { is_expected.to accept_argument(:webhook_url).of_type('String').with_permission('developers:manage') }
 
   it { is_expected.to accept_argument(:timezone).of_type('TimezoneEnum') }
 
-  it { is_expected.to accept_argument(:billing_configuration).of_type('OrganizationBillingConfigurationInput') }
-  it { is_expected.to accept_argument(:email_settings).of_type('[EmailSettingsEnum!]') }
+  it { is_expected.to accept_argument(:billing_configuration).of_type('OrganizationBillingConfigurationInput').with_permission('organization:invoices:view') }
+  it { is_expected.to accept_argument(:email_settings).of_type('[EmailSettingsEnum!]').with_permission('organization:emails:view') }
 end
+# rubocop:enable Layout/LineLength

--- a/spec/support/matchers/graphql_field_permissions_matcher.rb
+++ b/spec/support/matchers/graphql_field_permissions_matcher.rb
@@ -5,32 +5,38 @@
 #
 module RSpec
   module GraphqlMatchers
-    class HaveAField < BaseMatcher
+    module WithPermissions
       def with_permissions(expected_permissions)
-        @expectations << HaveAFieldMatchers::WithPermissions.new(expected_permissions)
+        @expectations << WithPermissionsMatcher.new(expected_permissions)
         self
       end
       alias with_permission with_permissions
     end
 
-    module HaveAFieldMatchers
-      class WithPermissions
-        def initialize(expected_permissions)
-          @expected_permissions = Array.wrap(expected_permissions)
-        end
+    class HaveAField < BaseMatcher
+      include WithPermissions
+    end
 
-        def description
-          "with permissions `#{@expected_permissions}`"
-        end
+    class AcceptArgument < BaseMatcher
+      include WithPermissions
+    end
 
-        def matches?(actual_field)
-          @actual_permissions = actual_field.permissions
-          @actual_permissions.sort == @expected_permissions.sort
-        end
+    class WithPermissionsMatcher
+      def initialize(expected_permissions)
+        @expected_permissions = Array.wrap(expected_permissions)
+      end
 
-        def failure_message
-          "#{description}, but it was `#{@actual_permissions}`"
-        end
+      def description
+        "with permissions `#{@expected_permissions}`"
+      end
+
+      def matches?(actual)
+        @actual_permissions = actual.permissions
+        @actual_permissions.sort == @expected_permissions.sort
+      end
+
+      def failure_message
+        "#{description}, but it was `#{@actual_permissions}`"
       end
     end
   end


### PR DESCRIPTION
## Context

Granular permissions are being added to Lago.

## Description

Following #1926,  #1941, #1952 and #1969, this PR add permissions restriction to Organization-related endpoints.

For organization, both mutations and resolvers are accessible without permissions but many fields/arguments are restricted. 

**Line length: Remember that soon, with StandardRb, there is no line length restrictions** 😬