### PR TITLE
fix (integrations-customers): scope integration customer under correct organization

### DIFF
--- a/app/services/integration_customers/create_or_update_service.rb
+++ b/app/services/integration_customers/create_or_update_service.rb
@@ -72,7 +72,7 @@ module IntegrationCustomers
 
       code = integration_customer_params[:integration_code]
 
-      @integration = Integrations::BaseIntegration.find_by(type:, code:)
+      @integration = Integrations::BaseIntegration.find_by(type:, code:, organization: customer.organization)
     end
 
     def integration_customer

--- a/spec/services/integration_customers/create_or_update_service_spec.rb
+++ b/spec/services/integration_customers/create_or_update_service_spec.rb
@@ -152,8 +152,15 @@ RSpec.describe IntegrationCustomers::CreateOrUpdateService, type: :service do
       let(:external_customer_id) { nil }
       let(:new_customer) { true }
 
+      let(:integration_two) { create(:netsuite_integration, organization: organization_two, code: integration.code) }
+      let(:organization_two) { create(:organization) }
+
+      before { integration_two }
+
       it 'calls create job' do
-        expect { service_call }.to have_enqueued_job(IntegrationCustomers::CreateJob)
+        expect do
+          service_call
+        end.to have_enqueued_job(IntegrationCustomers::CreateJob).with(hash_including(integration:))
       end
 
       context 'when updating existing customer without integration customer' do


### PR DESCRIPTION
## Context

Lago is actively adding new integrations

## Description

When creating integration customer, we should assign valid `integration_id` to it. If multiple organizations use the same `code` for certain `integration` object, there is a chance that wrong `integration` would be assign to the integration customer.
