### PR TITLE
fix(rbac): Adjust permissions

### DIFF
--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -32,7 +32,6 @@ subscriptions:
   view: true
   create:
   update:
-  delete:
 wallets:
   create:
   update:

--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -29,7 +29,7 @@ customers:
   update:
   delete:
 subscriptions:
-  view:
+  view: true
   create:
   update:
   delete:

--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -27,7 +27,6 @@ customers:
 subscriptions:
   create: false
   update: false
-  delete: false
 wallets:
   create: false
   update: false

--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -27,7 +27,6 @@ customers:
 subscriptions:
   create: true
   update: true
-  delete: true
 wallets:
   create: true
   update: true

--- a/app/graphql/concerns/can_require_permissions.rb
+++ b/app/graphql/concerns/can_require_permissions.rb
@@ -7,7 +7,10 @@ module CanRequirePermissions
 
   def ready?(**args)
     if defined? self.class::REQUIRED_PERMISSION
-      has_permission = context.dig(:permissions, self.class::REQUIRED_PERMISSION)
+      permissions_list = Array.wrap(self.class::REQUIRED_PERMISSION)
+      has_permission = permissions_list.any? do |permission|
+        context.dig(:permissions, permission)
+      end
       raise not_enough_permissions_error unless has_permission
     end
 

--- a/app/graphql/mutations/customers/update.rb
+++ b/app/graphql/mutations/customers/update.rb
@@ -5,7 +5,13 @@ module Mutations
     class Update < BaseMutation
       include AuthenticableApiUser
 
-      REQUIRED_PERMISSION = 'customers:update'
+      REQUIRED_PERMISSION = %w[
+        customers:update
+        customer_settings:update:tax_rates
+        customer_settings:update:payment_terms
+        customer_settings:update:grace_period
+        customer_settings:update:lang
+      ]
 
       graphql_name 'UpdateCustomer'
       description 'Updates an existing Customer'

--- a/app/graphql/mutations/customers/update_invoice_grace_period.rb
+++ b/app/graphql/mutations/customers/update_invoice_grace_period.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+# TODO: Remove this mutation
+# The Mutations::Customers::Update allows you to modify the customer grace period
 module Mutations
   module Customers
     class UpdateInvoiceGracePeriod < BaseMutation
       include AuthenticableApiUser
 
-      REQUIRED_PERMISSION = 'customers:update'
+      REQUIRED_PERMISSION = %w[customers:update customer_settings:update:grace_period]
 
       graphql_name 'UpdateCustomerInvoiceGracePeriod'
       description 'Assign the invoice grace period to Customers'

--- a/app/graphql/resolvers/payment_providers_resolver.rb
+++ b/app/graphql/resolvers/payment_providers_resolver.rb
@@ -5,7 +5,7 @@ module Resolvers
     include AuthenticableApiUser
     include RequiredOrganization
 
-    REQUIRED_PERMISSION = 'organization:integrations:view'
+    REQUIRED_PERMISSION = %w[organization:integrations:view customers:view]
 
     description "Query organization's payment providers"
 
@@ -26,11 +26,11 @@ module Resolvers
     def provider_type(type)
       case type
       when 'adyen'
-        'PaymentProviders::AdyenProvider'
+        PaymentProviders::AdyenProvider.to_s
       when 'stripe'
-        'PaymentProviders::StripeProvider'
+        PaymentProviders::StripeProvider.to_s
       when 'gocardless'
-        'PaymentProviders::GocardlessProvider'
+        PaymentProviders::GocardlessProvider.to_s
       else
         raise(NotImplementedError)
       end

--- a/app/graphql/types/base_argument.rb
+++ b/app/graphql/types/base_argument.rb
@@ -4,8 +4,13 @@ module Types
   class BaseArgument < GraphQL::Schema::Argument
     attr_reader :permissions
 
-    def initialize(*args, permission: nil, **kwargs, &block)
-      @permissions = [permission].compact
+    def initialize(*args, permission: nil, permissions: nil, **kwargs, &block)
+      @permissions = if permission
+        [permission].compact
+      elsif permissions
+        Array.wrap(permissions).compact
+      end
+
       super(*args, **kwargs, &block)
     end
   end

--- a/app/graphql/types/customers/billing_configuration_input.rb
+++ b/app/graphql/types/customers/billing_configuration_input.rb
@@ -5,7 +5,7 @@ module Types
     class BillingConfigurationInput < BaseInputObject
       graphql_name 'CustomerBillingConfigurationInput'
 
