### PR TITLE
feat(integrations): Add integration resources models - trigger jobs on save

### DIFF
--- a/app/jobs/integrations/aggregator/invoices/create_job.rb
+++ b/app/jobs/integrations/aggregator/invoices/create_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module Invoices
+      class CreateJob < ApplicationJob
+        queue_as 'integrations'
+
+        retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
+
+        # TODO:
+        def perform(invoice:)
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/integrations/aggregator/sales_orders/create_job.rb
+++ b/app/jobs/integrations/aggregator/sales_orders/create_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module SalesOrders
+      class CreateJob < ApplicationJob
+        queue_as 'integrations'
+
+        retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
+
+        # TODO:
+        def perform(invoice:)
+        end
+      end
+    end
+  end
+end

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -20,6 +20,7 @@ class CreditNote < ApplicationRecord
 
   has_many :applied_taxes, class_name: 'CreditNote::AppliedTax', dependent: :destroy
   has_many :taxes, through: :applied_taxes
+  has_many :integration_resources, as: :syncable
 
   has_one_attached :file
 

--- a/app/models/integration_resource.rb
+++ b/app/models/integration_resource.rb
@@ -1,0 +1,3 @@
+class IntegrationResource < ApplicationRecord
+  belongs_to :syncable, polymorphic: true
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -11,6 +11,10 @@ class Invoice < ApplicationRecord
 
   before_save :ensure_organization_sequential_id, if: -> { organization.per_organization? }
   before_save :ensure_number
+  after_create :trigger_invoice_sync, if: :finalized?
+  after_update :trigger_invoice_sync, if: -> { status_updated_to_finalized? }
+  after_create :trigger_sales_order_sync, if: :finalized?
+  after_update :trigger_sales_order_sync, if: -> { status_updated_to_finalized? }
 
   belongs_to :customer, -> { with_discarded }
   belongs_to :organization

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -11,10 +11,6 @@ class Invoice < ApplicationRecord
 
   before_save :ensure_organization_sequential_id, if: -> { organization.per_organization? }
   before_save :ensure_number
-  after_create :trigger_invoice_sync, if: :finalized?
-  after_update :trigger_invoice_sync, if: -> { status_updated_to_finalized? }
-  after_create :trigger_sales_order_sync, if: :finalized?
-  after_update :trigger_sales_order_sync, if: -> { status_updated_to_finalized? }
 
   belongs_to :customer, -> { with_discarded }
   belongs_to :organization

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -8,4 +8,7 @@ class Payment < ApplicationRecord
   belongs_to :payment_provider_customer, class_name: 'PaymentProviderCustomers::BaseCustomer'
 
   has_many :refunds
+  has_many :integration_resources, as: :syncable
+
+  delegate :customer, to: :invoice
 end

--- a/db/migrate/20240514081110_create_integration_resources.rb
+++ b/db/migrate/20240514081110_create_integration_resources.rb
@@ -1,0 +1,10 @@
+class CreateIntegrationResources < ActiveRecord::Migration[7.0]
+  def change
+    create_table :integration_resources, id: :uuid do |t|
+      t.references :syncable, polymorphic: true, index: true, null: false, type: :uuid
+      t.string :external_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_02_095122) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_14_081110) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -596,6 +596,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_02_095122) do
     t.datetime "updated_at", null: false
     t.index ["integration_id"], name: "index_integration_mappings_on_integration_id"
     t.index ["mappable_type", "mappable_id"], name: "index_integration_mappings_on_mappable"
+  end
+
+  create_table "integration_resources", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "syncable_type", null: false
+    t.uuid "syncable_id", null: false
+    t.string "external_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["syncable_type", "syncable_id"], name: "index_integration_resources_on_syncable"
   end
 
   create_table "integrations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/integration_resources.rb
+++ b/spec/factories/integration_resources.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :integration_resource do
+    association :syncable, factory: %i[invoice payment credit_note].sample
+    external_id { SecureRandom.uuid }
+  end
+end

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe CreditNote, type: :model do
 
   it_behaves_like 'paper_trail traceable'
 
+  it { is_expected.to have_many(:integration_resources) }
+
   describe 'sequential_id' do
     let(:invoice) { create(:invoice) }
     let(:customer) { invoice.customer }

--- a/spec/models/integration_resource_spec.rb
+++ b/spec/models/integration_resource_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe IntegrationResource, type: :model do
+  subject(:integration_resource) { create(:integration_resource) }
+
+  it { is_expected.to belong_to(:syncable) }
+end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -197,6 +197,344 @@ RSpec.describe Invoice, type: :model do
     end
   end
 
