### PR TITLE
misc(stripe): Handle Stripe::AuthenticationError when registering stripe webhook URL

### DIFF
--- a/app/jobs/payment_providers/stripe/register_webhook_job.rb
+++ b/app/jobs/payment_providers/stripe/register_webhook_job.rb
@@ -6,7 +6,7 @@ module PaymentProviders
       queue_as 'providers'
 
       def perform(stripe_provider)
-        result = PaymentProviders::StripeService.new.register_webhook(stripe_provider)
+        result = PaymentProviders::Stripe::RegisterWebhookService.call(stripe_provider)
         result.raise_if_error!
       end
     end

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -30,6 +30,7 @@ class SendWebhookJob < ApplicationJob
     'credit_note.created' => Webhooks::CreditNotes::CreatedService,
     'credit_note.generated' => Webhooks::CreditNotes::GeneratedService,
     'credit_note.provider_refund_failure' => Webhooks::CreditNotes::PaymentProviderRefundFailureService,
+    'payment_provider.error' => Webhooks::PaymentProviders::ErrorService,
     'subscription.terminated' => Webhooks::Subscriptions::TerminatedService,
     'subscription.started' => Webhooks::Subscriptions::StartedService,
     'subscription.termination_alert' => Webhooks::Subscriptions::TerminationAlertService,

--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -4,6 +4,18 @@ module PaymentProviders
   class StripeProvider < BaseProvider
     SUCCESS_REDIRECT_URL = 'https://stripe.com/'
 
+    # NOTE: find the complete list of event types at https://stripe.com/docs/api/events/types
+    WEBHOOKS_EVENTS = [
+      'setup_intent.succeeded',
+      'payment_intent.payment_failed',
+      'payment_intent.succeeded',
+      'payment_method.detached',
+      'charge.refund.updated',
+      'customer.updated',
+      'charge.succeeded',
+      'charge.dispute.closed',
+    ].freeze
+
     validates :secret_key, presence: true
     validates :success_redirect_url, url: true, allow_nil: true, length: {maximum: 1024}
 

--- a/app/serializers/v1/payment_providers/error_serializer.rb
+++ b/app/serializers/v1/payment_providers/error_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module PaymentProviders
+    class ErrorSerializer < ModelSerializer
+      def serialize
+        {
+          lago_payment_provider_id: model.id,
+          payment_provider_code: model.code,
+          payment_provider_name: model.name,
+          source: options[:provider_error][:source],
+          action: options[:provider_error][:action],
+          provider_error: options[:provider_error].except(:source, :action),
+        }
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/stripe/base_service.rb
+++ b/app/services/payment_providers/stripe/base_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    class BaseService < BaseService
+      def initialize(payment_provider)
+        @payment_provider = payment_provider
+
+        super
+      end
+
+      protected
+
+      attr_reader :payment_provider
+
+      delegate :organization, :organization_id, to: :payment_provider
+
+      def api_key
+        payment_provider.secret_key
+      end
+
+      def deliver_error_webhook(action:, error:)
+        return unless organization.webhook_endpoints.any?
+
+        SendWebhookJob.perform_later(
+          'payment_provider.error',
+          payment_provider,
+          provider_error: {
+            source: 'stripe',
+            action: action,
+            message: error.message,
+            code: error.code,
+          },
+        )
+      end
+    end
+  end
+end

--- a/app/services/payment_providers/stripe/register_webhook_service.rb
+++ b/app/services/payment_providers/stripe/register_webhook_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module PaymentProviders
+  module Stripe
+    class RegisterWebhookService < BaseService
+      def call
+        stripe_webhook = ::Stripe::WebhookEndpoint.create(
+          {
+            url: webhook_end_point,
+            enabled_events: PaymentProviders::StripeProvider::WEBHOOKS_EVENTS,
+          },
+          {api_key:},
+        )
+
+        payment_provider.update!(
+          webhook_id: stripe_webhook.id,
+          webhook_secret: stripe_webhook.secret,
+        )
+
+        result.payment_provider = payment_provider
+        result
+      rescue ActiveRecord::RecordInvalid => e
+        result.record_validation_failure!(record: e.record)
+      rescue ::Stripe::AuthenticationError => e
+        deliver_error_webhook(action: 'payment_provider.register_webhook', error: e)
+        result
+      end
+
+      private
+
+      def webhook_end_point
+        URI.join(
+          ENV['LAGO_API_URL'],
+          "webhooks/stripe/#{organization_id}?code=#{URI.encode_www_form_component(payment_provider.code)}"
+        )
+      end
+    end
+  end
+end