-      argument :document_locale, String, required: false
+      argument :document_locale, String, required: false, permissions: %w[customers:create customers:update customer_settings:update:lang]
     end
   end
 end

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -7,35 +7,37 @@ module Types
 
       argument :id, ID, required: true
 
-      argument :address_line1, String, required: false
-      argument :address_line2, String, required: false
-      argument :city, String, required: false
-      argument :country, Types::CountryCodeEnum, required: false
-      argument :currency, Types::CurrencyEnum, required: false
-      argument :email, String, required: false
-      argument :external_id, String, required: true
-      argument :external_salesforce_id, String, required: false
-      argument :invoice_grace_period, Integer, required: false
-      argument :legal_name, String, required: false
-      argument :legal_number, String, required: false
-      argument :logo_url, String, required: false
-      argument :name, String, required: true
-      argument :net_payment_term, Integer, required: false
-      argument :phone, String, required: false
-      argument :state, String, required: false
-      argument :tax_codes, [String], required: false
-      argument :tax_identification_number, String, required: false
-      argument :timezone, Types::TimezoneEnum, required: false
-      argument :url, String, required: false
-      argument :zipcode, String, required: false
+      argument :address_line1, String, required: false, permission: 'customers:update'
+      argument :address_line2, String, required: false, permission: 'customers:update'
+      argument :city, String, required: false, permission: 'customers:update'
+      argument :country, Types::CountryCodeEnum, required: false, permission: 'customers:update'
+      argument :currency, Types::CurrencyEnum, required: false, permission: 'customers:update'
+      argument :email, String, required: false, permission: 'customers:update'
+      argument :external_id, String, required: true, permission: 'customers:update'
+      argument :external_salesforce_id, String, required: false, permission: 'customers:update'
+      argument :legal_name, String, required: false, permission: 'customers:update'
+      argument :legal_number, String, required: false, permission: 'customers:update'
+      argument :logo_url, String, required: false, permission: 'customers:update'
+      argument :name, String, required: true, permission: 'customers:update'
+      argument :phone, String, required: false, permission: 'customers:update'
+      argument :state, String, required: false, permission: 'customers:update'
+      argument :tax_identification_number, String, required: false, permission: 'customers:update'
+      argument :timezone, Types::TimezoneEnum, required: false, permission: 'customers:update'
+      argument :url, String, required: false, permission: 'customers:update'
+      argument :zipcode, String, required: false, permission: 'customers:update'
 
-      argument :metadata, [Types::Customers::Metadata::Input], required: false
+      argument :metadata, [Types::Customers::Metadata::Input], required: false, permission: 'customers:update'
 
-      argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false
-      argument :payment_provider_code, String, required: false
-      argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false
+      argument :payment_provider, Types::PaymentProviders::ProviderTypeEnum, required: false, permission: 'customers:update'
+      argument :payment_provider_code, String, required: false, permission: 'customers:update'
+      argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false, permission: 'customers:update'
 
-      argument :integration_customer, Types::IntegrationCustomers::Input, required: false
+      argument :integration_customer, Types::IntegrationCustomers::Input, required: false, permission: 'customers:update'
+
+      # Customer settings
+      argument :invoice_grace_period, Integer, required: false, permissions: %w[customer_settings:update:grace_period customers:update]
+      argument :net_payment_term, Integer, required: false, permissions: %w[customer_settings:update:payment_terms customers:update]
+      argument :tax_codes, [String], required: false, permissions: %w[customer_settings:update:tax_rates customers:update]
 
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false
     end

--- a/app/graphql/types/payment_providers/adyen.rb
+++ b/app/graphql/types/payment_providers/adyen.rb
@@ -5,14 +5,15 @@ module Types
     class Adyen < Types::BaseObject
       graphql_name 'AdyenProvider'
 
-      field :api_key, String, null: true
       field :code, String, null: false
-      field :hmac_key, String, null: true
       field :id, ID, null: false
-      field :live_prefix, String, null: true
-      field :merchant_account, String, null: false
       field :name, String, null: false
