### PR TITLE
fix(filter): Fix multiple update of billable metric values

### DIFF
--- a/app/services/billable_metric_filters/create_or_update_batch_service.rb
+++ b/app/services/billable_metric_filters/create_or_update_batch_service.rb
@@ -26,11 +26,15 @@ module BillableMetricFilters
           if filter.persisted?
             deleted_values = filter.values - filter_param[:values]
 
-            filter_values = filter.filter_values
-              .where(billable_metric_filter_id: filter.id)
-              .where(values: deleted_values)
+            if deleted_values.present?
+              filter_values = filter.filter_values
+                .where(
+                  deleted_values.map { '? = ANY(values)' }.join(' OR '),
+                  *deleted_values,
+                )
 
-            filter_values.each { discard_filter_value(_1) }
+              filter_values.each { discard_filter_value(_1) }
+            end
           end
 
           filter.values = (filter_param[:values] || []).uniq

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
       [
         {
           key: 'region',
-          values: %w[Europe US Africa],
+          values: %w[Europe US Asia Africa],
         },
       ]
     end
 
-    let(:filter) { create(:billable_metric_filter, billable_metric:, key: 'region', values: %w[Europe US]) }
+    let(:filter) { create(:billable_metric_filter, billable_metric:, key: 'region', values: %w[Europe US Asia]) }
 
     before { filter }
 
@@ -88,7 +88,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
 
       expect(filter.reload).to have_attributes(
         key: 'region',
-        values: %w[Europe US Africa],
+        values: %w[Europe US Asia Africa],
       )
     end
 


### PR DESCRIPTION
## Context

Updating multiple values of a billable metric filter, does not discard the associated charge filter values, leading to future validation errors on plan update as the validation will fail with a `value_is_invalid` error

## Description

This PR fixes the issue by ensuring that all removed billable metric values are effectively removed from the charge filters