### PR TITLE
feat(anrok-integration): refactor create integration customer service

### DIFF
--- a/app/services/integration_customers/anrok_service.rb
+++ b/app/services/integration_customers/anrok_service.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class AnrokService < ::BaseService
+    def initialize(integration:, customer:, subsidiary_id:)
+      @customer = customer
+      @subsidiary_id = subsidiary_id
+      @integration = integration
+
+      super(nil)
+    end
+
+    def create
+      # For Anrok real customer sync happens with the first document sync. In the meantime,
+      # integration customer object needs to be stored on Lago side
+      new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
+        integration:,
+        customer:,
+        type: 'IntegrationCustomers::AnrokCustomer',
+        sync_with_provider: true
+      )
+
+      result.integration_customer = new_integration_customer
+      result
+    end
+
+    private
+
+    attr_reader :integration, :customer, :subsidiary_id
+  end
+end

--- a/app/services/integration_customers/create_service.rb
+++ b/app/services/integration_customers/create_service.rb
@@ -26,19 +26,15 @@ module IntegrationCustomers
     attr_reader :customer
 
     def sync_customer!
-      create_result = Integrations::Aggregator::Contacts::CreateService.call(integration:, customer:, subsidiary_id:)
-      return create_result if create_result.error
+      integration_customer_service = IntegrationCustomers::Factory.new_instance(integration:, customer:, subsidiary_id:)
 
-      new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
-        integration:,
-        customer:,
-        external_customer_id: create_result.contact_id,
-        type: customer_type,
-        subsidiary_id:,
-        sync_with_provider: true
-      )
+      return result unless integration_customer_service
 
-      result.integration_customer = new_integration_customer
+      sync_result = integration_customer_service.create
+
+      return sync_result if sync_result.error
+
+      result.integration_customer = sync_result.integration_customer
       result
     end
 

--- a/app/services/integration_customers/factory.rb
+++ b/app/services/integration_customers/factory.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class Factory
+    def self.new_instance(integration:, customer:, subsidiary_id:)
+      service_class(integration).new(integration:, customer:, subsidiary_id:)
+    end
+
+    def self.service_class(integration)
+      case integration&.type&.to_s
+      when 'Integrations::NetsuiteIntegration'
+        IntegrationCustomers::NetsuiteService
+      when 'Integrations::AnrokIntegration'
+        IntegrationCustomers::AnrokService
+      else
+        raise(NotImplementedError)
+      end
+    end
+  end
+end

--- a/app/services/integration_customers/netsuite_service.rb
+++ b/app/services/integration_customers/netsuite_service.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class NetsuiteService < ::BaseService
+    def initialize(integration:, customer:, subsidiary_id:)
+      @customer = customer
+      @subsidiary_id = subsidiary_id
+      @integration = integration
+
+      super(nil)
+    end
+
+    def create
+      create_result = Integrations::Aggregator::Contacts::CreateService.call(integration:, customer:, subsidiary_id:)
+      return create_result if create_result.error
+
+      new_integration_customer = IntegrationCustomers::BaseCustomer.create!(
+        integration:,
+        customer:,
+        external_customer_id: create_result.contact_id,
+        type: 'IntegrationCustomers::NetsuiteCustomer',
+        subsidiary_id:,
+        sync_with_provider: true
+      )
+
+      result.integration_customer = new_integration_customer
+      result
+    end
+
+    private
+
+    attr_reader :integration, :customer, :subsidiary_id
+  end
+end

--- a/spec/services/integration_customers/anrok_service_spec.rb
+++ b/spec/services/integration_customers/anrok_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe IntegrationCustomers::AnrokService, type: :service do
   let(:customer) { create(:customer, organization:) }
 
   describe '#create' do
-    subject(:service_call) { described_class.new(subsidiary_id: nil, integration:, customer:).create}
+    subject(:service_call) { described_class.new(subsidiary_id: nil, integration:, customer:).create }
 
     it 'returns integration customer' do
       result = service_call

--- a/spec/services/integration_customers/anrok_service_spec.rb
+++ b/spec/services/integration_customers/anrok_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationCustomers::AnrokService, type: :service do
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:organization) { membership.organization }
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer, organization:) }
+
+  describe '#create' do
+    subject(:service_call) { described_class.new(subsidiary_id: nil, integration:, customer:).create}
+
+    it 'returns integration customer' do
+      result = service_call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.integration_customer.external_customer_id).to eq(nil)
+        expect(result.integration_customer.integration_id).to eq(integration.id)
+        expect(result.integration_customer.customer_id).to eq(customer.id)
+        expect(result.integration_customer.type).to eq('IntegrationCustomers::AnrokCustomer')
+      end
+    end
+
+    it 'creates integration customer' do
+      expect { service_call }.to change(IntegrationCustomers::AnrokCustomer, :count).by(1)
+    end
+  end
+end

