### PR TITLE
feat (accounting-integrations): add logic for creating integration sales order

### DIFF
--- a/app/models/integration_resource.rb
+++ b/app/models/integration_resource.rb
@@ -1,4 +1,8 @@
 class IntegrationResource < ApplicationRecord
   belongs_to :syncable, polymorphic: true
   belongs_to :integration, class_name: 'Integrations::BaseIntegration'
+
+  RESOURCE_TYPES = %i[invoice sales_order payment credit_note].freeze
+
+  enum resource_type: RESOURCE_TYPES
 end

--- a/app/models/sales_order.rb
+++ b/app/models/sales_order.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SalesOrder < ApplicationRecord
+  self.table_name = 'invoices'
+
+  has_many :integration_resources, as: :syncable
+end

--- a/app/models/sales_order.rb
+++ b/app/models/sales_order.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class SalesOrder < ApplicationRecord
-  self.table_name = 'invoices'
-
-  has_many :integration_resources, as: :syncable
-end

--- a/app/services/integrations/aggregator/invoices/base_service.rb
+++ b/app/services/integrations/aggregator/invoices/base_service.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module Invoices
+      class BaseService < Integrations::Aggregator::BaseService
+        def initialize(invoice:)
+          @invoice = invoice
+
+          super(integration:)
+        end
+
+        private
+
+        attr_reader :invoice
+
+        delegate :customer, to: :invoice
+
+        def headers
+          {
+            'Connection-Id' => integration.connection_id,
+            'Authorization' => "Bearer #{secret_key}",
+            'Provider-Config-Key' => provider
+          }
+        end
+
+        def integration
+          return nil unless integration_customer
+
+          integration_customer&.integration
+        end
+
+        def integration_customer
+          @integration_customer ||= customer.integration_customers&.first
+        end
+
+        def billable_metric_item(fee)
+          integration
+            .integration_mappings
+            .find_by(mappable_type: 'BillableMetric', mappable_id: fee.billable_metric.id) || fallback_item
+        end
+
+        def add_on_item(fee)
+          integration
+            .integration_mappings
+            .find_by(mappable_type: 'AddOn', mappable_id: fee.add_on.id) || fallback_item
+        end
+
+        def item(fee)
+          mapped_item = if fee.charge?
+            billable_metric_item(fee)
+          elsif fee.add_on?
+            add_on_item(fee)
+          elsif fee.credit?
+            credit_item
+          elsif fee.commitment?
+            commitment_item
+          elsif fee.subscription?
+            subscription_item
+          end
+
+          {
+            'item' => mapped_item.external_id,
+            'account' => mapped_item.external_account_code,
+            'quantity' => fee.units,
+            'rate' => fee.precise_unit_amount
+          }
+        end
+
+        def discounts
+          output = []
+
+          if invoice.coupons_amount_cents > 0
+            output << {
+              'item' => coupon_item.external_id,
+              'account' => coupon_item.external_account_code,
+              'quantity' => 1,
+              'rate' => -amount(invoice.coupons_amount_cents)
+            }
+          end
+
+          if invoice.prepaid_credit_amount_cents > 0
+            output << {
+              'item' => credit_item.external_id,
+              'account' => credit_item.external_account_code,
+              'quantity' => 1,
+              'rate' => -amount(invoice.prepaid_credit_amount_cents)
+            }
+          end
+
+          if invoice.credit_notes_amount_cents > 0
+            output << {
+              'item' => credit_note_item.external_id,
+              'account' => credit_note_item.external_account_code,
+              'quantity' => 1,
+              'rate' => -amount(invoice.credit_notes_amount_cents)
+            }
+          end
+
+          output
+        end
+
+        def payload(type)
+          {
+            'type' => type,
+            'isDynamic' => false,
+            'columns' => {
+              'tranid' => invoice.id,
+              'entity' => integration_customer.external_customer_id,
+              'istaxable' => true,
+              'taxitem' => tax_item.external_id,
+              'taxamountoverride' => amount(invoice.taxes_amount_cents),
+              'otherrefnum' => invoice.number,
+              'custbody_lago_id' => invoice.id,
+              'custbody_ava_disable_tax_calculation' => true
+            },
+            'lines' => [
+              {
+                'sublistId' => 'item',
+                'lineItems' => invoice.fees.map { |fee| item(fee) } + discounts
+              },
+            ],
+            'options' => {
+              'ignoreMandatoryFields' => false
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/integrations/aggregator/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/create_service.rb
@@ -22,6 +22,7 @@ module Integrations
             external_id: result.external_id,
             syncable_id: invoice.id,
             syncable_type: 'Invoice',
+            resource_type: :invoice,
           )
 
           result

--- a/app/services/integrations/aggregator/sales_orders/create_service.rb
+++ b/app/services/integrations/aggregator/sales_orders/create_service.rb
@@ -21,7 +21,8 @@ module Integrations
             integration:,
             external_id: result.external_id,
             syncable_id: invoice.id,
-            syncable_type: 'SalesOrder',
+            syncable_type: 'Invoice',
+            resource_type: :sales_order,
           )
 
           result

