### PR TITLE
misc: Retry email jobs on Net::ReadTimeout error

### DIFF
--- a/app/jobs/send_email_job.rb
+++ b/app/jobs/send_email_job.rb
@@ -5,4 +5,5 @@ class SendEmailJob < ActionMailer::MailDeliveryJob
 
   retry_on ActiveJob::DeserializationError, wait: :exponentially_longer, attempts: 6
   retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 6
+  retry_on Net::ReadTimeout, wait: :exponentially_longer, attempts: 6
 end


### PR DESCRIPTION
## Description

This PR enable the auto-retry mechanism for email delivery in case of `Net::ReadTimeout` network error