### PR TITLE
misc: Enable TrailingCommaInArrayLiteral rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,9 +24,6 @@ Style/StringLiterals:
 Style/TrailingCommaInArguments:
   Enabled: false
 
-Style/TrailingCommaInArrayLiteral:
-  Enabled: false
-
 Performance/CaseWhenSplat:
   Enabled: true
 

--- a/Guardfile
+++ b/Guardfile
@@ -10,7 +10,7 @@ guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^app/controllers/(.+)_(controller)\.rb$}) do |m|
     [
       "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb",
-      "spec/requests/#{m[1]}_controller_spec.rb",
+      "spec/requests/#{m[1]}_controller_spec.rb"
     ]
   end
 end

--- a/app/controllers/api/v1/coupons_controller.rb
+++ b/app/controllers/api/v1/coupons_controller.rb
@@ -94,7 +94,7 @@ module Api
           :reusable,
           applies_to: [
             plan_codes: [],
-            billable_metric_codes: [],
+            billable_metric_codes: []
           ],
         )
       end

--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -144,7 +144,7 @@ module Api
             :refund_amount_cents,
             items: [
               :fee_id,
-              :amount_cents,
+              :amount_cents
             ],
           )
       end
@@ -159,7 +159,7 @@ module Api
             :invoice_id,
             items: [
               :fee_id,
-              :amount_cents,
+              :amount_cents
             ],
           )
       end

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -116,7 +116,7 @@ module Api
             :integration_type,
             :integration_code,
             :subsidiary_id,
-            :sync_with_provider,
+            :sync_with_provider
           ],
           billing_configuration: [
             :invoice_grace_period,
@@ -129,13 +129,13 @@ module Api
 
             # NOTE(legacy): vat has been moved to tax model
             :vat_rate,
-            provider_payment_methods: [],
+            provider_payment_methods: []
           ],
           metadata: [
             :id,
             :key,
             :value,
-            :display_in_invoice,
+            :display_in_invoice
           ],
           tax_codes: [],
         )

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -104,7 +104,7 @@ module Api
               :code,
               :timestamp,
               :external_subscription_id,
-              properties: {}, # rubocop:disable Style/HashAsLastArrayItem
+              properties: {} # rubocop:disable Style/HashAsLastArrayItem
             ],
           ).to_h.deep_symbolize_keys
       end

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -180,7 +180,7 @@ module Api
                 :unit_amount_cents,
                 :units,
                 :description,
-                {tax_codes: []},
+                {tax_codes: []}
               ],
             ).to_h.deep_symbolize_keys
       end
@@ -191,7 +191,7 @@ module Api
           metadata: [
             :id,
             :key,
-            :value,
+            :value
           ],
         )
       end

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -72,7 +72,7 @@ module Api
             :document_locale,
 
             # NOTE(legacy): vat has been moved to tax model
-            :vat_rate,
+            :vat_rate
           ],
         )
       end

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -95,7 +95,7 @@ module Api
             :id,
             :invoice_display_name,
             :amount_cents,
-            {tax_codes: []},
+            {tax_codes: []}
           ],
           charges: [
             :id,
@@ -115,17 +115,17 @@ module Api
                 {
                   properties: {},
                   values: {}
-                },
+                }
               ]
             },
             {
               group_properties: [
                 :group_id,
                 :invoice_display_name,
-                {values: {}},
+                {values: {}}
               ]
             },
-            {tax_codes: []},
+            {tax_codes: []}
           ],
         )
       end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -152,7 +152,7 @@ module Api
               :id,
               :invoice_display_name,
               :amount_cents,
-              {tax_codes: []},
+              {tax_codes: []}
             ],
             charges: [
               :id,
@@ -167,19 +167,19 @@ module Api
                   {
                     properties: {},
                     values: {}
-                  },
+                  }
                 ]
               },
               {
                 group_properties: [
                   :group_id,
                   {values: {}},
-                  :invoice_display_name,
+                  :invoice_display_name
                 ]
               },
-              {tax_codes: []},
+              {tax_codes: []}
             ]
-          },
+          }
         ]
       end
 

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -94,7 +94,7 @@ module Api
             :method,
             :target_ongoing_balance,
             :threshold_credits,
-            :trigger,
+            :trigger
           ],
         )
       end
@@ -116,7 +116,7 @@ module Api
             :threshold_credits,
             :trigger,
             :paid_credits,
-            :granted_credits,
+            :granted_credits
           ],
         )
       end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -77,7 +77,7 @@ class GraphqlController < ApplicationController
           {
             message: message || code,
             extensions: {status:, code:}
-          },
+          }
         ]
       },
     )

--- a/app/legacy_inputs/billable_metric_input.rb
+++ b/app/legacy_inputs/billable_metric_input.rb
@@ -10,14 +10,14 @@ class BillableMetricInput < BaseLegacyInput
           {
             key: group_args[:key],
             values: group_args[:values]
-          },
+          }
         ]
       else
         args[:filters] = [
           {
             key: group_args[:key],
             values: group_args[:values].map { |v| v[:name] }
-          },
+          }
         ]
 
         group_args[:values].each do |group|

--- a/app/models/adjusted_fee.rb
+++ b/app/models/adjusted_fee.rb
@@ -10,7 +10,7 @@ class AdjustedFee < ApplicationRecord
 
   ADJUSTED_FEE_TYPES = [
     :adjusted_units,
-    :adjusted_amount,
+    :adjusted_amount
   ].freeze
 
   enum fee_type: Fee::FEE_TYPES

--- a/app/models/analytics/gross_revenue.rb
+++ b/app/models/analytics/gross_revenue.rb
@@ -18,7 +18,7 @@ module Analytics
           and_months_sql = sanitize_sql(
             [
               "AND am.month >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL ':months months')",
-              {months: months_interval},
+              {months: months_interval}
             ],
           )
         end
@@ -114,7 +114,7 @@ module Analytics
           organization_id,
           args[:external_customer_id],
           args[:currency],
-          args[:months],
+          args[:months]
         ].join('/')
       end
     end

--- a/app/models/analytics/invoice_collection.rb
+++ b/app/models/analytics/invoice_collection.rb
@@ -12,7 +12,7 @@ module Analytics
           and_months_sql = sanitize_sql(
             [
               "AND am.month >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL ':months months')",
-              {months: months_interval},
+              {months: months_interval}
             ],
           )
         end
@@ -76,7 +76,7 @@ module Analytics
           Date.current.strftime('%Y-%m-%d'),
           organization_id,
           args[:currency],
-          args[:months],
+          args[:months]
         ].join('/')
       end
     end

--- a/app/models/analytics/invoiced_usage.rb
+++ b/app/models/analytics/invoiced_usage.rb
@@ -12,7 +12,7 @@ module Analytics
           and_months_sql = sanitize_sql(
             [
               "AND am.month >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL ':months months')",
-              {months: months_interval},
+              {months: months_interval}
             ],
           )
         end
@@ -88,7 +88,7 @@ module Analytics
           Date.current.strftime('%Y-%m-%d'),
           organization_id,
           args[:currency],
-          args[:months],
+          args[:months]
         ].join('/')
       end
     end

--- a/app/models/analytics/mrr.rb
+++ b/app/models/analytics/mrr.rb
@@ -12,7 +12,7 @@ module Analytics
           and_months_sql = sanitize_sql(
             [
               "AND am.month >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL ':months months')",
-              {months: months_interval},
+              {months: months_interval}
             ],
           )
         end
@@ -187,7 +187,7 @@ module Analytics
           Date.current.strftime('%Y-%m-%d'),
           organization_id,
           args[:currency],
-          args[:months],
+          args[:months]
         ].join('/')
       end
     end

--- a/app/models/applied_coupon.rb
+++ b/app/models/applied_coupon.rb
@@ -11,13 +11,13 @@ class AppliedCoupon < ApplicationRecord
 
   STATUSES = [
     :active,
-    :terminated,
+    :terminated
   ].freeze
 
   FREQUENCIES = [
     :once,
     :recurring,
-    :forever,
+    :forever
   ].freeze
 
   enum status: STATUSES

--- a/app/models/coupon.rb
+++ b/app/models/coupon.rb
@@ -16,23 +16,23 @@ class Coupon < ApplicationRecord
 
   STATUSES = [
     :active,
-    :terminated,
+    :terminated
   ].freeze
 
   EXPIRATION_TYPES = [
     :no_expiration,
-    :time_limit,
+    :time_limit
   ].freeze
 
   COUPON_TYPES = [
     :fixed_amount,
-    :percentage,
+    :percentage
   ].freeze
 
   FREQUENCIES = [
     :once,
     :recurring,
-    :forever,
+    :forever
   ].freeze
 
   enum status: STATUSES
@@ -61,7 +61,7 @@ class Coupon < ApplicationRecord
           [
             'coupons.status ASC',
             'coupons.expiration ASC',
-            'coupons.expiration_at ASC',
+            'coupons.expiration_at ASC'
           ].join(', '),
         ),
       )

--- a/app/models/integration_item.rb
+++ b/app/models/integration_item.rb
@@ -7,7 +7,7 @@ class IntegrationItem < ApplicationRecord
 
   ITEM_TYPES = [
     :standard,
-    :tax,
+    :tax
   ].freeze
 
   enum item_type: ITEM_TYPES

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -8,7 +8,7 @@ class Membership < ApplicationRecord
 
   STATUSES = [
     :active,
-    :revoked,
+    :revoked
   ].freeze
 
   ROLES = {

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -7,7 +7,7 @@ class Organization < ApplicationRecord
 
   EMAIL_SETTINGS = [
     'invoice.finalized',
-    'credit_note.created',
+    'credit_note.created'
   ].freeze
 
   has_many :memberships
@@ -43,7 +43,7 @@ class Organization < ApplicationRecord
 
   DOCUMENT_NUMBERINGS = [
     :per_customer,
-    :per_organization,
+    :per_organization
   ].freeze
 
   INTEGRATIONS = %w[netsuite okta].freeze

--- a/app/models/payment_providers/stripe_provider.rb
+++ b/app/models/payment_providers/stripe_provider.rb
@@ -13,7 +13,7 @@ module PaymentProviders
       'charge.refund.updated',
       'customer.updated',
       'charge.succeeded',
-      'charge.dispute.closed',
+      'charge.dispute.closed'
     ].freeze
 
     validates :secret_key, presence: true

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -21,7 +21,7 @@ class Subscription < ApplicationRecord
     :pending,
     :active,
     :terminated,
-    :canceled,
+    :canceled
   ].freeze
 
   BILLING_TIME = %i[

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -15,7 +15,7 @@ class Wallet < ApplicationRecord
 
   STATUSES = [
     :active,
-    :terminated,
+    :terminated
   ].freeze
 
   enum status: STATUSES

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -8,25 +8,25 @@ class WalletTransaction < ApplicationRecord
 
   STATUSES = [
     :pending,
-    :settled,
+    :settled
   ].freeze
 
   TRANSACTION_STATUSES = [
     :purchased,
     :granted,
     :voided,
-    :invoiced,
+    :invoiced
   ].freeze
 
   TRANSACTION_TYPES = [
     :inbound,
-    :outbound,
+    :outbound
   ].freeze
 
   SOURCES = [
     :manual,
     :interval,
-    :threshold,
+    :threshold
   ].freeze
 
   enum status: STATUSES

--- a/app/models/webhook_endpoint.rb
+++ b/app/models/webhook_endpoint.rb
@@ -5,7 +5,7 @@ class WebhookEndpoint < ApplicationRecord
 
   SIGNATURE_ALGOS = [
     :jwt,
-    :hmac,
+    :hmac
   ].freeze
 
   belongs_to :organization

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -61,7 +61,7 @@ module V1
             :charge,
             :group,
             :billable_metric,
-            {charge_filter: {values: :billable_metric_filter}},
+            {charge_filter: {values: :billable_metric_filter}}
           ],
         ),
         ::V1::FeeSerializer,

--- a/app/services/billable_metrics/breakdown/sum_service.rb
+++ b/app/services/billable_metrics/breakdown/sum_service.rb
@@ -43,7 +43,7 @@ module BillableMetrics
             amount: persisted_sum,
             duration: (to_date_in_customer_timezone + 1.day - from_date_in_customer_timezone).to_i,
             total_duration: period_duration,
-          ),
+          )
         ]
       end
 

--- a/app/services/charges/build_default_properties_service.rb
+++ b/app/services/charges/build_default_properties_service.rb
@@ -34,7 +34,7 @@ module Charges
             to_value: nil,
             per_unit_amount: '0',
             flat_amount: '0'
-          },
+          }
         ]
       }
     end
@@ -59,7 +59,7 @@ module Charges
             to_value: nil,
             per_unit_amount: '0',
             flat_amount: '0'
-          },
+          }
         ]
       }
     end
@@ -73,7 +73,7 @@ module Charges
             rate: '0',
             fixed_amount: '0',
             flat_amount: '0'
-          },
+          }
         ]
       }
     end

--- a/app/services/charges/charge_models/percentage_service.rb
+++ b/app/services/charges/charge_models/percentage_service.rb
@@ -73,7 +73,7 @@ module Charges
       def free_units_count
         [
           free_units_per_events,
-          aggregation_result.options[:running_total]&.count { |e| e < free_units_per_total_aggregation } || 0,
+          aggregation_result.options[:running_total]&.count { |e| e < free_units_per_total_aggregation } || 0
         ].excluding(0).min || 0
       end
 

--- a/app/services/credit_notes/create_from_termination.rb
+++ b/app/services/credit_notes/create_from_termination.rb
@@ -34,7 +34,7 @@ module CreditNotes
           {
             fee_id: last_subscription_fee.id,
             amount_cents: amount.truncate(CreditNote::DB_PRECISION_SCALE)
-          },
+          }
         ],
         reason: reason.to_sym,
         automatic: true,
@@ -102,7 +102,7 @@ module CreditNotes
           CreditNoteItem.new(
             fee_id: last_subscription_fee.id,
             precise_amount_cents: item_amount.truncate(CreditNote::DB_PRECISION_SCALE),
-          ),
+          )
         ],
       )
 

--- a/app/services/events/stores/clickhouse/weighted_sum_query.rb
+++ b/app/services/events/stores/clickhouse/weighted_sum_query.rb
@@ -144,7 +144,7 @@ module Events
             [
               groups,
               'toDateTime64(:from_datetime, 5, \'UTC\') AS timestamp',
-              "toDecimal128(#{initial_value[:value]}, :decimal_scale) AS difference",
+              "toDecimal128(#{initial_value[:value]}, :decimal_scale) AS difference"
             ].flatten.join(', ')
           end
 
