### PR TITLE
fix(tests): Clear enqueued jobs before each test run

### DIFF
--- a/spec/graphql/mutations/integrations/anrok/update_spec.rb
+++ b/spec/graphql/mutations/integrations/anrok/update_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Mutations::Integrations::Anrok::Update, type: :graphql do
           code:,
           apiKey: api_key
         }
-      },
+      }
     )
 
     result_data = result['data']['updateAnrokIntegration']

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -447,8 +447,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
             let(:old_plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: false) }
 
             it 'enqueues a job to bill the existing subscription' do
-              create_service.call
-              expect(BillSubscriptionJob).to have_been_enqueued.at_least(1).times
+              expect { create_service.call }.to have_enqueued_job(BillSubscriptionJob)
             end
           end
 
@@ -527,8 +526,7 @@ RSpec.describe Subscriptions::CreateService, type: :service do
             let(:plan) { create(:plan, amount_cents: 200, organization:, pay_in_advance: true) }
 
             it 'enqueues a job to bill the existing subscription' do
-              create_service.call
-              expect(BillSubscriptionJob).to have_been_enqueued.at_least(2).times
+              expect { create_service.call }.to have_enqueued_job(BillSubscriptionJob)
             end
           end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,10 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:deletion)
   end
 
+  config.before(:each) do
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+  end
+
   config.before do
     DatabaseCleaner.strategy = :transaction
   end


### PR DESCRIPTION
## Context

To ensure that our tests run reliably and do not interfere with each other, it's necessary to clear any enqueued jobs before each test. This prevents flaky tests caused by jobs being carried over from previous tests.

## Description

This PR adds a configuration to clear enqueued jobs before each test run. Specifically, it adds the following to the test setup:

```ruby
config.before(:each) do
  ActiveJob::Base.queue_adapter.enqueued_jobs.clear
end
