### PR TITLE
fix(subscription): Pending subscription cancel status

### DIFF
--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -13,9 +13,7 @@ module Subscriptions
     def call
       return result.not_found_failure!(resource: 'subscription') if subscription.blank?
 
-      if subscription.starting_in_the_future?
-        subscription.mark_as_terminated!
-      elsif subscription.pending?
+      if subscription.pending?
         subscription.mark_as_canceled!
       elsif !subscription.terminated?
         subscription.mark_as_terminated!

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Subscriptions::TerminateService do
     context 'when subscription is starting in the future' do
       let(:subscription) { create(:subscription, :pending) }
 
-      it 'terminates a subscription' do
+      it 'cancels a subscription' do
         result = terminate_service.call
 
         aggregate_failures do

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe Subscriptions::TerminateService do
     context 'when subscription is starting in the future' do
       let(:subscription) { create(:subscription, :pending) }
 
+      it 'terminates a subscription' do
+        result = terminate_service.call
+
+        aggregate_failures do
+          expect(result.subscription).to be_present
+          expect(result.subscription).to be_canceled
+          expect(result.subscription.canceled_at).to be_present
+          expect(result.subscription.terminated_at).to be_nil
+        end
+      end
+
       it 'does not enqueue a BillSubscriptionJob' do
         expect do
           terminate_service.call


### PR DESCRIPTION
## Context

This pull request addresses the issue where pending subscriptions are incorrectly marked as terminated when canceled. The goal is to ensure that pending subscriptions are marked as canceled, without incorrectly triggering termination-related webhooks.

## Description

When an active subscription is terminated, it should be marked as terminated, but when a pending subscription is deleted, it should be marked as canceled

