### PR TITLE
fix(invoice): make sure generating invoices are re-attached to the billing jobs

### DIFF
--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -58,8 +58,6 @@ module Invoices
       raise unless invoicing_reason.to_sym == :subscription_periodic
 
       result
-    rescue Sequenced::SequenceError
-      raise
     rescue => e
       result.fail_with_error!(e)
     end


### PR DESCRIPTION
## Context

In case of `Sequenced::SequenceError` in the `Invoices::SubscriptionService`, called by the `BillSubscriptionJob`, the generating invoice is not reattached to the renqueued job, leading to a dead job caused by a `ActiveRecord::RecordNotUnique` error.

This behavior leads to a lot of dead jobs that cannot be reprocessed automatically and that leave invoices stuck in the `generating` status

## Description

This PR makes sure that every error happening in the `Invoices::SubscriptionService` are converted into an error result, allowing the  `BillSubscriptionJob` to attached the generating `invoice` to the new generation attempt.

It should fix most of the `ActiveRecord::RecordNotUnique` errors happening in this job
