### PR TITLE
fix(wallet): Prevent from having duplicate Invoices::PrepaidCreditJob

### DIFF
--- a/app/jobs/invoices/prepaid_credit_job.rb
+++ b/app/jobs/invoices/prepaid_credit_job.rb
@@ -4,6 +4,8 @@ module Invoices
   class PrepaidCreditJob < ApplicationJob
     queue_as 'wallets'
 
+    unique :until_executed, on_conflict: :log
+
     def perform(invoice)
       Wallets::ApplyPaidCreditsService.new.call(invoice)
     end


### PR DESCRIPTION
## Description

We've recently seen an issue where we receive the `succeeded` webhook from Stripe several times at the same moment (some milliseconds interval) on some wallet transactions.

The goal of this PR is to add a unique lock on the `Invoices::PrepaidCreditJob` job to not impact the balance twice.