### PR TITLE
feat(wallet): Rename RecurringTransactionRule#rule_type to trigger

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -88,12 +88,12 @@ module Api
           :paid_credits,
           :granted_credits,
           :expiration_at,
-          # NOTE: Legacy field
-          :expiration_date,
+          :expiration_date, # NOTE: Legacy field
           recurring_transaction_rules: [
-            :rule_type,
+            :rule_type, # NOTE: Legacy field
             :interval,
             :threshold_credits,
+            :trigger,
           ],
         )
       end
@@ -106,13 +106,13 @@ module Api
         params.require(:wallet).permit(
           :name,
           :expiration_at,
-          # NOTE: Legacy field
-          :expiration_date,
+          :expiration_date, # NOTE: Legacy field
           recurring_transaction_rules: [
             :lago_id,
-            :rule_type,
+            :rule_type, # NOTE: Legacy field
             :interval,
             :threshold_credits,
+            :trigger,
             :paid_credits,
             :granted_credits,
           ],

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -90,7 +90,6 @@ module Api
           :expiration_at,
           :expiration_date, # NOTE: Legacy field
           recurring_transaction_rules: [
-            :rule_type, # NOTE: Legacy field
             :interval,
             :threshold_credits,
             :trigger,
@@ -109,7 +108,6 @@ module Api
           :expiration_date, # NOTE: Legacy field
           recurring_transaction_rules: [
             :lago_id,
-            :rule_type, # NOTE: Legacy field
             :interval,
             :threshold_credits,
             :trigger,

--- a/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
@@ -7,8 +7,8 @@ module Types
         graphql_name 'CreateRecurringTransactionRuleInput'
 
         argument :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, required: false
-        argument :rule_type, Types::Wallets::RecurringTransactionRules::RuleTypeEnum, required: true
         argument :threshold_credits, String, required: false
+        argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: true
       end
     end
   end

--- a/app/graphql/types/wallets/recurring_transaction_rules/object.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/object.rb
@@ -11,8 +11,8 @@ module Types
         field :granted_credits, String, null: false
         field :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, null: true
         field :paid_credits, String, null: false
-        field :rule_type, Types::Wallets::RecurringTransactionRules::RuleTypeEnum, null: false
         field :threshold_credits, String, null: true
+        field :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, null: false
 
         field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       end

--- a/app/graphql/types/wallets/recurring_transaction_rules/rule_type_enum.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/rule_type_enum.rb
@@ -6,7 +6,7 @@ module Types
       class RuleTypeEnum < Types::BaseEnum
         graphql_name 'RecurringTransactionRuleTypeEnum'
 
-        RecurringTransactionRule::RULE_TYPES.each do |type|
+        RecurringTransactionRule::TRIGGERS.each do |type|
           value type
         end
       end

--- a/app/graphql/types/wallets/recurring_transaction_rules/trigger_enum.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/trigger_enum.rb
@@ -3,8 +3,8 @@
 module Types
   module Wallets
     module RecurringTransactionRules
-      class RuleTypeEnum < Types::BaseEnum
-        graphql_name 'RecurringTransactionRuleTypeEnum'
+      class TriggerEnum < Types::BaseEnum
+        graphql_name 'RecurringTransactionTriggerEnum'
 
         RecurringTransactionRule::TRIGGERS.each do |type|
           value type

--- a/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
@@ -10,8 +10,8 @@ module Types
         argument :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, required: false
         argument :lago_id, ID, required: false
         argument :paid_credits, String, required: false
-        argument :rule_type, Types::Wallets::RecurringTransactionRules::RuleTypeEnum, required: false
         argument :threshold_credits, String, required: false
+        argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: false
       end
     end
   end

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -5,7 +5,7 @@ class RecurringTransactionRule < ApplicationRecord
 
   belongs_to :wallet
 
-  RULE_TYPES = [
+  TRIGGERS = [
     :interval,
     :threshold,
   ].freeze
@@ -17,6 +17,6 @@ class RecurringTransactionRule < ApplicationRecord
     :yearly,
   ].freeze
 
-  enum rule_type: RULE_TYPES
+  enum trigger: TRIGGERS
   enum interval: INTERVALS
 end

--- a/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
+++ b/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
@@ -6,11 +6,12 @@ module V1
       def serialize
         {
           lago_id: model.id,
-          rule_type: model.rule_type,
+          rule_type: model.trigger, # NOTE: Legacy field
           paid_credits: model.paid_credits,
           granted_credits: model.granted_credits,
           interval: model.interval,
           threshold_credits: model.threshold_credits,
+          trigger: model.trigger,
           created_at: model.created_at.iso8601,
         }
       end

--- a/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
+++ b/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
@@ -6,7 +6,6 @@ module V1
       def serialize
         {
           lago_id: model.id,
-          rule_type: model.trigger, # NOTE: Legacy field
           paid_credits: model.paid_credits,
           granted_credits: model.granted_credits,
           interval: model.interval,

--- a/app/services/wallets/balance/update_ongoing_service.rb
+++ b/app/services/wallets/balance/update_ongoing_service.rb
@@ -47,7 +47,7 @@ module Wallets
       end
 
       def handle_threshold_top_up(ongoing_usage_balance_cents)
-        threshold_rule = wallet.recurring_transaction_rules.where(rule_type: :threshold).first
+        threshold_rule = wallet.recurring_transaction_rules.where(trigger: :threshold).first
 
         return if threshold_rule.nil? || wallet.credits_ongoing_balance > threshold_rule.threshold_credits
         return if usage_amount_cents.positive? && ongoing_usage_balance_cents == usage_amount_cents

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -67,7 +67,7 @@ module Wallets
           INNER JOIN customers ON customers.id = wallets.customer_id
           INNER JOIN organizations ON organizations.id = customers.organization_id
         WHERE wallets.status = #{Wallet.statuses[:active]}
-          AND recurring_transaction_rules.rule_type = #{RecurringTransactionRule.rule_types[:interval]}
+          AND recurring_transaction_rules.trigger = #{RecurringTransactionRule.triggers[:interval]}
           AND recurring_transaction_rules.interval = #{RecurringTransactionRule.intervals[interval]}
           AND #{conditions.join(" AND ")}
         GROUP BY recurring_transaction_rules.id

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -65,7 +65,7 @@ module Wallets
         granted_credits:,
         threshold_credits: recurring_rule[:threshold_credits] || '0.0',
         interval: recurring_rule[:interval],
-        trigger: (recurring_rule[:trigger] || recurring_rule[:rule_type]).to_s
+        trigger: recurring_rule[:trigger].to_s
       )
     end
   end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -65,7 +65,7 @@ module Wallets
         granted_credits:,
         threshold_credits: recurring_rule[:threshold_credits] || '0.0',
         interval: recurring_rule[:interval],
-        rule_type: recurring_rule[:rule_type].to_s,
+        trigger: (recurring_rule[:trigger] || recurring_rule[:rule_type]).to_s
       )
     end
   end

--- a/app/services/wallets/recurring_transaction_rules/update_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/update_service.rb
@@ -20,10 +20,6 @@ module Wallets
           recurring_rule = wallet.recurring_transaction_rules.find_by(id: lago_id)
 
           if recurring_rule
-            # NOTE: Handle legacy field rule_type
-            rule_type = rule.delete(:rule_type)
-            rule[:trigger] = rule_type if rule_type && rule[:trigger].nil?
-
             recurring_rule.update!(rule)
 
             next

--- a/app/services/wallets/recurring_transaction_rules/update_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/update_service.rb
@@ -20,6 +20,10 @@ module Wallets
           recurring_rule = wallet.recurring_transaction_rules.find_by(id: lago_id)
 
           if recurring_rule
+            # NOTE: Handle legacy field rule_type
+            rule_type = rule.delete(:rule_type)
+            rule[:trigger] = rule_type if rule_type && rule[:trigger].nil?
+
             recurring_rule.update!(rule)
 
             next

--- a/app/services/wallets/validate_recurring_transaction_rules_service.rb
+++ b/app/services/wallets/validate_recurring_transaction_rules_service.rb
@@ -41,7 +41,7 @@ module Wallets
 
       return true if (type == 'interval' || trigger == 'interval') && RecurringTransactionRule.intervals.key?(rule[:interval])
 
-      if (type == 'threshold'|| trigger == 'threshold') && ::Validators::DecimalAmountService.new(rule[:threshold_credits]).valid_decimal?
+      if (type == 'threshold' || trigger == 'threshold') && ::Validators::DecimalAmountService.new(rule[:threshold_credits]).valid_decimal?
         return true
       end
 

--- a/app/services/wallets/validate_recurring_transaction_rules_service.rb
+++ b/app/services/wallets/validate_recurring_transaction_rules_service.rb
@@ -29,6 +29,7 @@ module Wallets
 
       rule = args[:recurring_transaction_rules].first
       type = rule[:rule_type]&.to_s
+      trigger = rule[:trigger]&.to_s
 
       if !::Validators::DecimalAmountService.new(rule[:paid_credits]).valid_amount? ||
           !::Validators::DecimalAmountService.new(rule[:granted_credits]).valid_amount?
@@ -38,9 +39,9 @@ module Wallets
         return
       end
 
-      return true if type == 'interval' && RecurringTransactionRule.intervals.key?(rule[:interval])
+      return true if (type == 'interval' || trigger == 'interval') && RecurringTransactionRule.intervals.key?(rule[:interval])
 
-      if type == 'threshold' && ::Validators::DecimalAmountService.new(rule[:threshold_credits]).valid_decimal?
+      if (type == 'threshold'|| trigger == 'threshold') && ::Validators::DecimalAmountService.new(rule[:threshold_credits]).valid_decimal?
         return true
       end
 

--- a/app/services/wallets/validate_recurring_transaction_rules_service.rb
+++ b/app/services/wallets/validate_recurring_transaction_rules_service.rb
@@ -28,7 +28,6 @@ module Wallets
       return true if args[:recurring_transaction_rules].count.zero?
 
       rule = args[:recurring_transaction_rules].first
-      type = rule[:rule_type]&.to_s
       trigger = rule[:trigger]&.to_s
 
       if !::Validators::DecimalAmountService.new(rule[:paid_credits]).valid_amount? ||
@@ -39,9 +38,9 @@ module Wallets
         return
       end
 
-      return true if (type == 'interval' || trigger == 'interval') && RecurringTransactionRule.intervals.key?(rule[:interval])
+      return true if trigger == 'interval' && RecurringTransactionRule.intervals.key?(rule[:interval])
 
-      if (type == 'threshold' || trigger == 'threshold') && ::Validators::DecimalAmountService.new(rule[:threshold_credits]).valid_decimal?
+      if trigger == 'threshold' && ::Validators::DecimalAmountService.new(rule[:threshold_credits]).valid_decimal?
         return true
       end
 

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -72,13 +72,13 @@ module Wallets
 
       recurring_rule = args[:recurring_transaction_rules].first
 
-      if (recurring_rule[:rule_type]&.to_s == 'interval' || recurring_rule[:trigger]&.to_s == 'interval') &&
+      if recurring_rule[:trigger]&.to_s == 'interval' &&
           RecurringTransactionRule.intervals.key?(recurring_rule[:interval])
 
         return true
       end
 
-      if (recurring_rule[:rule_type]&.to_s == 'threshold' || recurring_rule[:trigger]&.to_s == 'threshold') &&
+      if recurring_rule[:trigger]&.to_s == 'threshold' &&
           ::Validators::DecimalAmountService.new(recurring_rule[:threshold_credits]).valid_decimal?
 
         return true

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -72,13 +72,13 @@ module Wallets
 
       recurring_rule = args[:recurring_transaction_rules].first
 
-      if recurring_rule[:rule_type]&.to_s == 'interval' &&
+      if (recurring_rule[:rule_type]&.to_s == 'interval' || recurring_rule[:trigger]&.to_s == 'interval') &&
           RecurringTransactionRule.intervals.key?(recurring_rule[:interval])
 
         return true
       end
 
-      if recurring_rule[:rule_type]&.to_s == 'threshold' &&
+      if (recurring_rule[:rule_type]&.to_s == 'threshold' || recurring_rule[:trigger]&.to_s == 'threshold') &&
           ::Validators::DecimalAmountService.new(recurring_rule[:threshold_credits]).valid_decimal?
 
         return true

--- a/db/migrate/20240514072741_add_method_to_recurring_transaction_rules.rb
+++ b/db/migrate/20240514072741_add_method_to_recurring_transaction_rules.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddMethodToRecurringTransactionRules < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :recurring_transaction_rules, :rule_type, :trigger
+    add_column :recurring_transaction_rules, :method, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_02_095122) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_14_072741) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -873,13 +873,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_02_095122) do
 
   create_table "recurring_transaction_rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "wallet_id", null: false
