### PR TITLE
fix(subscription): check terminated_at for invoicing_reason

### DIFF
--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -131,10 +131,10 @@ module Invoices
     end
 
     def invoicing_reason_for_subscription(subscription)
-      # NOTE: upgrading is used as a not persisted reasong as it means
+      # NOTE: upgrading is used as a not persisted reason as it means
       #       one subscription starting and a second one terminating
       return invoicing_reason if invoicing_reason.to_sym != :upgrading
-      return :subscription_terminating if subscription.terminated?
+      return :subscription_terminating if subscription.terminated? && subscription.terminated_at <= timestamp
 
       :subscription_starting
     end

--- a/spec/services/invoices/create_invoice_subscription_service_spec.rb
+++ b/spec/services/invoices/create_invoice_subscription_service_spec.rb
@@ -260,5 +260,34 @@ RSpec.describe Invoices::CreateInvoiceSubscriptionService do
         end
       end
     end
+
+    context 'when invoicing reason is upgrading' do
+      let(:invoicing_reason) { :upgrading }
+      let(:status) { :terminated }
+      let(:timestamp) { Time.zone.parse('2023-10-01T00:00:00') }
+      let(:terminated_at) { timestamp }
+
+      it 'creates an invoice subscription' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice_subscriptions.count).to eq(1)
+
+          invoice_subscription = result.invoice_subscriptions.first
+          expect(invoice_subscription).to have_attributes(
+            invoice:,
+            subscription:,
+            timestamp: match_datetime(timestamp),
+            from_datetime: match_datetime(Time.zone.parse('2023-09-06T00:00:00')),
+            to_datetime: match_datetime(timestamp),
+            charges_from_datetime: match_datetime(Time.zone.parse('2023-09-06T00:00:00')),
+            charges_to_datetime: match_datetime(timestamp),
+            recurring: false,
+            invoicing_reason: 'subscription_terminating'
+          )
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

In some cases, when retrying to bill a subscription for a subscription start (after a dead job), it could end into an error if the subscription has been terminated in between the initial invoice and the retry.

## Description

This PR ensures that the `subscription_terminating` is assigned to the `invoice_subscription` only when it should