### PR TITLE
chore(invoices): Remove duplicated invoice amounts computations

### DIFF
--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -41,10 +41,6 @@ module Invoices
           end
         end
 
-        invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
-        invoice.sub_total_excluding_taxes_amount_cents = invoice.fees.sum(:amount_cents) -
-          invoice.coupons_amount_cents
-
         Credits::AppliedCouponsService.call(invoice:) if should_create_coupon_credit?
         Invoices::ComputeAmountsFromFees.call(invoice:)
 


### PR DESCRIPTION
## Description

When calculating fees with `Invoices:: CalculateFeesService` we sum all fees to add the total amount to the invoice.

It turned out that this computation is done in `Invoices::ComputeAmountsFromFees` line 49.

https://github.com/getlago/lago-api/blob/df93e6fe75a860f9fbf482d6211fa18c9a7dec52/app/services/invoices/compute_amounts_from_fees.rb#L19-L23

