### PR TITLE
feat(clickhouse): Update schema for events_raw

### DIFF
--- a/ci/clickhouse/config.xml
+++ b/ci/clickhouse/config.xml
@@ -19,26 +19,4 @@
             <path>/var/lib/clickhouse/access/</path>
         </local_directory>
     </user_directories>
-    <storage_configuration>
-        <disks>
-            <default>
-            </default>
-            <s3>
-              <type>local</type>
-              <path>/var/lib/clickhouse-s3/</path>
-            </s3>
-        </disks>
-        <policies>
-            <hot_cold>
-              <volumes>
-                <hot>
-                  <disk>default</disk>
-                </hot>
-                <cold>
-                  <disk>s3</disk>
-                </cold>
-              </volumes>
-            </hot_cold>
-        </policies>
-    </storage_configuration>
 </clickhouse>

--- a/db/clickhouse_migrate/20231024084411_create_events_raw.rb
+++ b/db/clickhouse_migrate/20231024084411_create_events_raw.rb
@@ -2,12 +2,7 @@ class CreateEventsRaw < ActiveRecord::Migration[7.0]
   def change
     options = <<-SQL
       MergeTree
-      PRIMARY KEY (organization_id, external_subscription_id, code, toStartOfDay(timestamp))
-      TTL
-        toDateTime(timestamp) TO VOLUME 'hot',
-        toDateTime(timestamp) + INTERVAL 90 DAY TO VOLUME 'cold'
-      SETTINGS
-        storage_policy = 'hot_cold';
+      ORDER BY (organization_id, external_subscription_id, code, timestamp)
     SQL
 
     create_table :events_raw, id: false, options: do |t|

--- a/db/clickhouse_schema.rb
+++ b/db/clickhouse_schema.rb
@@ -13,8 +13,8 @@
 ClickhouseActiverecord::Schema.define(version: 2023_10_30_163703) do
 
   # TABLE: events_raw
-  # SQL: CREATE TABLE default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime64(3), `code` String, `properties` Map(String, String) ) ENGINE = MergeTree PRIMARY KEY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) ORDER BY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) TTL toDateTime(timestamp) TO VOLUME 'hot', toDateTime(timestamp) + toIntervalDay(90) TO VOLUME 'cold' SETTINGS storage_policy = 'hot_cold', index_granularity = 8192
-  create_table "events_raw", id: false, options: "MergeTree PRIMARY KEY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) ORDER BY (organization_id, external_subscription_id, code, toStartOfDay(timestamp)) TTL toDateTime(timestamp) TO VOLUME 'hot', toDateTime(timestamp) + toIntervalDay(90) TO VOLUME 'cold' SETTINGS storage_policy = 'hot_cold', index_granularity = 8192", force: :cascade do |t|
+  # SQL: CREATE TABLE default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime64(3), `code` String, `properties` Map(String, String) ) ENGINE = MergeTree ORDER BY (organization_id, external_subscription_id, code, timestamp) SETTINGS index_granularity = 8192
+  create_table "events_raw", id: false, options: "MergeTree ORDER BY (organization_id, external_subscription_id, code, timestamp) SETTINGS index_granularity = 8192", force: :cascade do |t|
     t.string "organization_id", null: false
     t.string "external_customer_id", null: false
     t.string "external_subscription_id", null: false


### PR DESCRIPTION
## Context

This PR is part of the high usage event ingestion epic.

## Description

It refacts the migration to create `events_raw` table to remove the hot/cold storage approach as Clickhouse cloud does not provide this feature.