-    t.integer "rule_type", default: 0, null: false
+    t.integer "trigger", default: 0, null: false
     t.decimal "paid_credits", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "granted_credits", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "threshold_credits", precision: 30, scale: 5, default: "0.0"
     t.integer "interval", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "method", default: 0, null: false
     t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
   end
 

--- a/lib/tasks/custom_aggregation.rake
+++ b/lib/tasks/custom_aggregation.rake
@@ -6,13 +6,13 @@ namespace :custom_aggregation do
     # Custom aggregator
     def aggregate(event, previous_state, aggregation_properties)
       # TODO: change me
-      { total_units: BigDecimal('0'), amount: BigDecimal('0') }
+      {total_units: BigDecimal('0'), amount: BigDecimal('0')}
     end
 
     # Aggregation properties - TODO: change me
     aggregation_properties = {}
     # Intial state
-    previous_state = { total_units: BigDecimal('0'), amount: BigDecimal('0')}
+    previous_state = {total_units: BigDecimal('0'), amount: BigDecimal('0')}
     # Event list - TODO: change me
     events = [OpenStruct.new(properties: {})]
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1975,8 +1975,8 @@ input CreatePlanInput {
 
 input CreateRecurringTransactionRuleInput {
   interval: RecurringTransactionIntervalEnum
-  ruleType: RecurringTransactionRuleTypeEnum!
   thresholdCredits: String
+  trigger: RecurringTransactionTriggerEnum!
 }
 
 """
@@ -5555,11 +5555,11 @@ type RecurringTransactionRule {
   interval: RecurringTransactionIntervalEnum
   lagoId: ID!
   paidCredits: String!
-  ruleType: RecurringTransactionRuleTypeEnum!
   thresholdCredits: String
+  trigger: RecurringTransactionTriggerEnum!
 }
 
-enum RecurringTransactionRuleTypeEnum {
+enum RecurringTransactionTriggerEnum {
   interval
   threshold
 }
@@ -6829,8 +6829,8 @@ input UpdateRecurringTransactionRuleInput {
   interval: RecurringTransactionIntervalEnum
   lagoId: ID
   paidCredits: String
-  ruleType: RecurringTransactionRuleTypeEnum
   thresholdCredits: String
+  trigger: RecurringTransactionTriggerEnum
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -7926,28 +7926,28 @@
               "deprecationReason": null
             },
             {
-              "name": "ruleType",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "RecurringTransactionRuleTypeEnum",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "thresholdCredits",
               "description": null,
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "trigger",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "RecurringTransactionTriggerEnum",
+                  "ofType": null
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -28024,16 +28024,12 @@
               ]
             },
             {
-              "name": "ruleType",
+              "name": "thresholdCredits",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "RecurringTransactionRuleTypeEnum",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -28042,12 +28038,16 @@
               ]
             },
             {
-              "name": "thresholdCredits",
+              "name": "trigger",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "RecurringTransactionTriggerEnum",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -28061,7 +28061,7 @@
         },
         {
           "kind": "ENUM",
-          "name": "RecurringTransactionRuleTypeEnum",
+          "name": "RecurringTransactionTriggerEnum",
           "description": null,
           "interfaces": null,
           "possibleTypes": null,
@@ -33046,11 +33046,11 @@
               "deprecationReason": null
             },
             {
-              "name": "ruleType",
+              "name": "thresholdCredits",
               "description": null,
               "type": {
-                "kind": "ENUM",
-                "name": "RecurringTransactionRuleTypeEnum",
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null,
@@ -33058,11 +33058,11 @@
               "deprecationReason": null
             },
             {
-              "name": "thresholdCredits",
+              "name": "trigger",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "ENUM",
+                "name": "RecurringTransactionTriggerEnum",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/factories/recurring_transaction_rules.rb
+++ b/spec/factories/recurring_transaction_rules.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :recurring_transaction_rule do
     wallet
-    rule_type { 'interval' }
+    trigger { 'interval' }
     paid_credits { '10.00' }
     granted_credits { '10.00' }
     interval { 'monthly' }

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
           status
           currency
           expirationAt
-          recurringTransactionRules { lagoId, ruleType, interval, thresholdCredits, paidCredits, grantedCredits }
+          recurringTransactionRules { lagoId, trigger, interval, thresholdCredits, paidCredits, grantedCredits }
         }
       }
     GQL
@@ -47,7 +47,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
           currency: 'EUR',
           recurringTransactionRules: [
             {
-              ruleType: 'interval',
+              trigger: 'interval',
               interval: 'monthly',
             },
           ],
@@ -63,7 +63,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
       expect(result_data['expirationAt']).to eq(expiration_at.iso8601)
       expect(result_data['recurringTransactionRules'].count).to eq(1)
       expect(result_data['recurringTransactionRules'][0]['lagoId']).to be_present
-      expect(result_data['recurringTransactionRules'][0]['ruleType']).to eq('interval')
+      expect(result_data['recurringTransactionRules'][0]['trigger']).to eq('interval')
       expect(result_data['recurringTransactionRules'][0]['interval']).to eq('monthly')
       expect(result_data['recurringTransactionRules'][0]['paidCredits']).to eq('0.0')
       expect(result_data['recurringTransactionRules'][0]['grantedCredits']).to eq('0.0')

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
           name
           status
           expirationAt
-          recurringTransactionRules { lagoId, ruleType, interval, thresholdCredits, paidCredits, grantedCredits }
+          recurringTransactionRules { lagoId, trigger, interval, thresholdCredits, paidCredits, grantedCredits }
         }
       }
     GQL
@@ -51,7 +51,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
           recurringTransactionRules: [
             {
               lagoId: recurring_transaction_rule.id,
-              ruleType: 'interval',
+              trigger: 'interval',
               interval: 'weekly',
               paidCredits: '22.2',
               grantedCredits: '22.2',
@@ -69,7 +69,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
       expect(result_data['expirationAt']).to eq(expiration_at.iso8601)
       expect(result_data['recurringTransactionRules'].count).to eq(1)
       expect(result_data['recurringTransactionRules'][0]['lagoId']).to eq(recurring_transaction_rule.id)
-      expect(result_data['recurringTransactionRules'][0]['ruleType']).to eq('interval')
+      expect(result_data['recurringTransactionRules'][0]['trigger']).to eq('interval')
       expect(result_data['recurringTransactionRules'][0]['interval']).to eq('weekly')
       expect(result_data['recurringTransactionRules'][0]['paidCredits']).to eq('22.2')
       expect(result_data['recurringTransactionRules'][0]['grantedCredits']).to eq('22.2')

--- a/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::CreateInput do
   subject { described_class }
 
   it { is_expected.to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum') }
-  it { is_expected.to accept_argument(:rule_type).of_type('RecurringTransactionRuleTypeEnum!') }
+  it { is_expected.to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum!') }
   it { is_expected.to accept_argument(:threshold_credits).of_type('String') }
 end

--- a/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::Object do
   subject { described_class }
 
   it { is_expected.to have_field(:lago_id).of_type('ID!') }
-  it { is_expected.to have_field(:rule_type).of_type('RecurringTransactionRuleTypeEnum!') }
+  it { is_expected.to have_field(:trigger).of_type('RecurringTransactionTriggerEnum!') }
   it { is_expected.to have_field(:interval).of_type('RecurringTransactionIntervalEnum') }
 
   it { is_expected.to have_field(:threshold_credits).of_type('String') }

--- a/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::UpdateInput do
   subject { described_class }
 
   it { is_expected.to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum') }
-  it { is_expected.to accept_argument(:rule_type).of_type('RecurringTransactionRuleTypeEnum') }
+  it { is_expected.to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum') }
   it { is_expected.to accept_argument(:threshold_credits).of_type('String') }
   it { is_expected.to accept_argument(:lago_id).of_type('ID') }
   it { is_expected.to accept_argument(:paid_credits).of_type('String') }

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           expiration_at:,
           recurring_transaction_rules: [
             {
-              rule_type: 'interval',
+              trigger: 'interval',
               interval: 'monthly',
             },
           ],
@@ -86,7 +86,6 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           expect(response).to have_http_status(:success)
 
           expect(recurring_rules).to be_present
-          expect(recurring_rules.first[:rule_type]).to eq('interval')
           expect(recurring_rules.first[:interval]).to eq('monthly')
           expect(recurring_rules.first[:paid_credits]).to eq('10.0')
           expect(recurring_rules.first[:granted_credits]).to eq('10.0')
@@ -190,7 +189,6 @@ RSpec.describe Api::V1::WalletsController, type: :request do
 
           expect(recurring_rules).to be_present
           expect(recurring_rules.first[:lago_id]).to eq(recurring_transaction_rule.id)
-          expect(recurring_rules.first[:rule_type]).to eq('interval')
           expect(recurring_rules.first[:interval]).to eq('weekly')
           expect(recurring_rules.first[:paid_credits]).to eq('105.0')
           expect(recurring_rules.first[:granted_credits]).to eq('105.0')

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           expect(recurring_rules.first[:interval]).to eq('monthly')
           expect(recurring_rules.first[:paid_credits]).to eq('10.0')
           expect(recurring_rules.first[:granted_credits]).to eq('10.0')
+          expect(recurring_rules.first[:trigger]).to eq('interval')
         end
       end
     end
@@ -164,7 +165,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           recurring_transaction_rules: [
             {
               lago_id: recurring_transaction_rule.id,
-              rule_type: 'interval',
+              trigger: 'interval',
               interval: 'weekly',
               paid_credits: '105',
               granted_credits: '105',
@@ -193,6 +194,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           expect(recurring_rules.first[:interval]).to eq('weekly')
           expect(recurring_rules.first[:paid_credits]).to eq('105.0')
           expect(recurring_rules.first[:granted_credits]).to eq('105.0')
+          expect(recurring_rules.first[:trigger]).to eq('interval')
         end
       end
     end

--- a/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
+++ b/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe ::V1::Wallets::RecurringTransactionRuleSerializer do
 
     aggregate_failures do
       expect(result['recurring_transaction_rule']['lago_id']).to eq(recurring_transaction_rule.id)
-      expect(result['recurring_transaction_rule']['rule_type']).to eq(recurring_transaction_rule.trigger)
       expect(result['recurring_transaction_rule']['trigger']).to eq(recurring_transaction_rule.trigger)
       expect(result['recurring_transaction_rule']['interval']).to eq(recurring_transaction_rule.interval)
       expect(result['recurring_transaction_rule']['paid_credits']).to eq(recurring_transaction_rule.paid_credits.to_s)

--- a/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
+++ b/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe ::V1::Wallets::RecurringTransactionRuleSerializer do
 
     aggregate_failures do
       expect(result['recurring_transaction_rule']['lago_id']).to eq(recurring_transaction_rule.id)
-      expect(result['recurring_transaction_rule']['rule_type']).to eq(recurring_transaction_rule.rule_type)
+      expect(result['recurring_transaction_rule']['rule_type']).to eq(recurring_transaction_rule.trigger)
+      expect(result['recurring_transaction_rule']['trigger']).to eq(recurring_transaction_rule.trigger)
       expect(result['recurring_transaction_rule']['interval']).to eq(recurring_transaction_rule.interval)
       expect(result['recurring_transaction_rule']['paid_credits']).to eq(recurring_transaction_rule.paid_credits.to_s)
       expect(result['recurring_transaction_rule']['created_at']).to eq(recurring_transaction_rule.created_at.iso8601)

--- a/spec/services/wallets/balance/update_ongoing_service_spec.rb
+++ b/spec/services/wallets/balance/update_ongoing_service_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Wallets::Balance::UpdateOngoingService, type: :service do
 
     context 'with recurring transaction threshold rule' do
       let(:recurring_transaction_rule) do
-        create(:recurring_transaction_rule, wallet:, rule_type: 'threshold', threshold_credits: '6.0')
+        create(:recurring_transaction_rule, wallet:, trigger: 'threshold', threshold_credits: '6.0')
       end
 
       before { recurring_transaction_rule }
@@ -70,7 +70,7 @@ RSpec.describe Wallets::Balance::UpdateOngoingService, type: :service do
 
       context 'when border has NOT been crossed' do
         let(:recurring_transaction_rule) do
-          create(:recurring_transaction_rule, wallet:, rule_type: 'threshold', threshold_credits: '2.0')
+          create(:recurring_transaction_rule, wallet:, trigger: 'threshold', threshold_credits: '2.0')
         end
 
         it 'does not call wallet transaction create job' do

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
     let(:recurring_transaction_rule) do
       create(
         :recurring_transaction_rule,
-        rule_type: :interval,
+        trigger: :interval,
         wallet:,
         interval:,
         created_at: created_at + 1.second,

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Wallets::CreateService, type: :service do
       let(:rules) do
         [
           {
-            rule_type: 'interval',
+            trigger: 'interval',
             interval: 'monthly',
           },
         ]
@@ -107,7 +107,7 @@ RSpec.describe Wallets::CreateService, type: :service do
           expect(wallet.name).to eq('New Wallet')
           expect(rule.wallet_id).to eq(wallet.id)
           expect(wallet.reload.recurring_transaction_rules.count).to eq(1)
-          expect(rule.rule_type).to eq('interval')
+          expect(rule.trigger).to eq('interval')
           expect(rule.interval).to eq('monthly')
           expect(rule.threshold_credits).to eq(0.0)
           expect(rule.paid_credits).to eq(1.0)
@@ -119,11 +119,11 @@ RSpec.describe Wallets::CreateService, type: :service do
         let(:rules) do
           [
             {
-              rule_type: 'interval',
+              trigger: 'interval',
               interval: 'monthly',
             },
             {
-              rule_type: 'threshold',
+              trigger: 'threshold',
               threshold_credits: '1.0',
             },
           ]
@@ -140,7 +140,7 @@ RSpec.describe Wallets::CreateService, type: :service do
         let(:rules) do
           [
             {
-              rule_type: 'invalid',
+              trigger: 'invalid',
               interval: 'monthly',
             },
           ]
@@ -156,7 +156,7 @@ RSpec.describe Wallets::CreateService, type: :service do
         let(:rules) do
           [
             {
-              rule_type: 'threshold',
+              trigger: 'threshold',
               threshold_credits: 'abc',
             },
           ]

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -67,29 +67,6 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
       end
     end
 
-    context 'with legacy rule_type' do
-      let(:params) do
-        [
-          {
-            lago_id: recurring_transaction_rule.id,
-            rule_type: 'interval'
-          },
-        ]
-      end
-
-      it 'updates existing recurring transaction rule' do
-        result = update_service.call
-
-        rule = result.wallet.reload.recurring_transaction_rules.first
-
-        aggregate_failures do
-          expect(result.wallet.reload.recurring_transaction_rules.count).to eq(1)
-          expect(rule.id).to eq(recurring_transaction_rule.id)
-          expect(rule.trigger).to eq('interval')
-        end
-      end
-    end
-
     context 'when empty array is sent as argument' do
       let(:params) do
         []

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
     [
       {
         lago_id: recurring_transaction_rule.id,
-        rule_type: 'interval',
+        trigger: 'interval',
         interval: 'weekly',
         paid_credits: '105',
         granted_credits: '105',
@@ -30,7 +30,7 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
       aggregate_failures do
         expect(result.wallet.reload.recurring_transaction_rules.count).to eq(1)
         expect(rule.id).to eq(recurring_transaction_rule.id)
-        expect(rule.rule_type).to eq('interval')
+        expect(rule.trigger).to eq('interval')
         expect(rule.interval).to eq('weekly')
         expect(rule.threshold_credits).to eq(0.0)
         expect(rule.paid_credits).to eq(105.0)
@@ -42,7 +42,7 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
       let(:params) do
         [
           {
-            rule_type: 'interval',
+            trigger: 'interval',
             interval: 'weekly',
             paid_credits: '105',
             granted_credits: '105',
@@ -58,11 +58,34 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
         aggregate_failures do
           expect(result.wallet.reload.recurring_transaction_rules.count).to eq(1)
           expect(rule.id).not_to eq(recurring_transaction_rule.id)
-          expect(rule.rule_type).to eq('interval')
+          expect(rule.trigger).to eq('interval')
           expect(rule.interval).to eq('weekly')
           expect(rule.threshold_credits).to eq(0.0)
           expect(rule.paid_credits).to eq(105.0)
           expect(rule.granted_credits).to eq(105.0)
+        end
+      end
+    end
+
+    context 'with legacy rule_type' do
+      let(:params) do
+        [
+          {
+            lago_id: recurring_transaction_rule.id,
+            rule_type: 'interval'
+          },
+        ]
+      end
+
+      it 'updates existing recurring transaction rule' do
+        result = update_service.call
+
+        rule = result.wallet.reload.recurring_transaction_rules.first
+
+        aggregate_failures do
+          expect(result.wallet.reload.recurring_transaction_rules.count).to eq(1)
+          expect(rule.id).to eq(recurring_transaction_rule.id)
+          expect(rule.trigger).to eq('interval')
         end
       end
     end

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
       let(:rules) do
         [
           {
-            rule_type: 'interval',
+            trigger: 'interval',
             interval: 'weekly',
             paid_credits: '105',
             granted_credits: '105',
@@ -124,7 +124,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
 
           expect(result.wallet.reload.recurring_transaction_rules.count).to eq(1)
           expect(rule.id).not_to eq(recurring_transaction_rule.id)
-          expect(rule.rule_type).to eq('interval')
+          expect(rule.trigger).to eq('interval')
           expect(rule.interval).to eq('weekly')
           expect(rule.threshold_credits).to eq(0.0)
           expect(rule.paid_credits).to eq(105.0)
@@ -137,7 +137,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
           [
             {
               lago_id: recurring_transaction_rule.id,
-              rule_type: 'interval',
+              trigger: 'interval',
               interval: 'weekly',
               paid_credits: '105',
               granted_credits: '105',
@@ -155,7 +155,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
 
             expect(result.wallet.reload.recurring_transaction_rules.count).to eq(1)
             expect(rule.id).to eq(recurring_transaction_rule.id)
-            expect(rule.rule_type).to eq('interval')
+            expect(rule.trigger).to eq('interval')
             expect(rule.interval).to eq('weekly')
             expect(rule.threshold_credits).to eq(0.0)
             expect(rule.paid_credits).to eq(105.0)
@@ -169,7 +169,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
           [
             {
               lago_id: recurring_transaction_rule.id,
-              rule_type: 'threshold',
+              trigger: 'threshold',
               threshold_credits: '205',
               paid_credits: '105',
               granted_credits: '105',
@@ -187,7 +187,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
           aggregate_failures do
             expect(result.wallet.reload.recurring_transaction_rules.count).to eq(1)
             expect(rule.id).to eq(recurring_transaction_rule.id)
-            expect(rule.rule_type).to eq('threshold')
+            expect(rule.trigger).to eq('threshold')
             expect(rule.threshold_credits).to eq(205.0)
             expect(rule.paid_credits).to eq(105.0)
             expect(rule.granted_credits).to eq(105.0)
@@ -214,13 +214,13 @@ RSpec.describe Wallets::UpdateService, type: :service do
         let(:rules) do
           [
             {
-              rule_type: 'interval',
+              trigger: 'interval',
               interval: 'monthly',
               paid_credits: '105',
               granted_credits: '105',
             },
             {
-              rule_type: 'threshold',
+              trigger: 'threshold',
               threshold_credits: '1.0',
               paid_credits: '105',
               granted_credits: '105',
@@ -241,7 +241,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
         let(:rules) do
           [
             {
-              rule_type: 'invalid',
+              trigger: 'invalid',
               interval: 'monthly',
               paid_credits: '105',
               granted_credits: '105',
@@ -261,7 +261,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
         let(:rules) do
           [
             {
-              rule_type: 'threshold',
+              trigger: 'threshold',
               threshold_credits: 'abc',
               paid_credits: '105',
               granted_credits: '105',

--- a/spec/services/wallets/validate_recurring_transaction_rules_service_spec.rb
+++ b/spec/services/wallets/validate_recurring_transaction_rules_service_spec.rb
@@ -29,13 +29,13 @@ RSpec.describe Wallets::ValidateRecurringTransactionRulesService, type: :service
       let(:rules) do
         [
           {
-            rule_type: 'interval',
+            trigger: 'interval',
             interval: 'monthly',
             paid_credits: '105',
             granted_credits: '105',
           },
           {
-            rule_type: 'threshold',
+            trigger: 'threshold',
             threshold_credits: '1.0',
             paid_credits: '105',
             granted_credits: '105',
@@ -53,7 +53,7 @@ RSpec.describe Wallets::ValidateRecurringTransactionRulesService, type: :service
       let(:rules) do
         [
           {
-            rule_type: 'interval',
+            trigger: 'interval',
             interval: 'invalid',
             paid_credits: '105',
             granted_credits: '105',
@@ -71,7 +71,7 @@ RSpec.describe Wallets::ValidateRecurringTransactionRulesService, type: :service
       let(:rules) do
         [
           {
-            rule_type: 'threshold',
+            trigger: 'threshold',
             threshold_credits: 'invalid',
             paid_credits: '105',
             granted_credits: '105',

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -107,11 +107,11 @@ RSpec.describe Wallets::ValidateService, type: :service do
       let(:rules) do
         [
           {
-            rule_type: 'interval',
+            trigger: 'interval',
             interval: 'monthly',
           },
           {
-            rule_type: 'threshold',
+            trigger: 'threshold',
             threshold_credits: '-1.0',
           },
         ]
@@ -135,7 +135,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
         let(:rules) do
           [
             {
-              rule_type: 'interval',
+              trigger: 'interval',
               interval: 'invalid',
             },
           ]
@@ -151,7 +151,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
         let(:rules) do
           [
             {
-              rule_type: 'threshold',
+              trigger: 'threshold',
               threshold_credits: 'invalid',
             },
           ]


### PR DESCRIPTION
## Context

After the release of real-time wallet version 1, some customers have expressed concerns about odd or missing behaviors.

## Description

The goal of this PR is to rename `Wallet#rule_type` into `Wallet#trigger`.

A new column `method` has been added as well to not create another migration in the next PR.