### PR TITLE
feat(charges): Add `regroup_paid_fees` to Charge

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -105,6 +105,7 @@ module Api
             :pay_in_advance,
             :prorated,
             :invoiceable,
+            :regroup_paid_fees,
             :min_amount_cents,
             {
               properties: {}

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -15,6 +15,7 @@ module Types
       field :pay_in_advance, Boolean, null: false
       field :properties, Types::Charges::Properties, null: true
       field :prorated, Boolean, null: false
+      field :regroup_paid_fees, Types::Charges::RegroupPaidFeesEnum, null: true
 
       field :filters, [Types::ChargeFilters::Object], null: true
 

--- a/app/graphql/types/charges/regroup_paid_fees_enum.rb
+++ b/app/graphql/types/charges/regroup_paid_fees_enum.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module Charges
+    class RegroupPaidFeesEnum < Types::BaseEnum
+      Charge::REGROUPING_PAID_FEES_OPTIONS.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/serializers/v1/charge_serializer.rb
+++ b/app/serializers/v1/charge_serializer.rb
@@ -11,6 +11,7 @@ module V1
         created_at: model.created_at.iso8601,
         charge_model: model.charge_model,
         invoiceable: model.invoiceable,
+        regroup_paid_fees: model.regroup_paid_fees,
         pay_in_advance: model.pay_in_advance,
         prorated: model.prorated,
         min_amount_cents: model.min_amount_cents,

--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -14,8 +14,7 @@ module Invoices
     end
 
     def call
-      # TODO: check if related charges have correct `invoicing_strategy`
-      # return result unless has_charges_to_invoice?
+      return result unless has_charges_with_statement?
 
       return result if subscriptions.empty?
 
@@ -39,6 +38,11 @@ module Invoices
     private
 
     attr_accessor :subscriptions, :billing_at, :customer, :organization, :currency
+
+    def has_charges_with_statement?
+      plan_ids = subscriptions.pluck(:plan_id)
+      Charge.where(plan_id: plan_ids, pay_in_advance: true, invoiceable: false, regroup_paid_fees: :invoice).any?
+    end
 
     def create_group_invoice
       invoice = nil

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -103,6 +103,7 @@ module Plans
 
       if License.premium?
         charge.invoiceable = args[:invoiceable] unless args[:invoiceable].nil?
+        charge.regroup_paid_fees = args[:regroup_paid_fees] if args.has_key?(:regroup_paid_fees)
         charge.min_amount_cents = args[:min_amount_cents] || 0
       end
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -99,6 +99,7 @@ module Plans
 
       if License.premium?
         charge.invoiceable = params[:invoiceable] unless params[:invoiceable].nil?
+        charge.regroup_paid_fees = params[:regroup_paid_fees] if params.has_key?(:regroup_paid_fees)
         charge.min_amount_cents = params[:min_amount_cents] || 0
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
         missing_volume_ranges: missing_volume_ranges
         not_compatible_with_aggregation_type: not_compatible_with_aggregation_type
         not_compatible_with_pay_in_advance: not_compatible_with_pay_in_advance
+        only_compatible_with_pay_in_advance_and_non_invoiceable: only_compatible_with_pay_in_advance_and_non_invoiceable
         required: relation_must_exist
         taken: value_already_exist
         too_long: value_is_too_long

--- a/db/migrate/20220816120137_update_properties_on_percentage_charges.rb
+++ b/db/migrate/20220816120137_update_properties_on_percentage_charges.rb
@@ -3,6 +3,5 @@
 class UpdatePropertiesOnPercentageCharges < ActiveRecord::Migration[7.0]
   def change
     LagoApi::Application.load_tasks
-    Rake::Task['charges:update_properties_for_free_units'].invoke
   end
 end

--- a/db/migrate/20231218170631_add_rate_to_percentage_amount_details.rb
+++ b/db/migrate/20231218170631_add_rate_to_percentage_amount_details.rb
@@ -2,7 +2,11 @@
 
 class AddRateToPercentageAmountDetails < ActiveRecord::Migration[7.0]
   class Fee < ApplicationRecord
-    belongs_to :charge, -> { with_discarded }, optional: true
+    belongs_to :charge, optional: true
+  end
+
+  class Charge < ApplicationRecord
+    enum charge_model: %i[percentage graduated_percentage].freeze
   end
 
   def up

--- a/db/migrate/20240429141108_add_custom_aggregation_to_organizations.rb
+++ b/db/migrate/20240429141108_add_custom_aggregation_to_organizations.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+class Charge
+  attribute :regroup_paid_fees, :integer, default: nil
+end
+
 class AddCustomAggregationToOrganizations < ActiveRecord::Migration[7.0]
   def change
     add_column :organizations, :custom_aggregation, :boolean, default: false

--- a/db/migrate/20240702081109_add_regroup_paid_fees_to_charges.rb
+++ b/db/migrate/20240702081109_add_regroup_paid_fees_to_charges.rb
@@ -1,0 +1,5 @@
+class AddRegroupPaidFeesToCharges < ActiveRecord::Migration[7.1]
+  def change
+    add_column :charges, :regroup_paid_fees, :integer, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_01_083355) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_02_081109) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -225,6 +225,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_01_083355) do
     t.boolean "invoiceable", default: true, null: false
     t.boolean "prorated", default: false, null: false
     t.string "invoice_display_name"
