### PR TITLE
fix(stripe): Add more ignore invoice not found error when in test mode

### DIFF
--- a/app/services/payment_providers/stripe_service.rb
+++ b/app/services/payment_providers/stripe_service.rb
@@ -142,13 +142,15 @@ module PaymentProviders
       when 'payment_intent.payment_failed', 'payment_intent.succeeded'
         status = (event.type == 'payment_intent.succeeded') ? 'succeeded' : 'failed'
 
-        Invoices::Payments::StripeService
+        result = Invoices::Payments::StripeService
           .new.update_payment_status(
             organization_id: organization.id,
             provider_payment_id: event.data.object.id,
             status:,
             metadata: event.data.object.metadata.to_h.symbolize_keys
           )
+
+        result.raise_if_error! || result
       when 'payment_method.detached'
         result = PaymentProviderCustomers::StripeService
           .new


### PR DESCRIPTION
## Context

Similar to https://github.com/getlago/lago-api/pull/2124

Some dead jobs were received lately for `PaymentProviders::Stripe::HandleEventJob` with an `BaseService::NotFoundFailure (invoice_not_found)`  error.

The event type of the webhook was a `payment_intent.succeeded` and it was related to an `one_off` invoice.

After investigation it appears that the webhook was coming from Lago stripe account in test mode. Most certainly configured in a staging, and so was not related to production invoices.

## Description

This PR changes the invoice lookup behavior, to bubble-up a Not Found error if the invoice is not found in the DB. The webhook handler catches the error and ignore it if the event is coming from an account with the flag `"livemode": false`
