### PR TITLE
fix(current-usage): Manage connection pools with parallel threads

### DIFF
--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -67,7 +67,9 @@ module Invoices
         .order(Arel.sql('lower(unaccent(billable_metrics.name)) ASC'))
 
       invoice.fees = Parallel.flat_map(query.all, in_threads: ENV['LAGO_PARALLEL_THREADS_COUNT']&.to_i || 1) do |charge|
-        charge_usage(charge)
+        ActiveRecord::Base.connection_pool.with_connection do
+          charge_usage(charge)
+        end
       end
     end
 


### PR DESCRIPTION
## Context

This PR follows https://github.com/getlago/lago-api/pull/2076

## Description

It tries to fix an issue with the connection pool:
```
could not obtain a connection from the pool within 5.000 seconds (waited 5.000 seconds); all pooled connections were in use (ActiveRecord::ConnectionTimeoutError)
```
