### PR TITLE
feat(db): Add optional schema search path to the Postgres client

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,6 +9,9 @@ development:
     password: changeme
     database: lago
     port: 5432
+    <% if ENV['DATABASE_SCHEMA_SEARCH_PATH'].present? %>
+    schema_search_path: <%= ENV['DATABASE_SCHEMA_SEARCH_PATH'] %>
+    <% end %>
   events:
     <<: *default
     host: db
@@ -16,6 +19,9 @@ development:
     password: changeme
     database: lago
     port: 5432
+    <% if ENV['DATABASE_SCHEMA_SEARCH_PATH'].present? %>
+    schema_search_path: <%= ENV['DATABASE_SCHEMA_SEARCH_PATH'] %>
+    <% end %>
   clickhouse:
     adapter: clickhouse
     database: default
@@ -32,10 +38,16 @@ test:
     <<: *default
     url: <%= ENV['DATABASE_TEST_URL'].presence || ENV['DATABASE_URL'] %>
     schema_dump: <% if ENV['LAGO_DISABLE_SCHEMA_DUMP'].present? %> false <% else %> schema.rb <% end %>
+    <% if ENV['DATABASE_SCHEMA_SEARCH_PATH'].present? %>
+    schema_search_path: <%= ENV['DATABASE_SCHEMA_SEARCH_PATH'] %>
+    <% end %>
   events:
     <<: *default
     url: <%= ENV['DATABASE_TEST_URL'].presence || ENV['DATABASE_URL'] %>
     schema_dump: false
+    <% if ENV['DATABASE_SCHEMA_SEARCH_PATH'].present? %>
+    schema_search_path: <%= ENV['DATABASE_SCHEMA_SEARCH_PATH'] %>
+    <% end %>
   clickhouse:
     adapter: clickhouse
     database: <%= ENV.fetch('LAGO_CLICKHOUSE_DATABASE', 'default_test') %>
@@ -52,10 +64,16 @@ staging:
   primary:
     <<: *default
     url: <%= ENV['DATABASE_URL'] %>
+    <% if ENV['DATABASE_SCHEMA_SEARCH_PATH'].present? %>
+    schema_search_path: <%= ENV['DATABASE_SCHEMA_SEARCH_PATH'] %>
+    <% end %>
   events:
     <<: *default
     url: <%= ENV['DATABASE_URL'] %>
     database_tasks: false
+    <% if ENV['DATABASE_SCHEMA_SEARCH_PATH'].present? %>
+    schema_search_path: <%= ENV['DATABASE_SCHEMA_SEARCH_PATH'] %>
+    <% end %>
   clickhouse:
     adapter: clickhouse
     database: <%= ENV['LAGO_CLICKHOUSE_DATABASE'] %>
@@ -73,12 +91,18 @@ production:
     url: <%= ENV['DATABASE_URL'] %>
     pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
     prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
+    <% if ENV['DATABASE_SCHEMA_SEARCH_PATH'].present? %>
+    schema_search_path: <%= ENV['DATABASE_SCHEMA_SEARCH_PATH'] %>
+    <% end %>
   events:
     <<: *default
     url: <%= ENV['DATABASE_URL'] %>
     pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
     prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
     database_tasks: false
+    <% if ENV['DATABASE_SCHEMA_SEARCH_PATH'].present? %>
+    schema_search_path: <%= ENV['DATABASE_SCHEMA_SEARCH_PATH'] %>
+    <% end %>
   clickhouse:
     adapter: clickhouse
     database: <%= ENV['LAGO_CLICKHOUSE_DATABASE'] %>


### PR DESCRIPTION
## Context

Add support for specifying the schema that the Lago Postgres client uses when making a connection to the Postgres database, this allows the user to select which database schema Lago would use.

An environmental variable `DATABASE_SCHEMA_SEARCH_PATH` can be specified, allowing the user to set the search path / schema that Lago uses. The value follows the standard search_path format, which is just a comma separated list of schemas, e.g:  `someschema, public`, just like you would use `SET search_path = someschema, public`, or more notably, the same format that the `schema_search_path` field takes in `database.yml` to configure the client search path.

If the environmental variable is not specified, we simply skip adding the `schema_search_path` field entirely and use the normal default settings as usual. 

The reasons for supporting this are mainly but not limited to:
1. Some database providers, such as Supabase, automatically expose the public schema publicly, changing the schema to a custom private one is necessary to support these providers.
2. Some users may want to use a single Postgres database for both Lago and their app or analytics tool, supporting running Lago in a different schema than public can streamline this and allow avoiding conflicts, allowing users to write joins between their app and Lago, run analytics, or drop the need to read data from both a database and an API when creating front end application and instead use a single database read when just reading data.


## Description

This pull request introduces an enhancement to the database configuration, allowing the use of a schema search path for PostgreSQL databases across all environments (development, test, staging, and production).

This change aims to:
1. Improve security and data organization by avoiding the automatic exposure of the public schema by some providers, notably Supabase.
2. Facilitate the use of the PostgreSQL database for both Lago and other applications or analytics tools, supporting a different schema than public. This helps avoid conflicts, enables seamless joins between app data and Lago data, and simplifies analytics and frontend application development.

