### PR TITLE
feat(boundaries): Move charge_pay_in_advance_interval from Invoice to DatesService

### DIFF
--- a/app/graphql/types/invoice_subscription/object.rb
+++ b/app/graphql/types/invoice_subscription/object.rb
@@ -46,7 +46,7 @@ module Types
 
       def charge_pay_in_advance_interval
         @charge_pay_in_advance_interval ||=
-          object.invoice.charge_pay_in_advance_interval(object.timestamp, object.subscription)
+          ::Subscriptions::DatesService.charge_pay_in_advance_interval(object.timestamp, object.subscription)
       end
     end
   end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -220,19 +220,6 @@ class Invoice < ApplicationRecord
     }
   end
 
-  def charge_pay_in_advance_interval(timestamp, subscription)
-    date_service = Subscriptions::DatesService.new_instance(
-      subscription,
-      Time.zone.at(timestamp) + 1.day,
-      current_usage: true
-    )
-
-    {
-      charges_from_date: date_service.charges_from_datetime&.to_date,
-      charges_to_date: date_service.charges_to_datetime&.to_date
-    }
-  end
-
   def creditable_amount_cents
     return 0 if version_number < CREDIT_NOTES_MIN_VERSION || credit? || draft?
 

--- a/app/serializers/v1/fee_serializer.rb
+++ b/app/serializers/v1/fee_serializer.rb
@@ -56,9 +56,8 @@ module V1
     def date_boundaries
       if model.charge? && !model.pay_in_advance? && model.charge.pay_in_advance?
         subscription = model.subscription
-        invoice = model.invoice
-        timestamp = invoice.invoice_subscription(subscription.id).timestamp
-        interval = invoice.charge_pay_in_advance_interval(timestamp, subscription)
+        timestamp = model.invoice.invoice_subscription(subscription.id).timestamp
+        interval = ::Subscriptions::DatesService.charge_pay_in_advance_interval(timestamp, subscription)
 
         return {
           from_date: interval[:charges_from_date]&.to_datetime&.iso8601,

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -19,6 +19,23 @@ module Subscriptions
       klass.new(subscription, billing_at, current_usage)
     end
 
+    # Note: For context, the notion of `(from|to)_datetime` vs `charges_(from|to)_datetime` was introduced BEFORE
+    #       pay in advance charges were introduced. Pay in Advance charges should mostly use `(from|to)_datetime` range.
+    #       The boundaries might need a third range, like `in_advance_charges_(from|to)_datetime` for instance.
+    #       Ideally, we should also store the dates on EACH FEE.
+    def self.charge_pay_in_advance_interval(timestamp, subscription)
+      date_service = new_instance(
+        subscription,
+        Time.zone.at(timestamp) + 1.day,
+        current_usage: true
+      )
+
+      {
+        charges_from_date: date_service.charges_from_datetime&.to_date,
+        charges_to_date: date_service.charges_to_datetime&.to_date
+      }
+    end
+
     def initialize(subscription, billing_at, current_usage)
       @subscription = subscription
 

--- a/app/views/templates/invoices/v3/_subscription_details.slim
+++ b/app/views/templates/invoices/v3/_subscription_details.slim
@@ -86,7 +86,7 @@
         .invoice-resume.overflow-auto
           table.invoice-resume-table width="100%"
             tr
-              - pay_in_advance_interval = charge_pay_in_advance_interval(invoice_subscription(subscription.id).timestamp, subscription)
+              - pay_in_advance_interval = ::Subscriptions::DatesService.charge_pay_in_advance_interval(invoice_subscription(subscription.id).timestamp, subscription)
               td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(pay_in_advance_interval[:charges_from_date], format: :default), to_date: I18n.l(pay_in_advance_interval[:charges_to_date], format: :default))
               td.body-2 = I18n.t('invoice.unit')
               td.body-2 = I18n.t('invoice.tax_rate')

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -102,7 +102,7 @@
         .invoice-resume.overflow-auto class="mt-24"
           table.invoice-resume-table width="100%"
             tr.first_child
-              - pay_in_advance_interval = charge_pay_in_advance_interval(invoice_subscription.timestamp, subscription)
+              - pay_in_advance_interval = ::Subscriptions::DatesService.charge_pay_in_advance_interval(invoice_subscription.timestamp, subscription)
               td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(pay_in_advance_interval[:charges_from_date], format: :default), to_date: I18n.l(pay_in_advance_interval[:charges_to_date], format: :default))
               td.body-2 = I18n.t('invoice.units')
               td.body-2 = I18n.t('invoice.unit_price')


### PR DESCRIPTION
## Description

For Pay in Advance charges, the date boundaries are sometimes incorrectly computed. This was patch recently to ensure the dates show in the invoice, in the frontend and in the API are correct but the database is still not-so-correct.

Ideally, we would want to fix the boundaries and store the dates in each fees but it's a significant effort and I cannot do it now. This PR extract the previous patch from `Invoice` model to `DatesService` so I can reuse it for [Non Invoiceable fees](https://github.com/getlago/lago-api/pull/2185).

See these two PRs for more context: https://github.com/getlago/lago-api/pull/1188 and https://github.com/getlago/lago-api/pull/1540