### PR TITLE
misc: Auto retry PDF generate jobs in case of HTTP errors

### DIFF
--- a/app/jobs/invoices/generate_pdf_job.rb
+++ b/app/jobs/invoices/generate_pdf_job.rb
@@ -4,6 +4,8 @@ module Invoices
   class GeneratePdfJob < ApplicationJob
     queue_as 'invoices'
 
+    retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 6
+
     def perform(invoice)
       result = Invoices::GeneratePdfService.call(invoice:, context: 'api')
       result.raise_if_error!


### PR DESCRIPTION
## Context

From time to time some `Invoices::GeneratePdfJob` are failing with the following error:
```
HTTP 503 - URI: http://pdf-web.default.svc.cluster.local/forms/chromium/convert/html. Error: Service Unavailable
```

Since to fix the issue we usually just have to retry the job, the retry could be automated.

## Description

This PR adds a `retry_on` attribute for `LagoHttpClient::HttpError` for 6 attemps with exponnential wait time between each retry.