### PR TITLE
feat(invoice): Hide subscription fee when 0

### DIFF
--- a/app/views/helpers/fee_display_helper.rb
+++ b/app/views/helpers/fee_display_helper.rb
@@ -8,4 +8,11 @@ class FeeDisplayHelper
 
     " • #{fee.grouped_by.values.compact.join(" • ")}"
   end
+
+  def self.should_display_subscription_fee?(invoice_subscription)
+    return false if invoice_subscription.blank?
+    return true if invoice_subscription.charge_amount_cents.zero?
+
+    invoice_subscription.subscription_amount_cents.positive?
+  end
 end

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -15,15 +15,17 @@
           td.body-2 = I18n.t('invoice.unit_price')
           td.body-2 = I18n.t('invoice.tax_rate')
           td.body-2 = I18n.t('invoice.amount')
-        tr
-          - if subscription_fee&.invoice_display_name&.present?
-            td.body-1 = subscription_fee&.invoice_display_name
-          - else
-            td.body-1 = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.invoice_name)
-          td.body-2 = 1
-          td.body-2 = MoneyHelper.format(invoice_subscription.subscription_amount)
-          td.body-2 == TaxHelper.applied_taxes(subscription_fee)
-          td.body-2 = MoneyHelper.format(invoice_subscription.subscription_amount)
+
+        - if FeeDisplayHelper.should_display_subscription_fee?(invoice_subscription)
+          tr
+            - if subscription_fee&.invoice_display_name&.present?
+              td.body-1 = subscription_fee&.invoice_display_name
+            - else
+              td.body-1 = I18n.t('invoice.subscription_interval', plan_interval: I18n.t("invoice.#{subscription.plan.interval}"), plan_name: subscription.plan.invoice_name)
+            td.body-2 = 1
+            td.body-2 = MoneyHelper.format(invoice_subscription.subscription_amount)
+            td.body-2 == TaxHelper.applied_taxes(subscription_fee)
+            td.body-2 = MoneyHelper.format(invoice_subscription.subscription_amount)
 
         - if subscription? && subscription_fees(subscription.id).charge_kind.any?
           / Charges payed in advance on payed in advance plan


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/hide-fees-at-zero

## Context

Users do not want to display subscription fee on invoice when the amount is 0.

## Description

This PR ensures that the subscription fee is hidden on the invoice except when no other charge fees are visible as well
