### PR TITLE
feat: Enable Regroup Fees Feature

### DIFF
--- a/app/services/subscriptions/billing_service.rb
+++ b/app/services/subscriptions/billing_service.rb
@@ -23,8 +23,7 @@ module Subscriptions
           invoicing_reason: :subscription_periodic
         )
 
-        # NOTE: Commented until feature is fully released
-        # BillNonInvoiceableFeesJob.perform_later(billing_subscriptions, billing_at)
+        BillNonInvoiceableFeesJob.perform_later(billing_subscriptions, billing_at)
       end
     end
 

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -172,8 +172,7 @@ module Subscriptions
         after_commit do
           billing_at = Time.current + 1.second
           BillSubscriptionJob.perform_later(billable_subscriptions, billing_at.to_i, invoicing_reason: :upgrading)
-          # NOTE: Commented until feature is fully released
-          # BillNonInvoiceableFeesJob.perform_later(billable_subscriptions, billing_at)
+          BillNonInvoiceableFeesJob.perform_later(billable_subscriptions, billing_at)
         end
       end
 

--- a/app/services/subscriptions/terminate_service.rb
+++ b/app/services/subscriptions/terminate_service.rb
@@ -69,8 +69,7 @@ module Subscriptions
         [subscription]
       end
       BillSubscriptionJob.perform_later(billable_subscriptions, timestamp, invoicing_reason: :upgrading)
-      # NOTE: Commented until feature is fully released
-      # BillNonInvoiceableFeesJob.perform_later([subscription], rotation_date) # Ignore next subscription since there can't be events
+      BillNonInvoiceableFeesJob.perform_later([subscription], rotation_date) # Ignore next subscription since there can't be events
 
       SendWebhookJob.perform_later('subscription.terminated', subscription)
       SendWebhookJob.perform_later('subscription.started', next_subscription)
@@ -95,16 +94,14 @@ module Subscriptions
           subscription.terminated_at,
           invoicing_reason: :subscription_terminating
         )
-        # NOTE: Commented until feature is fully released
-        # BillNonInvoiceableFeesJob.set(wait: 2.seconds).perform_later([subscription], subscription.terminated_at)
+        BillNonInvoiceableFeesJob.set(wait: 2.seconds).perform_later([subscription], subscription.terminated_at)
       else
         BillSubscriptionJob.perform_now(
           [subscription],
           subscription.terminated_at,
           invoicing_reason: :subscription_terminating
         )
-        # NOTE: Commented until feature is fully released
-        # BillNonInvoiceableFeesJob.perform_now([subscription], subscription.terminated_at)
+        BillNonInvoiceableFeesJob.perform_now([subscription], subscription.terminated_at)
       end
     end
 

--- a/spec/scenarios/invoices/advance_charges_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 # NOTE: Skipped until feature is fully released
-xdescribe 'Advance Charges Invoices Scenarios', :scenarios, type: :request do
+describe 'Advance Charges Invoices Scenarios', :scenarios, type: :request do
   let(:organization) { create(:organization, webhook_url: nil) }
   let(:customer) { create(:customer, organization:) }
   let(:tax_rate) { 20 }

--- a/spec/scenarios/invoices/advance_charges_spec.rb
+++ b/spec/scenarios/invoices/advance_charges_spec.rb
@@ -23,7 +23,7 @@ describe 'Advance Charges Invoices Scenarios', :scenarios, type: :request do
 
   before do
     create(:tax, organization:, rate: tax_rate)
-    create(:standard_charge, pay_in_advance: true, invoiceable: false, prorated: true, billable_metric:, plan:, properties: {amount: '30', grouped_by: nil})
+    create(:standard_charge, regroup_paid_fees: 'invoice', pay_in_advance: true, invoiceable: false, prorated: true, billable_metric:, plan:, properties: {amount: '30', grouped_by: nil})
   end
 
   context 'when subscription is renewed' do
@@ -90,7 +90,7 @@ describe 'Advance Charges Invoices Scenarios', :scenarios, type: :request do
     let(:plan_upgrade) { create(:plan, organization:, pay_in_advance: true, amount_cents: 259) }
 
     before do
-      create(:standard_charge, pay_in_advance: true, invoiceable: false, prorated: true, billable_metric:, plan: plan_upgrade, properties: {amount: '60', grouped_by: nil})
+      create(:standard_charge, regroup_paid_fees: 'invoice', pay_in_advance: true, invoiceable: false, prorated: true, billable_metric:, plan: plan_upgrade, properties: {amount: '60', grouped_by: nil})
     end
 
     it 'generates an invoice with the correct charges' do
