### PR TITLE
feat(dunning): Add customer portal analytics resources

### DIFF
--- a/app/graphql/resolvers/customer_portal/analytics/invoice_collections_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/analytics/invoice_collections_resolver.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module CustomerPortal
+    module Analytics
+      class InvoiceCollectionsResolver < Resolvers::BaseResolver
+        include AuthenticableCustomerPortalUser
+
+        description "Query invoice collections of a customer portal user"
+
+        argument :months, Integer, required: false
+
+        type Types::Analytics::InvoiceCollections::Object.collection_type, null: false
+
+        def resolve(**args)
+          ::Analytics::InvoiceCollection.find_all_by(
+            context[:customer_portal_user].organization.id,
+            **args.merge(
+              currency: context[:customer_portal_user].currency,
+              external_customer_id: context[:customer_portal_user].external_id
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/customer_portal/analytics/overdue_balances_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/analytics/overdue_balances_resolver.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Resolvers
+  module CustomerPortal
+    module Analytics
+      class OverdueBalancesResolver < Resolvers::BaseResolver
+        include AuthenticableCustomerPortalUser
+
+        description "Query overdue balances of a customer portal user"
+
+        argument :months, Integer, required: false
+
+        type Types::Analytics::OverdueBalances::Object.collection_type, null: false
+
+        def resolve(**args)
+          ::Analytics::OverdueBalance.find_all_by(
+            context[:customer_portal_user].organization.id,
+            **args.merge(
+              currency: context[:customer_portal_user].currency,
+              external_customer_id: context[:customer_portal_user].external_id
+            )
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/analytics/gross_revenues/object.rb
+++ b/app/graphql/types/analytics/gross_revenues/object.rb
@@ -8,6 +8,7 @@ module Types
 
         field :amount_cents, GraphQL::Types::BigInt, null: true
         field :currency, Types::CurrencyEnum, null: true
+        field :invoices_count, GraphQL::Types::BigInt, null: false
         field :month, GraphQL::Types::ISO8601DateTime, null: false
       end
     end

--- a/app/graphql/types/analytics/overdue_balances/object.rb
+++ b/app/graphql/types/analytics/overdue_balances/object.rb
@@ -10,6 +10,10 @@ module Types
         field :currency, Types::CurrencyEnum, null: false
         field :lago_invoice_ids, [String], null: false
         field :month, GraphQL::Types::ISO8601DateTime, null: false
+
+        def lago_invoice_ids
+          JSON.parse(object["lago_invoice_ids"]).flatten
+        end
       end
     end
   end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -21,8 +21,10 @@ module Types
     field :current_version, resolver: Resolvers::VersionResolver
     field :customer, resolver: Resolvers::CustomerResolver
     field :customer_invoices, resolver: Resolvers::Customers::InvoicesResolver
+    field :customer_portal_invoice_collections, resolver: Resolvers::CustomerPortal::Analytics::InvoiceCollectionsResolver
     field :customer_portal_invoices, resolver: Resolvers::CustomerPortal::InvoicesResolver
     field :customer_portal_organization, resolver: Resolvers::CustomerPortal::OrganizationResolver
+    field :customer_portal_overdue_balances, resolver: Resolvers::CustomerPortal::Analytics::OverdueBalancesResolver
     field :customer_portal_user, resolver: Resolvers::CustomerPortal::CustomerResolver
     field :customer_usage, resolver: Resolvers::Customers::UsageResolver
     field :customers, resolver: Resolvers::CustomersResolver

--- a/app/models/analytics/gross_revenue.rb
+++ b/app/models/analytics/gross_revenue.rb
@@ -51,7 +51,7 @@ module Analytics
               i.issuing_date,
               i.total_amount_cents::float AS amount_cents,
               i.currency,
-              COALESCE(COUNT(i.id), 0) AS invoices_count,
+              COALESCE(COUNT(DISTINCT i.id), 0) AS invoices_count,
               COALESCE(SUM(refund_amount_cents::float),0) AS total_refund_amount_cents
             FROM invoices i
             LEFT JOIN customers c ON i.customer_id = c.id
@@ -83,7 +83,7 @@ module Analytics
             SELECT
               DATE_TRUNC('month', issuing_date) AS month,
               currency,
-              COALESCE(invoices_count, 0) AS invoices_count,
+              COALESCE(SUM(invoices_count), 0) AS invoices_count,
               COALESCE(SUM(amount_cents), 0) AS amount_cents,
               COALESCE(SUM(total_refund_amount_cents), 0) AS total_refund_amount_cents
             FROM (
@@ -91,12 +91,12 @@ module Analytics
               UNION ALL
               SELECT * FROM instant_charges
             ) AS gross_revenue
-            GROUP BY month, currency, total_refund_amount_cents, invoices_count
+            GROUP BY month, currency, total_refund_amount_cents
           )
           SELECT
             am.month,
             #{select_currency_sql},
-            COALESCE(cd.invoices_count, 0) AS invoices_count,
+            COALESCE(SUM(invoices_count), 0) AS invoices_count,
             SUM(cd.amount_cents - cd.total_refund_amount_cents) AS amount_cents
           FROM all_months am
           LEFT JOIN combined_data cd ON am.month = cd.month
@@ -104,7 +104,7 @@ module Analytics
           #{and_months_sql}
           #{and_currency_sql}
           AND cd.amount_cents IS NOT NULL
-          GROUP BY am.month, cd.currency, invoices_count
+          GROUP BY am.month, cd.currency
           ORDER BY am.month;
         SQL
 

--- a/app/models/analytics/invoice_collection.rb
+++ b/app/models/analytics/invoice_collection.rb
@@ -6,6 +6,12 @@ module Analytics
 
     class << self
       def query(organization_id, **args)
+        if args[:external_customer_id].present?
+          and_external_customer_id_sql = sanitize_sql(
+            ["AND c.external_id = :external_customer_id", args[:external_customer_id]]
+          )
+        end
+
         if args[:months].present?
           months_interval = (args[:months].to_i <= 1) ? 0 : args[:months].to_i - 1
 
@@ -48,15 +54,17 @@ module Analytics
                 COALESCE(COUNT(*), 0) AS invoices_count,
                 COALESCE(SUM(i.total_amount_cents::float), 0) AS amount_cents
             FROM invoices i
+            LEFT JOIN customers c ON i.customer_id = c.id
             WHERE i.organization_id = :organization_id
             AND i.status = 1
             AND i.payment_dispute_lost_at IS NULL
-            GROUP BY payment_status, month, currency
+            #{and_external_customer_id_sql}
+            GROUP BY payment_status, month, i.currency
           )
           SELECT
             am.month,
             payment_status,
-            currency,
+            ips.currency,
             COALESCE(invoices_count, 0) AS invoices_count,
             COALESCE(amount_cents, 0) AS amount_cents
           FROM all_months am
@@ -64,7 +72,7 @@ module Analytics
           WHERE am.month <= DATE_TRUNC('month', CURRENT_DATE)
           #{and_months_sql}
           #{and_currency_sql}
-          ORDER BY am.month, payment_status, currency;
+          ORDER BY am.month, payment_status, ips.currency;
         SQL
 
         sanitize_sql([sql, {organization_id:}.merge(args)])
@@ -75,6 +83,7 @@ module Analytics
           'invoice-collection',
           Date.current.strftime('%Y-%m-%d'),
           organization_id,
+          args[:external_customer_id],
           args[:currency],
           args[:months]
         ].join('/')

