### PR TITLE
misc(sidekiq): New approach for cron monitoring

### DIFF
--- a/app/jobs/clock/activate_subscriptions_job.rb
+++ b/app/jobs/clock/activate_subscriptions_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class ActivateSubscriptionsJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     unique :until_executed, on_conflict: :log

--- a/app/jobs/clock/create_interval_wallet_transactions_job.rb
+++ b/app/jobs/clock/create_interval_wallet_transactions_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class CreateIntervalWalletTransactionsJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     def perform

--- a/app/jobs/clock/events_validation_job.rb
+++ b/app/jobs/clock/events_validation_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class EventsValidationJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     unique :until_executed

--- a/app/jobs/clock/finalize_invoices_job.rb
+++ b/app/jobs/clock/finalize_invoices_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class FinalizeInvoicesJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     def perform

--- a/app/jobs/clock/free_trial_subscriptions_biller_job.rb
+++ b/app/jobs/clock/free_trial_subscriptions_biller_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class FreeTrialSubscriptionsBillerJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     def perform

--- a/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
+++ b/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class MarkInvoicesAsPaymentOverdueJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     def perform

--- a/app/jobs/clock/refresh_draft_invoices_job.rb
+++ b/app/jobs/clock/refresh_draft_invoices_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class RefreshDraftInvoicesJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     unique :until_executed, on_conflict: :log

--- a/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
+++ b/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class RefreshWalletsOngoingBalanceJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     unique :until_executed, on_conflict: :log

--- a/app/jobs/clock/subscriptions_biller_job.rb
+++ b/app/jobs/clock/subscriptions_biller_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class SubscriptionsBillerJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     def perform

--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class SubscriptionsToBeTerminatedJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     def perform

--- a/app/jobs/clock/terminate_coupons_job.rb
+++ b/app/jobs/clock/terminate_coupons_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class TerminateCouponsJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     def perform

--- a/app/jobs/clock/terminate_ended_subscriptions_job.rb
+++ b/app/jobs/clock/terminate_ended_subscriptions_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class TerminateEndedSubscriptionsJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     def perform

--- a/app/jobs/clock/terminate_wallets_job.rb
+++ b/app/jobs/clock/terminate_wallets_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class TerminateWalletsJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     def perform

--- a/app/jobs/clock/webhooks_cleanup_job.rb
+++ b/app/jobs/clock/webhooks_cleanup_job.rb
@@ -2,6 +2,8 @@
 
 module Clock
   class WebhooksCleanupJob < ApplicationJob
+    include SentryCronConcern
+
     queue_as 'clock'
 
     def perform

--- a/app/jobs/concerns/sentry_cron_concern.rb
+++ b/app/jobs/concerns/sentry_cron_concern.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module SentryCronConcern
+  extend ActiveSupport::Concern
+
+  included do
+    include Sentry::Cron::MonitorCheckIns
+
+    class_attribute :sentry # rubocop:disable ThreadSafety/ClassAndModuleAttributes
+
+    after_perform do
+      if ENV['SENTRY_ENABLE_CRONS'] && self.class.sentry.present?
+        self.class.sentry_monitor_check_ins(
+          slug: self.class.sentry['slug'],
+          monitor_config: Sentry::Cron::MonitorConfig.from_crontab(self.class.sentry['cron'])
+        )
+      end
+    end
+
+    def serialize
+      super.tap do |data|
+        data['sentry'] = self.class.sentry if self.class.sentry.present?
+      end
+    end
+
+    def deserialize(job_data)
+      super(job_data)
+      self.class.sentry = job_data['sentry']
+    end
+  end
+
+  class_methods do
+    def set(options)
+      if ENV['SENTRY_ENABLE_CRONS'] && options[:sentry].present?
+        self.sentry = options[:sentry]
+      end
+
+      super(options)
+    end
+  end
+end

--- a/clock.rb
+++ b/clock.rb
@@ -19,61 +19,91 @@ module Clockwork
   # NOTE: All clocks run every hour to take customer timezones into account
 
   every(5.minutes, 'schedule:activate_subscriptions') do
-    Clock::ActivateSubscriptionsJob.perform_later
+    Clock::ActivateSubscriptionsJob
+      .set(sentry: {"slug" => 'lago_activate_subscriptions', "cron" => '*/5 * * * *'})
+      .perform_later
   end
 
   every(5.minutes, 'schedule:refresh_draft_invoices') do
-    Clock::RefreshDraftInvoicesJob.perform_later
+    Clock::RefreshDraftInvoicesJob
+      .set(sentry: {"slug" => 'lago_refresh_draft_invoices', "cron" => '*/5 * * * *'})
+      .perform_later
   end
 
   if ENV['LAGO_MEMCACHE_SERVERS'].present? || ENV['LAGO_REDIS_CACHE_URL'].present?
     every(5.minutes, 'schedule:refresh_wallets_ongoing_balance') do
