### PR TITLE
misc(integrations): Remove connection_id from Integration types

### DIFF
--- a/app/graphql/types/integrations/netsuite.rb
+++ b/app/graphql/types/integrations/netsuite.rb
@@ -9,7 +9,6 @@ module Types
       field :client_id, String, null: true
       field :client_secret, String, null: true
       field :code, String, null: false
-      field :connection_id, ID, null: false
       field :has_mappings_configured, Boolean
       field :id, ID, null: false
       field :name, String, null: false

--- a/app/graphql/types/integrations/xero.rb
+++ b/app/graphql/types/integrations/xero.rb
@@ -6,7 +6,6 @@ module Types
       graphql_name 'XeroIntegration'
 
       field :code, String, null: false
-      field :connection_id, ID, null: false
       field :has_mappings_configured, Boolean
       field :id, ID, null: false
       field :name, String, null: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -4932,7 +4932,6 @@ type NetsuiteIntegration {
   clientId: String
   clientSecret: String
   code: String!
-  connectionId: ID!
   hasMappingsConfigured: Boolean
   id: ID!
   name: String!
@@ -7317,7 +7316,6 @@ enum WeightedIntervalEnum {
 
 type XeroIntegration {
   code: String!
-  connectionId: ID!
   hasMappingsConfigured: Boolean
   id: ID!
   name: String!

--- a/schema.json
+++ b/schema.json
@@ -22989,24 +22989,6 @@
               ]
             },
             {
-              "name": "connectionId",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "hasMappingsConfigured",
               "description": null,
               "type": {
@@ -36562,24 +36544,6 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "connectionId",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
                   "ofType": null
                 }
               },

--- a/spec/graphql/types/integrations/xero_spec.rb
+++ b/spec/graphql/types/integrations/xero_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Types::Integrations::Xero do
   it { is_expected.to have_field(:id).of_type('ID!') }
 
   it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:connection_id).of_type('ID!') }
   it { is_expected.to have_field(:has_mappings_configured).of_type('Boolean') }
   it { is_expected.to have_field(:name).of_type('String!') }
 


### PR DESCRIPTION
## Context

connectionId is not needed to be exposed to the UI after a connection is created or updated.

## Description

This PR removes `connectionId` from `NetsuiteIntegration` and `XeroIntegration`