### PR TITLE
feat(export-invoice-fees): Export invoice fees to CSV

### DIFF
--- a/app/mailers/data_export_mailer.rb
+++ b/app/mailers/data_export_mailer.rb
@@ -3,6 +3,7 @@
 class DataExportMailer < ApplicationMailer
   def completed
     @data_export = params[:data_export]
+    @resource_type = @data_export.resource_type.humanize.downcase
     user = @data_export.user
 
     return if @data_export.file.blank?
@@ -15,7 +16,7 @@ class DataExportMailer < ApplicationMailer
         from: ENV['LAGO_FROM_EMAIL'],
         subject: I18n.t(
           'email.data_export.completed.subject',
-          resource_type: @data_export.resource_type
+          resource_type: @resource_type
         )
       )
     end

--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'forwardable'
+
+module DataExports
+  module Csv
+    class InvoiceFees < Invoices
+      extend Forwardable
+
+      def call
+        ::CSV.generate(headers: true) do |csv|
+          csv << headers
+
+          query.invoices.find_each do |invoice|
+            serialized_invoice = serializer_klass
+              .new(invoice, includes: %i[fees subscriptions])
+              .serialize
+
+            subscriptions = serialized_invoice[:subscriptions].index_by do |sub|
+              sub[:lago_id]
+            end
+
+            serialized_invoice[:fees].each do |serialized_fee|
+              subscription_id = serialized_fee[:lago_subscription_id]
+              serialized_subscription = subscriptions[subscription_id]
+
+              csv << [
+                serialized_invoice[:lago_id],
+                serialized_invoice[:number],
+                serialized_invoice[:issuing_date],
+                serialized_fee[:lago_id],
+                serialized_fee[:item][:type],
+                serialized_fee[:item][:code],
+                serialized_fee[:item][:name],
+                serialized_fee[:item][:invoice_display_name],
+                serialized_fee[:item][:filter_invoice_display_name],
+                serialized_fee[:item][:grouped_by],
+                serialized_subscription&.dig(:external_id),
+                serialized_subscription&.dig(:plan_code),
+                serialized_fee[:from_date],
+                serialized_fee[:to_date],
+                serialized_fee[:total_amount_cents],
+                serialized_fee[:total_amount_currency],
+                serialized_fee[:units],
+                serialized_fee[:precise_unit_amount],
+                serialized_fee[:taxes_amount_cents]
+              ]
+            end
+          end
+        end
+      end
+
+      private
+
+      def headers
+        %w[
+          invoice_lago_id
+          invoice_number
+          invoice_issuing_date
+          fee_lago_id
+          fee_item_type
+          fee_item_code
+          fee_item_name
+          fee_item_invoice_display_name
+          fee_item_filter_invoice_display_name
+          fee_item_grouped_by
+          subscription_external_id
+          subscription_plan_code
+          fee_from_date
+          fee_to_date
+          fee_total_amount_cents
+          fee_amount_currency
+          fee_units
+          fee_precise_unit_amount
+          fee_taxes_amount_cents
+        ]
+      end
+    end
+  end
+end

--- a/app/services/data_exports/export_resources_service.rb
+++ b/app/services/data_exports/export_resources_service.rb
@@ -5,6 +5,8 @@ module DataExports
     EXPIRED_FAILURE_MESSAGE = 'Data Export already expired'
     PROCESSED_FAILURE_MESSAGE = 'Data Export already processed'
 
+    ResourceTypeNotSupportedError = Class.new(StandardError)
+
     def initialize(data_export:)
       @data_export = data_export
 
@@ -42,6 +44,10 @@ module DataExports
     def file_data
       case data_export.resource_type
       when "invoices" then Csv::Invoices.call(data_export:)
+      else
+        raise ResourceTypeNotSupportedError.new(
+          "'#{data_export.resource_type}' resource not supported"
+        )
       end
     end
 

--- a/app/services/data_exports/export_resources_service.rb
+++ b/app/services/data_exports/export_resources_service.rb
@@ -44,6 +44,7 @@ module DataExports
     def file_data
       case data_export.resource_type
       when "invoices" then Csv::Invoices.call(data_export:)
