### PR TITLE
misc: extend redis timeout property

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,6 +3,7 @@
 redis_config = {
   url: ENV['REDIS_URL'],
   pool_timeout: 5,
+  timeout: 5,
   ssl_params: {
     verify_mode: OpenSSL::SSL::VERIFY_NONE
   }


### PR DESCRIPTION
## Context

Lago uses Redis for storing sidekiq jobs and its operational data.

## Description

In order to avoid `RedisClient::ReadTimeoutError` we can increase `redis` timeout property. By default our redis version sets this property to `1s`.
