### PR TITLE
fix(integration-customers): update integration customers graphql input

### DIFF
--- a/app/graphql/types/integration_customers/input.rb
+++ b/app/graphql/types/integration_customers/input.rb
@@ -5,6 +5,8 @@ module Types
     class Input < Types::BaseInputObject
       graphql_name 'IntegrationCustomerInput'
 
+      argument :id, ID, required: false
+
       argument :external_customer_id, String, required: false
       argument :integration_code, String, required: false
       argument :integration_type, Types::Integrations::IntegrationTypeEnum, required: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -3622,6 +3622,7 @@ type IntegrationCollection {
 
 input IntegrationCustomerInput {
   externalCustomerId: String
+  id: ID
   integrationCode: String
   integrationType: IntegrationTypeEnum
   subsidiaryId: String

--- a/schema.json
+++ b/schema.json
@@ -16278,6 +16278,18 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "externalCustomerId",
               "description": null,
               "type": {

--- a/spec/graphql/types/integration_customers/input_spec.rb
+++ b/spec/graphql/types/integration_customers/input_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe Types::IntegrationCustomers::Input do
   subject { described_class }
 
+  it { is_expected.to accept_argument(:id).of_type('ID') }
   it { is_expected.to accept_argument(:external_customer_id).of_type('String') }
   it { is_expected.to accept_argument(:integration_type).of_type('IntegrationTypeEnum') }
   it { is_expected.to accept_argument(:integration_code).of_type('String') }


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR updates Input integration customer object for graphql side
