### PR TITLE
feat(wallet): Extract validation of RecurringTransactionRule

### DIFF
--- a/app/services/wallets/recurring_transaction_rules/validate_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/validate_service.rb
@@ -9,10 +9,10 @@ module Wallets
       end
 
       def call
-        return true if valid_interval?
-        return true if valid_threshold?
+        return false unless valid_trigger?
+        return false unless valid_method?
 
-        false
+        true
       end
 
       private
@@ -23,12 +23,28 @@ module Wallets
         @trigger ||= params[:trigger]&.to_s
       end
 
-      def valid_interval?
+      def method
+        @method ||= params[:method]&.to_s
+      end
+
+      def valid_trigger?
+        valid_interval_trigger? || valid_threshold_trigger?
+      end
+
+      def valid_interval_trigger?
         trigger == "interval" && RecurringTransactionRule.intervals.key?(params[:interval])
       end
 
-      def valid_threshold?
+      def valid_threshold_trigger?
         trigger == "threshold" && ::Validators::DecimalAmountService.new(params[:threshold_credits]).valid_decimal?
+      end
+
+      def valid_method?
+        (method == "target") ? valid_target_method? : true
+      end
+
+      def valid_target_method?
+        ::Validators::DecimalAmountService.new(params[:target_ongoing_balance]).valid_decimal?
       end
     end
   end

--- a/app/services/wallets/recurring_transaction_rules/validate_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/validate_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Wallets
+  module RecurringTransactionRules
+    class ValidateService < BaseService
+      def initialize(params:)
+        @params = params
+        super
+      end
+
+      def call
+        return true if valid_interval?
+        return true if valid_threshold?
+
+        false
+      end
+
+      private
+
+      attr_reader :params
+
+      def trigger
+        @trigger ||= params[:trigger]&.to_s
+      end
+
+      def valid_interval?
+        trigger == "interval" && RecurringTransactionRule.intervals.key?(params[:interval])
+      end
+
+      def valid_threshold?
+        trigger == "threshold" && ::Validators::DecimalAmountService.new(params[:threshold_credits]).valid_decimal?
+      end
+    end
+  end
+end

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -70,21 +70,9 @@ module Wallets
         return add_error(field: :recurring_transaction_rules, error_code: 'invalid_number_of_recurring_rules')
       end
 
-      recurring_rule = args[:recurring_transaction_rules].first
-
-      if recurring_rule[:trigger]&.to_s == 'interval' &&
-          RecurringTransactionRule.intervals.key?(recurring_rule[:interval])
-
-        return true
+      unless Wallets::RecurringTransactionRules::ValidateService.call(params: args[:recurring_transaction_rules].first)
+        add_error(field: :recurring_transaction_rules, error_code: "invalid_recurring_rule")
       end
-
-      if recurring_rule[:trigger]&.to_s == 'threshold' &&
-          ::Validators::DecimalAmountService.new(recurring_rule[:threshold_credits]).valid_decimal?
-
-        return true
-      end
-
-      add_error(field: :recurring_transaction_rules, error_code: 'invalid_recurring_rule')
     end
   end
 end

--- a/spec/graphql/mutations/wallets/create_spec.rb
+++ b/spec/graphql/mutations/wallets/create_spec.rb
@@ -58,7 +58,8 @@ RSpec.describe Mutations::Wallets::Create, type: :graphql do
             {
               method: 'target',
               trigger: 'interval',
-              interval: 'monthly'
+              interval: 'monthly',
+              targetOngoingBalance: '0.0'
             }
           ]
         }

--- a/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
@@ -44,5 +44,20 @@ RSpec.describe Wallets::RecurringTransactionRules::ValidateService do
         expect(validate_service.call).to be_falsey
       end
     end
+
+    context "when invalid method" do
+      let(:params) do
+        {
+          method: "target",
+          trigger: "interval",
+          interval: "weekly",
+          target_ongoing_balance: "invalid"
+        }
+      end
+
+      it "returns false" do
+        expect(validate_service.call).to be_falsey
+      end
+    end
   end
 end

--- a/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Wallets::RecurringTransactionRules::ValidateService do
+  subject(:validate_service) { described_class.new(params:) }
+
+  let(:params) do
+    {
+      trigger: "interval",
+      interval: "weekly",
+      paid_credits: "105",
+      granted_credits: "105"
+    }
+  end
+
+  describe "#call" do
+    it "returns true" do
+      expect(validate_service.call).to be_truthy
+    end
+
+    context "when invalid interval" do
+      let(:params) do
+        {
+          trigger: "interval",
+          interval: "invalid"
+        }
+      end
+
+      it "returns false" do
+        expect(validate_service.call).to be_falsey
+      end
+    end
+
+    context "when invalid threshold" do
+      let(:params) do
+        {
+          trigger: "threshold",
+          threshold_credits: "invalid"
+        }
+      end
+
+      it "returns false" do
+        expect(validate_service.call).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -130,38 +130,6 @@ RSpec.describe Wallets::ValidateService, type: :service do
         expect(validate_service).not_to be_valid
         expect(result.error.messages[:recurring_transaction_rules]).to eq(['invalid_number_of_recurring_rules'])
       end
-
-      context 'when invalid interval' do
-        let(:rules) do
-          [
-            {
-              trigger: 'interval',
-              interval: 'invalid'
-            }
-          ]
-        end
-
-        it 'returns false and result has errors' do
-          expect(validate_service).not_to be_valid
-          expect(result.error.messages[:recurring_transaction_rules]).to eq(['invalid_recurring_rule'])
-        end
-      end
-
-      context 'when invalid threshold credits' do
-        let(:rules) do
-          [
-            {
-              trigger: 'threshold',
-              threshold_credits: 'invalid'
-            }
-          ]
-        end
-
-        it 'returns false and result has errors' do
-          expect(validate_service).not_to be_valid
-          expect(result.error.messages[:recurring_transaction_rules]).to eq(['invalid_recurring_rule'])
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to extract how we're validating recurring transaction rule parameters into a separate class.
Indeed, we'll add other validations in the next PRs, and doing this prerequisite will help.