### PR TITLE
feat(wallet): Handle method and target_ongoing_balance for recurring transaction rule

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -91,6 +91,7 @@ module Api
           :expiration_date, # NOTE: Legacy field
           recurring_transaction_rules: [
             :interval,
+            :method,
             :threshold_credits,
             :trigger,
           ],
@@ -109,6 +110,7 @@ module Api
           recurring_transaction_rules: [
             :lago_id,
             :interval,
+            :method,
             :threshold_credits,
             :trigger,
             :paid_credits,

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -92,6 +92,7 @@ module Api
           recurring_transaction_rules: [
             :interval,
             :method,
+            :target_ongoing_balance,
             :threshold_credits,
             :trigger,
           ],
@@ -111,6 +112,7 @@ module Api
             :lago_id,
             :interval,
             :method,
+            :target_ongoing_balance,
             :threshold_credits,
             :trigger,
             :paid_credits,

--- a/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
@@ -7,6 +7,7 @@ module Types
         graphql_name 'CreateRecurringTransactionRuleInput'
 
         argument :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, required: false
+        argument :method, Types::Wallets::RecurringTransactionRules::MethodEnum, required: true
         argument :threshold_credits, String, required: false
         argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: true
       end

--- a/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
@@ -7,7 +7,8 @@ module Types
         graphql_name 'CreateRecurringTransactionRuleInput'
 
         argument :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, required: false
-        argument :method, Types::Wallets::RecurringTransactionRules::MethodEnum, required: true
+        argument :method, Types::Wallets::RecurringTransactionRules::MethodEnum, required: false
+        argument :target_ongoing_balance, String, required: false
         argument :threshold_credits, String, required: false
         argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: true
       end

--- a/app/graphql/types/wallets/recurring_transaction_rules/method_enum.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/method_enum.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module Wallets
+    module RecurringTransactionRules
+      class MethodEnum < Types::BaseEnum
+        graphql_name 'RecurringTransactionMethodEnum'
+
+        RecurringTransactionRule::METHODS.each do |type|
+          value type
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/wallets/recurring_transaction_rules/object.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/object.rb
@@ -10,11 +10,16 @@ module Types
 
         field :granted_credits, String, null: false
         field :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, null: true
+        field :method, Types::Wallets::RecurringTransactionRules::MethodEnum, null: false
         field :paid_credits, String, null: false
         field :threshold_credits, String, null: true
         field :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, null: false
 
         field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+
+        def method
+          object.method
+        end
       end
     end
   end

--- a/app/graphql/types/wallets/recurring_transaction_rules/object.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/object.rb
@@ -12,14 +12,13 @@ module Types
         field :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, null: true
         field :method, Types::Wallets::RecurringTransactionRules::MethodEnum, null: false
         field :paid_credits, String, null: false
+        field :target_ongoing_balance, String, null: true
         field :threshold_credits, String, null: true
         field :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, null: false
 
         field :created_at, GraphQL::Types::ISO8601DateTime, null: false
 
-        def method
-          object.method
-        end
+        delegate :method, to: :object
       end
     end
   end

--- a/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
@@ -11,6 +11,7 @@ module Types
         argument :lago_id, ID, required: false
         argument :method, Types::Wallets::RecurringTransactionRules::MethodEnum, required: false
         argument :paid_credits, String, required: false
+        argument :target_ongoing_balance, String, required: false
         argument :threshold_credits, String, required: false
         argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: false
       end

--- a/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
@@ -9,6 +9,7 @@ module Types
         argument :granted_credits, String, required: false
         argument :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, required: false
         argument :lago_id, ID, required: false
+        argument :method, Types::Wallets::RecurringTransactionRules::MethodEnum, required: false
         argument :paid_credits, String, required: false
         argument :threshold_credits, String, required: false
         argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: false

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -5,18 +5,24 @@ class RecurringTransactionRule < ApplicationRecord
 
   belongs_to :wallet
 
-  TRIGGERS = [
-    :interval,
-    :threshold,
-  ].freeze
-
   INTERVALS = [
     :weekly,
     :monthly,
     :quarterly,
-    :yearly,
+    :yearly
   ].freeze
 
-  enum trigger: TRIGGERS
+  METHODS = [
+    :fixed,
+    :target
+  ].freeze
+
+  TRIGGERS = [
+    :interval,
+    :threshold
+  ].freeze
+
   enum interval: INTERVALS
+  enum method: METHODS
+  enum trigger: TRIGGERS
 end

--- a/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
+++ b/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
@@ -10,6 +10,7 @@ module V1
           granted_credits: model.granted_credits,
           interval: model.interval,
           method: model.method,
+          target_ongoing_balance: model.target_ongoing_balance,
           threshold_credits: model.threshold_credits,
           trigger: model.trigger,
           created_at: model.created_at.iso8601

--- a/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
+++ b/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
@@ -9,6 +9,7 @@ module V1
           paid_credits: model.paid_credits,
           granted_credits: model.granted_credits,
           interval: model.interval,
+          method: model.method,
           threshold_credits: model.threshold_credits,
           trigger: model.trigger,
           created_at: model.created_at.iso8601

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -65,7 +65,7 @@ module Wallets
         granted_credits:,
         threshold_credits: recurring_rule[:threshold_credits] || '0.0',
         interval: recurring_rule[:interval],
-        method: recurring_rule[:method],
+        method: recurring_rule[:method] || 'fixed',
         trigger: recurring_rule[:trigger].to_s
       )
     end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -65,6 +65,7 @@ module Wallets
         granted_credits:,
         threshold_credits: recurring_rule[:threshold_credits] || '0.0',
         interval: recurring_rule[:interval],
