### PR TITLE
chore(kafka): add ingested_at field

### DIFF
--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -76,6 +76,7 @@ module Events
           timestamp: event.timestamp.to_f,
           code: event.code,
           properties: event.properties,
+          ingested_at: Time.zone.now.iso8601[...-1],
         }.to_json,
       )
     end

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -52,6 +52,7 @@ module Events
           timestamp: event.timestamp.iso8601[...-1], # NOTE: Removes trailing 'Z' to allow clickhouse parsing
           code: event.code,
           properties: event.properties,
+          ingested_at: Time.zone.now.iso8601[...-1],
         }.to_json,
       )
     end


### PR DESCRIPTION
## Description

- add `ingested_at` field on kafka payload
- it permit a better tracking on when an event is ingested