### PR TITLE
feat(dunning): Add overdue balance analytics endpoint

### DIFF
--- a/app/controllers/api/v1/analytics/overdue_balances_controller.rb
+++ b/app/controllers/api/v1/analytics/overdue_balances_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Analytics
+      class OverdueBalancesController < BaseController
+        def index
+          @result = ::Analytics::OverdueBalancesService.new(current_organization, **filters).call
+
+          super
+        end
+
+        private
+
+        def filters
+          {
+            external_customer_id: params[:external_customer_id],
+            currency: params[:currency]&.upcase,
+            months: params[:months]
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/models/analytics/overdue_balance.rb
+++ b/app/models/analytics/overdue_balance.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Analytics
+  class OverdueBalance < Base
+    self.abstract_class = true
+
+    class << self
+      def query(organization_id, **args)
+        if args[:external_customer_id].present?
+          and_external_customer_id_sql = sanitize_sql(
+            ["AND c.external_id = :external_customer_id", args[:external_customer_id]]
+          )
+        end
+
+        if args[:months].present?
+          months_interval = (args[:months].to_i <= 1) ? 0 : args[:months].to_i - 1
+
+          and_months_sql = sanitize_sql(
+            [
+              "AND am.month >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL ':months months')",
+              {months: months_interval}
+            ]
+          )
+        end
+
+        if args[:currency].present?
+          and_currency_sql = sanitize_sql(["AND invs.currency = :currency", args[:currency].upcase])
+          select_currency_sql = sanitize_sql(["COALESCE(invs.currency, :currency) as currency", args[:currency].upcase])
+        else
+          select_currency_sql = "invs.currency"
+        end
+
+        sql = <<~SQL.squish
+          WITH organization_creation_date AS (
+            SELECT
+              DATE_TRUNC('month', o.created_at) AS start_month
+            FROM organizations o
+            WHERE o.id = :organization_id
+          ),
+          all_months AS (
+            SELECT
+              generate_series(
+                (SELECT start_month FROM organization_creation_date),
+                DATE_TRUNC('month', CURRENT_DATE + INTERVAL '10 years'),
+                interval '1 month'
+              ) AS month
+          ),
+          payment_overdue_invoices AS (
+            SELECT
+              DATE_TRUNC('month', payment_due_date) AS month,
+              i.currency,
+              COALESCE(SUM(total_amount_cents), 0) AS total_amount_cents,
+              array_agg(DISTINCT i.id) AS ids
+            FROM invoices i
+            LEFT JOIN customers c ON i.customer_id = c.id
+            WHERE i.organization_id = :organization_id
+            AND i.payment_overdue IS TRUE
+            #{and_external_customer_id_sql}
+            GROUP BY month, i.currency, total_amount_cents
+            ORDER BY month ASC
+          )
+          SELECT
+            am.month,
+            #{select_currency_sql},
+            SUM(invs.total_amount_cents) AS amount_cents,
+            jsonb_agg(DISTINCT invoice_id) AS invoice_ids
+          FROM all_months am
+          LEFT JOIN payment_overdue_invoices invs ON am.month = invs.month, UNNEST(invs.ids) invoice_id
+          WHERE am.month <= DATE_TRUNC('month', CURRENT_DATE)
+          #{and_months_sql}
+          #{and_currency_sql}
+          AND invs.total_amount_cents IS NOT NULL
+          GROUP BY am.month, invs.currency
+          ORDER BY am.month;
+        SQL
+
+        sanitize_sql([sql, {organization_id:}.merge(args)])
+      end
+
+      def cache_key(organization_id, **args)
+        [
+          "overdue-balance",
+          Date.current.strftime("%Y-%m-%d"),
+          organization_id,
+          args[:external_customer_id],
+          args[:currency],
+          args[:months]
+        ].join("/")
+      end
+    end
+  end
+end

--- a/app/serializers/v1/analytics/overdue_balance_serializer.rb
+++ b/app/serializers/v1/analytics/overdue_balance_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Analytics
+    class OverdueBalanceSerializer < ModelSerializer
+      def serialize
+        {
+          month: model["month"],
+          amount_cents: model["amount_cents"],
+          currency: model["currency"],
+          invoice_ids: JSON.parse(model["invoice_ids"])
+        }
+      end
+    end
+  end
+end

--- a/app/serializers/v1/analytics/overdue_balance_serializer.rb
+++ b/app/serializers/v1/analytics/overdue_balance_serializer.rb
@@ -8,7 +8,7 @@ module V1
           month: model["month"],
           amount_cents: model["amount_cents"],
           currency: model["currency"],
-          invoice_ids: JSON.parse(model["invoice_ids"])
+          lago_invoice_ids: JSON.parse(model["invoice_ids"])
         }
       end
     end

