### PR TITLE
feat(wallet): Extract creation of wallet transaction rule

### DIFF
--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -23,13 +23,8 @@ module Wallets
         wallet.currency = wallet.customer.currency
         wallet.save!
 
-        if args[:recurring_transaction_rules] && License.premium?
-          create_recurring_transaction_rule(
-            recurring_transaction_rules: args[:recurring_transaction_rules],
-            paid_credits: args[:paid_credits],
-            granted_credits: args[:granted_credits],
-            wallet:,
-          )
+        if args[:recurring_transaction_rules]
+          Wallets::RecurringTransactionRules::CreateService.call(wallet:, wallet_params: args)
         end
       end
 
@@ -54,21 +49,6 @@ module Wallets
 
     def valid?(**args)
       Wallets::ValidateService.new(result, **args).valid?
-    end
-
-    def create_recurring_transaction_rule(recurring_transaction_rules:, paid_credits:, granted_credits:, wallet:)
-      recurring_rule = recurring_transaction_rules.first
-
-      RecurringTransactionRule.create!(
-        wallet:,
-        paid_credits:,
-        granted_credits:,
-        threshold_credits: recurring_rule[:threshold_credits] || '0.0',
-        interval: recurring_rule[:interval],
-        method: recurring_rule[:method] || 'fixed',
-        target_ongoing_balance: recurring_rule[:target_ongoing_balance],
-        trigger: recurring_rule[:trigger].to_s
-      )
     end
   end
 end

--- a/app/services/wallets/recurring_transaction_rules/create_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/create_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Wallets
+  module RecurringTransactionRules
+    class CreateService < BaseService
+      def initialize(wallet:, wallet_params:)
+        @wallet = wallet
+        @wallet_params = wallet_params
+
+        super
+      end
+
+      def call
+        return unless License.premium?
+
+        if method == 'fixed' && rule_params[:paid_credits].nil? && rule_params[:granted_credits].nil?
+          paid_credits = wallet_params[:paid_credits]
+          granted_credits = wallet_params[:granted_credits]
+        end
+
+        rule = wallet.recurring_transaction_rules.create!(
+          paid_credits: rule_params[:paid_credits] || paid_credits || 0.0,
+          granted_credits: rule_params[:granted_credits] || granted_credits || 0.0,
+          threshold_credits: rule_params[:threshold_credits] || 0.0,
+          interval: rule_params[:interval],
+          method:,
+          target_ongoing_balance: rule_params[:target_ongoing_balance],
+          trigger: rule_params[:trigger].to_s
+        )
+
+        result.recurring_transaction_rule = rule
+        result
+      end
+
+      private
+
+      attr_reader :wallet, :wallet_params
+
+      def rule_params
+        @rule_params ||= wallet_params[:recurring_transaction_rules].first
+      end
+
+      def method
+        @method ||= rule_params[:method] || 'fixed'
+      end
+    end
+  end
+end

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -102,22 +102,9 @@ RSpec.describe Wallets::CreateService, type: :service do
           expect { service_result }.to change(Wallet, :count).by(1)
 
           expect(service_result).to be_success
-
           wallet = service_result.wallet
-          rule = service_result.wallet.reload.recurring_transaction_rules.first
-
           expect(wallet.name).to eq('New Wallet')
           expect(wallet.reload.recurring_transaction_rules.count).to eq(1)
-          expect(rule).to have_attributes(
-            granted_credits: 0.0,
-            interval: "monthly",
-            method: "target",
-            paid_credits: 1.0,
-            target_ongoing_balance: 100.0,
-            threshold_credits: 0.0,
-            trigger: "interval",
-            wallet_id: wallet.id
-          )
         end
       end
 

--- a/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Wallets::RecurringTransactionRules::CreateService do
+  subject(:create_service) { described_class.new(wallet:, wallet_params:) }
+
+  let(:wallet) { create(:wallet) }
+  let(:wallet_params) do
+    {
+      paid_credits: "100.0",
+      granted_credits: "50.0",
+      recurring_transaction_rules: [rule_params]
+    }
+  end
+
+  let(:rule_params) do
+    {
+      interval: "monthly",
+      method: "target",
+      paid_credits: "10.0",
+      granted_credits: "5.0",
+      target_ongoing_balance: "100.0",
+      trigger: "interval"
+    }
+  end
+
+  describe "#call" do
+    context 'when freemium' do
+      it 'does not create any recurring transaction rule' do
+        expect { create_service.call }.not_to change { wallet.reload.recurring_transaction_rules.count }
+      end
+    end
+
+    context 'when premium' do
+      around { |test| lago_premium!(&test) }
+
+      it "creates rule with expected attributes" do
+        expect { create_service.call }.to change { wallet.reload.recurring_transaction_rules.count }.by(1)
+
+        expect(wallet.recurring_transaction_rules.first).to have_attributes(
+          granted_credits: 5.0,
+          interval: "monthly",
+          method: "target",
+          paid_credits: 10.0,
+          target_ongoing_balance: 100.0,
+          threshold_credits: 0.0,
+          trigger: "interval"
+        )
+      end
+
+      context 'when method is fixed' do
+        let(:rule_params) do
+          {
+            trigger: "threshold",
+            threshold_credits: "1.0"
+          }
+        end
+
+        it "creates rule with expected attributes" do
+          expect { create_service.call }.to change { wallet.reload.recurring_transaction_rules.count }.by(1)
+
+          expect(wallet.recurring_transaction_rules.first).to have_attributes(
+            granted_credits: 50.0,
+            method: "fixed",
+            paid_credits: 100.0,
+            target_ongoing_balance: nil,
+            threshold_credits: 1.0,
+            trigger: "threshold"
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to extract logic for the creation of wallet transaction rule into his own class.