### PR TITLE
fix(service): Use call_later for RetryAllJob and raise if error

### DIFF
--- a/app/graphql/mutations/invoices/retry_all_payments.rb
+++ b/app/graphql/mutations/invoices/retry_all_payments.rb
@@ -14,7 +14,7 @@ module Mutations
       type Types::Invoices::Object.collection_type
 
       def resolve
-        result = ::Invoices::Payments::RetryBatchService.new(organization_id: current_organization.id).call_later
+        result = ::Invoices::Payments::RetryBatchService.new(organization_id: current_organization.id).call_async
 
         result.success? ? result.invoices : result_error(result)
       end

--- a/app/jobs/invoices/payments/retry_all_job.rb
+++ b/app/jobs/invoices/payments/retry_all_job.rb
@@ -7,7 +7,7 @@ module Invoices
 
       def perform(organization_id:, invoice_ids:)
         result = Invoices::Payments::RetryBatchService.new(organization_id:).call(invoice_ids)
-        result.throw_error unless result.success?
+        result.raise_if_error!
       end
     end
   end

--- a/app/services/invoices/payments/retry_batch_service.rb
+++ b/app/services/invoices/payments/retry_batch_service.rb
@@ -9,7 +9,7 @@ module Invoices
         super
       end
 
-      def call_later
+      def call_async
         Invoices::Payments::RetryAllJob.perform_later(organization_id:, invoice_ids: invoices.ids)
 
         result.invoices = invoices

--- a/spec/services/invoices/payments/retry_batch_service_spec.rb
+++ b/spec/services/invoices/payments/retry_batch_service_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Invoices::Payments::RetryBatchService, type: :service do
   let(:customer) { create(:customer, payment_provider: 'stripe') }
   let(:organization) { customer.organization }
 
-  describe '#call_later' do
+  describe '#call_async' do
     it 'enqueues a job to retry all payments' do
       expect do
-        retry_batch_service.call_later
+        retry_batch_service.call_async
       end.to have_enqueued_job(Invoices::Payments::RetryAllJob)
     end
   end


### PR DESCRIPTION
## Description

Insignificant but `result.throw_error` doesn't exist.

@ivannovosad and @vincent-pochet recently introduced `call_async` in services so why not use it instead of `call_later`.
