### PR TITLE
feat(event): Add clickhouse pre-aggregation config

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/getlago/clickhouse-activerecord.git
-  revision: 4876bb07e16de9084c9b11dbe27b489235b03cc9
+  revision: 3c4b369a34fb5d27f2cf5d30c87b96ce5a940fc3
   specs:
     clickhouse-activerecord (1.0.9)
       activerecord (>= 7.1)

--- a/app/models/clickhouse/events_count_agg.rb
+++ b/app/models/clickhouse/events_count_agg.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Clickhouse
+  class EventsCountAgg < BaseRecord
+    self.table_name = 'events_count_agg'
+  end
+end

--- a/app/models/clickhouse/events_enriched.rb
+++ b/app/models/clickhouse/events_enriched.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Clickhouse
+  class EventsEnriched < BaseRecord
+    self.table_name = 'events_enriched'
+  end
+end

--- a/app/models/clickhouse/events_max_agg.rb
+++ b/app/models/clickhouse/events_max_agg.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Clickhouse
+  class EventsMaxAgg < BaseRecord
+    self.table_name = 'events_max_agg'
+  end
+end

--- a/app/models/clickhouse/events_sum_agg.rb
+++ b/app/models/clickhouse/events_sum_agg.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Clickhouse
+  class EventsSumAgg < BaseRecord
+    self.table_name = 'events_sum_agg'
+  end
+end

--- a/db/clickhouse_migrate/20240705080709_create_events_enriched.rb
+++ b/db/clickhouse_migrate/20240705080709_create_events_enriched.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CreateEventsEnriched < ActiveRecord::Migration[7.1]
+  def change
+    options = <<-SQL
+    ReplacingMergeTree
+    ORDER BY (
+      organization_id,
+      external_subscription_id,
+      code,
+      charge_id,
+      transaction_id
+    )
+    SQL
+
+    create_table :events_enriched, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :external_subscription_id, null: false
+      t.string :code, null: false
+      t.datetime :timestamp, null: false, precision: 3
+      t.string :transaction_id, null: false
+      t.map :properties, key_type: :string, value_type: :string, null: false
+      t.string :value
+      t.string :charge_id, null: false
+      t.string :aggregation_type
+      t.map :filters, key_type: :string, value_type: 'Array(String)', null: false
+      t.map :grouped_by, key_type: :string, value_type: :string, null: false
+    end
+  end
+end

--- a/db/clickhouse_migrate/20240705084952_create_events_enriched_queue.rb
+++ b/db/clickhouse_migrate/20240705084952_create_events_enriched_queue.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CreateEventsEnrichedQueue < ActiveRecord::Migration[7.1]
+  def change
+    options = <<-SQL
+      Kafka()
+      SETTINGS
+        kafka_broker_list = '#{ENV["LAGO_KAFKA_BOOTSTRAP_SERVERS"]}',
+        kafka_topic_list = '#{ENV["LAGO_KAFKA_ENRICHED_EVENTS_TOPIC"]}',
+        kafka_group_name = '#{ENV["LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP"]}',
+        kafka_format = 'JSONEachRow';
+    SQL
+
+    create_table :events_enriched_queue, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :external_subscription_id, null: false
+      t.string :code, null: false
+      t.string :timestamp, null: false
+      t.string :transaction_id, null: false
+      t.string :properties, null: false
+      t.string :value
+      t.string :charge_id, null: false
+      t.string :aggregation_type, null: false
+      t.string :filters
+      t.string :grouped_by
+    end
+  end
+end