@@ -180,7 +180,7 @@ describe 'Advance Charges Invoices Scenarios', :scenarios, type: :request do
     let(:plan_downgrade) { create(:plan, organization:, pay_in_advance: true, amount_cents: 19) }
 
     before do
-      create(:standard_charge, pay_in_advance: true, invoiceable: false, prorated: true, billable_metric:, plan: plan_downgrade, properties: {amount: '15', grouped_by: nil})
+      create(:standard_charge, regroup_paid_fees: 'invoice', pay_in_advance: true, invoiceable: false, prorated: true, billable_metric:, plan: plan_downgrade, properties: {amount: '15', grouped_by: nil})
     end
 
     it 'generates an invoice with the correct charges' do

--- a/spec/services/subscriptions/billing_service_spec.rb
+++ b/spec/services/subscriptions/billing_service_spec.rb
@@ -75,8 +75,16 @@ RSpec.describe Subscriptions::BillingService, type: :service do
               invoicing_reason: :subscription_periodic
             )
 
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with(
+              contain_exactly(subscription1, subscription2),
+              current_date
+            )
+
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription3], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription3], current_date)
         end
       end
 
@@ -101,6 +109,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued.with([subscription], current_date)
         end
       end
 
@@ -131,6 +141,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).not_to have_been_enqueued
               .with([subscription], billing_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillNonInvoiceableFeesJob).not_to have_been_enqueued
+              .with([subscription], billing_date)
           end
         end
       end
@@ -148,6 +160,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription], current_date)
         end
       end
 
@@ -159,6 +173,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).not_to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).not_to have_been_enqueued
+            .with([subscription], current_date)
         end
       end
     end
@@ -175,6 +191,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription], current_date)
         end
       end
 
@@ -197,6 +215,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+              .with([subscription], current_date)
           end
         end
       end
@@ -216,6 +236,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription], current_date)
         end
       end
 
@@ -237,6 +259,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription], current_date)
         end
       end
 
@@ -256,6 +280,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+              .with([subscription], current_date)
           end
         end
       end
@@ -272,6 +298,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription], current_date)
         end
       end
 
@@ -291,6 +319,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+              .with([subscription], current_date)
           end
         end
       end
@@ -305,6 +335,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+              .with([subscription], current_date)
           end
         end
       end
@@ -322,6 +354,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
           expect(BillSubscriptionJob).to have_been_enqueued
             .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+          expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+            .with([subscription], current_date)
         end
       end
 
@@ -341,6 +375,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+              .with([subscription], current_date)
           end
         end
       end
@@ -355,6 +391,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
             expect(BillSubscriptionJob).to have_been_enqueued
               .with([subscription], current_date.next_month.to_i, invoicing_reason: :subscription_periodic)
+            expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+              .with([subscription], current_date.next_month)
           end
         end
 
@@ -368,6 +406,8 @@ RSpec.describe Subscriptions::BillingService, type: :service do
 
               expect(BillSubscriptionJob).to have_been_enqueued
                 .with([subscription], current_date.to_i, invoicing_reason: :subscription_periodic)
+              expect(BillNonInvoiceableFeesJob).to have_been_enqueued
+                .with([subscription], current_date)
             end
           end
         end

--- a/spec/services/subscriptions/terminate_service_spec.rb
+++ b/spec/services/subscriptions/terminate_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Subscriptions::TerminateService do
     it 'enqueues a BillSubscriptionJob' do
       expect do
         terminate_service.call
-      end.to have_enqueued_job(BillSubscriptionJob)
+      end.to have_enqueued_job(BillSubscriptionJob).and have_enqueued_job(BillNonInvoiceableFeesJob)
     end
 
     it 'enqueues a SendWebhookJob' do
@@ -213,7 +213,7 @@ RSpec.describe Subscriptions::TerminateService do
       it 'enqueues a job to bill the existing subscription' do
         expect do
           terminate_service.terminate_and_start_next(timestamp:)
-        end.to have_enqueued_job(BillSubscriptionJob)
+        end.to have_enqueued_job(BillSubscriptionJob).and have_enqueued_job(BillNonInvoiceableFeesJob)
       end
     end
 


### PR DESCRIPTION
## Context

This PR aims to enable the code implemented in [PR #2171](https://github.com/getlago/lago-api/pull/2171) for the Regroup Fees feature. The previous implementation added the foundational code for this feature but left it commented out to await the completion of a subsequent PR that introduces the setting to toggle this feature.

The required setting functionality was added in [PR #2232](https://github.com/getlago/lago-api/pull/2232). With the merging of that PR, this feature can now be conditionally enabled based on the newly introduced setting.

