### PR TITLE
fix (integration-customers): adapt integration customer queries

### DIFF
--- a/app/graphql/types/credit_notes/object.rb
+++ b/app/graphql/types/credit_notes/object.rb
@@ -58,7 +58,7 @@ module Types
       end
 
       def external_integration_id
-        integration_customer = object.customer&.integration_customers&.first
+        integration_customer = object.customer&.integration_customers&.accounting_kind&.first
 
         return nil unless integration_customer
 

--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -66,7 +66,7 @@ module Types
       end
 
       def external_integration_id
-        integration_customer = object.customer&.integration_customers&.first
+        integration_customer = object.customer&.integration_customers&.accounting_kind&.first
 
         return nil unless integration_customer
 

--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -106,7 +106,7 @@ class CreditNote < ApplicationRecord
   end
 
   def should_sync_credit_note?
-    finalized? && customer.integration_customers.any? { |c| c.integration.sync_credit_notes }
+    finalized? && customer.integration_customers.accounting_kind.any? { |c| c.integration.sync_credit_notes }
   end
 
   def voidable?

--- a/app/models/integration_customers/base_customer.rb
+++ b/app/models/integration_customers/base_customer.rb
@@ -12,6 +12,10 @@ module IntegrationCustomers
 
     validates :customer_id, uniqueness: {scope: :type}
 
+    scope :accounting_kind, -> do
+      where(type: %w[IntegrationCustomers::NetsuiteCustomer IntegrationCustomers::XeroCustomer])
+    end
+
     settings_accessors :sync_with_provider
 
     def self.customer_type(type)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -279,11 +279,11 @@ class Invoice < ApplicationRecord
   end
 
   def should_sync_invoice?
-    finalized? && customer.integration_customers.any? { |c| c.integration.sync_invoices }
+    finalized? && customer.integration_customers.accounting_kind.any? { |c| c.integration.sync_invoices }
   end
 
   def should_sync_sales_order?
-    finalized? && customer.integration_customers.any? { |c| c.integration.sync_sales_orders }
+    finalized? && customer.integration_customers.accounting_kind.any? { |c| c.integration.sync_sales_orders }
   end
 
   private

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -13,6 +13,6 @@ class Payment < ApplicationRecord
   delegate :customer, to: :invoice
 
   def should_sync_payment?
-    invoice.finalized? && customer.integration_customers.any? { |c| c.integration.sync_payments }
+    invoice.finalized? && customer.integration_customers.accounting_kind.any? { |c| c.integration.sync_payments }
   end
 end

--- a/app/services/integrations/aggregator/invoices/base_service.rb
+++ b/app/services/integrations/aggregator/invoices/base_service.rb
@@ -31,7 +31,7 @@ module Integrations
         end
 
         def integration_customer
-          @integration_customer ||= customer&.integration_customers&.first
+          @integration_customer ||= customer&.integration_customers&.accounting_kind&.first
         end
 
         def payload(type)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_06_204557) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_08_195226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -535,7 +535,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_204557) do
 
   create_table "fees_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "fee_id", null: false
-    t.uuid "tax_id", null: false
+    t.uuid "tax_id"
     t.string "tax_description"
     t.string "tax_code", null: false
     t.string "tax_name", null: false
@@ -741,7 +741,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_06_204557) do
 
   create_table "invoices_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "invoice_id", null: false
-    t.uuid "tax_id", null: false
+    t.uuid "tax_id"
     t.string "tax_description"
     t.string "tax_code", null: false
     t.string "tax_name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_08_195226) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_06_204557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -535,7 +535,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_08_195226) do
 
   create_table "fees_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "fee_id", null: false
-    t.uuid "tax_id"
+    t.uuid "tax_id", null: false
     t.string "tax_description"
     t.string "tax_code", null: false
     t.string "tax_name", null: false
@@ -741,7 +741,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_08_195226) do
 
   create_table "invoices_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "invoice_id", null: false
-    t.uuid "tax_id"
+    t.uuid "tax_id", null: false
     t.string "tax_description"
     t.string "tax_code", null: false
     t.string "tax_name", null: false


### PR DESCRIPTION
## Context

Improve integration customer queries

## Description

Currently Accounting integrations, Netsuite and Xero, are supported in Lago but tax integration Anrok is currently being implemented.

This PR improves existing integration customers queries. Customer can have attached ONLY one accounting integration and ONLY one tax integration, but we want to avoid case that tax integration customer is returned in accounting context.
