### PR TITLE
feat(wallet): Add granted and paid credits on recurring transaction rule

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -4,9 +4,8 @@ module Api
   module V1
     class WalletsController < Api::BaseController
       def create
-        service = Wallets::CreateService.new
-        result = service.create(
-          WalletLegacyInput.new(
+        result = Wallets::CreateService.call(
+          params: WalletLegacyInput.new(
             current_organization,
             input_params
               .merge(organization_id: current_organization.id)
@@ -89,8 +88,10 @@ module Api
           :expiration_at,
           :expiration_date, # NOTE: Legacy field
           recurring_transaction_rules: [
+            :granted_credits,
             :interval,
             :method,
+            :paid_credits,
             :started_at,
             :target_ongoing_balance,
             :threshold_credits,

--- a/app/graphql/mutations/wallets/create.rb
+++ b/app/graphql/mutations/wallets/create.rb
@@ -16,14 +16,11 @@ module Mutations
       type Types::Wallets::Object
 
       def resolve(**args)
-        result = ::Wallets::CreateService
-          .new(context[:current_user])
-          .create(
-            args
-              .merge(organization_id: current_organization.id)
-              .merge(customer: current_customer(args[:customer_id]))
-              .except(:customer_id)
-          )
+        result = ::Wallets::CreateService.call(
+          params: args.merge(organization_id: current_organization.id)
+            .merge(customer: current_customer(args[:customer_id]))
+            .except(:customer_id)
+        )
 
         result.success? ? result.wallet : result_error(result)
       end

--- a/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
@@ -6,8 +6,10 @@ module Types
       class CreateInput < Types::BaseInputObject
         graphql_name 'CreateRecurringTransactionRuleInput'
 
+        argument :granted_credits, String, required: false
         argument :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, required: false
         argument :method, Types::Wallets::RecurringTransactionRules::MethodEnum, required: false
+        argument :paid_credits, String, required: false
         argument :started_at, GraphQL::Types::ISO8601DateTime, required: false
         argument :target_ongoing_balance, String, required: false
         argument :threshold_credits, String, required: false

--- a/app/services/wallets/balance/update_ongoing_service.rb
+++ b/app/services/wallets/balance/update_ongoing_service.rb
@@ -50,7 +50,6 @@ module Wallets
         threshold_rule = wallet.recurring_transaction_rules.where(trigger: :threshold).first
 
         return if threshold_rule.nil? || wallet.credits_ongoing_balance > threshold_rule.threshold_credits
-        return if usage_amount_cents.positive? && ongoing_usage_balance_cents == usage_amount_cents
         return if (pending_transactions_amount + credits_ongoing_balance) > threshold_rule.threshold_credits
 
         WalletTransactions::CreateJob.set(wait: 2.seconds).perform_later(

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -705,9 +705,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_30_123427) do
     t.boolean "skip_charges", default: false, null: false
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
-    t.index ["number"], name: "index_invoices_on_number"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
-    t.index ["sequential_id"], name: "index_invoices_on_sequential_id"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"
   end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1996,8 +1996,10 @@ input CreatePlanInput {
 }
 
 input CreateRecurringTransactionRuleInput {
+  grantedCredits: String
   interval: RecurringTransactionIntervalEnum
   method: RecurringTransactionMethodEnum
+  paidCredits: String
   startedAt: ISO8601DateTime
   targetOngoingBalance: String
   thresholdCredits: String

--- a/schema.json
+++ b/schema.json
@@ -8110,6 +8110,18 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "grantedCredits",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "interval",
               "description": null,
               "type": {
@@ -8127,6 +8139,18 @@
               "type": {
                 "kind": "ENUM",
                 "name": "RecurringTransactionMethodEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paidCredits",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -3,19 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe Wallets::CreateService, type: :service do
-  subject(:create_service) { described_class.new(membership.user) }
+  subject(:create_service) { described_class.new(params:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:, external_id: 'foobar', currency: customer_currency) }
   let(:customer_currency) { 'EUR' }
 
-  describe '.create' do
+  describe '#call' do
     let(:paid_credits) { '1.00' }
     let(:granted_credits) { '0.00' }
     let(:expiration_at) { (Time.current + 1.year).iso8601 }
 
-    let(:create_args) do
+    let(:params) do
       {
         name: 'New Wallet',
         customer:,
@@ -28,7 +28,7 @@ RSpec.describe Wallets::CreateService, type: :service do
       }
     end
 
-    let(:service_result) { create_service.create(**create_args) }
+    let(:service_result) { create_service.call }
 
     it 'creates a wallet' do
       aggregate_failures do
@@ -64,8 +64,7 @@ RSpec.describe Wallets::CreateService, type: :service do
       let(:customer_currency) { nil }
 
       it 'applies the currency to the customer' do
-        create_service.create(**create_args)
-
+        service_result
         expect(customer.reload.currency).to eq('EUR')
       end
     end
@@ -78,12 +77,14 @@ RSpec.describe Wallets::CreateService, type: :service do
           {
             interval: "monthly",
             method: "target",
+            paid_credits: "10.0",
+            granted_credits: "5.0",
             target_ongoing_balance: "100.0",
             trigger: "interval"
           }
         ]
       end
-      let(:create_args) do
+      let(:params) do
         {
           name: 'New Wallet',
           customer:,


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to be able to create recurring transaction rule by passing `granted_credits` and `paid_credits` fields (without taking the ones defined on the wallet object).