### PR TITLE
chore: rubocop

### DIFF
--- a/lib/tasks/custom_aggregation.rake
+++ b/lib/tasks/custom_aggregation.rake
@@ -6,13 +6,13 @@ namespace :custom_aggregation do
     # Custom aggregator
     def aggregate(event, previous_state, aggregation_properties)
       # TODO: change me
-      { total_units: BigDecimal('0'), amount: BigDecimal('0') }
+      {total_units: BigDecimal('0'), amount: BigDecimal('0')}
     end
 
     # Aggregation properties - TODO: change me
     aggregation_properties = {}
     # Intial state
-    previous_state = { total_units: BigDecimal('0'), amount: BigDecimal('0')}
+    previous_state = {total_units: BigDecimal('0'), amount: BigDecimal('0')}
     # Event list - TODO: change me
     events = [OpenStruct.new(properties: {})]
 


### PR DESCRIPTION
As we move toward Standard.rb, we might have some code merged that wasn't fixed with the latest rules. In PRs, rubocop only runs on modified files.


```
Offenses:

lib/tasks/custom_aggregation.rake:9:8: C: [Corrected] Layout/SpaceInsideHashLiteralBraces: Space inside { detected. (https://rubystyle.guide#spaces-braces)
      { total_units: BigDecimal('0'), amount: BigDecimal('0') }
       ^
lib/tasks/custom_aggregation.rake:9:62: C: [Corrected] Layout/SpaceInsideHashLiteralBraces: Space inside } detected. (https://rubystyle.guide#spaces-braces)
      { total_units: BigDecimal('0'), amount: BigDecimal('0') }
                                                             ^
lib/tasks/custom_aggregation.rake:15:23: C: [Corrected] Layout/SpaceInsideHashLiteralBraces: Space inside { detected. (https://rubystyle.guide#spaces-braces)
    previous_state = { total_units: BigDecimal('0'), amount: BigDecimal('0')}
                      ^

2132 files inspected, 3 offenses detected, 3 offenses corrected
```