### PR TITLE
fix(subscription): fix handling of started_at/ended_at

### DIFF
--- a/app/services/utils/datetime.rb
+++ b/app/services/utils/datetime.rb
@@ -3,7 +3,9 @@
 module Utils
   class Datetime
     def self.valid_format?(datetime)
-      datetime.respond_to?(:strftime) || datetime.is_a?(String) && DateTime._strptime(datetime).present?
+      datetime.respond_to?(:strftime) || datetime.is_a?(String) && Time.zone.parse(datetime.to_s).present?
+    rescue ArgumentError
+      false
     end
 
     def self.date_diff_with_timezone(from_datetime, to_datetime, timezone)

--- a/spec/services/utils/datetime_spec.rb
+++ b/spec/services/utils/datetime_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe Utils::Datetime, type: :service do
         expect(datetime).to be_valid_format(Time.current)
       end
     end
+
+    context 'when parameter is a string with microseconds' do
+      it 'returns true' do
+        expect(datetime).to be_valid_format('2024-05-30T09:45:44.394316274Z')
+      end
+    end
   end
 
   describe '.date_diff_with_timezone' do


### PR DESCRIPTION
## Context

Some issues have been reported on the go client with the handling of `started_at` and `ending_at`.
The go client is sending the values with milliseconds, leading to a bug with the validation on Lago side since the validator relies on `DateTime`, which is deprecated in favor of `Time`

## Description

This PR makes sure that Time with microseconds are correctly handled and validated
