### PR TITLE
feat(clickhouse): Rewrite count query without CTE

### DIFF
--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -67,18 +67,9 @@ module Events
       end
 
       def count
-        cte_sql = events.group(DEDUPLICATION_GROUP)
-          .select('COUNT(events_raw.transaction_id) as transaction_count')
-          .group(:transaction_id)
+        sql = events.reorder('')
+          .select('uniqExact(events_raw.transaction_id) AS event_count')
           .to_sql
-
-        sql = <<-SQL
-          with events as (#{cte_sql})
-
-          select
-            COUNT(events.transaction_count) AS events_count
-          from events
-        SQL
 
         ::Clickhouse::EventsRaw.connection.select_value(sql).to_i
       end

--- a/db/clickhouse_migrate/20231024084411_create_events_raw.rb
+++ b/db/clickhouse_migrate/20231024084411_create_events_raw.rb
@@ -2,7 +2,7 @@ class CreateEventsRaw < ActiveRecord::Migration[7.0]
   def change
     options = <<-SQL
       MergeTree
-      ORDER BY (organization_id, external_subscription_id, code, timestamp)
+      ORDER BY (organization_id, external_subscription_id, code, transaction_id, timestamp)
     SQL
 
     create_table :events_raw, id: false, options: do |t|

--- a/db/clickhouse_schema.rb
+++ b/db/clickhouse_schema.rb
@@ -13,8 +13,8 @@
 ClickhouseActiverecord::Schema.define(version: 2023_10_30_163703) do
 
   # TABLE: events_raw
-  # SQL: CREATE TABLE default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime64(3), `code` String, `properties` Map(String, String) ) ENGINE = MergeTree ORDER BY (organization_id, external_subscription_id, code, timestamp) SETTINGS index_granularity = 8192
-  create_table "events_raw", id: false, options: "MergeTree ORDER BY (organization_id, external_subscription_id, code, timestamp) SETTINGS index_granularity = 8192", force: :cascade do |t|
+  # SQL: CREATE TABLE default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime64(3), `code` String, `properties` Map(String, String) ) ENGINE = MergeTree ORDER BY (organization_id, external_subscription_id, code, transaction_id, timestamp) SETTINGS index_granularity = 8192
+  create_table "events_raw", id: false, options: "MergeTree ORDER BY (organization_id, external_subscription_id, code, transaction_id, timestamp) SETTINGS index_granularity = 8192", force: :cascade do |t|
     t.string "organization_id", null: false
     t.string "external_customer_id", null: false
     t.string "external_subscription_id", null: false


### PR DESCRIPTION
## Description

This PR is trying to improve query performance for the count aggregation on Clickhouse queries by removing the CTE in favor of a pure select query.

It also takes advantage of the `uniqExact` method to replace `COUNT(DISTINC`