### PR TITLE
feat(pdf): Ensure Invoice PDF is created before sending emails and webhooks

### DIFF
--- a/app/jobs/invoices/generate_pdf_and_notify_job.rb
+++ b/app/jobs/invoices/generate_pdf_and_notify_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Invoices
+  class GeneratePdfAndNotifyJob < ApplicationJob
+    queue_as 'pdf'
+
+    def perform(invoice:, email:)
+      result = Invoices::GeneratePdfService.call(invoice:)
+      result.raise_if_error!
+
+      if email
+        InvoiceMailer.with(invoice:).finalized.deliver_later
+      end
+    end
+  end
+end

--- a/app/jobs/invoices/generate_pdf_and_notify_job.rb
+++ b/app/jobs/invoices/generate_pdf_and_notify_job.rb
@@ -2,7 +2,13 @@
 
 module Invoices
   class GeneratePdfAndNotifyJob < ApplicationJob
-    queue_as 'pdf'
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_PDFS'])
+        :pdfs
+      else
+        :default
+      end
+    end
 
     def perform(invoice:, email:)
       result = Invoices::GeneratePdfService.call(invoice:)

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -77,7 +77,7 @@ module Customers
       IntegrationCustomers::CreateOrUpdateService.call(
         integration_customer_params: params[:integration_customer],
         customer: result.customer,
-        new_customer:,
+        new_customer:
       )
 
       track_customer_created(customer)
@@ -158,7 +158,7 @@ module Customers
       IntegrationCustomers::CreateOrUpdateService.call(
         integration_customer_params: args[:integration_customer]&.to_h,
         customer: result.customer,
-        new_customer: true,
+        new_customer: true
       )
 
       track_customer_created(customer)

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -114,7 +114,7 @@ module Customers
       IntegrationCustomers::CreateOrUpdateService.call(
         integration_customer_params: args[:integration_customer]&.to_h,
         customer: result.customer,
-        new_customer: false,
+        new_customer: false
       )
 
       result

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -34,7 +34,7 @@ module Invoices
 
       track_invoice_created(result.invoice)
       SendWebhookJob.perform_later('invoice.add_on_added', result.invoice) if should_deliver_webhook?
-      InvoiceMailer.with(invoice: result.invoice).finalized.deliver_later if should_deliver_email?
+      GeneratePdfAndNotifyJob.perform_later(invoice: result.invoice, email: should_deliver_email?)
 
       if result.invoice.should_sync_invoice?
         Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice: result.invoice)

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -30,7 +30,7 @@ module Invoices
 
       track_invoice_created(invoice)
       SendWebhookJob.perform_later('invoice.one_off_created', invoice) if should_deliver_webhook?
-      InvoiceMailer.with(invoice:).finalized.deliver_later if should_deliver_email?
+      GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
       Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
       Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
       Invoices::Payments::CreateService.new(invoice).call

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -40,7 +40,7 @@ module Invoices
       track_invoice_created(invoice)
 
       deliver_webhooks if should_deliver_webhook?
-      InvoiceMailer.with(invoice:).finalized.deliver_later if should_deliver_email?
+      GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
       Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
       Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
       Invoices::Payments::CreateService.new(invoice).call

--- a/app/services/invoices/finalize_service.rb
+++ b/app/services/invoices/finalize_service.rb
@@ -23,7 +23,7 @@ module Invoices
       end
 
       SendWebhookJob.perform_later('invoice.created', result.invoice) if invoice.organization.webhook_endpoints.any?
-      InvoiceMailer.with(invoice: invoice.reload).finalized.deliver_later if should_deliver_email?
+      GeneratePdfAndNotifyJob.perform_later(invoice: invoice.reload, email: should_deliver_email?)
       Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
       Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
       Invoices::Payments::CreateService.new(invoice).call

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -28,7 +28,7 @@ module Invoices
 
       track_invoice_created(result.invoice)
       SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice) if should_deliver_webhook?
-      InvoiceMailer.with(invoice: result.invoice).finalized.deliver_later if should_deliver_email?
+      GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
       Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
       Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
 

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -43,7 +43,7 @@ module Invoices
         SendWebhookJob.perform_later('invoice.drafted', invoice) if should_deliver_webhook?
       else
         SendWebhookJob.perform_later('invoice.created', invoice) if should_deliver_webhook?
-        InvoiceMailer.with(invoice:).finalized.deliver_later if should_deliver_finalized_email?
+        GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_finalized_email?)
         Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
         Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
         Invoices::Payments::CreateService.new(invoice).call

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -11,6 +11,7 @@ queues:
   - invoices
   - wallets
   - integrations
+  - pdf
 
 production:
   concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 10) %>

--- a/config/sidekiq_pdfs.yml
+++ b/config/sidekiq_pdfs.yml
@@ -2,15 +2,7 @@ concurrency: 10
 timeout: 25
 retry: 1
 queues:
