### PR TITLE
fix(go-cardless): Ignore refund not found when not comming from lago

### DIFF
--- a/app/services/payment_providers/gocardless_service.rb
+++ b/app/services/payment_providers/gocardless_service.rb
@@ -91,6 +91,7 @@ module PaymentProviders
               .new.update_status(
                 provider_refund_id: event.links.refund,
                 status: event.action,
+                metadata: event.metadata
               )
 
             return status_result unless status_result.success?

--- a/spec/services/credit_notes/refunds/gocardless_service_spec.rb
+++ b/spec/services/credit_notes/refunds/gocardless_service_spec.rb
@@ -217,17 +217,15 @@ RSpec.describe CreditNotes::Refunds::GocardlessService, type: :service do
     end
 
     context 'when refund is not found' do
-      it 'fails' do
+      it 'returns an empty result' do
         result = gocardless_service.update_status(
           provider_refund_id: 'foo',
           status: 'paid',
         )
 
         aggregate_failures do
-          expect(result).not_to be_success
-
-          expect(result.error).to be_a(BaseService::NotFoundFailure)
-          expect(result.error.resource).to eq('gocardless_refund')
+          expect(result).to be_success
+          expect(result.refund).to be_nil
         end
       end
     end


### PR DESCRIPTION
## Context

Some  `PaymentProviders::Gocardless::HandleEventJob` jobs are raising  `BaseService::NotFoundFailure` with a `gocardless_refund_not_found` error message.

It seems to happen when the related refund is not found in Lago database.
By looking at the event payload, it appears that no metadata was attached to the event, meaning that the refund was not emitted from Lago.

Since we cannot handle this event, we should ignore them and not raise any error.

## Description

This PR uses an approach that was previously introduce to handle stripe webhooks:
- Check for the `Refund` into the DB
- If not found, check for the metadata in the payload
- raise an error only if the metadata matches a Lago resource (invoice), return a success result otherwise