@@ -166,7 +166,7 @@ module Events
             [
               groups,
               "toDateTime64(:to_datetime, 5, 'UTC') AS timestamp",
-              'toDecimal128(0, :decimal_scale) AS difference',
+              'toDecimal128(0, :decimal_scale) AS difference'
             ].flatten.join(', ')
           end
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -125,7 +125,7 @@ module Events
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
             query.query,
-            {decimal_scale: DECIMAL_SCALE},
+            {decimal_scale: DECIMAL_SCALE}
           ],
         )
         result = ::Clickhouse::EventsRaw.connection.select_one(sql)
@@ -140,7 +140,7 @@ module Events
           ActiveRecord::Base.sanitize_sql_for_conditions(
             [
               query.breakdown_query,
-              {decimal_scale: DECIMAL_SCALE},
+              {decimal_scale: DECIMAL_SCALE}
             ],
           ),
         ).rows
@@ -156,7 +156,7 @@ module Events
               to_datetime: to_datetime.ceil,
               decimal_scale: DECIMAL_SCALE,
               timezone: customer.applicable_timezone
-            },
+            }
           ],
         )
         result = ::Clickhouse::EventsRaw.connection.select_one(sql)
@@ -174,7 +174,7 @@ module Events
               to_datetime: to_datetime.ceil,
               decimal_scale: DECIMAL_SCALE,
               timezone: customer.applicable_timezone
-            },
+            }
           ],
         )
 
@@ -189,7 +189,7 @@ module Events
             {
               to_datetime: to_datetime.ceil,
               decimal_scale: DECIMAL_SCALE
-            },
+            }
           ],
         )
 
@@ -206,7 +206,7 @@ module Events
               to_datetime: to_datetime.ceil,
               decimal_scale: DECIMAL_SCALE,
               timezone: customer.applicable_timezone
-            },
+            }
           ],
         )
         prepare_grouped_result(::Clickhouse::EventsRaw.connection.select_all(sql).rows)
@@ -396,7 +396,7 @@ module Events
               to_datetime: to_datetime.ceil,
               decimal_scale: DECIMAL_SCALE,
               initial_value: initial_value || 0
-            },
+            }
           ],
         )
 
@@ -431,7 +431,7 @@ module Events
               from_datetime:,
               to_datetime: to_datetime.ceil,
               decimal_scale: DECIMAL_SCALE
-            },
+            }
           ],
         )
 
@@ -451,7 +451,7 @@ module Events
                 to_datetime: to_datetime.ceil,
                 decimal_scale: DECIMAL_SCALE,
                 initial_value: initial_value || 0
-              },
+              }
             ],
           ),
         ).rows
@@ -498,7 +498,7 @@ module Events
           [
             'toDecimal128OrNull(events_raw.properties[?], ?) IS NOT NULL',
             aggregation_property,
-            DECIMAL_SCALE,
+            DECIMAL_SCALE
           ],
         )
       end

--- a/app/services/events/stores/postgres/weighted_sum_query.rb
+++ b/app/services/events/stores/postgres/weighted_sum_query.rb
@@ -146,7 +146,7 @@ module Events
               groups,
               'timestamp without time zone :from_datetime',
               initial_value[:value],
-              'timestamp without time zone :from_datetime',
+              'timestamp without time zone :from_datetime'
             ].flatten.join(', ')
           end
 
@@ -172,7 +172,7 @@ module Events
               groups,
               'timestamp without time zone :from_datetime',
               0,
-              'timestamp without time zone :from_datetime',
+              'timestamp without time zone :from_datetime'
             ].flatten.join(', ')
           end
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -44,7 +44,7 @@ module Events
             [
               "DISTINCT ON (#{groups.join(", ")}) #{groups.join(", ")}",
               'events.timestamp',
-              "(#{sanitized_property_name})::numeric AS value",
+              "(#{sanitized_property_name})::numeric AS value"
             ].join(', '),
           )
           .to_sql
@@ -108,7 +108,7 @@ module Events
               from_datetime:,
               to_datetime:,
               timezone: customer.applicable_timezone
-            },
+            }
           ],
         )
         result = ActiveRecord::Base.connection.select_one(sql)
@@ -125,7 +125,7 @@ module Events
               from_datetime:,
               to_datetime:,
               timezone: customer.applicable_timezone
-            },
+            }
           ],
         )
 
@@ -151,7 +151,7 @@ module Events
               from_datetime:,
               to_datetime:,
               timezone: customer.applicable_timezone
-            },
+            }
           ],
         )
         prepare_grouped_result(Event.connection.select_all(sql).rows)
@@ -265,7 +265,7 @@ module Events
               from_datetime:,
               to_datetime: to_datetime.ceil,
               initial_value: initial_value || 0
-            },
+            }
           ],
         )
 
@@ -299,7 +299,7 @@ module Events
             {
               from_datetime:,
               to_datetime: to_datetime.ceil
-            },
+            }
           ],
         )
 
@@ -317,7 +317,7 @@ module Events
                 from_datetime:,
                 to_datetime: to_datetime.ceil,
                 initial_value: initial_value || 0
-              },
+              }
             ],
           ),
         ).rows

--- a/app/services/fees/charge_service.rb
+++ b/app/services/fees/charge_service.rb
@@ -143,7 +143,7 @@ module Fees
         charge_filter&.id,
         (grouped_by || {}).map do |k, v|
           "#{k}-#{v}"
-        end.sort.join('|'),
+        end.sort.join('|')
       ].compact.join('|')
       key = 'default' if key.blank?
 

--- a/app/services/integrations/aggregator/invoices/base_service.rb
+++ b/app/services/integrations/aggregator/invoices/base_service.rb
@@ -118,7 +118,7 @@ module Integrations
               {
                 'sublistId' => 'item',
                 'lineItems' => invoice.fees.map { |fee| item(fee) } + discounts
-              },
+              }
             ],
             'options' => {
               'ignoreMandatoryFields' => false

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -226,7 +226,7 @@ module Invoices
                   name: invoice.number
                 }
               }
-            },
+            }
           ],
           mode: 'payment',
           success_url: success_redirect_url,

--- a/app/services/subscriptions/billing_service.rb
+++ b/app/services/subscriptions/billing_service.rb
@@ -141,7 +141,7 @@ module Subscriptions
         interval: :yearly,
         conditions: [
           "DATE_PART('day', (:today#{at_time_zone})) = 1",
-          "plans.bill_charges_monthly = 't'",
+          "plans.bill_charges_monthly = 't'"
         ],
       )
     end
@@ -153,7 +153,7 @@ module Subscriptions
         interval: :yearly,
         conditions: [
           "DATE_PART('month', (:today#{at_time_zone})) = 1",
-          "DATE_PART('day', (:today#{at_time_zone})) = 1",
+          "DATE_PART('day', (:today#{at_time_zone})) = 1"
         ],
       )
     end
@@ -164,7 +164,7 @@ module Subscriptions
         interval: :weekly,
         conditions: [
           "EXTRACT(ISODOW FROM (subscriptions.subscription_at#{at_time_zone})) =
-          EXTRACT(ISODOW FROM (:today#{at_time_zone}))",
+          EXTRACT(ISODOW FROM (:today#{at_time_zone}))"
         ],
       )
     end
@@ -279,7 +279,7 @@ module Subscriptions
         interval: :yearly,
         conditions: [
           "plans.bill_charges_monthly = 't'",
-          billing_day,
+          billing_day
         ],
       )
     end

--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -14,7 +14,7 @@ module Subscriptions
         'charge-usage',
         charge.id,
         subscription.id,
-        charge.updated_at.iso8601,
+        charge.updated_at.iso8601
       ].join('/')
     end
 

--- a/app/services/subscriptions/dates/quarterly_service.rb
+++ b/app/services/subscriptions/dates/quarterly_service.rb
@@ -117,7 +117,7 @@ module Subscriptions
           (subscription_at.month % 12).zero? ? 12 : (subscription_at.month % 12),
           ((subscription_at.month + 3) % 12).zero? ? 12 : ((subscription_at.month + 3) % 12),
           ((subscription_at.month + 6) % 12).zero? ? 12 : ((subscription_at.month + 6) % 12),
-          ((subscription_at.month + 9) % 12).zero? ? 12 : ((subscription_at.month + 9) % 12),
+          ((subscription_at.month + 9) % 12).zero? ? 12 : ((subscription_at.month + 9) % 12)
         ].sort
 
         # This is the case when we terminate subscription on On February 10 but anniversary date is on

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -79,7 +79,7 @@ module Wallets
         interval: :weekly,
         conditions: [
           "EXTRACT(ISODOW FROM (wallets.created_at#{at_time_zone})) =
-          EXTRACT(ISODOW FROM (:today#{at_time_zone}))",
+          EXTRACT(ISODOW FROM (:today#{at_time_zone}))"
         ],
       )
     end

--- a/db/migrate/20231017082921_fill_cached_aggregations.rb
+++ b/db/migrate/20231017082921_fill_cached_aggregations.rb
@@ -37,7 +37,7 @@ class FillCachedAggregations < ActiveRecord::Migration[7.0]
               .where([
                 "metadata->>'current_aggregation' IS NOT NULL",
                 "metadata->>'max_aggregation' IS NOT NULL",
-                "metadata->>'max_aggregation_with_proration' IS NOT NULL",
+                "metadata->>'max_aggregation_with_proration' IS NOT NULL"
               ].join(' OR '))
 
             events.find_each do |event|

--- a/lib/lago_utils/lago_utils/ruby_sandbox/safe_environment.rb
+++ b/lib/lago_utils/lago_utils/ruby_sandbox/safe_environment.rb
@@ -101,7 +101,7 @@ module LagoUtils
         :RubyToken,
         :RubyLex,
         :RUBYGEMS_ACTIVATION_MONITOR,
-        :JSON,
+        :JSON
       ].freeze
 
       KERNEL_S_METHODS = %w[

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
         {
           volume_ranges: [
             {from_value: 0, to_value: 100, per_unit_amount: '2', flat_amount: '1'},
-            {from_value: 101, to_value: nil, per_unit_amount: '1', flat_amount: '0'},
+            {from_value: 101, to_value: nil, per_unit_amount: '1', flat_amount: '0'}
           ]
         }
       end
@@ -69,7 +69,7 @@ FactoryBot.define do
               to_value: nil,
               rate: '0',
               flat_amount: '300'
-            },
+            }
           ]
         }
       end

--- a/spec/factories/payment_responses.rb
+++ b/spec/factories/payment_responses.rb
@@ -66,7 +66,7 @@ FactoryBot.define do
             'brands' => %w[amex bcmc cartebancaire mc visa visadankort],
             'name' => 'Credit Card',
             'type' => 'scheme'
-          },
+          }
         ],
         'storedPaymentMethods' => [
           {
@@ -81,7 +81,7 @@ FactoryBot.define do
             'supportedRecurringProcessingModels' => %w[CardOnFile Subscription UnscheduledCardOnFile],
             'supportedShopperInteractions' => %w[Ecommerce ContAuth],
             'type' => 'scheme'
-          },
+          }
         ]
       },
     )

--- a/spec/graphql/mutations/billable_metrics/create_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/create_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Mutations::BillableMetrics::Create, type: :graphql do
             {
               key: 'region',
               values: %w[usa europe]
-            },
+            }
           ]
         }
       },

--- a/spec/graphql/mutations/billable_metrics/update_spec.rb
+++ b/spec/graphql/mutations/billable_metrics/update_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Mutations::BillableMetrics::Update, type: :graphql do
             {
               key: 'region',
               values: %w[usa europe]
-            },
+            }
           ]
         }
       },

--- a/spec/graphql/mutations/credit_notes/create_spec.rb
+++ b/spec/graphql/mutations/credit_notes/create_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
             {
               feeId: fee2.id,
               amountCents: 5
-            },
+            }
           ]
         }
       },
@@ -125,7 +125,7 @@ RSpec.describe Mutations::CreditNotes::Create, type: :graphql do
               {
                 feeId: fee1.id,
                 amountCents: 15
-              },
+              }
             ]
           }
         },

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
               key: 'manager',
               value: 'John Doe',
               displayInInvoice: true
-            },
+            }
           ],
           taxCodes: [tax.code]
         }

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
               key: 'test-key',
               value: 'value',
               displayInInvoice: true
-            },
+            }
           ],
           taxCodes: [tax.code]
         }

--- a/spec/graphql/mutations/invoices/create_spec.rb
+++ b/spec/graphql/mutations/invoices/create_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Mutations::Invoices::Create, type: :graphql do
       },
       {
         addOnId: add_on_second.id
-      },
+      }
     ]
   end
   let(:mutation) do

--- a/spec/graphql/mutations/invoices/update_spec.rb
+++ b/spec/graphql/mutations/invoices/update_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Mutations::Invoices::Update, type: :graphql do
             {
               key: 'test-key',
               value: 'value'
-            },
+            }
           ]
         }
       },

--- a/spec/graphql/mutations/plans/create_spec.rb
+++ b/spec/graphql/mutations/plans/create_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
                   invoiceDisplayName: 'Payment Method',
                   properties: {amount: '100.00'},
                   values: {billable_metric_filter.key => %w[card sepa]}
-                },
+                }
               ]
             },
             {
@@ -154,7 +154,7 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
                     toValue: nil,
                     perUnitAmount: '3.00',
                     flatAmount: '3.00'
-                  },
+                  }
                 ]
               }
             },
@@ -174,7 +174,7 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
                     toValue: nil,
                     perUnitAmount: '3.00',
                     flatAmount: '3.00'
-                  },
+                  }
                 ]
               }
             },
@@ -194,10 +194,10 @@ RSpec.describe Mutations::Plans::Create, type: :graphql do
                     toValue: nil,
                     flatAmount: '3.00',
                     rate: '3'
-                  },
+                  }
                 ]
               }
-            },
+            }
           ]
         }
       },

--- a/spec/graphql/mutations/plans/update_spec.rb
+++ b/spec/graphql/mutations/plans/update_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
                   invoiceDisplayName: 'Payment method',
                   properties: {amount: '10.00'},
                   values: {billable_metric_filter.key => %w[card]}
-                },
+                }
               ]
             },
             {
@@ -137,7 +137,7 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
                     toValue: nil,
                     perUnitAmount: '3.00',
                     flatAmount: '3.00'
-                  },
+                  }
                 ]
               }
             },