--- a/app/models/analytics/overdue_balance.rb
+++ b/app/models/analytics/overdue_balance.rb
@@ -63,9 +63,9 @@ module Analytics
             am.month,
             #{select_currency_sql},
             SUM(invs.total_amount_cents) AS amount_cents,
-            jsonb_agg(DISTINCT invoice_id) AS invoice_ids
+            jsonb_agg(DISTINCT invs.ids) AS lago_invoice_ids
           FROM all_months am
-          LEFT JOIN payment_overdue_invoices invs ON am.month = invs.month, UNNEST(invs.ids) invoice_id
+          LEFT JOIN payment_overdue_invoices invs ON am.month = invs.month
           WHERE am.month <= DATE_TRUNC('month', CURRENT_DATE)
           #{and_months_sql}
           #{and_currency_sql}

--- a/app/serializers/v1/analytics/gross_revenue_serializer.rb
+++ b/app/serializers/v1/analytics/gross_revenue_serializer.rb
@@ -5,9 +5,10 @@ module V1
     class GrossRevenueSerializer < ModelSerializer
       def serialize
         {
-          month: model['month'],
-          amount_cents: model['amount_cents'],
-          currency: model['currency']
+          month: model["month"],
+          amount_cents: model["amount_cents"],
+          currency: model["currency"],
+          invoices_count: model["invoices_count"]
         }
       end
     end

--- a/app/serializers/v1/analytics/overdue_balance_serializer.rb
+++ b/app/serializers/v1/analytics/overdue_balance_serializer.rb
@@ -8,7 +8,7 @@ module V1
           month: model["month"],
           amount_cents: model["amount_cents"],
           currency: model["currency"],
