### PR TITLE
fix(integrations): Add integration id to integration customer input

### DIFF
--- a/app/graphql/types/integration_customers/input.rb
+++ b/app/graphql/types/integration_customers/input.rb
@@ -9,6 +9,7 @@ module Types
 
       argument :external_customer_id, String, required: false
       argument :integration_code, String, required: false
+      argument :integration_id, ID, required: false
       argument :integration_type, Types::Integrations::IntegrationTypeEnum, required: false
       argument :subsidiary_id, String, required: false
       argument :sync_with_provider, Boolean, required: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -3626,6 +3626,7 @@ input IntegrationCustomerInput {
   externalCustomerId: String
   id: ID
   integrationCode: String
+  integrationId: ID
   integrationType: IntegrationTypeEnum
   subsidiaryId: String
   syncWithProvider: Boolean

--- a/schema.json
+++ b/schema.json
@@ -16347,6 +16347,18 @@
               "deprecationReason": null
             },
             {
+              "name": "integrationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "integrationType",
               "description": null,
               "type": {

--- a/spec/graphql/types/integration_customers/input_spec.rb
+++ b/spec/graphql/types/integration_customers/input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::IntegrationCustomers::Input do
   it { is_expected.to accept_argument(:id).of_type('ID') }
   it { is_expected.to accept_argument(:external_customer_id).of_type('String') }
   it { is_expected.to accept_argument(:integration_type).of_type('IntegrationTypeEnum') }
+  it { is_expected.to accept_argument(:integration_id).of_type('ID') }
   it { is_expected.to accept_argument(:integration_code).of_type('String') }
   it { is_expected.to accept_argument(:subsidiary_id).of_type('String') }
   it { is_expected.to accept_argument(:sync_with_provider).of_type('Boolean') }


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR adds integration id to GraphQL integration customer input