### PR TITLE
fix(integrations): Fix creating an invoice when there's http error

### DIFF
--- a/app/services/integrations/aggregator/invoices/create_service.rb
+++ b/app/services/integrations/aggregator/invoices/create_service.rb
@@ -41,6 +41,8 @@ module Integrations
           deliver_error_webhook(customer:, code:, message:)
 
           raise e if e.error_code.to_i >= 500
+
+          result
         end
 
         def call_async

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -354,6 +354,10 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
           end.not_to raise_error(http_error)
         end
 
+        it 'returns result' do
+          expect(service_call).to be_a(BaseService::Result)
+        end
+
         it 'enqueues a SendWebhookJob' do
           expect { service_call }.to have_enqueued_job(SendWebhookJob)
         end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/integration-with-xero

## Context

Currently Lago does not support Xero integration.

## Description

There was a tricky bug in the Invoices service that when it raised a specific http error (4xx) it didn't return any result, it returned nil instead. This PR fixes that and the services returns a result even in that case.