### PR TITLE
fix(dates-service): Fix terminated dates service for min commitment calculations

### DIFF
--- a/app/services/commitments/dates_service.rb
+++ b/app/services/commitments/dates_service.rb
@@ -31,7 +31,8 @@ module Commitments
       Subscriptions::TerminatedDatesService.new(
         subscription: invoice_subscription.subscription,
         invoice: invoice_subscription.invoice,
-        date_service: ds
+        date_service: ds,
+        match_invoice_subscription: invoice_subscription.subscription.plan.pay_in_advance?
       ).call
     end
 

--- a/app/services/subscriptions/terminated_dates_service.rb
+++ b/app/services/subscriptions/terminated_dates_service.rb
@@ -2,10 +2,11 @@
 
 module Subscriptions
   class TerminatedDatesService
-    def initialize(subscription:, invoice:, date_service:)
+    def initialize(subscription:, invoice:, date_service:, match_invoice_subscription: true)
       @subscription = subscription
       @timestamp = invoice.invoice_subscriptions.first&.timestamp
       @date_service = date_service
+      @match_invoice_subscription = match_invoice_subscription
     end
 
     def call
@@ -26,12 +27,14 @@ module Subscriptions
       # We should calculate boundaries as if subscription was not terminated
       new_dates_service = Subscriptions::DatesService.new_instance(duplicate, timestamp, current_usage: false)
 
+      return new_dates_service unless match_invoice_subscription
+
       matching_invoice_subscription?(subscription, new_dates_service) ? date_service : new_dates_service
     end
 
     private
 
-    attr_reader :subscription, :timestamp, :date_service
+    attr_reader :subscription, :timestamp, :date_service, :match_invoice_subscription
 
     def matching_invoice_subscription?(subscription, date_service)
       base_query = InvoiceSubscription


### PR DESCRIPTION
## Context

Minimum commitment calculation was using incorrect dates service in when refreshing draft invoices for terminated subscriptions.

## Description

Fix terminated dates service to be able to skip calling `matching_invoice_subscription?` when creating the dates service.
