### PR TITLE
fix(logs): Rescue current_organization errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -40,5 +40,6 @@ class ApplicationController < ActionController::API
   def append_info_to_payload(payload)
     super
     payload[:organization_id] = current_organization&.id if defined? current_organization
+  rescue StandardError
   end
 end


### PR DESCRIPTION
## Description

- Rescue errors on logs organization id to avoid bad behavior when JWT token is expired