### PR TITLE
fix(integrations): Sync credit notes - create job

### DIFF
--- a/app/jobs/integrations/aggregator/credit_notes/create_job.rb
+++ b/app/jobs/integrations/aggregator/credit_notes/create_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module CreditNotes
+      class CreateJob < ApplicationJob
+        queue_as 'integrations'
+
+        retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
+
+        def perform(credit_note:)
+          result = Integrations::Aggregator::CreditNotes::CreateService.call(credit_note:)
+          result.raise_if_error!
+        end
+      end
+    end
+  end
+end

--- a/app/services/integrations/aggregator/credit_notes/create_service.rb
+++ b/app/services/integrations/aggregator/credit_notes/create_service.rb
@@ -54,8 +54,7 @@ module Integrations
 
         attr_reader :credit_note
 
-        delegate :customer, to: :credit_note, allow_nil: true
-        delegate :invoice, to: :credit_note
+        delegate :customer, :invoice, to: :credit_note, allow_nil: true
 
         def coupons
           output = []

--- a/spec/jobs/integrations/aggregator/credit_notes/create_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/credit_notes/create_job_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::CreditNotes::CreateJob, type: :job do
+  subject(:create_job) { described_class }
+
+  let(:service) { instance_double(Integrations::Aggregator::CreditNotes::CreateService) }
+  let(:credit_note) { create(:credit_note) }
+  let(:result) { BaseService::Result.new }
+
+  before do
+    allow(Integrations::Aggregator::CreditNotes::CreateService).to receive(:new).and_return(service)
+    allow(service).to receive(:call).and_return(result)
+  end
+
+  it 'calls the aggregator create credit_note service' do
+    described_class.perform_now(credit_note:)
+
+    aggregate_failures do
+      expect(Integrations::Aggregator::CreditNotes::CreateService).to have_received(:new)
+      expect(service).to have_received(:call)
+    end
+  end
+end

--- a/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
@@ -209,29 +209,28 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
     integration.save!
   end
 
-  # TODO: uncomment after jobs are merged
-  # describe '#call_async' do
-  #   subject(:service_call_async) { described_class.new(credit_note:).call_async }
+  describe '#call_async' do
+    subject(:service_call_async) { described_class.new(credit_note:).call_async }
 
-  #   context 'when credit_note exists' do
-  #     it 'enqueues credit_note create job' do
-  #       expect { service_call_async }.to enqueue_job(Integrations::Aggregator::CreditNotes::CreateJob)
-  #     end
-  #   end
+    context 'when credit_note exists' do
+      it 'enqueues credit_note create job' do
+        expect { service_call_async }.to enqueue_job(Integrations::Aggregator::CreditNotes::CreateJob)
+      end
+    end
 
-  #   context 'when credit_note does not exist' do
-  #     let(:credit_note) { nil }
+    context 'when credit_note does not exist' do
+      let(:credit_note) { nil }
 
-  #     it 'returns an error' do
-  #       result = service_call_async
+      it 'returns an error' do
+        result = service_call_async
 
-  #       aggregate_failures do
-  #         expect(result).not_to be_success
-  #         expect(result.error.error_code).to eq('credit_note_not_found')
-  #       end
-  #     end
-  #   end
-  # end
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.error_code).to eq('credit_note_not_found')
+        end
+      end
+    end
+  end
 
   describe '#call' do
     context 'when service call is successful' do


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR adds `Integrations::Aggregator::CreditNotes::CreateJob`