### PR TITLE
feat(wallet): Add started_at to recurring_transaction_rules

### DIFF
--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -91,6 +91,7 @@ module Api
           recurring_transaction_rules: [
             :interval,
             :method,
+            :started_at,
             :target_ongoing_balance,
             :threshold_credits,
             :trigger
@@ -111,6 +112,7 @@ module Api
             :lago_id,
             :interval,
             :method,
+            :started_at,
             :target_ongoing_balance,
             :threshold_credits,
             :trigger,

--- a/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/create_input.rb
@@ -8,6 +8,7 @@ module Types
 
         argument :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, required: false
         argument :method, Types::Wallets::RecurringTransactionRules::MethodEnum, required: false
+        argument :started_at, GraphQL::Types::ISO8601DateTime, required: false
         argument :target_ongoing_balance, String, required: false
         argument :threshold_credits, String, required: false
         argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: true

--- a/app/graphql/types/wallets/recurring_transaction_rules/object.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/object.rb
@@ -12,6 +12,7 @@ module Types
         field :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, null: true
         field :method, Types::Wallets::RecurringTransactionRules::MethodEnum, null: false
         field :paid_credits, String, null: false
+        field :started_at, GraphQL::Types::ISO8601DateTime, null: true
         field :target_ongoing_balance, String, null: true
         field :threshold_credits, String, null: true
         field :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, null: false

--- a/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/update_input.rb
@@ -11,6 +11,7 @@ module Types
         argument :lago_id, ID, required: false
         argument :method, Types::Wallets::RecurringTransactionRules::MethodEnum, required: false
         argument :paid_credits, String, required: false
+        argument :started_at, GraphQL::Types::ISO8601DateTime, required: false
         argument :target_ongoing_balance, String, required: false
         argument :threshold_credits, String, required: false
         argument :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, required: false

--- a/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
+++ b/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
@@ -10,6 +10,7 @@ module V1
           granted_credits: model.granted_credits,
           interval: model.interval,
           method: model.method,
+          started_at: model.started_at&.iso8601,
           target_ongoing_balance: model.target_ongoing_balance,
           threshold_credits: model.threshold_credits,
           trigger: model.trigger,

--- a/app/services/wallets/recurring_transaction_rules/create_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/create_service.rb
@@ -24,6 +24,7 @@ module Wallets
           threshold_credits: rule_params[:threshold_credits] || 0.0,
           interval: rule_params[:interval],
           method:,
+          started_at: rule_params[:started_at],
           target_ongoing_balance: rule_params[:target_ongoing_balance],
           trigger: rule_params[:trigger].to_s
         )

--- a/db/migrate/20240530123427_add_started_at_to_recurring_transaction_rules.rb
+++ b/db/migrate/20240530123427_add_started_at_to_recurring_transaction_rules.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddStartedAtToRecurringTransactionRules < ActiveRecord::Migration[7.0]
+  def change
+    add_column :recurring_transaction_rules, :started_at, :datetime
+    add_index :recurring_transaction_rules, :started_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_22_105942) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_30_123427) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -896,6 +896,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_05_22_105942) do
     t.datetime "updated_at", null: false
     t.integer "method", default: 0, null: false
     t.decimal "target_ongoing_balance", precision: 30, scale: 5