@@ -157,10 +157,10 @@ RSpec.describe Mutations::Plans::Update, type: :graphql do
                     toValue: nil,
                     perUnitAmount: '3.00',
                     flatAmount: '3.00'
-                  },
+                  }
                 ]
               }
-            },
+            }
           ]
         }
       }

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
             charges: [
               id: charge.id,
               billableMetricId: charge.billable_metric_id,
-              invoiceDisplayName: 'invoice display name',
+              invoiceDisplayName: 'invoice display name'
             ]
           }
         }

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
               method: 'target',
               trigger: 'interval',
               interval: 'monthly'
-            },
+            }
           ]
         }
       },

--- a/spec/graphql/mutations/wallets/update_spec.rb
+++ b/spec/graphql/mutations/wallets/update_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Mutations::Wallets::Update, type: :graphql do
               paidCredits: '22.2',
               grantedCredits: '22.2',
               targetOngoingBalance: '300'
-            },
+            }
           ]
         }
       },

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
             to_value: nil,
             per_unit_amount: '0.01',
             flat_amount: '0.01'
-          },
+          }
         ]
       },
     )

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe SendWebhookJob, type: :job do
         errors: [
           invalid_code: [SecureRandom.uuid],
           missing_aggregation_property: [SecureRandom.uuid],
-          missing_group_key: [SecureRandom.uuid],
+          missing_group_key: [SecureRandom.uuid]
         ]
       }
     end

--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe BillableMetric, type: :model do
                 name: 'italy',
                 key: 'cloud',
                 values: %w[google]
-              },
+              }
             ]
           },
         )

--- a/spec/models/charge_filter_spec.rb
+++ b/spec/models/charge_filter_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe ChargeFilter, type: :model do
     let(:values) do
       [
         create(:charge_filter_value, values: ['card'], charge_filter:, billable_metric_filter: method_filter),
-        create(:charge_filter_value, values: ['visa'], charge_filter:, billable_metric_filter: scheme_filter),
+        create(:charge_filter_value, values: ['visa'], charge_filter:, billable_metric_filter: scheme_filter)
       ]
     end
 
@@ -359,7 +359,7 @@ RSpec.describe ChargeFilter, type: :model do
     let(:values) do
       [
         create(:charge_filter_value, charge_filter:, values: ['credit'], billable_metric_filter: card),
-        create(:charge_filter_value, charge_filter:, values: ['visa'], billable_metric_filter: scheme),
+        create(:charge_filter_value, charge_filter:, values: ['visa'], billable_metric_filter: scheme)
       ]
     end
 
@@ -387,7 +387,7 @@ RSpec.describe ChargeFilter, type: :model do
           :charge_filter_value,
           values: [ChargeFilterValue::ALL_FILTER_VALUES],
           billable_metric_filter: scheme,
-        ),
+        )
       ]
     end
 

--- a/spec/requests/api/v1/billable_metrics_controller_spec.rb
+++ b/spec/requests/api/v1/billable_metrics_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::V1::BillableMetricsController, type: :request do
       key: 'cloud',
       values: [
         {name: 'AWS', key: 'region', values: %w[usa europe]},
-        {name: 'Google', key: 'region', values: ['usa']},
+        {name: 'Google', key: 'region', values: ['usa']}
       ]
     }
   end

--- a/spec/requests/api/v1/credit_notes_controller_spec.rb
+++ b/spec/requests/api/v1/credit_notes_controller_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe Api::V1::CreditNotesController, type: :request do
           {
             fee_id: fee2.id,
             amount_cents: 5
-          },
+          }
         ]
       }
     end

--- a/spec/requests/api/v1/customers/usage_controller_spec.rb
+++ b/spec/requests/api/v1/customers/usage_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
               to_value: nil,
               per_unit_amount: '0.01',
               flat_amount: '0.01'
-            },
+            }
           ]
         },
       )
@@ -44,7 +44,7 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
       [
         '/api/v1/customers',
         customer.external_id,
-        "current_usage?external_subscription_id=#{subscription.external_id}",
+        "current_usage?external_subscription_id=#{subscription.external_id}"
       ].join('/')
     end
 
@@ -361,7 +361,7 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
       [
         '/api/v1/customers',
         customer.external_id,
-        "past_usage?external_subscription_id=#{subscription.external_id}&periods_count=2",
+        "past_usage?external_subscription_id=#{subscription.external_id}&periods_count=2"
       ].join('/')
     end
 
@@ -406,7 +406,7 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
         [
           '/api/v1/customers',
           customer.external_id,
-          'past_usage',
+          'past_usage'
         ].join('/')
       end
 
@@ -422,7 +422,7 @@ RSpec.describe Api::V1::Customers::UsageController, type: :request do
         [
           '/api/v1/customers',
           customer.external_id,
-          "past_usage?billable_metric_code=foo&external_subscription_id=#{subscription.external_id}",
+          "past_usage?billable_metric_code=foo&external_subscription_id=#{subscription.external_id}"
         ].join('/')
       end
 

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe Api::V1::CustomersController, type: :request do
               key: 'Hello',
               value: 'Hi',
               display_in_invoice: true
-            },
+            }
           ]
         }
       end

--- a/spec/requests/api/v1/events_controller_spec.rb
+++ b/spec/requests/api/v1/events_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
               properties: {
                 foo: 'bar'
               }
-            },
+            }
           ],
         )
       end.to change(Event, :count).by(1)

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
           },
           {
             add_on_code: add_on_second.code
-          },
+          }
         ]
       }
     end
@@ -79,7 +79,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
             },
             {
               add_on_code: 'invalid'
-            },
+            }
           ]
         }
       end
@@ -120,7 +120,7 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
             {
               key: 'Hello',
               value: 'Hi'
-            },
+            }
           ]
         }
       end

--- a/spec/requests/api/v1/plans_controller_spec.rb
+++ b/spec/requests/api/v1/plans_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
               amount: '0.22'
             },
             tax_codes:
-          },
+          }
         ]
       }
     end
@@ -101,10 +101,10 @@ RSpec.describe Api::V1::PlansController, type: :request do
                     from_value: 2,
                     flat_amount: '0',
                     per_unit_amount: '3200'
-                  },
+                  }
                 ]
               }
-            },
+            }
           ]
         }
       end
@@ -146,9 +146,9 @@ RSpec.describe Api::V1::PlansController, type: :request do
                   group_id: group.id,
                   invoice_display_name: 'Europe',
                   values: {amount: '0.22'}
-                },
+                }
               ]
-            },
+            }
           ]
         }
       end
@@ -168,7 +168,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
               group_id: group.id,
               invoice_display_name: 'Europe',
               values: {amount: '0.22'}
-            },
+            }
           ],
         )
 
@@ -178,7 +178,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
               invoice_display_name: 'Europe',
               properties: {amount: '0.22'},
               values: {group.key.to_sym => [group.value]}
-            },
+            }
           ],
         )
       end
@@ -250,7 +250,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
               amount: '0.22'
             },
             tax_codes:
-          },
+          }
         ]
       }
     end
@@ -451,9 +451,9 @@ RSpec.describe Api::V1::PlansController, type: :request do
                   group_id: group.id,
                   invoice_display_name: 'Europe',
                   values: {amount: '0.22'}
-                },
+                }
               ]
-            },
+            }
           ]
         }
       end
@@ -473,7 +473,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
               group_id: group.id,
               invoice_display_name: 'Europe',
               values: {amount: '0.22'}
-            },
+            }
           ],
         )
 
@@ -483,7 +483,7 @@ RSpec.describe Api::V1::PlansController, type: :request do
               invoice_display_name: 'Europe',
               properties: {amount: '0.22'},
               values: {group.key.to_sym => [group.value]}
-            },
+            }
           ],
         )
       end

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
             {
               trigger: 'interval',
               interval: 'monthly'
-            },
+            }
           ]
         }
       end
@@ -170,7 +170,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
               interval: 'weekly',
               paid_credits: '105',
               granted_credits: '105'
-            },
+            }
           ]
         }
       end

--- a/spec/scenarios/billable_metrics/custom_aggregation_spec.rb
+++ b/spec/scenarios/billable_metrics/custom_aggregation_spec.rb
@@ -691,7 +691,7 @@ RSpec.describe 'Aggregation - Custom Aggregation Scenarios', :scenarios, type: :
               {from: 0, to: 10_000, rate: '0.4'},
               {from: 10_001, to: 15_000, rate: '0.3'},
               {from: 15_001, to: 22_000, rate: '0.25'},
-              {from: 22_001, to: nil, rate: '0.2'},
+              {from: 22_001, to: nil, rate: '0.2'}
             ],
             fx_rate: 0.88
           }
@@ -725,7 +725,7 @@ RSpec.describe 'Aggregation - Custom Aggregation Scenarios', :scenarios, type: :
               {from: 0, to: 10_000, amount: '0.6'},
               {from: 10_001, to: 15_000, amount: '0.5'},
               {from: 15_001, to: 22_000, amount: '0.45'},
-              {from: 22_001, to: nil, amount: '0.4'},
+              {from: 22_001, to: nil, amount: '0.4'}
             ]
           }
         },

--- a/spec/scenarios/charge_models/edit_with_filter_spec.rb
+++ b/spec/scenarios/charge_models/edit_with_filter_spec.rb
@@ -37,7 +37,7 @@ describe 'Change charge model with filters', :scenarios, type: :request do
           properties: {
             graduated_ranges: [
               {from_value: 0, to_value: 100, per_unit_amount: '10', flat_amount: '0'},
-              {from_value: 101, to_value: nil, per_unit_amount: '20', flat_amount: '0'},
+              {from_value: 101, to_value: nil, per_unit_amount: '20', flat_amount: '0'}
             ]
           },
           filters: [
@@ -46,15 +46,15 @@ describe 'Change charge model with filters', :scenarios, type: :request do
               properties: {
                 graduated_ranges: [
                   {from_value: 0, to_value: 100, per_unit_amount: '12', flat_amount: '0'},
-                  {from_value: 101, to_value: nil, per_unit_amount: '22', flat_amount: '0'},
+                  {from_value: 101, to_value: nil, per_unit_amount: '22', flat_amount: '0'}
                 ]
               },
               values: {
                 cloud: ['aws']
               }
-            },
+            }
           ]
-        },
+        }
       ],
     )
 

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -55,7 +55,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 to_value: nil,
                 per_unit_amount: '2',
                 flat_amount: '0'
-              },
+              }
             ]
           },
         )
@@ -234,7 +234,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                   to_value: nil,
                   per_unit_amount: '12',
                   flat_amount: '0'
-                },
+                }
               ]
             },
           )
@@ -340,7 +340,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                   to_value: nil,
                   per_unit_amount: '10',
                   flat_amount: '0'
-                },
+                }
               ]
             },
           )
@@ -451,7 +451,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                   to_value: nil,
                   per_unit_amount: '2',
                   flat_amount: '0'
-                },
+                }
               ]
             },
           )
@@ -591,7 +591,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                     to_value: nil,
                     per_unit_amount: '2',
                     flat_amount: '0'
-                  },
+                  }
                 ]
               },
             )
@@ -677,7 +677,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 to_value: nil,
                 per_unit_amount: '5',
                 flat_amount: '50'
-              },
+              }
             ]
           },
         )
@@ -850,7 +850,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                 to_value: nil,
                 per_unit_amount: '5',
                 flat_amount: '50'
-              },
+              }
             ]
           },
         )
@@ -1008,7 +1008,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
                   to_value: nil,
                   per_unit_amount: '15',
                   flat_amount: '30'
-                },
+                }
               ]
             },
           )

--- a/spec/scenarios/credit_note_spec.rb
+++ b/spec/scenarios/credit_note_spec.rb
@@ -116,7 +116,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
           {
             fee_id: fee2.id,
             amount_cents: fee2.amount_cents
-          },
+          }
         ],
       )
 
@@ -134,7 +134,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
           {
             fee_id: fee2.id,
             amount_cents: 26_260
-          },
+          }
         ],
       )
 
@@ -157,7 +157,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
           {
             fee_id: fee2.id,
             amount_cents: 26_260
-          },
+          }
         ],
       )
     end
@@ -322,7 +322,7 @@ describe 'Create credit note Scenarios', :scenarios, type: :request do
             {
               fee_id: fee5.id,
               amount_cents: 100
-            },
+            }
           ],
         )
 

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -643,7 +643,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
               to_value: nil,
               per_unit_amount: '0.01',
               flat_amount: '0.01'
-            },
+            }
           ]
         },
       )

--- a/spec/scenarios/plans/create_and_update_filters_spec.rb
+++ b/spec/scenarios/plans/create_and_update_filters_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe 'Create and edit plans with charge filters', :scenarios, type: :r
                 values: {
                   image_size: [ChargeFilterValue::ALL_FILTER_VALUES]
                 }
-              },
+              }
             ]
-          },
+          }
         ],
       )
     end
@@ -83,7 +83,7 @@ RSpec.describe 'Create and edit plans with charge filters', :scenarios, type: :r
         filters: [
           {key: 'image_size', values: %w[1024x1024 512x512]},
           {key: 'steps', values: %w[0-25 26-50 51-100]},
-          {key: 'model_name', values: %w[llama-1 llama-2 llama-3]},
+          {key: 'model_name', values: %w[llama-1 llama-2 llama-3]}
         ],
       )
     end
@@ -147,9 +147,9 @@ RSpec.describe 'Create and edit plans with charge filters', :scenarios, type: :r
                 invoice_display_name: 'f5',
                 properties: {amount: '1'},
                 values: {image_size: ['1024x1024']}
-              },
+              }
             ]
-          },
+          }
         ],
       )
 

--- a/spec/scenarios/subscriptions/billing_spec.rb
+++ b/spec/scenarios/subscriptions/billing_spec.rb
@@ -112,14 +112,14 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
 
         let(:before_billing_times) do
           [
-            DateTime.new(2023, 2, 12, 18, 0), # 12th of Feb 18:00 UTC - 12th of Feb 23:30 Asia/Kolkata
+            DateTime.new(2023, 2, 12, 18, 0) # 12th of Feb 18:00 UTC - 12th of Feb 23:30 Asia/Kolkata
           ]
         end
         let(:billing_times) do
           [
             DateTime.new(2023, 2, 12, 19, 0), # 12th of Feb 19:00 UTC - 13th of Feb 00:30 Asia/Kolkata
             DateTime.new(2023, 2, 13, 0, 0), # 13th of Feb 00:00 UTC - 13th of Feb 05:30 Asia/Kolkata
-            DateTime.new(2023, 2, 13, 18, 0), # 13th of Feb 18:00 UTC - 13th of Feb 23:30 Asia/Kolkata
+            DateTime.new(2023, 2, 13, 18, 0) # 13th of Feb 18:00 UTC - 13th of Feb 23:30 Asia/Kolkata
           ]
         end
         let(:after_billing_times) do
