### PR TITLE
fix (draft- invoices): refresh draft invoice only if there is active subscription

### DIFF
--- a/app/jobs/clock/refresh_draft_invoices_job.rb
+++ b/app/jobs/clock/refresh_draft_invoices_job.rb
@@ -5,9 +5,7 @@ module Clock
     queue_as 'clock'
 
     def perform
-      Invoice.ready_to_be_refreshed.find_each do |invoice|
-        next unless invoice.subscriptions.pluck(:status).include?('active')
-
+      Invoice.ready_to_be_refreshed.with_active_subscriptions.find_each do |invoice|
         Invoices::RefreshDraftJob.perform_later(invoice)
       end
     end

--- a/app/jobs/clock/refresh_draft_invoices_job.rb
+++ b/app/jobs/clock/refresh_draft_invoices_job.rb
@@ -6,6 +6,8 @@ module Clock
 
     def perform
       Invoice.ready_to_be_refreshed.find_each do |invoice|
+        next unless invoice.subscriptions.pluck(:status).include?('active')
+
         Invoices::RefreshDraftJob.perform_later(invoice)
       end
     end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -98,7 +98,7 @@ class Invoice < ApplicationRecord
 
   scope :with_active_subscriptions, -> {
     joins(:subscriptions)
-      .where(subscriptions: { status: 'active' })
+      .where(subscriptions: {status: 'active'})
       .distinct
   }
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -96,6 +96,12 @@ class Invoice < ApplicationRecord
 
   scope :payment_overdue, -> { where(payment_overdue: true) }
 
+  scope :with_active_subscriptions, -> {
+    joins(:subscriptions)
+      .where(subscriptions: { status: 'active' })
+      .distinct
+  }
+
   validates :issuing_date, :currency, presence: true
   validates :timezone, timezone: true, allow_nil: true
   validates :total_amount_cents, numericality: {greater_than_or_equal_to: 0}

--- a/spec/jobs/clock/refresh_draft_invoices_jobs_spec.rb
+++ b/spec/jobs/clock/refresh_draft_invoices_jobs_spec.rb
@@ -7,13 +7,25 @@ describe Clock::RefreshDraftInvoicesJob, job: true do
 
   describe '.perform' do
     let(:invoice) { create(:invoice, :draft) }
+    let(:subscription) { create(:subscription) }
+    let(:invoice_subscription) { create(:invoice_subscription, invoice:, subscription:) }
 
     before do
-      invoice
+      invoice_subscription
       allow(Invoices::RefreshDraftService).to receive(:call)
     end
 
     context 'when not ready to be refreshed' do
+      it 'does not call the refresh service' do
+        described_class.perform_now
+        expect(Invoices::RefreshDraftJob).not_to have_been_enqueued.with(invoice)
+      end
+    end
+
+    context 'when invoice is related only to terminated subscriptions' do
+      let(:invoice) { create(:invoice, :draft, ready_to_be_refreshed: true) }
+      let(:subscription) { create(:subscription, :terminated) }
+
       it 'does not call the refresh service' do
         described_class.perform_now
         expect(Invoices::RefreshDraftJob).not_to have_been_enqueued.with(invoice)


### PR DESCRIPTION
## Context

Prevent refreshing draft invoices which don't have at least one active subscription

## Description

If invoice is in draft status but subscriptions related to it are terminated, we don't want to refresh such an invoice each 5 minutes