### PR TITLE
fix(stripe): Ignore invoice not found error when in test mode

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -101,7 +101,11 @@ module Invoices
       delegate :organization, :customer, to: :invoice
 
       def create_payment(provider_payment_id:, metadata:)
-        @invoice = Invoice.find(metadata[:lago_invoice_id])
+        @invoice = Invoice.find_by(id: metadata[:lago_invoice_id])
+        unless @invoice
+          result.not_found_failure!(resource: 'invoice')
+          return
+        end
 
         increment_payment_attempts
 

--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -125,13 +125,15 @@ module PaymentProviders
 
         result.raise_if_error! || result
       when 'charge.succeeded'
-        Invoices::Payments::StripeService
+        result = Invoices::Payments::StripeService
           .new.update_payment_status(
             organization_id: organization.id,
             provider_payment_id: event.data.object.payment_intent,
             status: 'succeeded',
             metadata: event.data.object.metadata.to_h.symbolize_keys
           )
+
+        result.raise_if_error! || result
       when 'charge.dispute.closed'
         PaymentProviders::Webhooks::Stripe::ChargeDisputeClosedService.call(
           organization_id: organization.id,

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -421,6 +421,23 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
           )
         end
       end
+
+      context 'when invoice is not found' do
+        it 'raises a not found failure' do
+          result = stripe_service.update_payment_status(
+            organization_id: organization.id,
+            provider_payment_id: 'ch_123456',
+            status: 'succeeded',
+            metadata: {lago_invoice_id: 'invalid', payment_type: 'one-time'}
+          )
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::NotFoundFailure)
+            expect(result.error.message).to eq('invoice_not_found')
+          end
+        end
+      end
     end
 
     context 'when payment is not found' do


### PR DESCRIPTION
## Context

Some dead jobs were received lately for `PaymentProviders::Stripe::HandleEventJob` with an `ActiveRecord::RecordNotFound (Couldn't find Invoice with 'id'=XXXX)`  error.

The event type of the webhook was a `charge.succeeded` and it was related to an `one_off` invoice.

After investigation it appears that the webhook was comming from Lago stripe account in test mode. Most certainly configured in a staging, and so was not related to production invoices.

## Description

This PR changes the invoice lookup behavior, to bubble-up a Not Found error if the invoice is not found in the DB. The webhook handler catches the error and ignore it if the event is comming from an account with tthe flag `"livemode": false`
