### PR TITLE
fix(integrations): Sync credit notes add should_sync_credit_note?

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -105,6 +105,10 @@ class CreditNote < ApplicationRecord
       .includes(:fee)
   end
 
+  def should_sync_credit_note?
+    finalized? && customer.integration_customers.any? { |c| c.integration.sync_credit_notes }
+  end
+
   def voidable?
     return false if voided?
 

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -248,4 +248,83 @@ RSpec.describe CreditNote, type: :model do
         .to eq(credit_note.items.sum(&:precise_amount_cents) - credit_note.precise_coupons_adjustment_amount_cents)
     end
   end
+
+  describe '#should_sync_credit_note?' do
+    subject(:method_call) { credit_note.should_sync_credit_note? }
+
+    let(:credit_note) { create(:credit_note, customer:, organization:, status:) }
+    let(:organization) { create(:organization) }
+
+    context 'when credit note is not finalized' do
+      let(:status) { :draft }
+
+      context 'without integration customer' do
+        let(:customer) { create(:customer, organization:) }
+
+        it 'returns false' do
+          expect(method_call).to eq(false)
+        end
+      end
+
+      context 'with integration customer' do
+        let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+        let(:integration) { create(:netsuite_integration, organization:, sync_credit_notes:) }
+        let(:customer) { create(:customer, organization:) }
+
+        before { integration_customer }
+
+        context 'when sync credit notes is true' do
+          let(:sync_credit_notes) { true }
+
+          it 'returns false' do
+            expect(method_call).to eq(false)
+          end
+        end
+
+        context 'when sync credit notes is false' do
+          let(:sync_credit_notes) { false }
+
+          it 'returns false' do
+            expect(method_call).to eq(false)
+          end
+        end
+      end
+    end
+
+    context 'when credit note is finalized' do
+      let(:status) { :finalized }
+
+      context 'without integration customer' do
+        let(:customer) { create(:customer, organization:) }
+
+        it 'returns false' do
+          expect(method_call).to eq(false)
+        end
+      end
+
+      context 'with integration customer' do
+        let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+        let(:integration) { create(:netsuite_integration, organization:, sync_credit_notes:) }
+        let(:customer) { create(:customer, organization:) }
+
+        before { integration_customer }
+
+        context 'when sync credit notes is true' do
+          let(:sync_credit_notes) { true }
+
+          it 'returns true' do
+            expect(method_call).to eq(true)
+          end
+        end
+
+        context 'when sync credit notes is false' do
+          let(:sync_credit_notes) { false }
+
+          it 'returns false' do
+            expect(method_call).to eq(false)
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR adds `should_sync_credit_note?` method to `CreditNote` model.