### PR TITLE
feat(fees): Create recurring pay in advance fees on renewal

### DIFF
--- a/app/jobs/bill_recurring_pay_in_advance_charges_job.rb
+++ b/app/jobs/bill_recurring_pay_in_advance_charges_job.rb
@@ -5,8 +5,5 @@ class BillRecurringPayInAdvanceChargesJob < ApplicationJob
 
   def perform(subscriptions, timestamp)
     Fees::CreateRecurringPayInAdvanceService.call(subscriptions:, billing_at: Time.zone.at(timestamp))
-
-    # TODO: Should we retry the job if it fails?
-    # result.raise_if_error!
   end
 end

--- a/app/jobs/bill_recurring_pay_in_advance_charges_job.rb
+++ b/app/jobs/bill_recurring_pay_in_advance_charges_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class BillRecurringPayInAdvanceChargesJob < ApplicationJob
+  queue_as 'billing'
+
+  def perform(subscriptions, timestamp)
+    Fees::CreateRecurringPayInAdvanceService.call(subscriptions:, billing_at: Time.zone.at(timestamp))
+
+    # TODO: Should we retry the job if it fails?
+    # result.raise_if_error!
+  end
+end

--- a/app/services/fees/create_recurring_pay_in_advance_service.rb
+++ b/app/services/fees/create_recurring_pay_in_advance_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Fees
+  class CreateRecurringPayInAdvanceService < BaseService
+    def initialize(subscriptions:, billing_at:)
+      @subscriptions = subscriptions
+      @billing_at = billing_at
+
+      super
+    end
+
+    def call
+      plan_ids = subscriptions.select(&:active?).map(&:plan_id).uniq
+
+      Charge.joins(:billable_metric)
+        .where(plan_id: plan_ids, pay_in_advance: true, invoiceable: false)
+        .where(billable_metrics: {recurring: true})
+        .find_each do |charge|
+        last_fee = charge.fees.order(created_at: :desc).first
+        event = Event.find_by(id: last_fee&.pay_in_advance_event_id)
+
+        if event
+          Fees::CreatePayInAdvanceJob.perform_later(charge:, event:, billing_at:)
+        end
+      end
+
+      result
+    end
+
+    private
+
+    attr_reader :subscriptions, :billing_at
+  end
+end

--- a/app/services/fees/create_recurring_pay_in_advance_service.rb
+++ b/app/services/fees/create_recurring_pay_in_advance_service.rb
@@ -20,6 +20,8 @@ module Fees
           Fees::CreatePayInAdvanceJob.perform_later(charge:, event:, billing_at:)
         end
       end
+
+      result
     end
 
     private

--- a/app/services/subscriptions/billing_service.rb
+++ b/app/services/subscriptions/billing_service.rb
@@ -18,11 +18,9 @@ module Subscriptions
           end
         end
 
-        BillSubscriptionJob.perform_later(
-          billing_subscriptions,
-          billing_timestamp,
-          invoicing_reason: :subscription_periodic
-        )
+        BillSubscriptionJob.perform_later(billing_subscriptions, billing_timestamp, invoicing_reason: :subscription_periodic)
+
+        BillRecurringPayInAdvanceChargesJob.perform_later(billing_subscriptions, billing_timestamp)
       end
     end
 

