### PR TITLE
fix(charge_filter): Fix fee breakdown with filter

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -169,7 +169,7 @@ class Invoice < ApplicationRecord
 
     filters = {}
     if fee.charge_filter
-      result = ChargeFilters::MatchingAndIgnoredService.call(filter: charge_filter)
+      result = ChargeFilters::MatchingAndIgnoredService.call(filter: fee.charge_filter)
       filters[:charge_filter] = fee.charge_filter if fee.charge_filter
       filters[:matching_filters] = result.matching_filters
       filters[:ignored_filters] = result.ignored_filters

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -426,6 +426,16 @@ RSpec.describe Invoice, type: :model do
     it 'returns the fees of the corresponding invoice_subscription' do
       expect(invoice.recurring_breakdown(fee)).to eq([])
     end
+
+    context 'with charge filter' do
+      let(:charge_filter) { create(:charge_filter, charge:) }
+
+      before { fee.update(charge_filter:) }
+
+      it 'returns the fees of the corresponding invoice_subscription' do
+        expect(invoice.recurring_breakdown(fee)).to eq([])
+      end
+    end
   end
 
   describe '#charge_pay_in_advance_proration_range' do


### PR DESCRIPTION
## Description

This PR fixes the following issue happening when generating an invoice with a fee attached to a charge filter and requiring a breakdown (Unique count aggregation)

```
undefined local variable or method `charge_filter' for an instance of Invoice
```