### PR TITLE
misc: move InvoicesQuery params as filters

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -47,16 +47,16 @@ module Api
           page: params[:page],
           limit: params[:per_page] || PER_PAGE,
           search_term: params[:search_term],
-          payment_status: (params[:payment_status] if valid_payment_status?(params[:payment_status])),
-          payment_dispute_lost: params[:payment_dispute_lost],
           payment_overdue: (params[:payment_overdue] if %w[true false].include?(params[:payment_overdue])),
-          status: (params[:status] if valid_status?(params[:status])),
           filters: {
             currency: params[:currency],
             customer_external_id: params[:external_customer_id],
             invoice_type: params[:invoice_type],
             issuing_date_from: (Date.strptime(params[:issuing_date_from]) if valid_date?(params[:issuing_date_from])),
-            issuing_date_to: (Date.strptime(params[:issuing_date_to]) if valid_date?(params[:issuing_date_to]))
+            issuing_date_to: (Date.strptime(params[:issuing_date_to]) if valid_date?(params[:issuing_date_to])),
+            payment_dispute_lost: params[:payment_dispute_lost],
+            payment_status: (params[:payment_status] if valid_payment_status?(params[:payment_status])),
+            status: (params[:status] if valid_status?(params[:status]))
           }
         )
 

--- a/app/graphql/resolvers/customer_portal/invoices_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/invoices_resolver.rb
@@ -17,11 +17,13 @@ module Resolvers
       def resolve(status: nil, page: nil, limit: nil, search_term: nil)
         query = InvoicesQuery.new(organization: context[:customer_portal_user].organization)
         result = query.call(
-          customer_id: context[:customer_portal_user].id,
           search_term:,
           page:,
           limit:,
-          status:
+          filters: {
+            customer_id: context[:customer_portal_user].id,
+            status:
+          }
         )
 
         result.invoices

--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -22,10 +22,12 @@ module Resolvers
         query = InvoicesQuery.new(organization: current_organization)
         result = query.call(
           search_term:,
-          customer_id:,
           page:,
           limit:,
-          status:
+          filters: {
+            customer_id:,
+            status:
+          }
         )
 
         result.invoices

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -43,16 +43,16 @@ module Resolvers
         search_term:,
         page:,
         limit:,
-        payment_status:,
-        payment_dispute_lost:,
         payment_overdue:,
-        status:,
         filters: {
           currency:,
           customer_external_id:,
           invoice_type:,
           issuing_date_from:,
-          issuing_date_to:
+          issuing_date_to:,
+          payment_dispute_lost:,
+          payment_status:,
+          status:
         }
       )
 

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 class InvoicesQuery < BaseQuery
-  def call(search_term:, status:, page:, limit:, filters: {}, customer_id: nil, payment_status: nil, payment_dispute_lost: nil, payment_overdue: nil) # rubocop:disable Metrics/ParameterLists
+  def call(search_term:, page:, limit:, filters: {}, payment_overdue: nil)
     @search_term = search_term
-    @customer_id = customer_id
+    @customer_id = filters[:customer_id]
     @filters = filters
 
     invoices = base_scope.result.includes(:customer)
     invoices = invoices.where(currency: filters[:currency]) if filters[:currency]
     invoices = with_customer_external_id(invoices) if filters[:customer_external_id]
-    invoices = invoices.where(customer_id:) if customer_id.present?
+    invoices = invoices.where(customer_id: filters[:customer_id]) if filters[:customer_id].present?
     invoices = invoices.where(invoice_type: filters[:invoice_type]) if filters[:invoice_type]
     invoices = with_issuing_date_range(invoices) if filters[:issuing_date_from] || filters[:issuing_date_to]
-    invoices = invoices.where(status:) if status.present?
-    invoices = invoices.where(payment_status:) if payment_status.present?
-    invoices = invoices.where.not(payment_dispute_lost_at: nil) unless payment_dispute_lost.nil?
+    invoices = invoices.where(status: filters[:status]) if filters[:status].present?
+    invoices = invoices.where(payment_status: filters[:payment_status]) if filters[:payment_status].present?
+    invoices = invoices.where.not(payment_dispute_lost_at: nil) if filters[:payment_dispute_lost]
     invoices = invoices.where(payment_overdue:) if payment_overdue.present?
     invoices = invoices.order(issuing_date: :desc, created_at: :desc).page(page).per(limit)
 

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -83,12 +83,10 @@ module DataExports
 
       def query
         search_term = resource_query["search_term"]
