### PR TITLE
feat(xero): Add customer models and serializer

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -40,6 +40,7 @@ class Customer < ApplicationRecord
   has_one :adyen_customer, class_name: 'PaymentProviderCustomers::AdyenCustomer'
   has_one :netsuite_customer, class_name: 'IntegrationCustomers::NetsuiteCustomer'
   has_one :anrok_customer, class_name: 'IntegrationCustomers::AnrokCustomer'
+  has_one :xero_customer, class_name: 'IntegrationCustomers::XeroCustomer'
 
   PAYMENT_PROVIDERS = %w[stripe gocardless adyen].freeze
 

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -22,6 +22,8 @@ module IntegrationCustomers
         'IntegrationCustomers::OktaCustomer'
       when 'anrok'
         'IntegrationCustomers::AnrokCustomer'
+      when 'xero'
+        'IntegrationCustomers::XeroCustomer'
       else
         raise(NotImplementedError)
       end

--- a/app/models/integration_customers/xero_customer.rb
+++ b/app/models/integration_customers/xero_customer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module IntegrationCustomers
+  class XeroCustomer < BaseCustomer
+  end
+end

--- a/app/serializers/v1/integration_customer_serializer.rb
+++ b/app/serializers/v1/integration_customer_serializer.rb
@@ -20,6 +20,8 @@ module V1
         'netsuite'
       when 'IntegrationCustomers::AnrokCustomer'
         'anrok'
+      when 'IntegrationCustomers::XeroCustomer'
+        'xero'
       end
     end
   end

--- a/spec/factories/integration_customers.rb
+++ b/spec/factories/integration_customers.rb
@@ -11,4 +11,26 @@ FactoryBot.define do
       {sync_with_provider: true, subsidiary_id: Faker::Number.number(digits: 3)}
     end
   end
+
+  factory :anrok_customer, class: 'IntegrationCustomers::AnrokCustomer' do
+    association :integration, factory: :netsuite_integration
+    customer
+    type { 'IntegrationCustomers::AnrokCustomer' }
+    external_customer_id { SecureRandom.uuid }
+
+    settings do
+      {sync_with_provider: true}
+    end
+  end
+
+  factory :xero_customer, class: 'IntegrationCustomers::XeroCustomer' do
+    association :integration, factory: :xero_integration
+    customer
+    type { 'IntegrationCustomers::XeroCustomer' }
+    external_customer_id { SecureRandom.uuid }
+
+    settings do
+      {sync_with_provider: true}
+    end
+  end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Customer, type: :model do
 
   it { is_expected.to have_many(:integration_customers).dependent(:destroy) }
   it { is_expected.to have_one(:netsuite_customer) }
+  it { is_expected.to have_one(:anrok_customer) }
+  it { is_expected.to have_one(:xero_customer) }
 
   describe 'validations' do
     subject(:customer) do

--- a/spec/models/integration_customers/base_customer_spec.rb
+++ b/spec/models/integration_customers/base_customer_spec.rb
@@ -13,6 +13,54 @@ RSpec.describe IntegrationCustomers::BaseCustomer, type: :model do
   it { is_expected.to belong_to(:integration) }
   it { is_expected.to belong_to(:customer) }
 
+  describe '.customer_type' do
+    subject(:customer_type_call) { described_class.customer_type(type) }
+
+    context 'when type is netsuite' do
+      let(:type) { 'netsuite' }
+      let(:customer_type) { 'IntegrationCustomers::NetsuiteCustomer' }
+
+      it 'returns customer type' do
+        expect(subject).to eq(customer_type)
+      end
+    end
+
+    context 'when type is okta' do
+      let(:type) { 'okta' }
+      let(:customer_type) { 'IntegrationCustomers::OktaCustomer' }
+
+      it 'returns customer type' do
+        expect(subject).to eq(customer_type)
+      end
+    end
+
+    context 'when type is anrok' do
+      let(:type) { 'anrok' }
+      let(:customer_type) { 'IntegrationCustomers::AnrokCustomer' }
+
+      it 'returns customer type' do
+        expect(subject).to eq(customer_type)
+      end
+    end
+
+    context 'when type is xero' do
+      let(:type) { 'xero' }
+      let(:customer_type) { 'IntegrationCustomers::XeroCustomer' }
+
+      it 'returns customer type' do
+        expect(subject).to eq(customer_type)
+      end
+    end
+
+    context 'when type is not supported' do
+      let(:type) { 'n/a' }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
   describe '#push_to_settings' do
     it 'push the value into settings' do
       integration_customer.push_to_settings(key: 'key1', value: 'val1')

--- a/spec/serializers/v1/integration_customer_serializer_spec.rb
+++ b/spec/serializers/v1/integration_customer_serializer_spec.rb
@@ -18,4 +18,32 @@ RSpec.describe ::V1::IntegrationCustomerSerializer do
       'subsidiary_id' => integration_customer.subsidiary_id
     )
   end
+
+  describe '#type' do
+    subject(:type_call) { serializer.__send__(:type) }
+
+    let(:integration_customer) { create(:netsuite_customer) }
+
+    context 'when customer is a netsuite customer' do
+      it 'returns netsuite' do
+        expect(subject).to eq('netsuite')
+      end
+    end
+
+    context 'when customer is an anrok customer' do
+      let(:integration_customer) { create(:anrok_customer) }
+
+      it 'returns anrok' do
+        expect(subject).to eq('anrok')
+      end
+    end
+
+    context 'when customer is a xero customer' do
+      let(:integration_customer) { create(:xero_customer) }
+
+      it 'returns xero' do
+        expect(subject).to eq('xero')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-xero

## Context

Currently Lago does not support Xero integration.

## Description

This PR adds and modifies integration customer models and a serializer for Xero integration.