### PR TITLE
feat(fees): Only allow payment status to be changed if not attached to invoice yet

### DIFF
--- a/app/services/fees/update_service.rb
+++ b/app/services/fees/update_service.rb
@@ -13,7 +13,8 @@ module Fees
       return result.not_found_failure!(resource: 'fee') if fee.nil?
 
       if params.key?(:payment_status)
-        return result.not_allowed_failure!(code: 'invoiceable_fee') if fee.charge? && fee.charge&.invoiceable?
+        # Once a fee is attached to an invoice, the payment status is irrelevant, it must be the same as the invoice
+        return result.not_allowed_failure!(code: 'invoiced_fee') if fee.invoice_id
 
         unless valid_payment_status?(params[:payment_status])
           return result.single_validation_failure!(

--- a/spec/services/fees/update_service_spec.rb
+++ b/spec/services/fees/update_service_spec.rb
@@ -37,9 +37,8 @@ RSpec.describe Fees::UpdateService, type: :service do
       end
     end
 
-    context 'when fee charge is invoiceable' do
-      let(:charge) { create(:standard_charge, invoiceable: true) }
-      let(:fee) { create(:charge_fee, fee_type: 'charge', pay_in_advance: true, invoice: nil, charge:) }
+    context 'when fee is part of an invoice' do
+      let(:fee) { create(:charge_fee, fee_type: 'charge', invoice: create(:invoice)) }
 
       it 'returns a not allowed failure' do
         result = update_service.call
@@ -47,7 +46,7 @@ RSpec.describe Fees::UpdateService, type: :service do
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
-          expect(result.error.code).to eq('invoiceable_fee')
+          expect(result.error.code).to eq('invoiced_fee')
         end
       end
     end


### PR DESCRIPTION
## Description

When [non-invoiceable fees were introduced](https://github.com/getlago/lago-api/pull/1069), we only allowed change of `payment_status` if the fee was attached to a non-invoiceable charge.

What we really meant is _"the fee is standalone, not attached to an invoice"_. Now we're working on attaching the non-invoiceable fees to an invoice at the end of the period. See https://github.com/getlago/lago-api/pull/2171

I'm changing the condition so the fee can be updated, only if it's not attached to any invoice yet.
