### PR TITLE
bug: admin_count should count active memberships

### DIFF
--- a/app/graphql/types/memberships/metadata.rb
+++ b/app/graphql/types/memberships/metadata.rb
@@ -6,7 +6,7 @@ module Types
       field :admin_count, Integer, null: false
 
       def admin_count
-        context[:current_organization].memberships.admin.count
+        context[:current_organization].memberships.active.admin.count
       end
     end
   end

--- a/spec/graphql/resolvers/memberships_resolver_spec.rb
+++ b/spec/graphql/resolvers/memberships_resolver_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe Resolvers::MembershipsResolver, type: :graphql do
     end
   end
 
+  it 'returns the count of active admin memberships' do
+    create(:membership, organization: organization, role: :admin, status: :revoked)
+    create_list(:membership, 2, organization: organization, role: :finance)
+
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      query:,
+    )
+
+    expect(result['data']['memberships']['metadata']['adminCount']).to eq(1)
+  end
+
   describe 'traversal attack attempt' do
     let!(:other_org) { create(:organization) }
 


### PR DESCRIPTION
This metadata have been added recently

This value should only operate on active memberships of the current organization