### PR TITLE
misc(payment_webhook): Improve result management

### DIFF
--- a/app/services/base_service.rb
+++ b/app/services/base_service.rb
@@ -134,7 +134,7 @@ class BaseService
     end
 
     def raise_if_error!
-      return if success?
+      return self if success?
 
       raise(error)
     end
@@ -144,12 +144,12 @@ class BaseService
     attr_accessor :failure
   end
 
-  def self.call(*, **, &block)
-    new(*, **).call(&block)
+  def self.call(*, **, &)
+    new(*, **).call(&)
   end
 
-  def self.call_async(*, **, &block)
-    new(*, **).call_async(&block)
+  def self.call_async(*, **, &)
+    new(*, **).call_async(&)
   end
 
   def initialize(current_user = nil)

--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -88,7 +88,7 @@ module PaymentProviders
 
         if payment_type == 'one-time'
           update_result = update_payment_status(event, payment_type)
-          return update_result.raise_if_error! || update_result
+          return update_result.raise_if_error!
         end
 
         return result if amount != 0
@@ -96,7 +96,7 @@ module PaymentProviders
         service = PaymentProviderCustomers::AdyenService.new
 
         result = service.preauthorise(organization, event)
-        result.raise_if_error! || result
+        result.raise_if_error!
       when 'REFUND'
         service = CreditNotes::Refunds::AdyenService.new
 
@@ -104,7 +104,7 @@ module PaymentProviders
         status = (event['success'] == 'true') ? :succeeded : :failed
 
         result = service.update_status(provider_refund_id:, status:)
-        result.raise_if_error! || result
+        result.raise_if_error!
       when 'CHARGEBACK'
         PaymentProviders::Webhooks::Adyen::ChargebackService.call(
           organization_id: organization.id,
@@ -118,7 +118,7 @@ module PaymentProviders
         provider_refund_id = event['pspReference']
 
         result = service.update_status(provider_refund_id:, status: :failed)
-        result.raise_if_error! || result
+        result.raise_if_error!
       end
     end
 


### PR DESCRIPTION
## Description

This PR improves the `Result#raise_if_error!` method  in order to return the result if it is a success, allowing use to write thing like `return result.raise_if_error!` instead of `return result.raise_if_error! || result`

This new approach is then used in some refactors in `PaymentProviders::AdyenService` and `PaymentProviders::StripeService`

Finally a new `raise_if_error!` is added to the result of the `PaymentProviders::Webhooks::Stripe::ChargeDisputeClosedService#call` to ignore missing payment error when stripe has flag `livemode` set to `false`