### PR TITLE
chore(spec): Use `awesome_print` to debug tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'simplecov', require: false
   gem 'webmock'
+  gem 'awesome_print', require: false
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'simplecov', require: false
   gem 'webmock'
-  gem 'awesome_print', require: false
+  gem 'awesome_print'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,7 @@ GEM
       activesupport
     analytics-ruby (2.4.0)
     ast (2.4.2)
+    awesome_print (1.9.2)
     aws-eventstream (1.2.0)
     aws-partitions (1.605.0)
     aws-sdk-core (3.131.2)
@@ -853,6 +854,7 @@ DEPENDENCIES
   adyen-ruby-api-library
   after_commit_everywhere
   analytics-ruby (~> 2.4.0)
+  awesome_print
   aws-sdk-s3
   bcrypt
   bigdecimal

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,15 @@ require_relative '../config/environment'
 require 'spec_helper'
 require 'simplecov'
 
+require 'awesome_print'
+def pp(*args)
+  # Uncomment the following line if you can't find where you left a `pp` call
+  # ap caller.first
+  args.each do |arg|
+    ap arg, {sort_vars: false, sort_keys: false, indent: -2}
+  end
+end
+
 DatabaseCleaner.allow_remote_database_url = true
 
 SimpleCov.start do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,6 @@ require_relative '../config/environment'
 require 'spec_helper'
 require 'simplecov'
 
-require 'awesome_print'
 def pp(*args)
   # Uncomment the following line if you can't find where you left a `pp` call
   # ap caller.first


### PR DESCRIPTION
## Description

I use `pp` a lot to print variables or messages when I'm debugging with tests. Unfortunately, it's printing only one line without colors in my tests. It's all pretty in the console. I must be missing something but one solution I like is to use the `awesome_print` gem.

Am I the only one with this problem?

### BEFORE

![CleanShot 2024-06-06 at 15 27 47@2x](https://github.com/getlago/lago-api/assets/1525636/5a19c561-5abd-4500-9dcf-fef768586373)

### AFTER

![CleanShot 2024-06-06 at 15 26 26@2x](https://github.com/getlago/lago-api/assets/1525636/3f23aab3-01e7-4c1c-b683-5301f6bd27ee)

### BONUS

You can go and uncomment one line to easily see where you left your `pp`. 
Especially useful when you started editing gems 😬 

![CleanShot 2024-06-06 at 15 26 41@2x](https://github.com/getlago/lago-api/assets/1525636/f4221264-0594-4f99-9ace-d84b92c4e2de)

