### PR TITLE
fix(webhooks): change webhook payload format

### DIFF
--- a/app/graphql/types/webhooks/object.rb
+++ b/app/graphql/types/webhooks/object.rb
@@ -23,7 +23,9 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       def payload
-        object.payload&.to_json
+        return object.payload&.to_json unless object.payload.is_a?(String)
+
+        object.payload
       end
     end
   end

--- a/app/graphql/types/webhooks/object.rb
+++ b/app/graphql/types/webhooks/object.rb
@@ -21,6 +21,10 @@ module Types
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :last_retried_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      def payload
+        object.payload&.to_json&.to_s
+      end
     end
   end
 end

--- a/app/graphql/types/webhooks/object.rb
+++ b/app/graphql/types/webhooks/object.rb
@@ -23,7 +23,7 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       def payload
-        object.payload&.to_json&.to_s
+        object.payload&.to_json
       end
     end
   end


### PR DESCRIPTION
## Context

UI is expecting webhooks's paylaod to be parsable as JSON.

## Description

This PR fixes this issue on the graphql type side.