### PR TITLE
fix(integrations): Send webhook after create invoice fails

### DIFF
--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -54,7 +54,7 @@ module Integrations
           provider_error: {
             message:,
             error_code: code
-          },
+          }
         )
       end
 

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -45,6 +45,19 @@ module Integrations
         }
       end
 
+      def deliver_error_webhook(customer:, code:, message:)
+        SendWebhookJob.perform_later(
+          'customer.accounting_provider_error',
+          customer,
+          provider:,
+          provider_code: integration.code,
+          provider_error: {
+            message:,
+            error_code: code
+          },
+        )
+      end
+
       def tax_item
         @tax_item ||= collection_mapping(:tax) || fallback_item
       end

--- a/app/services/integrations/aggregator/contacts/base_service.rb
+++ b/app/services/integrations/aggregator/contacts/base_service.rb
@@ -24,19 +24,6 @@ module Integrations
             customer,
           )
         end
-
-        def deliver_error_webhook(customer:, code:, message:)
-          SendWebhookJob.perform_later(
-            'customer.accounting_provider_error',
-            customer,
-            provider:,
-            provider_code: integration.code,
-            provider_error: {
-              message:,
-              error_code: code
-            },
-          )
-        end
       end
     end
   end

--- a/app/services/integrations/aggregator/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/create_service.rb
@@ -26,6 +26,14 @@ module Integrations
           )
 
           result
+        rescue LagoHttpClient::HttpError => e
+          error = e.json_message
+          code = error['type']
+          message = error.dig('payload', 'message')
+
+          deliver_error_webhook(customer:, code:, message:)
+
+          raise e
         end
 
         def call_async

--- a/app/services/integrations/aggregator/sales_orders/create_service.rb
+++ b/app/services/integrations/aggregator/sales_orders/create_service.rb
@@ -26,6 +26,14 @@ module Integrations
           )
 
           result
+        rescue LagoHttpClient::HttpError => e
+          error = e.json_message
+          code = error['type']
+          message = error.dig('payload', 'message')
+
+          deliver_error_webhook(customer:, code:, message:)
+
+          raise e
         end
       end
     end

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -282,6 +282,12 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
           service_call
         end.to raise_error(http_error)
       end
+
+      it 'enqueues a SendWebhookJob' do
+        expect { service_call }
+          .to have_enqueued_job(SendWebhookJob)
+          .and raise_error(http_error)
+      end
     end
   end
 end

--- a/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
@@ -259,6 +259,12 @@ RSpec.describe Integrations::Aggregator::SalesOrders::CreateService do
           service_call
         end.to raise_error(http_error)
       end
+
+      it 'enqueues a SendWebhookJob' do
+        expect { service_call }
+          .to have_enqueued_job(SendWebhookJob)
+          .and raise_error(http_error)
+      end
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR adds a webhook that is sent after creating an invoice fails in Nango.