### PR TITLE
misc: membership role cannot be null

### DIFF
--- a/app/graphql/types/membership_type.rb
+++ b/app/graphql/types/membership_type.rb
@@ -8,7 +8,7 @@ module Types
     field :user, Types::UserType, null: false
 
     field :permissions, Types::PermissionsType, null: false
-    field :role, Types::Memberships::RoleEnum, null: true
+    field :role, Types::Memberships::RoleEnum, null: false
     field :status, Types::Memberships::StatusEnum, null: false
 
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -3889,7 +3889,7 @@ type Membership {
   organization: Organization!
   permissions: Permissions!
   revokedAt: ISO8601DateTime!
-  role: MembershipRole
+  role: MembershipRole!
   status: MembershipStatus!
   updatedAt: ISO8601DateTime!
   user: User!

--- a/schema.json
+++ b/schema.json
@@ -19078,9 +19078,13 @@
               "name": "role",
               "description": null,
               "type": {
-                "kind": "ENUM",
-                "name": "MembershipRole",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "MembershipRole",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/types/membership_type_spec.rb
+++ b/spec/graphql/types/membership_type_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Types::MembershipType do
   it { is_expected.to have_field(:user).of_type('User!') }
 
   it { is_expected.to have_field(:permissions).of_type('Permissions!') }
-  it { is_expected.to have_field(:role).of_type('MembershipRole') }
+  it { is_expected.to have_field(:role).of_type('MembershipRole!') }
   it { is_expected.to have_field(:status).of_type('MembershipStatus!') }
 
   it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }


### PR DESCRIPTION
Role attribute is always present on membership model so it's type definition should reflect this