--- a/spec/services/integration_customers/create_service_spec.rb
+++ b/spec/services/integration_customers/create_service_spec.rb
@@ -88,7 +88,25 @@ RSpec.describe IntegrationCustomers::CreateService, type: :service do
           end
 
           it 'creates integration customer' do
-            expect { service_call }.to change(IntegrationCustomers::BaseCustomer, :count).by(1)
+            expect { service_call }.to change(IntegrationCustomers::NetsuiteCustomer, :count).by(1)
+          end
+
+          context 'with anrok integration' do
+            let(:integration) { create(:anrok_integration, organization:) }
+            let(:params) do
+              {
+                integration_type: 'anrok',
+                integration_code:,
+                sync_with_provider:,
+                external_customer_id:,
+              }
+            end
+
+            before { organization.update!(premium_integrations: ['anrok']) }
+
+            it 'creates integration customer' do
+              expect { service_call }.to change(IntegrationCustomers::AnrokCustomer, :count).by(1)
+            end
           end
         end
       end

--- a/spec/services/integration_customers/create_service_spec.rb
+++ b/spec/services/integration_customers/create_service_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe IntegrationCustomers::CreateService, type: :service do
                 integration_type: 'anrok',
                 integration_code:,
                 sync_with_provider:,
-                external_customer_id:,
+                external_customer_id:
               }
             end
 

--- a/spec/services/integration_customers/netsuite_service_spec.rb
+++ b/spec/services/integration_customers/netsuite_service_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe IntegrationCustomers::NetsuiteService, type: :service do
   let(:subsidiary_id) { '1' }
 
   describe '#create' do
-    subject(:service_call) { described_class.new(subsidiary_id:, integration:, customer:).create}
+    subject(:service_call) { described_class.new(subsidiary_id:, integration:, customer:).create }
 
     let(:contact_id) { SecureRandom.uuid }
     let(:create_result) do

--- a/spec/services/integration_customers/netsuite_service_spec.rb
+++ b/spec/services/integration_customers/netsuite_service_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe IntegrationCustomers::NetsuiteService, type: :service do
+  let(:integration) { create(:netsuite_integration, organization:) }
+  let(:organization) { membership.organization }
+  let(:membership) { create(:membership) }
+  let(:customer) { create(:customer, organization:) }
+  let(:subsidiary_id) { '1' }
+
+  describe '#create' do
+    subject(:service_call) { described_class.new(subsidiary_id:, integration:, customer:).create}
+
+    let(:contact_id) { SecureRandom.uuid }
+    let(:create_result) do
+      result = BaseService::Result.new
+      result.contact_id = contact_id
+      result
+    end
+    let(:aggregator_contacts_create_service) do
+      instance_double(Integrations::Aggregator::Contacts::CreateService)
+    end
+
+    before do
+      allow(Integrations::Aggregator::Contacts::CreateService)
+        .to receive(:new).and_return(aggregator_contacts_create_service)
+
+      allow(aggregator_contacts_create_service).to receive(:call).and_return(create_result)
+    end
+
+    it 'returns integration customer' do
+      result = service_call
+
+      aggregate_failures do
+        expect(aggregator_contacts_create_service).to have_received(:call)
+        expect(result).to be_success
+        expect(result.integration_customer.subsidiary_id).to eq('1')
+        expect(result.integration_customer.external_customer_id).to eq(contact_id)
+        expect(result.integration_customer.integration_id).to eq(integration.id)
+        expect(result.integration_customer.customer_id).to eq(customer.id)
+        expect(result.integration_customer.type).to eq('IntegrationCustomers::NetsuiteCustomer')
+      end
+    end
+
+    it 'creates integration customer' do
+      expect { service_call }.to change(IntegrationCustomers::NetsuiteCustomer, :count).by(1)
+    end
+  end
+end


### PR DESCRIPTION
## Context

Lago does not support tax tool integrations, but support for it is currently being implemented.

## Description

This PR adds needed changes in create integration service.

Anrok does not sync customer right away. Instead, customer is synced when the first document is sent to the anrok.

Based on requirements from above, we changed a bit generic create service so that it works based on specific integration needs.