-      Clock::RefreshWalletsOngoingBalanceJob.perform_later unless ENV['LAGO_DISABLE_WALLET_REFRESH'] == 'true'
+      unless ENV['LAGO_DISABLE_WALLET_REFRESH'] == 'true'
+        Clock::RefreshWalletsOngoingBalanceJob
+          .set(sentry: {"slug" => 'lago_refresh_wallets_ongoing_balance', "cron" => '*/5 * * * *'})
+          .perform_later
+      end
     end
   end
 
   every(1.hour, 'schedule:terminate_ended_subscriptions', at: '*:05') do
-    Clock::TerminateEndedSubscriptionsJob.perform_later
+    Clock::TerminateEndedSubscriptionsJob
+      .set(sentry: {"slug" => 'lago_terminate_ended_subscriptions', "cron" => '5 */1 * * *'})
+      .perform_later
   end
 
   every(1.hour, 'schedule:bill_customers', at: '*:10') do
-    Clock::SubscriptionsBillerJob.perform_later
+    Clock::SubscriptionsBillerJob
+      .set(sentry: {"slug" => 'lago_bill_customers', "cron" => '10 */1 * * *'})
+      .perform_later
   end
 
   every(1.hour, 'schedule:finalize_invoices', at: '*:20') do
-    Clock::FinalizeInvoicesJob.perform_later
+    Clock::FinalizeInvoicesJob
+      .set(sentry: {"slug" => 'lago_finalize_invoices', "cron" => '20 */1 * * *'})
+      .perform_later
   end
 
   every(1.hour, 'schedule:mark_invoices_as_payment_overdue', at: '*:25') do
-    Clock::MarkInvoicesAsPaymentOverdueJob.perform_later
+    Clock::MarkInvoicesAsPaymentOverdueJob
+      .set(sentry: {"slug" => 'lago_mark_invoices_as_payment_overdue', "cron" => '25 */1 * * *'})
+      .perform_later
   end
 
   every(1.hour, 'schedule:terminate_coupons', at: '*:30') do
-    Clock::TerminateCouponsJob.perform_later
+    Clock::TerminateCouponsJob
+      .set(sentry: {"slug" => 'lago_terminate_coupons', "cron" => '30 */1 * * *'})
+      .perform_later
   end
 
   every(1.hour, 'schedule:bill_ended_trial_subscriptions', at: '*:35') do
-    Clock::FreeTrialSubscriptionsBillerJob.perform_later
+    Clock::FreeTrialSubscriptionsBillerJob
+      .set(sentry: {"slug" => 'lago_bill_ended_trial_subscriptions', "cron" => '35 */1 * * *'})
+      .perform_later
   end
 
   every(1.hour, 'schedule:terminate_wallets', at: '*:45') do
-    Clock::TerminateWalletsJob.perform_later
+    Clock::TerminateWalletsJob
+      .set(sentry: {"slug" => 'lago_terminate_wallets', "cron" => '45 */1 * * *'})
+      .perform_later
   end
 
   every(1.hour, 'schedule:termination_alert', at: '*:50') do
-    Clock::SubscriptionsToBeTerminatedJob.perform_later
+    Clock::SubscriptionsToBeTerminatedJob
+      .set(sentry: {"slug" => 'lago_termination_alert', "cron" => '50 */1 * * *'})
+      .perform_later
   end
 
   every(1.hour, 'schedule:top_up_wallet_interval_credits', at: '*:55') do
-    Clock::CreateIntervalWalletTransactionsJob.perform_later
+    Clock::CreateIntervalWalletTransactionsJob
+      .set(sentry: {"slug" => 'lago_top_up_wallet_interval_credits', "cron" => '55 */1 * * *'})
+      .perform_later
   end
 
   every(1.day, 'schedule:clean_webhooks', at: '01:00') do
-    Clock::WebhooksCleanupJob.perform_later
+    Clock::WebhooksCleanupJob
+      .set(sentry: {"slug" => 'lago_clean_webhooks', "cron" => '0 1 * * *'})
+      .perform_later
   end
 
   every(1.hour, 'schedule:post_validate_events', at: '*:05') do
-    Clock::EventsValidationJob.perform_later
+    Clock::EventsValidationJob
+      .set(sentry: {"slug" => 'lago_post_validate_events', "cron" => '5 */1 * * *'})
+      .perform_later
   rescue => e
     Sentry.capture_exception(e)
   end


### PR DESCRIPTION
## Context

This PR is a new approach to try to finally add cron monitoring on Sidekiq.
The logic was first introduced in https://github.com/getlago/lago-api/pull/2109 and https://github.com/getlago/lago-api/pull/1780

## Description

The new approach uses `ActiveJob.set` to pass cron arguments to the job, in order to avoid the issues we faced lately with the initial approach