@@ -135,7 +135,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
 
         let(:before_billing_times) do
           [
-            DateTime.new(2023, 2, 13, 4, 0), # 13th of Feb 04:00 UTC - 12th of Feb 23:00 America/Bogota
+            DateTime.new(2023, 2, 13, 4, 0) # 13th of Feb 04:00 UTC - 12th of Feb 23:00 America/Bogota
           ]
         end
         let(:billing_times) do
@@ -143,7 +143,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 2, 13, 5, 0), # 13th of Feb 05:00 UTC - 13th of Feb 00:00 America/Bogota
             DateTime.new(2023, 2, 13, 6, 0), # 13th of Feb 06:00 UTC - 13th of Feb 1:00 America/Bogota
             DateTime.new(2023, 2, 13, 3, 0), # 13th of Feb 23:00 UTC - 13th of Feb 18:00 America/Bogota
-            DateTime.new(2023, 2, 14, 4, 0), # 14th of Feb 04:00 UTC - 13th of Feb 23:00 America/Bogota
+            DateTime.new(2023, 2, 14, 4, 0) # 14th of Feb 04:00 UTC - 13th of Feb 23:00 America/Bogota
           ]
         end
         let(:after_billing_times) do
@@ -170,7 +170,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
 
         let(:before_billing_times) do
           [
-            DateTime.new(2023, 5, 22, 21, 0), # 22sd of May 21:00 UTC - 22sd of May 23:00 Europe/Paris
+            DateTime.new(2023, 5, 22, 21, 0) # 22sd of May 21:00 UTC - 22sd of May 23:00 Europe/Paris
           ]
         end
         let(:billing_times) do
@@ -178,7 +178,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 5, 22, 22, 0), # 22sd of May 22:00 UTC - 23rd of May 00:00 Europe/Paris
             DateTime.new(2023, 5, 23, 20, 0), # 23rd of May 20:00 UTC - 23rd of May 22:00 Europe/Paris
             DateTime.new(2023, 5, 23, 21, 0), # 23rd of May 21:00 UTC - 23rd of May 23:00 Europe/Paris
-            DateTime.new(2023, 5, 23, 22, 10), # 23rd of May 22:59 UTC - 24th of May 00:59 Europe/Paris
+            DateTime.new(2023, 5, 23, 22, 10) # 23rd of May 22:59 UTC - 24th of May 00:59 Europe/Paris
           ]
         end
         let(:after_billing_times) do
@@ -194,7 +194,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
 
         let(:before_billing_times) do
           [
-            DateTime.new(2023, 2, 15, 4, 0), # 15th of Feb 04:00 UTC - 14th of Feb 23:00 America/Bogota
+            DateTime.new(2023, 2, 15, 4, 0) # 15th of Feb 04:00 UTC - 14th of Feb 23:00 America/Bogota
           ]
         end
         let(:billing_times) do
@@ -202,7 +202,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 2, 15, 5, 0), # 15th of Feb 05:00 UTC - 15th of Feb 00:00 America/Bogota
             DateTime.new(2023, 2, 15, 6, 0), # 15th of Feb 06:00 UTC - 15th of Feb 1:00 America/Bogota
             DateTime.new(2023, 2, 15, 3, 0), # 15th of Feb 23:00 UTC - 15th of Feb 18:00 America/Bogota
-            DateTime.new(2023, 2, 16, 4, 0), # 16th of Feb 04:00 UTC - 15th of Feb 23:00 America/Bogota
+            DateTime.new(2023, 2, 16, 4, 0) # 16th of Feb 04:00 UTC - 15th of Feb 23:00 America/Bogota
           ]
         end
         let(:after_billing_times) do
@@ -238,13 +238,13 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
           [
             DateTime.new(2023, 2, 28, 19, 0), # 28 of Feb 19:00 UTC - 1st of Mar 00:30 Asia/Kolkata
             DateTime.new(2023, 3, 1, 0, 0), # 1st of Mar 00:00 UTC - 1st of Mar 05:30 Asia/Kolkata
-            DateTime.new(2023, 3, 1, 18, 0), # 1st of Mar 18:00 UTC - 1st of Mar 23:30 Asia/Kolkata
+            DateTime.new(2023, 3, 1, 18, 0) # 1st of Mar 18:00 UTC - 1st of Mar 23:30 Asia/Kolkata
           ]
         end
         let(:after_billing_times) do
           [
             DateTime.new(2023, 3, 1, 19, 0), # 1st of Mar 19:00 UTC - 2nd of Mar 00:30 Asia/Kolkata
-            DateTime.new(2023, 3, 2, 0, 0), # 2nd of Mar 00:00 UTC - 2nd of Mar 05:30 Asia/Kolkata
+            DateTime.new(2023, 3, 2, 0, 0) # 2nd of Mar 00:00 UTC - 2nd of Mar 05:30 Asia/Kolkata
           ]
         end
 
@@ -263,13 +263,13 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 3, 1, 5, 0), # 1st of Mar 05:00 UTC - 1st of Mar 00:00 America/Bogota
             DateTime.new(2023, 3, 1, 6, 0), # 1st of Mar 06:00 UTC - 1st of Mar 01:00 America/Bogota
             DateTime.new(2023, 3, 1, 0, 0), # 2nd of Mar 00:00 UTC - 1st of Mar 19:00 America/Bogota
-            DateTime.new(2023, 3, 2, 4, 0), # 2nd of Mar 04:00 UTC - 1st of Mar 23:00 America/Bogota
+            DateTime.new(2023, 3, 2, 4, 0) # 2nd of Mar 04:00 UTC - 1st of Mar 23:00 America/Bogota
           ]
         end
         let(:after_billing_times) do
           [
             DateTime.new(2023, 3, 2, 5, 0), # 2nd of Mar 05:00 UTC - 2nd of Mar 00:00 America/Bogota
-            DateTime.new(2023, 3, 3, 5, 0), # 3th of Mar 05:00 UTC - 3th of Mar 00:00 America/Bogota
+            DateTime.new(2023, 3, 3, 5, 0) # 3th of Mar 05:00 UTC - 3th of Mar 00:00 America/Bogota
           ]
         end
 
@@ -314,7 +314,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 12, 31, 2),
             DateTime.new(2024, 1, 31, 2),
             DateTime.new(2024, 2, 29, 2),
-            DateTime.new(2024, 3, 31, 2),
+            DateTime.new(2024, 3, 31, 2)
           ]
         end
 
@@ -339,7 +339,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 11, 30, 2),
             DateTime.new(2023, 12, 30, 2),
             DateTime.new(2024, 2, 29, 2),
-            DateTime.new(2024, 3, 30, 2),
+            DateTime.new(2024, 3, 30, 2)
           ]
         end
 
@@ -362,7 +362,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 9, 28, 2),
             DateTime.new(2023, 10, 28, 2),
             DateTime.new(2023, 11, 28, 2),
-            DateTime.new(2023, 12, 28, 2),
+            DateTime.new(2023, 12, 28, 2)
           ]
         end
 
@@ -377,14 +377,14 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
 
         let(:before_billing_times) do
           [
-            DateTime.new(2023, 3, 1, 18, 0), # 1st of Mar 18:00 UTC - 1st of Mar 23:30 Asia/Kolkata
+            DateTime.new(2023, 3, 1, 18, 0) # 1st of Mar 18:00 UTC - 1st of Mar 23:30 Asia/Kolkata
           ]
         end
         let(:billing_times) do
           [
             DateTime.new(2023, 3, 1, 19, 0), # 1st of Mar 19:00 UTC - 2nd of Mar 00:30 Asia/Kolkata
             DateTime.new(2023, 3, 2, 0, 0), # 2nd of Mar 00:00 UTC - 2nd of Mar 05:30 Asia/Kolkata
-            DateTime.new(2023, 3, 2, 18, 0), # 2nd of Mar 18:00 UTC - 2nd of Mar 23:30 Asia/Kolkata
+            DateTime.new(2023, 3, 2, 18, 0) # 2nd of Mar 18:00 UTC - 2nd of Mar 23:30 Asia/Kolkata
           ]
         end
         let(:after_billing_times) do
@@ -401,14 +401,14 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
         let(:before_billing_times) do
           [
             DateTime.new(2023, 3, 1, 23, 0), # 1st of Mar 23:00 UTC - 1st of Mar 18:00 America/Bogota
-            DateTime.new(2023, 3, 2, 4, 0), # 2nd of Mar 04:00 UTC - 1st of Mar 23:00 America/Bogota
+            DateTime.new(2023, 3, 2, 4, 0) # 2nd of Mar 04:00 UTC - 1st of Mar 23:00 America/Bogota
           ]
         end
         let(:billing_times) do
           [
             DateTime.new(2023, 3, 2, 6, 0), # 2nd of Mar 06:00 UTC - 2nd of Mar 01:00 America/Bogota
             DateTime.new(2023, 3, 1, 7, 0), # 2nd of Mar 07:00 UTC - 2nd of Mar 02:00 America/Bogota
-            DateTime.new(2023, 3, 3, 0, 0), # 3rd of Mar 00:00 UTC - 2nd of Mar 19:00 America/Bogota
+            DateTime.new(2023, 3, 3, 0, 0) # 3rd of Mar 00:00 UTC - 2nd of Mar 19:00 America/Bogota
           ]
         end
         let(:after_billing_times) do
@@ -444,13 +444,13 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
           [
             DateTime.new(2023, 3, 31, 19, 0), # 31 of Mar 19:00 UTC - 1st of Apr 00:30 Asia/Kolkata
             DateTime.new(2023, 4, 1, 0, 0), # 1st of Apr 00:00 UTC - 1st of Apr 05:30 Asia/Kolkata
-            DateTime.new(2023, 4, 1, 18, 0), # 1st of Apr 18:00 UTC - 1st of Apr 23:30 Asia/Kolkata
+            DateTime.new(2023, 4, 1, 18, 0) # 1st of Apr 18:00 UTC - 1st of Apr 23:30 Asia/Kolkata
           ]
         end
         let(:after_billing_times) do
           [
             DateTime.new(2023, 4, 1, 19, 0), # 1st of Apr 19:00 UTC - 2nd of Apr 00:30 Asia/Kolkata
-            DateTime.new(2023, 4, 2, 0, 0), # 2nd of Apr 00:00 UTC - 2nd of Apr 05:30 Asia/Kolkata
+            DateTime.new(2023, 4, 2, 0, 0) # 2nd of Apr 00:00 UTC - 2nd of Apr 05:30 Asia/Kolkata
           ]
         end
 
@@ -469,13 +469,13 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 4, 1, 5, 0), # 1st of Apr 05:00 UTC - 1st of Apr 00:00 America/Bogota
             DateTime.new(2023, 4, 1, 6, 0), # 1st of Apr 06:00 UTC - 1st of Apr 01:00 America/Bogota
             DateTime.new(2023, 4, 2, 0, 0), # 2nd of Apr 00:00 UTC - 1st of Apr 19:00 America/Bogota
-            DateTime.new(2023, 4, 2, 4, 0), # 2nd of Apr 04:00 UTC - 1st of Apr 23:00 America/Bogota
+            DateTime.new(2023, 4, 2, 4, 0) # 2nd of Apr 04:00 UTC - 1st of Apr 23:00 America/Bogota
           ]
         end
         let(:after_billing_times) do
           [
             DateTime.new(2023, 4, 2, 5, 0), # 2nd of Apr 05:00 UTC - 2nd of Apr 00:00 America/Bogota
-            DateTime.new(2023, 4, 3, 5, 0), # 3th of Apr 05:00 UTC - 3th of Apr 00:00 America/Bogota
+            DateTime.new(2023, 4, 3, 5, 0) # 3th of Apr 05:00 UTC - 3th of Apr 00:00 America/Bogota
           ]
         end
 
@@ -509,7 +509,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 3, 31, 1),
             DateTime.new(2023, 6, 30, 1),
             DateTime.new(2023, 9, 30, 2),
-            DateTime.new(2023, 12, 31, 2),
+            DateTime.new(2023, 12, 31, 2)
           ]
         end
 
@@ -524,7 +524,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 1, 30, 1),
             DateTime.new(2023, 4, 30, 1),
             DateTime.new(2023, 7, 30, 2),
-            DateTime.new(2023, 10, 30, 2),
+            DateTime.new(2023, 10, 30, 2)
           ]
         end
 
@@ -539,7 +539,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 2, 28, 1),
             DateTime.new(2023, 5, 28, 1),
             DateTime.new(2023, 8, 28, 2),
-            DateTime.new(2023, 11, 28, 2),
+            DateTime.new(2023, 11, 28, 2)
           ]
         end
 
@@ -554,14 +554,14 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
 
         let(:before_billing_times) do
           [
-            DateTime.new(2023, 5, 1, 18, 0), # 1st of May 18:00 UTC - 1st of May 23:30 Asia/Kolkata
+            DateTime.new(2023, 5, 1, 18, 0) # 1st of May 18:00 UTC - 1st of May 23:30 Asia/Kolkata
           ]
         end
         let(:billing_times) do
           [
             DateTime.new(2023, 5, 1, 19, 0), # 1st of May 19:00 UTC - 2nd of May 00:30 Asia/Kolkata
             DateTime.new(2023, 5, 2, 0, 0), # 2nd of May 00:00 UTC - 2nd of May 05:30 Asia/Kolkata
-            DateTime.new(2023, 5, 2, 18, 0), # 2nd of May 18:00 UTC - 2nd of May 23:30 Asia/Kolkata
+            DateTime.new(2023, 5, 2, 18, 0) # 2nd of May 18:00 UTC - 2nd of May 23:30 Asia/Kolkata
           ]
         end
         let(:after_billing_times) do
@@ -578,14 +578,14 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
         let(:before_billing_times) do
           [
             DateTime.new(2023, 5, 1, 23, 0), # 1st of May 23:00 UTC - 1st of May 18:00 America/Bogota
-            DateTime.new(2023, 5, 2, 4, 0), # 2nd of May 04:00 UTC - 1st of May 23:00 America/Bogota
+            DateTime.new(2023, 5, 2, 4, 0) # 2nd of May 04:00 UTC - 1st of May 23:00 America/Bogota
           ]
         end
         let(:billing_times) do
           [
             DateTime.new(2023, 5, 2, 6, 0), # 2nd of May 06:00 UTC - 2nd of May 01:00 America/Bogota
             DateTime.new(2023, 5, 1, 7, 0), # 2nd of May 07:00 UTC - 2nd of May 02:00 America/Bogota
-            DateTime.new(2023, 5, 3, 0, 0), # 3rd of May 00:00 UTC - 2nd of May 19:00 America/Bogota
+            DateTime.new(2023, 5, 3, 0, 0) # 3rd of May 00:00 UTC - 2nd of May 19:00 America/Bogota
           ]
         end
         let(:after_billing_times) do