--- a/db/clickhouse_migrate/20240705085501_create_events_enriched_mv.rb
+++ b/db/clickhouse_migrate/20240705085501_create_events_enriched_mv.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: false
+
+class CreateEventsEnrichedMv < ActiveRecord::Migration[7.1]
+  def change
+    sql = <<~SQL
+      SELECT
+        organization_id,
+        external_subscription_id,
+        transaction_id,
+        toDateTime64(timestamp, 3) AS timestamp,
+        code,
+        JSONExtract(properties, 'Map(String, String)') AS properties,
+        value,
+        charge_id,
+        aggregation_type,
+        JSONExtract(coalesce(filters, '{}'), 'Map(String, Array(String))') AS filters,
+        JSONExtract(coalesce(grouped_by, '{}'), 'Map(String, String)') AS grouped_by
+      FROM events_enriched_queue
+    SQL
+
+    create_view :events_enriched_mv, materialized: true, as: sql, to: 'events_enriched'
+  end
+end

--- a/db/clickhouse_migrate/20240705090006_create_events_sum_agg.rb
+++ b/db/clickhouse_migrate/20240705090006_create_events_sum_agg.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: false
+
+class CreateEventsSumAgg < ActiveRecord::Migration[7.1]
+  def change
+    options = <<-SQL
+      SummingMergeTree
+      PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp)
+    SQL
+
+    create_table :events_sum_agg, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :external_subscription_id, null: false
+      t.string :code, null: false
+      t.string :charge_id, null: false
+      t.decimal :value, precision: 26
+      t.datetime :timestamp, precision: 3, null: false
+      t.map :filters, key_type: :string, value_type: 'Array(String)', null: false
+      t.map :grouped_by, key_type: :string, value_type: :string, null: false
+    end
+  end
+end

--- a/db/clickhouse_migrate/20240705090006_create_events_sum_agg.rb
+++ b/db/clickhouse_migrate/20240705090006_create_events_sum_agg.rb
@@ -4,7 +4,7 @@ class CreateEventsSumAgg < ActiveRecord::Migration[7.1]
   def change
     options = <<-SQL
       SummingMergeTree
-      PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp)
+      PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by)
     SQL
 
     create_table :events_sum_agg, id: false, options: do |t|

--- a/db/clickhouse_migrate/20240705090310_create_events_sum_agg_mv.rb
+++ b/db/clickhouse_migrate/20240705090310_create_events_sum_agg_mv.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: false
+
+class CreateEventsSumAggMv < ActiveRecord::Migration[7.1]
+  def change
+    sql = <<-SQL
+    SELECT
+      organization_id,
+      external_subscription_id,
+      code,
+      charge_id,
+      sum(toDecimal128(value, 26)) as value,
+      toStartOfHour(timestamp) as timestamp
+    FROM events_enriched
+    WHERE aggregation_type = 'sum_agg'
+    GROUP BY
+      organization_id,
+      external_subscription_id,
+      code,
+      charge_id,
+      toStartOfHour(timestamp) as timestamp
+    SQL
+
+    create_view :events_sum_agg_mv, materialized: true, as: sql, to: 'events_sum_agg'
+  end
+end

--- a/db/clickhouse_migrate/20240705090310_create_events_sum_agg_mv.rb
+++ b/db/clickhouse_migrate/20240705090310_create_events_sum_agg_mv.rb
@@ -9,7 +9,9 @@ class CreateEventsSumAggMv < ActiveRecord::Migration[7.1]
       code,
       charge_id,
       sum(toDecimal128(value, 26)) as value,
-      toStartOfHour(timestamp) as timestamp
+      toStartOfHour(timestamp) as timestamp,
+      filters,
+      grouped_by
     FROM events_enriched
     WHERE aggregation_type = 'sum_agg'
     GROUP BY
@@ -17,7 +19,9 @@ class CreateEventsSumAggMv < ActiveRecord::Migration[7.1]
       external_subscription_id,
       code,
       charge_id,
-      toStartOfHour(timestamp) as timestamp
+      toStartOfHour(timestamp) as timestamp,
+      filters,
+      grouped_by
     SQL
 
     create_view :events_sum_agg_mv, materialized: true, as: sql, to: 'events_sum_agg'

