### PR TITLE
feat(integrations): Trigger credit notes sync

### DIFF
--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -60,6 +60,10 @@ module CreditNotes
         deliver_webhook
         deliver_email
         handle_refund if should_handle_refund?
+
+        if credit_note.should_sync_credit_note?
+          Integrations::Aggregator::CreditNotes::CreateJob.perform_later(credit_note:)
+        end
       end
 
       result

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -130,6 +130,10 @@ RSpec.describe CreditNotes::CreateService, type: :service do
       end.to have_enqueued_job(SendEmailJob)
     end
 
+    it_behaves_like 'syncs credit note' do
+      let(:service_call) { create_service.call }
+    end
+
     context 'when organization does not have right email settings' do
       before { invoice.organization.update!(email_settings: []) }
 

--- a/spec/support/shared_examples/integrations.rb
+++ b/spec/support/shared_examples/integrations.rb
@@ -33,3 +33,20 @@ RSpec.shared_examples 'syncs sales order' do
     end
   end
 end
+
+RSpec.shared_examples 'syncs credit note' do
+  context 'when it should sync credit note' do
+    let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+    let(:integration) { create(:netsuite_integration, organization:, sync_credit_notes: true) }
+
+    before do
+      allow(Integrations::Aggregator::CreditNotes::CreateJob).to receive(:perform_later)
+      integration_customer
+      service_call
+    end
+
+    it 'enqueues Integrations::Aggregator::CreditNotes::CreateJob' do
+      expect(Integrations::Aggregator::CreditNotes::CreateJob).to have_received(:perform_later)
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR modifies credit notes service to enqueue sync jobs for credit notes.