### PR TITLE
feat(integrations): Add should_sync_payment? to Payment

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -11,4 +11,8 @@ class Payment < ApplicationRecord
   has_many :integration_resources, as: :syncable
 
   delegate :customer, to: :invoice
+
+  def should_sync_payment?
+    invoice.finalized? && customer.integration_customers.any? { |c| c.integration.sync_payments }
+  end
 end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -9,4 +9,84 @@ RSpec.describe Payment, type: :model do
 
   it { is_expected.to have_many(:integration_resources) }
   it { is_expected.to delegate_method(:customer).to(:invoice) }
+
+  describe '#should_sync_payment?' do
+    subject(:method_call) { payment.should_sync_payment? }
+
+    let(:payment) { create(:payment, invoice:) }
+    let(:invoice) { create(:invoice, customer:, organization:, status:) }
+    let(:organization) { create(:organization) }
+
+    context 'when invoice is not finalized' do
+      let(:status) { %i[draft voided generating].sample }
+
+      context 'without integration customer' do
+        let(:customer) { create(:customer, organization:) }
+
+        it 'returns false' do
+          expect(method_call).to eq(false)
+        end
+      end
+
+      context 'with integration customer' do
+        let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+        let(:integration) { create(:netsuite_integration, organization:, sync_payments:) }
+        let(:customer) { create(:customer, organization:) }
+
+        before { integration_customer }
+
+        context 'when sync payments is true' do
+          let(:sync_payments) { true }
+
+          it 'returns false' do
+            expect(method_call).to eq(false)
+          end
+        end
+
+        context 'when sync payments is false' do
+          let(:sync_payments) { false }
+
+          it 'returns false' do
+            expect(method_call).to eq(false)
+          end
+        end
+      end
+    end
+
+    context 'when invoice is finalized' do
+      let(:status) { :finalized }
+
+      context 'without integration customer' do
+        let(:customer) { create(:customer, organization:) }
+
+        it 'returns false' do
+          expect(method_call).to eq(false)
+        end
+      end
+
+      context 'with integration customer' do
+        let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
+        let(:integration) { create(:netsuite_integration, organization:, sync_payments:) }
+        let(:customer) { create(:customer, organization:) }
+
+        before { integration_customer }
+
+        context 'when sync payments is true' do
+          let(:sync_payments) { true }
+
+          it 'returns true' do
+            expect(method_call).to eq(true)
+          end
+        end
+
+        context 'when sync payments is false' do
+          let(:sync_payments) { false }
+
+          it 'returns false' do
+            expect(method_call).to eq(false)
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR adds `should_sync_payment?` method to `Payment` model.