+        method: recurring_rule[:method],
         trigger: recurring_rule[:trigger].to_s
       )
     end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -66,6 +66,7 @@ module Wallets
         threshold_credits: recurring_rule[:threshold_credits] || '0.0',
         interval: recurring_rule[:interval],
         method: recurring_rule[:method] || 'fixed',
+        target_ongoing_balance: recurring_rule[:target_ongoing_balance],
         trigger: recurring_rule[:trigger].to_s
       )
     end

--- a/db/migrate/20240521143531_add_target_ongoing_balance_to_recurring_transaction_rules.rb
+++ b/db/migrate/20240521143531_add_target_ongoing_balance_to_recurring_transaction_rules.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddTargetOngoingBalanceToRecurringTransactionRules < ActiveRecord::Migration[7.0]
+  def change
+    add_column :recurring_transaction_rules,
+      :target_ongoing_balance,
+      :decimal,
+      precision: 30,
+      scale: 5
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -893,6 +893,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_22_105942) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "method", default: 0, null: false
+    t.decimal "target_ongoing_balance", precision: 30, scale: 5
     t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
   end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1975,7 +1975,8 @@ input CreatePlanInput {
 
 input CreateRecurringTransactionRuleInput {
   interval: RecurringTransactionIntervalEnum
-  method: RecurringTransactionMethodEnum!
+  method: RecurringTransactionMethodEnum
+  targetOngoingBalance: String
   thresholdCredits: String
   trigger: RecurringTransactionTriggerEnum!
 }
@@ -5604,6 +5605,7 @@ type RecurringTransactionRule {
   lagoId: ID!
   method: RecurringTransactionMethodEnum!
   paidCredits: String!
+  targetOngoingBalance: String
   thresholdCredits: String
   trigger: RecurringTransactionTriggerEnum!
 }
@@ -6925,6 +6927,7 @@ input UpdateRecurringTransactionRuleInput {
   lagoId: ID
   method: RecurringTransactionMethodEnum
   paidCredits: String
+  targetOngoingBalance: String
   thresholdCredits: String
   trigger: RecurringTransactionTriggerEnum
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -1975,6 +1975,7 @@ input CreatePlanInput {
 
 input CreateRecurringTransactionRuleInput {
   interval: RecurringTransactionIntervalEnum
+  method: RecurringTransactionMethodEnum!
   thresholdCredits: String
   trigger: RecurringTransactionTriggerEnum!
 }
@@ -5591,11 +5592,17 @@ enum RecurringTransactionIntervalEnum {
   yearly
 }
 
+enum RecurringTransactionMethodEnum {
+  fixed
+  target
+}
+
 type RecurringTransactionRule {
   createdAt: ISO8601DateTime!
   grantedCredits: String!
   interval: RecurringTransactionIntervalEnum
   lagoId: ID!
+  method: RecurringTransactionMethodEnum!
   paidCredits: String!
   thresholdCredits: String
   trigger: RecurringTransactionTriggerEnum!
@@ -6916,6 +6923,7 @@ input UpdateRecurringTransactionRuleInput {
   grantedCredits: String
   interval: RecurringTransactionIntervalEnum
   lagoId: ID
+  method: RecurringTransactionMethodEnum
   paidCredits: String
   thresholdCredits: String
   trigger: RecurringTransactionTriggerEnum

--- a/schema.json
+++ b/schema.json
@@ -7930,6 +7930,22 @@
               "deprecationReason": null
             },
             {
+              "name": "method",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "RecurringTransactionMethodEnum",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "thresholdCredits",
               "description": null,
               "type": {
@@ -28180,6 +28196,29 @@
           ]
         },
         {
+          "kind": "ENUM",
+          "name": "RecurringTransactionMethodEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "fixed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "target",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
           "kind": "OBJECT",
           "name": "RecurringTransactionRule",
           "description": null,
@@ -28247,6 +28286,24 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "method",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "RecurringTransactionMethodEnum",
                   "ofType": null
                 }
               },
@@ -33468,6 +33525,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "method",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "RecurringTransactionMethodEnum",
                 "ofType": null
               },
               "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -7933,13 +7933,21 @@
               "name": "method",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "RecurringTransactionMethodEnum",
-                  "ofType": null
-                }
+                "kind": "ENUM",
+                "name": "RecurringTransactionMethodEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetOngoingBalance",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -28332,6 +28340,20 @@
               ]
             },
             {
+              "name": "targetOngoingBalance",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "thresholdCredits",
               "description": null,
               "type": {
@@ -33545,6 +33567,18 @@
             },
             {
               "name": "paidCredits",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "targetOngoingBalance",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/spec/factories/recurring_transaction_rules.rb
+++ b/spec/factories/recurring_transaction_rules.rb
@@ -3,9 +3,9 @@
 FactoryBot.define do
   factory :recurring_transaction_rule do
     wallet
-    trigger { 'interval' }
-    paid_credits { '10.00' }
-    granted_credits { '10.00' }
-    interval { 'monthly' }
+    paid_credits { "10.00" }
+    granted_credits { "10.00" }
+    interval { "monthly" }
+    trigger { "interval" }
   end
 end

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -18,7 +18,16 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
           status
           currency
           expirationAt
-          recurringTransactionRules { lagoId, method, trigger, interval, thresholdCredits, paidCredits, grantedCredits }
+          recurringTransactionRules {
+            lagoId
+            method
+            trigger
+            interval
+            thresholdCredits
+            paidCredits
+            grantedCredits
+            targetOngoingBalance
+          }
         }
       }
     GQL

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
           status
           currency
           expirationAt
