### PR TITLE
misc: add Okta as an integration type union

### DIFF
--- a/app/graphql/resolvers/integrations_resolver.rb
+++ b/app/graphql/resolvers/integrations_resolver.rb
@@ -27,6 +27,8 @@ module Resolvers
       case type
       when 'netsuite'
         'Integrations::NetsuiteIntegration'
+      when 'okta'
+        'Integrations::OktaIntegration'
       else
         raise(NotImplementedError)
       end

--- a/app/graphql/types/integrations/object.rb
+++ b/app/graphql/types/integrations/object.rb
@@ -5,12 +5,15 @@ module Types
     class Object < Types::BaseUnion
       graphql_name 'Integration'
 
-      possible_types Types::Integrations::Netsuite
+      possible_types Types::Integrations::Netsuite,
+        Types::Integrations::Okta
 
       def self.resolve_type(object, _context)
         case object.class.to_s
         when 'Integrations::NetsuiteIntegration'
           Types::Integrations::Netsuite
+        when 'Integrations::OktaIntegration'
+          Types::Integrations::Okta
         else
           raise "Unexpected integration type: #{object.inspect}"
         end

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -18,6 +18,8 @@ module IntegrationCustomers
       case type
       when 'netsuite'
         'IntegrationCustomers::NetsuiteCustomer'
+      when 'okta'
+        'IntegrationCustomers::OktaCustomer'
       else
         raise(NotImplementedError)
       end

--- a/app/models/integrations/base_integration.rb
+++ b/app/models/integrations/base_integration.rb
@@ -31,6 +31,8 @@ module Integrations
       case type
       when 'netsuite'
         'Integrations::NetsuiteIntegration'
+      when 'okta'
+        'Integrations::OktaIntegration'
       else
         raise(NotImplementedError)
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3613,7 +3613,7 @@ An ISO 8601-encoded datetime
 """
 scalar ISO8601DateTime
 
-union Integration = NetsuiteIntegration
+union Integration = NetsuiteIntegration | OktaIntegration
 
 type IntegrationCollection {
   collection: [Integration!]!

--- a/schema.json
+++ b/schema.json
@@ -16206,6 +16206,11 @@
               "kind": "OBJECT",
               "name": "NetsuiteIntegration",
               "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "OktaIntegration",
+              "ofType": null
             }
           ],
           "fields": null,


### PR DESCRIPTION
Okta can be an integration type fetchable from the `integration` endpoint.

This PR adds it's type in the union definition, so we can query it on Frontend side.

Also, all resolvers switch are updated to handle this new type