### PR TITLE
fix(integrations): Fix payments sync when the invoice is not synced yet

### DIFF
--- a/app/jobs/integrations/aggregator/payments/create_job.rb
+++ b/app/jobs/integrations/aggregator/payments/create_job.rb
@@ -6,7 +6,7 @@ module Integrations
       class CreateJob < ApplicationJob
         queue_as 'integrations'
 
-        retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 3
+        retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 5
 
         def perform(payment:)
           result = Integrations::Aggregator::Payments::CreateService.call(payment:)

--- a/app/services/integrations/aggregator/payments/create_service.rb
+++ b/app/services/integrations/aggregator/payments/create_service.rb
@@ -72,7 +72,8 @@ module Integrations
                 'sublistId' => 'apply',
                 'lineItems' => [
                   {
-                    'doc' => integration_invoice.external_id,
+                    # If the invoice is not synced yet, lets raise an error and retry. (doc: nil is an invalid request)
+                    'doc' => integration_invoice&.external_id,
                     'apply' => true,
                     'amount' => amount(payment.amount_cents, resource: invoice)
                   }


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-netsuite

## Context

Currently Lago does not support accounting integrations

## Description

This PR fixes the problem when the invoice for a payment is not synced yet. In that case we let the payment sync job fail so that when it retries the invoice is already synced.