### PR TITLE
fix(subscriptions): Fix incorrect `error_details` when creating a subscription without `external_customer_id`

### DIFF
--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -25,7 +25,7 @@ module Subscriptions
     def call
       return result unless valid?(customer:, plan:, subscription_at:, ending_at: params[:ending_at])
       return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides)
-      return result.validation_failure!(errors: {external_customer_id: ['value_is_mandatory']}) if params[:external_customer_id].blank?
+      return result.validation_failure!(errors: {external_customer_id: ['value_is_mandatory']}) if params[:external_customer_id].blank? && api_context?
 
       plan.amount_currency = plan_overrides[:amount_currency] if plan_overrides[:amount_currency]
       plan.amount_cents = plan_overrides[:amount_cents] if plan_overrides[:amount_cents]

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -25,6 +25,7 @@ module Subscriptions
     def call
       return result unless valid?(customer:, plan:, subscription_at:, ending_at: params[:ending_at])
       return result.forbidden_failure! if !License.premium? && params.key?(:plan_overrides)
+      return result.validation_failure!(errors: {external_customer_id: ['value_is_mandatory']}) if params[:external_customer_id].blank?
 
       plan.amount_currency = plan_overrides[:amount_currency] if plan_overrides[:amount_currency]
       plan.amount_cents = plan_overrides[:amount_cents] if plan_overrides[:amount_cents]

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -93,6 +93,23 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
       end
     end
 
+    context 'without external_customer_id', :aggregate_failures do
+      let(:params) do
+        {
+          plan_code:,
+          name: 'subscription name',
+          external_id: SecureRandom.uuid
+        }
+      end
+
+      it 'returns an unprocessable_entity error' do
+        post_with_token(organization, '/api/v1/subscriptions', {subscription: params})
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json[:error_details]).to eq({external_customer_id: %w[value_is_mandatory]})
+      end
+    end
+
     context 'with invalid plan code' do
       let(:plan_code) { "#{plan.code}-invalid" }
 

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -96,6 +96,35 @@ RSpec.describe Subscriptions::CreateService, type: :service do
       end
     end
 
+    context 'when customer is invalid in an api context' do
+      let(:customer) do
+        build(:customer, organization:, currency: 'EUR', external_id: nil)
+      end
+
+      let(:params) do
+        {
+          plan_code:,
+          name:,
+          external_id:,
+          billing_time:,
+          subscription_at:,
+          subscription_id:
+        }
+      end
+
+      before { CurrentContext.source = 'api' }
+
+      it 'returns an error' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages[:external_customer_id]).to eq(['value_is_mandatory'])
+        end
+      end
+    end
+
     context 'when external_id is not given in an api context' do
       let(:external_id) { nil }
 


### PR DESCRIPTION
## Context

When a user tries to create a subscription via API without providing external_customer_id, the API returns a 422 error.

This is the expected behaviour, but the reason is incorrect: it says "external_id": ["value is mandatory"] instead of "external_customer_id": ["value is mandatory"].

## Description

Add guard clause to `Subscriptions::CreateService` to ensure `external_customer_id` is provider or return a validation error with the right details as result.