@@ -616,20 +616,20 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
 
         let(:before_billing_times) do
           [
-            DateTime.new(2022, 12, 31, 21, 0), # 31th of Dec 21:00 UTC - 31th of Dec 23:00 Europe/Paris
+            DateTime.new(2022, 12, 31, 21, 0) # 31th of Dec 21:00 UTC - 31th of Dec 23:00 Europe/Paris
           ]
         end
         let(:billing_times) do
           [
             DateTime.new(2022, 12, 31, 23, 0), # 31th of Dec 23:00 UTC - 1st of Jan 01:00 Europe/Paris
             DateTime.new(2023, 1, 1, 20, 0), # 1st of Jan 20:00 UTC - 1st of Jan 22:00 Europe/Paris
-            DateTime.new(2023, 1, 1, 21, 0), # 1st of Jan 21:00 UTC - 1st of Jan 23:00 Europe/Paris
+            DateTime.new(2023, 1, 1, 21, 0) # 1st of Jan 21:00 UTC - 1st of Jan 23:00 Europe/Paris
           ]
         end
         let(:after_billing_times) do
           [
             DateTime.new(2023, 1, 1, 22, 59), # 1st of Jan 22:59 UTC - 2nd of Jan 00:59 Europe/Paris
-            DateTime.new(2023, 1, 2, 0, 10), # 2nd of Jan 00:10 UTC - 2nd of Jan 02:10 Europe/Paris
+            DateTime.new(2023, 1, 2, 0, 10) # 2nd of Jan 00:10 UTC - 2nd of Jan 02:10 Europe/Paris
           ]
         end
 
@@ -647,7 +647,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
           [
             DateTime.new(2023, 1, 1, 5, 0), # 1st of Jan 05:00 UTC - 1st of Jan 00:00 America/Bogota
             DateTime.new(2023, 1, 1, 6, 0), # 1st of Jan 06:00 UTC - 1st of Jan 01:00 America/Bogota
-            DateTime.new(2023, 1, 2, 0, 0), # 2nd of Jan 00:00 UTC - 1st of Jan 19:00 America/Bogota
+            DateTime.new(2023, 1, 2, 0, 0) # 2nd of Jan 00:00 UTC - 1st of Jan 19:00 America/Bogota
           ]
         end
         let(:after_billing_times) do
@@ -684,7 +684,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
 
         let(:before_billing_times) do
           [
-            DateTime.new(2023, 4, 1, 21, 0), # 1st of April 21:00 UTC - 1st of April 23:00 Europe/Paris
+            DateTime.new(2023, 4, 1, 21, 0) # 1st of April 21:00 UTC - 1st of April 23:00 Europe/Paris
           ]
         end
         let(:billing_times) do
@@ -692,12 +692,12 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 4, 2, 23, 0), # 1st of April 23:00 UTC - 2nd of April 01:00 Europe/Paris
             DateTime.new(2023, 4, 2, 20, 0), # 2nd of April 20:00 UTC - 2nd of April 22:00 Europe/Paris
             DateTime.new(2023, 4, 2, 21, 0), # 2nd of April 21:00 UTC - 2nd of April 23:00 Europe/Paris
-            DateTime.new(2023, 4, 2, 22, 10), # 2nd of April 22:59 UTC - 3rd of April 00:59 Europe/Paris
+            DateTime.new(2023, 4, 2, 22, 10) # 2nd of April 22:59 UTC - 3rd of April 00:59 Europe/Paris
           ]
         end
         let(:after_billing_times) do
           [
-            DateTime.new(2023, 4, 3, 0, 10), # 3rd of April 00:10 UTC - 3rd of April 02:10 Europe/Paris
+            DateTime.new(2023, 4, 3, 0, 10) # 3rd of April 00:10 UTC - 3rd of April 02:10 Europe/Paris
           ]
         end
 
@@ -715,7 +715,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
           [
             DateTime.new(2023, 2, 4, 5, 0), # 4th of Feb 05:00 UTC - 4th of Feb 00:00 America/Bogota
             DateTime.new(2023, 2, 4, 6, 0), # 4th of Feb 06:00 UTC - 4th of Feb 01:00 America/Bogota
-            DateTime.new(2023, 2, 5, 0, 0), # 5th of Feb 00:00 UTC - 4th of Feb 19:00 America/Bogota
+            DateTime.new(2023, 2, 5, 0, 0) # 5th of Feb 00:00 UTC - 4th of Feb 19:00 America/Bogota
           ]
         end
         let(:after_billing_times) do
@@ -753,13 +753,13 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
           [
             DateTime.new(2023, 2, 28, 19, 0), # 28 of Feb 19:00 UTC - 1st of Mar 00:30 Asia/Kolkata
             DateTime.new(2023, 3, 1, 0, 0), # 1st of Mar 00:00 UTC - 1st of Mar 05:30 Asia/Kolkata
-            DateTime.new(2023, 3, 1, 18, 0), # 1st of Mar 18:00 UTC - 1st of Mar 23:30 Asia/Kolkata
+            DateTime.new(2023, 3, 1, 18, 0) # 1st of Mar 18:00 UTC - 1st of Mar 23:30 Asia/Kolkata
           ]
         end
         let(:after_billing_times) do
           [
             DateTime.new(2023, 3, 1, 19, 0), # 1st of Mar 19:00 UTC - 2nd of Mar 00:30 Asia/Kolkata
-            DateTime.new(2023, 3, 2, 0, 0), # 2nd of Mar 00:00 UTC - 2nd of Mar 05:30 Asia/Kolkata
+            DateTime.new(2023, 3, 2, 0, 0) # 2nd of Mar 00:00 UTC - 2nd of Mar 05:30 Asia/Kolkata
           ]
         end
 
@@ -778,13 +778,13 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 3, 1, 5, 0), # 1st of Mar 05:00 UTC - 1st of Mar 00:00 America/Bogota
             DateTime.new(2023, 3, 1, 6, 0), # 1st of Mar 06:00 UTC - 1st of Mar 01:00 America/Bogota
             DateTime.new(2023, 3, 1, 0, 0), # 2nd of Mar 00:00 UTC - 1st of Mar 19:00 America/Bogota
-            DateTime.new(2023, 3, 2, 4, 0), # 2nd of Mar 04:00 UTC - 1st of Mar 23:00 America/Bogota
+            DateTime.new(2023, 3, 2, 4, 0) # 2nd of Mar 04:00 UTC - 1st of Mar 23:00 America/Bogota
           ]
         end
         let(:after_billing_times) do
           [
             DateTime.new(2023, 3, 2, 5, 0), # 2nd of Mar 05:00 UTC - 2nd of Mar 00:00 America/Bogota
-            DateTime.new(2023, 3, 3, 5, 0), # 3th of Mar 05:00 UTC - 3th of Mar 00:00 America/Bogota
+            DateTime.new(2023, 3, 3, 5, 0) # 3th of Mar 05:00 UTC - 3th of Mar 00:00 America/Bogota
           ]
         end
 
@@ -819,7 +819,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
 
         let(:before_billing_times) do
           [
-            DateTime.new(2023, 4, 1, 21, 0), # 1st of April 21:00 UTC - 1st of April 23:00 Europe/Paris
+            DateTime.new(2023, 4, 1, 21, 0) # 1st of April 21:00 UTC - 1st of April 23:00 Europe/Paris
           ]
         end
         let(:billing_times) do
@@ -827,12 +827,12 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
             DateTime.new(2023, 4, 2, 22, 0), # 1st of April 23:00 UTC - 2nd of April 01:00 Europe/Paris
             DateTime.new(2023, 4, 2, 20, 0), # 2nd of April 20:00 UTC - 2nd of April 22:00 Europe/Paris
             DateTime.new(2023, 4, 2, 21, 0), # 2nd of April 21:00 UTC - 2nd of April 23:00 Europe/Paris
-            DateTime.new(2023, 4, 2, 22, 10), # 2nd of April 22:59 UTC - 3rd of April 00:59 Europe/Paris
+            DateTime.new(2023, 4, 2, 22, 10) # 2nd of April 22:59 UTC - 3rd of April 00:59 Europe/Paris
           ]
         end
         let(:after_billing_times) do
           [
-            DateTime.new(2023, 4, 3, 0, 10), # 3rd of April 00:10 UTC - 3rd of April 02:10 Europe/Paris
+            DateTime.new(2023, 4, 3, 0, 10) # 3rd of April 00:10 UTC - 3rd of April 02:10 Europe/Paris
           ]
         end
 
@@ -850,7 +850,7 @@ describe 'Billing Subscriptions Scenario', :scenarios, type: :request do
           [
             DateTime.new(2023, 3, 4, 5, 0), # 4th of Mar 05:00 UTC - 4th of Mar 00:00 America/Bogota
             DateTime.new(2023, 3, 4, 6, 0), # 4th of Mar 06:00 UTC - 4th of Mar 01:00 America/Bogota
-            DateTime.new(2023, 3, 5, 0, 0), # 5th of Mar 00:00 UTC - 4th of Mar 19:00 America/Bogota
+            DateTime.new(2023, 3, 5, 0, 0) # 5th of Mar 00:00 UTC - 4th of Mar 19:00 America/Bogota
           ]
         end
         let(:after_billing_times) do

--- a/spec/scenarios/taxes_on_invoice_spec.rb
+++ b/spec/scenarios/taxes_on_invoice_spec.rb
@@ -54,7 +54,7 @@ describe 'Taxes on Invoice Scenarios', :scenarios, type: :request do
                 min_amount_cents: 5000,
                 properties: {amount: '30'},
                 tax_codes: [organization.taxes.find_by(code: 'sales_tax').code]
-              },
+              }
             ]
           },
         )

--- a/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/charge_usage_serializer_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
         code: billable_metric.code,
         aggregation_type: billable_metric.aggregation_type,
         grouped_by: {'card_type' => 'visa'},
-      ),
+      )
     ]
   end
 
@@ -58,7 +58,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
             'grouped_by' => {'card_type' => 'visa'},
             'filters' => [],
             'groups' => []
-          },
+          }
         ],
       )
     end
@@ -91,7 +91,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
             units: fee1.units,
             amount_cents: fee1.amount_cents,
             events_count: fee1.events_count
-          },
+          }
         ]
       end
 
@@ -113,7 +113,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
             units: fee2.units,
             amount_cents: fee2.amount_cents,
             events_count: fee2.events_count
-          },
+          }
         ]
       end
 
@@ -144,7 +144,7 @@ RSpec.describe ::V1::Customers::ChargeUsageSerializer do
           aggregation_type: billable_metric.aggregation_type,
           grouped_by: {'card_type' => 'visa'},
           charge_filter:,
-        ),
+        )
       ]
     end
 

--- a/spec/serializers/v1/customers/usage_serializer_spec.rb
+++ b/spec/serializers/v1/customers/usage_serializer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ::V1::Customers::UsageSerializer do
           amount_cents: 5,
           amount_currency: 'EUR',
           groups: [],
-        ),
+        )
       ],
     )
   end

--- a/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/billable_metric_filters/create_or_update_batch_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
         {
           key: 'cloud',
           values: %w[aws gcp]
-        },
+        }
       ]
     end
 
@@ -75,7 +75,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
         {
           key: 'region',
           values: %w[Europe US Asia Africa]
-        },
+        }
       ]
     end
 
@@ -98,7 +98,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
           {
             key: 'region',
             values: %w[Europe]
-          },
+          }
         ]
       end
 
@@ -128,7 +128,7 @@ RSpec.describe BillableMetricFilters::CreateOrUpdateBatchService do
           {
             key: 'country',
             values: %w[USA France Germany]
-          },
+          }
         ]
       end
 

--- a/spec/services/billable_metrics/aggregations/count_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/count_service_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
             cloud: 'AWS',
             region: 'africa'
           },
-        ),
+        )
       ]
     end
 
@@ -180,7 +180,7 @@ RSpec.describe BillableMetrics::Aggregations::CountService, type: :service do
           subscription:,
           timestamp: Time.zone.now - 1.day,
           properties: {},
-        ),
+        )
       ]
     end
 

--- a/spec/services/billable_metrics/aggregations/custom_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/custom_service_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe BillableMetrics::Aggregations::CustomService, type: :service do
         ranges: [
           {from: 0, to: 10, storage_eu: '0', storage_us: '0', storage_asia: '0'},
           {from: 10, to: 20, storage_eu: '0.10', storage_us: '0.20', storage_asia: '0.30'},
-          {from: 20, to: nil, storage_eu: '0.20', storage_us: '0.30', storage_asia: '0.40'},
+          {from: 20, to: nil, storage_eu: '0.20', storage_us: '0.30', storage_asia: '0.40'}
         ]
       }
     }
@@ -122,7 +122,7 @@ RSpec.describe BillableMetrics::Aggregations::CustomService, type: :service do
         customer:,
         timestamp: Time.zone.now - 2.days,
         properties: {value: 35, storage_zone: 'storage_us'},
-      ),
+      )
     ]
   end
 
@@ -165,7 +165,7 @@ RSpec.describe BillableMetrics::Aggregations::CustomService, type: :service do
           customer:,
           timestamp: Time.zone.now - 4.days,
           properties: {value: 11, storage_zone: 'storage_eu'},
-        ),
+        )
       ]
     end
     let(:event) { event_list.first }
@@ -244,7 +244,7 @@ RSpec.describe BillableMetrics::Aggregations::CustomService, type: :service do
           subscription:,
           timestamp: Time.zone.now - 2.days,
           properties: {value: 11, storage_zone: 'storage_eu'},
-        ),
+        )
       ]
     end
 

--- a/spec/services/billable_metrics/aggregations/latest_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/latest_service_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
         properties: {
           total_count: 14
         },
-      ),
+      )
     ].flatten
   end
 
@@ -120,7 +120,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
           properties: {
             total_count: 14.2
           },
-        ),
+        )
       ]
     end
 
@@ -144,7 +144,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
           properties: {
             total_count: -5
           },
-        ),
+        )
       ]
     end
 
