### PR TITLE
fix(integrations): Add external_integration_id method to credit note …

### DIFF
--- a/app/graphql/types/credit_notes/object.rb
+++ b/app/graphql/types/credit_notes/object.rb
@@ -56,6 +56,19 @@ module Types
         object.should_sync_credit_note? &&
           object.integration_resources.where(resource_type: 'credit_note', syncable_type: 'CreditNote').none?
       end
+
+      def external_integration_id
+        integration_customer = object.customer&.integration_customers&.first
+
+        return nil unless integration_customer
+
+        IntegrationResource.find_by(
+          integration: integration_customer.integration,
+          syncable_id: object.id,
+          syncable_type: 'CreditNote',
+          resource_type: :credit_note
+        )&.external_id
+      end
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR adds missing `external_integration_id` method to credit note GraphQL type.