### PR TITLE
fix (integrations): enable optional code when creating mapping object

### DIFF
--- a/app/graphql/types/integration_mappings/create_input.rb
+++ b/app/graphql/types/integration_mappings/create_input.rb
@@ -5,7 +5,7 @@ module Types
     class CreateInput < Types::BaseInputObject
       graphql_name 'CreateIntegrationMappingInput'
 
-      argument :external_account_code, String, required: true
+      argument :external_account_code, String, required: false
       argument :external_id, String, required: true
       argument :external_name, String, required: false
       argument :integration_id, ID, required: true

--- a/app/graphql/types/integration_mappings/object.rb
+++ b/app/graphql/types/integration_mappings/object.rb
@@ -5,7 +5,7 @@ module Types
     class Object < Types::BaseObject
       graphql_name 'Mapping'
 
-      field :external_account_code, String, null: false
+      field :external_account_code, String, null: true
       field :external_id, String, null: false
       field :external_name, String, null: true
       field :id, ID, null: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -1888,7 +1888,7 @@ input CreateIntegrationMappingInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  externalAccountCode: String!
+  externalAccountCode: String
   externalId: String!
   externalName: String
   integrationId: ID!
@@ -3903,7 +3903,7 @@ enum MappableTypeEnum {
 }
 
 type Mapping {
-  externalAccountCode: String!
+  externalAccountCode: String
   externalId: String!
   externalName: String
   id: ID!

--- a/schema.json
+++ b/schema.json
@@ -7388,13 +7388,9 @@
               "name": "externalAccountCode",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -19204,13 +19200,9 @@
               "name": "externalAccountCode",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/spec/graphql/types/integration_mappings/create_input_spec.rb
+++ b/spec/graphql/types/integration_mappings/create_input_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Types::IntegrationMappings::CreateInput do
   it { is_expected.to accept_argument(:integration_id).of_type('ID!') }
   it { is_expected.to accept_argument(:mappable_id).of_type('ID!') }
   it { is_expected.to accept_argument(:mappable_type).of_type('MappableTypeEnum!') }
-  it { is_expected.to accept_argument(:external_account_code).of_type('String!') }
+  it { is_expected.to accept_argument(:external_account_code).of_type('String') }
   it { is_expected.to accept_argument(:external_id).of_type('String!') }
   it { is_expected.to accept_argument(:external_name).of_type('String') }
 end

--- a/spec/graphql/types/integration_mappings/object_spec.rb
+++ b/spec/graphql/types/integration_mappings/object_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Types::IntegrationMappings::Object do
   it { is_expected.to have_field(:integration_id).of_type('ID!') }
   it { is_expected.to have_field(:mappable_id).of_type('ID!') }
   it { is_expected.to have_field(:mappable_type).of_type('MappableTypeEnum!') }
-  it { is_expected.to have_field(:external_account_code).of_type('String!') }
+  it { is_expected.to have_field(:external_account_code).of_type('String') }
   it { is_expected.to have_field(:external_id).of_type('String!') }
   it { is_expected.to have_field(:external_name).of_type('String') }
 end


### PR DESCRIPTION
## Context

Currently Lago does not support tax integrations

## Description

When creating Anrok mapping object `code` is not required so we need to change our generic gql mapping definitions
