### PR TITLE
misc: Increase graphql max-complexity

### DIFF
--- a/app/graphql/lago_api_schema.rb
+++ b/app/graphql/lago_api_schema.rb
@@ -8,7 +8,7 @@ class LagoApiSchema < GraphQL::Schema
   use GraphQL::Dataloader
 
   max_depth 13
-  max_complexity 300
+  max_complexity 350
 
   # GraphQL-Ruby calls this when something goes wrong while running a query:
 


### PR DESCRIPTION
Currently, the overview of an invoice has a complexity of 305, that's why we decided to increase the value from 300 to 350.