### PR TITLE
misc: Add a task to soft remove duplicated filters

### DIFF
--- a/lib/tasks/filters.rake
+++ b/lib/tasks/filters.rake
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+namespace :filters do
+  desc 'Clean duplicated filters'
+  task :deduplicate => :environment do
+    charges = Charge.joins(:filters).includes(filters: { values: :billable_metric_filter }).distinct
+
+    charges.find_each do |charge|
+      next if charge.filters.count <= 1
+
+      charge.filters.each do |filter|
+        h = filter.to_h
+        next if filter.reload.deleted_at.present?
+
+        duplicates = charge.filters.select do |f|
+          next false if f.id == filter.id
+          next false if f.reload.deleted_at.present?
+
+          h.keys.sort == f.to_h.keys.sort && h.keys.all? { |k| h[k].sort == f.to_h[k].sort }
+        end
+
+        duplicates.each { |f| f.discard! }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

In some cases, the migration from groups to charge filters introduces some duplicated filters, leading to a risk of double billing of some events on some production accounts.

## Description

This PR introduces a new `filters:deduplicate` rake task to remove duplicated filters and only keep one for each group of keys/values 