### PR TITLE
fix(integration-customers): Fix integration customer update service

### DIFF
--- a/app/services/integrations/aggregator/contacts/update_service.rb
+++ b/app/services/integrations/aggregator/contacts/update_service.rb
@@ -40,6 +40,7 @@ module Integrations
             'values' => {
               'companyname' => customer.name,
               'subsidiary' => integration_customer.subsidiary_id,
+              'custentity_lago_sf_id' => customer.external_salesforce_id,
               'custentity_form_activeprospect_customer' => customer.name, # TODO: Will be removed
               'email' => customer.email,
               'phone' => customer.phone,

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
       'values' => {
         'companyname' => customer.name,
         'subsidiary' => integration_customer.subsidiary_id,
+        'custentity_lago_sf_id' => customer.external_salesforce_id,
         'custentity_form_activeprospect_customer' => customer.name,
         'email' => customer.email,
         'phone' => customer.phone,


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR fixes `Integrations::Aggregator::Contacts::UpdateService` because a new param `custentity_lago_sf_id` is present.