### PR TITLE
feat(wallet): Extract wallet threshold top up

### DIFF
--- a/app/services/wallets/balance/update_ongoing_service.rb
+++ b/app/services/wallets/balance/update_ongoing_service.rb
@@ -11,16 +11,14 @@ module Wallets
       end
 
       def call
-        ongoing_usage_balance_cents = wallet.ongoing_usage_balance_cents
         update_params = compute_update_params
         wallet.update!(update_params)
-        wallet.reload
 
         if update_params[:depleted_ongoing_balance] == true
           SendWebhookJob.perform_later('wallet.depleted_ongoing_balance', wallet)
         end
 
-        Wallets::TopUpService.call(wallet:)
+        ::Wallets::ThresholdTopUpService.call(wallet:)
 
         result.wallet = wallet
         result

--- a/app/services/wallets/balance/update_ongoing_service.rb
+++ b/app/services/wallets/balance/update_ongoing_service.rb
@@ -14,12 +14,13 @@ module Wallets
         ongoing_usage_balance_cents = wallet.ongoing_usage_balance_cents
         update_params = compute_update_params
         wallet.update!(update_params)
+        wallet.reload
 
         if update_params[:depleted_ongoing_balance] == true
           SendWebhookJob.perform_later('wallet.depleted_ongoing_balance', wallet)
         end
 
-        handle_threshold_top_up(ongoing_usage_balance_cents)
+        Wallets::TopUpService.call(wallet:)
 
         result.wallet = wallet
         result
@@ -46,23 +47,6 @@ module Wallets
         params
       end
 
-      def handle_threshold_top_up(ongoing_usage_balance_cents)
-        threshold_rule = wallet.recurring_transaction_rules.where(trigger: :threshold).first
-
-        return if threshold_rule.nil? || wallet.credits_ongoing_balance > threshold_rule.threshold_credits
-        return if (pending_transactions_amount + credits_ongoing_balance) > threshold_rule.threshold_credits
-
-        WalletTransactions::CreateJob.set(wait: 2.seconds).perform_later(
-          organization_id: wallet.organization.id,
-          params: {
-            wallet_id: wallet.id,
-            paid_credits: threshold_rule.paid_credits.to_s,
-            granted_credits: threshold_rule.granted_credits.to_s,
-            source: :threshold
-          }
-        )
-      end
-
       def currency
         @currency ||= wallet.ongoing_balance.currency
       end
@@ -77,10 +61,6 @@ module Wallets
 
       def credits_ongoing_balance
         wallet.credits_balance - usage_credits_amount
-      end
-
-      def pending_transactions_amount
-        wallet.wallet_transactions.pending.sum(:amount)
       end
     end
   end

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -10,8 +10,8 @@ module Wallets
           organization_id: wallet.organization.id,
           params: {
             wallet_id: wallet.id,
-            paid_credits: recurring_transaction_rule.paid_credits.to_s,
-            granted_credits: recurring_transaction_rule.granted_credits.to_s,
+            paid_credits: paid_credits(recurring_transaction_rule),
+            granted_credits: granted_credits(recurring_transaction_rule),
             source: :interval
           }
         )
@@ -22,6 +22,18 @@ module Wallets
 
     def today
       @today ||= Time.current
+    end
+
+    def paid_credits(rule)
+      return (rule.target_ongoing_balance - rule.wallet.credits_ongoing_balance).to_s if rule.target?
+
+      rule.paid_credits.to_s
+    end
+
+    def granted_credits(rule)
+      return "0.0" if rule.target?
+
+      rule.granted_credits.to_s
     end
 
     # NOTE: Retrieve list of recurring_transaction_rules that should create wallet transactions today

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -8,11 +8,7 @@ module Wallets
     end
 
     def call
-<<<<<<< HEAD
       return result unless valid?
