### PR TITLE
fix(integrations): Fix integration customer update service

### DIFF
--- a/app/services/integration_customers/update_service.rb
+++ b/app/services/integration_customers/update_service.rb
@@ -16,10 +16,12 @@ module IntegrationCustomers
       integration_customer.update!(external_customer_id:) if external_customer_id.present?
 
       if sync_with_provider
-        update_result = Integrations::Aggregator::Contacts::UpdateService.call(integration:, integration_customer:)
-        integration_customer.update!(subsidiary_id:)
+        integration_customer.subsidiary_id = subsidiary_id if subsidiary_id.present?
 
-        return update_result if update_result.error
+        update_result = Integrations::Aggregator::Contacts::UpdateService.call(integration:, integration_customer:)
+        return update_result unless update_result.success?
+
+        integration_customer.save!
       end
 
       result.integration_customer = integration_customer

--- a/spec/services/integration_customers/update_service_spec.rb
+++ b/spec/services/integration_customers/update_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe IntegrationCustomers::UpdateService, type: :service do
       context 'when sync with provider is true' do
         let(:sync_with_provider) { true }
 
-        context 'when customer external id is present' do
+        context 'when external customer id is present' do
           let(:external_customer_id) { SecureRandom.uuid }
 
           it 'returns integration customer' do
@@ -71,6 +71,19 @@ RSpec.describe IntegrationCustomers::UpdateService, type: :service do
               expect(result).to be_success
               expect(result.integration_customer).to eq(integration_customer)
               expect(result.integration_customer.external_customer_id).to eq(external_customer_id)
+            end
+          end
+        end
+
+        context 'when subsidiary id is present' do
+          it 'returns integration customer' do
+            result = service_call
+
+            aggregate_failures do
+              expect(aggregator_contacts_update_service).to have_received(:call)
+              expect(result).to be_success
+              expect(result.integration_customer).to eq(integration_customer)
+              expect(result.integration_customer.subsidiary_id).to eq(subsidiary_id)
             end
           end
         end
@@ -112,6 +125,20 @@ RSpec.describe IntegrationCustomers::UpdateService, type: :service do
             result = service_call
 
             expect(result.integration_customer.external_customer_id).to eq(external_customer_id)
+          end
+        end
+
+        context 'when subsidiary id is present' do
+          it 'does not calls aggregator update service' do
+            service_call
+
+            expect(aggregator_contacts_update_service).not_to have_received(:call)
+          end
+
+          it 'does not save subsidiary id' do
+            result = service_call
+
+            expect(result.integration_customer.subsidiary_id).not_to eq(subsidiary_id)
           end
         end
 


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR fixes a bug when the integration customer was not synced to Nango/Netsuite after an update.