--- a/spec/scenarios/fees/recurring_pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/fees/recurring_pay_in_advance_charges_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Recurring Pay In Advance Charges', :scenarios, type: :request do
+  let(:organization) { create(:organization, webhook_url: nil) }
+  let(:customer) { create(:customer, organization:) }
+  let(:billable_metric) { create(:unique_count_billable_metric, :recurring, organization:) }
+  let(:plan) { create(:plan, organization:, amount_cents: 499_00, pay_in_advance: true) }
+  let(:charge) { create(:charge, plan:, billable_metric:, pay_in_advance: true, invoiceable:, properties: {amount: '12'}) }
+
+  context 'when invoiceable is false' do
+    let(:invoiceable) { false }
+    let(:external_subscription_id) { SecureRandom.uuid }
+    let(:transaction_id) { SecureRandom.uuid }
+
+    before do
+      charge
+    end
+
+    it 'create fees when the period is renewed' do
+      travel_to(Time.zone.parse('2024-03-05T12:12:00')) do
+        create_subscription(
+          {
+            external_customer_id: customer.external_id,
+            external_id: external_subscription_id,
+            plan_code: plan.code
+          }
+        )
+        perform_billing
+        expect(customer.reload.invoices.count).to eq(1)
+      end
+
+      subscription = customer.subscriptions.sole
+
+      travel_to(Time.zone.parse('2024-03-15T10:00:00')) do
+        expect(subscription.fees.charge.count).to eq(0)
+
+        res = create_event({
+          code: billable_metric.code,
+          transaction_id:,
+          external_subscription_id:,
+          properties: {unique_id: 'id_1'}
+        })
+
+        expect(subscription.fees.charge.count).to eq(1)
+
+        fee = subscription.fees.charge.sole
+        expect(fee.units).to eq(1)
+        expect(fee.events_count).to eq(1)
+        expect(fee.amount_cents).to eq(12_00)
+        expect(fee.invoice_id).to be_nil
+        expect(fee.pay_in_advance_event_id).to eq(res.dig('event', 'lago_id'))
+
+        properties = fee.properties
+        expect(properties["charges_from_datetime"]).to eq('2024-03-05T12:12:00.000Z')
+        expect(properties["charges_to_datetime"]).to eq('2024-03-31T23:59:59.999Z')
+      end
+
+      travel_to(Time.zone.parse('2024-04-01T00:12:00')) do
+        perform_billing
+        expect(customer.reload.invoices.count).to eq(2)
+        expect(subscription.fees.charge.count).to eq(2)
+
+        fee = subscription.fees.charge.order(created_at: :desc).first
+        expect(fee.units).to eq(1)
+        expect(fee.events_count).to eq(1)
+        expect(fee.amount_cents).to eq(12_00)
+
+        properties = fee.properties
+        expect(properties["charges_from_datetime"]).to eq('2024-04-01T00:00:00.000Z')
+        expect(properties["charges_to_datetime"]).to eq('2024-04-30T23:59:59.999Z')
+      end
+    end
+  end
+end

--- a/spec/services/fees/create_recurring_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_recurring_pay_in_advance_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fees::CreateRecurringPayInAdvanceService do
+  subject(:service) { described_class.new(subscriptions: [subscription], billing_at:) }
+
+  let(:billing_at) { Time.current }
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:invoiceable_charge) { create(:standard_charge, plan:, pay_in_advance: true, invoiceable: true) }
+  let(:non_recurring_charge) { create(:standard_charge, plan:, pay_in_advance: true, invoiceable: false) }
+  let(:billable_metric) { create(:unique_count_billable_metric, :recurring, organization:) }
+  let(:recurring_charge) { create(:charge, billable_metric:, plan:, pay_in_advance: true, invoiceable: false, properties: {amount: '12'}) }
+  let(:subscription) { create(:subscription, plan:, customer:) }
+
+  before do
+    invoiceable_charge
+    non_recurring_charge
+  end
+
+  context 'when no charge is recurring' do
+    it 'does not enqueue any jobs' do
+      service.call
+      expect(Fees::CreatePayInAdvanceJob).not_to have_been_enqueued
+    end
+  end
+
+  context 'when a charge is recurring but there is no previous fees' do
+    before do
+      recurring_charge
+    end
+
+    it 'does not enqueue any jobs' do
+      service.call
+      expect(Fees::CreatePayInAdvanceJob).not_to have_been_enqueued
+    end
+  end
+
+  context 'when a charge is recurring and there is a previous fee but no event associated' do
+    before do
+      recurring_charge
+      create(:charge_fee, charge: recurring_charge, invoice: nil, subscription:, pay_in_advance_event_id: nil)
+    end
+
+    it 'enqueues a job' do
+      service.call
+      expect(Fees::CreatePayInAdvanceJob).not_to have_been_enqueued
+    end
+  end
+
+  context 'when a charge is recurring and there is a previous fee' do
+    let(:event) { create(:event) }
+
+    before do
+      recurring_charge
+      create(:charge_fee, charge: recurring_charge, invoice: nil, subscription:, pay_in_advance_event_id: event.id)
+    end
+
+    it 'enqueues a job' do
+      service.call
+      expect(Fees::CreatePayInAdvanceJob).to have_been_enqueued.with(charge: recurring_charge, event:, billing_at:)
+    end
+  end
+end

