### PR TITLE
fix(integrations): Fix has_mappings_configured in netsuite GraphQL type

### DIFF
--- a/app/graphql/types/integrations/netsuite.rb
+++ b/app/graphql/types/integrations/netsuite.rb
@@ -28,7 +28,6 @@ module Types
       def has_mappings_configured
         object.integration_collection_mappings
           .where(type: 'IntegrationCollectionMappings::NetsuiteCollectionMapping')
-          .where(mapping_type: :fallback_item)
           .any?
       end
     end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR fixes `has_mappings_configured` in netsuite GraphQL type