+      when "invoice_fees" then Csv::InvoiceFees.call(data_export:)
       else
         raise ResourceTypeNotSupportedError.new(
           "'#{data_export.resource_type}' resource not supported"

--- a/app/views/data_export_mailer/completed.slim
+++ b/app/views/data_export_mailer/completed.slim
@@ -20,7 +20,7 @@ div style='margin-bottom: 32px;width: 80px;height: 24px;'
 div style='margin-bottom: 24px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
   = I18n.t('email.data_export.completed.greetings')
 div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
-  = I18n.t('email.data_export.completed.intro')
+  = I18n.t('email.data_export.completed.intro', resource_type: @resource_type)
 table style='margin-bottom: 32px' width="100%" cellspacing="0" cellpadding="0"
   tr
     td

--- a/config/locales/en/email.yml
+++ b/config/locales/en/email.yml
@@ -16,7 +16,7 @@ en:
       completed:
         fallback_text: If the link has expired, please generate a new one from your Dashboard.
         greetings: Hello
-        intro: Your invoices export is ready! You can download it using the link below, which will be available for 7 days.
+        intro: Your %{resource_type} export is ready! You can download it using the link below, which will be available for 7 days.
         lago_team: The Lago Team
         main_cta_label: Download export
         subject: Your Lago %{resource_type} export in ready!

--- a/spec/mailers/data_export_mailer_spec.rb
+++ b/spec/mailers/data_export_mailer_spec.rb
@@ -9,9 +9,27 @@ RSpec.describe DataExportMailer, type: :mailer do
 
   describe '#completed' do
     let(:mailer) { data_export_mailer.with(data_export:).completed }
+    let(:file_url) { "https://api.lago.dev/rails/active_storage/blobs/redirect/eyJf" }
+
+    before do
+      allow(data_export).to receive(:file_url).and_return(file_url)
+    end
 
     specify do
       expect(mailer.to).to eq([data_export.user.email])
+      expect(mailer.subject).to eq("Your Lago invoices export in ready!")
+      expect(mailer.body.encoded).to match("Your invoices export is ready!")
+      expect(mailer.body.encoded).to match("will be available for 7 days")
+      expect(mailer.body.encoded).to match(data_export.file_url)
+    end
+
+    context "when the resource type is invoice_fees" do
+      let(:data_export) { create(:data_export, :completed, resource_type: 'invoice_fees') }
+
+      specify do
+        expect(mailer.subject).to eq("Your Lago invoice fees export in ready!")
+        expect(mailer.body.encoded).to match("Your invoice fees export is ready!")
+      end
     end
 
     context 'when data export is expired' do

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DataExports::Csv::InvoiceFees do
+  let(:data_export) do
+    create :data_export, :processing, resource_type: 'invoice_fees', resource_query:
+  end
+
+  let(:resource_query) do
+    {
+      currency:,
+      customer_external_id:,
+      invoice_type:,
+      issuing_date_from:,
+      issuing_date_to:,
+      payment_dispute_lost:,
+      payment_overdue:,
+      payment_status:,
+      search_term:,
+      status:
+    }
+  end
+
+  let(:currency) { 'EUR' }
+  let(:customer_external_id) { 'custext123' }
+  let(:invoice_type) { 'credit' }
+  let(:issuing_date_from) { '2023-12-25' }
+  let(:issuing_date_to) { '2024-07-01' }
+  let(:payment_dispute_lost) { false }
+  let(:payment_overdue) { true }
+  let(:payment_status) { 'pending' }
+  let(:search_term) { 'service ABC' }
+  let(:status) { 'finalized' }
+
+  let(:filters) do
+    {
+      "currency" => currency,
+      "customer_external_id" => customer_external_id,
+      "invoice_type" => invoice_type,
+      "issuing_date_from" => issuing_date_from,
+      "issuing_date_to" => issuing_date_to,
+      "payment_dispute_lost" => payment_dispute_lost,
+      "payment_overdue" => payment_overdue,
+      "payment_status" => payment_status
+    }
+  end
+
+  let(:serializer_klass) { class_double('V1::InvoiceSerializer') }
+  let(:invoice_serializer) do
+    instance_double('V1::InvoiceSerializer', serialize: serialized_invoice)
+  end
+
+  let(:invoices_query) { instance_double('InvoicesQuery') }
+  let(:query_results) do
+    BaseService::Result.new.tap do |result|
+      result.invoices = Invoice.all
+    end
+  end
+
+  let(:invoice) { create :invoice }
+  let(:serialized_invoice) do
+    {
+      lago_id: "292ef60b-9e0c-42e7-9f50-44d5af4162ec",
+      number: "TWI-2B86-170-001",
+      issuing_date: "2024-06-06",
+      subscriptions: [
+        {
+          lago_id: "80ebcc26-3703-4577-b13e-765591255df4",
+          external_id: "ff6c279c-9f6c-4962-987e-270936d52310",
+          plan_code: "all_charges"
+        }
+      ],
+      fees: [
+        {
+          lago_id: "cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302",
+          lago_subscription_id: "80ebcc26-3703-4577-b13e-765591255df4",
+          item: {
+            type: "charge",
+            code: "group",
+            name: "group",
+            invoice_display_name: "group",
+            filter_invoice_display_name: "Converted to EUR",
+            grouped_by: {
+              models: "model_1"
+            }
+          },
+          taxes_amount_cents: 0,
+          total_amount_cents: 10000,
+          total_amount_currency: "USD",
+          units: "100.0",
+          precise_unit_amount: "1.0",
+          from_date: "2024-05-08T00:00:00+00:00",
+          to_date: "2024-06-06T12:48:59+00:00"
+        },
+        {
+          lago_id: "5277b901-3da6-4a55-974a-ee1295978e98",
+          lago_subscription_id: "80ebcc26-3703-4577-b13e-765591255df4",
+          item: {
+            type: "charge",
+            code: "group",
+            name: "group",
+            invoice_display_name: "group",
+            filter_invoice_display_name: nil,
+            grouped_by: {
+              models: "model_2"
+            }
+          },
+          taxes_amount_cents: 0,
+          total_amount_cents: 20000,
+          total_amount_currency: "USD",
+          units: "200.0",
+          precise_unit_amount: "1.0",
+          from_date: "2024-05-08T00:00:00+00:00",
+          to_date: "2024-06-06T12:48:59+00:00"
+        },
+        {
+          lago_id: "86d3515f-2c4e-49de-9e81-99f8c22f38ad",
+          lago_subscription_id: "80ebcc26-3703-4577-b13e-765591255df4",
+          item: {
+            type: "charge",
+            code: "group",
+            name: "group",
+            invoice_display_name: "group",
+            filter_invoice_display_name: nil,
+            grouped_by: {
+              models: "model_3"
+            }
+          },
+          taxes_amount_cents: 0,
+          total_amount_cents: 30000,
+          total_amount_currency: "USD",
+          units: "300.0",
+          precise_unit_amount: "1.0",
+          from_date: "2024-05-08T00:00:00+00:00",
+          to_date: "2024-06-06T12:48:59+00:00"
+        },
+        {
+          lago_id: "203e6d6b-a5ff-4eb5-bbb9-01bfdf4f8d22",
+          lago_subscription_id: "80ebcc26-3703-4577-b13e-765591255df4",
+          item: {
+            type: "charge",
+            code: "filters",
+            name: "filters",
+            invoice_display_name: "filters",
+            filter_invoice_display_name: "model_1, input",
+            grouped_by: {}
+          },
+          taxes_amount_cents: 0,
+          total_amount_cents: 0,
+          total_amount_currency: "USD",
+          units: "0.0",
+          precise_unit_amount: "0.0",
+          from_date: "2024-05-08T00:00:00+00:00",
+          to_date: "2024-06-06T12:48:59+00:00"
+        },
+        {
+          lago_id: "af3b0a41-33c3-4f2c-a6e4-62402df59ee3",
+          lago_subscription_id: "80ebcc26-3703-4577-b13e-765591255df4",
+          item: {
+            type: "charge",
+            code: "filters",
+            name: "filters",
+            invoice_display_name: "filters",
+            filter_invoice_display_name: "model_2, output",
+            grouped_by: {}
+          },
+          taxes_amount_cents: 0,
+          total_amount_cents: 0,
+          total_amount_currency: "USD",
+          units: "0.0",
+          precise_unit_amount: "0.0",
+          from_date: "2024-05-08T00:00:00+00:00",
+          to_date: "2024-06-06T12:48:59+00:00"
+        },
+        {
+          lago_id: "282867c6-fa26-4c08-82b4-42d4128d4627",
+          lago_subscription_id: nil,
+          item: {
+            type: "charge",
+            code: "filters",
+            name: "filters",
+            invoice_display_name: "filters",
+            filter_invoice_display_name: nil,
+            grouped_by: {}
+          },
+          taxes_amount_cents: 0,
+          total_amount_cents: 0,
+          total_amount_currency: "USD",
+          units: "0.0",
+          precise_unit_amount: "0.0",
+          from_date: "2024-05-08T00:00:00+00:00",
+          to_date: "2024-06-06T12:48:59+00:00"
+        }
+      ]
+    }
+  end
+
+  before do
+    invoice
+
+    allow(serializer_klass)
+      .to receive(:new)
+      .and_return(invoice_serializer)
+
+    allow(InvoicesQuery)
+      .to receive(:new)
+      .with(organization: data_export.organization)
+      .and_return(invoices_query)
+
+    allow(invoices_query)
+      .to receive(:call)
+      .with(
+        search_term:,
+        status:,
+        page: nil,
+        limit: nil,
+        filters:
+      )
+      .and_return(query_results)
+  end
+
+  describe '#call' do
+    subject(:call) { described_class.new(data_export:, serializer_klass:).call }
+
+    it 'generates the correct CSV output' do
+      expected_csv = <<~CSV
+        invoice_lago_id,invoice_number,invoice_issuing_date,fee_lago_id,fee_item_type,fee_item_code,fee_item_name,fee_item_invoice_display_name,fee_item_filter_invoice_display_name,fee_item_grouped_by,subscription_external_id,subscription_plan_code,fee_from_date,fee_to_date,fee_total_amount_cents,fee_amount_currency,fee_units,fee_precise_unit_amount,fee_taxes_amount_cents
+        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,10000,USD,100.0,1.0,0
+        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,5277b901-3da6-4a55-974a-ee1295978e98,charge,group,group,group,,"{:models=>""model_2""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,20000,USD,200.0,1.0,0
+        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,86d3515f-2c4e-49de-9e81-99f8c22f38ad,charge,group,group,group,,"{:models=>""model_3""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,30000,USD,300.0,1.0,0
+        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,203e6d6b-a5ff-4eb5-bbb9-01bfdf4f8d22,charge,filters,filters,filters,"model_1, input",{},ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,0,USD,0.0,0.0,0
+        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,af3b0a41-33c3-4f2c-a6e4-62402df59ee3,charge,filters,filters,filters,"model_2, output",{},ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,0,USD,0.0,0.0,0
+        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,282867c6-fa26-4c08-82b4-42d4128d4627,charge,filters,filters,filters,,{},,,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,0,USD,0.0,0.0,0
+      CSV
+
+      expect(call).to eq(expected_csv)
+    end
+  end
+end

--- a/spec/services/data_exports/export_resources_service_spec.rb
+++ b/spec/services/data_exports/export_resources_service_spec.rb
@@ -89,5 +89,19 @@ RSpec.describe DataExports::ExportResourcesService, type: :service do
         end
       end
     end
+
+    context "when resource type is not supported" do
+      let(:data_export) { create :data_export, resource_type: 'unknown' }
+
+      it "returns a service failure result" do
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error.code).to eq(
+            "'unknown' resource not supported"
+          )
+          expect(data_export).to be_failed
+        end
+      end
+    end
   end
 end

--- a/spec/services/data_exports/export_resources_service_spec.rb
+++ b/spec/services/data_exports/export_resources_service_spec.rb
@@ -103,5 +103,21 @@ RSpec.describe DataExports::ExportResourcesService, type: :service do
         end
       end
     end
+
+    context "when resource type is invoice_fees" do
+      let(:data_export) { create :data_export, resource_type: 'invoice_fees', format: 'csv' }
+
+      before do
+        allow(DataExports::Csv::InvoiceFees).to receive(:call).and_return(:csv_content)
+      end
+
+      it "calls the Csv::InvoiceFees exporter" do
+        result
+
+        expect(DataExports::Csv::InvoiceFees)
+          .to have_received(:call)
+          .with(data_export:)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/ability-to-export-data-from-the-user-interface

## Context

In order to effortlessly download export of invoice fees by non-technical users, it is required to add a new CSV exporter and extend the export resource service and mailer.

## Description

This change adds a new CSV exporter for invoice fees;

also extends the `ExportResourcesService` to handle unknown resource types and invoice_fees.

and improve the mailer and its specs to support different kind of exported resources like invoice_fees.