### PR TITLE
fix(integrations): Address customer QA returns

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -146,7 +146,7 @@ module Api
           json: ::V1::CustomerSerializer.new(
             customer,
             root_name: 'customer',
-            includes: %i[taxes],
+            includes: %i[taxes integration_customers],
           ),
         )
       end

--- a/app/graphql/types/integrations/netsuite.rb
+++ b/app/graphql/types/integrations/netsuite.rb
@@ -13,7 +13,7 @@ module Types
       field :has_mappings_configured, Boolean
       field :id, ID, null: false
       field :name, String, null: false
-      field :script_endpoint_url, String, null: true
+      field :script_endpoint_url, String, null: false
       field :sync_credit_notes, Boolean
       field :sync_invoices, Boolean
       field :sync_payments, Boolean

--- a/app/graphql/types/integrations/netsuite/create_input.rb
+++ b/app/graphql/types/integrations/netsuite/create_input.rb
@@ -13,7 +13,7 @@ module Types
         argument :client_id, String, required: true
         argument :client_secret, String, required: true
         argument :connection_id, String, required: true
-        argument :script_endpoint_url, String, required: false
+        argument :script_endpoint_url, String, required: true
 
         argument :sync_credit_notes, Boolean, required: false
         argument :sync_invoices, Boolean, required: false

--- a/app/models/integrations/netsuite_integration.rb
+++ b/app/models/integrations/netsuite_integration.rb
@@ -2,7 +2,7 @@
 
 module Integrations
   class NetsuiteIntegration < BaseIntegration
-    validates :connection_id, :client_secret, :client_id, :account_id, presence: true
+    validates :connection_id, :client_secret, :client_id, :account_id, :script_endpoint_url, presence: true
 
     settings_accessors :client_id,
       :sync_credit_notes,

--- a/app/services/integration_customers/update_service.rb
+++ b/app/services/integration_customers/update_service.rb
@@ -13,9 +13,9 @@ module IntegrationCustomers
 
       return result.not_found_failure!(resource: 'integration_customer') unless integration_customer
 
-      if external_customer_id.present?
-        integration_customer.update!(external_customer_id:)
-      elsif sync_with_provider
+      integration_customer.update!(external_customer_id:) if external_customer_id.present?
+
+      if sync_with_provider
         update_result = Integrations::Aggregator::Contacts::UpdateService.call(integration:, integration_customer:)
         integration_customer.update!(subsidiary_id:)
 

--- a/app/services/integrations/netsuite/create_service.rb
+++ b/app/services/integrations/netsuite/create_service.rb
@@ -18,13 +18,12 @@ module Integrations
           client_secret: args[:client_secret],
           account_id: args[:account_id],
           connection_id: args[:connection_id],
+          script_endpoint_url: args[:script_endpoint_url],
           sync_credit_notes: ActiveModel::Type::Boolean.new.cast(args[:sync_credit_notes]),
           sync_invoices: ActiveModel::Type::Boolean.new.cast(args[:sync_invoices]),
           sync_payments: ActiveModel::Type::Boolean.new.cast(args[:sync_payments]),
           sync_sales_orders: ActiveModel::Type::Boolean.new.cast(args[:sync_sales_orders]),
         )
-
-        integration.script_endpoint_url = args[:script_endpoint_url] if args.key?(:script_endpoint_url)
 
         integration.save!
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1905,7 +1905,7 @@ input CreateNetsuiteIntegrationInput {
   code: String!
   connectionId: String!
   name: String!
-  scriptEndpointUrl: String
+  scriptEndpointUrl: String!
   syncCreditNotes: Boolean
   syncInvoices: Boolean
   syncPayments: Boolean
@@ -4785,7 +4785,7 @@ type NetsuiteIntegration {
   hasMappingsConfigured: Boolean
   id: ID!
   name: String!
-  scriptEndpointUrl: String
+  scriptEndpointUrl: String!
   syncCreditNotes: Boolean
   syncInvoices: Boolean
   syncPayments: Boolean

--- a/schema.json
+++ b/schema.json
@@ -7440,9 +7440,13 @@
               "name": "scriptEndpointUrl",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -22110,9 +22114,13 @@
               "name": "scriptEndpointUrl",
               "description": null,
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/types/integrations/netsuite_spec.rb
+++ b/spec/graphql/types/integrations/netsuite_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Types::Integrations::Netsuite do
   it { is_expected.to have_field(:code).of_type('String!') }
   it { is_expected.to have_field(:has_mappings_configured).of_type('Boolean') }
   it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:script_endpoint_url).of_type('String') }
+  it { is_expected.to have_field(:script_endpoint_url).of_type('String!') }
 
   it { is_expected.to have_field(:sync_credit_notes).of_type('Boolean') }
   it { is_expected.to have_field(:sync_invoices).of_type('Boolean') }

--- a/spec/services/integration_customers/update_service_spec.rb
+++ b/spec/services/integration_customers/update_service_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe IntegrationCustomers::UpdateService, type: :service do
             result = service_call
 
             aggregate_failures do
-              expect(aggregator_contacts_update_service).not_to have_received(:call)
+              expect(aggregator_contacts_update_service).to have_received(:call)
               expect(result).to be_success
               expect(result.integration_customer).to eq(integration_customer)
               expect(result.integration_customer.external_customer_id).to eq(external_customer_id)


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR fixes multiple issue we found during the QA:

- Missing `integration_customers` in the customer serializer
- Integration customer update was not called
- `script_endpoint_url` should be mandatory