### PR TITLE
feat(dunning): Add payment_overdue to invoice

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -36,6 +36,7 @@ module Types
 
       field :issuing_date, GraphQL::Types::ISO8601Date, null: false
       field :payment_due_date, GraphQL::Types::ISO8601Date, null: false
+      field :payment_overdue, Boolean, null: false
 
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
+++ b/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
@@ -13,6 +13,7 @@ module Clock
         .where(payment_due_date: ...Time.current)
         .find_each do |invoice|
           invoice.update!(payment_overdue: true)
+          SendWebhookJob.perform_later('invoice.payment_overdue', invoice)
         end
     end
   end

--- a/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
+++ b/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Clock
+  class MarkInvoicesAsPaymentOverdueJob < ApplicationJob
+    queue_as 'clock'
+
+    def perform
+      Invoice
+        .finalized
+        .not_succeeded
+        .where(payment_overdue: false)
+        .where(payment_dispute_lost_at: nil)
+        .where(payment_due_date: ...Time.current)
+        .find_each do |invoice|
+          invoice.update!(payment_overdue: true)
+        end
+    end
+  end
+end

--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -17,6 +17,7 @@ class SendWebhookJob < ApplicationJob
     'invoice.voided' => Webhooks::Invoices::VoidedService,
     'invoice.payment_dispute_lost' => Webhooks::Invoices::PaymentDisputeLostService,
     'invoice.payment_status_updated' => Webhooks::Invoices::PaymentStatusUpdatedService,
+    'invoice.payment_overdue' => Webhooks::Invoices::PaymentOverdueService,
     'invoice.payment_failure' => Webhooks::PaymentProviders::InvoicePaymentFailureService,
     'event.error' => Webhooks::Events::ErrorService,
     'events.errors' => Webhooks::Events::ValidationErrorsService,

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -281,6 +281,7 @@ class Invoice < ApplicationRecord
 
   def mark_as_dispute_lost!(timestamp = Time.current)
     self.payment_dispute_lost_at ||= timestamp
+    self.payment_overdue = false
     save!
   end
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -94,6 +94,8 @@ class Invoice < ApplicationRecord
         .where('invoices.created_at < ?', invoice.created_at)
     }
 
+  scope :payment_overdue, -> { where(payment_overdue: true) }
+
   validates :issuing_date, :currency, presence: true
   validates :timezone, timezone: true, allow_nil: true
   validates :total_amount_cents, numericality: {greater_than_or_equal_to: 0}

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -14,6 +14,7 @@ module V1
         status: model.status,
         payment_status: model.payment_status,
         payment_dispute_lost_at: model.payment_dispute_lost_at,
+        payment_overdue: model.payment_overdue,
         currency: model.currency,
         fees_amount_cents: model.fees_amount_cents,
         taxes_amount_cents: model.taxes_amount_cents,

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -77,7 +77,7 @@ module Customers
       IntegrationCustomers::CreateOrUpdateService.call(
         integration_customer_params: params[:integration_customer],
         customer: result.customer,
-        new_customer:,
+        new_customer:
       )
 
       track_customer_created(customer)
@@ -158,7 +158,7 @@ module Customers
       IntegrationCustomers::CreateOrUpdateService.call(
         integration_customer_params: args[:integration_customer]&.to_h,
         customer: result.customer,
-        new_customer: true,
+        new_customer: true
       )
 
       track_customer_created(customer)

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -114,7 +114,7 @@ module Customers
       IntegrationCustomers::CreateOrUpdateService.call(
         integration_customer_params: args[:integration_customer]&.to_h,
         customer: result.customer,
-        new_customer: false,
+        new_customer: false
       )
 
       result

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -40,6 +40,7 @@ module Invoices
       end
 
       ActiveRecord::Base.transaction do
+        invoice.payment_overdue = false if invoice.payment_overdue? && invoice.payment_status == 'succeeded'
         invoice.save!
 
         Invoices::Metadata::UpdateService.call(invoice:, params: params[:metadata]) if params[:metadata]

