### PR TITLE
feat(clickhouse): Refact in advance logic to handle non-PG events

### DIFF
--- a/app/jobs/events/pay_in_advance_job.rb
+++ b/app/jobs/events/pay_in_advance_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Events
+  class PayInAdvanceJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_EVENTS'])
+        :events
+      else
+        :default
+      end
+    end
+
+    def perform(event)
+      Events::PayInAdvanceService.call(event:).raise_if_error!
+    end
+  end
+end

--- a/app/jobs/events/pay_in_advance_job.rb
+++ b/app/jobs/events/pay_in_advance_job.rb
@@ -10,8 +10,15 @@ module Events
       end
     end
 
+    unique :until_executed, on_conflict: :log
+
     def perform(event)
       Events::PayInAdvanceService.call(event:).raise_if_error!
+    end
+
+    def lock_key_arguments
+      event = Events::CommonFactory.new_instance(source: arguments.first)
+      [event.organization_id, event.external_subscription_id, event.transaction_id]
     end
   end
 end

--- a/app/jobs/events/pay_in_advance_kafka_job.rb
+++ b/app/jobs/events/pay_in_advance_kafka_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Events
+  class PayInAdvanceKafkaJob < ApplicationJob
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_EVENTS'])
+        :events
+      else
+        :default
+      end
+    end
+
+    # NOTE: This job is called from the Kafka consumer, so we don't need to worry about locking
+    #       It's goal is only to enqueue the PayInAdvanceJob to be processed by Sidekiq
+    #       taking advantage of the "unique" logic
+    def perform(event)
+      Events::PayInAdvanceJob.perform_later(event)
+    end
+  end
+end

--- a/app/jobs/fees/create_pay_in_advance_job.rb
+++ b/app/jobs/fees/create_pay_in_advance_job.rb
@@ -4,7 +4,7 @@ module Fees
   class CreatePayInAdvanceJob < ApplicationJob
     queue_as :default
 
-    def perform(charge:, event:, billing_at: event.timestamp)
+    def perform(charge:, event:, billing_at: nil)
       result = Fees::CreatePayInAdvanceService.call(charge:, event:, billing_at:)
 
       result.raise_if_error!

--- a/app/jobs/fees/create_pay_in_advance_job.rb
+++ b/app/jobs/fees/create_pay_in_advance_job.rb
@@ -4,6 +4,8 @@ module Fees
   class CreatePayInAdvanceJob < ApplicationJob
     queue_as :default
 
+    unique :until_executed, on_conflict: :log
+
     def perform(charge:, event:, billing_at: nil)
       result = Fees::CreatePayInAdvanceService.call(charge:, event:, billing_at:)
 

--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -6,6 +6,8 @@ module Invoices
 
     retry_on Sequenced::SequenceError
 
+    unique :until_executed, on_conflict: :log
+
     def perform(charge:, event:, timestamp:, invoice: nil)
       result = Invoices::CreatePayInAdvanceChargeService.call(charge:, event:, timestamp:, invoice:)
       return if result.success?

--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -122,7 +122,7 @@ module BillableMetrics
           .where(grouped_by: grouped_by.presence || {})
           .order(timestamp: :desc, created_at: :desc)
 
-        query = query.where.not(event_id: event.id) if event.present?
+        query = query.where.not(event_transaction_id: event.transaction_id) if event.present?
         query = query.where(charge_filter_id: charge_filter.id) if charge_filter
 
         query.first

