### PR TITLE
feat(clickhouse): Introduce Events::Common for in advance aggregation

### DIFF
--- a/app/models/events/common.rb
+++ b/app/models/events/common.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Events
+  Common = Struct.new(:id, :organization_id, :transaction_id, :external_subscription_id, :timestamp, :code, :properties) do
+    def event_id
+      id || transaction_id
+    end
+
+    def organization
+      @organization ||= Organization.find_by(id: organization_id)
+    end
+
+    def billable_metric
+      @billable_metric ||= organization.billable_metrics.find_by(code: code)
+    end
+
+    def subscription
+      return @subscription if defined? @subscription
+
+      @subscription = organization
+        .subscriptions
+        .where(external_id: external_subscription_id)
+        .where("date_trunc('millisecond', started_at::timestamp) <= ?::timestamp", timestamp)
+        .where(
+          "terminated_at IS NULL OR date_trunc('millisecond', terminated_at::timestamp) >= ?",
+          timestamp
+        )
+        .order('terminated_at DESC NULLS FIRST, started_at DESC')
+        .first
+    end
+
+    def as_json
+      super.tap { |j| j['timestamp'] = timestamp.to_f }
+    end
+  end
+end

--- a/app/services/events/common_factory.rb
+++ b/app/services/events/common_factory.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Events
+  class CommonFactory
+    def self.new_instance(source:)
+      case source.class.name
+      when 'Events::Common'
+        source
+      when 'Hash'
+        Events::Common.new(
+          organization_id: source['organization_id'],
+          transaction_id: source['transaction_id'],
+          external_subscription_id: source['external_subscription_id'],
+          timestamp: Time.zone.at(source['timestamp'].to_f),
+          code: source['code'],
+          properties: source['properties']
+        )
+      when 'Event'
+        Events::Common.new(
+          id: source.id,
+          organization_id: source.organization_id,
+          transaction_id: source.transaction_id,
+          external_subscription_id: source.external_subscription_id,
+          timestamp: source.timestamp,
+          code: source.code,
+          properties: source.properties
+        )
+      when 'Clickhouse::EventsRaw'
+        Events::Common.new(
+          organization_id: source.organization_id,
+          transaction_id: source.transaction_id,
+          external_subscription_id: source.external_subscription_id,
+          timestamp: source.timestamp,
+          code: source.code,
+          properties: source.properties
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/clickhouse_events.rb
+++ b/spec/factories/clickhouse_events.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :clickhouse_events_raw, class: 'Clickhouse::EventsRaw' do
+    transient do
+      organization { create(:organization) }
+      billable_metric { create(:billable_metric, organization: organization) }
+      subscription { create(:subscription, organization: organization) }
+    end
+
+    organization_id { organization.id }
+    transaction_id { SecureRandom.uuid }
+    external_subscription_id { subscription.external_id }
+    timestamp { Time.current }
+    code { billable_metric.code }
+    properties { {} }
+  end
+end

--- a/spec/factories/common_events.rb
+++ b/spec/factories/common_events.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :common_event, class: 'Events::Common' do
+    transient do
+      organization { create(:organization) }
+      billable_metric { create(:billable_metric, organization: organization) }
+      subscription { create(:subscription, organization: organization) }
+    end
+
+    organization_id { organization.id }
+    transaction_id { SecureRandom.uuid }
+    external_subscription_id { subscription.external_id }
+    timestamp { Time.current }
+    code { billable_metric.code }
+    properties { {} }
+  end
+end

--- a/spec/models/events/common_spec.rb
+++ b/spec/models/events/common_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::Common do
+  subject(:event) do
+    described_class.new(
+      id: nil,
+      organization_id: organization.id,
+      transaction_id: SecureRandom.uuid,
+      external_subscription_id: subscription.external_id,
+      timestamp:,
+      code: billable_metric.code,
+      properties: {}
+    )
+  end
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization: organization) }
+  let(:timestamp) { Time.current - 1.second }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, organization:, customer:, plan:, started_at:) }
+
+  let(:started_at) { Time.current - 3.days }
+  let(:external_subscription_id) { subscription.external_id }
+
+  describe '#event_id' do
+    it 'returns the transaction_id' do
+      expect(event.event_id).to eq(event.transaction_id)
+    end
+
+    context 'when id is set' do
+      before { event.id = 'event-id' }
+
+      it 'returns the id' do
+        expect(event.event_id).to eq('event-id')
+      end
+    end
+  end
+
+  describe '#organization' do
+    it 'returns the organization' do
+      expect(event.organization).to eq(organization)
+    end
+  end
+
+  describe '#billable_metric' do
+    it 'returns the billable_metric' do
+      expect(event.billable_metric).to eq(billable_metric)
+    end
+  end
+
+  describe '#subscription' do
+    it 'returns the subscription' do
+      expect(event.subscription).to eq(subscription)
+    end
+
+    context 'when subscription is terminated' do
+      let(:subscription) { create(:subscription, :terminated, organization:, customer:, started_at:) }
+
+      it 'returns the subscription' do
+        expect(event.subscription).to eq(subscription)
+      end
+
+      context 'when subscription is terminated just after the ingestion' do
+        before do
+          subscription.update!(terminated_at: timestamp + 0.2.seconds)
+        end
+
+        it 'returns the subscription' do
+          expect(event.subscription).to eq(subscription)
+        end
+      end
+
+      context 'when a new active subscription exists' do
+        let(:started_at) { 1.month.ago }
+        let(:timestamp) { 1.week.ago }
+
+        let(:active_subscription) do
+          create(
+            :subscription,
+            customer:,
+            organization:,
+            started_at: 1.day.ago,
+            external_id: subscription.external_id
+          )
+        end
+
+        before { active_subscription }
+
+        it 'returns the active subscription' do
+          expect(event.subscription).to eq(subscription)
+        end
+      end
+
+      context 'when subscription is an upgrade/downgrade' do
+        let(:started_at) { 1.week.ago }
+
+        let(:terminated_subscription) do
+          create(
+            :subscription,
+            :terminated,
+            organization:,
+            customer:,
+            external_id: external_subscription_id,
+            started_at: 1.month.ago,
+            terminated_at: timestamp - 1.day
+          )
+        end
+
+        before { terminated_subscription }
+
+        it 'returns the subscription' do
+          expect(event.subscription).to eq(subscription)
+        end
+      end
+    end
+  end
+
+  describe '#as_json' do
+    it 'returns the event as json' do
+      expect(event.as_json).to include(
+        'organization_id' => organization.id,
+        'transaction_id' => event.transaction_id,
+        'external_subscription_id' => subscription.external_id,
+        'code' => billable_metric.code,
+        'properties' => {},
+        'timestamp' => timestamp.to_f
+      )
+    end
+  end
+end

