### PR TITLE
Reapply "misc: Add scheduler monitoring for sentry if enabled" (#2112)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,9 +65,9 @@ gem 'newrelic_rpm'
 gem 'opentelemetry-exporter-otlp'
 gem 'opentelemetry-instrumentation-all'
 gem 'opentelemetry-sdk'
-gem 'sentry-rails', '~> 5.12.0'
-gem 'sentry-ruby', '~> 5.12.0'
-gem 'sentry-sidekiq', '~> 5.12.0'
+gem 'sentry-rails', '~> 5.17.0'
+gem 'sentry-ruby', '~> 5.17.0'
+gem 'sentry-sidekiq', '~> 5.17.0'
 
 # Storage
 gem 'aws-sdk-s3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -742,13 +742,14 @@ GEM
     scenic (1.7.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    sentry-rails (5.12.0)
+    sentry-rails (5.17.3)
       railties (>= 5.0)
-      sentry-ruby (~> 5.12.0)
-    sentry-ruby (5.12.0)
+      sentry-ruby (~> 5.17.3)
+    sentry-ruby (5.17.3)
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.12.0)
-      sentry-ruby (~> 5.12.0)
+    sentry-sidekiq (5.17.3)
+      sentry-ruby (~> 5.17.3)
       sidekiq (>= 3.0)
     shellany (0.0.1)
     shoulda-matchers (6.2.0)
@@ -908,9 +909,9 @@ DEPENDENCIES
   ruby-lsp-rails
   sass-rails
   scenic
-  sentry-rails (~> 5.12.0)
-  sentry-ruby (~> 5.12.0)
-  sentry-sidekiq (~> 5.12.0)
+  sentry-rails (~> 5.17.0)
+  sentry-ruby (~> 5.17.0)
+  sentry-sidekiq (~> 5.17.0)
   shoulda-matchers
   sidekiq
   simplecov

--- a/app/jobs/clock/activate_subscriptions_job.rb
+++ b/app/jobs/clock/activate_subscriptions_job.rb
@@ -2,11 +2,12 @@
 
 module Clock
   class ActivateSubscriptionsJob < ApplicationJob
-    queue_as 'clock'
+    prepend SentryCronConcern
 
+    queue_as 'clock'
     unique :until_executed, on_conflict: :log
 
-    def perform
+    def perform(*)
       Subscriptions::ActivateService.new(timestamp: Time.current.to_i).activate_all_pending
     end
   end

--- a/app/jobs/clock/create_interval_wallet_transactions_job.rb
+++ b/app/jobs/clock/create_interval_wallet_transactions_job.rb
@@ -2,9 +2,11 @@
 
 module Clock
   class CreateIntervalWalletTransactionsJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
-    def perform
+    def perform(*)
       Wallets::CreateIntervalWalletTransactionsService.call
     end
   end

--- a/app/jobs/clock/events_validation_job.rb
+++ b/app/jobs/clock/events_validation_job.rb
@@ -2,11 +2,13 @@
 
 module Clock
   class EventsValidationJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
     unique :until_executed
 
-    def perform
+    def perform(*)
       # NOTE: refresh the last hour events materialized view
       Scenic.database.refresh_materialized_view(
         Events::LastHourMv.table_name,

--- a/app/jobs/clock/finalize_invoices_job.rb
+++ b/app/jobs/clock/finalize_invoices_job.rb
@@ -2,9 +2,11 @@
 
 module Clock
   class FinalizeInvoicesJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
-    def perform
+    def perform(*)
       Invoice.ready_to_be_finalized.each do |invoice|
         Invoices::FinalizeJob.perform_later(invoice)
       end

--- a/app/jobs/clock/free_trial_subscriptions_biller_job.rb
+++ b/app/jobs/clock/free_trial_subscriptions_biller_job.rb
@@ -2,9 +2,11 @@
 
 module Clock
   class FreeTrialSubscriptionsBillerJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
-    def perform
+    def perform(*)
       Subscriptions::FreeTrialBillingService.call
     end
   end

--- a/app/jobs/clock/refresh_draft_invoices_job.rb
+++ b/app/jobs/clock/refresh_draft_invoices_job.rb
@@ -2,9 +2,11 @@
 
 module Clock
   class RefreshDraftInvoicesJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
-    def perform
+    def perform(*)
       Invoice.ready_to_be_refreshed.find_each do |invoice|
         Invoices::RefreshDraftJob.perform_later(invoice)
       end

--- a/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
+++ b/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
@@ -2,9 +2,11 @@
 
 module Clock
   class RefreshWalletsOngoingBalanceJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
-    def perform
+    def perform(*)
       return unless License.premium?
 
       Wallet.active.find_each do |wallet|

--- a/app/jobs/clock/subscriptions_biller_job.rb
+++ b/app/jobs/clock/subscriptions_biller_job.rb
@@ -2,9 +2,11 @@
 
 module Clock
   class SubscriptionsBillerJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
-    def perform
+    def perform(*)
       Subscriptions::BillingService.call
     end
   end

--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -2,9 +2,11 @@
 
 module Clock
   class SubscriptionsToBeTerminatedJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
-    def perform
+    def perform(*)
       Subscription
         .joins(customer: :organization)
         .joins('left join webhooks on subscriptions.id = webhooks.object_id and ' \

--- a/app/jobs/clock/terminate_coupons_job.rb
+++ b/app/jobs/clock/terminate_coupons_job.rb
@@ -2,9 +2,11 @@
 
 module Clock
   class TerminateCouponsJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
-    def perform
+    def perform(*)
       Coupons::TerminateService.new.terminate_all_expired
     end
   end

--- a/app/jobs/clock/terminate_ended_subscriptions_job.rb
+++ b/app/jobs/clock/terminate_ended_subscriptions_job.rb
@@ -2,9 +2,11 @@
 
 module Clock
   class TerminateEndedSubscriptionsJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
-    def perform
+    def perform(*)
       Subscription
         .joins(customer: :organization)
         .active

--- a/app/jobs/clock/terminate_wallets_job.rb
+++ b/app/jobs/clock/terminate_wallets_job.rb
@@ -2,9 +2,11 @@
 
 module Clock
   class TerminateWalletsJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
-    def perform
+    def perform(*)
       Wallet.active.expired.find_each do |wallet|
         Wallets::TerminateService.call(wallet:)
       end

--- a/app/jobs/clock/webhooks_cleanup_job.rb
+++ b/app/jobs/clock/webhooks_cleanup_job.rb
@@ -2,9 +2,11 @@
 
 module Clock
   class WebhooksCleanupJob < ApplicationJob
+    prepend SentryCronConcern
+
     queue_as 'clock'
 
-    def perform
+    def perform(*)
       Webhook.where('updated_at < ?', 90.days.ago).destroy_all
     end
   end

--- a/app/jobs/concerns/sentry_cron_concern.rb
+++ b/app/jobs/concerns/sentry_cron_concern.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SentryCronConcern
+  include Sentry::Cron::MonitorCheckIns
+
+  def perform(sentry = {})
+    super
+  ensure
+    # NOTE: If sentry crons are enabled, check in
+    if ENV['SENTRY_ENABLE_CRONS']
+      sentry_monitor_check_ins(
+        slug: sentry[:slug],
+        monitor_config: Sentry::Cron::MonitorConfig.from_crontab(sentry[:cron])
+      )
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -19,57 +19,85 @@ module Clockwork
   # NOTE: All clocks run every hour to take customer timezones into account
 
   every(5.minutes, 'schedule:activate_subscriptions') do
-    Clock::ActivateSubscriptionsJob.perform_later
+    Clock::ActivateSubscriptionsJob.perform_later(
+      slug: 'activate_subscriptions', cron: '*/5 * * * *'
+    )
   end
 
   every(5.minutes, 'schedule:refresh_draft_invoices') do
-    Clock::RefreshDraftInvoicesJob.perform_later
+    Clock::RefreshDraftInvoicesJob.perform_later(
+      slug: 'lago_refresh_draft_invoices', cron: '*/5 * * * *'
+    )
   end
 
   if ENV['LAGO_MEMCACHE_SERVERS'].present? || ENV['LAGO_REDIS_CACHE_URL'].present?
     every(5.minutes, 'schedule:refresh_wallets_ongoing_balance') do
-      Clock::RefreshWalletsOngoingBalanceJob.perform_later unless ENV['LAGO_DISABLE_WALLET_REFRESH'] == 'true'
+      unless ActiveModel::Type::Boolean.new.cast(ENV['LAGO_DISABLE_WALLET_REFRESH'])
+        Clock::RefreshWalletsOngoingBalanceJob.perform_later(
+          slug: 'lago_refresh_wallets_ongoing_balance', cron: '*/5 * * * *'
+        )
+      end
     end
   end
 
   every(1.hour, 'schedule:terminate_ended_subscriptions', at: '*:05') do
-    Clock::TerminateEndedSubscriptionsJob.perform_later
+    Clock::TerminateEndedSubscriptionsJob.perform_later(
+      slug: 'lago_terminate_ended_subscriptions', cron: '5 */1 * * *'
+    )
   end
 
   every(1.hour, 'schedule:bill_customers', at: '*:10') do
-    Clock::SubscriptionsBillerJob.perform_later
+    Clock::SubscriptionsBillerJob.perform_later(
+      slug: 'lago_bill_customers', cron: '10 */1 * * *'
+    )
   end
 
   every(1.hour, 'schedule:finalize_invoices', at: '*:20') do
-    Clock::FinalizeInvoicesJob.perform_later
+    Clock::FinalizeInvoicesJob.perform_later(
+      slug: 'lago_finalize_invoices', cron: '20 */1 * * *'
+    )
   end
 
   every(1.hour, 'schedule:terminate_coupons', at: '*:30') do
-    Clock::TerminateCouponsJob.perform_later
+    Clock::TerminateCouponsJob.perform_later(
+      slug: 'lago_terminate_coupons', cron: '30 */1 * * *'
+    )
   end
 
   every(1.hour, 'schedule:bill_ended_trial_subscriptions', at: '*:35') do
-    Clock::FreeTrialSubscriptionsBillerJob.perform_later
+    Clock::FreeTrialSubscriptionsBillerJob.perform_later(
+      slug: 'lago_bill_ended_trial_subscriptions', cron: '35 */1 * * *'
+    )
   end
 
   every(1.hour, 'schedule:terminate_wallets', at: '*:45') do
-    Clock::TerminateWalletsJob.perform_later
+    Clock::TerminateWalletsJob.perform_later(
+      slug: 'lago_terminate_wallets', cron: '45 */1 * * *'
+    )
   end
 
   every(1.hour, 'schedule:termination_alert', at: '*:50') do
-    Clock::SubscriptionsToBeTerminatedJob.perform_later
+    Clock::SubscriptionsToBeTerminatedJob.perform_later(
+      slug: 'lago_termination_alert', cron: '50 */1 * * *'
+    )
   end
 
   every(1.hour, 'schedule:top_up_wallet_interval_credits', at: '*:55') do
-    Clock::CreateIntervalWalletTransactionsJob.perform_later
+    Clock::CreateIntervalWalletTransactionsJob.perform_later(
+      slug: 'lago_top_up_wallet_interval_credits', cron: '55 */1 * * *'
+    )
   end
 
   every(1.day, 'schedule:clean_webhooks', at: '01:00') do
-    Clock::WebhooksCleanupJob.perform_later
+    Clock::WebhooksCleanupJob.perform_later(
+      slug: 'lago_clean_webhooks', cron: '0 1 * * *'
+    )
   end
 
   every(1.hour, 'schedule:post_validate_events', at: '*:05') do
-    Clock::EventsValidationJob.perform_later
+    Clock::EventsValidationJob.perform_later(
+      slug: 'lago_post_validate_events', cron: '5 */1 * * *'
+    )
   rescue => e
     Sentry.capture_exception(e)
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,9 +16,11 @@ module LagoApi
       #{config.root}/lib/lago_eu_vat
       #{config.root}/app/views/helpers
       #{config.root}/app/support
+      #{config.root}/app/jobs/concerns
     ]
     config.api_only = true
     config.active_job.queue_adapter = :sidekiq
+    config.autoload_paths << Rails.root.join("app/jobs/concerns")
 
     # Configuration for active record encryption
     config.active_record.encryption.primary_key = ENV['ENCRYPTION_PRIMARY_KEY']

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,8 +3,9 @@
 if ENV['SENTRY_DSN']
   Sentry.init do |config|
     config.dsn = ENV['SENTRY_DSN']
+    config.release = Utils::VersionService.new.version.version.number
     config.breadcrumbs_logger = %i[active_support_logger http_logger]
-    config.traces_sample_rate = 0
+    config.traces_sample_rate = ENV['SENTRY_TRACES_SAMPLE_RATE'].to_f || 0
     config.environment = ENV['SENTRY_ENVIRONMENT'] || Rails.env
   end
 end


### PR DESCRIPTION
## Description

Reapply changes from https://github.com/getlago/lago-api/pull/2109 that were reverted in https://github.com/getlago/lago-api/pull/2112 due to errors with the clock job processing