### PR TITLE
feat(integrations): Trigger invoices and sales orders syncs

### DIFF
--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -41,6 +41,8 @@ module Invoices
 
       deliver_webhooks if should_deliver_webhook?
       InvoiceMailer.with(invoice:).finalized.deliver_later if should_deliver_email?
+      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+      Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
       Invoices::Payments::CreateService.new(invoice).call
 
       result

--- a/app/services/invoices/finalize_service.rb
+++ b/app/services/invoices/finalize_service.rb
@@ -24,6 +24,8 @@ module Invoices
 
       SendWebhookJob.perform_later('invoice.created', result.invoice) if invoice.organization.webhook_endpoints.any?
       InvoiceMailer.with(invoice: invoice.reload).finalized.deliver_later if should_deliver_email?
+      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+      Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
       Invoices::Payments::CreateService.new(invoice).call
       track_invoice_created(invoice)
 

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -29,6 +29,8 @@ module Invoices
       track_invoice_created(result.invoice)
       SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice) if should_deliver_webhook?
       InvoiceMailer.with(invoice: result.invoice).finalized.deliver_later if should_deliver_email?
+      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+      Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
 
       create_payment(result.invoice)
 

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -44,6 +44,8 @@ module Invoices
       else
         SendWebhookJob.perform_later('invoice.created', invoice) if should_deliver_webhook?
         InvoiceMailer.with(invoice:).finalized.deliver_later if should_deliver_finalized_email?
+        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+        Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
         Invoices::Payments::CreateService.new(invoice).call
         track_invoice_created(invoice)
       end

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -107,6 +107,14 @@ RSpec.describe Invoices::AddOnService, type: :service do
       expect(payment_create_service).to have_received(:call)
     end
 
+    it_behaves_like 'syncs invoice' do
+      let(:service_call) { invoice_service.create }
+    end
+
+    it_behaves_like 'syncs sales order' do
+      let(:service_call) { invoice_service.create }
+    end
+
     context 'when organization does not have a webhook endpoint' do
       before { applied_add_on.customer.organization.webhook_endpoints.destroy_all }
 

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -213,6 +213,14 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
     context 'with provided invoice' do
       let(:invoice) { create(:invoice, organization:, customer:, invoice_type: :subscription, status: :generating) }
 
+      it_behaves_like 'syncs invoice' do
+        let(:service_call) { invoice_service.call }
+      end
+
+      it_behaves_like 'syncs sales order' do
+        let(:service_call) { invoice_service.call }
+      end
+
       it 'does not re-create an invoice' do
         result = invoice_service.call
 

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe Invoices::CreateService, type: :service do
       end
     end
 
+    it_behaves_like 'syncs invoice' do
+      let(:service_call) { create_service.call }
+    end
+
+    it_behaves_like 'syncs sales order' do
+      let(:service_call) { create_service.call }
+    end
+
     it 'calls SegmentTrackJob' do
       invoice = create_service.call.invoice
 

--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -6,10 +6,14 @@ RSpec.describe Invoices::FinalizeService, type: :service do
   subject(:finalize_service) { described_class.new(invoice:) }
 
   describe '#call' do
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+
     let(:invoice) do
       create(
         :invoice,
         :draft,
+        customer:,
         subscriptions: [subscription],
         currency: 'EUR',
         issuing_date: Time.zone.at(timestamp).to_date,
@@ -30,7 +34,7 @@ RSpec.describe Invoices::FinalizeService, type: :service do
     let(:timestamp) { Time.zone.now - 1.year }
     let(:started_at) { Time.zone.now - 2.years }
     let(:fee) { create(:fee, invoice:, subscription:) }
-    let(:plan) { create(:plan, interval: 'monthly') }
+    let(:plan) { create(:plan, organization:, interval: 'monthly') }
     let(:credit_note) { create(:credit_note, :draft, invoice:) }
 
     before do
@@ -66,6 +70,14 @@ RSpec.describe Invoices::FinalizeService, type: :service do
         expect(result.invoice.fees.charge_kind.count).to eq(1)
         expect(result.invoice.fees.subscription_kind.count).to eq(1)
       end
+    end
+
+    it_behaves_like 'syncs invoice' do
+      let(:service_call) { finalize_service.call }
+    end
+
+    it_behaves_like 'syncs sales order' do
+      let(:service_call) { finalize_service.call }
     end
 
     it 'enqueues a SendWebhookJob' do

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -10,8 +10,10 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
   let(:timestamp) { Time.current.to_i }
 
   describe 'call' do
-    let(:customer) { create(:customer) }
-    let(:subscription) { create(:subscription, customer:) }
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, plan:, customer:) }
+    let(:plan) { create(:plan, organization:) }
     let(:wallet) { create(:wallet, customer:) }
     let(:wallet_transaction) do
       create(:wallet_transaction, wallet:, amount: '15.00', credit_amount: '15.00')
@@ -54,6 +56,14 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
       expect do
         invoice_service.call
       end.to have_enqueued_job(SendWebhookJob)
+    end
+
+    it_behaves_like 'syncs invoice' do
+      let(:service_call) { invoice_service.call }
+    end
+
+    it_behaves_like 'syncs sales order' do
+      let(:service_call) { invoice_service.call }
     end
 
     it 'does not enqueue an SendEmailJob' do

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -104,6 +104,14 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
       end
     end
 
+    it_behaves_like 'syncs invoice' do
+      let(:service_call) { invoice_service.call }
+    end
+
+    it_behaves_like 'syncs sales order' do
+      let(:service_call) { invoice_service.call }
+    end
+
     it 'enqueues a SendWebhookJob' do
       expect do
         invoice_service.call

--- a/spec/support/shared_examples/integrations.rb
+++ b/spec/support/shared_examples/integrations.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'syncs invoice' do
+  context 'when it should sync invoice' do
+    let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+    let(:integration) { create(:netsuite_integration, organization:, sync_invoices: true) }
+
+    before do
+      allow(Integrations::Aggregator::Invoices::CreateJob).to receive(:perform_later)
+      integration_customer
+      service_call
+    end
+
+    it 'enqueues Integrations::Aggregator::Invoices::CreateJob' do
+      expect(Integrations::Aggregator::Invoices::CreateJob).to have_received(:perform_later)
+    end
+  end
+end
+
+RSpec.shared_examples 'syncs sales order' do
+  context 'when it should sync sales order' do
+    let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+    let(:integration) { create(:netsuite_integration, organization:, sync_sales_orders: true) }
+
+    before do
+      allow(Integrations::Aggregator::SalesOrders::CreateJob).to receive(:perform_later)
+      integration_customer
+      service_call
+    end
+
+    it 'enqueues Integrations::Aggregator::SalesOrders::CreateJob' do
+      expect(Integrations::Aggregator::SalesOrders::CreateJob).to have_received(:perform_later)
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR modifies some of the invoice services to enqueue sync jobs for invoices and sales orders when needed.