-      field :success_redirect_url, String, null: true
+
+      field :api_key, String, null: true, permission: 'organization:integrations:view'
+      field :hmac_key, String, null: true, permission: 'organization:integrations:view'
+      field :live_prefix, String, null: true, permission: 'organization:integrations:view'
+      field :merchant_account, String, null: false, permission: 'organization:integrations:view'
+      field :success_redirect_url, String, null: true, permission: 'organization:integrations:view'
 
       # NOTE: Api key is a sensitive information. It should not be sent back to the
       #       front end application. Instead we send an obfuscated value

--- a/app/graphql/types/payment_providers/gocardless.rb
+++ b/app/graphql/types/payment_providers/gocardless.rb
@@ -6,11 +6,12 @@ module Types
       graphql_name 'GocardlessProvider'
 
       field :code, String, null: false
-      field :has_access_token, Boolean, null: false
       field :id, ID, null: false
       field :name, String, null: false
-      field :success_redirect_url, String, null: true
-      field :webhook_secret, String, null: true
+
+      field :has_access_token, Boolean, null: false, permission: 'organization:integrations:view'
+      field :success_redirect_url, String, null: true, permission: 'organization:integrations:view'
+      field :webhook_secret, String, null: true, permission: 'organization:integrations:view'
 
       # NOTE: Access token is a sensitive information. It should not be sent back to the
       #       front end application

--- a/app/graphql/types/payment_providers/stripe.rb
+++ b/app/graphql/types/payment_providers/stripe.rb
@@ -8,8 +8,9 @@ module Types
       field :code, String, null: false
       field :id, ID, null: false
       field :name, String, null: false
-      field :secret_key, String, null: true
-      field :success_redirect_url, String, null: true
+
+      field :secret_key, String, null: true, permission: 'organization:integrations:view'
+      field :success_redirect_url, String, null: true, permission: 'organization:integrations:view'
 
       # NOTE: Secret key is a sensitive information. It should not be sent back to the
       #       front end application. Instead we send an obfuscated value

--- a/schema.graphql
+++ b/schema.graphql
@@ -100,7 +100,7 @@ type AdyenProvider {
   hmacKey: String
   id: ID!
   livePrefix: String
-  merchantAccount: String!
+  merchantAccount: String
   name: String!
   successRedirectUrl: String
 }
@@ -3534,7 +3534,7 @@ type GenerateCustomerPortalUrlPayload {
 
 type GocardlessProvider {
   code: String!
-  hasAccessToken: Boolean!
+  hasAccessToken: Boolean
   id: ID!
   name: String!
   successRedirectUrl: String
@@ -5032,7 +5032,6 @@ type Permissions {
   plansUpdate: Boolean!
   plansView: Boolean!
   subscriptionsCreate: Boolean!
-  subscriptionsDelete: Boolean!
   subscriptionsUpdate: Boolean!
   subscriptionsView: Boolean!
   walletsCreate: Boolean!

--- a/schema.json
+++ b/schema.json
@@ -818,13 +818,9 @@
               "name": "merchantAccount",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -15589,13 +15585,9 @@
               "name": "hasAccessToken",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -24470,24 +24462,6 @@
               ]
             },
             {
-              "name": "subscriptionsDelete",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "subscriptionsUpdate",
               "description": null,
               "type": {
@@ -32406,18 +32380,6 @@
               "deprecationReason": null
             },
             {
-              "name": "invoiceGracePeriod",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "legalName",
               "description": null,
               "type": {
@@ -32470,18 +32432,6 @@
               "deprecationReason": null
             },
             {
-              "name": "netPaymentTerm",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "phone",
               "description": null,
               "type": {
@@ -32500,26 +32450,6 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "taxCodes",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                }
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -32636,6 +32566,50 @@
                 "kind": "INPUT_OBJECT",
                 "name": "IntegrationCustomerInput",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoiceGracePeriod",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "netPaymentTerm",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxCodes",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/mutations/customers/update_invoice_grace_period_spec.rb
+++ b/spec/graphql/mutations/customers/update_invoice_grace_period_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Mutations::Customers::UpdateInvoiceGracePeriod, type: :graphql do
-  let(:required_permissions) { 'customers:update' }
+  let(:required_permissions) { 'customer_settings:update:grace_period' }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
@@ -24,7 +24,7 @@ RSpec.describe Mutations::Customers::UpdateInvoiceGracePeriod, type: :graphql do
   around { |test| lago_premium!(&test) }
 
   it_behaves_like 'requires current user'
-  it_behaves_like 'requires permission', 'customers:update'
+  it_behaves_like 'requires permission', %w[customers:update customer_settings:update:grace_period]
 
   it 'updates a customer' do
     result = execute_graphql(

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
             invoiceGracePeriod: 2,
             timezone: 'TZ_EUROPE_PARIS'
           })
-        },
+        }
       )
 
       result_data = result['data']['updateCustomer']

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
   let(:customer) { create(:customer, organization:) }
   let(:stripe_provider) { create(:stripe_provider, organization:) }
   let(:tax) { create(:tax, organization:) }