+    t.integer "regroup_paid_fees"
     t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"
     t.index ["deleted_at"], name: "index_charges_on_deleted_at"
     t.index ["plan_id"], name: "index_charges_on_plan_id"

--- a/lib/tasks/charges.rake
+++ b/lib/tasks/charges.rake
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 
 namespace :charges do
-  desc 'Update Properties for Fixed Fee and Free Units'
-  task update_properties_for_free_units: :environment do
-    # Notes: We consider that we don’t have any clients with a percentage charge
-    # created containing a fixed_amount. All existing charges have fixed_amount
-    # and fixed_amount_target with a null value.
-
-    Charge.unscoped.percentage.where("properties -> 'fixed_amount_target' IS NOT NULL").find_each do |charge|
-      charge.properties.delete('fixed_amount_target')
-      charge.properties['free_units_per_events'] = nil
-      charge.properties['free_units_per_total_aggregation'] = nil
-      charge.save!
-    end
-  end
-
   desc 'Set graduated properties to hash and rename volume ranges'
   task update_graduated_properties_to_hash: :environment do
     # Rename existing volume ranges from `ranges: []` to `volume_ranges: []`

--- a/schema.graphql
+++ b/schema.graphql
@@ -257,6 +257,7 @@ type Charge {
   payInAdvance: Boolean!
   properties: Properties
   prorated: Boolean!
+  regroupPaidFees: RegroupPaidFeesEnum
   taxes: [Tax!]
   updatedAt: ISO8601DateTime!
 }
@@ -5806,6 +5807,10 @@ input RegisterUserInput {
   email: String!
   organizationName: String!
   password: String!
+}
+
+enum RegroupPaidFeesEnum {
+  invoice
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -2588,6 +2588,20 @@
               ]
             },
             {
+              "name": "regroupPaidFees",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "RegroupPaidFeesEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "taxes",
               "description": null,
               "type": {
@@ -30029,6 +30043,23 @@
             }
           ],
           "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "RegroupPaidFeesEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "invoice",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
         },
         {
           "kind": "OBJECT",

--- a/spec/factories/charges.rb
+++ b/spec/factories/charges.rb
@@ -85,5 +85,11 @@ FactoryBot.define do
     trait :pay_in_advance do
       pay_in_advance { true }
     end
+
+    trait :regroup_paid_fees do
+      pay_in_advance { true }
+      invoiceable { false }
+      regroup_paid_fees { 'invoice' }
+    end
   end
 end

--- a/spec/graphql/types/charges/object_spec.rb
+++ b/spec/graphql/types/charges/object_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Types::Charges::Object do
   it { is_expected.to have_field(:invoice_display_name).of_type('String') }
   it { is_expected.to have_field(:billable_metric).of_type('BillableMetric!') }
   it { is_expected.to have_field(:charge_model).of_type('ChargeModelEnum!') }
+  it { is_expected.to have_field(:regroup_paid_fees).of_type('RegroupPaidFeesEnum') }
   it { is_expected.to have_field(:invoiceable).of_type('Boolean!') }
   it { is_expected.to have_field(:min_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:pay_in_advance).of_type('Boolean!') }

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
     context 'with existing standalone fees' do
       before do
         tax
-        charge = create(:standard_charge, plan: subscription.plan, charge_model: 'standard')
+        charge = create(:standard_charge, :regroup_paid_fees, plan: subscription.plan)
         create_list(:charge_fee, 3, :succeeded, invoice_id: nil, subscription:, charge:, amount_cents: 100, properties: fee_boundaries)
         create_list(:charge_fee, 2, :failed, invoice_id: nil, subscription:, charge:, amount_cents: 100, properties: fee_boundaries)
       end
@@ -97,7 +97,7 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
     context 'with integration requiring sync' do
       before do
         tax
-        charge = create(:standard_charge, plan: subscription.plan, charge_model: 'standard')
+        charge = create(:standard_charge, :regroup_paid_fees, plan: subscription.plan)
         create(:charge_fee, :succeeded, invoice_id: nil, subscription:, charge:, amount_cents: 100, properties: fee_boundaries)
 
         allow_any_instance_of(Invoice).to receive(:should_sync_invoice?).and_return(true) # rubocop:disable RSpec/AnyInstance

--- a/spec/services/plans/create_service_spec.rb
+++ b/spec/services/plans/create_service_spec.rb
@@ -196,6 +196,7 @@ RSpec.describe Plans::CreateService, type: :service do
             charge_model: 'graduated_percentage',
             pay_in_advance: true,
             invoiceable: false,
+            regroup_paid_fees: 'invoice',
             properties: {
               graduated_percentage_ranges: [
                 {
@@ -238,6 +239,7 @@ RSpec.describe Plans::CreateService, type: :service do
           {
             pay_in_advance: true,
             invoiceable: false,
+            regroup_paid_fees: 'invoice',
             charge_model: 'graduated_percentage'
           }
         )


### PR DESCRIPTION
## Context

When your charge is pay in advance but not invoiceable, the fees are created but not attached to any invoice.
This adds an options so at the end of the period, you get a new invoice showing all PAID fees. unpaid fees are ignored.

See also https://github.com/getlago/lago-api/pull/2171

## Description

We're dropping the idea of `invoice_strategy` because it turned out to be a bad idea. Instead we're adding `regroup_paid_fees` attribute that takes only one value today `invoice`.

