### PR TITLE
feat(integrations): Add integration and integration_code to customer input

### DIFF
--- a/app/graphql/types/customers/create_customer_input.rb
+++ b/app/graphql/types/customers/create_customer_input.rb
@@ -33,6 +33,8 @@ module Types
       argument :payment_provider_code, String, required: false
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false
 
+      argument :integration_customer, Types::IntegrationCustomers::Input, required: false
+
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false
     end
   end

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -35,6 +35,8 @@ module Types
       argument :payment_provider_code, String, required: false
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false
 
+      argument :integration_customer, Types::IntegrationCustomers::Input, required: false
+
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false
     end
   end

--- a/app/graphql/types/integration_customers/input.rb
+++ b/app/graphql/types/integration_customers/input.rb
@@ -6,6 +6,8 @@ module Types
       graphql_name 'IntegrationCustomerInput'
 
       argument :external_customer_id, String, required: false
+      argument :integration, Types::Integrations::IntegrationTypeEnum, required: false
+      argument :integration_code, String, required: false
       argument :subsidiary_id, String, required: false
       argument :sync_with_provider, Boolean, required: false
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1782,6 +1782,7 @@ input CreateCustomerInput {
   email: String
   externalId: String!
   externalSalesforceId: String
+  integrationCustomer: IntegrationCustomerInput
   invoiceGracePeriod: Int
   legalName: String
   legalNumber: String
@@ -3617,6 +3618,14 @@ union Integration = NetsuiteIntegration
 type IntegrationCollection {
   collection: [Integration!]!
   metadata: CollectionMetadata!
+}
+
+input IntegrationCustomerInput {
+  externalCustomerId: String
+  integration: IntegrationTypeEnum
+  integrationCode: String
+  subsidiaryId: String
+  syncWithProvider: Boolean
 }
 
 type IntegrationItem {
@@ -6611,6 +6620,7 @@ input UpdateCustomerInput {
   externalId: String!
   externalSalesforceId: String
   id: ID!
+  integrationCustomer: IntegrationCustomerInput
   invoiceGracePeriod: Int
   legalName: String
   legalNumber: String

--- a/schema.json
+++ b/schema.json
@@ -6732,6 +6732,18 @@
               "deprecationReason": null
             },
             {
+              "name": "integrationCustomer",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "IntegrationCustomerInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "billingConfiguration",
               "description": null,
               "type": {
@@ -16255,6 +16267,77 @@
             }
           ],
           "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "IntegrationCustomerInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "externalCustomerId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "integration",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "IntegrationTypeEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "integrationCode",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subsidiaryId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "syncWithProvider",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "enumValues": null
         },
         {
@@ -31571,6 +31654,18 @@
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "ProviderCustomerInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "integrationCustomer",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "IntegrationCustomerInput",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/types/integration_customers/input_spec.rb
+++ b/spec/graphql/types/integration_customers/input_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Types::IntegrationCustomers::Input do
   subject { described_class }
 
   it { is_expected.to accept_argument(:external_customer_id).of_type('String') }
+  it { is_expected.to accept_argument(:integration).of_type('IntegrationTypeEnum') }
+  it { is_expected.to accept_argument(:integration_code).of_type('String') }
   it { is_expected.to accept_argument(:subsidiary_id).of_type('String') }
   it { is_expected.to accept_argument(:sync_with_provider).of_type('Boolean') }
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR adds `integration` and `integration_code` to integration customer input and adds this input to customer inputs.