+  describe '#save' do
+    context 'with a new record' do
+      subject { invoice.save! }
+
+      let(:invoice) { build(:invoice, customer:, organization:, status:) }
+
+      context 'when invoice is finalized' do
+        let(:status) { :finalized }
+
+        context 'without integration customer' do
+          let(:customer) { create(:customer, organization:) }
+
+          it 'does not enqueue invoice create job' do
+            expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+          end
+
+          it 'does not enqueue sales order create job' do
+            expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+          end
+        end
+
+        context 'with integration customer' do
+          let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+          let(:integration) { create(:netsuite_integration, organization:, sync_invoices:, sync_sales_orders:) }
+          let(:customer) { create(:customer, organization:) }
+
+          before { integration_customer }
+
+          context 'when sync invoices is true' do
+            let(:sync_invoices) { true }
+
+            context 'when sync sales orders is true' do
+              let(:sync_sales_orders) { true }
+
+              it 'enqueues invoice create job' do
+                expect { subject }.to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob).with(invoice:)
+              end
+
+              it 'enqueues sales order create job' do
+                expect { subject }.to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob).with(invoice:)
+              end
+            end
+
+            context 'when sync sales orders is false' do
+              let(:sync_sales_orders) { false }
+
+              it 'enqueues invoice create job' do
+                expect { subject }.to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob).with(invoice:)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+          end
+
+          context 'when sync invoices is false' do
+            let(:sync_invoices) { false }
+
+            context 'when sync sales orders is true' do
+              let(:sync_sales_orders) { true }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'enqueues sales order create job' do
+                expect { subject }.to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob).with(invoice:)
+              end
+            end
+
+            context 'when sync sales orders is false' do
+              let(:sync_sales_orders) { false }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+          end
+        end
+      end
+
+      context 'when invoice is not finalized' do
+        let(:status) { %i[draft voided generating].sample }
+
+        context 'without integration customer' do
+          let(:customer) { create(:customer, organization:) }
+
+          it 'does not enqueue invoice create job' do
+            expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+          end
+
+          it 'does not enqueue sales order create job' do
+            expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+          end
+        end
+
+        context 'with integration customer' do
+          let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+          let(:integration) { create(:netsuite_integration, organization:, sync_invoices:, sync_sales_orders:) }
+          let(:customer) { create(:customer, organization:) }
+
+          before { integration_customer }
+
+          context 'when sync invoices is true' do
+            let(:sync_invoices) { true }
+
+            context 'when sync sales orders is true' do
+              let(:sync_sales_orders) { true }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+
+            context 'when sync sales orders is false' do
+              let(:sync_sales_orders) { false }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+          end
+
+          context 'when sync invoices is false' do
+            let(:sync_invoices) { false }
+
+            context 'when sync sales orders is true' do
+              let(:sync_sales_orders) { true }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+
+            context 'when sync sales orders is false' do
+              let(:sync_sales_orders) { false }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context 'with an existing record' do
+      subject { invoice.update!(status: new_status) }
+
+      let(:invoice) { create(:invoice, customer:, organization:, status:) }
+
+      before { invoice }
+
+      context 'when status changed to finalized' do
+        let(:status) { %i[draft generating].sample }
+        let(:new_status) { :finalized }
+
+        context 'without integration customer' do
+          let(:customer) { create(:customer, organization:) }
+
+          it 'does not enqueue invoice create job' do
+            expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+          end
+
+          it 'does not enqueue sales order create job' do
+            expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+          end
+        end
+
+        context 'with integration customer' do
+          let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+          let(:integration) { create(:netsuite_integration, organization:, sync_invoices:, sync_sales_orders:) }
+          let(:customer) { create(:customer, organization:) }
+
+          before { integration_customer }
+
+          context 'when sync invoices is true' do
+            let(:sync_invoices) { true }
+
+            context 'when sync sales orders is true' do
+              let(:sync_sales_orders) { true }
+
+              it 'enqueues invoice create job' do
+                expect { subject }.to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob).with(invoice:)
+              end
+
+              it 'enqueues sales order create job' do
+                expect { subject }.to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob).with(invoice:)
+              end
+            end
+
+            context 'when sync sales orders is false' do
+              let(:sync_sales_orders) { false }
+
+              it 'enqueues invoice create job' do
+                expect { subject }.to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob).with(invoice:)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+          end
+
+          context 'when sync invoices is false' do
+            let(:sync_invoices) { false }
+
+            context 'when sync sales orders is true' do
+              let(:sync_sales_orders) { true }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'enqueues sales order create job' do
+                expect { subject }.to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob).with(invoice:)
+              end
+            end
+
+            context 'when sync sales orders is false' do
+              let(:sync_sales_orders) { false }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+          end
+        end
+      end
+
+      context 'when status did not change to finalized' do
+        let(:status) { :finalized }
+        let(:new_status) { %i[draft finalized voided].sample }
+
+        context 'without integration customer' do
+          let(:customer) { create(:customer, organization:) }
+
+          it 'does not enqueue invoice create job' do
+            expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+          end
+
+          it 'does not enqueue sales order create job' do
+            expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+          end
+        end
+
+        context 'with integration customer' do
+          let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+          let(:integration) { create(:netsuite_integration, organization:, sync_invoices:, sync_sales_orders:) }
+          let(:customer) { create(:customer, organization:) }
+
+          before { integration_customer }
+
+          context 'when sync invoices is true' do
+            let(:sync_invoices) { true }
+
+            context 'when sync sales orders is true' do
+              let(:sync_sales_orders) { true }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+
+            context 'when sync sales orders is false' do
+              let(:sync_sales_orders) { false }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+          end
+
+          context 'when sync invoices is false' do
+            let(:sync_invoices) { false }
+
+            context 'when sync sales orders is true' do
+              let(:sync_sales_orders) { true }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+
+            context 'when sync sales orders is false' do
+              let(:sync_sales_orders) { false }
+
+              it 'does not enqueue invoice create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::Invoices::CreateJob)
+              end
+
+              it 'does not enqueue sales order create job' do
+                expect { subject }.not_to have_enqueued_job(Integrations::Aggregator::SalesOrders::CreateJob)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
   describe 'number' do
     let(:organization) { create(:organization, name: 'LAGO') }
     let(:customer) { create(:customer, organization:) }

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -6,4 +6,7 @@ RSpec.describe Payment, type: :model do
   subject(:payment) { create(:payment) }
 
   it_behaves_like 'paper_trail traceable'
+
+  it { is_expected.to have_many(:integration_resources) }
+  it { is_expected.to delegate_method(:customer).to(:invoice) }
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR adds callbacks to `Invoice` model that trigger syncs. 