@@ -165,7 +165,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
           customer:,
           subscription:,
           timestamp: Time.current,
-        ),
+        )
       ]
     end
 
@@ -219,7 +219,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
             total_count: 12,
             region: 'africa'
           },
-        ),
+        )
       ].flatten
     end
 
@@ -260,7 +260,7 @@ RSpec.describe BillableMetrics::Aggregations::LatestService, type: :service do
           properties: {
             total_count: 12
           },
-        ),
+        )
       ]
     end
 

--- a/spec/services/billable_metrics/aggregations/max_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/max_service_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
         properties: {
           total_count: 12
         },
-      ),
+      )
     ].flatten
   end
 
@@ -120,7 +120,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
           properties: {
             total_count: 14.2
           },
-        ),
+        )
       ]
     end
 
@@ -144,7 +144,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
           properties: {
             total_count: 'foo_bar'
           },
-        ),
+        )
       ]
     end
 
@@ -169,7 +169,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
           customer:,
           subscription:,
           timestamp: Time.zone.now - 1.day,
-        ),
+        )
       ]
     end
 
@@ -211,7 +211,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
             total_count: 12,
             region: 'africa'
           },
-        ),
+        )
       ]
     end
 
@@ -260,7 +260,7 @@ RSpec.describe BillableMetrics::Aggregations::MaxService, type: :service do
           properties: {
             total_count: 12
           },
-        ),
+        )
       ]
     end
 

--- a/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
+++ b/spec/services/billable_metrics/aggregations/weighted_sum_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
       {timestamp: Time.zone.parse('2023-08-01 02:00:00'), value: -4},
       {timestamp: Time.zone.parse('2023-08-01 04:00:00'), value: -2},
       {timestamp: Time.zone.parse('2023-08-01 05:00:00'), value: 10},
-      {timestamp: Time.zone.parse('2023-08-01 05:30:00'), value: -10},
+      {timestamp: Time.zone.parse('2023-08-01 05:30:00'), value: -10}
     ]
   end
 
@@ -80,7 +80,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
   context 'with a single event' do
     let(:events_values) do
       [
-        {timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 1000},
+        {timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 1000}
       ]
     end
 
@@ -108,7 +108,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
     let(:events_values) do
       [
         {timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 3},
-        {timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 3},
+        {timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 3}
       ]
     end
 
@@ -220,7 +220,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
           {timestamp: DateTime.parse('2023-08-01 02:00:00'), value: -4},
           {timestamp: DateTime.parse('2023-08-01 04:00:00'), value: -2},
           {timestamp: DateTime.parse('2023-08-01 05:00:00'), value: 10},
-          {timestamp: DateTime.parse('2023-08-01 05:30:00'), value: -10},
+          {timestamp: DateTime.parse('2023-08-01 05:30:00'), value: -10}
         ]
       end
 
@@ -243,7 +243,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
 
     let(:events_values) do
       [
-        {timestamp: DateTime.parse('2023-08-01 00:00:00.000'), value: 1000, region: 'europe'},
+        {timestamp: DateTime.parse('2023-08-01 00:00:00.000'), value: 1000, region: 'europe'}
       ]
     end
 
@@ -275,7 +275,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
         {timestamp: Time.zone.parse('2023-08-01 02:00:00'), value: -4, agent_name: 'frodo'},
         {timestamp: Time.zone.parse('2023-08-01 04:00:00'), value: -2, agent_name: 'frodo'},
         {timestamp: Time.zone.parse('2023-08-01 05:00:00'), value: 10, agent_name: 'frodo'},
-        {timestamp: Time.zone.parse('2023-08-01 05:30:00'), value: -10, agent_name: 'frodo'},
+        {timestamp: Time.zone.parse('2023-08-01 05:30:00'), value: -10, agent_name: 'frodo'}
       ]
     end
 
@@ -313,7 +313,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
           {timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 3, agent_name: 'aragorn'},
 
           {timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 3, agent_name: 'frodo'},
-          {timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 3, agent_name: 'frodo'},
+          {timestamp: Time.zone.parse('2023-08-01 00:00:00.000'), value: 3, agent_name: 'frodo'}
         ]
       end
 
@@ -355,7 +355,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
             timestamp: from_datetime - 1.day,
             current_aggregation: 1000,
             grouped_by: {'agent_name' => 'frodo'},
-          ),
+          )
         ]
       end
 
@@ -472,7 +472,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
             {timestamp: DateTime.parse('2023-08-01 02:00:00'), value: -4, agent_name: 'frodo'},
             {timestamp: DateTime.parse('2023-08-01 04:00:00'), value: -2, agent_name: 'frodo'},
             {timestamp: DateTime.parse('2023-08-01 05:00:00'), value: 10, agent_name: 'frodo'},
-            {timestamp: DateTime.parse('2023-08-01 05:30:00'), value: -10, agent_name: 'frodo'},
+            {timestamp: DateTime.parse('2023-08-01 05:30:00'), value: -10, agent_name: 'frodo'}
           ]
         end
 
@@ -506,7 +506,7 @@ RSpec.describe BillableMetrics::Aggregations::WeightedSumService, type: :service
             region: 'europe',
             agent_name: 'aragorn'
           },
-          {timestamp: DateTime.parse('2023-08-01 00:00:00.000'), value: 1000, region: 'europe', agent_name: 'frodo'},
+          {timestamp: DateTime.parse('2023-08-01 00:00:00.000'), value: 1000, region: 'europe', agent_name: 'frodo'}
         ]
       end
 

--- a/spec/services/billable_metrics/create_service_spec.rb
+++ b/spec/services/billable_metrics/create_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
           key: 'cloud',
           values: [
             {name: 'AWS', key: 'region', values: %w[usa europe]},
-            {name: 'Google', key: 'region', values: ['usa']},
+            {name: 'Google', key: 'region', values: ['usa']}
           ]
         }
       end
@@ -76,7 +76,7 @@ RSpec.describe BillableMetrics::CreateService, type: :service do
           {
             key: 'cloud',
             values: %w[aws google]
-          },
+          }
         ]
       end
 

--- a/spec/services/billable_metrics/update_service_spec.rb
+++ b/spec/services/billable_metrics/update_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
           key: 'cloud',
           values: [
             {name: 'AWS', key: 'region', values: %w[usa europe]},
-            {name: 'Google', key: 'region', values: ['usa']},
+            {name: 'Google', key: 'region', values: ['usa']}
           ]
         }
       end
@@ -85,7 +85,7 @@ RSpec.describe BillableMetrics::UpdateService, type: :service do
           {
             key: 'cloud',
             values: %w[aws google]
-          },
+          }
         ]
       end
 

--- a/spec/services/charge_filters/create_or_update_batch_service_spec.rb
+++ b/spec/services/charge_filters/create_or_update_batch_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
           },
           invoice_display_name: 'Visa debit domestic card payment',
           properties: {amount: '20'}
-        },
+        }
       ]
     end
 
@@ -120,7 +120,7 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
           charge_filter: filter,
           billable_metric_filter: scheme_filter,
           values: ['visa'],
-        ),
+        )
       ]
     end
 
@@ -133,7 +133,7 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
           },
           invoice_display_name: 'New display name',
           properties: {amount: '20'}
-        },
+        }
       ]
     end
 
@@ -159,7 +159,7 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
             },
             invoice_display_name: 'New display name',
             properties: {amount: '20'}
-          },
+          }
         ]
       end
 
@@ -185,7 +185,7 @@ RSpec.describe ChargeFilters::CreateOrUpdateBatchService do
             },
             invoice_display_name: 'New display name',
             properties: {amount: '20'}
-          },
+          }
         ]
       end
 

--- a/spec/services/charge_filters/event_matching_service_spec.rb
+++ b/spec/services/charge_filters/event_matching_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ChargeFilters::EventMatchingService, type: :service do
         values: %w[visa mastercard],
         billable_metric_filter: scheme,
         charge_filter: filter1,
-      ),
+      )
     ]
   end
 
@@ -61,7 +61,7 @@ RSpec.describe ChargeFilters::EventMatchingService, type: :service do
         billable_metric_filter: scheme,
         charge_filter: filter2,
       ),
-      create(:charge_filter_value, values: ['credit'], billable_metric_filter: card_type, charge_filter: filter2),
+      create(:charge_filter_value, values: ['credit'], billable_metric_filter: card_type, charge_filter: filter2)
     ]
   end
 

--- a/spec/services/charge_filters/matching_and_ignored_service_spec.rb
+++ b/spec/services/charge_filters/matching_and_ignored_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
     [
       create(:charge_filter_value, values: ['25'], billable_metric_filter: filter_steps, charge_filter: f1),
       create(:charge_filter_value, values: ['512'], billable_metric_filter: filter_size, charge_filter: f1),
-      create(:charge_filter_value, values: ['llama-2'], billable_metric_filter: filter_model, charge_filter: f1),
+      create(:charge_filter_value, values: ['llama-2'], billable_metric_filter: filter_model, charge_filter: f1)
     ]
   end
 
@@ -27,7 +27,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
   let(:f2_values) do
     [
       create(:charge_filter_value, values: ['25'], billable_metric_filter: filter_steps, charge_filter: f2),
-      create(:charge_filter_value, values: ['512'], billable_metric_filter: filter_size, charge_filter: f2),
+      create(:charge_filter_value, values: ['512'], billable_metric_filter: filter_size, charge_filter: f2)
     ]
   end
 
@@ -45,7 +45,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
         values: [ChargeFilterValue::ALL_FILTER_VALUES],
         billable_metric_filter: filter_size,
         charge_filter: f3,
-      ),
+      )
     ]
   end
 
@@ -57,7 +57,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
         values: [ChargeFilterValue::ALL_FILTER_VALUES],
         billable_metric_filter: filter_size,
         charge_filter: f4,
-      ),
+      )
     ]
   end
 
@@ -69,7 +69,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
         values: ['512'],
         billable_metric_filter: filter_size,
         charge_filter: f5,
-      ),
+      )
     ]
   end
 
@@ -103,7 +103,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
       expect(service_result.ignored_filters).to eq(
         [
           {'model' => %w[llama-2], 'size' => %w[512], 'steps' => %w[25]},
-          {'size' => ['1024'], 'steps' => %w[50 75 100]},
+          {'size' => ['1024'], 'steps' => %w[50 75 100]}
         ],
       )
     end
@@ -117,7 +117,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
       expect(service_result.ignored_filters).to eq(
         [
           {'model' => ['llama-2'], 'size' => ['512'], 'steps' => ['25']},
-          {'size' => ['512'], 'steps' => ['25']},
+          {'size' => ['512'], 'steps' => ['25']}
         ],
       )
     end
@@ -133,7 +133,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
           {'model' => ['llama-2'], 'size' => ['512'], 'steps' => ['25']},
           {'size' => ['512'], 'steps' => ['25']},
           {'size' => %w[512 1024], 'steps' => %w[25 50 75 100]},
-          {'size' => ['512']},
+          {'size' => ['512']}
         ],
       )
     end
@@ -149,7 +149,7 @@ RSpec.describe ChargeFilters::MatchingAndIgnoredService do
           {'model' => ['llama-2'], 'size' => ['512'], 'steps' => ['25']},
           {'size' => ['512'], 'steps' => ['25']},
           {'size' => %w[512 1024], 'steps' => %w[25 50 75 100]},
-          {'size' => ['1024']},
+          {'size' => ['1024']}
         ],
       )
     end

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService, type: :service do
                 to_value: nil,
                 per_unit_amount: '0.01',
                 flat_amount: '0.01'
-              },
+              }
             ]
           },
         )
@@ -122,7 +122,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService, type: :service do
                 to_value: nil,
                 flat_amount: '0.01',
                 rate: '2'
-              },
+              }
             ]
           },
         )

--- a/spec/services/charges/build_default_properties_service_spec.rb
+++ b/spec/services/charges/build_default_properties_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Charges::BuildDefaultPropertiesService, type: :service do
                 to_value: nil,
                 per_unit_amount: '0',
                 flat_amount: '0'
-              },
+              }
             ]
           },
         )
@@ -67,7 +67,7 @@ RSpec.describe Charges::BuildDefaultPropertiesService, type: :service do
                 to_value: nil,
                 per_unit_amount: '0',
                 flat_amount: '0'
-              },
+              }
             ]
           },
         )
@@ -87,7 +87,7 @@ RSpec.describe Charges::BuildDefaultPropertiesService, type: :service do
                 rate: '0',
                 fixed_amount: '0',
                 flat_amount: '0'
-              },
+              }
             ]
           },
         )

--- a/spec/services/charges/charge_models/graduated_percentage_service_spec.rb
+++ b/spec/services/charges/charge_models/graduated_percentage_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
             to_value: nil,
             flat_amount: '400',
             rate: '3'
-          },
+          }
         ]
       },
     )
@@ -64,7 +64,7 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
               total_with_flat_amount: 0,
               rate: 1.0,
               units: '0.0'
-            },
+            }
           ]
         },
       )
@@ -90,7 +90,7 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
               total_with_flat_amount: 200.01,
               rate: 1.0,
               units: '1.0'
-            },
+            }
           ]
         },
       )
@@ -116,7 +116,7 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
               total_with_flat_amount: 200.1,
               rate: 1.0,
               units: '10.0'
-            },
+            }
           ]
         },
       )
@@ -151,7 +151,7 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
               total_with_flat_amount: 300.02,
               rate: 2.0,
               units: '1.0'
-            },
+            }
           ]
         },
       )
@@ -186,7 +186,7 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
               total_with_flat_amount: 300.04,
               rate: 2.0,
               units: '2.0'
-            },
+            }
           ]
         },
       )
@@ -230,7 +230,7 @@ RSpec.describe Charges::ChargeModels::GraduatedPercentageService, type: :service
               total_with_flat_amount: 400.03,
               rate: 3.0,
               units: '1.0'
-            },
+            }
           ]
         },
       )

--- a/spec/services/charges/charge_models/graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/graduated_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
             to_value: nil,
             per_unit_amount: '5',
             flat_amount: '3'
-          },
+          }
         ]
       },
     )
@@ -62,7 +62,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
               total_with_flat_amount: 0,
               per_unit_amount: 0,
               units: '0.0'
-            },
+            }
           ]
         },
       )
@@ -86,7 +86,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
               total_with_flat_amount: 12,
               per_unit_amount: 10,
               units: '1.0'
-            },
+            }
           ]
         },
       )
@@ -110,7 +110,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
               total_with_flat_amount: 102,
               per_unit_amount: 10,
               units: '10.0'
