### PR TITLE
feat(papertrail): Add Lago Version to papertrail metadata

### DIFF
--- a/app/models/concerns/paper_trail_traceable.rb
+++ b/app/models/concerns/paper_trail_traceable.rb
@@ -6,7 +6,8 @@ module PaperTrailTraceable
   included do
     has_paper_trail(
       meta: {
-        whodunnit: proc { |_| CurrentContext.membership }
+        whodunnit: proc { |_| CurrentContext.membership },
+        lago_version: LAGO_VERSION.number
       }
     )
   end

--- a/db/migrate/20240703061352_add_lago_version_to_versions.rb
+++ b/db/migrate/20240703061352_add_lago_version_to_versions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLagoVersionToVersions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :versions, :lago_version, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_02_081109) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_03_061352) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -999,6 +999,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_02_081109) do
     t.jsonb "object"
     t.jsonb "object_changes"
     t.datetime "created_at"
+    t.string "lago_version"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 

--- a/spec/support/shared_examples/paper_trail_traceable.rb
+++ b/spec/support/shared_examples/paper_trail_traceable.rb
@@ -7,6 +7,7 @@ RSpec.shared_examples 'paper_trail traceable' do
     CurrentContext.membership = 'membership/f03f5cd7-9f6f-4d06-85c4-7ea22d65aa5b'
     subject.save!
     expect(subject.versions.last.whodunnit).to eq('membership/f03f5cd7-9f6f-4d06-85c4-7ea22d65aa5b')
+    expect(subject.versions.last.lago_version).to eq('test')
     CurrentContext.membership = nil
   end
 end


### PR DESCRIPTION
## Description

Every time a change is made to a model, we store the changes in a `versions` table managed by the [papertrail gem](https://github.com/paper-trail-gem/paper_trail).

This PR adds the version of Lago to help debugging, especially self hosted versions.

Only possible because of [this PR](https://github.com/getlago/lago-api/pull/2204).