### PR TITLE
feat(dunning): Add Resolvers::Analytics::OverdueBalancesResolver

### DIFF
--- a/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
+++ b/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module Analytics
+    class OverdueBalancesResolver < Resolvers::BaseResolver
+      include AuthenticableApiUser
+      include RequiredOrganization
+
+      REQUIRED_PERMISSION = 'analytics:view'
+
+      description 'Query overdue balances of an organization'
+
+      argument :currency, Types::CurrencyEnum, required: false
+      argument :external_customer_id, String, required: false
+      argument :months, Integer, required: false
+
+      type Types::Analytics::OverdueBalances::Object.collection_type, null: false
+
+      def resolve(**args)
+        ::Analytics::OverdueBalance.find_all_by(current_organization.id, **args)
+      end
+    end
+  end
+end

--- a/app/graphql/types/analytics/overdue_balances/object.rb
+++ b/app/graphql/types/analytics/overdue_balances/object.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Types
+  module Analytics
+    module OverdueBalances
+      class Object < Types::BaseObject
+        graphql_name 'OverdueBalance'
+
+        field :amount_cents, GraphQL::Types::BigInt, null: false
+        field :currency, Types::CurrencyEnum, null: false
+        field :lago_invoice_ids, [String], null: false
+        field :month, GraphQL::Types::ISO8601DateTime, null: false
+      end
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -48,6 +48,7 @@ module Types
     field :memberships, resolver: Resolvers::MembershipsResolver
     field :mrrs, resolver: Resolvers::Analytics::MrrsResolver
     field :organization, resolver: Resolvers::OrganizationResolver
+    field :overdue_balances, resolver: Resolvers::Analytics::OverdueBalancesResolver
     field :password_reset, resolver: Resolvers::PasswordResetResolver
     field :payment_provider, resolver: Resolvers::PaymentProviderResolver
     field :payment_providers, resolver: Resolvers::PaymentProvidersResolver

--- a/schema.graphql
+++ b/schema.graphql
@@ -5028,6 +5028,18 @@ input OrganizationBillingConfigurationInput {
   invoiceGracePeriod: Int
 }
 
+type OverdueBalance {
+  amountCents: BigInt!
+  currency: CurrencyEnum!
+  lagoInvoiceIds: [String!]!
+  month: ISO8601DateTime!
+}
+
+type OverdueBalanceCollection {
+  collection: [OverdueBalance!]!
+  metadata: CollectionMetadata!
+}
+
 union PaymentProvider = AdyenProvider | GocardlessProvider | StripeProvider
 
 type PaymentProviderCollection {
@@ -5537,6 +5549,11 @@ type Query {
   Query the current organization
   """
   organization: CurrentOrganization
+
+  """
+  Query overdue balances of an organization
+  """
+  overdueBalances(currency: CurrencyEnum, externalCustomerId: String, months: Int): OverdueBalanceCollection!
 
   """
   Query a password reset by token

--- a/schema.json
+++ b/schema.json
@@ -23825,6 +23825,156 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "OverdueBalance",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "currency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "lagoInvoiceIds",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "month",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OverdueBalanceCollection",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "OverdueBalance",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
           "kind": "UNION",
           "name": "PaymentProvider",
           "description": null,
@@ -28145,6 +28295,59 @@
               "deprecationReason": null,
               "args": [
 
+              ]
+            },
+            {
+              "name": "overdueBalances",
+              "description": "Query overdue balances of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OverdueBalanceCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "externalCustomerId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "months",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
               ]
             },
             {

--- a/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Resolvers::Analytics::OverdueBalancesResolver, type: :graphql do
+  let(:required_permission) { 'analytics:view' }
+  let(:query) do
+    <<~GQL
+      query($currency: CurrencyEnum, $externalCustomerId: String, $months: Int) {
+        overdueBalances(currency: $currency, externalCustomerId: $externalCustomerId, months: $months) {
+          collection {
+            amountCents
+            currency
+            lagoInvoiceIds
+            month
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+
+  it_behaves_like 'requires current user'
+  it_behaves_like 'requires current organization'
+  it_behaves_like 'requires permission', 'analytics:view'
+
+  it 'returns a list of overdue balances' do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:
+    )
+
+    expect(result['data']['overdueBalances']['collection']).to eq([])
+  end
+
+  describe '#resolve' do
+    subject(:resolve) { resolver.resolve }
+
+    let(:resolver) { described_class.new(object: nil, context: nil, field: nil) }
+    let(:current_organization) { create(:organization) }
+
+    before do
+      allow(Analytics::OverdueBalance).to receive(:find_all_by).and_return([])
+      allow(resolver).to receive(:current_organization).and_return(current_organization)
+
+      resolve
+    end
+
+    it 'calls ::Analytics::OverdueBalance.find_all_by' do
+      expect(Analytics::OverdueBalance).to have_received(:find_all_by).with(current_organization.id)
+    end
+  end
+end

--- a/spec/graphql/types/analytics/overdue_balances/object_spec.rb
+++ b/spec/graphql/types/analytics/overdue_balances/object_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Analytics::OverdueBalances::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:currency).of_type('CurrencyEnum!') }
+  it { is_expected.to have_field(:lago_invoice_ids).of_type('[String!]!') }
+  it { is_expected.to have_field(:month).of_type('ISO8601DateTime!') }
+end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/regroup-invoices-to-generate-one-payment-intent

## Context

We want to be able to group invoices to generate one payment.
Today we don't track payment terms and do not mention whether a payment or an invoice is overdue.

## Description

The goal of this PR is to add an analytics graphql endpoint for fetching overdue balances per month and per currency.
