### PR TITLE
feat: Add ability to soft delete fees

### DIFF
--- a/app/controllers/api/v1/fees_controller.rb
+++ b/app/controllers/api/v1/fees_controller.rb
@@ -49,10 +49,30 @@ module Api
         end
       end
 
+      def destroy
+        fee = Fee.from_organization(current_organization).find_by(id: params[:id])
+        result = ::Fees::DestroyService.call(fee:)
+
+        if result.success?
+          render_fee(result.fee)
+        else
+          render_error_response(result)
+        end
+      end
+
       private
 
       def update_params
         params.require(:fee).permit(:payment_status)
+      end
+
+      def render_fee(fee)
+        render(
+          json: ::V1::FeeSerializer.new(
+            fee,
+            root_name: 'fee'
+          )
+        )
       end
 
       def index_filters

--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -2,6 +2,9 @@
 
 class Fee < ApplicationRecord
   include Currencies
+  include Discard::Model
+  self.discard_column = :deleted_at
+  default_scope -> { kept }
 
   belongs_to :invoice, optional: true
   belongs_to :charge, -> { with_discarded }, optional: true

--- a/app/services/fees/destroy_service.rb
+++ b/app/services/fees/destroy_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Fees
+  class DestroyService < BaseService
+    def initialize(fee:)
+      @fee = fee
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'fee') unless fee
+      return result.not_allowed_failure!(code: 'invoiced_fee') if fee.invoice_id
+
+      fee.discard!
+
+      result.fee = fee
+      result
+    end
+
+    private
+
+    attr_reader :fee
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
         post :estimate_fees, on: :collection
       end
       resources :applied_coupons, only: %i[create index]
-      resources :fees, only: %i[show update index]
+      resources :fees, only: %i[show update index destroy]
       resources :invoices, only: %i[create update show index] do
         post :download, on: :member
         post :void, on: :member

--- a/db/migrate/20240701184757_add_deleted_at_to_fees.rb
+++ b/db/migrate/20240701184757_add_deleted_at_to_fees.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToFees < ActiveRecord::Migration[7.1]
+  def change
+    add_column :fees, :deleted_at, :datetime
+    add_index :fees, :deleted_at
+  end
+end

--- a/db/migrate/20240701184757_add_deleted_at_to_fees.rb
+++ b/db/migrate/20240701184757_add_deleted_at_to_fees.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDeletedAtToFees < ActiveRecord::Migration[7.1]
   def change
     add_column :fees, :deleted_at, :datetime

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -520,10 +520,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_204557) do
     t.uuid "charge_filter_id"
     t.jsonb "grouped_by", default: {}, null: false
     t.string "pay_in_advance_event_transaction_id"
+    t.datetime "deleted_at"
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_filter_id"], name: "index_fees_on_charge_filter_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
+    t.index ["deleted_at"], name: "index_fees_on_deleted_at"
     t.index ["group_id"], name: "index_fees_on_group_id"
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"
     t.index ["invoiceable_type", "invoiceable_id"], name: "index_fees_on_invoiceable"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -225,7 +225,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_204557) do
     t.boolean "invoiceable", default: true, null: false
     t.boolean "prorated", default: false, null: false
     t.string "invoice_display_name"
-    t.integer "regroup_paid_fees"
     t.index ["billable_metric_id"], name: "index_charges_on_billable_metric_id"
     t.index ["deleted_at"], name: "index_charges_on_deleted_at"
     t.index ["plan_id"], name: "index_charges_on_plan_id"
@@ -520,10 +519,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_204557) do
     t.uuid "charge_filter_id"
     t.jsonb "grouped_by", default: {}, null: false
     t.string "pay_in_advance_event_transaction_id"
+    t.datetime "deleted_at"
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_filter_id"], name: "index_fees_on_charge_filter_id"
     t.index ["charge_id"], name: "index_fees_on_charge_id"
+    t.index ["deleted_at"], name: "index_fees_on_deleted_at"
     t.index ["group_id"], name: "index_fees_on_group_id"
     t.index ["invoice_id"], name: "index_fees_on_invoice_id"
     t.index ["invoiceable_type", "invoiceable_id"], name: "index_fees_on_invoiceable"