--- a/db/clickhouse_migrate/20240709095907_create_events_count_agg.rb
+++ b/db/clickhouse_migrate/20240709095907_create_events_count_agg.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: false
+
+class CreateEventsCountAgg < ActiveRecord::Migration[7.1]
+  def change
+    options = <<-SQL
+      SummingMergeTree
+      PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp)
+    SQL
+
+    create_table :events_count_agg, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :external_subscription_id, null: false
+      t.string :code, null: false
+      t.string :charge_id, null: false
+      t.decimal :value, precision: 26
+      t.datetime :timestamp, precision: 3, null: false
+      t.map :filters, key_type: :string, value_type: 'Array(String)', null: false
+      t.map :grouped_by, key_type: :string, value_type: :string, null: false
+    end
+  end
+end

--- a/db/clickhouse_migrate/20240709095907_create_events_count_agg.rb
+++ b/db/clickhouse_migrate/20240709095907_create_events_count_agg.rb
@@ -4,7 +4,7 @@ class CreateEventsCountAgg < ActiveRecord::Migration[7.1]
   def change
     options = <<-SQL
       SummingMergeTree
-      PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp)
+      PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by)
     SQL
 
     create_table :events_count_agg, id: false, options: do |t|

--- a/db/clickhouse_migrate/20240709100047_create_events_count_agg_mv.rb
+++ b/db/clickhouse_migrate/20240709100047_create_events_count_agg_mv.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: false
+
+class CreateEventsCountAggMv < ActiveRecord::Migration[7.1]
+  def change
+    sql = <<-SQL
+    SELECT
+      organization_id,
+      external_subscription_id,
+      code,
+      charge_id,
+      sum(toDecimal128(value, 26)) as value,
+      toStartOfHour(timestamp) as timestamp
+    FROM events_enriched
+    WHERE aggregation_type = 'count_agg'
+    GROUP BY
+      organization_id,
+      external_subscription_id,
+      code,
+      charge_id,
+      toStartOfHour(timestamp) as timestamp
+    SQL
+
+    create_view :events_count_agg_mv, materialized: true, as: sql, to: 'events_count_agg'
+  end
+end

--- a/db/clickhouse_migrate/20240709100047_create_events_count_agg_mv.rb
+++ b/db/clickhouse_migrate/20240709100047_create_events_count_agg_mv.rb
@@ -9,7 +9,9 @@ class CreateEventsCountAggMv < ActiveRecord::Migration[7.1]
       code,
       charge_id,
       sum(toDecimal128(value, 26)) as value,
-      toStartOfHour(timestamp) as timestamp
+      toStartOfHour(timestamp) as timestamp,
+      filters,
+      grouped_by
     FROM events_enriched
     WHERE aggregation_type = 'count_agg'
     GROUP BY
@@ -17,7 +19,9 @@ class CreateEventsCountAggMv < ActiveRecord::Migration[7.1]
       external_subscription_id,
       code,
       charge_id,
-      toStartOfHour(timestamp) as timestamp
+      toStartOfHour(timestamp) as timestamp,
+      filters,
+      grouped_by
     SQL
 
     create_view :events_count_agg_mv, materialized: true, as: sql, to: 'events_count_agg'

--- a/db/clickhouse_migrate/20240709135506_create_events_max_agg.rb
+++ b/db/clickhouse_migrate/20240709135506_create_events_max_agg.rb
@@ -4,7 +4,7 @@ class CreateEventsMaxAgg < ActiveRecord::Migration[7.1]
   def change
     options = <<-SQL
       AggregatingMergeTree()
-      PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp)
+      PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by)
     SQL
 
     create_table :events_max_agg, id: false, options: do |t|