-        status = resource_query["status"]
-        filters = resource_query.except("search_term", "status")
+        filters = resource_query.except("search_term")
 
         InvoicesQuery.new(organization: organization).call(
           search_term:,
-          status:,
           page: nil,
           limit: nil,
           filters:

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -90,10 +90,12 @@ RSpec.describe InvoicesQuery, type: :query do
   it 'returns all invoices' do
     result = invoice_query.call(
       search_term: nil,
-      status: nil,
-      payment_status: nil,
       page: 1,
-      limit: 10
+      limit: 10,
+      filters: {
+        payment_status: nil,
+        status: nil
+      }
     )
 
     returned_ids = result.invoices.pluck(:id)
@@ -113,10 +115,11 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 2 invoices' do
       result = invoice_query.call(
         search_term: nil,
-        status: 'draft',
-        payment_status: nil,
         page: 1,
-        limit: 10
+        limit: 10,
+        filters: {
+          status: 'draft'
+        }
       )
 
       returned_ids = result.invoices.pluck(:id)
@@ -136,10 +139,11 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 1 invoices' do
       result = invoice_query.call(
         search_term: nil,
-        status: nil,
-        payment_status: 'failed',
         page: 1,
-        limit: 10
+        limit: 10,
+        filters: {
+          payment_status: 'failed'
+        }
       )
 
       returned_ids = result.invoices.pluck(:id)
@@ -159,10 +163,11 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 1 invoices' do
       result = invoice_query.call(
         search_term: nil,
-        status: nil,
-        payment_dispute_lost: true,
         page: 1,
-        limit: 10
+        limit: 10,
+        filters: {
+          payment_dispute_lost: true,
+        }
       )
 
       returned_ids = result.invoices.pluck(:id)
@@ -371,8 +376,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 1 invoices' do
       result = invoice_query.call(
         search_term: invoice_fourth.id.scan(/.{10}/).first,
-        status: nil,
-        payment_status: nil,
         page: 1,
         limit: 10
       )
@@ -394,8 +397,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 1 invoices' do
       result = invoice_query.call(
         search_term: invoice_first.number,
-        status: nil,
-        payment_status: nil,
         page: 1,
         limit: 10
       )
@@ -417,8 +418,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 2 invoices' do
       result = invoice_query.call(
         search_term: customer_second.external_id,
-        status: nil,
-        payment_status: nil,
         page: 1,
         limit: 10
       )
@@ -440,8 +439,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 3 invoices' do
       result = invoice_query.call(
         search_term: 'rick',
-        status: nil,
-        payment_status: nil,
         page: 1,
         limit: 10
       )
@@ -464,8 +461,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 2 invoices' do
       result = invoice_query.call(
         search_term: 'gmail',
-        status: nil,
-        payment_status: nil,
         page: 1,
         limit: 10
       )
@@ -486,11 +481,12 @@ RSpec.describe InvoicesQuery, type: :query do
   context 'when searching for /44444444/ term' do
     it 'returns 1 invoices' do
       result = invoice_query.call(
-        customer_id: customer_second.id,
         search_term: '44444444',
-        status: nil,
         page: 1,
-        limit: 10
+        limit: 10,
+        filters: {
+          customer_id: customer_second.id
+        }
       )
 
       returned_ids = result.invoices.pluck(:id)
@@ -509,11 +505,12 @@ RSpec.describe InvoicesQuery, type: :query do
   context 'when searching for another customer with no invoice' do
     it 'returns 0 invoices' do
       result = invoice_query.call(
-        customer_id: create(:customer, organization:).id,
         search_term: nil,
-        status: nil,
         page: 1,
-        limit: 10
+        limit: 10,
+        filters: {
+          customer_id: create(:customer, organization:).id
+        }
       )
 
       returned_ids = result.invoices.pluck(:id)

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -188,7 +188,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns expected invoices' do
       result = invoice_query.call(
         search_term: nil,
-        status: nil,
         payment_overdue: true,
         page: 1,
         limit: 10
@@ -202,7 +201,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 1 invoice' do
       result = invoice_query.call(
         search_term: nil,
-        status: nil,
         filters: {
           invoice_type: 'credit'
         },
@@ -222,7 +220,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 1 invoice' do
       result = invoice_query.call(
         search_term: nil,
-        status: nil,
         filters: {
           currency: 'USD'
         },
@@ -242,7 +239,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 2 invoices' do
       result = invoice_query.call(
         search_term: nil,
-        status: nil,
         filters: {
           customer_external_id: customer_second.external_id
         },
@@ -265,7 +261,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 4 invoices' do
       result = invoice_query.call(
         search_term: nil,
-        status: nil,
         filters: {
           issuing_date_from: 2.days.ago.iso8601
         },
@@ -288,7 +283,6 @@ RSpec.describe InvoicesQuery, type: :query do
       it 'returns a failed result' do
         result = invoice_query.call(
           search_term: nil,
-          status: nil,
           filters: {
             issuing_date_from: 'invalid_date_value'
           },
@@ -309,7 +303,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 2 invoices' do
       result = invoice_query.call(
         search_term: nil,
-        status: nil,
         filters: {
           issuing_date_to: 2.weeks.ago.iso8601
         },
@@ -331,7 +324,6 @@ RSpec.describe InvoicesQuery, type: :query do
       it 'returns a failed result' do
         result = invoice_query.call(
           search_term: nil,
-          status: nil,
           filters: {
             issuing_date_to: 'invalid_date_value'
           },
@@ -352,7 +344,6 @@ RSpec.describe InvoicesQuery, type: :query do
     it 'returns 2 invoices' do
       result = invoice_query.call(
         search_term: nil,
-        status: nil,
         filters: {
           issuing_date_from: 2.weeks.ago.iso8601,
           issuing_date_to: 1.week.ago.iso8601

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe InvoicesQuery, type: :query do
         page: 1,
         limit: 10,
         filters: {
-          payment_dispute_lost: true,
+          payment_dispute_lost: true
         }
       )
 

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe DataExports::Csv::Invoices do
       "issuing_date_to" => issuing_date_to,
       "payment_dispute_lost" => payment_dispute_lost,
       "payment_overdue" => payment_overdue,
-      "payment_status" => payment_status
+      "payment_status" => payment_status,
+      "status" => status
     }
   end
 
@@ -101,7 +102,6 @@ RSpec.describe DataExports::Csv::Invoices do
       .to receive(:call)
       .with(
         search_term:,
-        status:,
         page: nil,
         limit: nil,
         filters:


### PR DESCRIPTION
## Context

Before adding more filters to the  `InvoicesQuery` object and making harder to work with it, this change moves the existing filters to the filters hash.

## Description

Move existing filters to filters hash in `InvoicesQuery` object
Add some documentation to make easier to discover the available filters in the query object.