--- a/spec/services/events/common_factory_spec.rb
+++ b/spec/services/events/common_factory_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::CommonFactory do
+  describe '.new_instance' do
+    context 'when source is an instance of Events::Common' do
+      let(:source) { build(:common_event) }
+
+      it 'returns the source' do
+        expect(described_class.new_instance(source:)).to eq(source)
+      end
+    end
+
+    context 'when source is a hash' do
+      let(:source) { build(:common_event).as_json }
+
+      it 'returns a new instance of Events::Common', :aggregate_failures do
+        new_instance = described_class.new_instance(source:)
+
+        expect(new_instance.id).to be_nil
+        expect(new_instance.organization_id).to eq(source['organization_id'])
+        expect(new_instance.transaction_id).to eq(source['transaction_id'])
+        expect(new_instance.external_subscription_id).to eq(source['external_subscription_id'])
+        expect(new_instance.timestamp).to eq(Time.zone.at(source['timestamp'].to_f))
+        expect(new_instance.code).to eq(source['code'])
+        expect(new_instance.properties).to eq(source['properties'])
+      end
+    end
+
+    context 'when source is an instance of Event' do
+      let(:source) { create(:event) }
+
+      it 'returns a new instance of Events::Common', :aggregate_failures do
+        new_instance = described_class.new_instance(source:)
+
+        expect(new_instance.id).to eq(source.id)
+        expect(new_instance.organization_id).to eq(source.organization_id)
+        expect(new_instance.transaction_id).to eq(source.transaction_id)
+        expect(new_instance.external_subscription_id).to eq(source.external_subscription_id)
+        expect(new_instance.timestamp).to eq(source.timestamp)
+        expect(new_instance.code).to eq(source.code)
+        expect(new_instance.properties).to eq(source.properties)
+      end
+    end
+
+    context 'when source is an instance of Clickhouse::EventsRaw', clickhouse: true do
+      let(:source) { create(:clickhouse_events_raw) }
+
+      it 'returns a new instance of Events::Common', :aggregate_failures do
+        new_instance = described_class.new_instance(source:)
+
+        expect(new_instance.id).to be_nil
+        expect(new_instance.organization_id).to eq(source.organization_id)
+        expect(new_instance.transaction_id).to eq(source.transaction_id)
+        expect(new_instance.external_subscription_id).to eq(source.external_subscription_id)
+        expect(new_instance.timestamp).to eq(source.timestamp)
+        expect(new_instance.code).to eq(source.code)
+        expect(new_instance.properties).to eq(source.properties)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Today Clickhouse integration does not support pay in advance aggregation.
To do so, we need to refactor some logic that relies on the `events` table located in Postgres database to move to a DB agnostic approach. It will allow us to handle events coming from the API and from Kafka (via Sidekiq)

## Description

This PR, introduces a new model `Events::Common` and a `Events::CommonFactory` to create an instance from any source.
This model will later be used in place of `Event` model in all location related to `pay_in_advance` aggregation
