### PR TITLE
misc(integration-customers): Delete integration customers when integration is deleted

### DIFF
--- a/app/models/integrations/base_integration.rb
+++ b/app/models/integrations/base_integration.rb
@@ -19,6 +19,10 @@ module Integrations
       class_name: 'IntegrationCollectionMappings::BaseCollectionMapping',
       foreign_key: :integration_id,
       dependent: :destroy
+    has_many :integration_customers,
+      class_name: 'IntegrationCustomers::BaseCustomer',
+      foreign_key: :integration_id,
+      dependent: :destroy
 
     validates :code, uniqueness: {scope: :organization_id}
     validates :name, presence: true

--- a/spec/models/integrations/base_integration_spec.rb
+++ b/spec/models/integrations/base_integration_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Integrations::BaseIntegration, type: :model do
 
   it { is_expected.to have_many(:integration_mappings).dependent(:destroy) }
   it { is_expected.to have_many(:integration_collection_mappings).dependent(:destroy) }
+  it { is_expected.to have_many(:integration_customers).dependent(:destroy) }
+  it { is_expected.to have_many(:integration_items).dependent(:destroy) }
 
   describe '.secrets_json' do
     it { expect(integration.secrets_json).to eq(secrets) }


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR handles destroying dependent integration customers after an integration is deleted.