### PR TITLE
feat(events): Refactor PayInAdvance Billable Metric validation

### DIFF
--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -25,6 +25,7 @@ class BillableMetric < ApplicationRecord
     latest_agg: 6,
     custom_agg: 7
   }.freeze
+  AGGREGATION_TYPES_PAYABLE_IN_ADVANCE = %i[count_agg sum_agg unique_count_agg custom_agg].freeze
 
   WEIGHTED_INTERVAL = {seconds: 'seconds'}.freeze
 
@@ -90,6 +91,10 @@ class BillableMetric < ApplicationRecord
         }
       end
     }
+  end
+
+  def payable_in_advance?
+    AGGREGATION_TYPES_PAYABLE_IN_ADVANCE.include?(aggregation_type.to_sym)
   end
 
   private

--- a/spec/models/billable_metric_spec.rb
+++ b/spec/models/billable_metric_spec.rb
@@ -163,4 +163,16 @@ RSpec.describe BillableMetric, type: :model do
       end
     end
   end
+
+  describe '#payable_in_advance?' do
+    it do
+      described_class::AGGREGATION_TYPES_PAYABLE_IN_ADVANCE.each do |agg|
+        expect(build(:billable_metric, aggregation_type: agg)).to be_payable_in_advance
+      end
+
+      (described_class::AGGREGATION_TYPES.keys - described_class::AGGREGATION_TYPES_PAYABLE_IN_ADVANCE).each do |agg|
+        expect(build(:billable_metric, aggregation_type: agg)).not_to be_payable_in_advance
+      end
+    end
+  end
 end

--- a/spec/services/events/post_process_service_spec.rb
+++ b/spec/services/events/post_process_service_spec.rb
@@ -98,10 +98,7 @@ RSpec.describe Events::PostProcessService, type: :service do
 
     context 'when event matches an pay_in_advance charge that is not invoiceable' do
       let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric:, invoiceable: false) }
-      let(:billable_metric) do
-        create(:billable_metric, organization:, aggregation_type: 'sum_agg', field_name: 'item_id')
-      end
-
+      let(:billable_metric) { create(:billable_metric, organization:, aggregation_type: 'sum_agg', field_name: 'item_id') }
       let(:event_properties) { {billable_metric.field_name => '12'} }
 
       before { charge }


### PR DESCRIPTION
## Description

Whenever a event associated with PayInAdvance charge is recieved, we create a Fee for this event.

The validation was performed only after we create the Fee for `invoiceable: false` charges creating some disparities if the charge is invoiceable or not.

I realized that there is already a validation on the aggregation in the Charge model, which I refactored.

~I have removed all the validation in the PostProcess events because, you're not supposed to be able to create invalid charge (see Charge model validation) and if you send events without the `properties[bm.field_name]`, I'm not sure it should fail silently.~ It creates a fee even without valid properties so I'm keeping the condition as-is, but earlier in the function.