--- a/app/services/webhooks/payment_providers/error_service.rb
+++ b/app/services/webhooks/payment_providers/error_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module PaymentProviders
+    class ErrorService < Webhooks::BaseService
+      private
+
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::PaymentProviders::ErrorSerializer.new(
+          object,
+          root_name: object_type,
+          provider_error: options[:provider_error],
+        )
+      end
+
+      def webhook_type
+        'payment_provider.error'
+      end
+
+      def object_type
+        'payment_provider_error'
+      end
+    end
+  end
+end

--- a/spec/jobs/payment_providers/stripe/register_webhook_job_spec.rb
+++ b/spec/jobs/payment_providers/stripe/register_webhook_job_spec.rb
@@ -3,22 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe PaymentProviders::Stripe::RegisterWebhookJob, type: :job do
-  let(:stripe_service) { instance_double(PaymentProviders::StripeService) }
   let(:result) { BaseService::Result.new }
 
   let(:stripe_provider) { create(:stripe_provider) }
 
   before do
-    allow(PaymentProviders::StripeService).to receive(:new)
-      .and_return(stripe_service)
-    allow(stripe_service).to receive(:register_webhook)
+    allow(PaymentProviders::Stripe::RegisterWebhookService).to receive(:call)
       .and_return(result)
   end
 
   it 'calls the register webhook service' do
     described_class.perform_now(stripe_provider)
 
-    expect(PaymentProviders::StripeService).to have_received(:new)
-    expect(stripe_service).to have_received(:register_webhook)
+    expect(PaymentProviders::Stripe::RegisterWebhookService).to have_received(:call)
   end
 end

--- a/spec/serializers/v1/payment_providers/error_serializer_spec.rb
+++ b/spec/serializers/v1/payment_providers/error_serializer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::PaymentProviders::ErrorSerializer do
+  subject(:serializer) { described_class.new(payment_provider, options) }
+
+  let(:payment_provider) { create(:stripe_provider) }
+  let(:options) do
+    {
+      'provider_error' => {
+        'source' => 'stripe',
+        'action' => 'payment_provider.register_webhook',
+        'error_message' => 'message',
+        'error_code' => nil,
+      },
+    }.with_indifferent_access
+  end
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['data']['lago_payment_provider_id']).to eq(payment_provider.id)
+      expect(result['data']['payment_provider_code']).to eq(payment_provider.code)
+      expect(result['data']['payment_provider_name']).to eq(payment_provider.name)
+      expect(result['data']['source']).to eq('stripe')
+      expect(result['data']['action']).to eq('payment_provider.register_webhook')
+      expect(result['data']['provider_error']).to eq({'error_message' => 'message', 'error_code' => nil})
+    end
+  end
+end

--- a/spec/services/payment_providers/stripe/register_webhook_service_spec.rb
+++ b/spec/services/payment_providers/stripe/register_webhook_service_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentProviders::Stripe::RegisterWebhookService do
+  subject(:provider_service) { described_class.new(payment_provider) }
+
+  let(:organization) { create(:organization) }
+  let(:payment_provider) { create(:stripe_provider, organization:) }
+
+  describe '.call' do
+    let(:stripe_webhook) do
+      ::Stripe::WebhookEndpoint.construct_from(
+        id: 'we_123456',
+        secret: 'whsec_123456',
+      )
+    end
+
+    before do
+      allow(::Stripe::WebhookEndpoint)
+        .to receive(:create)
+        .and_return(stripe_webhook)
+    end
+
+    it 'registers a webhook on stripe' do
+      result = provider_service.call
+
+      expect(result).to be_success
+
+      aggregate_failures do
+        expect(result.payment_provider.webhook_id).to eq('we_123456')
+        expect(result.payment_provider.webhook_secret).to eq('whsec_123456')
+      end
+    end
+
+    context 'when authentication fails on stripe API' do
+      before do
+        allow(::Stripe::WebhookEndpoint)
+          .to receive(:create)
+          .and_raise(::Stripe::AuthenticationError.new(
+            'This API call cannot be made with a publishable API key. Please use a secret API key. You can find a list of your API keys at https://dashboard.stripe.com/account/apikeys.'
+          ))
+      end
+
+      it 'delivers an error webhook' do
+        result = provider_service.call
+
+        expect(result).to be_success
+
+        expect(SendWebhookJob).to have_been_enqueued
+          .with(
+            'payment_provider.error',
+            payment_provider,
+            provider_error: {
+              source: 'stripe',
+              action: 'payment_provider.register_webhook',
+              message: 'This API call cannot be made with a publishable API key. Please use a secret API key. You can find a list of your API keys at https://dashboard.stripe.com/account/apikeys.',
+              code: nil,
+            },
+          )
+      end
+    end
+  end
+end

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -90,36 +90,6 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
     end
   end
 
