### PR TITLE
fix(bm): Handle colon in billable metric code

### DIFF
--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -105,6 +105,11 @@ module Events
         boundaries[:charges_duration]
       end
 
+      def sanitize_colon(query)
+        # NOTE: escape ':' to avoid ActiveRecord::PreparedStatementInvalid,
+        query.gsub("'#{code}'", "'#{code.gsub(":", "\\:")}'")
+      end
+
       attr_accessor :numeric_property, :aggregation_property, :use_from_boundary, :grouped_by
 
       protected

--- a/app/services/events/stores/clickhouse/weighted_sum_query.rb
+++ b/app/services/events/stores/clickhouse/weighted_sum_query.rb
@@ -60,7 +60,7 @@ module Events
         delegate :events, :charges_duration, :sanitized_property_name, :sanitized_numeric_property, to: :store
 
         def events_cte_sql
-          <<-SQL
+          <<~SQL
             WITH events_data AS (
               (#{initial_value_sql})
               UNION ALL

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -115,7 +115,7 @@ module Events
         query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: self)
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.query,
+            sanitize_colon(query.query),
             {decimal_scale: DECIMAL_SCALE}
           ]
         )
@@ -130,7 +130,7 @@ module Events
         ::Clickhouse::EventsRaw.connection.select_all(
           ActiveRecord::Base.sanitize_sql_for_conditions(
             [
-              query.breakdown_query,
+              sanitize_colon(query.breakdown_query),
               {decimal_scale: DECIMAL_SCALE}
             ]
           )
@@ -141,7 +141,7 @@ module Events
         query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: self)
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.prorated_query,
+            sanitize_colon(query.prorated_query),
             {
               from_datetime:,
               to_datetime: to_datetime.ceil,
@@ -159,7 +159,7 @@ module Events
         query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: self)
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.prorated_breakdown_query(with_remove:),
+            sanitize_colon(query.prorated_breakdown_query(with_remove:)),
             {
               from_datetime:,
               to_datetime: to_datetime.ceil,
@@ -176,7 +176,7 @@ module Events
         query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: self)
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.grouped_query,
+            sanitize_colon(query.grouped_query),
             {
               to_datetime: to_datetime.ceil,
               decimal_scale: DECIMAL_SCALE
@@ -191,7 +191,7 @@ module Events
         query = Events::Stores::Clickhouse::UniqueCountQuery.new(store: self)
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.grouped_prorated_query,
+            sanitize_colon(query.grouped_prorated_query),
             {
               from_datetime:,
               to_datetime: to_datetime.ceil,
@@ -381,7 +381,7 @@ module Events
 
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.query,
+            sanitize_colon(query.query),
             {
               from_datetime:,
               to_datetime: to_datetime.ceil,
@@ -417,7 +417,7 @@ module Events
 
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.grouped_query(initial_values: formated_initial_values),
+            sanitize_colon(query.grouped_query(initial_values: formated_initial_values)),
             {
               from_datetime:,
               to_datetime: to_datetime.ceil,
@@ -436,7 +436,7 @@ module Events
         ::Clickhouse::EventsRaw.connection.select_all(
           ActiveRecord::Base.sanitize_sql_for_conditions(
             [
-              query.breakdown_query,
+              sanitize_colon(query.breakdown_query),
               {
                 from_datetime:,
                 to_datetime: to_datetime.ceil,

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -103,7 +103,7 @@ module Events
         query = Events::Stores::Postgres::UniqueCountQuery.new(store: self)
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.prorated_query,
+            sanitize_colon(query.prorated_query),
             {
               from_datetime:,
               to_datetime:,
@@ -120,7 +120,7 @@ module Events
         query = Events::Stores::Postgres::UniqueCountQuery.new(store: self)
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.prorated_breakdown_query(with_remove:),
+            sanitize_colon(query.prorated_breakdown_query(with_remove:)),
             {
               from_datetime:,
               to_datetime:,
@@ -146,7 +146,7 @@ module Events
         query = Events::Stores::Postgres::UniqueCountQuery.new(store: self)
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.grouped_prorated_query,
+            sanitize_colon(query.grouped_prorated_query),
             {
               from_datetime:,
               to_datetime:,
@@ -260,7 +260,7 @@ module Events
 
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.query,
+            sanitize_colon(query.query),
             {
               from_datetime:,
               to_datetime: to_datetime.ceil,
@@ -295,7 +295,7 @@ module Events
 
         sql = ActiveRecord::Base.sanitize_sql_for_conditions(
           [
-            query.grouped_query(initial_values: formated_initial_values),
+            sanitize_colon(query.grouped_query(initial_values: formated_initial_values)),
             {
               from_datetime:,
               to_datetime: to_datetime.ceil
@@ -312,7 +312,7 @@ module Events
         ActiveRecord::Base.connection.select_all(
           ActiveRecord::Base.sanitize_sql_for_conditions(
             [
-              query.breakdown_query,
+              sanitize_colon(query.breakdown_query),
               {
                 from_datetime:,
                 to_datetime: to_datetime.ceil,

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
     )
   end
 
-  let(:billable_metric) { create(:billable_metric, field_name: 'value') }
+  let(:billable_metric) { create(:billable_metric, field_name: 'value', code: 'bm:code') }
   let(:organization) { billable_metric.organization }
 
   let(:customer) { create(:customer, organization:) }

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
     )
   end
 
-  let(:billable_metric) { create(:billable_metric, field_name: 'value') }
+  let(:billable_metric) { create(:billable_metric, field_name: 'value', code: 'bm:code') }
   let(:organization) { billable_metric.organization }
 
   let(:customer) { create(:customer, organization:) }


### PR DESCRIPTION
## Context

This PR is a fix for https://github.com/getlago/lago/issues/345

It makes sure that `:` symbol is correctly escaped when present in a billable metric code.

This change was made possible by the recent update of rails to 7.1.3
See https://github.com/rails/rails/pull/48852/files for reference