### PR TITLE
feat(wallet): Accept negative values for threshold_credits

### DIFF
--- a/app/services/validators/decimal_amount_service.rb
+++ b/app/services/validators/decimal_amount_service.rb
@@ -26,10 +26,6 @@ module Validators
       BigDecimal(amount).positive?
     end
 
-    private
-
-    attr_reader :amount, :decimal_amount
-
     def valid_decimal?
       # NOTE: as we want to be the more precise with decimals, we only
       # accept amount that are in string to avoid float bad parsing
@@ -46,5 +42,9 @@ module Validators
     rescue ArgumentError, TypeError
       false
     end
+
+    private
+
+    attr_reader :amount, :decimal_amount
   end
 end

--- a/app/services/wallets/validate_recurring_transaction_rules_service.rb
+++ b/app/services/wallets/validate_recurring_transaction_rules_service.rb
@@ -40,7 +40,7 @@ module Wallets
 
       return true if type == 'interval' && RecurringTransactionRule.intervals.key?(rule[:interval])
 
-      if type == 'threshold' && ::Validators::DecimalAmountService.new(rule[:threshold_credits]).valid_amount?
+      if type == 'threshold' && ::Validators::DecimalAmountService.new(rule[:threshold_credits]).valid_decimal?
         return true
       end
 

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -79,7 +79,7 @@ module Wallets
       end
 
       if recurring_rule[:rule_type]&.to_s == 'threshold' &&
-          ::Validators::DecimalAmountService.new(recurring_rule[:threshold_credits]).valid_amount?
+          ::Validators::DecimalAmountService.new(recurring_rule[:threshold_credits]).valid_decimal?
 
         return true
       end

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
           },
           {
             rule_type: 'threshold',
-            threshold_credits: '1.0',
+            threshold_credits: '-1.0',
           },
         ]
       end


### PR DESCRIPTION
## Context

When users create or edit a wallet they can define a recurring top-up rule.

If the rule is based on a threshold, the user can define this specific threshold.

Today the value set can be 0 or positive - we should be able to define a negative value also.

## Description

The goal of this PR is to accept negative values for `threshold_credits` by only validating the presence of a decimal instead of a positive amount.
