### PR TITLE
fix(integration-customer): Fix create service

### DIFF
--- a/app/graphql/types/customers/create_customer_input.rb
+++ b/app/graphql/types/customers/create_customer_input.rb
@@ -33,7 +33,7 @@ module Types
       argument :payment_provider_code, String, required: false
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false
 
-      argument :netsuite_customer, Types::IntegrationCustomers::Input, required: false
+      argument :integration_customer, Types::IntegrationCustomers::Input, required: false
 
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false
     end

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -35,7 +35,7 @@ module Types
       argument :payment_provider_code, String, required: false
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false
 
-      argument :netsuite_customer, Types::IntegrationCustomers::Input, required: false
+      argument :integration_customer, Types::IntegrationCustomers::Input, required: false
 
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false
     end

--- a/app/graphql/types/integration_customers/netsuite.rb
+++ b/app/graphql/types/integration_customers/netsuite.rb
@@ -12,8 +12,6 @@ module Types
       field :subsidiary_id, String, null: true
       field :sync_with_provider, Boolean, null: true
 
-      private
-
       def integration_type
         object.integration&.type
         case object.integration&.type

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -73,6 +73,14 @@ module Customers
       handle_api_billing_configuration(customer, params, new_customer)
 
       result.customer = customer.reload
+
+      # TODO:
+      # IntegrationCustomers::CreateOrUpdateService.call(
+      #   integration_customer_params: params[:integration_customer],
+      #   customer: result.customer,
+      #   new_customer:,
+      # )
+
       track_customer_created(customer)
       result
     rescue BaseService::ServiceFailure => e
@@ -147,6 +155,14 @@ module Customers
       create_billing_configuration(customer, billing_configuration)
 
       result.customer = customer
+
+      # TODO:
+      # IntegrationCustomers::CreateOrUpdateService.call(
+      #   integration_customer_params: args[:integration_customer]&.to_h,
+      #   customer: result.customer,
+      #   new_customer: true,
+      # )
+
       track_customer_created(customer)
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -16,6 +16,8 @@ module Customers
       end
 
       old_payment_provider = customer.payment_provider
+      # TODO:
+      # old_provider_customer = customer.provider_customer
       ActiveRecord::Base.transaction do
         billing_configuration = args[:billing_configuration]&.to_h || {}
         if args.key?(:currency)
@@ -75,7 +77,14 @@ module Customers
       customer.external_id = args[:external_id] if customer.editable? && args.key?(:external_id)
 
       ActiveRecord::Base.transaction do
+        # TODO:
+        # if old_provider_customer && args[:payment_provider].nil? && args[:payment_provider_code].present?
+        #   old_provider_customer.destroy!
+        #   customer.payment_provider_code = nil
+        # end
+
         customer.save!
+        customer = customer.reload
 
         if customer.organization.eu_tax_management
           eu_tax_code = Customers::EuAutoTaxesService.call(customer:)
@@ -103,6 +112,14 @@ module Customers
       end
 
       result.customer = customer
+
+      # TODO:
+      # IntegrationCustomers::CreateOrUpdateService.call(
+      #   integration_customer_params: args[:integration_customer]&.to_h,
+      #   customer: result.customer,
+      #   new_customer: false,
+      # )
+
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/integration_customers/create_or_update_service.rb
+++ b/app/services/integration_customers/create_or_update_service.rb
@@ -49,13 +49,16 @@ module IntegrationCustomers
 
     def skip_creating_integration_customer?
       integration_customer.nil? &&
+        integration_customer_params.blank? &&
         integration_customer_params[:sync_with_provider].blank? &&
         integration_customer_params[:external_customer_id].blank?
     end
 
     def integration
       return @integration if defined? @integration
-      return nil unless integration_customer_params[:integration_type] && integration_customer_params[:integration_code]
+      return nil unless integration_customer_params &&
+        integration_customer_params[:integration_type] &&
+        integration_customer_params[:integration_code]
 
       type = Integrations::BaseIntegration.integration_type(integration_customer_params[:integration_type])
       code = integration_customer_params[:integration_code]

--- a/schema.graphql
+++ b/schema.graphql
@@ -1782,6 +1782,7 @@ input CreateCustomerInput {
   email: String
   externalId: String!
   externalSalesforceId: String
+  integrationCustomer: IntegrationCustomerInput
   invoiceGracePeriod: Int
   legalName: String
   legalNumber: String
@@ -1789,7 +1790,6 @@ input CreateCustomerInput {
   metadata: [CustomerMetadataInput!]
   name: String!
   netPaymentTerm: Int
-  netsuiteCustomer: IntegrationCustomerInput
   paymentProvider: ProviderTypeEnum
   paymentProviderCode: String
   phone: String
@@ -6622,6 +6622,7 @@ input UpdateCustomerInput {
   externalId: String!
   externalSalesforceId: String
   id: ID!
+  integrationCustomer: IntegrationCustomerInput
   invoiceGracePeriod: Int
   legalName: String
   legalNumber: String
@@ -6629,7 +6630,6 @@ input UpdateCustomerInput {
   metadata: [CustomerMetadataInput!]
   name: String!
   netPaymentTerm: Int
-  netsuiteCustomer: IntegrationCustomerInput
   paymentProvider: ProviderTypeEnum
   paymentProviderCode: String
   phone: String

--- a/schema.json
+++ b/schema.json
@@ -6732,7 +6732,7 @@
               "deprecationReason": null
             },
             {
-              "name": "netsuiteCustomer",
+              "name": "integrationCustomer",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
@@ -31689,7 +31689,7 @@
               "deprecationReason": null
             },
             {
-              "name": "netsuiteCustomer",
+              "name": "integrationCustomer",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR fixes create service for integration customers when the params are empty.