### PR TITLE
chore(perf): Add missing frozen_string_literal comment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ AllCops:
 Style/StringLiterals:
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: true
+
 Performance/CaseWhenSplat:
   Enabled: true
 

--- a/app/jobs/data_exports/export_resources_job.rb
+++ b/app/jobs/data_exports/export_resources_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DataExports
   class ExportResourcesJob < ApplicationJob
     queue_as :default

--- a/app/mailers/data_export_mailer.rb
+++ b/app/mailers/data_export_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DataExportMailer < ApplicationMailer
   def completed
     @data_export = params[:data_export]

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DataExport < ApplicationRecord
   EXPORT_FORMATS = %w[csv].freeze
   STATUSES = %w[pending processing completed failed].freeze

--- a/app/models/integration_resource.rb
+++ b/app/models/integration_resource.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class IntegrationResource < ApplicationRecord
   belongs_to :syncable, polymorphic: true
   belongs_to :integration, class_name: 'Integrations::BaseIntegration'

--- a/app/services/data_exports/create_service.rb
+++ b/app/services/data_exports/create_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DataExports
   class CreateService < BaseService
     def initialize(organization:, user:, format:, resource_type:, resource_query:)

--- a/app/services/data_exports/export_resources_service.rb
+++ b/app/services/data_exports/export_resources_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DataExports
   class ExportResourcesService < BaseService
     def call

--- a/db/clickhouse_migrate/20231024084411_create_events_raw.rb
+++ b/db/clickhouse_migrate/20231024084411_create_events_raw.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateEventsRaw < ActiveRecord::Migration[7.0]
   def change
     options = <<-SQL

--- a/db/migrate/20230720204311_add_signature_to_webhook_endpoints.rb
+++ b/db/migrate/20230720204311_add_signature_to_webhook_endpoints.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSignatureToWebhookEndpoints < ActiveRecord::Migration[7.0]
   def change
     add_column :webhook_endpoints, :signature_algo, :integer, default: 0, null: false # 0 is JWT

--- a/db/migrate/20240514081110_create_integration_resources.rb
+++ b/db/migrate/20240514081110_create_integration_resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateIntegrationResources < ActiveRecord::Migration[7.0]
   def change
     create_table :integration_resources, id: :uuid do |t|

--- a/db/migrate/20240520115450_add_integration_id_to_integration_resources.rb
+++ b/db/migrate/20240520115450_add_integration_id_to_integration_resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddIntegrationIdToIntegrationResources < ActiveRecord::Migration[7.0]
   def up
     remove_index :integration_items, [:external_id, :integration_id]

--- a/db/migrate/20240522105942_add_resource_type_to_integration_resources.rb
+++ b/db/migrate/20240522105942_add_resource_type_to_integration_resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddResourceTypeToIntegrationResources < ActiveRecord::Migration[7.0]
   def change
     add_column :integration_resources, :resource_type, :integer, null: false, default: 0

--- a/db/migrate/20240619082054_add_in_advance_charge_periodic_invoicing_reason.rb
+++ b/db/migrate/20240619082054_add_in_advance_charge_periodic_invoicing_reason.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddInAdvanceChargePeriodicInvoicingReason < ActiveRecord::Migration[7.0]
   def up
     execute <<-SQL

--- a/db/migrate/20240625090742_create_data_exports.rb
+++ b/db/migrate/20240625090742_create_data_exports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateDataExports < ActiveRecord::Migration[7.0]
   def change
     create_table :data_exports, id: :uuid do |t|

--- a/db/migrate/20240628083654_add_membership_id_and_organization_id_to_data_exports.rb
+++ b/db/migrate/20240628083654_add_membership_id_and_organization_id_to_data_exports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddMembershipIdAndOrganizationIdToDataExports < ActiveRecord::Migration[7.1]
   def change
     add_reference :data_exports, :membership, foreign_key: true, type: :uuid

--- a/db/migrate/20240628083830_remove_user_id_from_data_exports.rb
+++ b/db/migrate/20240628083830_remove_user_id_from_data_exports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveUserIdFromDataExports < ActiveRecord::Migration[7.1]
   def change
     remove_reference :data_exports, :user, null: false, foreign_key: true, type: :uuid

--- a/db/migrate/20240702081109_add_regroup_paid_fees_to_charges.rb
+++ b/db/migrate/20240702081109_add_regroup_paid_fees_to_charges.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRegroupPaidFeesToCharges < ActiveRecord::Migration[7.1]
   def change
     add_column :charges, :regroup_paid_fees, :integer, default: nil

--- a/spec/factories/data_exports.rb
+++ b/spec/factories/data_exports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :data_export do
     organization

--- a/spec/factories/integration_resources.rb
+++ b/spec/factories/integration_resources.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :integration_resource do
     association :syncable, factory: %i[invoice payment credit_note].sample

--- a/spec/jobs/data_exports/export_resources_job_spec.rb
+++ b/spec/jobs/data_exports/export_resources_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DataExports::ExportResourcesJob, type: :job do

--- a/spec/mailers/data_export_mailer_spec.rb
+++ b/spec/mailers/data_export_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DataExportMailer, type: :mailer do

--- a/spec/mailers/previews/base_preview_mailer.rb
+++ b/spec/mailers/previews/base_preview_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BasePreviewMailer < ActionMailer::Preview
   def self.call(...)
     message = nil

--- a/spec/mailers/previews/data_export_mailer_preview.rb
+++ b/spec/mailers/previews/data_export_mailer_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DataExportMailerPreview < BasePreviewMailer
   def completed
     data_export = FactoryBot.create :data_export, :completed

--- a/spec/models/data_export_spec.rb
+++ b/spec/models/data_export_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DataExport, type: :model do

--- a/spec/models/integration_resource_spec.rb
+++ b/spec/models/integration_resource_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe IntegrationResource, type: :model do

--- a/spec/services/data_exports/create_service_spec.rb
+++ b/spec/services/data_exports/create_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DataExports::CreateService, type: :service do

--- a/spec/services/data_exports/export_resources_service_spec.rb
+++ b/spec/services/data_exports/export_resources_service_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DataExports::ExportResourcesService, type: :service do


### PR DESCRIPTION
## Description

When reviewing PR I realized that many new files don't have the `# frozen_string_literal: true` comment.
I believe the rule was removed when we updated the code style recently.