--- a/app/services/events/common_factory.rb
+++ b/app/services/events/common_factory.rb
@@ -8,6 +8,7 @@ module Events
         source
       when 'Hash'
         Events::Common.new(
+          id: source['id'],
           organization_id: source['organization_id'],
           transaction_id: source['transaction_id'],
           external_subscription_id: source['external_subscription_id'],
@@ -27,6 +28,7 @@ module Events
         )
       when 'Clickhouse::EventsRaw'
         Events::Common.new(
+          id: nil,
           organization_id: source.organization_id,
           transaction_id: source.transaction_id,
           external_subscription_id: source.external_subscription_id,

--- a/app/services/events/pay_in_advance_service.rb
+++ b/app/services/events/pay_in_advance_service.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Events
+  class PayInAdvanceService < BaseService
+    def initialize(event:)
+      @event = Events::CommonFactory.new_instance(source: event)
+      super
+    end
+
+    def call
+      return unless billable_metric
+      return unless can_create_fee?
+
+      # NOTE: Temporary condition to support both Postgres and Clickhouse (via kafka)
+      if kafka_producer_enabled?
+        # NOTE: when clickhouse, ignore event coming from postgres (Rest API)
+        return if event.id.present? && event.organization.clickhouse_aggregation?
+
+        # NOTE: without clickhouse, ignore events coming from kafka
+        return if event.id.nil? && !event.organization.clickhouse_aggregation?
+      end
+
+      charges.where(invoiceable: false).find_each do |charge|
+        Fees::CreatePayInAdvanceJob.perform_later(charge:, event: event.as_json)
+      end
+
+      charges.where(invoiceable: true).find_each do |charge|
+        Invoices::CreatePayInAdvanceChargeJob.perform_later(charge:, event: event.as_json, timestamp: event.timestamp)
+      end
+
+      result.event = event
+      result
+    end
+
+    private
+
+    attr_reader :event
+
+    delegate :billable_metric, :properties, :charges, to: :event
+
+    def charges
+      return Charge.none unless event.subscription
+
+      event.subscription
+        .plan
+        .charges
+        .pay_in_advance
+        .joins(:billable_metric)
+        .where(billable_metrics: {id: event.billable_metric.id})
+    end
+
+    def can_create_fee?
+      # NOTE: `custom_agg` and `count_agg` are the only 2 aggregations
+      #       that don't require a field set in property.
+      #       For other aggregation, if the field isn't set we shouldn't create a fee/invoice.
+      billable_metric.count_agg? || billable_metric.custom_agg? || properties[billable_metric.field_name].present?
+    end
+
+    def kafka_producer_enabled?
+      ENV['LAGO_KAFKA_BOOTSTRAP_SERVERS'].present? && ENV['LAGO_KAFKA_RAW_EVENTS_TOPIC'].present?
+    end
+  end
+end

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -2,10 +2,10 @@
 
 module Fees
   class CreatePayInAdvanceService < BaseService
-    def initialize(charge:, event:, billing_at: event.timestamp, estimate: false)
+    def initialize(charge:, event:, billing_at: nil, estimate: false)
       @charge = charge
-      @event = event
-      @billing_at = billing_at
+      @event = Events::CommonFactory.new_instance(source: event)
+      @billing_at = billing_at || @event.timestamp
       @estimate = estimate
 
       super
@@ -37,7 +37,7 @@ module Fees
     attr_reader :charge, :event, :billing_at, :estimate
 
     delegate :billable_metric, to: :charge
-    delegate :subscription, :customer, to: :event
+    delegate :subscription, to: :event
 
     def create_fee(properties:, charge_filter: nil)
       ActiveRecord::Base.transaction do

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -4,7 +4,7 @@ module Invoices
   class CreatePayInAdvanceChargeService < BaseService
     def initialize(charge:, event:, timestamp:, invoice: nil)
       @charge = charge
-      @event = event
+      @event = Events::CommonFactory.new_instance(source: event)
       @timestamp = timestamp
 
       # NOTE: In case of retry when the creation process failed,
@@ -58,7 +58,8 @@ module Invoices
 
     attr_accessor :timestamp, :charge, :event, :invoice
 
-    delegate :subscription, :customer, to: :event
+    delegate :subscription, to: :event
+    delegate :customer, to: :subscription
 
     def create_generating_invoice
       invoice_result = Invoices::CreateGeneratingService.call(

--- a/spec/factories/cached_aggregations.rb
+++ b/spec/factories/cached_aggregations.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     organization
     association :charge, factory: :standard_charge
     event_id { SecureRandom.uuid }
+    event_transaction_id { SecureRandom.uuid }
     external_subscription_id { SecureRandom.uuid }
     timestamp { Time.current }
   end

--- a/spec/jobs/events/pay_in_advance_job_spec.rb
+++ b/spec/jobs/events/pay_in_advance_job_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::PayInAdvanceJob, type: :job do
+  let(:pay_in_advance_service) { instance_double(Events::PayInAdvanceService) }
+  let(:result) { BaseService::Result.new }
+
+  let(:event) { build(:common_event) }
+
+  it 'calls the event pay in advance service' do
+    allow(Events::PayInAdvanceService).to receive(:call)
+      .with(event:)
+      .and_return(result)
+
+    described_class.perform_now(event)
+
+    expect(Events::PayInAdvanceService).to have_received(:call)
+  end
+end

--- a/spec/jobs/fees/create_pay_in_advance_job_spec.rb
+++ b/spec/jobs/fees/create_pay_in_advance_job_spec.rb
@@ -8,20 +8,13 @@ RSpec.describe Fees::CreatePayInAdvanceJob, type: :job do
 
   let(:result) { BaseService::Result.new }
 
-  let(:instant_service) do
-    instance_double(Fees::CreatePayInAdvanceService)
-  end
-
   it 'delegates to the pay_in_advance aggregation service' do
-    allow(Fees::CreatePayInAdvanceService).to receive(:new)
-      .with(charge:, event:, billing_at: event.timestamp)
-      .and_return(instant_service)
-    allow(instant_service).to receive(:call)
+    allow(Fees::CreatePayInAdvanceService).to receive(:call)
+      .with(charge:, event:, billing_at: nil)
       .and_return(result)
 
     described_class.perform_now(charge:, event:)
 
-    expect(Fees::CreatePayInAdvanceService).to have_received(:new)
-    expect(instant_service).to have_received(:call)
+    expect(Fees::CreatePayInAdvanceService).to have_received(:call)
   end
 end

--- a/spec/services/events/pay_in_advance_service_spec.rb
+++ b/spec/services/events/pay_in_advance_service_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::PayInAdvanceService, type: :service do
+  let(:in_advance_service) { described_class.new(event:) }
+
+  let(:organization) { create(:organization) }
+  let(:billable_metric) { create(:billable_metric, organization:) }
+  let(:plan) { create(:plan, organization:) }
+  let(:subscription) { create(:subscription, organization:, plan:, started_at:) }
+  let(:event_properties) { {} }
+  let(:timestamp) { Time.current - 1.second }
+  let(:code) { billable_metric&.code }
+  let(:external_subscription_id) { subscription.external_id }
+  let(:started_at) { Time.current - 3.days }
+
+  let(:event) do
+    build(
+      :common_event,
+      id: SecureRandom.uuid,
+      organization_id: organization.id,
+      code:,
+      external_subscription_id: subscription.external_id,
+      properties: event_properties
+    )
+  end
+
+  describe '#call' do
+    let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric:, invoiceable: false) }
+    let(:billable_metric) do
+      create(:billable_metric, organization:, aggregation_type: 'sum_agg', field_name: 'item_id')
+    end
+
+    let(:event_properties) { {billable_metric.field_name => '12'} }
+
+    before { charge }
+
+    it 'enqueues a job to perform the pay_in_advance aggregation' do
+      expect { in_advance_service.call }.to have_enqueued_job(Fees::CreatePayInAdvanceJob)
+    end
+
+    context 'when charge is invoiceable' do
+      before { charge.update!(invoiceable: true) }
+
+      it 'does not enqueue a job to perform the pay_in_advance aggregation' do
+        expect { in_advance_service.call }.not_to have_enqueued_job(Fees::CreatePayInAdvanceJob)
+      end
+    end
+
+    context 'when multiple charges have the billable metric' do
+      before { create(:standard_charge, :pay_in_advance, plan:, billable_metric:, invoiceable: false) }
+
+      it 'enqueues a job for each charge' do
+        expect { in_advance_service.call }.to have_enqueued_job(Fees::CreatePayInAdvanceJob).twice
+      end
+    end
+
+    context 'when event matches a pay_in_advance charge that is invoiceable' do
+      let(:charge) { create(:standard_charge, :pay_in_advance, plan:, billable_metric:, invoiceable: true) }
+      let(:billable_metric) do
+        create(:billable_metric, organization:, aggregation_type: 'sum_agg', field_name: 'item_id')
+      end
+
+      let(:event_properties) { {billable_metric.field_name => '12'} }
+
+      before { charge }
+
+      it 'enqueues a job to create the pay_in_advance charge invoice' do
+        expect { in_advance_service.call }.to have_enqueued_job(Invoices::CreatePayInAdvanceChargeJob)
+      end
+
+      context 'when charge is not invoiceable' do
+        before { charge.update!(invoiceable: false) }
+
+        it 'does not enqueue a job to create the pay_in_advance charge invoice' do
+          expect { in_advance_service.call }
+            .not_to have_enqueued_job(Invoices::CreatePayInAdvanceChargeJob)
+        end
+      end
+
+      context 'when multiple charges have the billable metric' do
+        before { create(:standard_charge, :pay_in_advance, plan:, billable_metric:, invoiceable: true) }
+
+        it 'enqueues a job for each charge' do
+          expect { in_advance_service.call }
+            .to have_enqueued_job(Invoices::CreatePayInAdvanceChargeJob).twice
+        end
+      end
+
+      context 'when value for sum_agg is negative' do
+        let(:event_properties) { {billable_metric.field_name => '-5'} }
+
+        it 'enqueues a job' do
+          expect { in_advance_service.call }
+            .to have_enqueued_job(Invoices::CreatePayInAdvanceChargeJob)
+        end
+      end
+
+      context 'when event field name does not batch the BM one' do
+        let(:event_properties) { {'wrong_field_name' => '-5'} }
+
+        it 'does not enqueue a job' do
+          expect { in_advance_service.call }
+            .not_to have_enqueued_job(Invoices::CreatePayInAdvanceChargeJob)
+        end
+      end
+    end
+
+    context 'when event is comming from kafka' do
+      before do
+        ENV['LAGO_KAFKA_BOOTSTRAP_SERVERS'] ||= 'kafla:9092'
+        ENV['LAGO_KAFKA_RAW_EVENTS_TOPIC'] ||= 'raw_events'
+
+        event.id = nil
+      end
+
+      it 'does not process the event' do
+        expect do
+          expect { in_advance_service.call }.not_to have_enqueued_job(Fees::CreatePayInAdvanceJob)
+        end.not_to have_enqueued_job(Invoices::CreatePayInAdvanceChargeJob)
+      end
+
+      context 'when organization is using clickhouse' do
+        before { organization.update!(clickhouse_aggregation: true) }
+
+        it 'enqueues a job to perform the pay_in_advance aggregation' do
+          expect { in_advance_service.call }.to have_enqueued_job(Fees::CreatePayInAdvanceJob)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -18,12 +18,14 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
   let(:estimate) { false }
 
   let(:event) do
