### PR TITLE
feat (anrok-integration): add support for connection_id

### DIFF
--- a/app/graphql/types/integrations/anrok/create_input.rb
+++ b/app/graphql/types/integrations/anrok/create_input.rb
@@ -10,6 +10,7 @@ module Types
         argument :name, String, required: true
 
         argument :api_key, String, required: true
+        argument :connection_id, String, required: true
       end
     end
   end

--- a/app/models/integrations/anrok_integration.rb
+++ b/app/models/integrations/anrok_integration.rb
@@ -2,8 +2,8 @@
 
 module Integrations
   class AnrokIntegration < BaseIntegration
-    validates :api_key, presence: true
+    validates :connection_id, :api_key, presence: true
 
-    secrets_accessors :api_key
+    secrets_accessors :connection_id, :api_key
   end
 end

--- a/app/services/integrations/anrok/create_service.rb
+++ b/app/services/integrations/anrok/create_service.rb
@@ -14,6 +14,7 @@ module Integrations
           organization:,
           name: args[:name],
           code: args[:code],
+          connection_id: args[:connection_id],
           api_key: args[:api_key]
         )
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1714,6 +1714,7 @@ input CreateAnrokIntegrationInput {
   """
   clientMutationId: String
   code: String!
+  connectionId: String!
   name: String!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -6094,6 +6094,22 @@
               "deprecationReason": null
             },
             {
+              "name": "connectionId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {

--- a/spec/factories/integrations.rb
+++ b/spec/factories/integrations.rb
@@ -38,7 +38,7 @@ FactoryBot.define do
     name { 'Anrok Integration' }
 
     secrets do
-      {api_key: SecureRandom.uuid}.to_json
+      {connection_id: SecureRandom.uuid, api_key: SecureRandom.uuid}.to_json
     end
   end
 

--- a/spec/graphql/mutations/integrations/anrok/create_spec.rb
+++ b/spec/graphql/mutations/integrations/anrok/create_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe Mutations::Integrations::Anrok::Create, type: :graphql do
         input: {
           code:,
           name:,
-          apiKey: '123456789'
+          apiKey: '123456789',
+          connectionId: 'this-is-random-uuid'
         }
       }
     )
@@ -51,6 +52,7 @@ RSpec.describe Mutations::Integrations::Anrok::Create, type: :graphql do
       expect(result_data['code']).to eq(code)
       expect(result_data['name']).to eq(name)
       expect(result_data['apiKey']).to eq('••••••••…789')
+      expect(Integrations::AnrokIntegration.order(:created_at).last.connection_id).to eq('this-is-random-uuid')
     end
   end
 end

--- a/spec/models/integrations/anrok_integration_spec.rb
+++ b/spec/models/integrations/anrok_integration_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Integrations::AnrokIntegration, type: :model do
   subject(:anrok_integration) { build(:anrok_integration) }
 
   it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:connection_id) }
 
   describe 'validations' do
     it 'validates uniqueness of the code' do

--- a/spec/models/integrations/anrok_integration_spec.rb
+++ b/spec/models/integrations/anrok_integration_spec.rb
@@ -19,4 +19,11 @@ RSpec.describe Integrations::AnrokIntegration, type: :model do
       expect(anrok_integration.api_key).to eq('123abc456')
     end
   end
+
+  describe '.connection_id' do
+    it 'assigns and retrieve a secret pair' do
+      anrok_integration.connection_id = 'connection_id'
+      expect(anrok_integration.connection_id).to eq('connection_id')
+    end
+  end
 end

--- a/spec/services/integrations/anrok/create_service_spec.rb
+++ b/spec/services/integrations/anrok/create_service_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Integrations::Anrok::CreateService, type: :service do
         name:,
         code: 'anrok1',
         organization_id: organization.id,
+        connection_id: 'conn1',
         api_key: '123456789'
       }
     end
@@ -61,6 +62,7 @@ RSpec.describe Integrations::Anrok::CreateService, type: :service do
 
             integration = Integrations::AnrokIntegration.order(:created_at).last
             expect(integration.name).to eq(name)
+            expect(integration.connection_id).to eq('conn1')
           end
 
           it 'returns an integration in result object' do


### PR DESCRIPTION
## Context

Currently Lago does not support tax integrations

## Description

When Lago create integration object, `connection_id` also needs to be stored. This is identifier in Nango (integrations aggregator) and it will be used in all requests from Lago's BE.
