### PR TITLE
fix: Ensure Consistent Return of `result` Object on Stripe Exceptions

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -58,7 +58,7 @@ module Invoices
 
         deliver_error_webhook(e)
         update_invoice_payment_status(payment_status: :failed, deliver_webhook: false)
-        nil
+        result
       rescue Stripe::RateLimitError, Stripe::APIConnectionError
         raise # Let the auto-retry process do its own job
       rescue Stripe::StripeError => e


### PR DESCRIPTION
#### Description
This PR addresses an issue where the `create` method in the `Invoices::Payments::StripeService` class could return `nil` in case of certain Stripe exceptions. This inconsistency in the return type could lead to unexpected behaviors in the calling code.
