### PR TITLE
feat(gql): Add admin_count custom metadata for organization members

### DIFF
--- a/app/graphql/resolvers/memberships_resolver.rb
+++ b/app/graphql/resolvers/memberships_resolver.rb
@@ -10,7 +10,7 @@ module Resolvers
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
 
-    type Types::MembershipType.collection_type, null: false
+    type Types::MembershipType.collection_type(metadata_type: Types::Memberships::Metadata), null: false
 
     def resolve(page: nil, limit: nil)
       current_organization

--- a/app/graphql/types/memberships/metadata.rb
+++ b/app/graphql/types/memberships/metadata.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Memberships
+    class Metadata < GraphqlPagination::CollectionMetadataType
+      field :admin_count, Integer, null: false
+
+      def admin_count
+        context[:current_organization].memberships.admin.count
+      end
+    end
+  end
+end

--- a/app/services/memberships/revoke_service.rb
+++ b/app/services/memberships/revoke_service.rb
@@ -4,7 +4,6 @@ module Memberships
   class RevokeService < BaseService
     def call(id)
       membership = Membership.find_by(id:)
-      pp membership.organization.memberships.admin.count == 1 && membership.admin?
       return result.not_found_failure!(resource: 'membership') unless membership
       return result.not_allowed_failure!(code: 'cannot_revoke_own_membership') if result.user.id == membership.user.id
       return result.not_allowed_failure!(code: 'last_admin') if membership.organization.memberships.admin.count == 1 && membership.admin?

--- a/app/services/memberships/revoke_service.rb
+++ b/app/services/memberships/revoke_service.rb
@@ -4,8 +4,10 @@ module Memberships
   class RevokeService < BaseService
     def call(id)
       membership = Membership.find_by(id:)
+      pp membership.organization.memberships.admin.count == 1 && membership.admin?
       return result.not_found_failure!(resource: 'membership') unless membership
       return result.not_allowed_failure!(code: 'cannot_revoke_own_membership') if result.user.id == membership.user.id
+      return result.not_allowed_failure!(code: 'last_admin') if membership.organization.memberships.admin.count == 1 && membership.admin?
 
       membership.mark_as_revoked!
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -3898,7 +3898,7 @@ type Membership {
 
 type MembershipCollection {
   collection: [Membership!]!
-  metadata: CollectionMetadata!
+  metadata: Metadata!
 }
 
 enum MembershipRole {
@@ -3910,6 +3910,14 @@ enum MembershipRole {
 enum MembershipStatus {
   active
   revoked
+}
+
+type Metadata {
+  adminCount: Int!
+  currentPage: Int!
+  limitValue: Int!
+  totalCount: Int!
+  totalPages: Int!
 }
 
 type Mrr {

--- a/schema.json
+++ b/schema.json
@@ -19208,7 +19208,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "OBJECT",
-                  "name": "CollectionMetadata",
+                  "name": "Metadata",
                   "ofType": null
                 }
               },
@@ -19273,6 +19273,109 @@
               "deprecationReason": null
             }
           ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Metadata",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "adminCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "currentPage",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "limitValue",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "totalCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "totalPages",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
         },
         {
           "kind": "OBJECT",

--- a/spec/graphql/resolvers/memberships_resolver_spec.rb
+++ b/spec/graphql/resolvers/memberships_resolver_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Resolvers::MembershipsResolver, type: :graphql do
       query {
         memberships(limit: 5) {
           collection { id }
-          metadata { currentPage, totalCount }
+          metadata { currentPage, totalCount, adminCount }
         }
       }
     GQL
@@ -21,6 +21,9 @@ RSpec.describe Resolvers::MembershipsResolver, type: :graphql do
   it_behaves_like 'requires current organization'
 
   it 'returns a list of memberships' do
+    create(:membership, organization: organization, role: :admin)
+    create_list(:membership, 2, organization: organization, role: :finance)
+
     result = execute_graphql(
       current_user: membership.user,
       current_organization: organization,
@@ -34,7 +37,8 @@ RSpec.describe Resolvers::MembershipsResolver, type: :graphql do
       expect(memberships_response['collection'].first['id']).to eq(membership.id)
 
       expect(memberships_response['metadata']['currentPage']).to eq(1)
-      expect(memberships_response['metadata']['totalCount']).to eq(1)
+      expect(memberships_response['metadata']['totalCount']).to eq(4)
+      expect(memberships_response['metadata']['adminCount']).to eq(2)
     end
   end
 

--- a/spec/services/memberships/revoke_service_spec.rb
+++ b/spec/services/memberships/revoke_service_spec.rb
@@ -40,5 +40,17 @@ RSpec.describe Memberships::RevokeService, type: :service do
         end
       end
     end
+
+    context 'when removing the last admin' do
+      let(:membership) { create(:membership, role: :finance) }
+      let(:admin_membership) { create(:membership, organization: membership.organization, role: :admin) }
+
+      it 'returns an error' do
+        result = revoke_service.call(admin_membership.id)
+
+        expect(result).not_to be_success
+        expect(result.error.code).to eq('last_admin')
+      end
+    end
   end
 end

--- a/spec/services/memberships/revoke_service_spec.rb
+++ b/spec/services/memberships/revoke_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Memberships::RevokeService, type: :service do
     end
 
     context 'when revoking another membership' do
-      let(:another_membership) { create(:membership) }
+      let(:another_membership) { create(:membership, organization: membership.organization) }
 
       it 'revokes the membership' do
         freeze_time do


### PR DESCRIPTION
## Context

Granular permissions are being added to Lago.

## Description

In the frontend, we need to know how many admins there are currently on the app. We're adding a new custom attribute to the pagination metadata 😎
https://github.com/RenoFi/graphql-pagination?tab=readme-ov-file#custom-metadata

The backend is also updated so it won't let you delete the last admin anyway.