### PR TITLE
feat: add link to payment methods

### DIFF
--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -6,6 +6,7 @@ module PaymentProviderCustomers
 
     validates :provider_payment_methods, presence: true
     validate :allowed_provider_payment_methods
+    validate :link_payment_method_can_exist_only_with_card
 
     settings_accessors :payment_method_id
 
@@ -21,6 +22,12 @@ module PaymentProviderCustomers
 
     def allowed_provider_payment_methods
       return if (provider_payment_methods - PAYMENT_METHODS).blank?
+
+      errors.add(:provider_payment_methods, :invalid)
+    end
+
+    def link_payment_method_can_exist_only_with_card
+      return if provider_payment_methods.exclude?('link') || provider_payment_methods.include?('card')
 
       errors.add(:provider_payment_methods, :invalid)
     end

--- a/app/models/payment_provider_customers/stripe_customer.rb
+++ b/app/models/payment_provider_customers/stripe_customer.rb
@@ -2,7 +2,7 @@
 
 module PaymentProviderCustomers
   class StripeCustomer < BaseCustomer
-    PAYMENT_METHODS = %w[card sepa_debit us_bank_account bacs_debit].freeze
+    PAYMENT_METHODS = %w[card sepa_debit us_bank_account bacs_debit link].freeze
 
     validates :provider_payment_methods, presence: true
     validate :allowed_provider_payment_methods

--- a/schema.graphql
+++ b/schema.graphql
@@ -5257,6 +5257,7 @@ input ProviderCustomerInput {
 enum ProviderPaymentMethodsEnum {
   bacs_debit
   card
+  link
   sepa_debit
   us_bank_account
 }

--- a/schema.json
+++ b/schema.json
@@ -26768,6 +26768,12 @@
               "deprecationReason": null
             },
             {
+              "name": "link",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "us_bank_account",
               "description": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -26768,12 +26768,6 @@
               "deprecationReason": null
             },
             {
-              "name": "link",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "us_bank_account",
               "description": null,
               "isDeprecated": false,
@@ -26781,6 +26775,12 @@
             },
             {
               "name": "bacs_debit",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/models/payment_provider_customers/stripe_customer_spec.rb
+++ b/spec/models/payment_provider_customers/stripe_customer_spec.rb
@@ -89,6 +89,24 @@ RSpec.describe PaymentProviderCustomers::StripeCustomer, type: :model do
           expect(errors.where(:provider_payment_methods, :invalid)).not_to be_present
         end
       end
+
+      context 'when it contains link type' do
+        let(:provider_payment_methods) { %w[link] }
+
+        context 'when required provider payment method card is missing' do
+          it 'adds error on provider payment methods' do
+            expect(errors.where(:provider_payment_methods, :invalid)).to be_present
+          end
+        end
+
+        context 'when required provider payment method card exists' do
+          let(:provider_payment_methods) { %w[link card] }
+
+          it 'does not add error on provider payment methods' do
+            expect(errors.where(:provider_payment_methods, :invalid)).not_to be_present
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

This PR was previously opened at: https://github.com/getlago/lago-api/pull/2228

## Context and Description from the previous PR

### Context

My customers prefer the Link payment method (https://link.com/) not to be confused with stripe payment links (https://docs.stripe.com/payments/link) when checking out with stripe. In order to reasonably migrate existing customers with Link payment methods, I'll need this as an option. This payment method is compatible with Payment Intents.

Slack conversation: https://lago-community.slack.com/archives/C03MCH55EL8/p1719509722047739

References https://github.com/getlago/lago-api/pull/1738
### Description

Adds the link payment method to the stripe customer
