### PR TITLE
fix(draft-invoice): fix invoice reason logic for draft invoices

### DIFF
--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -17,9 +17,11 @@ module Invoices
       @invoicing_reason = if @recurring
         :subscription_periodic
       else
-        invoice_subscriptions.first&.invoicing_reason&.to_sym || :upgrading if invoice_subscriptions.count == 1
-
-        :upgrading
+        if invoice_subscriptions.count == 1
+          invoice_subscriptions.first&.invoicing_reason&.to_sym || :upgrading
+        else
+          :upgrading
+        end
       end
 
       super

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -16,12 +16,10 @@ module Invoices
       #       one subscription starting and a second one terminating
       @invoicing_reason = if @recurring
         :subscription_periodic
+      elsif invoice_subscriptions.count == 1
+        invoice_subscriptions.first&.invoicing_reason&.to_sym || :upgrading
       else
-        if invoice_subscriptions.count == 1
-          invoice_subscriptions.first&.invoicing_reason&.to_sym || :upgrading
-        else
-          :upgrading
-        end
+        :upgrading
       end
 
       super

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -6,17 +6,20 @@ module Invoices
       @invoice = invoice
       @subscription_ids = invoice.subscriptions.pluck(:id)
       @context = context
+      @invoice_subscriptions = invoice.invoice_subscriptions
 
       # NOTE: Recurring status (meaning billed automatically from the recurring billing process)
       #       should be kept to prevent double billing on billing day
-      @recurring = invoice.invoice_subscriptions.first&.recurring || false
+      @recurring = invoice_subscriptions.first&.recurring || false
 
       # NOTE: upgrading is used as a not persisted reasong as it means
       #       one subscription starting and a second one terminating
       @invoicing_reason = if @recurring
         :subscription_periodic
       else
-        invoice.invoice_subscriptions.first&.invoicing_reason&.to_sym || :upgrading
+        invoice_subscriptions.first&.invoicing_reason&.to_sym || :upgrading if invoice_subscriptions.count == 1
+
+        :upgrading
       end
 
       super
@@ -41,7 +44,7 @@ module Invoices
 
         invoice.fees.destroy_all
 
-        invoice.invoice_subscriptions.destroy_all
+        invoice_subscriptions.destroy_all
         invoice.applied_taxes.destroy_all
 
         Invoices::CreateInvoiceSubscriptionService.call(
@@ -75,7 +78,7 @@ module Invoices
 
     private
 
-    attr_accessor :invoice, :subscription_ids, :invoicing_reason, :recurring, :context
+    attr_accessor :invoice, :subscription_ids, :invoicing_reason, :recurring, :context, :invoice_subscriptions
 
     def fetch_timestamp
       fee = invoice.fees.first

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
         refresh_service.call
 
         expect(invoice.reload.invoice_subscriptions.pluck(:invoicing_reason))
-          .to match_array(%w(subscription_terminating subscription_starting))
+          .to match_array(%w[subscription_terminating subscription_starting])
       end
     end
 

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -55,6 +55,80 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
       end
     end
 
+    context 'when refreshing upgrading invoice' do
+      let(:invoice2) do
+        create(:invoice, status:, organization:, customer:)
+      end
+      let(:invoice_subscription) do
+        create(
+          :invoice_subscription,
+          invoice:,
+          subscription:,
+          recurring: false,
+          invoicing_reason: 'subscription_terminating'
+        )
+      end
+      let(:invoice_subscription2) do
+        create(
+          :invoice_subscription,
+          invoice:,
+          subscription: subscription2,
+          recurring: false,
+          invoicing_reason: 'subscription_starting'
+        )
+      end
+      let(:invoice_subscription3) do
+        create(
+          :invoice_subscription,
+          invoice: invoice2,
+          subscription: subscription2,
+          recurring: false,
+          invoicing_reason: 'subscription_terminating'
+        )
+      end
+      let(:subscription) do
+        create(
+          :subscription,
+          customer:,
+          organization:,
+          subscription_at: started_at - 1.month,
+          started_at: started_at - 1.month,
+          created_at: started_at - 1.month,
+          terminated_at: started_at,
+          status: :terminated
+        )
+      end
+      let(:subscription2) do
+        create(
+          :subscription,
+          customer:,
+          organization:,
+          subscription_at: started_at,
+          started_at:,
+          created_at: started_at,
+          previous_subscription_id: subscription.id
+        )
+      end
+
+      before do
+        invoice_subscription2
+        invoice_subscription3
+
+        subscription2.mark_as_terminated!
+
+        allow(Invoices::CalculateFeesService).to receive(:call).and_return(BaseService::Result.new)
+
+        invoice.update!(created_at: started_at)
+      end
+
+      it 'correctly creates invoice_subscriptions without duplicating invoicing reason' do
+        refresh_service.call
+
+        expect(invoice.reload.invoice_subscriptions.pluck(:invoicing_reason))
+          .to match_array(%w(subscription_terminating subscription_starting))
+      end
+    end
+
     it 'regenerates fees' do
       fee = create(:fee, invoice:)
       create(:standard_charge, plan: subscription.plan, charge_model: 'standard')


### PR DESCRIPTION
## Context

When refreshing invoice, that is result of the upgrade operation, we didn't calculate correctly invoice reason. If there are multiple subscriptions, old logic could lead to fetching invalid reason and consequently to the DB index uniqueness error.

## Description

This PR handles described scenario and adds related tests.
