### PR TITLE
misc: Add a rake task to expire the cache of a given subscription

### DIFF
--- a/app/services/subscriptions/charge_cache_service.rb
+++ b/app/services/subscriptions/charge_cache_service.rb
@@ -2,6 +2,10 @@
 
 module Subscriptions
   class ChargeCacheService < BaseService
+    def self.expire_for_subscription(subscription)
+      subscription.plan.charges.each { new(subscription: subscription, charge: _1).expire_cache }
+    end
+
     def initialize(subscription:, charge:)
       @subscription = subscription
       @charge = charge

--- a/lib/tasks/cache.rake
+++ b/lib/tasks/cache.rake
@@ -11,4 +11,12 @@ namespace :cache do
       end
     end
   end
+
+  desc 'Expire cache for a given subscription'
+  task expire_subscription_cache: :environment do
+    subscription = Subscription.find(ENV['subscription_id'])
+    puts "Expiring cache for subscription #{subscription.id}"
+
+    Subscriptions::ChargeCacheService.expire_for_subscription(subscription)
+  end
 end


### PR DESCRIPTION
## Context

This PR adds a new rake task to allow the removal of the cache of a given subscription:
```bash
rails cache:expire_subscription_cache subscription_id=XXX
```
