### PR TITLE
fix(integration-customers): Fix integration customer create service

### DIFF
--- a/app/services/integration_customers/base_service.rb
+++ b/app/services/integration_customers/base_service.rb
@@ -10,10 +10,6 @@ module IntegrationCustomers
     end
 
     def call
-      if !License.premium? || (customer.organization.premium_integrations & Organization::INTEGRATIONS).blank?
-        return result.not_allowed_failure!(code: 'premium_integration_missing')
-      end
-
       result.not_found_failure!(resource: 'integration') unless integration
       result
     end
@@ -27,7 +23,7 @@ module IntegrationCustomers
     end
 
     def customer_type
-      @customer_type ||= IntegrationCustomers::BaseCustomer.customer_type(params[:integration])
+      @customer_type ||= IntegrationCustomers::BaseCustomer.customer_type(params[:integration_type])
     end
 
     def subsidiary_id

--- a/app/services/integrations/aggregator/contacts/create_service.rb
+++ b/app/services/integrations/aggregator/contacts/create_service.rb
@@ -40,6 +40,7 @@ module Integrations
               'companyname' => customer.name,
               'subsidiary' => subsidiary_id,
               'custentity_lago_id' => customer.id,
+              'custentity_lago_sf_id' => customer.external_salesforce_id,
               'custentity_form_activeprospect_customer' => customer.name, # TODO: Will be removed
               'email' => customer.email,
               'phone' => customer.phone,

--- a/spec/services/integration_customers/create_service_spec.rb
+++ b/spec/services/integration_customers/create_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe IntegrationCustomers::CreateService, type: :service do
 
     let(:params) do
       {
-        integration: 'netsuite',
+        integration_type: 'netsuite',
         integration_code:,
         sync_with_provider:,
         external_customer_id:,
@@ -22,21 +22,6 @@ RSpec.describe IntegrationCustomers::CreateService, type: :service do
     end
 
     let(:subsidiary_id) { '1' }
-
-    context 'without netsuite premium integration present' do
-      let(:integration_code) { 'not_exists' }
-      let(:sync_with_provider) { true }
-      let(:external_customer_id) { nil }
-
-      it 'returns an error' do
-        result = service_call
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error.code).to eq('premium_integration_missing')
-        end
-      end
-    end
 
     context 'with netsuite premium integration present' do
       let(:integration_code) { integration.code }

--- a/spec/services/integration_customers/update_service_spec.rb
+++ b/spec/services/integration_customers/update_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe IntegrationCustomers::UpdateService, type: :service do
 
     let(:params) do
       {
-        integration: 'netsuite',
+        integration_type: 'netsuite',
         integration_code:,
         sync_with_provider:,
         external_customer_id:,
@@ -26,21 +26,6 @@ RSpec.describe IntegrationCustomers::UpdateService, type: :service do
     let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
 
     before { integration_customer }
-
-    context 'without netsuite premium integration present' do
-      let(:integration_code) { 'not_exists' }
-      let(:sync_with_provider) { true }
-      let(:external_customer_id) { nil }
-
-      it 'returns an error' do
-        result = service_call
-
-        aggregate_failures do
-          expect(result).not_to be_success
-          expect(result.error.code).to eq('premium_integration_missing')
-        end
-      end
-    end
 
     context 'with netsuite premium integration present' do
       let(:integration_code) { integration.code }

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
         'companyname' => customer.name,
         'subsidiary' => subsidiary_id,
         'custentity_lago_id' => customer.id,
+        'custentity_lago_sf_id' => customer.external_salesforce_id,
         'custentity_form_activeprospect_customer' => customer.name,
         'email' => customer.email,
         'phone' => customer.phone,


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR fixes `Integrations::Aggregator::Contacts::CreateService` because a new param `custentity_lago_sf_id` is mandatory now.