### PR TITLE
feat(invoice): Introduce charge_in_advance invoice status

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -48,7 +48,7 @@ class Invoice < ApplicationRecord
     allow_nil: true,
     with_model_currency: :currency
 
-  INVOICE_TYPES = %i[subscription add_on credit one_off].freeze
+  INVOICE_TYPES = %i[subscription add_on credit one_off charge_in_advance].freeze
   PAYMENT_STATUS = %i[pending succeeded failed].freeze
   STATUS = %i[draft finalized voided generating].freeze
 

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -63,10 +63,9 @@ module Invoices
     def create_generating_invoice
       invoice_result = Invoices::CreateGeneratingService.call(
         customer:,
-        invoice_type: :subscription,
+        invoice_type: :charge_in_advance,
         currency: customer.currency,
-        datetime: Time.zone.at(timestamp),
-        charge_in_advance: true
+        datetime: Time.zone.at(timestamp)
       ) do |invoice|
         Invoices::CreateInvoiceSubscriptionService
           .call(invoice:, subscriptions: [subscription], timestamp:, invoicing_reason: :in_advance_charge)

--- a/schema.graphql
+++ b/schema.graphql
@@ -3831,6 +3831,7 @@ type InvoiceSubscription {
 
 enum InvoiceTypeEnum {
   add_on
+  charge_in_advance
   credit
   one_off
   subscription

--- a/schema.json
+++ b/schema.json
@@ -18702,6 +18702,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "charge_in_advance",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/services/invoices/create_generating_service_spec.rb
+++ b/spec/services/invoices/create_generating_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Invoices::CreateGeneratingService, type: :service do
   subject(:create_service) do
-    described_class.new(customer:, invoice_type:, currency:, datetime:, charge_in_advance:)
+    described_class.new(customer:, invoice_type:, currency:, datetime:)
   end
 
   let(:customer) { create(:customer) }
@@ -97,7 +97,7 @@ RSpec.describe Invoices::CreateGeneratingService, type: :service do
       end
 
       context 'when charge pay in advance invoice is generated' do
-        let(:charge_in_advance) { true }
+        let(:invoice_type) { :charge_in_advance }
 
         it 'creates an invoice with correct issuing date' do
           result = create_service.call

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
         expect(result.invoice.payment_due_date.to_date).to eq(timestamp)
         expect(result.invoice.organization_id).to eq(organization.id)
         expect(result.invoice.customer_id).to eq(customer.id)
-        expect(result.invoice.invoice_type).to eq('subscription')
+        expect(result.invoice.invoice_type).to eq('charge_in_advance')
         expect(result.invoice.payment_status).to eq('pending')
 
         expect(result.invoice.fees.where(fee_type: :charge).count).to eq(1)


### PR DESCRIPTION
## Description

When a plan has a `pay_in_advance` charge, we create an invoice every time we receive an event related to this charge.

Today, these invoices are `invoice_type: :subscription`. This PR create a new type of invoice named `charge_in_advance`.

* This allows us to differentiate them from `subscription` invoice which is created at the beginning of a new period.
* The same webhook are triggered but the invoice objects now has a different status.
* On the first day of the period, the subscription invoice might have only charge fees (pay in arrears) but no subscription fee. It's still a `subscription` invoice because it happened "on billing day". The type is more related to "when and how" it happens than what fees it holds.
* ~Existing invoices will *NOT* be migrated and will continue to be have `subscription` type forever.~ I think we need to migrate the data otherwise we can never safely rely on this type and it becomes useless to even introduce it.


I believe we recently introduce the `charge_in_advance` argument to the `Invoices::CreateGeneratingService` because this type was lacking. See https://github.com/getlago/lago-api/pull/1800

### Why now?

We're looking new invoices for few new feature:
* progressing invoicing 
* "non invoiceable fees" invoice (we'll find a better name)
and I think this type is missing.


### Breaking change?

Because the `invoice_type` received in the webook will change, we might consider this as a breaking change.
How should we handle this? I believe it's acceptable since it will be part of the changelog for selfhosted and we can warn cloud users before this is released.


What do you think? What am I missing?