### PR TITLE
feat(export invoices): Add GraphQL invoices filters

### DIFF
--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -9,6 +9,7 @@ module Resolvers
 
     description 'Query invoices'
 
+    argument :currency, Types::CurrencyEnum, required: false
     argument :invoice_type, Types::Invoices::InvoiceTypeEnum, required: false
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
@@ -21,6 +22,7 @@ module Resolvers
     type Types::Invoices::Object.collection_type, null: false
 
     def resolve( # rubocop:disable Metrics/ParameterLists
+      currency: nil,
       invoice_type: nil,
       page: nil,
       limit: nil,
@@ -40,6 +42,7 @@ module Resolvers
         payment_overdue:,
         status:,
         filters: {
+          currency:,
           invoice_type:
         }
       )

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -10,6 +10,7 @@ module Resolvers
     description 'Query invoices'
 
     argument :currency, Types::CurrencyEnum, required: false
+    argument :customer_external_id, String, required: false
     argument :invoice_type, Types::Invoices::InvoiceTypeEnum, required: false
     argument :issuing_date_from, GraphQL::Types::ISO8601Date, required: false
     argument :issuing_date_to, GraphQL::Types::ISO8601Date, required: false
@@ -25,6 +26,7 @@ module Resolvers
 
     def resolve( # rubocop:disable Metrics/ParameterLists
       currency: nil,
+      customer_external_id: nil,
       invoice_type: nil,
       issuing_date_from: nil,
       issuing_date_to: nil,
@@ -47,6 +49,7 @@ module Resolvers
         status:,
         filters: {
           currency:,
+          customer_external_id:,
           invoice_type:,
           issuing_date_from:,
           issuing_date_to:

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -9,7 +9,7 @@ module Resolvers
 
     description 'Query invoices'
 
-    argument :ids, [ID], required: false, description: 'List of invoice IDs to fetch'
+    argument :invoice_type, Types::Invoices::InvoiceTypeEnum, required: false
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
     argument :payment_dispute_lost, Boolean, required: false
@@ -21,7 +21,7 @@ module Resolvers
     type Types::Invoices::Object.collection_type, null: false
 
     def resolve( # rubocop:disable Metrics/ParameterLists
-      ids: nil,
+      invoice_type: nil,
       page: nil,
       limit: nil,
       payment_status: nil,
@@ -40,7 +40,7 @@ module Resolvers
         payment_overdue:,
         status:,
         filters: {
-          ids:
+          invoice_type:
         }
       )
 

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -11,6 +11,8 @@ module Resolvers
 
     argument :currency, Types::CurrencyEnum, required: false
     argument :invoice_type, Types::Invoices::InvoiceTypeEnum, required: false
+    argument :issuing_date_from, GraphQL::Types::ISO8601Date, required: false
+    argument :issuing_date_to, GraphQL::Types::ISO8601Date, required: false
     argument :limit, Integer, required: false
     argument :page, Integer, required: false
     argument :payment_dispute_lost, Boolean, required: false
@@ -24,6 +26,8 @@ module Resolvers
     def resolve( # rubocop:disable Metrics/ParameterLists
       currency: nil,
       invoice_type: nil,
+      issuing_date_from: nil,
+      issuing_date_to: nil,
       page: nil,
       limit: nil,
       payment_status: nil,
@@ -43,7 +47,9 @@ module Resolvers
         status:,
         filters: {
           currency:,
-          invoice_type:
+          invoice_type:,
+          issuing_date_from:,
+          issuing_date_to:
         }
       )
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -5521,7 +5521,7 @@ type Query {
   """
   Query invoices
   """
-  invoices(invoiceType: InvoiceTypeEnum, limit: Int, page: Int, paymentDisputeLost: Boolean, paymentOverdue: Boolean, paymentStatus: [InvoicePaymentStatusTypeEnum!], searchTerm: String, status: InvoiceStatusTypeEnum): InvoiceCollection!
+  invoices(currency: CurrencyEnum, invoiceType: InvoiceTypeEnum, limit: Int, page: Int, paymentDisputeLost: Boolean, paymentOverdue: Boolean, paymentStatus: [InvoicePaymentStatusTypeEnum!], searchTerm: String, status: InvoiceStatusTypeEnum): InvoiceCollection!
 
   """
   Query memberships of an organization

--- a/schema.graphql
+++ b/schema.graphql
@@ -5521,7 +5521,7 @@ type Query {
   """
   Query invoices
   """
-  invoices(currency: CurrencyEnum, invoiceType: InvoiceTypeEnum, issuingDateFrom: ISO8601Date, issuingDateTo: ISO8601Date, limit: Int, page: Int, paymentDisputeLost: Boolean, paymentOverdue: Boolean, paymentStatus: [InvoicePaymentStatusTypeEnum!], searchTerm: String, status: InvoiceStatusTypeEnum): InvoiceCollection!
+  invoices(currency: CurrencyEnum, customerExternalId: String, invoiceType: InvoiceTypeEnum, issuingDateFrom: ISO8601Date, issuingDateTo: ISO8601Date, limit: Int, page: Int, paymentDisputeLost: Boolean, paymentOverdue: Boolean, paymentStatus: [InvoicePaymentStatusTypeEnum!], searchTerm: String, status: InvoiceStatusTypeEnum): InvoiceCollection!
 
   """
   Query memberships of an organization

--- a/schema.graphql
+++ b/schema.graphql
@@ -5521,19 +5521,7 @@ type Query {
   """
   Query invoices
   """
-  invoices(
-    """
-    List of invoice IDs to fetch
-    """
-    ids: [ID!]
-    limit: Int
-    page: Int
-    paymentDisputeLost: Boolean
-    paymentOverdue: Boolean
-    paymentStatus: [InvoicePaymentStatusTypeEnum!]
-    searchTerm: String
-    status: InvoiceStatusTypeEnum
-  ): InvoiceCollection!
+  invoices(invoiceType: InvoiceTypeEnum, limit: Int, page: Int, paymentDisputeLost: Boolean, paymentOverdue: Boolean, paymentStatus: [InvoicePaymentStatusTypeEnum!], searchTerm: String, status: InvoiceStatusTypeEnum): InvoiceCollection!
 
   """
   Query memberships of an organization

--- a/schema.graphql
+++ b/schema.graphql
@@ -5521,7 +5521,7 @@ type Query {
   """
   Query invoices
   """
-  invoices(currency: CurrencyEnum, invoiceType: InvoiceTypeEnum, limit: Int, page: Int, paymentDisputeLost: Boolean, paymentOverdue: Boolean, paymentStatus: [InvoicePaymentStatusTypeEnum!], searchTerm: String, status: InvoiceStatusTypeEnum): InvoiceCollection!
+  invoices(currency: CurrencyEnum, invoiceType: InvoiceTypeEnum, issuingDateFrom: ISO8601Date, issuingDateTo: ISO8601Date, limit: Int, page: Int, paymentDisputeLost: Boolean, paymentOverdue: Boolean, paymentStatus: [InvoicePaymentStatusTypeEnum!], searchTerm: String, status: InvoiceStatusTypeEnum): InvoiceCollection!
 
   """
   Query memberships of an organization

--- a/schema.json
+++ b/schema.json
@@ -28100,20 +28100,12 @@
               "deprecationReason": null,
               "args": [
                 {
-                  "name": "ids",
-                  "description": "List of invoice IDs to fetch",
+                  "name": "invoiceType",
+                  "description": null,
                   "type": {
-                    "kind": "LIST",
-                    "name": null,
-                    "ofType": {
-                      "kind": "NON_NULL",
-                      "name": null,
-                      "ofType": {
-                        "kind": "SCALAR",
-                        "name": "ID",
-                        "ofType": null
-                      }
-                    }
+                    "kind": "ENUM",
+                    "name": "InvoiceTypeEnum",
+                    "ofType": null
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -28100,6 +28100,18 @@
               "deprecationReason": null,
               "args": [
                 {
+                  "name": "currency",
+                  "description": null,
+                  "type": {
+                    "kind": "ENUM",
+                    "name": "CurrencyEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "invoiceType",
                   "description": null,
                   "type": {

--- a/schema.json
+++ b/schema.json
@@ -28112,6 +28112,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "customerExternalId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "invoiceType",
                   "description": null,
                   "type": {

--- a/schema.json
+++ b/schema.json
@@ -28124,6 +28124,30 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "issuingDateFrom",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "issuingDateTo",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ISO8601Date",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "limit",
                   "description": null,
                   "type": {

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -225,4 +225,49 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
       end
     end
   end
+
+  context 'when filtering by currency' do
+    let(:invoice_third) do
+      create(
+        :invoice,
+        customer: customer_second,
+        organization:,
+        currency: 'USD'
+      )
+    end
+
+    let(:query) do
+      <<~GQL
+        query {
+          invoices(limit: 5, currency: USD) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    before do
+      invoice_third
+    end
+
+    it 'returns all invoices with currency USD' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      invoices_response = result['data']['invoices']
+
+      aggregate_failures do
+        expect(invoices_response['collection'].count).to eq(1)
+        expect(invoices_response['collection'].first['id']).to eq(invoice_third.id)
+
+        expect(invoices_response['metadata']['currentPage']).to eq(1)
+        expect(invoices_response['metadata']['totalCount']).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -180,4 +180,49 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
       end
     end
   end
+
+  context 'when filtering by invoice type' do
+    let(:invoice_third) do
+      create(
+        :invoice,
+        customer: customer_second,
+        invoice_type: 'one_off',
+        organization:
+      )
+    end
+
+    let(:query) do
+      <<~GQL
+        query {
+          invoices(limit: 5, invoiceType: one_off) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    before do
+      invoice_third
+    end
+
+    it 'returns all invoices with type one_off' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      invoices_response = result['data']['invoices']
+
+      aggregate_failures do
+        expect(invoices_response['collection'].count).to eq(1)
+        expect(invoices_response['collection'].first['id']).to eq(invoice_third.id)
+
+        expect(invoices_response['metadata']['currentPage']).to eq(1)
+        expect(invoices_response['metadata']['totalCount']).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -270,4 +270,53 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
       end
     end
   end
+
+  context 'when filtering by issuing date' do
+    let(:invoice_third) do
+      create(
+        :invoice,
+        customer: customer_second,
+        organization:,
+        issuing_date: 1.week.ago
+      )
+    end
+
+    let(:query) do
+      <<~GQL
+        query {
+          invoices(
+            limit: 5,
+            issuingDateFrom: "#{2.weeks.ago.to_date.iso8601}",
+            issuingDateTo: "#{1.week.ago.to_date.iso8601}"
+          ) {
+            collection { id }
+            metadata { currentPage, totalCount }
+          }
+        }
+      GQL
+    end
+
+    before do
+      invoice_third
+    end
+
+    it 'returns all invoices issued within the from and to dates' do
+      result = execute_graphql(
+        current_user: membership.user,
+        current_organization: organization,
+        permissions: required_permission,
+        query:
+      )
+
+      invoices_response = result['data']['invoices']
+
+      aggregate_failures do
+        expect(invoices_response['collection'].count).to eq(1)
+        expect(invoices_response['collection'].first['id']).to eq(invoice_third.id)
+
+        expect(invoices_response['metadata']['currentPage']).to eq(1)
+        expect(invoices_response['metadata']['totalCount']).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/ability-to-export-data-from-the-user-interface

## Context

In order to effortlessly download export of invoices by non-technical users, it is required to extend the invoices filtering capabilities.

## Description

This change includes new filters to the GraphQL invoices resolver to query invoices by:

* invoice_type
* currency
* issuing_date (from and to range)
* customer external_id

Also drops support for filtering by ids as this filter is not in use.