-          recurringTransactionRules { lagoId, trigger, interval, thresholdCredits, paidCredits, grantedCredits }
+          recurringTransactionRules { lagoId, method, trigger, interval, thresholdCredits, paidCredits, grantedCredits }
         }
       }
     GQL
@@ -30,7 +30,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
   it_behaves_like 'requires current organization'
   it_behaves_like 'requires permission', 'wallets:create'
 
-  it 'create a wallet' do
+  it 'creates a wallet' do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
@@ -47,6 +47,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
           currency: 'EUR',
           recurringTransactionRules: [
             {
+              method: 'target',
               trigger: 'interval',
               interval: 'monthly'
             },
@@ -63,6 +64,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
       expect(result_data['expirationAt']).to eq(expiration_at.iso8601)
       expect(result_data['recurringTransactionRules'].count).to eq(1)
       expect(result_data['recurringTransactionRules'][0]['lagoId']).to be_present
+      expect(result_data['recurringTransactionRules'][0]['method']).to eq('target')
       expect(result_data['recurringTransactionRules'][0]['trigger']).to eq('interval')
       expect(result_data['recurringTransactionRules'][0]['interval']).to eq('monthly')
       expect(result_data['recurringTransactionRules'][0]['paidCredits']).to eq('0.0')

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
           name
           status
           expirationAt
-          recurringTransactionRules { lagoId, trigger, interval, thresholdCredits, paidCredits, grantedCredits }
+          recurringTransactionRules { lagoId, method, trigger, interval, thresholdCredits, paidCredits, grantedCredits }
         }
       }
     GQL
