### PR TITLE
feat (netsuite-integration): Add BE support for netsuite TBA

### DIFF
--- a/app/graphql/types/integrations/netsuite.rb
+++ b/app/graphql/types/integrations/netsuite.rb
@@ -28,6 +28,8 @@ module Types
       end
 
       def token_secret
+        return nil unless object.token_secret
+
         "#{"•" * 8}…#{object.token_secret[-3..]}"
       end
 

--- a/app/graphql/types/integrations/netsuite.rb
+++ b/app/graphql/types/integrations/netsuite.rb
@@ -18,11 +18,17 @@ module Types
       field :sync_invoices, Boolean
       field :sync_payments, Boolean
       field :sync_sales_orders, Boolean
+      field :token_id, String, null: true
+      field :token_secret, String, null: true
 
       # NOTE: Client secret is a sensitive information. It should not be sent back to the
       #       front end application. Instead we send an obfuscated value
       def client_secret
         "#{"•" * 8}…#{object.client_secret[-3..]}"
+      end
+
+      def token_secret
+        "#{"•" * 8}…#{object.token_secret[-3..]}"
       end
 
       def has_mappings_configured

--- a/app/graphql/types/integrations/netsuite/create_input.rb
+++ b/app/graphql/types/integrations/netsuite/create_input.rb
@@ -14,6 +14,8 @@ module Types
         argument :client_secret, String, required: true
         argument :connection_id, String, required: true
         argument :script_endpoint_url, String, required: true
+        argument :token_id, String, required: true
+        argument :token_secret, String, required: true
 
         argument :sync_credit_notes, Boolean, required: false
         argument :sync_invoices, Boolean, required: false

--- a/app/graphql/types/integrations/netsuite/update_input.rb
+++ b/app/graphql/types/integrations/netsuite/update_input.rb
@@ -16,6 +16,8 @@ module Types
         argument :client_secret, String, required: false
         argument :connection_id, String, required: false
         argument :script_endpoint_url, String, required: false
+        argument :token_id, String, required: false
+        argument :token_secret, String, required: false
 
         argument :sync_credit_notes, Boolean, required: false
         argument :sync_invoices, Boolean, required: false

--- a/app/models/integrations/netsuite_integration.rb
+++ b/app/models/integrations/netsuite_integration.rb
@@ -9,8 +9,9 @@ module Integrations
       :sync_invoices,
       :sync_payments,
       :sync_sales_orders,
-      :script_endpoint_url
-    secrets_accessors :connection_id, :client_secret
+      :script_endpoint_url,
+      :token_id
+    secrets_accessors :connection_id, :client_secret, :token_secret
 
     def account_id=(value)
       push_to_settings(key: 'account_id', value: value&.downcase&.strip&.split(' ')&.join('-'))

--- a/app/services/integrations/aggregator/accounts_service.rb
+++ b/app/services/integrations/aggregator/accounts_service.rb
@@ -21,7 +21,7 @@ module Integrations
         {
           'Connection-Id' => integration.connection_id,
           'Authorization' => "Bearer #{secret_key}",
-          'Provider-Config-Key' => provider
+          'Provider-Config-Key' => provider_key
         }
       end
 

--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -32,6 +32,15 @@ module Integrations
         end
       end
 
+      def provider_key
+        case integration.type
+        when 'Integrations::NetsuiteIntegration'
+          'netsuite-tba'
+        when 'Integrations::XeroIntegration'
+          'xero'
+        end
+      end
+
       def http_client
         LagoHttpClient::Client.new(endpoint_url)
       end

--- a/app/services/integrations/aggregator/contacts/base_service.rb
+++ b/app/services/integrations/aggregator/contacts/base_service.rb
@@ -14,7 +14,7 @@ module Integrations
           {
             'Connection-Id' => integration.connection_id,
             'Authorization' => "Bearer #{secret_key}",
-            'Provider-Config-Key' => provider
+            'Provider-Config-Key' => provider_key
           }
         end
 

--- a/app/services/integrations/aggregator/invoices/base_service.rb
+++ b/app/services/integrations/aggregator/invoices/base_service.rb
@@ -20,7 +20,7 @@ module Integrations
           {
             'Connection-Id' => integration.connection_id,
             'Authorization' => "Bearer #{secret_key}",
-            'Provider-Config-Key' => provider
+            'Provider-Config-Key' => provider_key
           }
         end
 