+    t.datetime "started_at"
+    t.index ["started_at"], name: "index_recurring_transaction_rules_on_started_at"
     t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
   end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1976,6 +1976,7 @@ input CreatePlanInput {
 input CreateRecurringTransactionRuleInput {
   interval: RecurringTransactionIntervalEnum
   method: RecurringTransactionMethodEnum
+  startedAt: ISO8601DateTime
   targetOngoingBalance: String
   thresholdCredits: String
   trigger: RecurringTransactionTriggerEnum!
@@ -5604,6 +5605,7 @@ type RecurringTransactionRule {
   lagoId: ID!
   method: RecurringTransactionMethodEnum!
   paidCredits: String!
+  startedAt: ISO8601DateTime
   targetOngoingBalance: String
   thresholdCredits: String
   trigger: RecurringTransactionTriggerEnum!
@@ -6926,6 +6928,7 @@ input UpdateRecurringTransactionRuleInput {
   lagoId: ID
   method: RecurringTransactionMethodEnum
   paidCredits: String
+  startedAt: ISO8601DateTime
   targetOngoingBalance: String
   thresholdCredits: String
   trigger: RecurringTransactionTriggerEnum

--- a/schema.json
+++ b/schema.json
@@ -7964,6 +7964,18 @@
               "deprecationReason": null
             },
             {
+              "name": "startedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "targetOngoingBalance",
               "description": null,
               "type": {
@@ -28388,6 +28400,20 @@
               ]
             },
             {
+              "name": "startedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "targetOngoingBalance",
               "description": null,
               "type": {
@@ -33619,6 +33645,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
                 "ofType": null
               },
               "defaultValue": null,

--- a/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/create_input_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::CreateInput do
 
   it { is_expected.to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum') }
   it { is_expected.to accept_argument(:method).of_type('RecurringTransactionMethodEnum') }
+  it { is_expected.to accept_argument(:started_at).of_type('ISO8601DateTime') }
   it { is_expected.to accept_argument(:target_ongoing_balance).of_type('String') }
   it { is_expected.to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum!') }
   it { is_expected.to accept_argument(:threshold_credits).of_type('String') }

--- a/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/object_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::Object do
   it { is_expected.to have_field(:trigger).of_type('RecurringTransactionTriggerEnum!') }
   it { is_expected.to have_field(:interval).of_type('RecurringTransactionIntervalEnum') }
 
+  it { is_expected.to have_field(:started_at).of_type('ISO8601DateTime') }
   it { is_expected.to have_field(:target_ongoing_balance).of_type('String') }
   it { is_expected.to have_field(:threshold_credits).of_type('String') }
   it { is_expected.to have_field(:paid_credits).of_type('String!') }

--- a/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
+++ b/spec/graphql/types/wallets/recurring_transaction_rules/update_input_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Types::Wallets::RecurringTransactionRules::UpdateInput do
 
   it { is_expected.to accept_argument(:interval).of_type('RecurringTransactionIntervalEnum') }
   it { is_expected.to accept_argument(:method).of_type('RecurringTransactionMethodEnum') }
+  it { is_expected.to accept_argument(:started_at).of_type('ISO8601DateTime') }
   it { is_expected.to accept_argument(:target_ongoing_balance).of_type('String') }
   it { is_expected.to accept_argument(:trigger).of_type('RecurringTransactionTriggerEnum') }
   it { is_expected.to accept_argument(:threshold_credits).of_type('String') }

--- a/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
+++ b/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ::V1::Wallets::RecurringTransactionRuleSerializer do
       "trigger" => recurring_transaction_rule.trigger,
       "interval" => recurring_transaction_rule.interval,
       "paid_credits" => recurring_transaction_rule.paid_credits.to_s,
+      "started_at" => recurring_transaction_rule.started_at&.iso8601,
       "target_ongoing_balance" => recurring_transaction_rule.target_ongoing_balance,
       "threshold_credits" => recurring_transaction_rule.threshold_credits.to_s,
       "granted_credits" => recurring_transaction_rule.granted_credits.to_s,

--- a/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Wallets::RecurringTransactionRules::CreateService do
       method: "target",
       paid_credits: "10.0",
       granted_credits: "5.0",
+      started_at: "2024-05-30T12:48:26Z",
       target_ongoing_balance: "100.0",
       trigger: "interval"
     }
@@ -43,6 +44,7 @@ RSpec.describe Wallets::RecurringTransactionRules::CreateService do
           interval: "monthly",
           method: "target",
           paid_credits: 10.0,
+          started_at: Time.parse("2024-05-30T12:48:26Z"),
           target_ongoing_balance: 100.0,
           threshold_credits: 0.0,
           trigger: "interval"

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
   subject(:update_service) { described_class.new(wallet:, params:) }
@@ -11,18 +11,19 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
     [
       {
         lago_id: recurring_transaction_rule.id,
-        trigger: 'interval',
-        interval: 'weekly',
-        paid_credits: '105',
-        granted_credits: '105'
+        trigger: "interval",
+        interval: "weekly",
+        paid_credits: "105",
+        granted_credits: "105",
+        started_at: "2024-05-30T12:48:26Z"
       }
     ]
   end
 
-  describe '#call' do
+  describe "#call" do
     before { recurring_transaction_rule }
 
-    it 'updates existing recurring transaction rule' do
+    it "updates existing recurring transaction rule" do
       result = update_service.call
 
       rule = result.wallet.reload.recurring_transaction_rules.first
@@ -35,13 +36,14 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
           interval: "weekly",
           method: "fixed",
           paid_credits: 105.0,
+          started_at: Time.parse("2024-05-30T12:48:26Z"),
           threshold_credits: 0.0,
           trigger: "interval"
         )
       end
     end
 
-    context 'with added rule without id' do
+    context "with added rule without id" do
       let(:params) do
         [
           {
@@ -55,7 +57,7 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
         ]
       end
 
-      it 'creates new recurring transaction rule and removes existing' do
+      it "creates new recurring transaction rule and removes existing" do
         result = update_service.call
 
         rule = result.wallet.reload.recurring_transaction_rules.first
@@ -76,12 +78,12 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
       end
     end
 
-    context 'when empty array is sent as argument' do
+    context "when empty array is sent as argument" do
       let(:params) do
         []
       end
 
-      it 'sanitizes not needed rules' do
+      it "sanitizes not needed rules" do
         result = update_service.call
 
         expect(result.wallet.reload.recurring_transaction_rules.count).to eq(0)


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/define-a-target-balance-to-reach-for-recurring-top-up

## Context

We want to allow users to top-up their wallets to reach a specific target balance.

We can currently define a fixed top-up but we want to add the ability to specify a dynamic top-up (target balance to reach).

## Description

The goal of this PR is to add `started_at` to `recurring_transaction_rules`.