-          lago_invoice_ids: JSON.parse(model["invoice_ids"])
+          lago_invoice_ids: JSON.parse(model["lago_invoice_ids"]).flatten
         }
       end
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3721,6 +3721,7 @@ input GraduatedRangeInput {
 type GrossRevenue {
   amountCents: BigInt
   currency: CurrencyEnum
+  invoicesCount: BigInt!
   month: ISO8601DateTime!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -5453,6 +5453,11 @@ type Query {
   customerInvoices(customerId: ID!, limit: Int, page: Int, searchTerm: String, status: [InvoiceStatusTypeEnum!]): InvoiceCollection!
 
   """
+  Query invoice collections of a customer portal user
+  """
+  customerPortalInvoiceCollections(months: Int): FinalizedInvoiceCollectionCollection!
+
+  """
   Query invoices of a customer
   """
   customerPortalInvoices(limit: Int, page: Int, searchTerm: String, status: [InvoiceStatusTypeEnum!]): InvoiceCollection!
@@ -5461,6 +5466,11 @@ type Query {
   Query customer portal organization
   """
   customerPortalOrganization: Organization
+
+  """
+  Query overdue balances of a customer portal user
+  """
+  customerPortalOverdueBalances(months: Int): OverdueBalanceCollection!
 
   """
   Query a customer portal user

--- a/schema.json
+++ b/schema.json
@@ -17139,6 +17139,24 @@
               ]
             },
             {
+              "name": "invoicesCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "month",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -27873,6 +27873,35 @@
               ]
             },
             {
+              "name": "customerPortalInvoiceCollections",
+              "description": "Query invoice collections of a customer portal user",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FinalizedInvoiceCollectionCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "months",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "customerPortalInvoices",
               "description": "Query invoices of a customer",
               "type": {
@@ -27957,6 +27986,35 @@
               "deprecationReason": null,
               "args": [
 
+              ]
+            },
+            {
+              "name": "customerPortalOverdueBalances",
+              "description": "Query overdue balances of a customer portal user",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OverdueBalanceCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "months",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
               ]
             },
             {

--- a/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Resolvers::Analytics::GrossRevenuesResolver, type: :graphql do
             month
             amountCents
             currency
+            invoicesCount
           }
         }
       }

--- a/spec/graphql/resolvers/customer_portal/analytics/invoice_collections_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/analytics/invoice_collections_resolver_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::CustomerPortal::Analytics::InvoiceCollectionsResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query {
+        customerPortalInvoiceCollections {
+          collection {
+            month
+            amountCents
+            invoicesCount
+            currency
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:organization) { create(:organization, created_at: DateTime.new(2024, 1, 15)) }
+  let(:membership) { create(:membership, organization:) }
+  let(:customer) { create(:customer, organization:, currency: "USD") }
+
+  it_behaves_like "requires a customer portal user"
+
+  it "returns a list of invoice collections" do
+    travel_to(DateTime.new(2024, 2, 10)) do
+      create(:invoice, organization:, customer:, total_amount_cents: 1000, currency: "USD")
+      create(:invoice, organization:, customer:, total_amount_cents: 2000, currency: "USD")
+
+      result = execute_graphql(customer_portal_user: customer, query:)
+      invoice_collections_response = result["data"]["customerPortalInvoiceCollections"]
+
+      expect(invoice_collections_response["collection"]).to contain_exactly(
+        "month" => include("2024-02-01"),
+        "currency" => "USD",
+        "amountCents" => "3000",
+        "invoicesCount" => "2"
+      )
+    end
+  end
+end

--- a/spec/graphql/resolvers/customer_portal/analytics/overdue_balances_resolver_spec.rb
+++ b/spec/graphql/resolvers/customer_portal/analytics/overdue_balances_resolver_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::CustomerPortal::Analytics::OverdueBalancesResolver, type: :graphql do
+  let(:query) do
+    <<~GQL
+      query {
+        customerPortalOverdueBalances {
+          collection {
+            month
+            amountCents
+            lagoInvoiceIds
+            currency
+          }
+        }
+      }
+    GQL
+  end
+
+  let(:organization) { create(:organization, created_at: DateTime.new(2024, 1, 15)) }
+  let(:membership) { create(:membership, organization:) }
+  let(:customer) { create(:customer, organization:, currency: "USD") }
+
+  it_behaves_like "requires a customer portal user"
+
+  it "returns a list of overdue balances" do
+    travel_to(DateTime.new(2024, 2, 10)) do
+      create(:invoice, organization:, customer:, total_amount_cents: 1000, currency: "USD")
+      i1 = create(:invoice, organization:, customer:, total_amount_cents: 2000, currency: "USD", payment_overdue: true)
+      i2 = create(:invoice, organization:, customer:, total_amount_cents: 2000, currency: "USD", payment_overdue: true)
+
+      result = execute_graphql(customer_portal_user: customer, query:)
+      overdue_balances_response = result["data"]["customerPortalOverdueBalances"]
+
+      expect(overdue_balances_response["collection"]).to contain_exactly(
+        "month" => include("2024-02-01"),
+        "currency" => "USD",
+        "amountCents" => "4000",
+        "lagoInvoiceIds" => contain_exactly(i1.id, i2.id)
+      )
+    end
+  end
+end

--- a/spec/models/analytics/invoice_collection_spec.rb
+++ b/spec/models/analytics/invoice_collection_spec.rb
@@ -1,54 +1,55 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Analytics::InvoiceCollection, type: :model do
-  describe '.cache_key' do
+  describe ".cache_key" do
     subject(:invoice_collection_cache_key) { described_class.cache_key(organization_id, **args) }
 
     let(:organization_id) { SecureRandom.uuid }
-    let(:currency) { 'EUR' }
+    let(:external_customer_id) { "customer_01" }
+    let(:currency) { "EUR" }
     let(:months) { 12 }
-    let(:date) { Date.current.strftime('%Y-%m-%d') }
+    let(:date) { Date.current.strftime("%Y-%m-%d") }
 
-    context 'with no arguments' do
+    context "with no arguments" do
       let(:args) { {} }
-      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}//" }
+      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}///" }
 
