### PR TITLE
misc: Upgrade Sentry gem and enable version tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,9 +66,9 @@ gem 'newrelic_rpm'
 gem 'opentelemetry-exporter-otlp'
 gem 'opentelemetry-instrumentation-all'
 gem 'opentelemetry-sdk'
-gem 'sentry-rails', '~> 5.12.0'
-gem 'sentry-ruby', '~> 5.12.0'
-gem 'sentry-sidekiq', '~> 5.12.0'
+gem 'sentry-rails', '~> 5.18.0'
+gem 'sentry-ruby', '~> 5.18.0'
+gem 'sentry-sidekiq', '~> 5.18.0'
 
 # Storage
 gem 'aws-sdk-s3', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -760,13 +760,14 @@ GEM
     scenic (1.7.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
-    sentry-rails (5.12.0)
+    sentry-rails (5.18.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.12.0)
-    sentry-ruby (5.12.0)
+      sentry-ruby (~> 5.18.0)
+    sentry-ruby (5.18.0)
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sentry-sidekiq (5.12.0)
-      sentry-ruby (~> 5.12.0)
+    sentry-sidekiq (5.18.0)
+      sentry-ruby (~> 5.18.0)
       sidekiq (>= 3.0)
     shellany (0.0.1)
     shoulda-matchers (6.2.0)
@@ -928,9 +929,9 @@ DEPENDENCIES
   ruby-lsp-rails
   sass-rails
   scenic
-  sentry-rails (~> 5.12.0)
-  sentry-ruby (~> 5.12.0)
-  sentry-sidekiq (~> 5.12.0)
+  sentry-rails (~> 5.18.0)
+  sentry-ruby (~> 5.18.0)
+  sentry-sidekiq (~> 5.18.0)
   shoulda-matchers
   sidekiq
   simplecov

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,8 +3,10 @@
 if ENV['SENTRY_DSN']
   Sentry.init do |config|
     config.dsn = ENV['SENTRY_DSN']
+    config.release = LAGO_VERSION.number
     config.breadcrumbs_logger = %i[active_support_logger http_logger]
     config.traces_sample_rate = 0
+    config.traces_sample_rate = ENV['SENTRY_TRACES_SAMPLE_RATE'].to_f || 0
     config.environment = ENV['SENTRY_ENVIRONMENT'] || Rails.env
   end
 end


### PR DESCRIPTION
## Description

This PR: 
- Upgrades Sentry gems to 5.18.0
- Enhance the details sent to Sentry by adding the version and by using the `SENTRY_TRACES_SAMPLE_RATE` to configure the sample rate sent to Sentry