### PR TITLE
fix(adyen): Retry payment creation on Faraday::ConnectionFailed

### DIFF
--- a/app/jobs/invoices/payments/adyen_create_job.rb
+++ b/app/jobs/invoices/payments/adyen_create_job.rb
@@ -7,6 +7,8 @@ module Invoices
 
       unique :until_executed
 
+      retry_on Faraday::ConnectionFailed, wait: :exponentially_longer, attempts: 6
+
       def perform(invoice)
         result = Invoices::Payments::AdyenService.new(invoice).create
         result.raise_if_error!


### PR DESCRIPTION
## Context
Some `Invoices::Payments::AdyenCreateJob ` failed with a `Faraday::ConnectionFailed`

Since it is a temporary error with the Adyen API, these jobs should be reprocessed automatically instead of ending in the dead queue.

## Description

This PR adds the retry system for the `Faraday::ConnectionFailed`