--- a/spec/services/subscriptions/billing_service_spec.rb
+++ b/spec/services/subscriptions/billing_service_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription3], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
         end
       end
 
@@ -101,6 +102,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
         end
       end
 
@@ -131,6 +133,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).not_to have_been_enqueued
               .with([subscription], billing_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillRecurringPayInAdvanceChargesJob).not_to have_been_enqueued.with([subscription], billing_date.to_i)
           end
         end
       end
@@ -148,6 +151,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
         end
       end
 
@@ -159,6 +163,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).not_to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillRecurringPayInAdvanceChargesJob).not_to have_been_enqueued.with([subscription], current_date.to_i)
         end
       end
     end
@@ -175,6 +180,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
         end
       end
 
@@ -197,6 +203,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
           end
         end
       end
@@ -216,6 +223,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
         end
       end
 
@@ -237,6 +245,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
         end
       end
 
@@ -256,6 +265,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
           end
         end
       end
@@ -272,6 +282,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
         end
       end
 
@@ -291,6 +302,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
           end
         end
       end
@@ -305,6 +317,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
           end
         end
       end
@@ -322,6 +335,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
         end
       end
 
@@ -341,6 +355,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
           end
         end
       end
@@ -355,6 +370,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.next_month.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.next_month.to_i)
           end
         end
 
@@ -368,6 +384,7 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
               expect(BillSubscriptionJob).to have_been_enqueued
                 .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+              expect(BillRecurringPayInAdvanceChargesJob).to have_been_enqueued.with([subscription], current_date.to_i)
             end
           end
         end


### PR DESCRIPTION
## Context

When a charge is `invoiceable: true, pay_in_advance: true` an invoice is created every time an event is received. If the Billable Metrics attached is `recurring: true`, each month this charge will be added to the subscription invoice.

If the charge is `invoiceable: false, pay_in_advance: true` a fee is created every time an even is received (but no invoice). If the Billable Metrics attached is `recurring: true`, nothing happens each months.

We want to change this behavior and create a new Fee each month.

## Description

#### Current Behavior

1. **Invoiceable Charges:**
   - When `invoiceable: true` and `pay_in_advance: true`:
     - An invoice is created every time an event is received.
     - If the Billable Metrics attached are `recurring: true`, this charge is added to the subscription invoice each month.

2. **Non-Invoiceable Charges:**
   - When `invoiceable: false` and `pay_in_advance: true`:
     - A fee is created every time an event is received (but no invoice is generated).
     - If the Billable Metrics attached are `recurring: true`, nothing happens each month.


#### New Behavior
1. **Invoiceable Charges:**
   - No changes. Invoiceable charges will continue to function as before.
   
2. **Non-Invoiceable Charges:**
   - When `invoiceable: false` and`pay_in_advance: true`:
    - A fee will still be created every time an event is received (with no invoice generated).
    - If the Billable Metrics attached are `recurring: true`, a new fee will now be created each month, ensuring consistent billing for recurring metrics.

#### Change

We have updated the system to ensure that recurring non-invoiceable charges generate a new fee each month.

#### Details of Implementation

1. **Job Dispatch:**
   - We introduced a job `BillRecurringPayInAdvanceChargesJob` which is dispatched in the `app/services/subscriptions/billing_service.rb` to handle the creation of recurring fees each month.
   - This job is scheduled to run at the beginning of each billing cycle.

2. **Reusing Existing Code:**
   - The job uses the existing `Fees::CreateRecurringPayInAdvanceService` to handle the logic for creating recurring fees.

3. **Trigger Conditions:**
   - The job is triggered under the following conditions:
     - Subscriptions must be active.
     - The charge must have `invoiceable: false` and `pay_in_advance: true`.
     - The Billable Metrics attached to the charge must be `recurring: true`.

4. **Using Previous Fee and Event:**
   - The service checks the most recent fee created for the charge.
   - It retrieves the associated event from the last fee (`pay_in_advance_event_id`).
   - If an event is found, a new fee is created for the current billing period based on the previous event..
