### PR TITLE
misc: Ignore TrailingCommaInHashLiteral commit for blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Enable TrailingCommaInHashLiteral rubocop rule for all files
-2ca7ae1b4c1b1a7809d0d4b6cd02fc4e45e3d731
+3803519f622313a50def9b5261dfce899bdaf12d


### PR DESCRIPTION
The goal of this PR is to put the appropriate commit SHA for ignoring TrailingCommaInHashLiteral changes on the blame.