### PR TITLE
fix(integrations): Fix creating a deleted customer

### DIFF
--- a/app/services/integration_customers/create_or_update_service.rb
+++ b/app/services/integration_customers/create_or_update_service.rb
@@ -11,7 +11,7 @@ module IntegrationCustomers
     end
 
     def call
-      return if integration_customers.nil?
+      return if integration_customers.nil? || customer.nil?
 
       sanitize_integration_customers
 

--- a/spec/services/integration_customers/create_or_update_service_spec.rb
+++ b/spec/services/integration_customers/create_or_update_service_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe IntegrationCustomers::CreateOrUpdateService, type: :service do
       end
     end
 
+    context 'without customer' do
+      let(:integration_code) { integration.code }
+      let(:sync_with_provider) { true }
+      let(:external_customer_id) { nil }
+      let(:new_customer) { true }
+      let(:customer) { nil }
+
+      it 'does not call create job' do
+        expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::CreateJob)
+      end
+
+      it 'does not call update job' do
+        expect { service_call }.not_to have_enqueued_job(IntegrationCustomers::UpdateJob)
+      end
+    end
+
     context 'without external fields set' do
       let(:integration_code) { integration.code }
       let(:sync_with_provider) { false }


### PR DESCRIPTION
## Context

We were getting a lot of dead jobs when trying to sync a deleted customer to nango (netsuite).

## Description

This PR fixes the issue by not trying to sync a non-existent (deleted) customer.