### PR TITLE
feat(accounting-integrations): add strategy service for creating or updating integration customers

### DIFF
--- a/app/jobs/integration_customers/create_job.rb
+++ b/app/jobs/integration_customers/create_job.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class CreateJob < ApplicationJob
+    queue_as 'integrations'
+
+    retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
+
+    def perform(integration_customer_params:, integration:, customer:)
+      result = IntegrationCustomers::CreateService.call(params: integration_customer_params, integration:, customer:)
+      result.raise_if_error!
+    end
+  end
+end

--- a/app/jobs/integration_customers/update_job.rb
+++ b/app/jobs/integration_customers/update_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class UpdateJob < ApplicationJob
+    queue_as 'integrations'
+
+    retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
+
+    def perform(integration_customer_params:, integration:, integration_customer:)
+      result = IntegrationCustomers::UpdateService.call(
+        params: integration_customer_params,
+        integration:,
+        integration_customer:,
+      )
+      result.raise_if_error!
+    end
+  end
+end

--- a/app/services/integration_customers/create_or_update_service.rb
+++ b/app/services/integration_customers/create_or_update_service.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class CreateOrUpdateService < ::BaseService
+    def initialize(integration_customer_params:, customer:, new_customer:)
+      @integration_customer_params = integration_customer_params
+      @customer = customer
+      @new_customer = new_customer
+
+      super(nil)
+    end
+
+    def call
+      return unless integration
+      return if skip_creating_integration_customer?
+
+      if remove_integration_customer?
+        integration_customer.destroy!
+        return
+      end
+
+      if create_integration_customer?
+        IntegrationCustomers::CreateJob.perform_later(integration_customer_params:, integration:, customer:)
+      elsif update_integration_customer?
+        IntegrationCustomers::UpdateJob.perform_later(integration_customer_params:, integration:, integration_customer:)
+      end
+    end
+
+    private
+
+    attr_reader :integration_customer_params, :customer, :new_customer, :integration_customer, :integration
+
+    def create_integration_customer?
+      (new_customer && integration_customer_params[:sync_with_provider]) ||
+        (new_customer && integration_customer_params[:external_customer_id]) ||
+        (!new_customer && integration_customer.nil? && integration_customer_params[:sync_with_provider]) ||
+        (!new_customer && integration_customer.nil? && integration_customer_params[:external_customer_id])
+    end
+
+    def update_integration_customer?
+      !new_customer && integration_customer
+    end
+
+    def remove_integration_customer?
+      !new_customer &&
+        integration_customer &&
+        integration_customer_params[:external_customer_id].blank?
+    end
+
+    def skip_creating_integration_customer?
+      integration_customer.nil? &&
+        integration_customer_params[:sync_with_provider].blank? &&
+        integration_customer_params[:external_customer_id].blank?
+    end
+
+    def integration
+      return @integration if defined? @integration
+      return nil unless integration_customer_params[:integration] && integration_customer_params[:integration_code]
+
+      type = Integrations::BaseIntegration.integration_type(integration_customer_params[:integration])
+      code = integration_customer_params[:integration_code]
+
+      @integration = Integrations::BaseIntegration.find_by(type:, code:)
+    end
+
+    def integration_customer
+      @integration_customer ||= IntegrationCustomers::BaseCustomer.find_by(integration:, customer:)
+    end
+  end
+end

--- a/app/services/integrations/aggregator/items_service.rb
+++ b/app/services/integrations/aggregator/items_service.rb
@@ -3,8 +3,8 @@
 module Integrations
   module Aggregator
     class ItemsService < BaseService
-      LIMIT = 300
-      MAX_SUBSEQUENT_REQUESTS = 10
+      LIMIT = 450
+      MAX_SUBSEQUENT_REQUESTS = 15
 
       def action_path
         "v1/#{provider}/items"

--- a/spec/jobs/integration_customers/create_job_spec.rb
+++ b/spec/jobs/integration_customers/create_job_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationCustomers::CreateJob, type: :job do
+  subject(:create_job) { described_class }
+
+  let(:create_service) { instance_double(IntegrationCustomers::CreateService) }
+  let(:integration) { create(:netsuite_integration) }
+  let(:customer) { create(:customer) }
+  let(:result) { BaseService::Result.new }
+  let(:integration_customer_params) do
+    {
+      sync_with_provider: true,
+    }
+  end
+
+  before do
+    allow(IntegrationCustomers::CreateService).to receive(:new).and_return(create_service)
+    allow(create_service).to receive(:call).and_return(result)
+  end
+
+  it 'calls the create service' do
+    described_class.perform_now(integration_customer_params:, integration:, customer:)
+
+    expect(IntegrationCustomers::CreateService).to have_received(:new)
+    expect(create_service).to have_received(:call)
+  end
+end