--- a/app/services/integrations/aggregator/items_service.rb
+++ b/app/services/integrations/aggregator/items_service.rb
@@ -39,7 +39,7 @@ module Integrations
         {
           'Connection-Id' => integration.connection_id,
           'Authorization' => "Bearer #{secret_key}",
-          'Provider-Config-Key' => provider
+          'Provider-Config-Key' => provider_key
         }
       end
 

--- a/app/services/integrations/aggregator/send_restlet_endpoint_service.rb
+++ b/app/services/integrations/aggregator/send_restlet_endpoint_service.rb
@@ -25,7 +25,7 @@ module Integrations
 
       def headers
         {
-          'Provider-Config-Key' => 'netsuite',
+          'Provider-Config-Key' => 'netsuite-tba',
           'Authorization' => "Bearer #{secret_key}"
         }
       end

--- a/app/services/integrations/aggregator/subsidiaries_service.rb
+++ b/app/services/integrations/aggregator/subsidiaries_service.rb
@@ -21,7 +21,7 @@ module Integrations
         {
           'Connection-Id' => integration.connection_id,
           'Authorization' => "Bearer #{secret_key}",
-          'Provider-Config-Key' => provider
+          'Provider-Config-Key' => provider_key
         }
       end
 

--- a/app/services/integrations/aggregator/sync_service.rb
+++ b/app/services/integrations/aggregator/sync_service.rb
@@ -9,7 +9,7 @@ module Integrations
 
       def call
         payload = {
-          provider_config_key: provider,
+          provider_config_key: provider_key,
           syncs: sync_list
         }
 

--- a/app/services/integrations/aggregator/tax_items_service.rb
+++ b/app/services/integrations/aggregator/tax_items_service.rb
@@ -39,7 +39,7 @@ module Integrations
         {
           'Connection-Id' => integration.connection_id,
           'Authorization' => "Bearer #{secret_key}",
-          'Provider-Config-Key' => provider
+          'Provider-Config-Key' => provider_key
         }
       end
 

--- a/app/services/integrations/netsuite/create_service.rb
+++ b/app/services/integrations/netsuite/create_service.rb
@@ -17,6 +17,8 @@ module Integrations
           client_id: args[:client_id],
           client_secret: args[:client_secret],
           account_id: args[:account_id],
+          token_id: args[:token_id],
+          token_secret: args[:token_secret],
           connection_id: args[:connection_id],
           script_endpoint_url: args[:script_endpoint_url],
           sync_credit_notes: ActiveModel::Type::Boolean.new.cast(args[:sync_credit_notes]),

--- a/schema.graphql
+++ b/schema.graphql
@@ -1955,6 +1955,8 @@ input CreateNetsuiteIntegrationInput {
   syncInvoices: Boolean
   syncPayments: Boolean
   syncSalesOrders: Boolean
+  tokenId: String!
+  tokenSecret: String!
 }
 
 """
@@ -4980,6 +4982,8 @@ type NetsuiteIntegration {
   syncInvoices: Boolean
   syncPayments: Boolean
   syncSalesOrders: Boolean
+  tokenId: String
+  tokenSecret: String
 }
 
 """