--- a/db/clickhouse_migrate/20240709135506_create_events_max_agg.rb
+++ b/db/clickhouse_migrate/20240709135506_create_events_max_agg.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: false
+
+class CreateEventsMaxAgg < ActiveRecord::Migration[7.1]
+  def change
+    options = <<-SQL
+      AggregatingMergeTree()
+      PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp)
+    SQL
+
+    create_table :events_max_agg, id: false, options: do |t|
+      t.string :organization_id, null: false
+      t.string :external_subscription_id, null: false
+      t.string :code, null: false
+      t.string :charge_id, null: false
+      t.datetime :timestamp, precision: 3, null: false
+      t.map :filters, key_type: :string, value_type: 'Array(String)', null: false
+      t.map :grouped_by, key_type: :string, value_type: :string, null: false
+    end
+
+    add_column :events_max_agg, :value, 'AggregateFunction(max, Decimal(38, 26))', null: false # rubocop:disable Rails/NotNullColumn
+  end
+end

--- a/db/clickhouse_migrate/20240709135535_create_events_max_agg_mv.rb
+++ b/db/clickhouse_migrate/20240709135535_create_events_max_agg_mv.rb
@@ -9,7 +9,9 @@ class CreateEventsMaxAggMv < ActiveRecord::Migration[7.1]
       code,
       charge_id,
       maxState(toDecimal128(coalesce(value, '0'), 26)) as value,
-      toStartOfHour(timestamp) as timestamp
+      toStartOfHour(timestamp) as timestamp,
+      filters,
+      grouped_by
     FROM events_enriched
     WHERE aggregation_type = 'max_agg'
     GROUP BY
@@ -17,7 +19,9 @@ class CreateEventsMaxAggMv < ActiveRecord::Migration[7.1]
       external_subscription_id,
       code,
       charge_id,
-      toStartOfHour(timestamp) as timestamp
+      toStartOfHour(timestamp) as timestamp,
+      filters,
+      grouped_by
     SQL
 
     create_view :events_max_agg_mv, materialized: true, as: sql, to: 'events_max_agg'

--- a/db/clickhouse_migrate/20240709135535_create_events_max_agg_mv.rb
+++ b/db/clickhouse_migrate/20240709135535_create_events_max_agg_mv.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: false
+
+class CreateEventsMaxAggMv < ActiveRecord::Migration[7.1]
+  def change
+    sql = <<-SQL
+    SELECT
+      organization_id,
+      external_subscription_id,
+      code,
+      charge_id,
+      maxState(toDecimal128(coalesce(value, '0'), 26)) as value,
+      toStartOfHour(timestamp) as timestamp
+    FROM events_enriched
+    WHERE aggregation_type = 'max_agg'
+    GROUP BY
+      organization_id,
+      external_subscription_id,
+      code,
+      charge_id,
+      toStartOfHour(timestamp) as timestamp
+    SQL
+
+    create_view :events_max_agg_mv, materialized: true, as: sql, to: 'events_max_agg'
+  end
+end

--- a/db/clickhouse_schema.rb
+++ b/db/clickhouse_schema.rb
@@ -13,8 +13,8 @@
 ClickhouseActiverecord::Schema.define(version: 2024_07_09_135535) do
 
   # TABLE: events_count_agg
-  # SQL: CREATE TABLE default.events_count_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(26, 0)), `timestamp` DateTime64(3), `filters` Map(String, Array(String)), `grouped_by` Map(String, String) ) ENGINE = SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192
-  create_table "events_count_agg", id: false, options: "SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192", force: :cascade do |t|
+  # SQL: CREATE TABLE default.events_count_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(26, 0)), `timestamp` DateTime64(3), `filters` Map(String, Array(String)), `grouped_by` Map(String, String) ) ENGINE = SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) SETTINGS index_granularity = 8192
+  create_table "events_count_agg", id: false, options: "SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) SETTINGS index_granularity = 8192", force: :cascade do |t|
     t.string "organization_id", null: false
     t.string "external_subscription_id", null: false
     t.string "code", null: false
