### PR TITLE
misc(billable_metric): preload filters and groups in index route

### DIFF
--- a/app/controllers/api/v1/billable_metrics_controller.rb
+++ b/app/controllers/api/v1/billable_metrics_controller.rb
@@ -84,6 +84,7 @@ module Api
 
       def index
         metrics = current_organization.billable_metrics
+          .includes(:filters, :groups)
           .order(created_at: :desc)
           .page(params[:page])
           .per(params[:per_page] || PER_PAGE)

--- a/app/models/billable_metric.rb
+++ b/app/models/billable_metric.rb
@@ -60,7 +60,7 @@ class BillableMetric < ApplicationRecord
   end
 
   def active_groups
-    scope = groups.order(created_at: :asc)
+    scope = groups
     scope = scope.with_discarded if discarded?
     scope
   end


### PR DESCRIPTION
## Context

The billable metric index route appears to be slow in API in some cases.

## Description

This PR tries to speed it up a bit by preloading attached `filters` and `groups` . 

NOTE: Billable metric serializer is also exposing three counters: (`active_subscriptions_count`, `draft_invoices_count` and `        plans_count`), that are slowing down this route. A discussion will be opened about it soon.