### PR TITLE
misc: Add unique lock on refresh jobs

### DIFF
--- a/app/jobs/clock/refresh_draft_invoices_job.rb
+++ b/app/jobs/clock/refresh_draft_invoices_job.rb
@@ -4,6 +4,8 @@ module Clock
   class RefreshDraftInvoicesJob < ApplicationJob
     queue_as 'clock'
 
+    unique :until_executed
+
     def perform
       Invoice.ready_to_be_refreshed.with_active_subscriptions.find_each do |invoice|
         Invoices::RefreshDraftJob.perform_later(invoice)

--- a/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
+++ b/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
@@ -4,6 +4,8 @@ module Clock
   class RefreshWalletsOngoingBalanceJob < ApplicationJob
     queue_as 'clock'
 
+    unique :until_executed
+
     def perform
       return unless License.premium?
 

--- a/app/jobs/invoices/refresh_draft_job.rb
+++ b/app/jobs/invoices/refresh_draft_job.rb
@@ -4,6 +4,8 @@ module Invoices
   class RefreshDraftJob < ApplicationJob
     queue_as 'invoices'
 
+    unique :until_executed
+
     def perform(invoice)
       ::Invoices::RefreshDraftService.call(invoice:)
     end

--- a/app/jobs/wallets/refresh_ongoing_balance_job.rb
+++ b/app/jobs/wallets/refresh_ongoing_balance_job.rb
@@ -4,6 +4,8 @@ module Wallets
   class RefreshOngoingBalanceJob < ApplicationJob
     queue_as 'wallets'
 
+    unique :until_executed
+
     def perform(wallet)
       Wallets::Balance::RefreshOngoingService.call(wallet:)
     end


### PR DESCRIPTION
The goal of this PR is to ensure that only one refresh job can be processed at a time.
The lock is released automatically when the job finishes its execution