### PR TITLE
fix(stripe): Handle IdempotencyError when creating customer

### DIFF
--- a/spec/services/payment_provider_customers/stripe_service_spec.rb
+++ b/spec/services/payment_provider_customers/stripe_service_spec.rb
@@ -124,6 +124,22 @@ RSpec.describe PaymentProviderCustomers::StripeService, type: :service do
           )
       end
     end
+
+    context 'with idempotency issue' do
+      before do
+        allow(Stripe::Customer).to receive(:create)
+          .and_raise(Stripe::IdempotencyError.new('idempotency'))
+
+        allow(Stripe::Customer).to receive(:list)
+          .and_return([Stripe::Customer.new(id: 'cus_123456')])
+      end
+
+      it 'fetches the stripe customer from the API' do
+        result = stripe_service.create
+
+        expect(result.stripe_customer.provider_customer_id).to eq('cus_123456')
+      end
+    end
   end
 
   describe '#update' do


### PR DESCRIPTION
## Context

This PR is an attempt to handle `Stripe::IdempotencyError` happening when a customer creation via API failed and does not properly save the `provider_customer_id` on the `PayementProviderCustoner::StripCustomer` instance.

The issue appears in some rare case of race conditions, but it puts the customer in an instable state, as it cannot be synced again on Stripe due to idempotency protection.

## Description

In case of `Stripe::IdempotencyError`, the service not tries to fetch the StripeCustomer from the API using the customer email. If only one matches the email, it is returned by the service and its ID is saved in the `provider_customer_id` field.
