### PR TITLE
fix(invoice): Ignore duplicated_invoices error for recurring billing

### DIFF
--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -51,6 +51,11 @@ module Invoices
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
+    rescue BaseService::ServiceFailure => e
+      raise unless e.code.to_s == 'duplicated_invoices'
+      raise unless invoicing_reason.to_sym == :subscription_periodic
+
+      result
     rescue Sequenced::SequenceError
       raise
     rescue => e


### PR DESCRIPTION
## Context

On days when a lot of invoices have to be generated, it's not uncommon that a `BillSubscriptionJob` job enqueued for processing stays in the queue for more than 1 hour. Since the clock job is running every hour, a new job to bill the same subscription might be enqueued twice (or more).

A logic to prevent double billing of the invoices was added (an index at DB level and a condition in the service creating the invoice subscription). Today this logic is simply raising an error leading to a lot of dead jobs. Since the invoice already exists, the dead job is generating a lot of useless noise and have to been manually removed.

## Description

This PR silents the  `BaseService::ServiceFailure` error with code `duplicated_invoices` in `Invoices::SubscriptionSerivces` when the `invoicing_reason` is `subscription_periodic`.