@@ -997,7 +998,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_204557) do
     t.jsonb "object"
     t.jsonb "object_changes"
     t.datetime "created_at"
-    t.string "lago_version"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
@@ -1222,16 +1222,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_204557) do
       billable_metrics.field_name,
       charges.plan_id,
       charges.id AS charge_id,
-          CASE
-              WHEN (charges.charge_model = 0) THEN (charges.properties -> 'grouped_by'::text)
-              ELSE NULL::jsonb
-          END AS grouped_by,
       charge_filters.id AS charge_filter_id,
       json_object_agg(billable_metric_filters.key, COALESCE(charge_filter_values."values", '{}'::character varying[]) ORDER BY billable_metric_filters.key) FILTER (WHERE (billable_metric_filters.key IS NOT NULL)) AS filters,
           CASE
-              WHEN (charges.charge_model = 0) THEN (charge_filters.properties -> 'grouped_by'::text)
+              WHEN (charges.charge_model = 0) THEN COALESCE((charge_filters.properties -> 'grouped_by'::text), (charges.properties -> 'grouped_by'::text))
               ELSE NULL::jsonb
-          END AS filters_grouped_by
+          END AS grouped_by
      FROM ((((billable_metrics
        JOIN charges ON ((charges.billable_metric_id = billable_metrics.id)))
        LEFT JOIN charge_filters ON ((charge_filters.charge_id = charges.id)))

--- a/spec/requests/api/v1/fees_controller_spec.rb
+++ b/spec/requests/api/v1/fees_controller_spec.rb
@@ -146,6 +146,18 @@ RSpec.describe Api::V1::FeesController, type: :request do
         expect(response).to have_http_status(:ok)
       end
     end
+
+    context 'when fee exist but is attached to an invoice' do
+      let(:invoice) { create(:invoice, organization:, customer:) }
+      let(:fee) do
+        create(:charge_fee, fee_type: 'charge', pay_in_advance: true, subscription:, invoice:)
+      end
+
+      it 'dont delete the fee' do
+        delete_with_token(organization, "/api/v1/fees/#{fee.id}")
+        expect(response).to have_http_status(:method_not_allowed)
+      end
+    end
   end
 
   describe 'GET /fees' do

--- a/spec/requests/api/v1/fees_controller_spec.rb
+++ b/spec/requests/api/v1/fees_controller_spec.rb
@@ -132,6 +132,22 @@ RSpec.describe Api::V1::FeesController, type: :request do
     end
   end
 
+  describe 'DELETE /fees/:id' do
+    let(:customer) { create(:customer, organization:) }
+    let(:subscription) { create(:subscription, customer:) }
+    let(:update_params) { {payment_status: 'succeeded'} }
+    let(:fee) do
+      create(:charge_fee, fee_type: 'charge', pay_in_advance: true, subscription:, invoice: nil)
+    end
+
+    context 'when fee exist' do
+      it 'deletes the fee' do
+        delete_with_token(organization, "/api/v1/fees/#{fee.id}")
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
   describe 'GET /fees' do
     let(:customer) { create(:customer, organization:) }
     let(:subscription) { create(:subscription, customer:) }


### PR DESCRIPTION
**Context**
We already utilize the `discard` gem for soft deletion in other models within our application. However, the fees model currently lacks this functionality. Additionally, there is a need to ensure that fees associated with invoices are protected from deletion to maintain data integrity.

**Description**
This PR extends the use of the `discard` gem to the fees model, enabling the soft deletion of fees. Furthermore, a validation is added to ensure that only fees not attached to any invoice can be deleted. If a deletion attempt is made on a fee associated with an invoice, the system will respond with a `405 Method Not Allowed` status and an error code `invoiced_fee`. This ensures that while fees can be logically removed from active use, those associated with invoices remain intact, preserving the integrity of invoice-related data.

<img width="867" alt="Screenshot 2024-07-08 at 14 26 58" src="https://github.com/getlago/lago-api/assets/1700595/720edde9-2c7d-47a7-925d-5f58efc5f47a">



