### PR TITLE
feat(deprecation): Add reset methods

### DIFF
--- a/app/models/deprecation.rb
+++ b/app/models/deprecation.rb
@@ -19,11 +19,15 @@ class Deprecation
     end
 
     def get_all_as_csv(feature_name)
-      CSV.generate do |csv|
-        csv << %w[organization_id last_seen_at count]
+      lines = get_all(feature_name)
+      orgs = Organization.find(lines.pluck(:organization_id)).index_by(&:id)
 
-        get_all(feature_name).each do |d|
-          csv << [d[:organization_id], d[:last_seen_at], d[:count]]
+      CSV.generate do |csv|
+        csv << %w[org_id org_name org_email last_event_sent_at count]
+
+        lines.each do |d|
+          o = orgs[d[:organization_id]]
+          csv << [d[:organization_id], o.name, o.email, d[:last_seen_at], d[:count]]
         end
       end
     end

--- a/app/models/deprecation.rb
+++ b/app/models/deprecation.rb
@@ -35,6 +35,17 @@ class Deprecation
       {organization_id:, last_seen_at:, count:}
     end
 
+    def reset_all(feature_name)
+      Organization.pluck(:id).each do |organization_id|
+        reset(feature_name, organization_id)
+      end
+    end
+
+    def reset(feature_name, organization_id)
+      Rails.cache.delete(cache_key(feature_name, organization_id, 'count'))
+      Rails.cache.delete(cache_key(feature_name, organization_id, 'last_seen_at'))
+    end
+
     private
 
     def cache_key(feature_name, organization_id, suffix)

--- a/spec/models/deprecation_spec.rb
+++ b/spec/models/deprecation_spec.rb
@@ -49,4 +49,22 @@ RSpec.describe Deprecation, type: :model, cache: :redis do
       expect(described_class.get_all_as_csv(feature_name)).to eq(csv)
     end
   end
+
+  describe '.reset' do
+    it 'deletes deprecation data for an organization' do
+      described_class.reset(feature_name, organization.id)
+
+      expect(Rails.cache.read("deprecation:#{feature_name}:#{organization.id}:last_seen_at")).to be_nil
+      expect(Rails.cache.read("deprecation:#{feature_name}:#{organization.id}:count")).to be_nil
+    end
+  end
+
+  describe '.reset_all' do
+    it 'deletes deprecation data for all organizations' do
+      described_class.reset_all(feature_name)
+
+      expect(Rails.cache.read("deprecation:#{feature_name}:#{organization.id}:last_seen_at")).to be_nil
+      expect(Rails.cache.read("deprecation:#{feature_name}:#{organization.id}:count")).to be_nil
+    end
+  end
 end

--- a/spec/models/deprecation_spec.rb
+++ b/spec/models/deprecation_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe Deprecation, type: :model, cache: :redis do
 
   describe '.get_all_as_csv' do
     it 'returns deprecation data for all organizations' do
-      csv = "organization_id,last_seen_at,count\n"
-      csv += "#{organization.id},2024-05-22T14:58:20.280Z,101\n"
+      csv = "org_id,org_name,org_email,last_event_sent_at,count\n"
+      csv += "#{organization.id},#{organization.name},#{organization.email},2024-05-22T14:58:20.280Z,101\n"
       expect(described_class.get_all_as_csv(feature_name)).to eq(csv)
     end
   end


### PR DESCRIPTION
## Context

`Deprecation` model helps track some usage in Redis.

## Description

Before removing some features, like sending Events without `external_subscription_id`, we want to ensure that no hosted customer still rely on them.

I'm adding a simple way to reset the reports.

```ruby
Deprecation.reset_all :feature_name
```

I'm also improving the CSV export.