@@ -7046,6 +7050,8 @@ input UpdateNetsuiteIntegrationInput {
   syncInvoices: Boolean
   syncPayments: Boolean
   syncSalesOrders: Boolean
+  tokenId: String
+  tokenSecret: String
 }
 
 """

--- a/schema.json
+++ b/schema.json
@@ -7908,6 +7908,38 @@
               "deprecationReason": null
             },
             {
+              "name": "tokenId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tokenSecret",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "syncCreditNotes",
               "description": null,
               "type": {
@@ -23500,6 +23532,34 @@
               "args": [
 
               ]
+            },
+            {
+              "name": "tokenId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "tokenSecret",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
             }
           ],
           "inputFields": null,
@@ -34363,6 +34423,30 @@
             },
             {
               "name": "scriptEndpointUrl",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tokenId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tokenSecret",
               "description": null,
               "type": {
                 "kind": "SCALAR",

--- a/spec/graphql/mutations/integrations/netsuite/create_spec.rb
+++ b/spec/graphql/mutations/integrations/netsuite/create_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Mutations::Integrations::Netsuite::Create, type: :graphql do
           syncInvoices,
           syncCreditNotes,
           syncPayments,
-          scriptEndpointUrl
+          scriptEndpointUrl,
+          tokenId,
+          tokenSecret
         }
       }
     GQL
@@ -50,6 +52,8 @@ RSpec.describe Mutations::Integrations::Netsuite::Create, type: :graphql do
           accountId: '012',
           clientId: '123',
           clientSecret: '456',
+          tokenId: 'xyz',
+          tokenSecret: 'zyx',
           connectionId: 'this-is-random-uuid'
         }
       }
@@ -61,6 +65,8 @@ RSpec.describe Mutations::Integrations::Netsuite::Create, type: :graphql do
       expect(result_data['id']).to be_present
       expect(result_data['code']).to eq(code)
       expect(result_data['name']).to eq(name)
+      expect(result_data['tokenId']).to eq('xyz')
+      expect(result_data['tokenSecret']).to eq('••••••••…zyx')
       expect(result_data['scriptEndpointUrl']).to eq(script_endpoint_url)
     end
   end

--- a/spec/graphql/resolvers/integrations/subsidiaries_resolver_spec.rb
+++ b/spec/graphql/resolvers/integrations/subsidiaries_resolver_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Resolvers::Integrations::SubsidiariesResolver, type: :graphql do
     {
       'Connection-Id' => integration.connection_id,
       'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-      'Provider-Config-Key' => 'netsuite'
+      'Provider-Config-Key' => 'netsuite-tba'
     }
   end
 

--- a/spec/graphql/types/integrations/netsuite_spec.rb
+++ b/spec/graphql/types/integrations/netsuite_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe Types::Integrations::Netsuite do
   it { is_expected.to have_field(:has_mappings_configured).of_type('Boolean') }
   it { is_expected.to have_field(:name).of_type('String!') }
   it { is_expected.to have_field(:script_endpoint_url).of_type('String!') }
+  it { is_expected.to have_field(:token_id).of_type('String') }
+  it { is_expected.to have_field(:token_secret).of_type('String') }
 
   it { is_expected.to have_field(:sync_credit_notes).of_type('Boolean') }
   it { is_expected.to have_field(:sync_invoices).of_type('Boolean') }

--- a/spec/services/integrations/aggregator/accounts_service_spec.rb
+++ b/spec/services/integrations/aggregator/accounts_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Integrations::Aggregator::AccountsService do
       {
         'Connection-Id' => integration.connection_id,
         'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-        'Provider-Config-Key' => 'netsuite'
+        'Provider-Config-Key' => 'netsuite-tba'
       }
     end
 

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
     {
       'Connection-Id' => integration.connection_id,
       'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-      'Provider-Config-Key' => integration_type
+      'Provider-Config-Key' => integration_type_key
     }
   end
 
@@ -35,6 +35,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
       context 'when response is a string' do
         let(:integration) { create(:netsuite_integration, organization:) }
         let(:integration_type) { 'netsuite' }
+        let(:integration_type_key) { 'netsuite-tba' }
 
         let(:params) do
           {
@@ -81,6 +82,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
       context 'when response is a hash' do
         let(:integration) { create(:xero_integration, organization:) }
         let(:integration_type) { 'xero' }
+        let(:integration_type_key) { 'xero' }
 
         let(:params) do
           [
@@ -145,6 +147,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
     context 'when service call is not successful' do
       let(:integration) { create(:netsuite_integration, organization:) }
       let(:integration_type) { 'netsuite' }
+      let(:integration_type_key) { 'netsuite-tba' }
 
       let(:params) do
         {

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
     {
       'Connection-Id' => integration.connection_id,
       'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-      'Provider-Config-Key' => integration_type
+      'Provider-Config-Key' => integration_type_key
     }
   end
 
@@ -31,6 +31,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
         let(:integration) { create(:netsuite_integration, organization:) }
         let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
         let(:integration_type) { 'netsuite' }
+        let(:integration_type_key) { 'netsuite-tba' }
 
         let(:params) do
           {
@@ -74,6 +75,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
         let(:integration) { create(:xero_integration, organization:) }
         let(:integration_customer) { create(:xero_customer, integration:, customer:) }
         let(:integration_type) { 'xero' }
+        let(:integration_type_key) { 'xero' }
 
         let(:params) do
           [
@@ -115,6 +117,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
       let(:integration) { create(:netsuite_integration, organization:) }
       let(:integration_customer) { create(:netsuite_customer, integration:, customer:) }
       let(:integration_type) { 'netsuite' }
+      let(:integration_type_key) { 'netsuite-tba' }
 
       let(:params) do
         {

--- a/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/credit_notes/create_service_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Integrations::Aggregator::CreditNotes::CreateService do
     {
       'Connection-Id' => integration.connection_id,
       'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-      'Provider-Config-Key' => 'netsuite'
+      'Provider-Config-Key' => 'netsuite-tba'
     }
   end
 

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
     {
       'Connection-Id' => integration.connection_id,
       'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-      'Provider-Config-Key' => 'netsuite'
+      'Provider-Config-Key' => 'netsuite-tba'
     }
   end
 

--- a/spec/services/integrations/aggregator/items_service_spec.rb
+++ b/spec/services/integrations/aggregator/items_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Integrations::Aggregator::ItemsService do
       {
         'Connection-Id' => integration.connection_id,
         'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-        'Provider-Config-Key' => 'netsuite'
+        'Provider-Config-Key' => 'netsuite-tba'
       }
     end
     let(:params) do

--- a/spec/services/integrations/aggregator/payments/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/payments/create_service_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Integrations::Aggregator::Payments::CreateService do
     {
       'Connection-Id' => integration.connection_id,
       'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-      'Provider-Config-Key' => 'netsuite'
+      'Provider-Config-Key' => 'netsuite-tba'
     }
   end
 

--- a/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/sales_orders/create_service_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Integrations::Aggregator::SalesOrders::CreateService do
     {
       'Connection-Id' => integration.connection_id,
       'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-      'Provider-Config-Key' => 'netsuite'
+      'Provider-Config-Key' => 'netsuite-tba'
     }
   end
 

--- a/spec/services/integrations/aggregator/subsidiaries_service_spec.rb
+++ b/spec/services/integrations/aggregator/subsidiaries_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Integrations::Aggregator::SubsidiariesService do
       {
         'Connection-Id' => integration.connection_id,
         'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-        'Provider-Config-Key' => 'netsuite'
+        'Provider-Config-Key' => 'netsuite-tba'
       }
     end
 

--- a/spec/services/integrations/aggregator/sync_service_spec.rb
+++ b/spec/services/integrations/aggregator/sync_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Integrations::Aggregator::SyncService do
       expect(LagoHttpClient::Client).to have_received(:new)
         .with(sync_endpoint)
       expect(lago_client).to have_received(:post_with_response) do |payload|
-        expect(payload[:provider_config_key]).to eq('netsuite')
+        expect(payload[:provider_config_key]).to eq('netsuite-tba')
         expect(payload[:syncs]).to eq(syncs_list)
       end
     end
@@ -45,7 +45,7 @@ RSpec.describe Integrations::Aggregator::SyncService do
         expect(LagoHttpClient::Client).to have_received(:new)
           .with(sync_endpoint)
         expect(lago_client).to have_received(:post_with_response) do |payload|
-          expect(payload[:provider_config_key]).to eq('netsuite')
+          expect(payload[:provider_config_key]).to eq('netsuite-tba')
           expect(payload[:syncs]).to eq(%w[netsuite-items-sync])
         end
       end

--- a/spec/services/integrations/aggregator/tax_items_service_spec.rb
+++ b/spec/services/integrations/aggregator/tax_items_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Integrations::Aggregator::TaxItemsService do
       {
         'Connection-Id' => integration.connection_id,
         'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
-        'Provider-Config-Key' => 'netsuite'
+        'Provider-Config-Key' => 'netsuite-tba'
       }
     end
     let(:params) do

--- a/spec/services/integrations/netsuite/create_service_spec.rb
+++ b/spec/services/integrations/netsuite/create_service_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe Integrations::Netsuite::CreateService, type: :service do
         connection_id: 'conn1',
         client_id: 'cl1',
         client_secret: 'secret',
+        token_id: 'xyz',
+        token_secret: 'zyx',
         account_id: 'acc1',
         script_endpoint_url:
       }
@@ -70,6 +72,8 @@ RSpec.describe Integrations::Netsuite::CreateService, type: :service do
 
             integration = Integrations::NetsuiteIntegration.order(:created_at).last
             expect(integration.name).to eq(name)
+            expect(integration.token_id).to eq('xyz')
+            expect(integration.token_secret).to eq('zyx')
             expect(integration.script_endpoint_url).to eq(script_endpoint_url)
           end
 


### PR DESCRIPTION
## Context

Currently Lago is integrated with netsuite accounting tool.

## Description

This PR adds BE support required fields related to the token based auth.

Also, Lago's integration aggregator changed definition for 'Provider-Config-Key' property so that is also tackled
