### PR TITLE
feat (integration-customers): add external account id to the anrok GQL response

### DIFF
--- a/app/graphql/types/integrations/anrok.rb
+++ b/app/graphql/types/integrations/anrok.rb
@@ -23,9 +23,9 @@ module Types
       end
 
       def external_account_id
-        return nil unless object.api_key&.include?('/')
+        return nil unless object.api_key.include?('/')
 
-        object.api_key&.split('/')[0]
+        object.api_key.split('/')[0]
       end
     end
   end

--- a/app/graphql/types/integrations/anrok.rb
+++ b/app/graphql/types/integrations/anrok.rb
@@ -7,6 +7,7 @@ module Types
 
       field :api_key, String, null: false
       field :code, String, null: false
+      field :external_account_id, String, null: true
       field :has_mappings_configured, Boolean
       field :id, ID, null: false
       field :name, String, null: false
@@ -19,6 +20,12 @@ module Types
 
       def has_mappings_configured
         object.integration_collection_mappings.where(type: 'IntegrationCollectionMappings::AnrokCollectionMapping').any?
+      end
+
+      def external_account_id
+        return nil unless object.api_key&.include?('/')
+
+        object.api_key&.split('/')[0]
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -138,6 +138,7 @@ type AnrokCustomer {
 type AnrokIntegration {
   apiKey: String!
   code: String!
+  externalAccountId: String
   hasMappingsConfigured: Boolean
   id: ID!
   name: String!

--- a/schema.json
+++ b/schema.json
@@ -1184,6 +1184,20 @@
               ]
             },
             {
+              "name": "externalAccountId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "hasMappingsConfigured",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/integrations/anrok/create_spec.rb
+++ b/spec/graphql/mutations/integrations/anrok/create_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Mutations::Integrations::Anrok::Create, type: :graphql do
           id,
           code,
           name,
-          apiKey
+          apiKey,
+          externalAccountId
         }
       }
     GQL
@@ -39,7 +40,7 @@ RSpec.describe Mutations::Integrations::Anrok::Create, type: :graphql do
         input: {
           code:,
           name:,
-          apiKey: '123456789',
+          apiKey: '123/456/789',
           connectionId: 'this-is-random-uuid'
         }
       }
@@ -52,6 +53,7 @@ RSpec.describe Mutations::Integrations::Anrok::Create, type: :graphql do
       expect(result_data['code']).to eq(code)
       expect(result_data['name']).to eq(name)
       expect(result_data['apiKey']).to eq('••••••••…789')
+      expect(result_data['externalAccountId']).to eq('123')
       expect(Integrations::AnrokIntegration.order(:created_at).last.connection_id).to eq('this-is-random-uuid')
     end
   end

--- a/spec/graphql/types/integrations/anrok_spec.rb
+++ b/spec/graphql/types/integrations/anrok_spec.rb
@@ -11,4 +11,5 @@ RSpec.describe Types::Integrations::Anrok do
   it { is_expected.to have_field(:code).of_type('String!') }
   it { is_expected.to have_field(:has_mappings_configured).of_type('Boolean') }
   it { is_expected.to have_field(:name).of_type('String!') }
+  it { is_expected.to have_field(:external_account_id).of_type('String') }
 end


### PR DESCRIPTION
## Context

Currently multiple tax and accounting integration are being added to the Lago app

## Description

This PR adds `externalAccountId` to the GQL response of the integration object.

This field is is needed for the UI to build the URL link for anrok customer. We can extract this data from api key but we don't want to expose whole api key object so new field in the response is added.
