### PR TITLE
feat: add link to payment methods

### DIFF
--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -2,7 +2,7 @@
 
 module PaymentProviderCustomers
   class StripeCustomer < BaseCustomer
-    PAYMENT_METHODS = %w[card sepa_debit us_bank_account bacs_debit].freeze
+    PAYMENT_METHODS = %w[card sepa_debit us_bank_account bacs_debit link].freeze
 
     validates :provider_payment_methods, presence: true
     validate :allowed_provider_payment_methods

--- a/schema.graphql
+++ b/schema.graphql
@@ -5246,6 +5246,7 @@ input ProviderCustomerInput {
 enum ProviderPaymentMethodsEnum {
   bacs_debit
   card
+  link
   sepa_debit
   us_bank_account
 }

--- a/schema.json
+++ b/schema.json
@@ -26682,6 +26682,12 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "us_bank_account",
               "description": null,
               "isDeprecated": false,


### PR DESCRIPTION
## Context

My customers prefer the Link payment method (https://link.com/) not to be confused with stripe payment links (https://docs.stripe.com/payments/link) when checking out with stripe. In order to reasonably migrate existing customers with Link payment methods, I'll need this as an option. This payment method is compatible with Payment Intents.

Slack conversation: https://lago-community.slack.com/archives/C03MCH55EL8/p1719509722047739

References #1738 

## Description

Adds the link payment method to the stripe customer 
