### PR TITLE
fix(events): update event subscription method

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -50,9 +50,9 @@ class Event < EventsRecord
     end
 
     scope
-      .where("date_trunc('second', started_at::timestamp) <= ?::timestamp", timestamp)
+      .where("date_trunc('millisecond', started_at::timestamp) <= ?::timestamp", timestamp)
       .where(
-        "terminated_at IS NULL OR date_trunc('second', terminated_at::timestamp) >= ?",
+        "terminated_at IS NULL OR date_trunc('millisecond', terminated_at::timestamp) >= ?",
         timestamp,
       )
       .order('terminated_at DESC NULLS FIRST, started_at DESC')

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -88,6 +88,16 @@ RSpec.describe Event, type: :model do
         expect(event.subscription).to eq(subscription)
       end
 
+      context 'when subscription is terminated just after the ingestion' do
+        before do
+          subscription.update!(terminated_at: timestamp + 0.2.seconds)
+        end
+
+        it 'returns the subscription' do
+          expect(event.subscription).to eq(subscription)
+        end
+      end
+
       context 'when a new active subscription exists' do
         let(:started_at) { 1.month.ago }
         let(:timestamp) { 1.week.ago }


### PR DESCRIPTION
## Context

Sometimes we receive `Error: NoMethodError: undefined method 'plan' for nil` error in `Fees::CreatePayInAdvanceJob`

We need to update `subscription` method in `event` model.

## Description

If the precision of `terminated_at` is higher than seconds which are used in condition (e.g., milliseconds), it could result in a discrepancy where the truncated timestamp used in the condition might not match exactly with the provided timestamp.

Based on investigation and various tests, it seems that using `millisecond` precision solves the issue
 