-            },
+            }
           ]
         },
       )
@@ -143,7 +143,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
               total_with_flat_amount: 8,
               per_unit_amount: 5,
               units: '1.0'
-            },
+            }
           ]
         },
       )
@@ -176,7 +176,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
               total_with_flat_amount: 13,
               per_unit_amount: 5,
               units: '2.0'
-            },
+            }
           ]
         },
       )
@@ -218,7 +218,7 @@ RSpec.describe Charges::ChargeModels::GraduatedService, type: :service do
               total_with_flat_amount: 8,
               per_unit_amount: 5,
               units: '1.0'
-            },
+            }
           ]
         },
       )

--- a/spec/services/charges/charge_models/grouped_standard_service_spec.rb
+++ b/spec/services/charges/charge_models/grouped_standard_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Charges::ChargeModels::GroupedStandardService do
         grouped_by: {'cloud' => 'gcp'},
         aggregation: 20,
         count: 7
-      },
+      }
     ]
   end
 

--- a/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
+++ b/spec/services/charges/charge_models/prorated_graduated_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Charges::ChargeModels::ProratedGraduatedService, type: :service d
             to_value: nil,
             per_unit_amount: '5',
             flat_amount: '50'
-          },
+          }
         ]
       },
     )
@@ -260,7 +260,7 @@ RSpec.describe Charges::ChargeModels::ProratedGraduatedService, type: :service d
                 to_value: nil,
                 per_unit_amount: '5',
                 flat_amount: '50'
-              },
+              }
             ]
           },
         )
@@ -303,7 +303,7 @@ RSpec.describe Charges::ChargeModels::ProratedGraduatedService, type: :service d
               to_value: nil,
               per_unit_amount: '2',
               flat_amount: '0'
-            },
+            }
           ]
         },
       )

--- a/spec/services/charges/charge_models/volume_service_spec.rb
+++ b/spec/services/charges/charge_models/volume_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Charges::ChargeModels::VolumeService, type: :service do
         volume_ranges: [
           {from_value: 0, to_value: 100, per_unit_amount: '2', flat_amount: '10'},
           {from_value: 101, to_value: 200, per_unit_amount: '1', flat_amount: '0'},
-          {from_value: 201, to_value: nil, per_unit_amount: '0.5', flat_amount: '50'},
+          {from_value: 201, to_value: nil, per_unit_amount: '0.5', flat_amount: '50'}
         ]
       },
     )

--- a/spec/services/charges/override_service_spec.rb
+++ b/spec/services/charges/override_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Charges::OverrideService, type: :service do
             :group_property,
             group: group2,
             values: {amount: '20', amount_currency: 'EUR'},
-          ),
+          )
         ],
       )
     end
@@ -47,7 +47,7 @@ RSpec.describe Charges::OverrideService, type: :service do
           {
             group_id: group.id,
             values: {amount: '100'}
-          },
+          }
         ]
       }
     end
@@ -118,7 +118,7 @@ RSpec.describe Charges::OverrideService, type: :service do
               :charge_filter,
               charge:,
               properties: {amount: '20'},
-            ),
+            )
           ]
         end
 
@@ -135,7 +135,7 @@ RSpec.describe Charges::OverrideService, type: :service do
               charge_filter: filters.second,
               billable_metric_filter:,
               values: [billable_metric_filter.values.second],
-            ),
+            )
           ]
         end
 
@@ -151,7 +151,7 @@ RSpec.describe Charges::OverrideService, type: :service do
                 properties: {amount: '10'},
                 invoice_display_name: 'invoice display name',
                 values: {billable_metric_filter.key => [billable_metric_filter.values.first]}
-              },
+              }
             ]
           }
         end

--- a/spec/services/charges/validators/graduated_percentage_service_spec.rb
+++ b/spec/services/charges/validators/graduated_percentage_service_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
         let(:ranges) do
           [
             {from_value: 0, to_value: 100},
-            {from_value: 120, to_value: 1000},
+            {from_value: 120, to_value: 1000}
           ]
         end
 
@@ -96,7 +96,7 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
         let(:ranges) do
           [
             {from_value: 0, to_value: 100},
-            {from_value: 90, to_value: 1000},
+            {from_value: 90, to_value: 1000}
           ]
         end
 
@@ -218,7 +218,7 @@ RSpec.describe Charges::Validators::GraduatedPercentageService, type: :service d
             to_value: nil,
             rate: '1',
             flat_amount: '30'
-          },
+          }
         ]
       end
 

--- a/spec/services/charges/validators/graduated_service_spec.rb
+++ b/spec/services/charges/validators/graduated_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
       let(:ranges) do
         [
           {from_value: 0, to_value: 100},
-          {from_value: 120, to_value: 100},
+          {from_value: 120, to_value: 100}
         ]
       end
 
@@ -73,7 +73,7 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
       let(:ranges) do
         [
           {from_value: 0, to_value: 100},
-          {from_value: 90, to_value: 100},
+          {from_value: 90, to_value: 100}
         ]
       end
 
@@ -197,7 +197,7 @@ RSpec.describe Charges::Validators::GraduatedService, type: :service do
             to_value: nil,
             per_unit_amount: '15',
             flat_amount: '30'
-          },
+          }
         ]
       end
 

--- a/spec/services/charges/validators/percentage_service_spec.rb
+++ b/spec/services/charges/validators/percentage_service_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
           expect(percentage_service.result.error.messages.keys).to eq(
             [
               :fixed_amount,
-              :free_units_per_total_aggregation,
+              :free_units_per_total_aggregation
             ],
           )
           expect(percentage_service.result.error.messages[:fixed_amount])
@@ -197,7 +197,7 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
           expect(percentage_service.result.error.messages.keys).to eq(
             [
               :fixed_amount,
-              :free_units_per_total_aggregation,
+              :free_units_per_total_aggregation
             ],
           )
           expect(percentage_service.result.error.messages[:fixed_amount])
@@ -244,7 +244,7 @@ RSpec.describe Charges::Validators::PercentageService, type: :service do
             [
               :fixed_amount,
               :free_units_per_events,
-              :free_units_per_total_aggregation,
+              :free_units_per_total_aggregation
             ],
           )
           expect(percentage_service.result.error.messages[:fixed_amount])

--- a/spec/services/charges/validators/volume_service_spec.rb
+++ b/spec/services/charges/validators/volume_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
       let(:ranges) do
         [
           {from_value: 0, to_value: 100},
-          {from_value: 120, to_value: 100},
+          {from_value: 120, to_value: 100}
         ]
       end
 
@@ -73,7 +73,7 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
       let(:ranges) do
         [
           {from_value: 0, to_value: 100},
-          {from_value: 90, to_value: 100},
+          {from_value: 90, to_value: 100}
         ]
       end
 
@@ -197,7 +197,7 @@ RSpec.describe Charges::Validators::VolumeService, type: :service do
             to_value: nil,
             per_unit_amount: '15',
             flat_amount: '30'
-          },
+          }
         ]
       end
 

--- a/spec/services/credit_notes/apply_taxes_service_spec.rb
+++ b/spec/services/credit_notes/apply_taxes_service_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
         amount_cents: 50,
         precise_amount_cents: 50,
         amount_currency: invoice.currency,
-      ),
+      )
     ]
   end
 

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       {
         fee_id: fee2.id,
         amount_cents: 5
-      },
+      }
     ]
   end
 
@@ -152,7 +152,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
           {
             fee_id: fee2.id,
             amount_cents: 15
-          },
+          }
         ]
       end
 
@@ -388,7 +388,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
           {
             fee_id: fee2.id,
             amount_cents: 5
-          },
+          }
         ]
       end
 

--- a/spec/services/credit_notes/estimate_service_spec.rb
+++ b/spec/services/credit_notes/estimate_service_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CreditNotes::EstimateService, type: :service do
       {
         fee_id: fee2.id,
         amount_cents: 5
-      },
+      }
     ]
   end
 
@@ -101,7 +101,7 @@ RSpec.describe CreditNotes::EstimateService, type: :service do
         {
           fee_id: fee2.id,
           amount_cents: 15
-        },
+        }
       ]
     end
 

--- a/spec/services/credit_notes/refresh_draft_service_spec.rb
+++ b/spec/services/credit_notes/refresh_draft_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe CreditNotes::RefreshDraftService, type: :service do
       {
         credit_note_item_id: credit_note_item.id,
         fee_amount_cents: credit_note_item.fee&.amount_cents
-      },
+      }
     ]
   end
 

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Customers::CreateService, type: :service do
               key: 'manager address',
               value: 'Test',
               display_in_invoice: false
-            },
+            }
           ]
         }
       end
@@ -269,7 +269,7 @@ RSpec.describe Customers::CreateService, type: :service do
                 key: 'Added key',
                 value: 'Added value',
                 display_in_invoice: true
-              },
+              }
             ]
           }
         end
@@ -335,7 +335,7 @@ RSpec.describe Customers::CreateService, type: :service do
                   key: 'Added key5',
                   value: 'Added value5',
                   display_in_invoice: true
-                },
+                }
               ]
             }
           end
@@ -916,7 +916,7 @@ RSpec.describe Customers::CreateService, type: :service do
               key: 'manager address',
               value: 'Test',
               display_in_invoice: false
-            },
+            }
           ]
         }
       end

--- a/spec/services/customers/metadata/update_service_spec.rb
+++ b/spec/services/customers/metadata/update_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Customers::Metadata::UpdateService do
         key: 'Added key',
         value: 'Added value',
         display_in_invoice: true
-      },
+      }
     ]
   end
 

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Customers::UpdateService, type: :service do
               key: 'Added key',
               value: 'Added value',
               display_in_invoice: true
-            },
+            }
           ]
         }
       end

--- a/spec/services/events/create_batch_service_spec.rb
+++ b/spec/services/events/create_batch_service_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Events::CreateBatchService, type: :service do
                 transaction_id: '123456',
                 properties: {foo: 'bar'},
                 timestamp:
-              },
+              }
             ]
           }
         end
@@ -135,7 +135,7 @@ RSpec.describe Events::CreateBatchService, type: :service do
               transaction_id: SecureRandom.uuid,
               properties: {foo: 'bar'},
               timestamp:
-            },
+            }
           ]
         }
       end
@@ -161,7 +161,7 @@ RSpec.describe Events::CreateBatchService, type: :service do
               transaction_id: SecureRandom.uuid,
               properties: {foo: 'bar'},
               timestamp:
-            },
+            }
           ]
         }
       end
@@ -187,7 +187,7 @@ RSpec.describe Events::CreateBatchService, type: :service do
               transaction_id: SecureRandom.uuid,
               properties: {foo: 'bar'},
               timestamp:
-            },
+            }
           ]
         }
       end

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
           code:,
           timestamp: boundaries[:from_datetime] + 2.days,
           properties: {billable_metric.field_name => 2},
-        ),
+        )
       ]
     end
 
@@ -423,7 +423,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
           code:,
           timestamp: boundaries[:from_datetime] + 2.days,
           properties: {billable_metric.field_name => 2},
-        ),
+        )
       ]
     end
 
@@ -877,7 +877,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
         {timestamp: Time.zone.parse('2023-03-01 02:00:00'), value: -4},
         {timestamp: Time.zone.parse('2023-03-01 04:00:00'), value: -2},
         {timestamp: Time.zone.parse('2023-03-01 05:00:00'), value: 10},
-        {timestamp: Time.zone.parse('2023-03-01 05:30:00'), value: -10},
+        {timestamp: Time.zone.parse('2023-03-01 05:30:00'), value: -10}
       ]
     end
 
@@ -910,7 +910,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     context 'with a single event' do
       let(:events_values) do
         [
-          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 1000},
+          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 1000}
         ]
       end
 
@@ -931,7 +931,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
       let(:events_values) do
         [
           {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 3},
-          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 3},
+          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 3}
         ]
       end
 
@@ -961,7 +961,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
       let(:events_values) do
         [
-          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 1000, region: 'europe'},
+          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 1000, region: 'europe'}
         ]
       end
 
@@ -1000,7 +1000,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
         {timestamp: Time.zone.parse('2023-03-01 02:00:00'), value: -4},
         {timestamp: Time.zone.parse('2023-03-01 04:00:00'), value: -2},
         {timestamp: Time.zone.parse('2023-03-01 05:00:00'), value: 10},
-        {timestamp: Time.zone.parse('2023-03-01 05:30:00'), value: -10},
+        {timestamp: Time.zone.parse('2023-03-01 05:30:00'), value: -10}
       ]
     end
 
@@ -1059,7 +1059,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
         [
           {groups: {'agent_name' => 'frodo', 'other' => nil}, value: 1000},
           {groups: {'agent_name' => 'aragorn', 'other' => nil}, value: 1000},
-          {groups: {'agent_name' => nil, 'other' => nil}, value: 1000},
+          {groups: {'agent_name' => nil, 'other' => nil}, value: 1000}
         ]
       end
 

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
           code:,
           timestamp: boundaries[:from_datetime] + 2.days,
           properties: {billable_metric.field_name => 2},
-        ),
+        )
       ]
     end
 
@@ -427,7 +427,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
           code:,
           timestamp: boundaries[:from_datetime] + 2.days,
           properties: {billable_metric.field_name => 2},
-        ),
+        )
       ]
     end
 
@@ -876,7 +876,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
         {timestamp: Time.zone.parse('2023-03-01 02:00:00'), value: -4},
         {timestamp: Time.zone.parse('2023-03-01 04:00:00'), value: -2},
         {timestamp: Time.zone.parse('2023-03-01 05:00:00'), value: 10},
-        {timestamp: Time.zone.parse('2023-03-01 05:30:00'), value: -10},
+        {timestamp: Time.zone.parse('2023-03-01 05:30:00'), value: -10}
       ]
     end
 
@@ -915,7 +915,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     context 'with a single event' do
       let(:events_values) do
         [
-          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 1000},
+          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 1000}
         ]
       end
 
@@ -936,7 +936,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
       let(:events_values) do
         [
           {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 3},
-          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 3},
+          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 3}
         ]
       end
 
@@ -966,7 +966,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
 
       let(:events_values) do
         [
-          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 1000, region: 'europe'},
+          {timestamp: Time.zone.parse('2023-03-01 00:00:00.000'), value: 1000, region: 'europe'}
         ]
       end
 
@@ -1005,7 +1005,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
         {timestamp: Time.zone.parse('2023-03-01 02:00:00'), value: -4},
         {timestamp: Time.zone.parse('2023-03-01 04:00:00'), value: -2},
         {timestamp: Time.zone.parse('2023-03-01 05:00:00'), value: 10},
