### PR TITLE
feat(wallet): Refresh wallet balance on update

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -22,13 +22,12 @@ module Api
       end
 
       def update
-        service = Wallets::UpdateService.new
-        result = service.update(
+        result = Wallets::UpdateService.call(
           wallet: current_organization.wallets.find_by(id: params[:id]),
-          args: WalletLegacyInput.new(
+          params: WalletLegacyInput.new(
             current_organization,
-            update_params.merge(id: params[:id]).to_h.deep_symbolize_keys,
-          ).update_input,
+            update_params.merge(id: params[:id]).to_h.deep_symbolize_keys
+          ).update_input
         )
 
         if result.success?

--- a/app/graphql/mutations/wallets/update.rb
+++ b/app/graphql/mutations/wallets/update.rb
@@ -17,13 +17,7 @@ module Mutations
 
       def resolve(**args)
         wallet = context[:current_user].wallets.find_by(id: args[:id])
-
-        result = ::Wallets::UpdateService
-          .new(context[:current_user])
-          .update(
-            wallet:,
-            args:,
-          )
+        result = ::Wallets::UpdateService.call(wallet:, params: args)
 
         result.success? ? result.wallet : result_error(result)
       end

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -2,17 +2,24 @@
 
 module Wallets
   class UpdateService < BaseService
-    def update(wallet:, args:)
+    def initialize(wallet:, params:)
+      @wallet = wallet
+      @params = params
+
+      super
+    end
+
+    def call
       return result.not_found_failure!(resource: 'wallet') unless wallet
-      return result unless valid_expiration_at?(expiration_at: args[:expiration_at])
-      return result unless valid_recurring_transaction_rules?(**args)
+      return result unless valid_expiration_at?(expiration_at: params[:expiration_at])
+      return result unless valid_recurring_transaction_rules?
 
       ActiveRecord::Base.transaction do
-        wallet.name = args[:name] if args.key?(:name)
-        wallet.expiration_at = args[:expiration_at] if args.key?(:expiration_at)
+        wallet.name = params[:name] if params.key?(:name)
+        wallet.expiration_at = params[:expiration_at] if params.key?(:expiration_at)
 
-        if args[:recurring_transaction_rules] && License.premium?
-          Wallets::RecurringTransactionRules::UpdateService.call(wallet:, params: args[:recurring_transaction_rules])
+        if params[:recurring_transaction_rules] && License.premium?
+          Wallets::RecurringTransactionRules::UpdateService.call(wallet:, params: params[:recurring_transaction_rules])
         end
 
         wallet.save!
@@ -26,8 +33,10 @@ module Wallets
 
     private
 
-    def valid_recurring_transaction_rules?(**args)
-      Wallets::ValidateRecurringTransactionRulesService.new(result, **args).valid?
+    attr_reader :wallet, :params
+
+    def valid_recurring_transaction_rules?
+      Wallets::ValidateRecurringTransactionRulesService.new(result, **params).valid?
     end
 
     def valid_expiration_at?(expiration_at:)

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -25,6 +25,8 @@ module Wallets
         wallet.save!
       end
 
+      Wallets::Balance::RefreshOngoingService.call(wallet:)
+
       result.wallet = wallet
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe Wallets::UpdateService, type: :service do
       end
     end
 
+    it "calls Wallets::Balance::RefreshOngoingService" do
+      allow(Wallets::Balance::RefreshOngoingService).to receive(:call)
+      update_service.call
+      expect(Wallets::Balance::RefreshOngoingService).to have_received(:call).with(wallet:)
+    end
+
     context 'when wallet is not found' do
       let(:wallet) { nil }
 


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to:
- Refactor `Wallets::UpdateService#update` to `Wallets::UpdateService#call`
- Refresh wallet balance on update