### PR TITLE
fix(pdf): Move GeneratePdfJob to new pdfs queue

### DIFF
--- a/app/jobs/invoices/generate_pdf_and_notify_job.rb
+++ b/app/jobs/invoices/generate_pdf_and_notify_job.rb
@@ -6,9 +6,11 @@ module Invoices
       if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_PDFS'])
         :pdfs
       else
-        :default
+        :invoices
       end
     end
+
+    retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 6
 
     def perform(invoice:, email:)
       result = Invoices::GeneratePdfService.call(invoice:)

--- a/app/jobs/invoices/generate_pdf_job.rb
+++ b/app/jobs/invoices/generate_pdf_job.rb
@@ -2,7 +2,13 @@
 
 module Invoices
   class GeneratePdfJob < ApplicationJob
-    queue_as 'invoices'
+    queue_as do
+      if ActiveModel::Type::Boolean.new.cast(ENV['SIDEKIQ_PDFS'])
+        :pdfs
+      else
+        :invoices
+      end
+    end
 
     retry_on LagoHttpClient::HttpError, wait: :exponentially_longer, attempts: 6
 


### PR DESCRIPTION
## Description

We recently introduced a new queue to generate PDF https://github.com/getlago/lago-api/pull/2121

This PR moves the existing `GeneratePdfJob` to this queue.