-  - default
-  - mailers
-  - clock
-  - providers
-  - billing
-  - webhook
-  - invoices
-  - wallets
-  - integrations
+  - pdfs
 
 production:
   concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 10) %>

--- a/scripts/start.pdfs.worker.dev.sh
+++ b/scripts/start.pdfs.worker.dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+bundle install
+bundle exec sidekiq -C config/sidekiq_pdfs.yml

--- a/scripts/start.pdfs.worker.sh
+++ b/scripts/start.pdfs.worker.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+bundle exec sidekiq -C config/sidekiq_pdfs.yml

--- a/spec/graphql/mutations/credit_notes/download_spec.rb
+++ b/spec/graphql/mutations/credit_notes/download_spec.rb
@@ -8,10 +8,6 @@ RSpec.describe Mutations::CreditNotes::Download, type: :graphql do
   let(:organization) { credit_note.organization }
   let(:membership) { create(:membership, organization:) }
 
-  let(:pdf_response) do
-    File.read(Rails.root.join('spec/fixtures/blank.pdf'))
-  end
-
   let(:mutation) do
     <<~GQL
       mutation($input: DownloadCreditNoteInput!) {
@@ -23,10 +19,7 @@ RSpec.describe Mutations::CreditNotes::Download, type: :graphql do
     GQL
   end
 
-  before do
-    stub_request(:post, "#{ENV["LAGO_PDF_URL"]}/forms/chromium/convert/html")
-      .to_return(body: pdf_response, status: 200)
-  end
+  before { stub_pdf_generation }
 
   it_behaves_like 'requires current user'
   it_behaves_like 'requires current organization'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -57,6 +57,7 @@ RSpec.configure do |config|
   config.include ApiHelper, type: :request
   config.include ScenariosHelper
   config.include LicenseHelper
+  config.include PdfHelper
   config.include ActiveSupport::Testing::TimeHelpers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/monthly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/quarterly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/weekly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/yearly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -68,9 +65,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/monthly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/quarterly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/weekly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/yearly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -68,9 +65,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_advance_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:, currency: 'EUR') }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -27,9 +24,6 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
   let(:subscription) { customer.subscriptions.first.reload }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     # Create the subscription

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/monthly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/quarterly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/weekly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/yearly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -68,9 +65,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/monthly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/quarterly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/weekly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -67,9 +64,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/yearly_spec.rb
@@ -6,9 +6,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:timezone) { 'UTC' }
   let(:customer) { create(:customer, organization:, timezone:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
   let(:plan) do
     create(
@@ -68,9 +65,6 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
   let(:minimum_commitment) { create(:commitment, :minimum_commitment, plan:, amount_cents: 1_000_000) }
 
   before do
-    allow(Utils::PdfGenerator).to receive(:new).and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call).and_return(pdf_result)
-
     minimum_commitment
 
     create(

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -5,18 +5,8 @@ require 'rails_helper'
 describe 'Invoices Scenarios', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil, email_settings: []) }
   let(:tax) { create(:tax, organization:, rate: 20) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
-  before do
-    tax
-
-    allow(Utils::PdfGenerator).to receive(:new)
-      .and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call)
-      .and_return(pdf_result)
-  end
+  before { tax }
 
   context 'when pay in advance subscription with free trial used on several subscriptions' do
     let(:organization) { create(:organization, webhook_url: nil) }
@@ -1658,18 +1648,8 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
     context 'when invoice grace period is removed' do
       let(:organization) { create(:organization, webhook_url: nil, invoice_grace_period: 3) }
       let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 1000) }
-      let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-      let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-      let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
       around { |test| lago_premium!(&test) }
