### PR TITLE
feat(wallet): Remove duplication on wallet rules validation

### DIFF
--- a/app/services/wallets/recurring_transaction_rules/validate_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/validate_service.rb
@@ -11,6 +11,7 @@ module Wallets
       def call
         return false unless valid_trigger?
         return false unless valid_method?
+        return false unless valid_credits?
 
         true
       end
@@ -40,11 +41,18 @@ module Wallets
       end
 
       def valid_method?
-        (method == "target") ? valid_target_method? : true
+        (method == "target") ? valid_decimal?(params[:target_ongoing_balance]) : true
       end
 
-      def valid_target_method?
-        ::Validators::DecimalAmountService.new(params[:target_ongoing_balance]).valid_decimal?
+      def valid_credits?
+        return true unless params[:paid_credits] || params[:granted_credits]
+
+        params[:paid_credits] && valid_decimal?(params[:paid_credits]) ||
+          params[:granted_credits] && valid_decimal?(params[:granted_credits])
+      end
+
+      def valid_decimal?(value)
+        ::Validators::DecimalAmountService.new(value).valid_decimal?
       end
     end
   end

--- a/app/services/wallets/recurring_transaction_rules/validate_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/validate_service.rb
@@ -41,7 +41,9 @@ module Wallets
       end
 
       def valid_method?
-        (method == "target") ? valid_decimal?(params[:target_ongoing_balance]) : true
+        return valid_decimal?(params[:target_ongoing_balance]) if method == "target"
+
+        true
       end
 
       def valid_credits?

--- a/app/services/wallets/validate_recurring_transaction_rules_service.rb
+++ b/app/services/wallets/validate_recurring_transaction_rules_service.rb
@@ -27,24 +27,9 @@ module Wallets
     def valid_transaction_rules?
       return true if args[:recurring_transaction_rules].count.zero?
 
-      rule = args[:recurring_transaction_rules].first
-      trigger = rule[:trigger]&.to_s
-
-      if !::Validators::DecimalAmountService.new(rule[:paid_credits]).valid_amount? ||
-          !::Validators::DecimalAmountService.new(rule[:granted_credits]).valid_amount?
-
-        add_error(field: :recurring_transaction_rules, error_code: 'invalid_recurring_rule')
-
-        return
+      unless Wallets::RecurringTransactionRules::ValidateService.call(params: args[:recurring_transaction_rules].first)
+        add_error(field: :recurring_transaction_rules, error_code: "invalid_recurring_rule")
       end
-
-      return true if trigger == 'interval' && RecurringTransactionRule.intervals.key?(rule[:interval])
-
-      if trigger == 'threshold' && ::Validators::DecimalAmountService.new(rule[:threshold_credits]).valid_decimal?
-        return true
-      end
-
-      add_error(field: :recurring_transaction_rules, error_code: 'invalid_recurring_rule')
     end
   end
 end

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -169,7 +169,8 @@ RSpec.describe Api::V1::WalletsController, type: :request do
               trigger: 'interval',
               interval: 'weekly',
               paid_credits: '105',
-              granted_credits: '105'
+              granted_credits: '105',
+              target_ongoing_balance: '300'
             }
           ]
         }

--- a/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Wallets::RecurringTransactionRules::ValidateService do
   let(:params) do
     {
       trigger: "interval",
-      interval: "weekly",
-      paid_credits: "105",
-      granted_credits: "105"
+      interval: "weekly"
     }
   end
 
@@ -52,6 +50,20 @@ RSpec.describe Wallets::RecurringTransactionRules::ValidateService do
           trigger: "interval",
           interval: "weekly",
           target_ongoing_balance: "invalid"
+        }
+      end
+
+      it "returns false" do
+        expect(validate_service.call).to be_falsey
+      end
+    end
+
+    context "when invalid credits" do
+      let(:params) do
+        {
+          trigger: "interval",
+          interval: "weekly",
+          paid_credits: "invalid"
         }
       end
 

--- a/spec/services/wallets/validate_recurring_transaction_rules_service_spec.rb
+++ b/spec/services/wallets/validate_recurring_transaction_rules_service_spec.rb
@@ -48,41 +48,5 @@ RSpec.describe Wallets::ValidateRecurringTransactionRulesService, type: :service
         expect(result.error.messages[:recurring_transaction_rules]).to eq(['invalid_number_of_recurring_rules'])
       end
     end
-
-    context 'when invalid interval' do
-      let(:rules) do
-        [
-          {
-            trigger: 'interval',
-            interval: 'invalid',
-            paid_credits: '105',
-            granted_credits: '105'
-          }
-        ]
-      end
-
-      it 'returns false and result has errors' do
-        expect(validate_service).not_to be_valid
-        expect(result.error.messages[:recurring_transaction_rules]).to eq(['invalid_recurring_rule'])
-      end
-    end
-
-    context 'when invalid threshold credits' do
-      let(:rules) do
-        [
-          {
-            trigger: 'threshold',
-            threshold_credits: 'invalid',
-            paid_credits: '105',
-            granted_credits: '105'
-          }
-        ]
-      end
-
-      it 'returns false and result has errors' do
-        expect(validate_service).not_to be_valid
-        expect(result.error.messages[:recurring_transaction_rules]).to eq(['invalid_recurring_rule'])
-      end
-    end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to:

- Add validation on credits for recurring transaction rules
- Remove duplication on wallet rules validation