### PR TITLE
fix(integrations): Add external_integration_id to CreditNote GraphQL type

### DIFF
--- a/app/graphql/types/credit_notes/object.rb
+++ b/app/graphql/types/credit_notes/object.rb
@@ -45,6 +45,7 @@ module Types
         description 'Check if credit note can be voided'
       end
 
+      field :external_integration_id, String, null: true
       field :integration_syncable, GraphQL::Types::Boolean, null: false
 
       def applied_taxes

--- a/schema.graphql
+++ b/schema.graphql
@@ -2028,6 +2028,7 @@ type CreditNote {
   currency: CurrencyEnum!
   customer: Customer!
   description: String
+  externalIntegrationId: String
   fileUrl: String
   id: ID!
   integrationSyncable: Boolean!

--- a/schema.json
+++ b/schema.json
@@ -8446,6 +8446,20 @@
               ]
             },
             {
+              "name": "externalIntegrationId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "fileUrl",
               "description": null,
               "type": {

--- a/spec/graphql/types/credit_notes/object_spec.rb
+++ b/spec/graphql/types/credit_notes/object_spec.rb
@@ -42,5 +42,6 @@ RSpec.describe Types::CreditNotes::Object do
 
   it { is_expected.to have_field(:can_be_voided).of_type('Boolean!') }
 
+  it { is_expected.to have_field(:external_integration_id).of_type('String') }
   it { is_expected.to have_field(:integration_syncable).of_type('Boolean!') }
 end

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -50,5 +50,6 @@ RSpec.describe Types::Invoices::Object do
   it { is_expected.to have_field(:invoice_subscriptions).of_type('[InvoiceSubscription!]') }
   it { is_expected.to have_field(:subscriptions).of_type('[Subscription!]') }
 
+  it { is_expected.to have_field(:external_integration_id).of_type('String') }
   it { is_expected.to have_field(:integration_syncable).of_type('Boolean!') }
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR adds external_integration_id to CreditNote GraphQL type