### PR TITLE
feat(accounting-integrations): add credit note type in collection mapping

### DIFF
--- a/app/models/integration_collection_mappings/base_collection_mapping.rb
+++ b/app/models/integration_collection_mappings/base_collection_mapping.rb
@@ -9,7 +9,7 @@ module IntegrationCollectionMappings
 
     belongs_to :integration, class_name: 'Integrations::BaseIntegration'
 
-    MAPPING_TYPES = %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit].freeze
+    MAPPING_TYPES = %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit credit_note].freeze
 
     enum mapping_type: MAPPING_TYPES
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -3875,6 +3875,7 @@ type MappingCollection {
 
 enum MappingTypeEnum {
   coupon
+  credit_note
   fallback_item
   minimum_commitment
   prepaid_credit

--- a/schema.json
+++ b/schema.json
@@ -18966,6 +18966,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "credit_note",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/models/integration_collection_mappings/netsuite_collection_mapping_spec.rb
+++ b/spec/models/integration_collection_mappings/netsuite_collection_mapping_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe IntegrationCollectionMappings::NetsuiteCollectionMapping, type: :
   subject(:mapping) { build(:netsuite_collection_mapping) }
 
   let(:mapping_types) do
-    %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit]
+    %i[fallback_item coupon subscription_fee minimum_commitment tax prepaid_credit credit_note]
   end
 
   it { is_expected.to define_enum_for(:mapping_type).with_values(mapping_types) }


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integration

## Description

This PR adds new type `credit_note` which also needs to be mapped
