### PR TITLE
feat(dunning): Add payment_overdue filter on invoices

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -55,6 +55,7 @@ module Api
         invoices = invoices.where(status: params[:status]) if valid_status?(params[:status])
         invoices = invoices.where(date_from_criteria) if valid_date?(params[:issuing_date_from])
         invoices = invoices.where(date_to_criteria) if valid_date?(params[:issuing_date_to])
+        invoices = invoices.where(payment_overdue: params[:payment_overdue]) if %w[true false].include?(params[:payment_overdue])
         invoices = invoices.order(created_at: :desc)
           .page(params[:page])
           .per(params[:per_page] || PER_PAGE)

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -13,6 +13,7 @@ module Resolvers
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
     argument :payment_dispute_lost, Boolean, required: false
+    argument :payment_overdue, Boolean, required: false
     argument :payment_status, [Types::Invoices::PaymentStatusTypeEnum], required: false
     argument :search_term, String, required: false
     argument :status, Types::Invoices::StatusTypeEnum, required: false
@@ -26,7 +27,8 @@ module Resolvers
       payment_status: nil,
       status: nil,
       search_term: nil,
-      payment_dispute_lost: nil
+      payment_dispute_lost: nil,
+      payment_overdue: nil
     )
       query = InvoicesQuery.new(organization: current_organization)
       result = query.call(
@@ -35,6 +37,7 @@ module Resolvers
         limit:,
         payment_status:,
         payment_dispute_lost:,
+        payment_overdue:,
         status:,
         filters: {
           ids:

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class InvoicesQuery < BaseQuery
-  def call(search_term:, status:, page:, limit:, filters: {}, customer_id: nil, payment_status: nil, payment_dispute_lost: nil) # rubocop:disable Metrics/ParameterLists
+  def call(search_term:, status:, page:, limit:, filters: {}, customer_id: nil, payment_status: nil, payment_dispute_lost: nil, payment_overdue: nil) # rubocop:disable Metrics/ParameterLists
     @search_term = search_term
     @customer_id = customer_id
 
@@ -11,6 +11,7 @@ class InvoicesQuery < BaseQuery
     invoices = invoices.where(status:) if status.present?
     invoices = invoices.where(payment_status:) if payment_status.present?
     invoices = invoices.where.not(payment_dispute_lost_at: nil) unless payment_dispute_lost.nil?
+    invoices = invoices.where(payment_overdue:) if payment_overdue.present?
     invoices = invoices.order(issuing_date: :desc, created_at: :desc).page(page).per(limit)
 
     result.invoices = invoices

--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -12,7 +12,10 @@ module Invoices
 
       result.invoice = invoice
 
-      invoice.void!
+      ActiveRecord::Base.transaction do
+        invoice.payment_overdue = false if invoice.payment_overdue?
+        invoice.void!
+      end
 
       invoice.credits.each do |credit|
         res = CreditNotes::RecreditService.call(credit:)

--- a/schema.graphql
+++ b/schema.graphql
@@ -5500,6 +5500,7 @@ type Query {
     limit: Int
     page: Int
     paymentDisputeLost: Boolean
+    paymentOverdue: Boolean
     paymentStatus: [InvoicePaymentStatusTypeEnum!]
     searchTerm: String
     status: InvoiceStatusTypeEnum

--- a/schema.json
+++ b/schema.json
@@ -27850,6 +27850,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "paymentOverdue",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "paymentStatus",
                   "description": null,
                   "type": {

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe InvoicesQuery, type: :query do
       organization:,
       status: 'finalized',
       payment_status: 'failed',
+      payment_overdue: true,
       customer: customer_first,
       number: '3333333333'
     )
@@ -196,6 +197,20 @@ RSpec.describe InvoicesQuery, type: :query do
         expect(returned_ids).not_to include(invoice_fifth.id)
         expect(returned_ids).to include(invoice_sixth.id)
       end
+    end
+  end
+
+  context 'when filtering by payment overdue' do
+    it 'returns expected invoices' do
+      result = invoice_query.call(
+        search_term: nil,
+        status: nil,
+        payment_overdue: true,
+        page: 1,
+        limit: 10
+      )
+
+      expect(result.invoices.pluck(:id)).to eq([invoice_third.id])
     end
   end
 

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -355,6 +355,18 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
         expect(json[:invoices].first[:lago_id]).to eq(invoice3.id)
       end
     end
+
+    context 'with payment overdue param' do
+      let(:invoice) { create(:invoice, customer:, payment_overdue: true, organization:) }
+
+      it 'returns payment overdue invoices' do
+        create(:invoice, customer:, organization:)
+        get_with_token(organization, '/api/v1/invoices?payment_overdue=true')
+
+        expect(response).to have_http_status(:success)
+        expect(json[:invoices].map { |i| i[:lago_id] }).to eq([invoice.id])
+      end
+    end
   end
 
   describe 'PUT /invoices/:id/refresh' do

--- a/spec/services/invoices/void_service_spec.rb
+++ b/spec/services/invoices/void_service_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Invoices::VoidService, type: :service do
     end
 
     context 'when the invoice is finalized' do
-      let(:invoice) { create(:invoice, status: :finalized, payment_status:) }
+      let(:invoice) { create(:invoice, status: :finalized, payment_status:, payment_overdue: true) }
 
       context 'when the payment status is succeeded' do
         let(:payment_status) { :succeeded }
@@ -78,6 +78,10 @@ RSpec.describe Invoices::VoidService, type: :service do
             expect(result.invoice.voided_at).to be_present
             # expect(result.invoice.balance_amount_cents).to eq(0)
           end
+        end
+
+        it "marks the invoice's payment overdue as false" do
+          expect { void_service.call }.to change(invoice, :payment_overdue).from(true).to(false)
         end
       end
     end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/regroup-invoices-to-generate-one-payment-intent

## Context

We want to be able to group invoices to generate one payment.
Today we don't track payment terms and do not mention whether a payment or an invoice is overdue.

## Description

The goal of this PR is to add `payment_overdue` filter when fetching invoices.