--- a/app/services/analytics/overdue_balances_service.rb
+++ b/app/services/analytics/overdue_balances_service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Analytics
+  class OverdueBalancesService < BaseService
+    def call
+      @records = ::Analytics::OverdueBalance.find_all_by(organization.id, **filters)
+
+      result.records = records
+      result
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
         get :invoiced_usage, to: 'invoiced_usages#index', as: :invoiced_usage
         get :invoice_collection, to: 'invoice_collections#index', as: :invoice_collection
         get :mrr, to: 'mrrs#index', as: :mrr
+        get :overdue_balance, to: 'overdue_balances#index', as: :overdue_balance
       end
 
       resources :customers, param: :external_id, only: %i[create index show destroy] do

--- a/spec/models/analytics/overdue_balance_spec.rb
+++ b/spec/models/analytics/overdue_balance_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Analytics::OverdueBalance, type: :model do
+  describe ".cache_key" do
+    subject(:overdue_balance_cache_key) { described_class.cache_key(organization_id, **args) }
+
+    let(:organization_id) { SecureRandom.uuid }
+    let(:external_customer_id) { "customer_01" }
+    let(:currency) { "EUR" }
+    let(:months) { 12 }
+    let(:date) { Date.current.strftime("%Y-%m-%d") }
+
+    context "with no arguments" do
+      let(:args) { {} }
+      let(:cache_key) { "overdue-balance/#{date}/#{organization_id}///" }
+
+      it "returns the cache key" do
+        expect(overdue_balance_cache_key).to eq(cache_key)
+      end
+    end
+
+    context "with customer external id, currency and months" do
+      let(:args) { {external_customer_id:, currency:, months:} }
+
+      let(:cache_key) do
+        "overdue-balance/#{date}/#{organization_id}/#{external_customer_id}/#{currency}/#{months}"
+      end
+
+      it "returns the cache key" do
+        expect(overdue_balance_cache_key).to eq(cache_key)
+      end
+    end
+
+    context "with customer external id" do
+      let(:args) { {external_customer_id:} }
+
+      let(:cache_key) do
+        "overdue-balance/#{date}/#{organization_id}/#{external_customer_id}//"
+      end
+
+      it "returns the cache key" do
+        expect(overdue_balance_cache_key).to eq(cache_key)
+      end
+    end
+
+    context "with currency" do
+      let(:args) { {currency:} }
+      let(:cache_key) { "overdue-balance/#{date}/#{organization_id}//#{currency}/" }
+
+      it "returns the cache key" do
+        expect(overdue_balance_cache_key).to eq(cache_key)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::Analytics::OverdueBalancesController, type: :request do
+  describe "GET /analytics/overdue_balances" do
+    let(:customer) { create(:customer, organization:) }
+    let(:organization) { create(:organization, created_at: DateTime.new(2023, 11, 1)) }
+
+    it "returns the overdue balance" do
+      travel_to(DateTime.new(2024, 1, 15)) do
+        create(:invoice, customer:, organization:)
+        i1 = create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 2.months.ago, total_amount_cents: 1000)
+        i2 = create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 5.days.ago, total_amount_cents: 2000)
+        i3 = create(:invoice, customer:, organization:, payment_overdue: true, payment_due_date: 1.day.ago, total_amount_cents: 3000)
+
+        get_with_token(organization, "/api/v1/analytics/overdue_balance")
+
+        expect(response).to have_http_status(:success)
+        expect(json[:overdue_balances]).to match_array(
+          [
+            {
+              month: "2023-11-01T00:00:00.000Z",
+              amount_cents: "1000.0",
+              currency: "EUR",
+              invoice_ids: [i1.id]
+            },
+            {
+              month: "2024-01-01T00:00:00.000Z",
+              amount_cents: "5000.0",
+              currency: "EUR",
+              invoice_ids: match_array([i2.id, i3.id])
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
+++ b/spec/requests/api/v1/analytics/overdue_balances_controller_spec.rb
@@ -23,13 +23,13 @@ RSpec.describe Api::V1::Analytics::OverdueBalancesController, type: :request do
               month: "2023-11-01T00:00:00.000Z",
               amount_cents: "1000.0",
               currency: "EUR",
-              invoice_ids: [i1.id]
+              lago_invoice_ids: [i1.id]
             },
             {
               month: "2024-01-01T00:00:00.000Z",
               amount_cents: "5000.0",
               currency: "EUR",
-              invoice_ids: match_array([i2.id, i3.id])
+              lago_invoice_ids: match_array([i2.id, i3.id])
             }
           ]
         )

