### PR TITLE
misc: Do not raise ActiveJob::Uniqueness::JobNotUnique

### DIFF
--- a/app/jobs/clock/refresh_draft_invoices_job.rb
+++ b/app/jobs/clock/refresh_draft_invoices_job.rb
@@ -4,7 +4,7 @@ module Clock
   class RefreshDraftInvoicesJob < ApplicationJob
     queue_as 'clock'
 
-    unique :until_executed
+    unique :until_executed, on_conflict: :log
 
     def perform
       Invoice.ready_to_be_refreshed.with_active_subscriptions.find_each do |invoice|

--- a/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
+++ b/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
@@ -4,7 +4,7 @@ module Clock
   class RefreshWalletsOngoingBalanceJob < ApplicationJob
     queue_as 'clock'
 
-    unique :until_executed
+    unique :until_executed, on_conflict: :log
 
     def perform
       return unless License.premium?

--- a/app/jobs/invoices/payments/stripe_create_job.rb
+++ b/app/jobs/invoices/payments/stripe_create_job.rb
@@ -5,7 +5,7 @@ module Invoices
     class StripeCreateJob < ApplicationJob
       queue_as 'providers'
 
-      unique :until_executed
+      unique :until_executed, on_conflict: :log
 
       retry_on Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
       retry_on Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6

--- a/app/jobs/invoices/refresh_draft_job.rb
+++ b/app/jobs/invoices/refresh_draft_job.rb
@@ -4,7 +4,7 @@ module Invoices
   class RefreshDraftJob < ApplicationJob
     queue_as 'invoices'
 
-    unique :until_executed
+    unique :until_executed, on_conflict: :log
 
     def perform(invoice)
       ::Invoices::RefreshDraftService.call(invoice:)

--- a/app/jobs/wallets/refresh_ongoing_balance_job.rb
+++ b/app/jobs/wallets/refresh_ongoing_balance_job.rb
@@ -4,7 +4,7 @@ module Wallets
   class RefreshOngoingBalanceJob < ApplicationJob
     queue_as 'wallets'
 
-    unique :until_executed
+    unique :until_executed, on_conflict: :log
 
     def perform(wallet)
       Wallets::Balance::RefreshOngoingService.call(wallet:)


### PR DESCRIPTION
We don't want to raise `ActiveJob::Uniqueness::JobNotUnique` when refreshing wallets and invoices.
The goal of this PR is to log them instead.