@@ -58,8 +58,8 @@ ClickhouseActiverecord::Schema.define(version: 2024_07_09_135535) do
   end
 
   # TABLE: events_max_agg
-  # SQL: CREATE TABLE default.events_max_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `timestamp` DateTime64(3), `filters` Map(String, Array(String)), `grouped_by` Map(String, String), `value` AggregateFunction(max, Decimal(38, 26)) ) ENGINE = AggregatingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192
-  create_table "events_max_agg", id: false, options: "AggregatingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192", force: :cascade do |t|
+  # SQL: CREATE TABLE default.events_max_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `timestamp` DateTime64(3), `filters` Map(String, Array(String)), `grouped_by` Map(String, String), `value` AggregateFunction(max, Decimal(38, 26)) ) ENGINE = AggregatingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) SETTINGS index_granularity = 8192
+  create_table "events_max_agg", id: false, options: "AggregatingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) SETTINGS index_granularity = 8192", force: :cascade do |t|
     t.string "organization_id", null: false
     t.string "external_subscription_id", null: false
     t.string "code", null: false
@@ -95,8 +95,8 @@ ClickhouseActiverecord::Schema.define(version: 2024_07_09_135535) do
   end
 
   # TABLE: events_sum_agg
-  # SQL: CREATE TABLE default.events_sum_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(26, 0)), `timestamp` DateTime64(3), `filters` Map(String, Array(String)), `grouped_by` Map(String, String) ) ENGINE = SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192
-  create_table "events_sum_agg", id: false, options: "SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192", force: :cascade do |t|
+  # SQL: CREATE TABLE default.events_sum_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(26, 0)), `timestamp` DateTime64(3), `filters` Map(String, Array(String)), `grouped_by` Map(String, String) ) ENGINE = SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) SETTINGS index_granularity = 8192
+  create_table "events_sum_agg", id: false, options: "SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by) SETTINGS index_granularity = 8192", force: :cascade do |t|
     t.string "organization_id", null: false
     t.string "external_subscription_id", null: false
     t.string "code", null: false
@@ -108,8 +108,8 @@ ClickhouseActiverecord::Schema.define(version: 2024_07_09_135535) do
   end
 
   # TABLE: events_sum_agg_mv
-  # SQL: CREATE MATERIALIZED VIEW default.events_sum_agg_mv TO default.events_sum_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(38, 26)), `timestamp` DateTime ) AS SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'sum_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp
-  create_table "events_sum_agg_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'sum_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp", force: :cascade do |t|
+  # SQL: CREATE MATERIALIZED VIEW default.events_sum_agg_mv TO default.events_sum_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(38, 26)), `timestamp` DateTime, `filters` Map(String, Array(String)), `grouped_by` Map(String, String) ) AS SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp, filters, grouped_by FROM default.events_enriched WHERE aggregation_type = 'sum_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by
+  create_table "events_sum_agg_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp, filters, grouped_by FROM default.events_enriched WHERE aggregation_type = 'sum_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by", force: :cascade do |t|
   end
 
   # TABLE: events_raw_mv
@@ -118,8 +118,8 @@ ClickhouseActiverecord::Schema.define(version: 2024_07_09_135535) do
   end
 
   # TABLE: events_max_agg_mv