--- a/app/services/webhooks/invoices/payment_overdue_service.rb
+++ b/app/services/webhooks/invoices/payment_overdue_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Invoices
+    class PaymentOverdueService < Webhooks::BaseService
+      private
+
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::InvoiceSerializer.new(
+          object,
+          root_name: "invoice",
+          includes: %i[customer fees applied_taxes]
+        )
+      end
+
+      def webhook_type
+        "invoice.payment_overdue"
+      end
+
+      def object_type
+        "invoice"
+      end
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -44,6 +44,10 @@ module Clockwork
     Clock::FinalizeInvoicesJob.perform_later
   end
 
+  every(1.hour, 'schedule:mark_invoices_as_payment_overdue', at: '*:25') do
+    Clock::MarkInvoicesAsPaymentOverdueJob.perform_later
+  end
+
   every(1.hour, 'schedule:terminate_coupons', at: '*:30') do
     Clock::TerminateCouponsJob.perform_later
   end

--- a/db/migrate/20240611074215_add_payment_overdue_to_invoices.rb
+++ b/db/migrate/20240611074215_add_payment_overdue_to_invoices.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddPaymentOverdueToInvoices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :invoices, :payment_overdue, :boolean, default: false
+    add_index :invoices, :payment_overdue
+
+    reversible do |dir|
+      dir.up do
+        # Set existing invoices as payment_overdue
+        execute <<-SQL
+          UPDATE invoices
+            SET payment_overdue = true
+            WHERE status = 1 -- finalized
+            AND payment_status != 1 -- not succeeded
+            AND payment_dispute_lost_at IS NULL -- not lost dispute
+            AND payment_due_date < NOW(); -- due date is in the past
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_07_095208) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_11_074215) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -706,11 +706,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_07_095208) do
     t.boolean "ready_to_be_refreshed", default: false, null: false
     t.datetime "payment_dispute_lost_at"
     t.boolean "skip_charges", default: false, null: false
+    t.boolean "payment_overdue", default: false
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["number"], name: "index_invoices_on_number"
     t.index ["organization_id"], name: "index_invoices_on_organization_id"
     t.index ["sequential_id"], name: "index_invoices_on_sequential_id"
