### PR TITLE
misc(stripe): Avoid dead job for invalid key when creating customers

### DIFF
--- a/app/jobs/payment_provider_customers/stripe_create_job.rb
+++ b/app/jobs/payment_provider_customers/stripe_create_job.rb
@@ -12,6 +12,8 @@ module PaymentProviderCustomers
     def perform(stripe_customer)
       result = PaymentProviderCustomers::StripeService.new(stripe_customer).create
       result.raise_if_error!
+    rescue BaseService::UnauthorizedFailure => e
+      Rails.logger.warn(e.message)
     end
   end
 end


### PR DESCRIPTION
## Description

This PR ensures that the `PaymentProviderCustomers::StripeCreateJob` does not end in the dead job queue if the stripe api secret is invalid. 

It will only deliver an error webhook to the account owner.