### PR TITLE
feat(integrations): return external_id in invoice graphql object

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -52,6 +52,7 @@ module Types
       field :invoice_subscriptions, [Types::InvoiceSubscription::Object]
       field :subscriptions, [Types::Subscriptions::Object]
 
+      field :integration_external_id, String, null: true
       field :integration_syncable, GraphQL::Types::Boolean, null: false
 
       def applied_taxes
@@ -61,6 +62,19 @@ module Types
       def integration_syncable
         object.should_sync_invoice? &&
           object.integration_resources.where(resource_type: 'invoice', syncable_type: 'Invoice').none?
+      end
+
+      def integration_external_id
+        integration_customer = object.customer&.integration_customers&.first
+
+        return nil unless integration_customer
+
+        IntegrationResource.find_by(
+          integration: integration_customer.integration,
+          syncable_id: object.id,
+          syncable_type: 'Invoice',
+          resource_type: :invoice
+        )&.external_id
       end
     end
   end

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -52,7 +52,7 @@ module Types
       field :invoice_subscriptions, [Types::InvoiceSubscription::Object]
       field :subscriptions, [Types::Subscriptions::Object]
 
-      field :integration_external_id, String, null: true
+      field :external_integration_id, String, null: true
       field :integration_syncable, GraphQL::Types::Boolean, null: false
 
       def applied_taxes
@@ -64,7 +64,7 @@ module Types
           object.integration_resources.where(resource_type: 'invoice', syncable_type: 'Invoice').none?
       end
 
-      def integration_external_id
+      def external_integration_id
         integration_customer = object.customer&.integration_customers&.first
 
         return nil unless integration_customer

--- a/schema.graphql
+++ b/schema.graphql
@@ -3693,6 +3693,7 @@ type Invoice {
   feesAmountCents: BigInt!
   fileUrl: String
   id: ID!
+  integrationExternalId: String
   integrationSyncable: Boolean!
   invoiceSubscriptions: [InvoiceSubscription!]
   invoiceType: InvoiceTypeEnum!

--- a/schema.graphql
+++ b/schema.graphql
@@ -3689,11 +3689,11 @@ type Invoice {
   creditableAmountCents: BigInt!
   currency: CurrencyEnum
   customer: Customer!
+  externalIntegrationId: String
   fees: [Fee!]
   feesAmountCents: BigInt!
   fileUrl: String
   id: ID!
-  integrationExternalId: String
   integrationSyncable: Boolean!
   invoiceSubscriptions: [InvoiceSubscription!]
   invoiceType: InvoiceTypeEnum!

--- a/schema.json
+++ b/schema.json
@@ -17014,6 +17014,20 @@
               ]
             },
             {
+              "name": "externalIntegrationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "fees",
               "description": null,
               "type": {
@@ -17078,20 +17092,6 @@
                   "name": "ID",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "integrationExternalId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/schema.json
+++ b/schema.json
@@ -17086,6 +17086,20 @@
               ]
             },
             {
+              "name": "integrationExternalId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "integrationSyncable",
               "description": null,
               "type": {


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR adds `external_id` to the invoice object so that proper URL on integration provider can be displayed in the UI