-  # SQL: CREATE MATERIALIZED VIEW default.events_max_agg_mv TO default.events_max_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` AggregateFunction(max, Decimal(38, 26)), `timestamp` DateTime ) AS SELECT organization_id, external_subscription_id, code, charge_id, maxState(toDecimal128(coalesce(value, '0'), 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'max_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp
-  create_table "events_max_agg_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_subscription_id, code, charge_id, maxState(toDecimal128(coalesce(value, '0'), 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'max_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp", force: :cascade do |t|
+  # SQL: CREATE MATERIALIZED VIEW default.events_max_agg_mv TO default.events_max_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` AggregateFunction(max, Decimal(38, 26)), `timestamp` DateTime, `filters` Map(String, Array(String)), `grouped_by` Map(String, String) ) AS SELECT organization_id, external_subscription_id, code, charge_id, maxState(toDecimal128(coalesce(value, '0'), 26)) AS value, toStartOfHour(timestamp) AS timestamp, filters, grouped_by FROM default.events_enriched WHERE aggregation_type = 'max_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by
+  create_table "events_max_agg_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_subscription_id, code, charge_id, maxState(toDecimal128(coalesce(value, '0'), 26)) AS value, toStartOfHour(timestamp) AS timestamp, filters, grouped_by FROM default.events_enriched WHERE aggregation_type = 'max_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by", force: :cascade do |t|
   end
 
   # TABLE: events_enriched_mv
@@ -128,8 +128,8 @@ ClickhouseActiverecord::Schema.define(version: 2024_07_09_135535) do
   end
 
   # TABLE: events_count_agg_mv
-  # SQL: CREATE MATERIALIZED VIEW default.events_count_agg_mv TO default.events_count_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(38, 26)), `timestamp` DateTime ) AS SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'count_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp
-  create_table "events_count_agg_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'count_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp", force: :cascade do |t|
+  # SQL: CREATE MATERIALIZED VIEW default.events_count_agg_mv TO default.events_count_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(38, 26)), `timestamp` DateTime, `filters` Map(String, Array(String)), `grouped_by` Map(String, String) ) AS SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp, filters, grouped_by FROM default.events_enriched WHERE aggregation_type = 'count_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by
+  create_table "events_count_agg_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp, filters, grouped_by FROM default.events_enriched WHERE aggregation_type = 'count_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp, filters, grouped_by", force: :cascade do |t|
   end
 
 end

