### PR TITLE
fix(netsuite-integration): limit netsuite payload rate

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -5,6 +5,8 @@ module Integrations
     module Invoices
       module Payloads
         class Netsuite < BasePayload
+          MAX_DECIMALS = 15
+
           def body
             {
               'type' => type,
@@ -92,13 +94,13 @@ module Integrations
           def limited_rate(precise_unit_amount)
             unit_amount_str = precise_unit_amount.to_s
 
-            return precise_unit_amount if unit_amount_str.length <= 15
+            return precise_unit_amount if unit_amount_str.length <= MAX_DECIMALS
 
             decimal_position = unit_amount_str.index('.')
 
             return precise_unit_amount unless decimal_position
 
-            precise_unit_amount.round(14 - decimal_position)
+            precise_unit_amount.round(MAX_DECIMALS - 1 - decimal_position)
           end
         end
       end

--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -52,7 +52,7 @@ module Integrations
               'item' => mapped_item.external_id,
               'account' => mapped_item.external_account_code,
               'quantity' => fee.units,
-              'rate' => fee.precise_unit_amount
+              'rate' => limited_rate(fee.precise_unit_amount)
             }
           end
 
@@ -87,6 +87,18 @@ module Integrations
             end
 
             output
+          end
+
+          def limited_rate(precise_unit_amount)
+            unit_amount_str = precise_unit_amount.to_s
+
+            return precise_unit_amount if unit_amount_str.length <= 15
+
+            decimal_position = unit_amount_str.index('.')
+
+            return precise_unit_amount unless decimal_position
+
+            precise_unit_amount.round(14 - decimal_position)
           end
         end
       end

--- a/spec/services/integrations/aggregator/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/create_service_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
       invoice:,
       charge:,
       units: 2,
-      precise_unit_amount: 4.12,
+      precise_unit_amount: 4.12121212123337777,
       created_at: current_time
     )
   end
@@ -161,7 +161,7 @@ RSpec.describe Integrations::Aggregator::Invoices::CreateService do
               'item' => 'm2',
               'account' => 'm22',
               'quantity' => 2,
-              'rate' => 4.12
+              'rate' => 4.1212121212334
             },
             {
               'item' => '2',


### PR DESCRIPTION
## Description

Netsuite only support decimals of to 14 digits if there is decimal point. This PR adapts this use-case