-
-      before do
-        allow(Utils::PdfGenerator).to receive(:new)
-          .and_return(pdf_generator)
-        allow(pdf_generator).to receive(:call)
-          .and_return(pdf_result)
-      end
 
       it 'finalizes draft invoices' do
         create_subscription(

--- a/spec/scenarios/spending_minimum_spec.rb
+++ b/spec/scenarios/spending_minimum_spec.rb
@@ -8,18 +8,8 @@ describe 'Spending Minimum Scenarios', :scenarios, type: :request do
   let(:tax) { create(:tax, organization:, rate: 20) }
   let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 5000) }
   let(:metric) { create(:billable_metric, organization:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
-  before do
-    tax
-
-    allow(Utils::PdfGenerator).to receive(:new)
-      .and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call)
-      .and_return(pdf_result)
-  end
+  before { tax }
 
   context 'when invoice grace period' do
     let(:customer) { create(:customer, organization:, invoice_grace_period: 3) }

--- a/spec/scenarios/terminate_pay_in_advance_spec.rb
+++ b/spec/scenarios/terminate_pay_in_advance_spec.rb
@@ -8,18 +8,8 @@ describe 'Terminate Pay in Advance Scenarios', :scenarios, type: :request do
   let(:tax) { create(:tax, organization:, rate: 20) }
   let(:plan) { create(:plan, pay_in_advance: true, organization:, amount_cents: 5000) }
   let(:metric) { create(:billable_metric, organization:) }
-  let(:pdf_generator) { instance_double(Utils::PdfGenerator) }
-  let(:pdf_file) { StringIO.new(File.read(Rails.root.join('spec/fixtures/blank.pdf'))) }
-  let(:pdf_result) { OpenStruct.new(io: pdf_file) }
 
-  before do
-    tax
-
-    allow(Utils::PdfGenerator).to receive(:new)
-      .and_return(pdf_generator)
-    allow(pdf_generator).to receive(:call)
-      .and_return(pdf_result)
-  end
+  before { tax }
 
   it 'creates expected credit note and invoice' do
     ### 8 Feb: Create and terminate subscription

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -54,28 +54,28 @@ RSpec.describe Invoices::AddOnService, type: :service do
       end.to have_enqueued_job(SendWebhookJob)
     end
 
-    it 'does not enqueue an SendEmailJob' do
+    it 'enqueue an GeneratePdfAndNotifyJob with email false' do
       expect do
         invoice_service.create
-      end.not_to have_enqueued_job(SendEmailJob)
+      end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
     end
 
     context 'with lago_premium' do
       around { |test| lago_premium!(&test) }
 
-      it 'enqueues an SendEmailJob' do
+      it 'enqueues an GeneratePdfAndNotifyJob with email true' do
         expect do
           invoice_service.create
-        end.to have_enqueued_job(SendEmailJob)
+        end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: true))
       end
 
       context 'when organization does not have right email settings' do
         before { applied_add_on.customer.organization.update!(email_settings: []) }
 
-        it 'does not enqueue an SendEmailJob' do
+        it 'enqueue an GeneratePdfAndNotifyJob with email false' do
           expect do
             invoice_service.create
-          end.not_to have_enqueued_job(SendEmailJob)
+          end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
         end
       end
     end

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -102,10 +102,10 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
       end.to have_enqueued_job(SendWebhookJob)
     end
 
-    it 'does not enqueue an SendEmailJob' do
+    it 'enqueues GeneratePdfAndNotifyJob with email false' do
       expect do
         create_service.call
-      end.not_to have_enqueued_job(SendEmailJob)
+      end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
     end
 
     context 'when invoice amount in cents is zero' do
@@ -146,19 +146,19 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
     context 'with lago_premium' do
       around { |test| lago_premium!(&test) }
 
-      it 'enqueues an SendEmailJob' do
+      it 'enqueues GeneratePdfAndNotifyJob with email true' do
         expect do
           create_service.call
-        end.to have_enqueued_job(SendEmailJob)
+        end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: true))
       end
 
       context 'when organization does not have right email settings' do
         before { customer.organization.update!(email_settings: []) }
 
-        it 'does not enqueue an SendEmailJob' do
+        it 'enqueues GeneratePdfAndNotifyJob with email false' do
           expect do
             create_service.call
-          end.not_to have_enqueued_job(SendEmailJob)
+          end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
         end
       end
     end

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -151,28 +151,28 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
       end.to have_enqueued_job(SendWebhookJob).with('fee.created', Fee)
     end
 
-    it 'does not enqueue an SendEmailJob' do
+    it 'enqueues GeneratePdfAndNotifyJob with email false' do
       expect do
         invoice_service.call
-      end.not_to have_enqueued_job(SendEmailJob)
+      end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
     end
 
     context 'with lago_premium' do
       around { |test| lago_premium!(&test) }
 
-      it 'enqueues an SendEmailJob' do
+      it 'enqueues GeneratePdfAndNotifyJob with email true' do
         expect do
           invoice_service.call
-        end.to have_enqueued_job(SendEmailJob)
+        end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: true))
       end
 
       context 'when organization does not have right email settings' do
         let(:email_settings) { [] }
 
-        it 'does not enqueue an SendEmailJob' do
+        it 'enqueues GeneratePdfAndNotifyJob with email false' do
           expect do
             invoice_service.call
-          end.not_to have_enqueued_job(SendEmailJob)
+          end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
         end
       end
     end

--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -86,28 +86,28 @@ RSpec.describe Invoices::FinalizeService, type: :service do
       end.to have_enqueued_job(SendWebhookJob).with('invoice.created', Invoice)
     end
 
-    it 'does not enqueue an SendEmailJob' do
+    it 'enqueues GeneratePdfAndNotifyJob with email false' do
       expect do
         finalize_service.call
-      end.not_to have_enqueued_job(SendEmailJob)
+      end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
     end
 
     context 'with lago_premium' do
       around { |test| lago_premium!(&test) }
 