-    create(
-      :event,
-      external_subscription_id: subscription.external_id,
-      external_customer_id: customer.external_id,
-      organization_id: organization.id,
-      properties: event_properties
+    Events::CommonFactory.new_instance(
+      source: create(
+        :event,
+        external_subscription_id: subscription.external_id,
+        external_customer_id: customer.external_id,
+        organization_id: organization.id,
+        properties: event_properties
+      )
     )
   end
 
@@ -252,11 +254,13 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
       end
 
       let(:event) do
-        create(
-          :event,
-          organization:,
-          external_subscription_id: subscription.external_id,
-          properties: {'operator' => 'foo'}
+        Events::CommonFactory.new_instance(
+          source: create(
+            :event,
+            organization:,
+            external_subscription_id: subscription.external_id,
+            properties: {'operator' => 'foo'}
+          )
         )
       end
 

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -21,11 +21,13 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
   let(:email_settings) { ['invoice.finalized', 'credit_note.created'] }
 
   let(:event) do
-    create(
-      :event,
-      external_subscription_id: subscription.external_id,
-      external_customer_id: customer.external_id,
-      organization_id: organization.id
+    Events::CommonFactory.new_instance(
+      source: create(
+        :event,
+        external_subscription_id: subscription.external_id,
+        external_customer_id: customer.external_id,
+        organization_id: organization.id
+      )
     )
   end
 


### PR DESCRIPTION
## Context

Today Clickhouse integration does not support pay in advance aggregation.
To do so, we need to refactor some logic that relies on the `events` table located in Postgres database to move to a DB agnostic approach. It will allow us to handle events coming from the API and from Kafka (via Sidekiq)

## Description

This PR refactors the `pay_in_advance` handling by extracting the logic into a new `Events::PayInAdvanceJob` that will also be called by the comming `pay_in_advance` ingest service

The service takes advantage of the new `Events::Common` model