### PR TITLE
fix(integrations): Trigger full resync

### DIFF
--- a/app/services/integrations/aggregator/sync_service.rb
+++ b/app/services/integrations/aggregator/sync_service.rb
@@ -10,7 +10,8 @@ module Integrations
       def call
         payload = {
           provider_config_key: provider,
-          syncs: sync_list
+          syncs: sync_list,
+          full_resync: true
         }
 
         response = http_client.post_with_response(payload, headers)


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-xero

## Context

Currently Lago does not support Xero integration.

## Description

This PR adds `full_resync: true` to the sync service, the incremental sync is not working currently for Netsuite integration.