-      it 'returns the cache key' do
+      it "returns the cache key" do
         expect(invoice_collection_cache_key).to eq(cache_key)
       end
     end
 
-    context 'with currency and months' do
-      let(:args) { {currency:, months:} }
+    context "with customer external id, currency and months" do
+      let(:args) { {external_customer_id:, currency:, months:} }
 
       let(:cache_key) do
-        "invoice-collection/#{date}/#{organization_id}/#{currency}/#{months}"
+        "invoice-collection/#{date}/#{organization_id}/#{external_customer_id}/#{currency}/#{months}"
       end
 
-      it 'returns the cache key' do
+      it "returns the cache key" do
         expect(invoice_collection_cache_key).to eq(cache_key)
       end
     end
 
-    context 'with months' do
+    context "with months" do
       let(:args) { {months:} }
 
       let(:cache_key) do
-        "invoice-collection/#{date}/#{organization_id}//#{months}"
+        "invoice-collection/#{date}/#{organization_id}///#{months}"
       end
 
-      it 'returns the cache key' do
+      it "returns the cache key" do
         expect(invoice_collection_cache_key).to eq(cache_key)
       end
     end
 
-    context 'with currency' do
+    context "with currency" do
       let(:args) { {currency:} }
-      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}/#{currency}/" }
+      let(:cache_key) { "invoice-collection/#{date}/#{organization_id}//#{currency}/" }
 
-      it 'returns the cache key' do
+      it "returns the cache key" do
         expect(invoice_collection_cache_key).to eq(cache_key)
       end
     end

--- a/spec/serializers/v1/analytics/gross_revenue_serializer_spec.rb
+++ b/spec/serializers/v1/analytics/gross_revenue_serializer_spec.rb
@@ -1,25 +1,29 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ::V1::Analytics::GrossRevenueSerializer do
-  subject(:serializer) { described_class.new(gross_revenue, root_name: 'gross_revenue') }
+  subject(:serializer) { described_class.new(gross_revenue, root_name: "gross_revenue") }
 
   let(:gross_revenue) do
     {
-      'month' => Time.current.beginning_of_month.iso8601,
-      'amount_cents' => 100,
-      'currency' => 'EUR'
+      "month" => "2024-06-01T00:00:00Z",
+      "amount_cents" => 100,
+      "currency" => "EUR",
+      "invoices_count" => 1
     }
   end
 
   let(:result) { JSON.parse(serializer.to_json) }
 
-  it 'serializes the gross revenue' do
-    aggregate_failures do
-      expect(result['gross_revenue']['month']).to eq(Time.current.beginning_of_month.iso8601)
-      expect(result['gross_revenue']['amount_cents']).to eq(100)
-      expect(result['gross_revenue']['currency']).to eq('EUR')
-    end
+  it "serializes the gross revenue" do
+    expect(result["gross_revenue"]).to eq(
+      {
+        "month" => "2024-06-01T00:00:00Z",
+        "amount_cents" => 100,
+        "currency" => "EUR",
+        "invoices_count" => 1
+      }
+    )
   end
 end

--- a/spec/serializers/v1/analytics/overdue_balance_serializer_spec.rb
+++ b/spec/serializers/v1/analytics/overdue_balance_serializer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ::V1::Analytics::OverdueBalanceSerializer do
       "month" => "2024-06-01T00:00:00Z",
       "amount_cents" => 100,
       "currency" => "EUR",
-      "invoice_ids" => "[\"1\", \"2\", \"3\"]"
+      "lago_invoice_ids" => "[\"1\", \"2\", \"3\"]"
     }
   end
 


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/regroup-invoices-to-generate-one-payment-intent

## Context

We want to be able to group invoices to generate one payment.
Today we don't track payment terms and do not mention whether a payment or an invoice is overdue.

## Description

The goal of this PR is to add an analytics graphql endpoint for fetching overdue balances per month and per currency at the customer portal level.
