### PR TITLE
fix(integrations): Add an association and indices

### DIFF
--- a/app/models/integration_item.rb
+++ b/app/models/integration_item.rb
@@ -12,8 +12,7 @@ class IntegrationItem < ApplicationRecord
 
   enum item_type: ITEM_TYPES
 
-  validates :external_id, presence: true
-  validates :external_id, uniqueness: {scope: :integration_id}
+  validates :external_id, presence: true, uniqueness: {scope: %i[integration_id item_type]}
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[external_account_code external_id external_name]

--- a/app/models/integration_resource.rb
+++ b/app/models/integration_resource.rb
@@ -1,3 +1,4 @@
 class IntegrationResource < ApplicationRecord
   belongs_to :syncable, polymorphic: true
+  belongs_to :integration, class_name: 'Integrations::BaseIntegration'
 end

--- a/app/models/integrations/base_integration.rb
+++ b/app/models/integrations/base_integration.rb
@@ -11,6 +11,7 @@ module Integrations
     belongs_to :organization
 
     has_many :integration_items, dependent: :destroy, foreign_key: :integration_id
+    has_many :integration_resources, dependent: :destroy, foreign_key: :integration_id
     has_many :integration_mappings,
       class_name: 'IntegrationMappings::BaseMapping',
       foreign_key: :integration_id,

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -376,11 +376,4 @@ class Invoice < ApplicationRecord
   def status_changed_to_finalized?
     status_changed?(from: 'draft', to: 'finalized') || status_changed?(from: 'generating', to: 'finalized')
   end
-
-  def status_updated_to_finalized?
-    saved_change_to_status&.first.present? &&
-      saved_change_to_status&.first != 'finalized' &&
-      saved_change_to_status&.last.present? &&
-      finalized?
-  end
 end

--- a/db/migrate/20240520115450_add_integration_id_to_integration_resources.rb
+++ b/db/migrate/20240520115450_add_integration_id_to_integration_resources.rb
@@ -1,0 +1,20 @@
+class AddIntegrationIdToIntegrationResources < ActiveRecord::Migration[7.0]
+  def up
+    remove_index :integration_items, [:external_id, :integration_id]
+
+    add_index :integration_items,
+      [:external_id, :integration_id, :item_type],
+      name: :index_int_items_on_external_id_and_int_id_and_type,
+      unique: true
+
+    add_reference :integration_resources, :integration, type: :uuid, foreign_key: true
+  end
+
+  def down
+    remove_index :integration_items, [:external_id, :integration_id, :item_type]
+
+    add_index :integration_items, [:external_id, :integration_id], unique: true
+
+    remove_reference :integration_resources, :integration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_14_081110) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_20_115450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -582,7 +582,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_14_081110) do
     t.string "external_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["external_id", "integration_id"], name: "index_integration_items_on_external_id_and_integration_id", unique: true
+    t.index ["external_id", "integration_id", "item_type"], name: "index_int_items_on_external_id_and_int_id_and_type", unique: true
     t.index ["integration_id"], name: "index_integration_items_on_integration_id"
   end
 
@@ -604,6 +604,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_14_081110) do
     t.string "external_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "integration_id"
+    t.index ["integration_id"], name: "index_integration_resources_on_integration_id"
     t.index ["syncable_type", "syncable_id"], name: "index_integration_resources_on_syncable"
   end
 
@@ -1093,6 +1095,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_14_081110) do
   add_foreign_key "integration_customers", "integrations"
   add_foreign_key "integration_items", "integrations"
   add_foreign_key "integration_mappings", "integrations"
+  add_foreign_key "integration_resources", "integrations"
   add_foreign_key "integrations", "organizations"
   add_foreign_key "invites", "memberships"
   add_foreign_key "invites", "organizations"

--- a/spec/factories/integration_resources.rb
+++ b/spec/factories/integration_resources.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :integration_resource do
     association :syncable, factory: %i[invoice payment credit_note].sample
+    association :integration, factory: :netsuite_integration
     external_id { SecureRandom.uuid }
   end
 end

--- a/spec/models/integration_item_spec.rb
+++ b/spec/models/integration_item_spec.rb
@@ -3,7 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe IntegrationItem, type: :model do
+  subject(:integration_item) { build(:integration_item) }
+
   it { is_expected.to belong_to(:integration) }
 
   it { is_expected.to validate_presence_of(:external_id) }
+
+  it 'validates uniqueness of external id' do
+    expect(integration_item).to validate_uniqueness_of(:external_id).scoped_to([:integration_id, :item_type])
+  end
 end

--- a/spec/models/integration_resource_spec.rb
+++ b/spec/models/integration_resource_spec.rb
@@ -4,4 +4,5 @@ RSpec.describe IntegrationResource, type: :model do
   subject(:integration_resource) { create(:integration_resource) }
 
   it { is_expected.to belong_to(:syncable) }
+  it { is_expected.to belong_to(:integration) }
 end

--- a/spec/models/integrations/base_integration_spec.rb
+++ b/spec/models/integrations/base_integration_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Integrations::BaseIntegration, type: :model do
   it { is_expected.to have_many(:integration_collection_mappings).dependent(:destroy) }
   it { is_expected.to have_many(:integration_customers).dependent(:destroy) }
   it { is_expected.to have_many(:integration_items).dependent(:destroy) }
+  it { is_expected.to have_many(:integration_resources).dependent(:destroy) }
 
   describe '.secrets_json' do
     it { expect(integration.secrets_json).to eq(secrets) }


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR handles the following:

- Add `integration_id` foreign key in `integration_resources` DB table
- Remove `status_updated_to_finalized?` method in invoice model - not needed anymore
- Change uniqueness validation in `IntegrationItem` `external_id`: the scope should be `validates :external_id, uniqueness: {scope: [:integration_id, :item_type]}`