@@ -51,6 +51,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
           recurringTransactionRules: [
             {
               lagoId: recurring_transaction_rule.id,
+              method: 'target',
               trigger: 'interval',
               interval: 'weekly',
               paidCredits: '22.2',
@@ -69,6 +70,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
       expect(result_data['expirationAt']).to eq(expiration_at.iso8601)
       expect(result_data['recurringTransactionRules'].count).to eq(1)
       expect(result_data['recurringTransactionRules'][0]['lagoId']).to eq(recurring_transaction_rule.id)
+      expect(result_data['recurringTransactionRules'][0]['method']).to eq('target')
       expect(result_data['recurringTransactionRules'][0]['trigger']).to eq('interval')
       expect(result_data['recurringTransactionRules'][0]['interval']).to eq('weekly')
       expect(result_data['recurringTransactionRules'][0]['paidCredits']).to eq('22.2')

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -20,7 +20,16 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
           name
           status
           expirationAt
-          recurringTransactionRules { lagoId, method, trigger, interval, thresholdCredits, paidCredits, grantedCredits }
+          recurringTransactionRules {
+            lagoId
+            method
+            trigger
+            interval
+            thresholdCredits
+            paidCredits
+            grantedCredits
+            targetOngoingBalance
+          }
         }
       }
     GQL
@@ -55,7 +64,8 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
               trigger: 'interval',
               interval: 'weekly',
               paidCredits: '22.2',
-              grantedCredits: '22.2'
+              grantedCredits: '22.2',
+              targetOngoingBalance: '300'
             },
           ]
         }
@@ -64,17 +74,22 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
 
     result_data = result['data']['updateCustomerWallet']
 
-    aggregate_failures do
-      expect(result_data['name']).to eq('New name')
-      expect(result_data['status']).to eq('active')
-      expect(result_data['expirationAt']).to eq(expiration_at.iso8601)
-      expect(result_data['recurringTransactionRules'].count).to eq(1)
-      expect(result_data['recurringTransactionRules'][0]['lagoId']).to eq(recurring_transaction_rule.id)
-      expect(result_data['recurringTransactionRules'][0]['method']).to eq('target')
-      expect(result_data['recurringTransactionRules'][0]['trigger']).to eq('interval')
-      expect(result_data['recurringTransactionRules'][0]['interval']).to eq('weekly')
-      expect(result_data['recurringTransactionRules'][0]['paidCredits']).to eq('22.2')
-      expect(result_data['recurringTransactionRules'][0]['grantedCredits']).to eq('22.2')
-    end
+    expect(result_data).to include(
+      "id" => wallet.id,
+      "name" => "New name",
+      "status" => "active",
+      "expirationAt" => expiration_at.iso8601
+    )
+
+    expect(result_data['recurringTransactionRules'].count).to eq(1)
+    expect(result_data['recurringTransactionRules'][0]).to include(
+      "lagoId" => recurring_transaction_rule.id,
+      "method" => "target",
+      "trigger" => "interval",
+      "interval" => "weekly",
+      "paidCredits" => "22.2",
+      "grantedCredits" => "22.2",
+      "targetOngoingBalance" => "300.0"
+    )
   end
 end