--- a/spec/serializers/v1/analytics/overdue_balance_serializer_spec.rb
+++ b/spec/serializers/v1/analytics/overdue_balance_serializer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ::V1::Analytics::OverdueBalanceSerializer do
+  subject(:serializer) { described_class.new(overdue_balance, root_name: "overdue_balance") }
+
+  let(:overdue_balance) do
+    {
+      "month" => "2024-06-01T00:00:00Z",
+      "amount_cents" => 100,
+      "currency" => "EUR",
+      "invoice_ids" => "[\"1\", \"2\", \"3\"]"
+    }
+  end
+
+  let(:result) { JSON.parse(serializer.to_json) }
+
+  it "serializes the overdue balance" do
+    expect(result["overdue_balance"]).to eq(
+      {
+        "month" => "2024-06-01T00:00:00Z",
+        "amount_cents" => 100,
+        "currency" => "EUR",
+        "invoice_ids" => ["1", "2", "3"]
+      }
+    )
+  end
+end

--- a/spec/serializers/v1/analytics/overdue_balance_serializer_spec.rb
+++ b/spec/serializers/v1/analytics/overdue_balance_serializer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ::V1::Analytics::OverdueBalanceSerializer do
         "month" => "2024-06-01T00:00:00Z",
         "amount_cents" => 100,
         "currency" => "EUR",
-        "invoice_ids" => ["1", "2", "3"]
+        "lago_invoice_ids" => ["1", "2", "3"]
       }
     )
   end

--- a/spec/services/analytics/overdue_balances_service_spec.rb
+++ b/spec/services/analytics/overdue_balances_service_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Analytics::OverdueBalancesService, type: :service do
+  let(:service) { described_class.new(organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+
+  describe "#call" do
+    subject(:service_call) { service.call }
+
+    it "returns success" do
+      expect(service_call).to be_success
+    end
+
+    it "calls Analytics::OverdueBalance" do
+      allow(Analytics::OverdueBalance).to receive(:find_all_by)
+      service_call
+      expect(Analytics::OverdueBalance).to have_received(:find_all_by).with(organization.id)
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/regroup-invoices-to-generate-one-payment-intent

## Context

We want to be able to group invoices to generate one payment.
Today we don't track payment terms and do not mention whether a payment or an invoice is overdue.

## Description

The goal of this PR is to add an analytics endpoint for fetching overdue balances per month and per currency.
