### PR TITLE
feat(integrations): support array of integration customers

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -111,7 +111,7 @@ module Api
           :timezone,
           :net_payment_term,
           :external_salesforce_id,
-          integration_customer: [
+          integration_customers: [
             :external_customer_id,
             :integration_type,
             :integration_code,

--- a/app/graphql/types/customers/create_customer_input.rb
+++ b/app/graphql/types/customers/create_customer_input.rb
@@ -33,7 +33,7 @@ module Types
       argument :payment_provider_code, String, required: false
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false
 
-      argument :integration_customer, Types::IntegrationCustomers::Input, required: false
+      argument :integration_customers, [Types::IntegrationCustomers::Input], required: false
 
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false
     end

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -32,7 +32,7 @@ module Types
       argument :payment_provider_code, String, required: false, permission: 'customers:update'
       argument :provider_customer, Types::PaymentProviderCustomers::ProviderInput, required: false, permission: 'customers:update'
 
-      argument :integration_customer, Types::IntegrationCustomers::Input, required: false, permission: 'customers:update'
+      argument :integration_customers, [Types::IntegrationCustomers::Input], required: false, permission: 'customers:update'
 
       # Customer settings
       argument :invoice_grace_period, Integer, required: false, permissions: %w[customer_settings:update:grace_period customers:update]

--- a/app/serializers/v1/integration_customer_serializer.rb
+++ b/app/serializers/v1/integration_customer_serializer.rb
@@ -21,7 +21,6 @@ module V1
       when 'IntegrationCustomers::AnrokCustomer'
         'anrok'
       end
-      end
     end
   end
 end

--- a/app/serializers/v1/integration_customer_serializer.rb
+++ b/app/serializers/v1/integration_customer_serializer.rb
@@ -18,6 +18,9 @@ module V1
       case model.type
       when 'IntegrationCustomers::NetsuiteCustomer'
         'netsuite'
+      when 'IntegrationCustomers::AnrokCustomer'
+        'anrok'
+      end
       end
     end
   end

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -188,9 +188,7 @@ module Customers
 
       input_types = integration_customers&.map { |c| c.to_h.deep_symbolize_keys }&.map { |c| c[:integration_type] }
 
-      return true if input_types.length == input_types.uniq.length
-
-      false
+      input_types.length == input_types.uniq.length
     end
 
     def create_metadata(customer:, args:)

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -75,7 +75,7 @@ module Customers
       result.customer = customer.reload
 
       IntegrationCustomers::CreateOrUpdateService.call(
-        integration_customer_params: params[:integration_customer],
+        integration_customers: params[:integration_customers],
         customer: result.customer,
         new_customer:
       )
@@ -156,7 +156,7 @@ module Customers
       result.customer = customer
 
       IntegrationCustomers::CreateOrUpdateService.call(
-        integration_customer_params: args[:integration_customer]&.to_h,
+        integration_customers: args[:integration_customers],
         customer: result.customer,
         new_customer: true
       )

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -15,6 +15,13 @@ module Customers
         )
       end
 
+      unless valid_integration_customers_count?(integration_customers: params[:integration_customers])
+        return result.single_validation_failure!(
+          field: :integration_customers,
+          error_code: 'invalid_count_per_integration_type'
+        )
+      end
+
       ActiveRecord::Base.transaction do
         customer.name = params[:name] if params.key?(:name)
         customer.country = params[:country]&.upcase if params.key?(:country)
@@ -172,6 +179,16 @@ module Customers
     def valid_metadata_count?(metadata:)
       return true if metadata.blank?
       return true if metadata.count <= ::Metadata::CustomerMetadata::COUNT_PER_CUSTOMER
+
+      false
+    end
+
+    def valid_integration_customers_count?(integration_customers:)
+      return true if integration_customers.blank?
+
+      input_types = integration_customers&.map { |c| c.to_h.deep_symbolize_keys }&.map { |c| c[:integration_type] }
+
+      return true if input_types.length == input_types.uniq.length
 
       false
     end

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -112,7 +112,7 @@ module Customers
       result.customer = customer
 
       IntegrationCustomers::CreateOrUpdateService.call(
-        integration_customer_params: args[:integration_customer]&.to_h,
+        integration_customers: args[:integration_customers],
         customer: result.customer,
         new_customer: false
       )

--- a/app/services/integration_customers/create_or_update_service.rb
+++ b/app/services/integration_customers/create_or_update_service.rb
@@ -3,7 +3,7 @@
 module IntegrationCustomers
   class CreateOrUpdateService < ::BaseService
     def initialize(integration_customers:, customer:, new_customer:)
-      @integration_customers = integration_customers&.map { |m| m.to_h.deep_symbolize_keys }
+      @integration_customers = integration_customers&.map { |c| c.to_h.deep_symbolize_keys }
       @customer = customer
       @new_customer = new_customer
 

--- a/app/services/integration_customers/create_or_update_service.rb
+++ b/app/services/integration_customers/create_or_update_service.rb
@@ -2,8 +2,8 @@
 
 module IntegrationCustomers
   class CreateOrUpdateService < ::BaseService
-    def initialize(integration_customer_params:, customer:, new_customer:)
-      @integration_customer_params = integration_customer_params
+    def initialize(integration_customers:, customer:, new_customer:)
+      @integration_customers = integration_customers&.map { |m| m.to_h.deep_symbolize_keys }
       @customer = customer
       @new_customer = new_customer
 
@@ -11,24 +11,34 @@ module IntegrationCustomers
     end
 
     def call
-      return unless integration
-      return if skip_creating_integration_customer?
+      return unless integration_customers
 
-      if remove_integration_customer?
-        integration_customer.destroy!
-        return
-      end
+      integration_customers.each do |int_customer_params|
+        @integration_customer_params = int_customer_params
 
-      if create_integration_customer?
-        IntegrationCustomers::CreateJob.perform_later(integration_customer_params:, integration:, customer:)
-      elsif update_integration_customer?
-        IntegrationCustomers::UpdateJob.perform_later(integration_customer_params:, integration:, integration_customer:)
+        next unless integration
+        next if skip_creating_integration_customer?
+
+        if remove_integration_customer?
+          integration_customer.destroy!
+          next
+        end
+
+        if create_integration_customer?
+          IntegrationCustomers::CreateJob.perform_later(integration_customer_params:, integration:, customer:)
+        elsif update_integration_customer?
+          IntegrationCustomers::UpdateJob.perform_later(
+            integration_customer_params:,
+            integration:,
+            integration_customer:
+          )
+        end
       end
     end
 
     private
 
-    attr_reader :integration_customer_params, :customer, :new_customer
+    attr_reader :integration_customer_params, :customer, :new_customer, :integration_customers
 
     def create_integration_customer?
       (new_customer && integration_customer_params[:sync_with_provider]) ||
@@ -49,9 +59,7 @@ module IntegrationCustomers
 
     def skip_creating_integration_customer?
       integration_customer.nil? &&
-        integration_customer_params.blank? &&
-        integration_customer_params[:sync_with_provider].blank? &&
-        integration_customer_params[:external_customer_id].blank?
+        integration_customer_params.blank?
     end
 
     def integration

--- a/app/services/integration_customers/create_service.rb
+++ b/app/services/integration_customers/create_service.rb
@@ -44,9 +44,12 @@ module IntegrationCustomers
         customer:,
         external_customer_id: params[:external_customer_id],
         type: customer_type,
-        subsidiary_id:,
         sync_with_provider: false
       )
