### PR TITLE
fix(gql): Add credit note filter on query

### DIFF
--- a/app/queries/credit_notes_query.rb
+++ b/app/queries/credit_notes_query.rb
@@ -18,7 +18,7 @@ class CreditNotesQuery < BaseQuery
   attr_reader :search_term
 
   def base_scope
-    CreditNote.finalized.ransack(search_params)
+    CreditNote.joins(:customer).where('customers.organization_id = ?', organization.id).finalized.ransack(search_params)
   end
 
   def search_params

--- a/spec/graphql/resolvers/credit_notes_resolver_spec.rb
+++ b/spec/graphql/resolvers/credit_notes_resolver_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Resolvers::CreditNotesResolver, type: :graphql do
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:, organization:) }
-  let(:credit_note) { create(:credit_note, organization:, customer:) }
+  let(:credit_note) { create(:credit_note, customer:) }
   let(:customer_id) { nil }
   let(:search_term) { nil }
 
@@ -79,7 +79,7 @@ RSpec.describe Resolvers::CreditNotesResolver, type: :graphql do
     let(:search_term) { "yolo" }
 
     it 'returns a list of finalized credit_notes matching the terms' do
-      create(:credit_note, number: 'yolo', organization:)
+      create(:credit_note, number: 'yolo', customer: create(:customer, organization:))
 
       result = execute_graphql(
         current_user: membership.user,


### PR DESCRIPTION
## Context

We'll be adding a new view to list all credit notes for all customers

## Description

This PR adapts the query to scope to the organization instead of the customers.