--- a/spec/jobs/integration_customers/update_job_spec.rb
+++ b/spec/jobs/integration_customers/update_job_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationCustomers::UpdateJob, type: :job do
+  subject(:create_job) { described_class }
+
+  let(:update_service) { instance_double(IntegrationCustomers::UpdateService) }
+  let(:integration) { create(:netsuite_integration) }
+  let(:integration_customer) { create(:netsuite_customer, integration:) }
+  let(:result) { BaseService::Result.new }
+  let(:integration_customer_params) do
+    {
+      sync_with_provider: true,
+    }
+  end
+
+  before do
+    allow(IntegrationCustomers::UpdateService).to receive(:new).and_return(update_service)
+    allow(update_service).to receive(:call).and_return(result)
+  end
+
+  it 'calls the update service' do
+    described_class.perform_now(integration_customer_params:, integration:, integration_customer:)
+
+    expect(IntegrationCustomers::UpdateService).to have_received(:new)
+    expect(update_service).to have_received(:call)
+  end
+end

--- a/spec/services/integration_customers/create_or_update_service_spec.rb
+++ b/spec/services/integration_customers/create_or_update_service_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationCustomers::CreateOrUpdateService, type: :service do
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:organization) { membership.organization }
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subsidiary_id) { '1' }
+  let(:integration_customer_params) do
+    {
+      integration: 'netsuite',
+      integration_code:,
+      sync_with_provider:,
+      external_customer_id:,
+      subsidiary_id:,
+    }
+  end
+
+  describe '#call' do
+    subject(:service_call) { described_class.call(integration_customer_params:, customer:, new_customer:) }
+
+    context 'without integration' do
+      let(:integration_code) { 'not_exists' }
+      let(:sync_with_provider) { true }
+      let(:external_customer_id) { nil }
+      let(:new_customer) { true }
+
+      it 'does not call create job' do
+        expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::CreateJob)
+      end
+
+      it 'does not call update job' do
+        expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::UpdateJob)
+      end
+    end
+
+    context 'without external fields set' do
+      let(:integration_code) { integration.code }
+      let(:sync_with_provider) { false }
+      let(:external_customer_id) { nil }
+      let(:new_customer) { true }
+
+      it 'does not call create job' do
+        expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::CreateJob)
+      end
+
+      it 'does not call update job' do
+        expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::UpdateJob)
+      end
+    end
+
+    context 'when removing integration customer' do
+      let(:integration_customer) { create(:netsuite_customer, customer:, integration:) }
+      let(:integration_code) { integration.code }
+      let(:sync_with_provider) { true }
+      let(:external_customer_id) { nil }
+      let(:new_customer) { false }
+
+      before do
+        IntegrationCustomers::BaseCustomer.destroy_all
+
+        integration_customer
+      end
+
+      it 'removes integration customer object' do
+        service_call
+
+        expect(IntegrationCustomers::BaseCustomer.count).to eq(0)
+      end
+    end
+
+    context 'when creating integration customer' do
+      let(:integration_code) { integration.code }
+      let(:sync_with_provider) { true }
+      let(:external_customer_id) { nil }
+      let(:new_customer) { true }
+
+      it 'calls create job' do
+        expect { service_call }.to have_enqueued_job(IntegrationCustomers::CreateJob)
+      end
+
+      context 'with updating mode' do
+        let(:new_customer) { false }
+
+        it 'calls create job' do
+          expect { service_call }.to have_enqueued_job(IntegrationCustomers::CreateJob)
+        end
+      end
+    end
+
+    context 'when updating integration customer' do
+      let(:integration_customer) { create(:netsuite_customer, customer:, integration:) }
+      let(:integration_code) { integration.code }
+      let(:sync_with_provider) { true }
+      let(:external_customer_id) { '12345' }
+      let(:new_customer) { false }
+
+      before { integration_customer }
+
+      it 'calls create job' do
+        expect { service_call }.to have_enqueued_job(IntegrationCustomers::UpdateJob)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR handles strategy service for accounting customers.

This service will be called from `customers/create_service.rb` and `customers/update_service.rb`.

The main goal of this service is to determine if we should:
- skip syncing accounting customer
- create integration customer
- update integration customer (remove one)

Based on decision we call appropriate job so that the whole logic of accounting customer is extracted and can be retried. Accounting customer does not need to be in the same DB transaction and the main goal was that the whole process which handles accounting customer does not add extra complexity in customer create/update services.