-        {timestamp: Time.zone.parse('2023-03-01 05:30:00'), value: -10},
+        {timestamp: Time.zone.parse('2023-03-01 05:30:00'), value: -10}
       ]
     end
 
@@ -1070,7 +1070,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
         [
           {groups: {'agent_name' => 'frodo', 'other' => nil}, value: 1000},
           {groups: {'agent_name' => 'aragorn', 'other' => nil}, value: 1000},
-          {groups: {'agent_name' => nil, 'other' => nil}, value: 1000},
+          {groups: {'agent_name' => nil, 'other' => nil}, value: 1000}
         ]
       end
 

--- a/spec/services/fees/charge_service_spec.rb
+++ b/spec/services/fees/charge_service_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe Fees::ChargeService do
                   to_value: nil,
                   per_unit_amount: '0.01',
                   flat_amount: '0.01'
-                },
+                }
               ]
             },
           )
@@ -1277,7 +1277,7 @@ RSpec.describe Fees::ChargeService do
                 to_value: nil,
                 per_unit_amount: '0.01',
                 flat_amount: '0.01'
-              },
+              }
             ]
           },
         )
@@ -1302,7 +1302,7 @@ RSpec.describe Fees::ChargeService do
                 to_value: nil,
                 per_unit_amount: '0.03',
                 flat_amount: '0.01'
-              },
+              }
             ]
           },
         )
@@ -1323,7 +1323,7 @@ RSpec.describe Fees::ChargeService do
                 to_value: nil,
                 per_unit_amount: '0',
                 flat_amount: '0'
-              },
+              }
             ]
           },
         )
@@ -1407,7 +1407,7 @@ RSpec.describe Fees::ChargeService do
           charge:,
           properties: {
             volume_ranges: [
-              {from_value: 0, to_value: nil, per_unit_amount: '2', flat_amount: '10'},
+              {from_value: 0, to_value: nil, per_unit_amount: '2', flat_amount: '10'}
             ]
           },
         )
@@ -1427,7 +1427,7 @@ RSpec.describe Fees::ChargeService do
           charge:,
           properties: {
             volume_ranges: [
-              {from_value: 0, to_value: nil, per_unit_amount: '1', flat_amount: '10'},
+              {from_value: 0, to_value: nil, per_unit_amount: '1', flat_amount: '10'}
             ]
           },
         )
@@ -1443,7 +1443,7 @@ RSpec.describe Fees::ChargeService do
           billable_metric:,
           properties: {
             volume_ranges: [
-              {from_value: 0, to_value: nil, per_unit_amount: '0', flat_amount: '0'},
+              {from_value: 0, to_value: nil, per_unit_amount: '0', flat_amount: '0'}
             ]
           },
         )
@@ -1532,7 +1532,7 @@ RSpec.describe Fees::ChargeService do
                 to_value: nil,
                 flat_amount: '0.01',
                 rate: '2'
-              },
+              }
             ]
           },
         )
@@ -1557,7 +1557,7 @@ RSpec.describe Fees::ChargeService do
                 to_value: nil,
                 flat_amount: '0.01',
                 rate: '3'
-              },
+              }
             ]
           },
         )
@@ -1578,7 +1578,7 @@ RSpec.describe Fees::ChargeService do
                 to_value: nil,
                 flat_amount: '1',
                 rate: '0'
-              },
+              }
             ]
           },
         )
@@ -1824,7 +1824,7 @@ RSpec.describe Fees::ChargeService do
                 to_value: nil,
                 per_unit_amount: '0.01',
                 flat_amount: '0.01'
-              },
+              }
             ]
           },
         )

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
             values: %w[visa mastercard],
             billable_metric_filter: scheme,
             charge_filter: filter,
-          ),
+          )
         ]
       end
 

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Fees::OneOffService do
       },
       {
         add_on_code: add_on_second.code
-      },
+      }
     ]
   end
 
@@ -86,7 +86,7 @@ RSpec.describe Fees::OneOffService do
           },
           {
             add_on_code: 'invalid'
-          },
+          }
         ]
       end
 
@@ -106,7 +106,7 @@ RSpec.describe Fees::OneOffService do
             units: 2,
             description: 'desc-123',
             tax_codes: [tax2.code]
-          },
+          }
         ]
       end
 

--- a/spec/services/groups/create_or_update_batch_service_spec.rb
+++ b/spec/services/groups/create_or_update_batch_service_spec.rb
@@ -62,9 +62,9 @@ RSpec.describe Groups::CreateOrUpdateBatchService, type: :service do
                 name: 'AWS',
                 key: 'country',
                 values: %w[France]
-              },
+              }
             ]
-          },
+          }
         ]
       }
     end
@@ -121,7 +121,7 @@ RSpec.describe Groups::CreateOrUpdateBatchService, type: :service do
             name: 'Google',
             key: 'region',
             values: %w[usa usa]
-          },
+          }
         ]
       }
     end

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -176,9 +176,9 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
               'account' => '11',
               'quantity' => 1,
               'rate' => -60.0
-            },
+            }
           ]
-        },
+        }
       ],
       'options' => {
         'ignoreMandatoryFields' => false

--- a/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
@@ -176,9 +176,9 @@ RSpec.describe Integrations::Aggregator::SalesOrders::CreateService do
               'account' => '11',
               'quantity' => 1,
               'rate' => -60.0
-            },
+            }
           ]
-        },
+        }
       ],
       'options' => {
         'ignoreMandatoryFields' => false

--- a/spec/services/invoices/create_service_spec.rb
+++ b/spec/services/invoices/create_service_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Invoices::CreateService, type: :service do
       },
       {
         add_on_code: add_on_second.code
-      },
+      }
     ]
   end
 
@@ -108,7 +108,7 @@ RSpec.describe Invoices::CreateService, type: :service do
             unit_amount_cents: 0,
             units: 2,
             description: 'desc-123'
-          },
+          }
         ]
       end
 
@@ -248,7 +248,7 @@ RSpec.describe Invoices::CreateService, type: :service do
           },
           {
             add_on_code: 'invalid'
-          },
+          }
         ]
       end
 

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
         'charge-usage',
         charge.id,
         subscription.id,
-        charge.updated_at.iso8601,
+        charge.updated_at.iso8601
       ].join('/')
 
       expect do

--- a/spec/services/invoices/metadata/update_service_spec.rb
+++ b/spec/services/invoices/metadata/update_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Invoices::Metadata::UpdateService do
       {
         key: 'Added key',
         value: 'Added value'
-      },
+      }
     ]
   end
 

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
                 livemode: false,
                 metadata: {},
                 type: 'card'
-              },
+              }
             ],
           ))
       end

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Invoices::UpdateService do
             {
               key: 'Added key',
               value: 'Added value'
-            },
+            }
           ]
         }
       end
@@ -155,7 +155,7 @@ RSpec.describe Invoices::UpdateService do
               {
                 key: 'Added key5',
                 value: 'Added value5'
-              },
+              }
             ]
           }
         end

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -57,14 +57,14 @@ RSpec.describe Plans::CreateService, type: :service do
             {
               group_id: group.id,
               values: {amount: '100'}
-            },
+            }
           ],
           filters: [
             {
               values: {billable_metric_filter.key => ['card']},
               invoice_display_name: 'Card filter',
               properties: {amount: '90'}
-            },
+            }
           ]
         },
         {
@@ -85,10 +85,10 @@ RSpec.describe Plans::CreateService, type: :service do
                 to_value: nil,
                 per_unit_amount: '3',
                 flat_amount: '3'
-              },
+              }
             ]
           }
-        },
+        }
       ]
     end
 
@@ -188,7 +188,7 @@ RSpec.describe Plans::CreateService, type: :service do
               {
                 group_id: group.id,
                 values: {amount: '100'}
-              },
+              }
             ]
           },
           {
@@ -209,10 +209,10 @@ RSpec.describe Plans::CreateService, type: :service do
                   to_value: nil,
                   rate: '2',
                   flat_amount: '3'
-                },
+                }
               ]
             }
-          },
+          }
         ]
       end
 
@@ -291,10 +291,10 @@ RSpec.describe Plans::CreateService, type: :service do
                     to_value: nil,
                     rate: '2',
                     flat_amount: '3'
-                  },
+                  }
                 ]
               }
-            },
+            }
           ]
         end
 

--- a/spec/services/plans/override_service_spec.rb
+++ b/spec/services/plans/override_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Plans::OverrideService, type: :service do
             :group_property,
             group:,
             values: {amount: '10', amount_currency: 'EUR'},
-          ),
+          )
         ],
       )
     end
@@ -60,7 +60,7 @@ RSpec.describe Plans::OverrideService, type: :service do
         {
           id: charge.id,
           min_amount_cents: 1000
-        },
+        }
       ]
     end
 
@@ -141,7 +141,7 @@ RSpec.describe Plans::OverrideService, type: :service do
               to_value: nil,
               per_unit_amount: '0.01',
               flat_amount: '0.01'
-            },
+            }
           ]
         },
       )

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Plans::UpdateService, type: :service do
           {
             group_id: group.id,
             values: {amount: '100'}
-          },
+          }
         ],
         tax_codes: [tax1.code]
       },
@@ -74,10 +74,10 @@ RSpec.describe Plans::UpdateService, type: :service do
               to_value: nil,
               per_unit_amount: '3',
               flat_amount: '3'
-            },
+            }
           ]
         }
-      },
+      }
     ]
   end
 
@@ -244,7 +244,7 @@ RSpec.describe Plans::UpdateService, type: :service do
               properties: {
                 amount: '100'
               }
-            },
+            }
           ]
         end
 
@@ -277,10 +277,10 @@ RSpec.describe Plans::UpdateService, type: :service do
                     to_value: nil,
                     rate: '2',
                     flat_amount: '3'
-                  },
+                  }
                 ]
               }
-            },
+            }
           ]
         end
 
@@ -538,14 +538,14 @@ RSpec.describe Plans::UpdateService, type: :service do
                 {
                   group_id: group.id,
                   values: {amount: '100'}
-                },
+                }
               ],
               filters: [
                 {
                   invoice_display_name: 'Card filter',
                   properties: {amount: '90'},
                   values: {billable_metric_filter.key => ['card']}
-                },
+                }
               ]
             },
             {
@@ -556,7 +556,7 @@ RSpec.describe Plans::UpdateService, type: :service do
                 amount: '300'
               },
               tax_codes: [tax1.code]
-            },
+            }
           ]
         }
       end
@@ -637,7 +637,7 @@ RSpec.describe Plans::UpdateService, type: :service do
               billable_metric_id: sum_billable_metric.id,
               charge_model: 'standard',
               tax_codes: [tax2.code]
-            },
+            }
           ]
         }
       end
@@ -744,7 +744,7 @@ RSpec.describe Plans::UpdateService, type: :service do
               properties: {
                 amount: '300'
               }
-            },
+            }
           ]
         }
       end

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Wallets::CreateService, type: :service do
             method: "target",
             target_ongoing_balance: "100.0",
             trigger: "interval"
-          },
+          }
         ]
       end
       let(:create_args) do
@@ -131,7 +131,7 @@ RSpec.describe Wallets::CreateService, type: :service do
             {
               trigger: 'threshold',
               threshold_credits: '1.0'
-            },
+            }
           ]
         end
 
@@ -148,7 +148,7 @@ RSpec.describe Wallets::CreateService, type: :service do
             {
               trigger: 'invalid',
               interval: 'monthly'
-            },
+            }
           ]
         end
 
@@ -164,7 +164,7 @@ RSpec.describe Wallets::CreateService, type: :service do
             {
               trigger: 'threshold',
               threshold_credits: 'abc'
-            },
+            }
           ]
         end
 

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
         interval: 'weekly',
         paid_credits: '105',
         granted_credits: '105'
-      },
+      }
     ]
   end
 
@@ -51,7 +51,7 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
             paid_credits: "105",
             target_ongoing_balance: "300",
             trigger: "interval"
-          },
+          }
         ]
       end
 

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
             interval: 'weekly',
             paid_credits: '105',
             granted_credits: '105'
-          },
+          }
         ]
       end
       let(:update_args) do
@@ -141,7 +141,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
               interval: 'weekly',
               paid_credits: '105',
               granted_credits: '105'
-            },
+            }
           ]
         end
 
@@ -173,7 +173,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
               threshold_credits: '205',
               paid_credits: '105',
               granted_credits: '105'
-            },
+            }
           ]
         end
 
@@ -224,7 +224,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
               threshold_credits: '1.0',
               paid_credits: '105',
               granted_credits: '105'
-            },
+            }
           ]
         end
 
@@ -245,7 +245,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
               interval: 'monthly',
               paid_credits: '105',
               granted_credits: '105'
-            },
+            }
           ]
         end
 
@@ -265,7 +265,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
               threshold_credits: 'abc',
               paid_credits: '105',
               granted_credits: '105'
-            },
+            }
           ]
         end
 

--- a/spec/services/wallets/validate_recurring_transaction_rules_service_spec.rb
+++ b/spec/services/wallets/validate_recurring_transaction_rules_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Wallets::ValidateRecurringTransactionRulesService, type: :service
             threshold_credits: '1.0',
             paid_credits: '105',
             granted_credits: '105'
-          },
+          }
         ]
       end
 
@@ -57,7 +57,7 @@ RSpec.describe Wallets::ValidateRecurringTransactionRulesService, type: :service
             interval: 'invalid',
             paid_credits: '105',
             granted_credits: '105'
-          },
+          }
         ]
       end
 
@@ -75,7 +75,7 @@ RSpec.describe Wallets::ValidateRecurringTransactionRulesService, type: :service
             threshold_credits: 'invalid',
             paid_credits: '105',
             granted_credits: '105'
-          },
+          }
         ]
       end
 

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
           {
             trigger: 'threshold',
             threshold_credits: '-1.0'
-          },
+          }
         ]
       end
       let(:args) do
@@ -137,7 +137,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
             {
               trigger: 'interval',
               interval: 'invalid'
-            },
+            }
           ]
         end
 
@@ -153,7 +153,7 @@ RSpec.describe Wallets::ValidateService, type: :service do
             {
               trigger: 'threshold',
               threshold_credits: 'invalid'
-            },
+            }
           ]
         end
 


### PR DESCRIPTION
As we want to migrate to StandardRB, the goal of this PR is to enable TrailingCommaInArrayLiteral on Rubocop.

And fix all the current offenses in the codebase.

We'll add the commit sha into the .git-blame-ignore-revs on a future PR.