--- a/db/clickhouse_schema.rb
+++ b/db/clickhouse_schema.rb
@@ -10,7 +10,65 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ClickhouseActiverecord::Schema.define(version: 2023_10_30_163703) do
+ClickhouseActiverecord::Schema.define(version: 2024_07_09_135535) do
+
+  # TABLE: events_count_agg
+  # SQL: CREATE TABLE default.events_count_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(26, 0)), `timestamp` DateTime64(3), `filters` Map(String, Array(String)), `grouped_by` Map(String, String) ) ENGINE = SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192
+  create_table "events_count_agg", id: false, options: "SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192", force: :cascade do |t|
+    t.string "organization_id", null: false
+    t.string "external_subscription_id", null: false
+    t.string "code", null: false
+    t.string "charge_id", null: false
+    t.decimal "value", precision: 26
+    t.datetime "timestamp", precision: 3, null: false
+    t.map "filters", key_type: "string", value_type: "Array(String)", null: false
+    t.map "grouped_by", key_type: "string", value_type: "string", null: false
+  end
+
+  # TABLE: events_enriched
+  # SQL: CREATE TABLE default.events_enriched ( `organization_id` String, `external_subscription_id` String, `code` String, `timestamp` DateTime64(3), `transaction_id` String, `properties` Map(String, String), `value` Nullable(String), `charge_id` String, `aggregation_type` Nullable(String), `filters` Map(String, Array(String)), `grouped_by` Map(String, String) ) ENGINE = ReplacingMergeTree ORDER BY (organization_id, external_subscription_id, code, charge_id, transaction_id) SETTINGS index_granularity = 8192
+  create_table "events_enriched", id: false, options: "ReplacingMergeTree ORDER BY (organization_id, external_subscription_id, code, charge_id, transaction_id) SETTINGS index_granularity = 8192", force: :cascade do |t|
+    t.string "organization_id", null: false
+    t.string "external_subscription_id", null: false
+    t.string "code", null: false
+    t.datetime "timestamp", precision: 3, null: false
+    t.string "transaction_id", null: false
+    t.map "properties", key_type: "string", value_type: "string", null: false
+    t.string "value"
+    t.string "charge_id", null: false
+    t.string "aggregation_type"
+    t.map "filters", key_type: "string", value_type: "Array(String)", null: false
+    t.map "grouped_by", key_type: "string", value_type: "string", null: false
+  end
+
+  # TABLE: events_enriched_queue
+  # SQL: CREATE TABLE default.events_enriched_queue ( `organization_id` String, `external_subscription_id` String, `code` String, `timestamp` String, `transaction_id` String, `properties` String, `value` Nullable(String), `charge_id` String, `aggregation_type` String, `filters` Nullable(String), `grouped_by` Nullable(String) ) ENGINE = Kafka SETTINGS kafka_broker_list = '*****', kafka_topic_list = '', kafka_group_name = '*****', kafka_format = 'JSONEachRow'
+  create_table "events_enriched_queue", id: false, options: "Kafka SETTINGS kafka_broker_list = '*****', kafka_topic_list = '', kafka_group_name = '*****', kafka_format = 'JSONEachRow'", force: :cascade do |t|
+    t.string "organization_id", null: false
+    t.string "external_subscription_id", null: false
+    t.string "code", null: false
+    t.string "timestamp", null: false
+    t.string "transaction_id", null: false
+    t.string "properties", null: false
+    t.string "value"
+    t.string "charge_id", null: false
+    t.string "aggregation_type", null: false
+    t.string "filters"
+    t.string "grouped_by"
+  end
+
+  # TABLE: events_max_agg
+  # SQL: CREATE TABLE default.events_max_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `timestamp` DateTime64(3), `filters` Map(String, Array(String)), `grouped_by` Map(String, String), `value` AggregateFunction(max, Decimal(38, 26)) ) ENGINE = AggregatingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192
+  create_table "events_max_agg", id: false, options: "AggregatingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192", force: :cascade do |t|
+    t.string "organization_id", null: false
+    t.string "external_subscription_id", null: false
+    t.string "code", null: false
+    t.string "charge_id", null: false
+    t.datetime "timestamp", precision: 3, null: false
+    t.map "filters", key_type: "string", value_type: "Array(String)", null: false
+    t.map "grouped_by", key_type: "string", value_type: "string", null: false
+    t.decimal "value", precision: 38, scale: 26, null: false
+  end
 
   # TABLE: events_raw
   # SQL: CREATE TABLE default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime64(3), `code` String, `properties` Map(String, String) ) ENGINE = MergeTree ORDER BY (organization_id, external_subscription_id, code, transaction_id, timestamp) SETTINGS index_granularity = 8192
@@ -36,9 +94,42 @@ ClickhouseActiverecord::Schema.define(version: 2023_10_30_163703) do
     t.string "properties", null: false
   end
 
+  # TABLE: events_sum_agg
+  # SQL: CREATE TABLE default.events_sum_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(26, 0)), `timestamp` DateTime64(3), `filters` Map(String, Array(String)), `grouped_by` Map(String, String) ) ENGINE = SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192
+  create_table "events_sum_agg", id: false, options: "SummingMergeTree PRIMARY KEY (organization_id, external_subscription_id, code, charge_id, timestamp) ORDER BY (organization_id, external_subscription_id, code, charge_id, timestamp) SETTINGS index_granularity = 8192", force: :cascade do |t|
+    t.string "organization_id", null: false
+    t.string "external_subscription_id", null: false
+    t.string "code", null: false
+    t.string "charge_id", null: false
+    t.decimal "value", precision: 26
+    t.datetime "timestamp", precision: 3, null: false
+    t.map "filters", key_type: "string", value_type: "Array(String)", null: false
+    t.map "grouped_by", key_type: "string", value_type: "string", null: false
+  end
+
+  # TABLE: events_sum_agg_mv
+  # SQL: CREATE MATERIALIZED VIEW default.events_sum_agg_mv TO default.events_sum_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(38, 26)), `timestamp` DateTime ) AS SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'sum_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp
+  create_table "events_sum_agg_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'sum_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp", force: :cascade do |t|
+  end
+
   # TABLE: events_raw_mv
   # SQL: CREATE MATERIALIZED VIEW default.events_raw_mv TO default.events_raw ( `organization_id` String, `external_customer_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime64(3), `code` String, `properties` Map(String, String) ) AS SELECT organization_id, external_customer_id, external_subscription_id, transaction_id, toDateTime64(timestamp, 3) AS timestamp, code, JSONExtract(properties, 'Map(String, String)') AS properties FROM default.events_raw_queue
   create_table "events_raw_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_customer_id, external_subscription_id, transaction_id, toDateTime64(timestamp, 3) AS timestamp, code, JSONExtract(properties, 'Map(String, String)') AS properties FROM default.events_raw_queue", force: :cascade do |t|
