### PR TITLE
feat (tax-integrations): add anrok graphql type

### DIFF
--- a/app/graphql/resolvers/integrations_resolver.rb
+++ b/app/graphql/resolvers/integrations_resolver.rb
@@ -29,6 +29,8 @@ module Resolvers
         'Integrations::NetsuiteIntegration'
       when 'okta'
         'Integrations::OktaIntegration'
+      when 'anrok'
+        'Integrations::AnrokIntegration'
       else
         raise(NotImplementedError)
       end

--- a/app/graphql/types/integrations/anrok.rb
+++ b/app/graphql/types/integrations/anrok.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Types
+  module Integrations
+    class Anrok < Types::BaseObject
+      graphql_name 'AnrokIntegration'
+
+      field :api_key, String, null: false
+      field :code, String, null: false
+      field :has_mappings_configured, Boolean
+      field :id, ID, null: false
+      field :name, String, null: false
+
+      # NOTE: Client secret is a sensitive information. It should not be sent back to the
+      #       front end application. Instead we send an obfuscated value
+      def api_key
+        "#{"•" * 8}…#{object.api_key[-3..]}"
+      end
+
+      def has_mappings_configured
+        object.integration_collection_mappings.where(type: 'IntegrationCollectionMappings::AnrokCollectionMapping').any?
+      end
+    end
+  end
+end

--- a/app/graphql/types/integrations/object.rb
+++ b/app/graphql/types/integrations/object.rb
@@ -6,7 +6,8 @@ module Types
       graphql_name 'Integration'
 
       possible_types Types::Integrations::Netsuite,
-        Types::Integrations::Okta
+        Types::Integrations::Okta,
+        Types::Integrations::Anrok
 
       def self.resolve_type(object, _context)
         case object.class.to_s
@@ -14,6 +15,8 @@ module Types
           Types::Integrations::Netsuite
         when 'Integrations::OktaIntegration'
           Types::Integrations::Okta
+        when 'Integrations::AnrokIntegration'
+          Types::Integrations::Anrok
         else
           raise "Unexpected integration type: #{object.inspect}"
         end

--- a/schema.graphql
+++ b/schema.graphql
@@ -115,6 +115,14 @@ enum AggregationTypeEnum {
   weighted_sum_agg
 }
 
+type AnrokIntegration {
+  apiKey: String!
+  code: String!
+  hasMappingsConfigured: Boolean
+  id: ID!
+  name: String!
+}
+
 type AppliedAddOn {
   addOn: AddOn!
   amountCents: BigInt!
@@ -3617,7 +3625,7 @@ An ISO 8601-encoded datetime
 """
 scalar ISO8601DateTime
 
-union Integration = NetsuiteIntegration | OktaIntegration
+union Integration = AnrokIntegration | NetsuiteIntegration | OktaIntegration
 
 type IntegrationCollection {
   collection: [Integration!]!

--- a/schema.json
+++ b/schema.json
@@ -923,6 +923,105 @@
         },
         {
           "kind": "OBJECT",
+          "name": "AnrokIntegration",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "apiKey",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "code",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "hasMappingsConfigured",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "AppliedAddOn",
           "description": null,
           "interfaces": [
@@ -16282,6 +16381,11 @@
           "description": null,
           "interfaces": null,
           "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "AnrokIntegration",
+              "ofType": null
+            },
             {
               "kind": "OBJECT",
               "name": "NetsuiteIntegration",

--- a/spec/graphql/types/integrations/anrok_spec.rb
+++ b/spec/graphql/types/integrations/anrok_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Integrations::Anrok do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type('ID!') }
+
+  it { is_expected.to have_field(:api_key).of_type('String!') }
+  it { is_expected.to have_field(:code).of_type('String!') }
+  it { is_expected.to have_field(:has_mappings_configured).of_type('Boolean') }
+  it { is_expected.to have_field(:name).of_type('String!') }
+end


### PR DESCRIPTION
## Context

Lago does not support tax tool integrations, but support for it is currently being implemented.

## Description

This PR adds required graphql type for Anrok integration