### PR TITLE
fix: missing permissions attribute in MembershipType

### DIFF
--- a/app/graphql/types/membership_type.rb
+++ b/app/graphql/types/membership_type.rb
@@ -14,5 +14,9 @@ module Types
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :revoked_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+    def permissions
+      object.permissions_hash.transform_keys { |key| key.tr(':', '_') }
+    end
   end
 end

--- a/spec/graphql/resolvers/current_user_resolver_spec.rb
+++ b/spec/graphql/resolvers/current_user_resolver_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Resolvers::CurrentUserResolver, type: :graphql do
           premium
           memberships {
             role
+            permissions { invoicesView }
             status
             organization {
               name
@@ -36,6 +37,7 @@ RSpec.describe Resolvers::CurrentUserResolver, type: :graphql do
       expect(result['data']['currentUser']['id']).to eq(user.id)
       expect(result['data']['currentUser']['premium']).to be_falsey
       expect(result['data']['currentUser']['memberships'][0]['role']).to eq 'admin'
+      expect(result['data']['currentUser']['memberships'][0]['permissions']).to eq({ 'invoicesView' => true })
       expect(result['data']['currentUser']['memberships'][0]['organization']['name']).not_to be_empty
     end
   end

--- a/spec/graphql/types/membership_type_spec.rb
+++ b/spec/graphql/types/membership_type_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::MembershipType do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type('ID!') }
+
+  it { is_expected.to have_field(:organization).of_type('Organization!') }
+  it { is_expected.to have_field(:user).of_type('User!') }
+
+  it { is_expected.to have_field(:permissions).of_type('Permissions!') }
+  it { is_expected.to have_field(:role).of_type('MembershipRole') }
+  it { is_expected.to have_field(:status).of_type('MembershipStatus!') }
+
+  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:revoked_at).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+end


### PR DESCRIPTION
I realized the `permissions` field was never implemented (nor tested). 🤦‍♂️