+  let(:external_id) { SecureRandom.uuid }
 
   let(:mutation) do
     <<~GQL
@@ -40,6 +41,33 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
     }
   end
 
+  let(:input) do
+    {
+      id: customer.id,
+      name: 'Updated customer',
+      taxIdentificationNumber: '2246',
+      externalId: external_id,
+      paymentProvider: 'stripe',
+      currency: 'USD',
+      netPaymentTerm: 3,
+      providerCustomer: {
+        providerCustomerId: 'cu_12345',
+        providerPaymentMethods: %w[card sepa_debit]
+      },
+      billingConfiguration: {
+        documentLocale: 'fr'
+      },
+      metadata: [
+        {
+          key: 'test-key',
+          value: 'value',
+          displayInInvoice: true
+        }
+      ],
+      taxCodes: [tax.code]
+    }
+  end
+
   before do
     stub_request(:post, 'https://api.stripe.com/v1/checkout/sessions')
       .to_return(status: 200, body: body.to_json, headers: {})
@@ -48,41 +76,23 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
   end
 
   it_behaves_like 'requires current user'
-  it_behaves_like 'requires permission', 'customers:update'
+  it_behaves_like 'requires permission', %w[
+    customers:update
+    customer_settings:update:tax_rates
+    customer_settings:update:payment_terms
+    customer_settings:update:grace_period
+    customer_settings:update:lang
+  ]
 
   it 'updates a customer' do
     stripe_provider
-    external_id = SecureRandom.uuid
 
     result = execute_graphql(
       current_user: membership.user,
       permissions: required_permissions,
       query: mutation,
       variables: {
-        input: {
-          id: customer.id,
-          name: 'Updated customer',
-          taxIdentificationNumber: '2246',
-          externalId: external_id,
-          paymentProvider: 'stripe',
-          currency: 'EUR',
-          netPaymentTerm: 3,
-          providerCustomer: {
-            providerCustomerId: 'cu_12345',
-            providerPaymentMethods: %w[card sepa_debit]
-          },
-          billingConfiguration: {
-            documentLocale: 'fr'
-          },
-          metadata: [
-            {
-              key: 'test-key',
-              value: 'value',
-              displayInInvoice: true
-            }
-          ],
-          taxCodes: [tax.code]
-        }
+        input:
       }
     )
 
@@ -94,7 +104,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       expect(result_data['taxIdentificationNumber']).to eq('2246')
       expect(result_data['externalId']).to eq(external_id)
       expect(result_data['paymentProvider']).to eq('stripe')
-      expect(result_data['currency']).to eq('EUR')
+      expect(result_data['currency']).to eq('USD')
       expect(result_data['timezone']).to be_nil
       expect(result_data['netPaymentTerm']).to eq(3)
       expect(result_data['invoiceGracePeriod']).to be_nil
@@ -132,6 +142,50 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       aggregate_failures do
         expect(result_data['timezone']).to eq('TZ_EUROPE_PARIS')
         expect(result_data['invoiceGracePeriod']).to eq(2)
+      end
+    end
+  end
+
+  context 'when user can only update customer settings' do
+    around { |test| lago_premium!(&test) }
+
+    it 'updates a customer' do
+      result = execute_graphql(
+        current_user: membership.user,
+        permissions: %w[
+          customer_settings:update:tax_rates
+          customer_settings:update:payment_terms
+          customer_settings:update:grace_period
+          customer_settings:update:lang
+        ],
+        query: mutation,
+        variables: {
+          input: input.merge({
+            invoiceGracePeriod: 2,
+            timezone: 'TZ_EUROPE_PARIS'
+          })
+        },
+      )
+
+      result_data = result['data']['updateCustomer']
+
+      aggregate_failures do
+        # What should have changed
+        expect(result_data['id']).to be_present
+        expect(result_data['taxes'][0]['code']).to eq(tax.code)
+        expect(result_data['netPaymentTerm']).to eq(3)
+        expect(result_data['invoiceGracePeriod']).to eq 2
+        expect(result_data['billingConfiguration']['documentLocale']).to eq('fr')
+
+        # What should not have changed
+        expect(result_data['name']).not_to eq('Updated customer')
+        expect(result_data['taxIdentificationNumber']).to be_nil
+        expect(result_data['externalId']).not_to eq(external_id)
+        expect(result_data['paymentProvider']).to be_nil
+        expect(result_data['currency']).to eq('EUR')
+        expect(result_data['timezone']).to be_nil
+        expect(result_data['providerCustomer']).to be_nil
+        expect(result_data['metadata']).to be_empty
       end
     end
   end

