### PR TITLE
fix(stripe): Enable auto retry for APIConnectionError on payment job

### DIFF
--- a/app/jobs/invoices/payments/stripe_create_job.rb
+++ b/app/jobs/invoices/payments/stripe_create_job.rb
@@ -8,6 +8,7 @@ module Invoices
       unique :until_executed
 
       retry_on Stripe::RateLimitError, wait: :exponentially_longer, attempts: 6
+      retry_on Stripe::APIConnectionError, wait: :exponentially_longer, attempts: 6
 
       def perform(invoice)
         result = Invoices::Payments::StripeService.new(invoice).create


### PR DESCRIPTION
## Description

This pull request enables the auto retry for `Stripe::APIConnectionError` on `Invoices::Payments::StripeCreateJob` to avoid dead jobs that should just be retried