### PR TITLE
misc(events): Add option to remove event validations job

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -100,11 +100,13 @@ module Clockwork
       .perform_later
   end
 
-  every(1.hour, 'schedule:post_validate_events', at: '*:05') do
-    Clock::EventsValidationJob
-      .set(sentry: {"slug" => 'lago_post_validate_events', "cron" => '5 */1 * * *'})
-      .perform_later
-  rescue => e
-    Sentry.capture_exception(e)
+  unless ActiveModel::Type::Boolean.new.cast(ENV['LAGO_DISABLE_EVENTS_VALIDATION'])
+    every(1.hour, 'schedule:post_validate_events', at: '*:05') do
+      Clock::EventsValidationJob
+        .set(sentry: {"slug" => 'lago_post_validate_events', "cron" => '5 */1 * * *'})
+        .perform_later
+    rescue => e
+      Sentry.capture_exception(e)
+    end
   end
 end


### PR DESCRIPTION
## Context

This is a very bad feature, we should think about disable it, and remove it very soon.
Scalability = 0

## Description

- Give the option to disable the events validation
