### PR TITLE
misc(integrations): Improve reliability of syncing and fetching items

### DIFF
--- a/app/jobs/integrations/aggregator/perform_sync_job.rb
+++ b/app/jobs/integrations/aggregator/perform_sync_job.rb
@@ -11,12 +11,10 @@ module Integrations
         sync_result = Integrations::Aggregator::SyncService.call(integration:)
         sync_result.raise_if_error!
 
-        items_result = Integrations::Aggregator::ItemsService.call(integration:)
-        items_result.raise_if_error!
+        Integrations::Aggregator::FetchItemsJob.set(wait: 5.seconds).perform_later(integration:)
 
         if sync_tax_items
-          tax_items_result = Integrations::Aggregator::TaxItemsService.call(integration:)
-          tax_items_result.raise_if_error!
+          Integrations::Aggregator::FetchTaxItemsJob.set(wait: 5.seconds).perform_later(integration:)
         end
       end
     end

--- a/app/services/integrations/netsuite/create_service.rb
+++ b/app/services/integrations/netsuite/create_service.rb
@@ -27,13 +27,11 @@ module Integrations
 
         integration.save!
 
-        if integration.type == 'Integrations::NetsuiteIntegration'
-          Integrations::Aggregator::SendRestletEndpointJob.perform_later(integration:)
-          Integrations::Aggregator::PerformSyncJob.set(wait: 2.seconds).perform_later(
-            integration:,
-            sync_tax_items: true
-          )
-        end
+        Integrations::Aggregator::SendRestletEndpointJob.perform_later(integration:)
+        Integrations::Aggregator::PerformSyncJob.set(wait: 2.seconds).perform_later(
+          integration:,
+          sync_tax_items: true
+        )
 
         result.integration = integration
         result

--- a/spec/jobs/integrations/aggregator/perform_sync_job_spec.rb
+++ b/spec/jobs/integrations/aggregator/perform_sync_job_spec.rb
@@ -34,18 +34,12 @@ RSpec.describe Integrations::Aggregator::PerformSyncJob, type: :job do
       end
     end
 
-    it 'calls the aggregator items service' do
-      aggregate_failures do
-        expect(Integrations::Aggregator::ItemsService).to have_received(:new)
-        expect(items_service).to have_received(:call)
-      end
+    it 'enqueues the aggregator fetch items job' do
+      expect(Integrations::Aggregator::FetchItemsJob).to have_been_enqueued
     end
 
-    it 'calls the aggregator tax items service' do
-      aggregate_failures do
-        expect(Integrations::Aggregator::TaxItemsService).to have_received(:new)
-        expect(tax_items_service).to have_received(:call)
-      end
+    it 'enqueues the aggregator fetch tax items job' do
+      expect(Integrations::Aggregator::FetchTaxItemsJob).to have_been_enqueued
     end
   end
 
@@ -59,18 +53,12 @@ RSpec.describe Integrations::Aggregator::PerformSyncJob, type: :job do
       end
     end
 
-    it 'calls the aggregator items service' do
-      aggregate_failures do
-        expect(Integrations::Aggregator::ItemsService).to have_received(:new)
-        expect(items_service).to have_received(:call)
-      end
+    it 'enqueues the aggregator fetch items job' do
+      expect(Integrations::Aggregator::FetchItemsJob).to have_been_enqueued
     end
 
-    it 'does not call the aggregator tax items service' do
-      aggregate_failures do
-        expect(Integrations::Aggregator::TaxItemsService).not_to have_received(:new)
-        expect(tax_items_service).not_to have_received(:call)
-      end
+    it 'does not enqueue the aggregator fetch tax items job' do
+      expect(Integrations::Aggregator::FetchTaxItemsJob).not_to have_been_enqueued
     end
   end
 end


### PR DESCRIPTION
## Context

Right now we fetch the integration items right after we initiate the sync.
The problem is that the sync just started and didn't finish yet.

## Description

Move the items fetching to jobs instead of services and schedule them for later.