### PR TITLE
fix(gql): Missing billing_configuration solution for OrganizationType

### DIFF
--- a/app/graphql/types/base_organization_type.rb
+++ b/app/graphql/types/base_organization_type.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Types
+  class BaseOrganizationType < BaseObject
+    def billing_configuration
+      {
+        id: "#{object&.id}-c0nf", # Each nested object needs ID so that appollo cache system can work properly
+        vat_rate: object&.vat_rate,
+        invoice_footer: object&.invoice_footer,
+        invoice_grace_period: object&.invoice_grace_period,
+        document_locale: object&.document_locale,
+        eu_tax_management: object&.eu_tax_management,
+      }
+    end
+  end
+end

--- a/app/graphql/types/current_organization_type.rb
+++ b/app/graphql/types/current_organization_type.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Types
-  class CurrentOrganizationType < Types::BaseObject
+  class CurrentOrganizationType < Types::BaseOrganizationType
     description 'Current Organization Type'
 
     field :id, ID, null: false
@@ -46,17 +46,6 @@ module Types
     field :adyen_payment_providers, [Types::PaymentProviders::Adyen], permission: 'organization:integrations:view'
     field :gocardless_payment_providers, [Types::PaymentProviders::Gocardless], permission: 'organization:integrations:view'
     field :stripe_payment_providers, [Types::PaymentProviders::Stripe], permission: 'organization:integrations:view'
-
-    def billing_configuration
-      {
-        id: "#{object&.id}-c0nf", # Each nested object needs ID so that appollo cache system can work properly
-        vat_rate: object&.vat_rate,
-        invoice_footer: object&.invoice_footer,
-        invoice_grace_period: object&.invoice_grace_period,
-        document_locale: object&.document_locale,
-        eu_tax_management: object&.eu_tax_management,
-      }
-    end
 
     def webhook_url
       object.webhook_endpoints.map(&:webhook_url).first

--- a/app/graphql/types/organization_type.rb
+++ b/app/graphql/types/organization_type.rb
@@ -10,7 +10,7 @@ module Types
   #
   # Ex: current organization > memberships > another member > organizations can lead to an organization
   #     the current user is not supposed to have access to
-  class OrganizationType < Types::BaseObject
+  class OrganizationType < Types::BaseOrganizationType
     description 'Safe Organization Type'
 
     field :id, ID, null: false

--- a/spec/graphql/resolvers/customer_portal/organization_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/organization_resolver_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Resolvers::CustomerPortal::OrganizationResolver, type: :graphql d
         customerPortalOrganization {
           id
           name
+          billingConfiguration {
+            id
+            documentLocale
+          }
         }
       }
     GQL
@@ -31,6 +35,8 @@ RSpec.describe Resolvers::CustomerPortal::OrganizationResolver, type: :graphql d
     aggregate_failures do
       expect(data['id']).to eq(organization.id)
       expect(data['name']).to eq(organization.name)
+      expect(data['billingConfiguration']['id']).to eq("#{organization.id}-c0nf")
+      expect(data['billingConfiguration']['documentLocale']).to eq('en')
     end
   end
 end


### PR DESCRIPTION
## Description

I recently refactored GraphQL `OrganizationType` https://github.com/getlago/lago-api/pull/1919

`billing_configuration` is exposed in both Types but I forgot the resolution method in on type.