### PR TITLE
chore(tests): Add cache metadata to configure Rails.cache driver

### DIFF
--- a/spec/graphql/mutations/auth/okta/accept_invite_spec.rb
+++ b/spec/graphql/mutations/auth/okta/accept_invite_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Mutations::Auth::Okta::AcceptInvite, type: :graphql do
+RSpec.describe Mutations::Auth::Okta::AcceptInvite, type: :graphql, cache: :memory do
   let(:organization) { create(:organization) }
   let(:invite) { create(:invite, email: 'foo@bar.com', organization:) }
   let(:okta_integration) { create(:okta_integration, domain: 'bar.com', organization_name: 'foo', organization:) }
@@ -10,7 +10,6 @@ RSpec.describe Mutations::Auth::Okta::AcceptInvite, type: :graphql do
   let(:okta_token_response) { OpenStruct.new(body: {access_token: 'access_token'}) }
   let(:okta_userinfo_response) { OpenStruct.new({email: 'foo@bar.com'}) }
   let(:state) { SecureRandom.uuid }
-  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
 
   let(:mutation) do
     <<~GQL
@@ -29,8 +28,7 @@ RSpec.describe Mutations::Auth::Okta::AcceptInvite, type: :graphql do
     invite
     okta_integration
 
-    allow(Rails).to receive(:cache).and_return(memory_store)
-    memory_store.write(state, 'foo@bar.com')
+    Rails.cache.write(state, 'foo@bar.com')
 
     allow(LagoHttpClient::Client).to receive(:new).and_return(lago_http_client)
     allow(lago_http_client).to receive(:post_url_encoded).and_return(okta_token_response)

--- a/spec/graphql/mutations/auth/okta/login_spec.rb
+++ b/spec/graphql/mutations/auth/okta/login_spec.rb
@@ -2,13 +2,12 @@
 
 require 'rails_helper'
 
-RSpec.describe Mutations::Auth::Okta::Login, type: :graphql do
+RSpec.describe Mutations::Auth::Okta::Login, type: :graphql, cache: :memory do
   let(:okta_integration) { create(:okta_integration, domain: 'bar.com', organization_name: 'foo') }
   let(:lago_http_client) { instance_double(LagoHttpClient::Client) }
   let(:okta_token_response) { OpenStruct.new(body: {access_token: 'access_token'}) }
   let(:okta_userinfo_response) { OpenStruct.new({email: 'foo@bar.com'}) }
   let(:state) { SecureRandom.uuid }
-  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
 
   let(:mutation) do
     <<~GQL
@@ -26,8 +25,7 @@ RSpec.describe Mutations::Auth::Okta::Login, type: :graphql do
   before do
     okta_integration
 
-    allow(Rails).to receive(:cache).and_return(memory_store)
-    memory_store.write(state, 'foo@bar.com')
+    Rails.cache.write(state, 'foo@bar.com')
 
     allow(LagoHttpClient::Client).to receive(:new).and_return(lago_http_client)
     allow(lago_http_client).to receive(:post_url_encoded).and_return(okta_token_response)

--- a/spec/graphql/mutations/memberships/revoke_spec.rb
+++ b/spec/graphql/mutations/memberships/revoke_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Mutations::Memberships::Revoke, type: :graphql do
       permissions: required_permission,
       query: mutation,
       variables: {
-        input: {id: membership.id},
+        input: {id: membership.id}
       },
     )
 

--- a/spec/services/auth/okta/accept_invite_service_spec.rb
+++ b/spec/services/auth/okta/accept_invite_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Auth::Okta::AcceptInviteService do
+RSpec.describe Auth::Okta::AcceptInviteService, cache: :memory do
   subject(:service) { described_class.new(invite_token:, code: 'code', state:) }
 
   let(:organization) { create(:organization) }
