### PR TITLE
feat(tax-integration): add anrok model changes

### DIFF
--- a/app/models/integrations/anrok_integration.rb
+++ b/app/models/integrations/anrok_integration.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Integrations
+  class AnrokIntegration < BaseIntegration
+    validates :api_key, presence: true
+
+    secrets_accessors :api_key
+  end
+end

--- a/app/models/integrations/base_integration.rb
+++ b/app/models/integrations/base_integration.rb
@@ -34,6 +34,8 @@ module Integrations
         'Integrations::NetsuiteIntegration'
       when 'okta'
         'Integrations::OktaIntegration'
+      when 'anrok'
+        'Integrations::AnrokIntegration'
       else
         raise(NotImplementedError)
       end

--- a/spec/factories/integrations.rb
+++ b/spec/factories/integrations.rb
@@ -30,4 +30,15 @@ FactoryBot.define do
       {client_secret: SecureRandom.uuid}.to_json
     end
   end
+
+  factory :anrok_integration, class: 'Integrations::AnrokIntegration' do
+    organization
+    type { 'Integrations::AnrokIntegration' }
+    code { 'anrok' }
+    name { 'Anrok Integration' }
+
+    secrets do
+      {api_key: SecureRandom.uuid}.to_json
+    end
+  end
 end

--- a/spec/models/integrations/anrok_integration_spec.rb
+++ b/spec/models/integrations/anrok_integration_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::AnrokIntegration, type: :model do
+  subject(:anrok_integration) { build(:anrok_integration) }
+
+  it { is_expected.to validate_presence_of(:name) }
+
+  describe 'validations' do
+    it 'validates uniqueness of the code' do
+      expect(anrok_integration).to validate_uniqueness_of(:code).scoped_to(:organization_id)
+    end
+  end
+
+  describe '.api_key' do
+    it 'assigns and retrieve an api_key' do
+      anrok_integration.api_key = '123abc456'
+      expect(anrok_integration.api_key).to eq('123abc456')
+    end
+  end
+end


### PR DESCRIPTION
## Context

Lago does not support tax tool integrations, but support for it is being implemented.

## Description

This PR adds required model changes. We are using existing `integrations` table.
