### PR TITLE
fix (integrations): add possibility to filter bm and add-ons in graphql resolvers

### DIFF
--- a/app/graphql/types/add_ons/object.rb
+++ b/app/graphql/types/add_ons/object.rb
@@ -25,7 +25,9 @@ module Types
 
       field :taxes, [Types::Taxes::Object]
 
-      field :integration_mappings, [Types::IntegrationMappings::Object], null: true
+      field :integration_mappings, [Types::IntegrationMappings::Object], null: true do
+        argument :integration_id, ID, required: false
+      end
 
       def customers_count
         object.applied_add_ons.select(:customer_id).distinct.count
@@ -33,6 +35,12 @@ module Types
 
       def applied_add_ons_count
         object.applied_add_ons.count
+      end
+
+      def integration_mappings(integration_id: nil)
+        mappings = object.integration_mappings
+        mappings = mappings.where(integration_id:) if integration_id
+        mappings
       end
     end
   end

--- a/app/graphql/types/billable_metrics/object.rb
+++ b/app/graphql/types/billable_metrics/object.rb
@@ -30,7 +30,9 @@ module Types
       field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
-      field :integration_mappings, [Types::IntegrationMappings::Object], null: true
+      field :integration_mappings, [Types::IntegrationMappings::Object], null: true do
+        argument :integration_id, ID, required: false
+      end
 
       def subscriptions_count
         object.plans.joins(:subscriptions).count
@@ -51,6 +53,12 @@ module Types
 
       def plans_count
         object.plans.distinct.count
+      end
+
+      def integration_mappings(integration_id: nil)
+        mappings = object.integration_mappings
+        mappings = mappings.where(integration_id:) if integration_id
+        mappings
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -62,7 +62,7 @@ type AddOn {
   deletedAt: ISO8601DateTime
   description: String
   id: ID!
-  integrationMappings: [Mapping!]
+  integrationMappings(integrationId: ID): [Mapping!]
   invoiceDisplayName: String
   name: String!
   organization: Organization
@@ -178,7 +178,7 @@ type BillableMetric {
   fieldName: String
   filters: [BillableMetricFilter!]
   id: ID!
-  integrationMappings: [Mapping!]
+  integrationMappings(integrationId: ID): [Mapping!]
   name: String!
   organization: Organization
   plansCount: Int!

--- a/schema.json
+++ b/schema.json
@@ -464,7 +464,18 @@
               "isDeprecated": false,
               "deprecationReason": null,
               "args": [
-
+                {
+                  "name": "integrationId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
               ]
             },
             {
@@ -1677,7 +1688,18 @@
               "isDeprecated": false,
               "deprecationReason": null,
               "args": [
-
+                {
+                  "name": "integrationId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
               ]
             },
             {

--- a/spec/graphql/resolvers/add_ons_resolver_spec.rb
+++ b/spec/graphql/resolvers/add_ons_resolver_spec.rb
@@ -43,4 +43,50 @@ RSpec.describe Resolvers::AddOnsResolver, type: :graphql do
       expect(add_ons_response['metadata']['totalCount']).to eq(1)
     end
   end
+
+  context 'with integration mappings' do
+    let(:integration) { create(:netsuite_integration, organization:) }
+    let(:netsuite_mapping) { create(:netsuite_mapping, integration:, mappable_type: 'AddOn', mappable_id: add_on.id) }
+    let(:netsuite_mapping2) { create(:netsuite_mapping, external_name: 'Bla') }
+    let(:query) do
+      <<~GQL
+        query($integrationId: ID) {
+          addOns(limit: 5) {
+            collection { id name integrationMappings(integrationId: $integrationId) { externalId externalName } }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    before do
+      integration
+      netsuite_mapping
+      netsuite_mapping2
+    end
+
+    it 'returns a list of add-ons' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+        variables: {integrationId: integration.id},
+      )
+
+      add_ons_response = result['data']['addOns']
+
+      aggregate_failures do
+        expect(add_ons_response['collection'].first['id']).to eq(add_on.id)
+        expect(add_ons_response['collection'].first['name']).to eq(add_on.name)
+
+        expect(add_ons_response['collection'].first['integrationMappings'].count).to eq(1)
+        expect(add_ons_response['collection'].first['integrationMappings'].first['externalName'])
+          .to eq('Credits and Discounts')
+
+        expect(add_ons_response['metadata']['currentPage']).to eq(1)
+        expect(add_ons_response['metadata']['totalCount']).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Currently Lago does not support accounting integrations

## Description

This PR adds possibility to filter (by integration id) all mappings that belong to certain add-on or billable metric.