### PR TITLE
chore(factories): Don't use Faker names for random codes

### DIFF
--- a/spec/factories/add_ons.rb
+++ b/spec/factories/add_ons.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     organization
     name { Faker::Name.name }
     invoice_display_name { Faker::Fantasy::Tolkien.location }
-    code { Faker::Name.first_name }
+    code { Faker::Alphanumeric.alphanumeric(number: 10) }
     description { 'test description' }
     amount_cents { 200 }
     amount_currency { 'EUR' }

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -9,8 +9,8 @@ FactoryBot.define do
 
     organization_id { create(:organization).id }
 
-    transaction_id { SecureRandom.uuid }
-    code { Faker::Name.name.underscore }
+    transaction_id { "tr_#{SecureRandom.hex}" }
+    code { Faker::Alphanumeric.alphanumeric(number: 10) }
     timestamp { Time.current }
 
     external_customer_id { customer.external_id }
@@ -34,8 +34,8 @@ FactoryBot.define do
     external_customer_id { source_customer.external_id }
     external_subscription_id { source_subscription.external_id }
 
-    transaction_id { SecureRandom.uuid }
-    code { Faker::Name.name.underscore }
+    transaction_id { "tr_#{SecureRandom.hex}" }
+    code { Faker::Alphanumeric.alphanumeric(number: 10) }
     timestamp { Time.current }
   end
 end


### PR DESCRIPTION
## Context

Many have models have `code` attribute which is typically a few letter long.

## Description

Some factories relied on `Faker::Name.first_name` to generate code, unfortunately it's more likely to create collition than a random suite of letters. It actually happened today!

* Used `Faker::Alphanumeric.alphanumeric(number: 10)` to generate code attribute (all others already work this way)
* Changed `transaction_id` to a random string so it creates less confusion when debugging. I'd expect UUID to be linked to another model ID but here it's something "random" from the customer sending event.

 
![CleanShot 2024-06-27 at 11 36 10@2x](https://github.com/getlago/lago-api/assets/1525636/a3db751b-2a52-406e-9884-fc23a474b4e5)