@@ -12,15 +12,13 @@ RSpec.describe Auth::Okta::AcceptInviteService do
   let(:lago_http_client) { instance_double(LagoHttpClient::Client) }
   let(:okta_token_response) { OpenStruct.new(body: {access_token: 'access_token'}) }
   let(:okta_userinfo_response) { OpenStruct.new({email: 'foo@bar.com'}) }
-  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
   let(:state) { SecureRandom.uuid }
 
   before do
     okta_integration
     invite_token
 
-    allow(Rails).to receive(:cache).and_return(memory_store)
-    memory_store.write(state, 'foo@bar.com')
+    Rails.cache.write(state, 'foo@bar.com')
 
     allow(LagoHttpClient::Client).to receive(:new).and_return(lago_http_client)
     allow(lago_http_client).to receive(:post_url_encoded).and_return(okta_token_response)

--- a/spec/services/auth/okta/login_service_spec.rb
+++ b/spec/services/auth/okta/login_service_spec.rb
@@ -2,20 +2,18 @@
 
 require 'rails_helper'
 
-RSpec.describe Auth::Okta::LoginService do
+RSpec.describe Auth::Okta::LoginService, cache: :memory do
   let(:service) { described_class.new(code: 'code', state:) }
   let(:okta_integration) { create(:okta_integration, domain: 'bar.com', organization_name: 'foo') }
   let(:lago_http_client) { instance_double(LagoHttpClient::Client) }
   let(:okta_token_response) { OpenStruct.new(body: {access_token: 'access_token'}) }
   let(:okta_userinfo_response) { OpenStruct.new({email: 'foo@bar.com'}) }
-  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
   let(:state) { SecureRandom.uuid }
 
   before do
     okta_integration
 
-    allow(Rails).to receive(:cache).and_return(memory_store)
-    memory_store.write(state, 'foo@bar.com')
+    Rails.cache.write(state, 'foo@bar.com')
 
     allow(LagoHttpClient::Client).to receive(:new).and_return(lago_http_client)
     allow(lago_http_client).to receive(:post_url_encoded).and_return(okta_token_response)

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Invoices::CustomerUsageService, type: :service do
+RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
   subject(:usage_service) do
     described_class.new(membership.user, customer_id:, subscription_id:)
   end
@@ -50,14 +50,10 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
     )
   end
 
-  let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
-  let(:cache) { Rails.cache }
-
   describe '#call' do
     before do
       events if subscription
       charge
-      allow(Rails).to receive(:cache).and_return(memory_store)
       Rails.cache.clear
 
       tax
@@ -73,7 +69,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service do
 
       expect do
         usage_service.call
-      end.to change { cache.exist?(key) }.from(false).to(true)
+      end.to change { Rails.cache.exist?(key) }.from(false).to(true)
     end
 
     it 'initializes an invoice' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,19 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
   end
 
+  # Custom metadata
+  config.before do |example|
+    if example.metadata[:cache]
+      Rails.cache = if example.metadata[:cache].to_sym == :memory
+        ActiveSupport::Cache.lookup_store(:memory_store)
+      elsif example.metadata[:cache].to_sym == :null
+        ActiveSupport::Cache.lookup_store(:null_store)
+      else
+        raise "Unknown cache store: #{example.metadata[:cache]}"
+      end
+    end
+  end
+
   config.before(:each, transaction: false) do
     DatabaseCleaner.strategy = :deletion
   end


### PR DESCRIPTION
## Description

I was writing tests with redis cache driver and realized we didn't have an easy way to set the drivers in tests.
This first PR introduce a simple way to pass metadata to your test and rspec will ensure that the correct cache driver is set.

It avoids mocking `Rails.cache`. 

In a following PR, I'll add the Redis driver (because I need it).

Note that it can be set on `describe` or `example`.

```rb
RSpec.describe Invites::AcceptService cache: :memory do

  context 'with cache' do
    it do
      # Rails.cache is using the memory driver
    end
  end

  context 'without cache', cache: :null do
    it do
      # Rails.cache is using the null driver
    end
  end
end
```