### PR TITLE
feat: Add Discard Handling for AuthenticationError

### DIFF
--- a/app/jobs/invoices/payments/stripe_create_job.rb
+++ b/app/jobs/invoices/payments/stripe_create_job.rb
@@ -9,6 +9,7 @@ module Invoices
 
       retry_on Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
       retry_on Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
+      discard_on Stripe::AuthenticationError
 
       def perform(invoice)
         result = Invoices::Payments::StripeService.new(invoice).create

--- a/app/jobs/invoices/payments/stripe_create_job.rb
+++ b/app/jobs/invoices/payments/stripe_create_job.rb
@@ -9,7 +9,9 @@ module Invoices
 
       retry_on Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
       retry_on Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
-      discard_on Stripe::AuthenticationError
+      discard_on Stripe::AuthenticationError do |_, error|
+        Rails.logger.warn(error.message)
+      end
 
       def perform(invoice)
         result = Invoices::Payments::StripeService.new(invoice).create

--- a/app/jobs/invoices/payments/stripe_create_job.rb
+++ b/app/jobs/invoices/payments/stripe_create_job.rb
@@ -9,9 +9,6 @@ module Invoices
 
       retry_on Stripe::RateLimitError, wait: :polynomially_longer, attempts: 6
       retry_on Stripe::APIConnectionError, wait: :polynomially_longer, attempts: 6
-      discard_on Stripe::AuthenticationError do |_, error|
-        Rails.logger.warn(error.message)
-      end
 
       def perform(invoice)
         result = Invoices::Payments::StripeService.new(invoice).create

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -52,11 +52,11 @@ module Invoices
         result.payment = payment
         result
       rescue Stripe::AuthenticationError, Stripe::CardError, Stripe::InvalidRequestError, Stripe::PermissionError => e
-        deliver_error_webhook(e)
         # NOTE: Do not mark the invoice as failed if the amount is too small for Stripe
         #       For now we keep it as pending, the user can still update it manually
         return if e.code == 'amount_too_small'
 
+        deliver_error_webhook(e)
         update_invoice_payment_status(payment_status: :failed, deliver_webhook: false)
         nil
       rescue Stripe::RateLimitError, Stripe::APIConnectionError => e

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -60,8 +60,11 @@ module Invoices
         update_invoice_payment_status(payment_status: :failed, deliver_webhook: false)
         nil
       rescue Stripe::RateLimitError, Stripe::APIConnectionError => e
+        raise # Let the auto-retry process do its own job
+      rescue Stripe::StripeError => e
         deliver_error_webhook(e)
         raise
+       end
       end
 
       def update_payment_status(organization_id:, provider_payment_id:, status:, metadata: {})

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -59,6 +59,9 @@ module Invoices
 
         update_invoice_payment_status(payment_status: :failed, deliver_webhook: false)
         nil
+      rescue Stripe::RateLimitError, Stripe::APIConnectionError => e
+        deliver_error_webhook(e)
+        raise
       end
 
       def update_payment_status(organization_id:, provider_payment_id:, status:, metadata: {})

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -59,12 +59,11 @@ module Invoices
         deliver_error_webhook(e)
         update_invoice_payment_status(payment_status: :failed, deliver_webhook: false)
         nil
-      rescue Stripe::RateLimitError, Stripe::APIConnectionError => e
+      rescue Stripe::RateLimitError, Stripe::APIConnectionError
         raise # Let the auto-retry process do its own job
       rescue Stripe::StripeError => e
         deliver_error_webhook(e)
         raise
-       end
       end
 
       def update_payment_status(organization_id:, provider_payment_id:, status:, metadata: {})


### PR DESCRIPTION
### Context:
In this pull request, we change the error handling within the StripeCreateJob by discarding jobs that encounter Stripe::AuthenticationError. This change ensures that we prevent creating noise 

### Description:
- When a `Stripe::AuthenticationError` is raised, it indicates an issue with the authentication credentials. Since this is a non-recoverable error in the job context, retries are unnecessary.
- Customers are already notified of such errors through a webhook, making additional retries redundant and potentially confusing for the customer.

#### Additional Context:
- The `update_payment_method_id` method in the related service sends a webhook notification when any `Stripe::StripeError` is raised, ensuring customers are informed of issues promptly.

<img width="867" alt="Screenshot 2024-07-02 at 18 30 10" src="https://github.com/getlago/lago-api/assets/1700595/ddc79a87-3cac-44a9-971e-1d8e2df174c0">