+    t.index ["payment_overdue"], name: "index_invoices_on_payment_overdue"
     t.check_constraint "net_payment_term >= 0", name: "check_organizations_on_net_payment_term"
   end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -3744,6 +3744,7 @@ type Invoice {
   paymentDisputeLosable: Boolean!
   paymentDisputeLostAt: ISO8601DateTime
   paymentDueDate: ISO8601Date!
+  paymentOverdue: Boolean!
   paymentStatus: InvoicePaymentStatusTypeEnum!
   prepaidCreditAmountCents: BigInt!
   refundableAmountCents: BigInt!

--- a/schema.json
+++ b/schema.json
@@ -17680,6 +17680,24 @@
               ]
             },
             {
+              "name": "paymentOverdue",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "paymentStatus",
               "description": null,
               "type": {

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Types::Invoices::Object do
   it { is_expected.to have_field(:total_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:issuing_date).of_type('ISO8601Date!') }
   it { is_expected.to have_field(:payment_due_date).of_type('ISO8601Date!') }
+  it { is_expected.to have_field(:payment_overdue).of_type('Boolean!') }
 
   it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
   it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }

--- a/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
+++ b/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
@@ -6,16 +6,27 @@ describe Clock::MarkInvoicesAsPaymentOverdueJob, job: true do
   subject { described_class }
 
   describe ".perform" do
+    let(:overdue_invoice) { create(:invoice, payment_due_date: 1.day.ago) }
+
+    before do
+      overdue_invoice
+    end
+
     it "marks expected invoices as payment overdue" do
       create(:invoice, :draft, payment_due_date: 1.day.ago)
       create(:invoice, :succeeded, payment_due_date: 1.day.ago)
       create(:invoice, payment_due_date: 1.day.ago, payment_dispute_lost_at: 1.day.ago)
       create(:invoice, payment_due_date: nil)
       create(:invoice, payment_due_date: 1.day.from_now)
-      overdue_invoice = create(:invoice, payment_due_date: 1.day.ago)
 
       described_class.perform_now
       expect(Invoice.payment_overdue).to eq([overdue_invoice])
+    end
+
+    it "enqueues a SendWebhookJob" do
+      expect do
+        described_class.perform_now
+      end.to have_enqueued_job(SendWebhookJob).with("invoice.payment_overdue", Invoice)
     end
   end
 end

--- a/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
+++ b/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Clock::MarkInvoicesAsPaymentOverdueJob, job: true do
+  subject { described_class }
+
+  describe ".perform" do
+    it "marks expected invoices as payment overdue" do
+      create(:invoice, :draft, payment_due_date: 1.day.ago)
+      create(:invoice, :succeeded, payment_due_date: 1.day.ago)
+      create(:invoice, payment_due_date: 1.day.ago, payment_dispute_lost_at: 1.day.ago)
+      create(:invoice, payment_due_date: nil)
+      create(:invoice, payment_due_date: 1.day.from_now)
+      overdue_invoice = create(:invoice, payment_due_date: 1.day.ago)
+
+      described_class.perform_now
+      expect(Invoice.payment_overdue).to eq([overdue_invoice])
+    end
+  end
+end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -944,13 +944,14 @@ RSpec.describe Invoice, type: :model do
     subject(:mark_as_dispute_lost_call) { invoice.mark_as_dispute_lost! }
 
     context 'when record is new' do
-      let(:invoice) { build(:invoice, payment_dispute_lost_at:) }
+      let(:invoice) { build(:invoice, payment_dispute_lost_at:, payment_overdue: true) }
 
       context 'when payment is not disputed' do
         let(:payment_dispute_lost_at) { nil }
 
         it 'changes payment disputed lost date' do
           expect { mark_as_dispute_lost_call }.to change(invoice, :payment_dispute_lost_at).from(nil)
+            .and change(invoice, :payment_overdue).from(true).to(false)
         end
       end
 

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe ::V1::InvoiceSerializer do
         'status' => invoice.status,
         'payment_status' => invoice.payment_status,
         'payment_dispute_lost_at' => invoice.payment_dispute_lost_at,
+        'payment_overdue' => invoice.payment_overdue,
         'currency' => invoice.currency,
         'fees_amount_cents' => invoice.fees_amount_cents,
         'coupons_amount_cents' => invoice.coupons_amount_cents,

--- a/spec/services/invoices/update_service_spec.rb
+++ b/spec/services/invoices/update_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Invoices::UpdateService do
     described_class.new(invoice:, params: update_args, webhook_notification:)
   end
 
-  let(:invoice) { create(:invoice) }
+  let(:invoice) { create(:invoice, payment_overdue: true) }
   let(:invoice_id) { invoice.id }
   let(:webhook_notification) { false }
 
@@ -29,7 +29,10 @@ RSpec.describe Invoices::UpdateService do
       aggregate_failures do
         expect(result).to be_success
         expect(result.invoice).to eq(invoice)
-        expect(result.invoice.payment_status).to eq(update_args[:payment_status])
+        expect(result.invoice).to have_attributes(
+          payment_overdue: false,
+          payment_status: update_args[:payment_status]
+        )
       end
     end
 

--- a/spec/services/webhooks/invoices/payment_overdue_service_spec.rb
+++ b/spec/services/webhooks/invoices/payment_overdue_service_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::Invoices::PaymentOverdueService do
+  subject(:webhook_service) { described_class.new(object: invoice) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:invoice) { create(:invoice, payment_overdue: true, customer:, organization:) }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "invoice.payment_overdue", "invoice"
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/regroup-invoices-to-generate-one-payment-intent

## Context

We want to be able to group invoices to generate one payment.
Today we don't track payment terms and do not mention whether a payment or an invoice is overdue.

## Description

The goal of this PR is to add:

- `payment_overdue`

to `invoice`