--- a/app/services/integrations/aggregator/sales_orders/create_service.rb
+++ b/app/services/integrations/aggregator/sales_orders/create_service.rb
@@ -2,26 +2,26 @@
 
 module Integrations
   module Aggregator
-    module Invoices
-      class CreateService < BaseService
+    module SalesOrders
+      class CreateService < Integrations::Aggregator::Invoices::BaseService
         def action_path
-          "v1/#{provider}/invoices"
+          "v1/#{provider}/salesorders"
         end
 
         def call
           return unless integration
-          return unless integration.sync_invoices
+          return unless integration.sync_sales_orders
           return unless invoice.finalized?
           return unless fallback_item
 
-          response = http_client.post_with_response(payload('invoice'), headers)
+          response = http_client.post_with_response(payload('salesorder'), headers)
           result.external_id = JSON.parse(response.body)
 
           IntegrationResource.create!(
             integration:,
             external_id: result.external_id,
             syncable_id: invoice.id,
-            syncable_type: 'Invoice',
+            syncable_type: 'SalesOrder',
           )
 
           result

--- a/db/migrate/20240522105942_add_resource_type_to_integration_resources.rb
+++ b/db/migrate/20240522105942_add_resource_type_to_integration_resources.rb
@@ -1,0 +1,5 @@
+class AddResourceTypeToIntegrationResources < ActiveRecord::Migration[7.0]
+  def change
+    add_column :integration_resources, :resource_type, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_20_115450) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_22_105942) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -605,6 +605,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_20_115450) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "integration_id"
+    t.integer "resource_type", default: 0, null: false
     t.index ["integration_id"], name: "index_integration_resources_on_integration_id"
     t.index ["syncable_type", "syncable_id"], name: "index_integration_resources_on_syncable"
   end

--- a/spec/models/integration_resource_spec.rb
+++ b/spec/models/integration_resource_spec.rb
@@ -5,4 +5,6 @@ RSpec.describe IntegrationResource, type: :model do
 
   it { is_expected.to belong_to(:syncable) }
   it { is_expected.to belong_to(:integration) }
+
+  it { is_expected.to define_enum_for(:resource_type).with_values(%i[invoice sales_order payment credit_note]) }
 end

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -238,6 +238,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
 
         expect(integration_resource.syncable_id).to eq(invoice.id)
         expect(integration_resource.syncable_type).to eq('Invoice')
+        expect(integration_resource.resource_type).to eq('invoice')
       end
     end
 

--- a/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
@@ -237,7 +237,8 @@ RSpec.describe Integrations::Aggregator::SalesOrders::CreateService do
         integration_resource = IntegrationResource.order(created_at: :desc).first
 
         expect(integration_resource.syncable_id).to eq(invoice.id)
-        expect(integration_resource.syncable_type).to eq('SalesOrder')
+        expect(integration_resource.syncable_type).to eq('Invoice')
+        expect(integration_resource.resource_type).to eq('sales_order')
       end
     end
 

--- a/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Integrations::Aggregator::Invoices::CreateService do
+RSpec.describe Integrations::Aggregator::SalesOrders::CreateService do
   subject(:service_call) { described_class.call(invoice:) }
 
   let(:integration) { create(:netsuite_integration, organization:) }
@@ -10,7 +10,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
   let(:customer) { create(:customer, organization:) }
   let(:organization) { create(:organization) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
-  let(:endpoint) { 'https://api.nango.dev/v1/netsuite/invoices' }
+  let(:endpoint) { 'https://api.nango.dev/v1/netsuite/salesorders' }
   let(:add_on) { create(:add_on, organization:) }
   let(:billable_metric) { create(:billable_metric, organization:) }
   let(:charge) { create(:standard_charge, billable_metric:) }
@@ -125,7 +125,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
 
   let(:params) do
     {
-      'type' => 'invoice',
+      'type' => 'salesorder',
       'isDynamic' => false,
       'columns' => {
         'tranid' => invoice.id,
@@ -203,7 +203,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
     minimum_commitment_fee
     charge_fee
 
-    integration.sync_invoices = true
+    integration.sync_sales_orders = true
     integration.save!
   end
 
@@ -237,7 +237,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
         integration_resource = IntegrationResource.order(created_at: :desc).first
 
         expect(integration_resource.syncable_id).to eq(invoice.id)
-        expect(integration_resource.syncable_type).to eq('Invoice')
+        expect(integration_resource.syncable_type).to eq('SalesOrder')
       end
     end
 


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR adds logic for creating sales order in accounting provider.

The base for sales order is Lago's invoice. Payload is pretty much similar to the payload for creating invoice in accounting provider.