-      it 'enqueues an SendEmailJob' do
+      it 'enqueues GeneratePdfAndNotifyJob with email true' do
         expect do
           finalize_service.call
-        end.to have_enqueued_job(SendEmailJob)
+        end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: true))
       end
 
       context 'when organization does not have right email settings' do
         before { invoice.organization.update!(email_settings: []) }
 
-        it 'does not enqueue an SendEmailJob' do
+        it 'enqueues GeneratePdfAndNotifyJob with email false' do
           expect do
             finalize_service.call
-          end.not_to have_enqueued_job(SendEmailJob)
+          end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
         end
       end
     end

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
     it 'does not enqueue an SendEmailJob' do
       expect do
         invoice_service.call
-      end.not_to have_enqueued_job(SendEmailJob)
+      end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
     end
 
     context 'with lago_premium' do
@@ -78,7 +78,7 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
       it 'enqueues an SendEmailJob' do
         expect do
           invoice_service.call
-        end.to have_enqueued_job(SendEmailJob)
+        end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: true))
       end
 
       context 'when organization does not have right email settings' do
@@ -87,7 +87,7 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
         it 'does not enqueue an SendEmailJob' do
           expect do
             invoice_service.call
-          end.not_to have_enqueued_job(SendEmailJob)
+          end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,12 @@ RSpec.configure do |config|
         raise "Unknown cache store: #{example.metadata[:cache]}"
       end
     end
+
+    # if example.metadata[:scenarios]
+    #   WebMock.stub_request(:post, %r{/forms/chromium/convert/html$}).to_return(
+    #     status: 200, body: String.new, headers: {'Content-Type' => 'application/pdf'}
+    #   )
+    # end
   end
 
   config.before(:each, transaction: false) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,12 +39,6 @@ RSpec.configure do |config|
         raise "Unknown cache store: #{example.metadata[:cache]}"
       end
     end
-
-    # if example.metadata[:scenarios]
-    #   WebMock.stub_request(:post, %r{/forms/chromium/convert/html$}).to_return(
-    #     status: 200, body: String.new, headers: {'Content-Type' => 'application/pdf'}
-    #   )
-    # end
   end
 
   config.before(:each, transaction: false) do

--- a/spec/support/pdf_helper.rb
+++ b/spec/support/pdf_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.before(:each, :scenarios) do
+    stub_pdf_generation
+  end
+end
+
+module PdfHelper
+  def stub_pdf_generation(response_body = nil, status = 200)
+    response_body ||= File.read(Rails.root.join('spec/fixtures/blank.pdf'))
+
+    stub_request(:post, "#{ENV["LAGO_PDF_URL"]}/forms/chromium/convert/html")
+      .to_return(body: response_body, status: status)
+  end
+end


### PR DESCRIPTION
### Context
Separate PDF generation into a different Worker and Queue (:pdf). 

### Description
Move PDF generation to a distinct worker and queue.  
Change the process to generate the PDF and send the email 


> [!CAUTION]
> This PR introduces a new sidekiq queue named `pdf`.
> Other than the sidekiq config here, what else should be updated?


### Changes Introduced

- **New Job Implementation**: Introduced a new job `GeneratePdfAndNotifyJob` to handle the PDF generation and email notification.
- **Mailer Invocation Update**: Modified the invoicing process to utilize the new job, ensuring the email is sent only after the PDF is successfully generated.
- **Test Configuration**: Added a `PdfHelper` module and updated RSpec configuration to stub PDF generation in tests tagged with `:scenarios`, reducing repetitive stubbing code in individual tests.

## Webhook Events

> [!IMPORTANT]  
> Stop listening to `invoice.created` to request the PDF creation via the API. Instead, listen to `invoice.generated` event, which always has the PDF file url.

### `invoice.created` webhook

This webhook is sent after the invoice object is created, in the webhook payload you get an `invoice` object but the PDF link is not set yet. The PDF was not generated yet.

Until now, users would typically call back our API to request the PDF generation. **This is now deprecated!**

Instead, wait for the `invoice.generated` webhook.

### `invoice.generated` webhook

This webhook is sent when the invoice PDF is generated. Until now, we generated the PDF only if you requested it via the API, via the UI or if the invoice was sent over email. If you don't send invoice over email, you would rarely receive this event.

Now, **the PDF is generated every time an Invoice model is created**. It's now recommended to listent this event if you want the PDF file URL to be part of the webhook payload.

| Webhook name | Desc |
|----------------:|--------|
| `invoice.created` | This webhook indicates that the invoice has been created, but the PDF is not yet ready. It's delivered fast after the invoice creation. |
| `invoice.generated` | This webhook indicates that the PDF has been generated. You receive the Invoice object WITH the PDF URL. This webhook is sent a bit after `invoice.created` because generating PDF is typically a bit longer. |
