### PR TITLE
fix: Startup script does not always perform migrations

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,6 +9,7 @@ development:
     password: changeme
     database: lago
     port: 5432
+    schema_search_path: "public"
   events:
     <<: *default
     host: db
@@ -73,6 +74,7 @@ production:
     url: <%= ENV['DATABASE_URL'] %>
     pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
     prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
+    schema_search_path: <%= ENV.fetch('POSTGRES_SCHEMA', 'public') %>
   events:
     <<: *default
     url: <%= ENV['DATABASE_URL'] %>

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -6,11 +6,13 @@ then
 fi
 
 rm -f ./tmp/pids/server.pid
-bundle exec rails db:migrate:primary
 
 if [ -v LAGO_CLICKHOUSE_ENABLED ] && [ "$LAGO_CLICKHOUSE_ENABLED" == "true" ]
 then
+  bundle exec rails db:migrate:primary
   bundle exec rake db:migrate:clickhouse
+else
+  bundle exec rails db:migrate
 fi
 
 bundle exec rails signup:seed_organization


### PR DESCRIPTION
## Context

This PR is a fix for https://github.com/getlago/lago-api/issues/1945#issuecomment-2206942237

## Description

Lago startup script is relying on the `rails db:migrate:primary` to perform the migration at startup.

Since in some situation, only one database is configured in the `database.yml` file, the command is failing with the following error:
```
Unrecognized command "db:migrate:primary" (Rails::Command::UnrecognizedCommandError)
Did you mean?  db:migrate:up
```

This PR fixes this by using `rails db:migrate` instead when only one database is present.
