### PR TITLE
fix(webhook): Deserialize payload for older webhooks

### DIFF
--- a/app/graphql/types/webhooks/object.rb
+++ b/app/graphql/types/webhooks/object.rb
@@ -23,9 +23,7 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       def payload
-        return object.payload&.to_json unless object.payload.is_a?(String)
-
-        object.payload
+        object.payload&.to_json
       end
     end
   end

--- a/app/models/webhook.rb
+++ b/app/models/webhook.rb
@@ -17,6 +17,19 @@ class Webhook < ApplicationRecord
     %w[id webhook_type]
   end
 
+  # Up until 1.4.0, we stored the payload as a string. This method
+  # ensures that we can still read the old payloads.
+  # Webhooks created after 1.4.0 will have the payload stored as a hash.
+  # Webhooks are deleted after 90 days, so we can remove this method 90 days after every client has updated to 1.4.0.
+  def payload
+    attr = super
+    if attr.is_a?(String)
+      JSON.parse(attr)
+    else
+      attr
+    end
+  end
+
   def generate_headers
     signature = case webhook_endpoint.signature_algo&.to_sym
     when :jwt

--- a/spec/factories/webhooks.rb
+++ b/spec/factories/webhooks.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     association :webhook_endpoint, factory: :webhook_endpoint
     association :object, factory: :invoice
 
-    payload { Faker::Json.shallow_json(width: 3) }
+    payload { Faker::Types.rb_hash(number: 3) }
     webhook_type { 'invoice.created' }
     endpoint { Faker::Internet.url }
 

--- a/spec/graphql/resolvers/webhooks_resolver_spec.rb
+++ b/spec/graphql/resolvers/webhooks_resolver_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Resolvers::WebhooksResolver, type: :graphql do
     <<~GQL
       query {
         webhooks(limit: 5, webhookEndpointId: "#{webhook_endpoint.id}") {
-          collection { id }
+          collection { id payload }
           metadata { currentPage, totalCount }
         }
       }
@@ -36,10 +36,38 @@ RSpec.describe Resolvers::WebhooksResolver, type: :graphql do
     )
 
     webhooks_response = result['data']['webhooks']
+    webhook = webhooks_response['collection'].first
 
     aggregate_failures do
       expect(webhooks_response['collection'].count).to eq(webhook_endpoint.webhooks.count)
       expect(webhooks_response['metadata']['currentPage']).to eq(1)
+      expect(webhook['payload']).to be_a String
+      expect(JSON.parse(webhook['payload'])).to be_a Hash
+    end
+  end
+
+  context 'when the webhook payload is json-serialized in the database' do
+    it 'returns a list of webhooks' do
+      Webhook.all.find_each do |w|
+        w.update_column(:payload, {'foo' => 'bar'}.to_json) # rubocop:disable Rails/SkipsModelValidations
+      end
+
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:,
+      )
+
+      webhooks_response = result['data']['webhooks']
+      webhook = webhooks_response['collection'].first
+
+      aggregate_failures do
+        expect(webhooks_response['collection'].count).to eq(webhook_endpoint.webhooks.count)
+        expect(webhooks_response['metadata']['currentPage']).to eq(1)
+        expect(webhook['payload']).to be_a String
+        expect(JSON.parse(webhook['payload'])).to be_a Hash
+      end
     end
   end
 end

--- a/spec/models/webhook_spec.rb
+++ b/spec/models/webhook_spec.rb
@@ -10,6 +10,21 @@ RSpec.describe Webhook, type: :model do
   it { is_expected.to belong_to(:webhook_endpoint) }
   it { is_expected.to belong_to(:object).optional }
 
+  describe '#payload' do
+    it 'returns a hash' do
+      expect(webhook.payload).to be_a(Hash)
+    end
+
+    context 'when payload was stored as json' do
+      it 'returns a hash' do
+        webhook.update_column(:payload, {'key' => 'value'}.to_json) # rubocop:disable Rails/SkipsModelValidations
+
+        expect(webhook.reload.payload).to eq({'key' => 'value'})
+        expect(webhook.read_attribute(:payload)).to be_a String
+      end
+    end
+  end
+
   describe '#generate_headers' do
     it 'generates the query headers' do
       headers = webhook.generate_headers


### PR DESCRIPTION
## Context

I recently [refactored the webhook](https://github.com/getlago/lago-api/pull/1993) model to split the SendWebhookJob into 2 jobs.
The payload was previously stored as a string (json serialized hash) inside a JSON column. 
It's now a hash stored in a JSON column.

I introduced a bug where the webhook sent to the GraphQL API wasn't in the format expected.
@lovrocolic fixed in https://github.com/getlago/lago-api/pull/2053

## Description

Currently, if you open an old webhook, `w.payload` will return a string. Newer payload would return a hash.
This PR ensures you always get a hash.

Note that there was no release since #1993.

Webhooks are deleted after 90 days, so "one day", all webhooks will be stored in hash.