### PR TITLE
fix(service): Ignore current_user if it's not an instance of User

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -155,7 +155,7 @@ class BaseService
   def initialize(current_user = nil)
     @result = Result.new
     @source = CurrentContext&.source
-    result.user = current_user
+    result.user = current_user.is_a?(User) ? current_user : nil
   end
 
   def call(**args, &block)

--- a/spec/services/base_service_spec.rb
+++ b/spec/services/base_service_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::BaseService, type: :service do
+  subject(:service) { described_class.new }
+
+  it { is_expected.to be_kind_of(AfterCommitEverywhere) }
+  it { is_expected.to respond_to(:call) }
+  it { is_expected.to respond_to(:call_async) }
+
+  context 'with current_user' do
+    it 'assigns the current_user to the result' do
+      user = create(:user)
+      result = described_class.new(user).send :result
+
+      expect(result.user).to eq(user)
+    end
+
+    it 'does not assign the current_user to the result if it isn\'t a User' do
+      result = described_class.new([]).send :result
+
+      expect(result.user).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Description

All services inherit from `BaseService`. Many services override the `initialize` constructor method and call `super`.

The BaseService constructor only accepts one argument: the current user. When we call `super` without parenthesis, the argument are forwarded to the parent. Most of the time, we call the parent constructor without the parenthesis.

It means that in many many case, the result returned by the service has a `result.user` which old something else, not a user.
We heavily use the named parameters so most of the time, it's a hash with the argument of the descendant service.

One way to fix this is to go and modify all calls to `super` and replace them with `super(nil)`. I think a better way is to ignore the current_user if it's not an instance of `User`.

### Example

```ruby
module AddOns
  class DestroyService < BaseService
    def initialize(add_on:)
      @add_on = add_on
      super
    end

    # ...

  end
end
```

![CleanShot 2024-06-05 at 14 43 16@2x](https://github.com/getlago/lago-api/assets/1525636/ade737ff-8978-406c-9919-60425c3b35b0)

