### PR TITLE
feat(fees): Add billing_at arg to CreatePayInAdvance flow

### DIFF
--- a/app/jobs/fees/create_pay_in_advance_job.rb
+++ b/app/jobs/fees/create_pay_in_advance_job.rb
@@ -4,8 +4,8 @@ module Fees
   class CreatePayInAdvanceJob < ApplicationJob
     queue_as :default
 
-    def perform(charge:, event:)
-      result = Fees::CreatePayInAdvanceService.call(charge:, event:)
+    def perform(charge:, event:, billing_at: event.timestamp)
+      result = Fees::CreatePayInAdvanceService.call(charge:, event:, billing_at:)
 
       result.raise_if_error!
     end

--- a/spec/jobs/fees/create_pay_in_advance_job_spec.rb
+++ b/spec/jobs/fees/create_pay_in_advance_job_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Fees::CreatePayInAdvanceJob, type: :job do
 
   it 'delegates to the pay_in_advance aggregation service' do
     allow(Fees::CreatePayInAdvanceService).to receive(:new)
-      .with(charge:, event:)
+      .with(charge:, event:, billing_at: event.timestamp)
       .and_return(instant_service)
     allow(instant_service).to receive(:call)
       .and_return(result)

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
-  subject(:fee_service) { described_class.new(charge:, event:, estimate:) }
+  subject(:fee_service) { described_class.new(charge:, event:, billing_at: event.timestamp, estimate:) }
 
   let(:organization) { create(:organization) }
   let(:billable_metric) { create(:billable_metric, organization:) }


### PR DESCRIPTION
## Context

When a charge is `invoiceable: true, pay_in_advance: true` an invoice is created every time an event is received. If the  Billable Metrics attached is `recurring: true`, each month this charge will be added to the subscription invoice.

If the charge is `invoiceable: false, pay_in_advance: true` a fee is created every time an even is received (but no invoice). If the  Billable Metrics attached is `recurring: true`, nothing happens each months.

We want to change this behavior and create a new Fee each month.

## Description

Each time a new fee is created for the new period, we'll continue to attach it to the same event that triggered it in the first place.

In this PR, we extract the "timestamp" into an arg so on following months, we can use the correct billing date instead of relying on the time of the event.

Without this change, the boundaries of any fee would always be the boundaries computed at the time of the event.