+
+      if integration&.type&.to_s == 'Integrations::NetsuiteIntegration'
+        new_integration_customer.subsidiary_id = subsidiary_id
+      end
 
       result.integration_customer = new_integration_customer
       result

--- a/schema.graphql
+++ b/schema.graphql
@@ -1813,7 +1813,7 @@ input CreateCustomerInput {
   email: String
   externalId: String!
   externalSalesforceId: String
-  integrationCustomer: IntegrationCustomerInput
+  integrationCustomers: [IntegrationCustomerInput!]
   invoiceGracePeriod: Int
   legalName: String
   legalNumber: String
@@ -6838,7 +6838,7 @@ input UpdateCustomerInput {
   externalId: String!
   externalSalesforceId: String
   id: ID!
-  integrationCustomer: IntegrationCustomerInput
+  integrationCustomers: [IntegrationCustomerInput!]
   invoiceGracePeriod: Int
   legalName: String
   legalNumber: String

--- a/schema.json
+++ b/schema.json
@@ -7021,12 +7021,20 @@
               "deprecationReason": null
             },
             {
-              "name": "integrationCustomer",
+              "name": "integrationCustomers",
               "description": null,
               "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "IntegrationCustomerInput",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "IntegrationCustomerInput",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -32886,12 +32894,20 @@
               "deprecationReason": null
             },
             {
-              "name": "integrationCustomer",
+              "name": "integrationCustomers",
               "description": null,
               "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "IntegrationCustomerInput",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "IntegrationCustomerInput",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,


### PR DESCRIPTION
## Context

Currently Lago app is being extended with accounting and tax integrations

## Description

For accounting integrations, we could have only **one** integration customer per customer create/update request.

However, with tax integrations, Lago should support multiple integration customers per request. That being said, Lago should be able to create integration customer object related to tax provider and integration customer object for accounting provider.

This PR handles described scenario and supports array of integration customers from both GQL and API.

This update is NOT a breaking change since released accounting integration is premium add-on and is not being used in production yet.