### PR TITLE
misc(stripe): Avoid dead jobs for register webhook errors

### DIFF
--- a/app/services/payment_providers/stripe/register_webhook_service.rb
+++ b/app/services/payment_providers/stripe/register_webhook_service.rb
@@ -24,6 +24,11 @@ module PaymentProviders
       rescue ::Stripe::AuthenticationError => e
         deliver_error_webhook(action: 'payment_provider.register_webhook', error: e)
         result
+      rescue ::Stripe::InvalidRequestError => e
+        raise if e.message != "You have reached the maximum of 16 test webhook endpoints."
+
+        deliver_error_webhook(action: 'payment_provider.register_webhook', error: e)
+        result
       end
 
       private


### PR DESCRIPTION
## Context

The `PaymentProviders::Stripe::RegisterWebhookJob`  job sometimes failed to register the webhook on Stripe and raises a
`Stripe::InvalidRequestError (You have reached the maximum of 16 test webhook endpoints)`.

Since this error cannot be fixed by Lago and requires a manual action on the customer side and since most of the time the it is related to a test API key, it should not end in the dead queue.

## Description

This PR changes the current behavior to avoid generating a dead job but to emit a `payment_provider.error` error webhook instead