-=======
-      return result unless valid?(**params)
->>>>>>> 62c2da89 (feat(wallet): Add granted and paid credits on recurring transaction rule)
 
       wallet = Wallet.new(
         customer_id: result.current_customer.id,
@@ -58,11 +54,7 @@ module Wallets
 
     attr_reader :params
 
-<<<<<<< HEAD
     def valid?
-=======
-    def valid?(**params)
->>>>>>> 62c2da89 (feat(wallet): Add granted and paid credits on recurring transaction rule)
       Wallets::ValidateService.new(result, **params).valid?
     end
   end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -8,7 +8,11 @@ module Wallets
     end
 
     def call
+<<<<<<< HEAD
       return result unless valid?
+=======
+      return result unless valid?(**params)
+>>>>>>> 62c2da89 (feat(wallet): Add granted and paid credits on recurring transaction rule)
 
       wallet = Wallet.new(
         customer_id: result.current_customer.id,
@@ -54,7 +58,11 @@ module Wallets
 
     attr_reader :params
 
+<<<<<<< HEAD
     def valid?
+=======
+    def valid?(**params)
+>>>>>>> 62c2da89 (feat(wallet): Add granted and paid credits on recurring transaction rule)
       Wallets::ValidateService.new(result, **params).valid?
     end
   end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -28,7 +28,7 @@ module Wallets
         wallet.currency = wallet.customer.currency
         wallet.save!
 
-        if params[:recurring_transaction_rules]
+        if params[:recurring_transaction_rules].present?
           Wallets::RecurringTransactionRules::CreateService.call(wallet:, wallet_params: params)
         end
       end

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Wallets
+  class ThresholdTopUpService < BaseService
+    def initialize(wallet:)
+      @wallet = wallet
+      super
+    end
+
+    def call
+      return if threshold_rule.nil?
+      return if wallet.credits_ongoing_balance > threshold_rule.threshold_credits
+      return if (pending_transactions_amount + wallet.credits_ongoing_balance) > threshold_rule.threshold_credits
+
+      WalletTransactions::CreateJob.set(wait: 2.seconds).perform_later(
+        organization_id: wallet.organization.id,
+        params: {
+          wallet_id: wallet.id,
+          paid_credits: threshold_rule.paid_credits.to_s,
+          granted_credits: threshold_rule.granted_credits.to_s,
+          source: :threshold
+        }
+      )
+    end
+
+    private
+
+    attr_reader :wallet
+
+    def threshold_rule
+      @threshold_rule ||= wallet.recurring_transaction_rules.where(trigger: :threshold).first
+    end
+
+    def pending_transactions_amount
+      @pending_transactions_amount ||= wallet.wallet_transactions.pending.sum(:amount)
+    end
+  end
+end

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -16,8 +16,8 @@ module Wallets
         organization_id: wallet.organization.id,
         params: {
           wallet_id: wallet.id,
-          paid_credits: threshold_rule.paid_credits.to_s,
-          granted_credits: threshold_rule.granted_credits.to_s,
+          paid_credits:,
+          granted_credits:,
           source: :threshold
         }
       )
@@ -33,6 +33,18 @@ module Wallets
 
     def pending_transactions_amount
       @pending_transactions_amount ||= wallet.wallet_transactions.pending.sum(:amount)
+    end
+
+    def paid_credits
+      return (threshold_rule.target_ongoing_balance - wallet.credits_ongoing_balance).to_s if threshold_rule.target?
+
+      threshold_rule.paid_credits.to_s
+    end
+
+    def granted_credits
+      return "0.0" if threshold_rule.target?
+
+      threshold_rule.granted_credits.to_s
     end
   end
 end

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -7,7 +7,7 @@ module Wallets
       valid_paid_credits_amount? if args[:paid_credits]
       valid_granted_credits_amount? if args[:granted_credits]
       valid_expiration_at? if args[:expiration_at]
-      valid_recurring_transaction_rules? if args[:recurring_transaction_rules]
+      valid_recurring_transaction_rules? if args[:recurring_transaction_rules].present?
 
       if errors?
         result.validation_failure!(errors:)
@@ -66,7 +66,7 @@ module Wallets
     end
 
     def valid_recurring_transaction_rules?
-      if args[:recurring_transaction_rules].count != 1
+      if args[:recurring_transaction_rules].count > 1
         return add_error(field: :recurring_transaction_rules, error_code: 'invalid_number_of_recurring_rules')
       end
 

--- a/spec/services/wallets/balance/update_ongoing_service_spec.rb
+++ b/spec/services/wallets/balance/update_ongoing_service_spec.rb
@@ -56,53 +56,5 @@ RSpec.describe Wallets::Balance::UpdateOngoingService, type: :service do
           .with('wallet.depleted_ongoing_balance', Wallet)
       end
     end
-
-    context 'with recurring transaction threshold rule' do
-      let(:recurring_transaction_rule) do
-        create(:recurring_transaction_rule, wallet:, trigger: 'threshold', threshold_credits: '6.0')
-      end
-
-      before { recurring_transaction_rule }
-
-      it 'calls wallet transaction create job when threshold border has been crossed' do
-        expect { update_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
-      end
-
-      context 'when border has NOT been crossed' do
-        let(:recurring_transaction_rule) do
-          create(:recurring_transaction_rule, wallet:, trigger: 'threshold', threshold_credits: '2.0')
-        end
-
-        it 'does not call wallet transaction create job' do
-          expect { update_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
-        end
-      end
-
-      context 'with pending transactions' do
-        it 'does not call wallet transaction create job' do
-          create(:wallet_transaction, wallet:, amount: 1.0, credit_amount: 1.0, status: 'pending')
-          expect { update_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
-        end
-      end
-
-      context 'without any usage' do
-        let(:wallet) do
-          create(
-            :wallet,
-            balance_cents: 200,
-            ongoing_balance_cents: 200,
-            ongoing_usage_balance_cents: 0,
-            credits_balance: 2.0,
-            credits_ongoing_balance: 2.0,
-            credits_ongoing_usage_balance: 0.0
-          )
-        end
-        let(:credits_amount) { BigDecimal('0.0') }
-
-        it 'calls wallet transaction create job' do
-          expect { update_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
-        end
-      end
-    end
   end
 end

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Wallets::ThresholdTopUpService, type: :service do
   subject(:top_up_service) { described_class.new(wallet:) }
@@ -17,50 +17,74 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
     )
   end
 
-  describe '#call' do
+  describe "#call" do
     let(:recurring_transaction_rule) do
-      create(:recurring_transaction_rule, wallet:, trigger: 'threshold', threshold_credits: '6.0')
+      create(
+        :recurring_transaction_rule,
+        wallet:,
+        trigger: "threshold",
+        threshold_credits: "6.0",
+        paid_credits: "10.0",
+        granted_credits: "3.0"
+      )
     end
 
     before { recurring_transaction_rule }
 
-    it 'calls wallet transaction create job when threshold border has been crossed' do
+    it "calls wallet transaction create job with expected params" do
       expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+        .with(
+          organization_id: wallet.organization.id,
+          params: {
+            wallet_id: wallet.id,
+            paid_credits: "10.0",
+            granted_credits: "3.0",
+            source: :threshold
+          }
+        )
     end
 
-    context 'when border has NOT been crossed' do
+    context "when border has NOT been crossed" do
       let(:recurring_transaction_rule) do
-        create(:recurring_transaction_rule, wallet:, trigger: 'threshold', threshold_credits: '2.0')
+        create(:recurring_transaction_rule, wallet:, trigger: "threshold", threshold_credits: "2.0")
       end
 
-      it 'does not call wallet transaction create job' do
+      it "does not call wallet transaction create job" do
         expect { top_up_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
       end
     end
 
-    context 'with pending transactions' do
-      it 'does not call wallet transaction create job' do
-        create(:wallet_transaction, wallet:, amount: 1.0, credit_amount: 1.0, status: 'pending')
+    context "with pending transactions" do
+      it "does not call wallet transaction create job" do
+        create(:wallet_transaction, wallet:, amount: 1.0, credit_amount: 1.0, status: "pending")
+
         expect { top_up_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
       end
     end
 
-    context 'without any usage' do
-      let(:wallet) do
+    context "when method is target" do
+      let(:recurring_transaction_rule) do
         create(
-          :wallet,
-          balance_cents: 200,
-          ongoing_balance_cents: 200,
-          ongoing_usage_balance_cents: 0,
-          credits_balance: 2.0,
-          credits_ongoing_balance: 2.0,
-          credits_ongoing_usage_balance: 0.0,
+          :recurring_transaction_rule,
+          wallet:,
+          trigger: "threshold",
+          threshold_credits: "6.0",
+          method: "target",
+          target_ongoing_balance: "200"
         )
       end
-      let(:credits_amount) { BigDecimal('0.0') }
 
-      it 'calls wallet transaction create job' do
+      it "calls wallet transaction create job with expected params" do
         expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+          .with(
+            organization_id: wallet.organization.id,
+            params: {
+              wallet_id: wallet.id,
+              paid_credits: "194.5",
+              granted_credits: "0.0",
+              source: :threshold
+            }
+          )
       end
     end
   end

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
       ongoing_usage_balance_cents: 450,
       credits_balance: 10.0,
       credits_ongoing_balance: 5.5,
-      credits_ongoing_usage_balance: 4.0,
+      credits_ongoing_usage_balance: 4.0
     )
   end
 

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Wallets::ThresholdTopUpService, type: :service do
+  subject(:top_up_service) { described_class.new(wallet:) }
+
+  let(:wallet) do
+    create(
+      :wallet,
+      balance_cents: 1000,
+      ongoing_balance_cents: 550,
+      ongoing_usage_balance_cents: 450,
+      credits_balance: 10.0,
+      credits_ongoing_balance: 5.5,
+      credits_ongoing_usage_balance: 4.0,
+    )
+  end
+
+  describe '#call' do
+    let(:recurring_transaction_rule) do
+      create(:recurring_transaction_rule, wallet:, trigger: 'threshold', threshold_credits: '6.0')
+    end
+
+    before { recurring_transaction_rule }
+
+    it 'calls wallet transaction create job when threshold border has been crossed' do
+      expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+    end
+
+    context 'when border has NOT been crossed' do
+      let(:recurring_transaction_rule) do
+        create(:recurring_transaction_rule, wallet:, trigger: 'threshold', threshold_credits: '2.0')
+      end
+
+      it 'does not call wallet transaction create job' do
+        expect { top_up_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
+      end
+    end
+
+    context 'with pending transactions' do
+      it 'does not call wallet transaction create job' do
+        create(:wallet_transaction, wallet:, amount: 1.0, credit_amount: 1.0, status: 'pending')
+        expect { top_up_service.call }.not_to have_enqueued_job(WalletTransactions::CreateJob)
+      end
+    end
+
+    context 'without any usage' do
+      let(:wallet) do
+        create(
+          :wallet,
+          balance_cents: 200,
+          ongoing_balance_cents: 200,
+          ongoing_usage_balance_cents: 0,
+          credits_balance: 2.0,
+          credits_ongoing_balance: 2.0,
+          credits_ongoing_usage_balance: 0.0,
+        )
+      end
+      let(:credits_amount) { BigDecimal('0.0') }
+
+      it 'calls wallet transaction create job' do
+        expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to:
- extract wallet top up into his own class
- handle target top up