### PR TITLE
fix: Quantified Event migration

### DIFF
--- a/db/migrate/20240603080144_fix_quantified_event_migration.rb
+++ b/db/migrate/20240603080144_fix_quantified_event_migration.rb
@@ -26,7 +26,7 @@ class FixQuantifiedEventMigration < ActiveRecord::Migration[7.0]
     SQL
 
     QuantifiedEvent.find_by_sql(sql).each do |quantified_event|
-      CachedAggregation.find_or_create!(
+      CachedAggregation.find_or_create_by!(
         organization_id: quantified_event.organization_id,
         charge_id: quantified_event.charge_id,
         timestamp: quantified_event.added_at,


### PR DESCRIPTION
## Context

A migration task to migrate `QuantifedEvent` into `CachedAggregation`
was invalid and did not migrate the values in a proper way, leading to
issue with the computation of recurring weighted sum aggregation

## Description

This PR adds the same migration with a fix for
`started_at`/`terminated_at` boundaries