--- a/spec/graphql/mutations/integrations/anrok/update_spec.rb
+++ b/spec/graphql/mutations/integrations/anrok/update_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Mutations::Integrations::Anrok::Update, type: :graphql do
           code:,
           apiKey: api_key
         }
-      },
+      }
     )
 
     result_data = result['data']['updateAnrokIntegration']

--- a/spec/graphql/mutations/payment_providers/adyen/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/adyen/create_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe Mutations::PaymentProviders::Adyen::Create, type: :graphql do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
-      permissions: required_permission,
+      # You wouldn't have `create` without `view` permission
+      # `view` is necessary to retrieve the created record in the response
+      permissions: [required_permission, 'organization:integrations:view'],
       query: mutation,
       variables: {
         input: {

--- a/spec/graphql/mutations/payment_providers/adyen/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/adyen/update_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe Mutations::PaymentProviders::Adyen::Update, type: :graphql do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
-      permissions: required_permission,
+      # You wouldn't have `create` without `view` permission
+      # `view` is necessary to retrieve the created record in the response
+      permissions: [required_permission, 'organization:integrations:view'],
       query: mutation,
       variables: {
         input: {
@@ -49,7 +51,9 @@ RSpec.describe Mutations::PaymentProviders::Adyen::Update, type: :graphql do
       result = execute_graphql(
         current_user: membership.user,
         current_organization: membership.organization,
-        permissions: required_permission,
+        # You wouldn't have `create` without `view` permission
+        # `view` is necessary to retrieve the created record in the response
+        permissions: [required_permission, 'organization:integrations:view'],
         query: mutation,
         variables: {
           input: {

--- a/spec/graphql/mutations/payment_providers/gocardless/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/gocardless/create_spec.rb
@@ -46,7 +46,9 @@ RSpec.describe Mutations::PaymentProviders::Gocardless::Create, type: :graphql d
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
-      permissions: required_permission,
+      # You wouldn't have `create` without `view` permission
+      # `view` is necessary to retrieve the created record in the response
+      permissions: [required_permission, 'organization:integrations:view'],
       query: mutation,
       variables: {
         input: {

--- a/spec/graphql/mutations/payment_providers/gocardless/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/gocardless/update_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe Mutations::PaymentProviders::Gocardless::Update, type: :graphql d
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
-      permissions: required_permission,
+      # You wouldn't have `create` without `view` permission
+      # `view` is necessary to retrieve the created record in the response
+      permissions: [required_permission, 'organization:integrations:view'],
       query: mutation,
       variables: {
         input: {

--- a/spec/graphql/mutations/payment_providers/stripe/create_spec.rb
+++ b/spec/graphql/mutations/payment_providers/stripe/create_spec.rb
@@ -33,7 +33,9 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Create, type: :graphql do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
-      permissions: required_permission,
+      # You wouldn't have `create` without `view` permission
+      # `view` is necessary to retrieve the created record in the response
+      permissions: [required_permission, 'organization:integrations:view'],
       query: mutation,
       variables: {
         input: {

--- a/spec/graphql/mutations/payment_providers/stripe/update_spec.rb
+++ b/spec/graphql/mutations/payment_providers/stripe/update_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe Mutations::PaymentProviders::Stripe::Update, type: :graphql do
     result = execute_graphql(
       current_user: membership.user,
       current_organization: membership.organization,
-      permissions: required_permission,
+      # You wouldn't have `create` without `view` permission
+      # `view` is necessary to retrieve the created record in the response
+      permissions: [required_permission, 'organization:integrations:view'],
       query: mutation,
       variables: {
         input: {

--- a/spec/graphql/resolvers/payment_providers_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_providers_resolver_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe Resolvers::PaymentProvidersResolver, type: :graphql do
           current_user: membership.user,
           current_organization: organization,
           permissions: required_permission,
-          query:,
+          query:
         )
 
         expect(adyen_provider.live_prefix).to be_a String
@@ -202,7 +202,7 @@ RSpec.describe Resolvers::PaymentProvidersResolver, type: :graphql do
           current_user: membership.user,
           current_organization: organization,
           permissions: ['organization:integrations:view'],
-          query:,
+          query:
         )
 
         payment_providers_response = result['data']['paymentProviders']['collection']

--- a/spec/graphql/types/payment_providers/adyen_spec.rb
+++ b/spec/graphql/types/payment_providers/adyen_spec.rb
@@ -6,11 +6,12 @@ RSpec.describe Types::PaymentProviders::Adyen do
   subject { described_class }
 
   it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:api_key).of_type('String') }
   it { is_expected.to have_field(:code).of_type('String!') }
   it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:hmac_key).of_type('String') }
-  it { is_expected.to have_field(:live_prefix).of_type('String') }
-  it { is_expected.to have_field(:merchant_account).of_type('String!') }
-  it { is_expected.to have_field(:success_redirect_url).of_type('String') }
+
+  it { is_expected.to have_field(:api_key).of_type('String').with_permission('organization:integrations:view') }
+  it { is_expected.to have_field(:hmac_key).of_type('String').with_permission('organization:integrations:view') }
+  it { is_expected.to have_field(:live_prefix).of_type('String').with_permission('organization:integrations:view') }
+  it { is_expected.to have_field(:merchant_account).of_type('String').with_permission('organization:integrations:view') }
+  it { is_expected.to have_field(:success_redirect_url).of_type('String').with_permission('organization:integrations:view') }
 end

--- a/spec/graphql/types/payment_providers/gocardless_spec.rb
+++ b/spec/graphql/types/payment_providers/gocardless_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Types::PaymentProviders::Gocardless do
   it { is_expected.to have_field(:id).of_type('ID!') }
   it { is_expected.to have_field(:code).of_type('String!') }
   it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:has_access_token).of_type('Boolean!') }
-  it { is_expected.to have_field(:success_redirect_url).of_type('String') }
-  it { is_expected.to have_field(:webhook_secret).of_type('String') }
+
+  it { is_expected.to have_field(:has_access_token).of_type('Boolean').with_permission('organization:integrations:view') }
+  it { is_expected.to have_field(:success_redirect_url).of_type('String').with_permission('organization:integrations:view') }
+  it { is_expected.to have_field(:webhook_secret).of_type('String').with_permission('organization:integrations:view') }
 end

--- a/spec/graphql/types/payment_providers/stripe_spec.rb
+++ b/spec/graphql/types/payment_providers/stripe_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Types::PaymentProviders::Stripe do
   it { is_expected.to have_field(:id).of_type('ID!') }
   it { is_expected.to have_field(:code).of_type('String!') }
   it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:secret_key).of_type('String') }
-  it { is_expected.to have_field(:success_redirect_url).of_type('String') }
+
+  it { is_expected.to have_field(:secret_key).of_type('String').with_permission('organization:integrations:view') }
+  it { is_expected.to have_field(:success_redirect_url).of_type('String').with_permission('organization:integrations:view') }
 end

--- a/spec/support/shared_examples/graphql_requirements.rb
+++ b/spec/support/shared_examples/graphql_requirements.rb
@@ -14,7 +14,9 @@ end
 
 RSpec.shared_examples 'requires permission' do |permission|
   it "requires #{permission} permission" do
-    expect(described_class::REQUIRED_PERMISSION).to eq(permission)
+    actual = Array.wrap(described_class::REQUIRED_PERMISSION).sort
+    expected = Array.wrap(permission).sort
+    expect(actual).to eq expected
   end
 end
 


### PR DESCRIPTION
## Context

Granular permissions are coming to Lago.

## Description

After some testing we realized a few things weren't working as expected. 

The diff is  long but this PR basically adjust mutations and resolver permissions. Some mutations need to be access with multiple permission, then the Input will control what field can be updated depending on your permissions.

I also removed `subscriptions:delete` because it wasn't used. We use `subscriptions:update` to terminate a subscriptions, it can't be "deleted".

