### PR TITLE
misc: improve active job uniqueness's redlock server host generation

### DIFF
--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -6,8 +6,11 @@ ActiveJob::Uniqueness.configure do |config|
   if ENV['REDIS_PASSWORD'].present? && !ENV['REDIS_PASSWORD'].empty?
     uri = URI(ENV['REDIS_URL'])
     host = [uri.host, uri.path].join('')
-    host = [host, uri.query].join('?')
+    
+    if !uri.query.nil? && !uri.query.empty?
+      host = [host, uri.query].join('?')
+    end
 
-    config.redlock_servers = ["redis://:#{ENV["REDIS_PASSWORD"]}@#{host}:#{uri.port}"]
+    config.redlock_servers = ["#{uri.scheme}://:#{ENV["REDIS_PASSWORD"]}@#{host}:#{uri.port}"]
   end
 end

--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -6,7 +6,7 @@ ActiveJob::Uniqueness.configure do |config|
   if ENV['REDIS_PASSWORD'].present? && !ENV['REDIS_PASSWORD'].empty?
     uri = URI(ENV['REDIS_URL'])
     host = [uri.host, uri.path].join('')
-    
+
     if uri.query.present?
       host = [host, uri.query].join('?')
     end

--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -7,7 +7,7 @@ ActiveJob::Uniqueness.configure do |config|
     uri = URI(ENV['REDIS_URL'])
     host = [uri.host, uri.path].join('')
     
-    if !uri.query.nil? && !uri.query.empty?
+    if uri.query.present?
       host = [host, uri.query].join('?')
     end
 


### PR DESCRIPTION
## Context

Few days ago I tried to deploy `api-clock` service but got stuck with the following error:
"[ActiveJob] Failed enqueuing Clock::ActivateSubscriptionsJob to Sidekiq(clock): Redis::CannotConnectError (Waited 0.1 seconds)"

The problem turned out to be that my Redis instance doesn't allow connecting without the proper URL Schema (which is `rediss://` in my case) and with the unnecessary `?` which is always added between the host and the port that is currently generated.

Currently with the following environment variables:
- `REDIS_URL=rediss://:example-token@redis-host.com:6379`
- `REDIS_PASSWORD=example-token`

The generated Redlock server host is: `redis://:example-token@redis-host.com?:6379` instead of `rediss://:example-token@redis-host.com:6379` (notice the URL schema and the extra question mark after the host).

## Description

To solve this I added additional check if the `REDIS_URL` has a query part and used `uri.schema` instead of hard coding the `redis://` schema.

I've tested this in my staging environment and it works perfectly