--- a/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::CreateInput do
   subject { described_class }
 
   it { is_expected.to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum') }
+  it { is_expected.to accept_argument(:method).of_type('RecurringTransactionMethodEnum!') }
   it { is_expected.to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum!') }
   it { is_expected.to accept_argument(:threshold_credits).of_type('String') }
 end

--- a/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::CreateInput do
   subject { described_class }
 
   it { is_expected.to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum') }
-  it { is_expected.to accept_argument(:method).of_type('RecurringTransactionMethodEnum!') }
+  it { is_expected.to accept_argument(:method).of_type('RecurringTransactionMethodEnum') }
+  it { is_expected.to accept_argument(:target_ongoing_balance).of_type('String') }
   it { is_expected.to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum!') }
   it { is_expected.to accept_argument(:threshold_credits).of_type('String') }
 end

--- a/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::Object do
   subject { described_class }
 
   it { is_expected.to have_field(:lago_id).of_type('ID!') }
+  it { is_expected.to have_field(:method).of_type('RecurringTransactionMethodEnum!') }
   it { is_expected.to have_field(:trigger).of_type('RecurringTransactionTriggerEnum!') }
   it { is_expected.to have_field(:interval).of_type('RecurringTransactionIntervalEnum') }
 

--- a/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::Object do
   it { is_expected.to have_field(:trigger).of_type('RecurringTransactionTriggerEnum!') }
   it { is_expected.to have_field(:interval).of_type('RecurringTransactionIntervalEnum') }
 
+  it { is_expected.to have_field(:target_ongoing_balance).of_type('String') }
   it { is_expected.to have_field(:threshold_credits).of_type('String') }
   it { is_expected.to have_field(:paid_credits).of_type('String!') }
   it { is_expected.to have_field(:granted_credits).of_type('String!') }

--- a/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::UpdateInput do
 
   it { is_expected.to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum') }
   it { is_expected.to accept_argument(:method).of_type('RecurringTransactionMethodEnum') }
+  it { is_expected.to accept_argument(:target_ongoing_balance).of_type('String') }
   it { is_expected.to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum') }
   it { is_expected.to accept_argument(:threshold_credits).of_type('String') }
   it { is_expected.to accept_argument(:lago_id).of_type('ID') }

--- a/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::UpdateInput do
   subject { described_class }
 
   it { is_expected.to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum') }
+  it { is_expected.to accept_argument(:method).of_type('RecurringTransactionMethodEnum') }
   it { is_expected.to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum') }
   it { is_expected.to accept_argument(:threshold_credits).of_type('String') }
   it { is_expected.to accept_argument(:lago_id).of_type('ID') }

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           expect(recurring_rules.first[:interval]).to eq('monthly')
           expect(recurring_rules.first[:paid_credits]).to eq('10.0')
           expect(recurring_rules.first[:granted_credits]).to eq('10.0')
+          expect(recurring_rules.first[:method]).to eq('fixed')
           expect(recurring_rules.first[:trigger]).to eq('interval')
         end
       end
@@ -164,6 +165,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           recurring_transaction_rules: [
             {
               lago_id: recurring_transaction_rule.id,
+              method: 'target',
               trigger: 'interval',
               interval: 'weekly',
               paid_credits: '105',
@@ -192,6 +194,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           expect(recurring_rules.first[:interval]).to eq('weekly')
           expect(recurring_rules.first[:paid_credits]).to eq('105.0')
           expect(recurring_rules.first[:granted_credits]).to eq('105.0')
+          expect(recurring_rules.first[:method]).to eq('target')
           expect(recurring_rules.first[:trigger]).to eq('interval')
         end
       end

--- a/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
+++ b/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
@@ -10,17 +10,16 @@ RSpec.describe ::V1::Wallets::RecurringTransactionRuleSerializer do
   it 'serializes the object' do
     result = JSON.parse(serializer.to_json)
 
-    aggregate_failures do
-      expect(result['recurring_transaction_rule']['lago_id']).to eq(recurring_transaction_rule.id)
-      expect(result['recurring_transaction_rule']['method']).to eq(recurring_transaction_rule.method)
-      expect(result['recurring_transaction_rule']['trigger']).to eq(recurring_transaction_rule.trigger)
-      expect(result['recurring_transaction_rule']['interval']).to eq(recurring_transaction_rule.interval)
-      expect(result['recurring_transaction_rule']['paid_credits']).to eq(recurring_transaction_rule.paid_credits.to_s)
-      expect(result['recurring_transaction_rule']['created_at']).to eq(recurring_transaction_rule.created_at.iso8601)
-      expect(result['recurring_transaction_rule']['threshold_credits'])
-        .to eq(recurring_transaction_rule.threshold_credits.to_s)
-      expect(result['recurring_transaction_rule']['granted_credits'])
-        .to eq(recurring_transaction_rule.granted_credits.to_s)
-    end
+    expect(result["recurring_transaction_rule"]).to include(
+      "lago_id" => recurring_transaction_rule.id,
+      "method" => recurring_transaction_rule.method,
+      "trigger" => recurring_transaction_rule.trigger,
+      "interval" => recurring_transaction_rule.interval,
+      "paid_credits" => recurring_transaction_rule.paid_credits.to_s,
+      "target_ongoing_balance" => recurring_transaction_rule.target_ongoing_balance,
+      "threshold_credits" => recurring_transaction_rule.threshold_credits.to_s,
+      "granted_credits" => recurring_transaction_rule.granted_credits.to_s,
+      "created_at" => recurring_transaction_rule.created_at.iso8601
+    )
   end
 end

--- a/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
+++ b/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ::V1::Wallets::RecurringTransactionRuleSerializer do
 
     aggregate_failures do
       expect(result['recurring_transaction_rule']['lago_id']).to eq(recurring_transaction_rule.id)
+      expect(result['recurring_transaction_rule']['method']).to eq(recurring_transaction_rule.method)
       expect(result['recurring_transaction_rule']['trigger']).to eq(recurring_transaction_rule.trigger)
       expect(result['recurring_transaction_rule']['interval']).to eq(recurring_transaction_rule.interval)
       expect(result['recurring_transaction_rule']['paid_credits']).to eq(recurring_transaction_rule.paid_credits.to_s)

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe Wallets::CreateService, type: :service do
         end
       end
 
-      context 'when rule type is invalid' do
+      context 'when trigger is invalid' do
         let(:rules) do
           [
             {

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -76,8 +76,10 @@ RSpec.describe Wallets::CreateService, type: :service do
       let(:rules) do
         [
           {
-            trigger: 'interval',
-            interval: 'monthly'
+            interval: "monthly",
+            method: "target",
+            target_ongoing_balance: "100.0",
+            trigger: "interval",
           },
         ]
       end
@@ -105,13 +107,17 @@ RSpec.describe Wallets::CreateService, type: :service do
           rule = service_result.wallet.reload.recurring_transaction_rules.first
 
           expect(wallet.name).to eq('New Wallet')
-          expect(rule.wallet_id).to eq(wallet.id)
           expect(wallet.reload.recurring_transaction_rules.count).to eq(1)
-          expect(rule.trigger).to eq('interval')
-          expect(rule.interval).to eq('monthly')
-          expect(rule.threshold_credits).to eq(0.0)
-          expect(rule.paid_credits).to eq(1.0)
-          expect(rule.granted_credits).to eq(0.0)
+          expect(rule).to have_attributes(
+            granted_credits: 0.0,
+            interval: "monthly",
+            method: "target",
+            paid_credits: 1.0,
+            target_ongoing_balance: 100.0,
+            threshold_credits: 0.0,
+            trigger: "interval",
+            wallet_id: wallet.id
+          )
         end
       end
 

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Wallets::CreateService, type: :service do
             interval: "monthly",
             method: "target",
             target_ongoing_balance: "100.0",
-            trigger: "interval",
+            trigger: "interval"
           },
         ]
       end

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -29,12 +29,15 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
 
       aggregate_failures do
         expect(result.wallet.reload.recurring_transaction_rules.count).to eq(1)
-        expect(rule.id).to eq(recurring_transaction_rule.id)
-        expect(rule.trigger).to eq('interval')
-        expect(rule.interval).to eq('weekly')
-        expect(rule.threshold_credits).to eq(0.0)
-        expect(rule.paid_credits).to eq(105.0)
-        expect(rule.granted_credits).to eq(105.0)
+        expect(rule).to have_attributes(
+          granted_credits: 105.0,
+          id: recurring_transaction_rule.id,
+          interval: "weekly",
+          method: "fixed",
+          paid_credits: 105.0,
+          threshold_credits: 0.0,
+          trigger: "interval"
+        )
       end
     end
 
@@ -42,10 +45,12 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
       let(:params) do
         [
           {
-            trigger: 'interval',
-            interval: 'weekly',
-            paid_credits: '105',
-            granted_credits: '105'
+            granted_credits: "105",
+            interval: "weekly",
+            method: "target",
+            paid_credits: "105",
+            target_ongoing_balance: "300",
+            trigger: "interval"
           },
         ]
       end
@@ -57,12 +62,16 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
 
         aggregate_failures do
           expect(result.wallet.reload.recurring_transaction_rules.count).to eq(1)
+          expect(rule).to have_attributes(
+            granted_credits: 105.0,
+            interval: "weekly",
+            method: "target",
+            paid_credits: 105.0,
+            target_ongoing_balance: 300.0,
+            threshold_credits: 0.0,
+            trigger: "interval"
+          )
           expect(rule.id).not_to eq(recurring_transaction_rule.id)
-          expect(rule.trigger).to eq('interval')
-          expect(rule.interval).to eq('weekly')
-          expect(rule.threshold_credits).to eq(0.0)
-          expect(rule.paid_credits).to eq(105.0)
-          expect(rule.granted_credits).to eq(105.0)
         end
       end
     end

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
         end
       end
 
-      context 'when rule type is invalid' do
+      context 'when trigger is invalid' do
         let(:rules) do
           [
             {


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to:
- add `target_ongoing_balance` to `recurring_transaction_rules` table
- accept `method` and `target_ongoing_balance` on wallet creation (API & GraphQL)
- accept `method` and `target_ongoing_balance` on wallet update (API & GraphQL)