+  end
+
+  # TABLE: events_max_agg_mv
+  # SQL: CREATE MATERIALIZED VIEW default.events_max_agg_mv TO default.events_max_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` AggregateFunction(max, Decimal(38, 26)), `timestamp` DateTime ) AS SELECT organization_id, external_subscription_id, code, charge_id, maxState(toDecimal128(coalesce(value, '0'), 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'max_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp
+  create_table "events_max_agg_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_subscription_id, code, charge_id, maxState(toDecimal128(coalesce(value, '0'), 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'max_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp", force: :cascade do |t|
+  end
+
+  # TABLE: events_enriched_mv
+  # SQL: CREATE MATERIALIZED VIEW default.events_enriched_mv TO default.events_enriched ( `organization_id` String, `external_subscription_id` String, `transaction_id` String, `timestamp` DateTime64(3), `code` String, `properties` Map(String, String), `value` Nullable(String), `charge_id` String, `aggregation_type` String, `filters` Map(String, Array(String)), `grouped_by` Map(String, String) ) AS SELECT organization_id, external_subscription_id, transaction_id, toDateTime64(timestamp, 3) AS timestamp, code, JSONExtract(properties, 'Map(String, String)') AS properties, value, charge_id, aggregation_type, JSONExtract(coalesce(filters, '{}'), 'Map(String, Array(String))') AS filters, JSONExtract(coalesce(grouped_by, '{}'), 'Map(String, String)') AS grouped_by FROM default.events_enriched_queue
+  create_table "events_enriched_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_subscription_id, transaction_id, toDateTime64(timestamp, 3) AS timestamp, code, JSONExtract(properties, 'Map(String, String)') AS properties, value, charge_id, aggregation_type, JSONExtract(coalesce(filters, '{}'), 'Map(String, Array(String))') AS filters, JSONExtract(coalesce(grouped_by, '{}'), 'Map(String, String)') AS grouped_by FROM default.events_enriched_queue", force: :cascade do |t|
+  end
+
+  # TABLE: events_count_agg_mv
+  # SQL: CREATE MATERIALIZED VIEW default.events_count_agg_mv TO default.events_count_agg ( `organization_id` String, `external_subscription_id` String, `code` String, `charge_id` String, `value` Nullable(Decimal(38, 26)), `timestamp` DateTime ) AS SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'count_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp
+  create_table "events_count_agg_mv", view: true, materialized: true, id: false, as: "SELECT organization_id, external_subscription_id, code, charge_id, sum(toDecimal128(value, 26)) AS value, toStartOfHour(timestamp) AS timestamp FROM default.events_enriched WHERE aggregation_type = 'count_agg' GROUP BY organization_id, external_subscription_id, code, charge_id, timestamp", force: :cascade do |t|
   end
 
 end


### PR DESCRIPTION
## Context

This PR is part of the real-time aggregation epic

## Description

This PR adds new tables, queues and materlialized views in Clickhouse to allow pre-aggregation of events, based on all the work done on the ingest and post-process services