-  describe '.register_webhook' do
-    let(:stripe_provider) do
-      create(:stripe_provider, organization:)
-    end
-
-    let(:stripe_webhook) do
-      ::Stripe::WebhookEndpoint.construct_from(
-        id: 'we_123456',
-        secret: 'whsec_123456',
-      )
-    end
-
-    before do
-      allow(::Stripe::WebhookEndpoint)
-        .to receive(:create)
-        .and_return(stripe_webhook)
-    end
-
-    it 'registers a webhook on stripe' do
-      result = stripe_service.register_webhook(stripe_provider)
-
-      expect(result).to be_success
-
-      aggregate_failures do
-        expect(result.stripe_provider.webhook_id).to eq('we_123456')
-        expect(result.stripe_provider.webhook_secret).to eq('whsec_123456')
-      end
-    end
-  end
-
   describe '.refresh_webhook' do
     let(:stripe_provider) do
       create(:stripe_provider, organization:)
@@ -147,8 +117,8 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
       expect(result).to be_success
 
       aggregate_failures do
-        expect(result.stripe_provider.webhook_id).to eq('we_123456')
-        expect(result.stripe_provider.webhook_secret).to eq('whsec_123456')
+        expect(result.payment_provider.webhook_id).to eq('we_123456')
+        expect(result.payment_provider.webhook_secret).to eq('whsec_123456')
       end
     end
   end

--- a/spec/services/webhooks/payment_providers/error_service_spec.rb
+++ b/spec/services/webhooks/payment_providers/error_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::PaymentProviders::ErrorService do
+  subject(:webhook_service) { described_class.new(object: payment_provider, options: webhook_options) }
+
+  let(:payment_provider) { create(:stripe_provider, organization:) }
+  let(:organization) { create(:organization) }
+  let(:webhook_options) { {provider_error: {message: 'message', error_code: 'code', source: 'stripe', action: 'payment_provider.register_webhook'}} }
+
+  describe '.call' do
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+
+    before do
+      allow(LagoHttpClient::Client).to receive(:new)
+        .with(organization.webhook_endpoints.first.webhook_url)
+        .and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response)
+    end
+
+    it 'builds payload with payment_provider.error webhook type' do
+      webhook_service.call
+
+      aggregate_failures do
+        expect(LagoHttpClient::Client).to have_received(:new)
+          .with(organization.webhook_endpoints.first.webhook_url)
+        expect(lago_client).to have_received(:post_with_response) do |payload|
+          expect(payload[:webhook_type]).to eq('payment_provider.error')
+          expect(payload[:object_type]).to eq('payment_provider_error')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Some `PaymentProviders::Stripe::RegisterWebhookJob` are failing with a `Stripe::AuthenticationError` error.
The error message is:
```
This API call cannot be made with a publishable API key. Please use a secret API key. You can find a list of your API keys at https://dashboard.stripe.com/account/apikeys.
```

Since this error cannot be handled by Lago, but must be addressed by the Lago organization admin, we need to inform the admin about it by sending a webhook and silent the error.

## Description

The PR refactors the stripe webhook endpoint creation by:
- Moving the registration logic from the generic `PaymentProviders::StripeService` into a dedicated `PaymentProviders::Stripe::RegisterWebhookService`
- Handling `Stripe::AuthenticationError`
  - Delivering a `payment_provider.error`
  - Returning an empty result