### PR TITLE
misc: Enable TrailingCommaInBlockArgs rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,9 +27,6 @@ Style/TrailingCommaInArguments:
 Style/TrailingCommaInArrayLiteral:
   Enabled: false
 
-Style/TrailingCommaInBlockArgs:
-  Enabled: false
-
 Performance/CaseWhenSplat:
   Enabled: true
 


### PR DESCRIPTION
No offenses are currently present on the codebase.