### PR TITLE
fix(pdf): Add read timeout for PDF service calls

### DIFF
--- a/app/services/utils/pdf_generator.rb
+++ b/app/services/utils/pdf_generator.rb
@@ -33,7 +33,7 @@ module Utils
     end
 
     def render_pdf
-      http_client = LagoHttpClient::Client.new(pdf_url)
+      http_client = LagoHttpClient::Client.new(pdf_url, read_timeout: 300)
 
       response = http_client.post_multipart_file(
         file1: prepare_http_files(render_html, 'text/html', 'index.html'),

--- a/lib/lago_http_client/lago_http_client/client.rb
+++ b/lib/lago_http_client/lago_http_client/client.rb
@@ -6,9 +6,9 @@ module LagoHttpClient
   class Client
     RESPONSE_SUCCESS_CODES = [200, 201, 202, 204].freeze
 
-    def initialize(url)
+    def initialize(url, read_timeout: 60)
       @uri = URI(url)
-      @http_client = Net::HTTP.new(uri.host, uri.port)
+      @http_client = Net::HTTP.new(uri.host, uri.port, read_timeout:)
       @http_client.use_ssl = true if uri.scheme == 'https'
     end
 


### PR DESCRIPTION
## Description

- PDF service is configured to have a 300s timeout
- Add support for HttpClient to support higher read timeout
