### PR TITLE
feat(dx): Add `find` helper in Rails console

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Rails::ConsoleMethods
+  def find(id)
+    if /^gid/.match?(id)
+      GlobalID::Locator.locate(id)
+    elsif EmailValidator::EMAIL_REGEXP.match?(id)
+      User.find_by email: id
+    else
+      raise "Don't know how to resolve this ¯\\_(ツ)_/¯. Please provide a valid email or Global ID."
+    end
+  end
+end


### PR DESCRIPTION
## Description

On support, I often found myself using `GlobalID::Locator.locate` because this is how the job arguments are displayed in Sidekiq UI.

I'm proposing this helper that loads only in the Rails console to easily retrieve things. What else would you like to see there?

I'm thinking for UUID we could try to resolve `Organization` and `Invoice` to see if one matches

![CleanShot 2024-07-08 at 10 40 08@2x](https://github.com/getlago/lago-api/assets/1525636/bf55c784-7b20-4778-9248-fc0bcc27efc8)
