### PR TITLE
fix(integration-customers): fix incorrectly cached variables

### DIFF
--- a/app/services/integration_customers/create_or_update_service.rb
+++ b/app/services/integration_customers/create_or_update_service.rb
@@ -54,6 +54,7 @@ module IntegrationCustomers
     def remove_integration_customer?
       !new_customer &&
         integration_customer &&
+        integration_customer.external_customer_id &&
         integration_customer_params[:external_customer_id].blank?
     end
 
@@ -63,19 +64,29 @@ module IntegrationCustomers
     end
 
     def integration
-      return @integration if defined? @integration
+      type = Integrations::BaseIntegration.integration_type(integration_customer_params[:integration_type])
+
+      if defined? @integration
+        return @integration if @integration&.type == type
+      end
+
       return nil unless integration_customer_params &&
         integration_customer_params[:integration_type] &&
         integration_customer_params[:integration_code]
 
-      type = Integrations::BaseIntegration.integration_type(integration_customer_params[:integration_type])
       code = integration_customer_params[:integration_code]
 
       @integration = Integrations::BaseIntegration.find_by(type:, code:)
     end
 
     def integration_customer
-      @integration_customer ||= IntegrationCustomers::BaseCustomer.find_by(integration:, customer:)
+      type = IntegrationCustomers::BaseCustomer.customer_type(integration_customer_params[:integration_type])
+
+      if defined? @integration_customer
+        return @integration_customer if @integration_customer&.type == type
+      end
+
+      @integration_customer = IntegrationCustomers::BaseCustomer.find_by(integration:, customer:)
     end
   end
 end

--- a/app/services/integration_customers/create_or_update_service.rb
+++ b/app/services/integration_customers/create_or_update_service.rb
@@ -66,9 +66,7 @@ module IntegrationCustomers
     def integration
       type = Integrations::BaseIntegration.integration_type(integration_customer_params[:integration_type])
 
-      if defined? @integration
-        return @integration if @integration&.type == type
-      end
+      return @integration if defined?(@integration) &&  @integration&.type == type
 
       return nil unless integration_customer_params &&
         integration_customer_params[:integration_type] &&
@@ -82,9 +80,7 @@ module IntegrationCustomers
     def integration_customer
       type = IntegrationCustomers::BaseCustomer.customer_type(integration_customer_params[:integration_type])
 
-      if defined? @integration_customer
-        return @integration_customer if @integration_customer&.type == type
-      end
+      return @integration_customer if defined?(@integration_customer) && @integration_customer&.type == type
 
       @integration_customer = IntegrationCustomers::BaseCustomer.find_by(integration:, customer:)
     end

--- a/app/services/integration_customers/create_or_update_service.rb
+++ b/app/services/integration_customers/create_or_update_service.rb
@@ -66,7 +66,7 @@ module IntegrationCustomers
     def integration
       type = Integrations::BaseIntegration.integration_type(integration_customer_params[:integration_type])
 
-      return @integration if defined?(@integration) &&  @integration&.type == type
+      return @integration if defined?(@integration) && @integration&.type == type
 
       return nil unless integration_customer_params &&
         integration_customer_params[:integration_type] &&

--- a/spec/services/integration_customers/create_or_update_service_spec.rb
+++ b/spec/services/integration_customers/create_or_update_service_spec.rb
@@ -108,6 +108,42 @@ RSpec.describe IntegrationCustomers::CreateOrUpdateService, type: :service do
         end
       end
 
+      context 'when adding one new integration customer' do
+        let(:integration_anrok) { create(:anrok_integration, organization:) }
+        let(:integration_customer) { create(:netsuite_customer, customer:, integration:) }
+        let(:new_customer) { false }
+
+        let(:integration_customers) do
+          [
+            {
+              integration_type: 'netsuite',
+              integration_code:,
+              sync_with_provider:,
+              external_customer_id:,
+              subsidiary_id:
+            },
+            {
+              integration_type: 'anrok',
+              integration_code: integration_anrok.code,
+              sync_with_provider: true,
+              external_customer_id: nil
+            }
+          ]
+        end
+
+        before do
+          integration_anrok
+
+          IntegrationCustomers::BaseCustomer.destroy_all
+
+          integration_customer
+        end
+
+        it 'calls create job' do
+          expect { service_call }.to have_enqueued_job(IntegrationCustomers::CreateJob).exactly(:once)
+        end
+      end
+
       context 'with updating mode' do
         let(:new_customer) { false }
 


### PR DESCRIPTION
## Context

Lago is currently adding more integrations; accounting and tax ones

## Description

Integration customer logic was originally written for one `integration_customer` object per `customer`. Recently the logic changed so that we support array in the input side.

However, we haven't changed memoization logic. The issue was that only the first object got cached and all subsequent params hashes got linked to the invalid `@integration` and `@integration_customer` instance variables.

This PR fixes described problem.
