### PR TITLE
misc: Force external_subscription_id when creating events

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -61,13 +61,9 @@ module Api
       end
 
       def estimate_fees
-        if create_params[:external_subscription_id].blank?
-          Deprecation.report('estimate_fees_missing_external_subscription_id', current_organization.id)
-        end
-
         result = Fees::EstimatePayInAdvanceService.call(
           organization: current_organization,
-          params: estimate_fees_params
+          params: create_params
         )
 
         if result.success?
@@ -93,19 +89,6 @@ module Api
             :transaction_id,
             :code,
             :timestamp,
-            :external_subscription_id,
-            properties: {}
-          )
-      end
-
-      def estimate_fees_params
-        params
-          .require(:event)
-          .permit(
-            :transaction_id,
-            :code,
-            :timestamp,
-            :external_customer_id,
             :external_subscription_id,
             properties: {}
           )

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -67,7 +67,7 @@ module Api
 
         result = Fees::EstimatePayInAdvanceService.call(
           organization: current_organization,
-          params: create_params
+          params: estimate_fees_params
         )
 
         if result.success?
@@ -91,9 +91,21 @@ module Api
           .require(:event)
           .permit(
             :transaction_id,
-            :external_customer_id,
             :code,
             :timestamp,
+            :external_subscription_id,
+            properties: {}
+          )
+      end
+
+      def estimate_fees_params
+        params
+          .require(:event)
+          .permit(
+            :transaction_id,
+            :code,
+            :timestamp,
+            :external_customer_id,
             :external_subscription_id,
             properties: {}
           )
@@ -104,7 +116,6 @@ module Api
           .permit(
             events: [
               :transaction_id,
-              :external_customer_id,
               :code,
               :timestamp,
               :external_subscription_id,

--- a/app/serializers/v1/event_serializer.rb
+++ b/app/serializers/v1/event_serializer.rb
@@ -7,7 +7,6 @@ module V1
         lago_id: model.id,
         transaction_id: model.transaction_id,
         lago_customer_id: model.customer_id,
-        external_customer_id: model.external_customer_id,
         code: model.code,
         timestamp: model.timestamp.iso8601(3),
         properties: model.properties,

--- a/app/services/events/create_batch_service.rb
+++ b/app/services/events/create_batch_service.rb
@@ -40,7 +40,6 @@ module Events
         event.organization_id = organization.id
         event.code = event_params[:code]
         event.transaction_id = event_params[:transaction_id]
-        event.external_customer_id = event_params[:external_customer_id]
         event.external_subscription_id = event_params[:external_subscription_id]
         event.properties = event_params[:properties] || {}
         event.metadata = metadata || {}

--- a/app/services/events/create_service.rb
+++ b/app/services/events/create_service.rb
@@ -15,7 +15,6 @@ module Events
       event.organization_id = organization.id
       event.code = params[:code]
       event.transaction_id = params[:transaction_id]
-      event.external_customer_id = params[:external_customer_id]
       event.external_subscription_id = params[:external_subscription_id]
       event.properties = params[:properties] || {}
       event.metadata = metadata || {}

--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -48,11 +48,7 @@ module Events
     def customer
       return @customer if defined? @customer
 
-      @customer = if event.external_subscription_id
-        organization.subscriptions.find_by(external_id: event.external_subscription_id)&.customer
-      else
-        Customer.find_by(external_id: event.external_customer_id, organization_id: organization.id)
-      end
+      @customer = organization.subscriptions.find_by(external_id: event.external_subscription_id)&.customer
     end
 
     def subscriptions

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -13,7 +13,6 @@ FactoryBot.define do
     code { Faker::Alphanumeric.alphanumeric(number: 10) }
     timestamp { Time.current }
 
-    external_customer_id { customer.external_id }
     external_subscription_id { subscription.external_id }
   end
 
@@ -31,7 +30,6 @@ FactoryBot.define do
     end
 
     organization_id { source_organization.id }
-    external_customer_id { source_customer.external_id }
     external_subscription_id { source_subscription.external_id }
 
     transaction_id { "tr_#{SecureRandom.hex}" }

--- a/spec/requests/api/v1/events_controller_spec.rb
+++ b/spec/requests/api/v1/events_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
           event: {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
             timestamp: Time.current.to_i,
             properties: {
               foo: 'bar'
@@ -30,7 +30,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
       end.to change(Event, :count).by(1)
 
       expect(response).to have_http_status(:success)
-      expect(json[:event][:external_customer_id]).to eq(customer.external_id)
+      expect(json[:event][:external_subscription_id]).to eq(subscription.external_id)
     end
 
     context 'with duplicated transaction_id' do
@@ -46,7 +46,6 @@ RSpec.describe Api::V1::EventsController, type: :request do
             event: {
               code: metric.code,
               transaction_id: event.transaction_id,
-              external_customer_id: customer.external_id,
               external_subscription_id: subscription.external_id,
               timestamp: Time.current.to_i,
               properties: {
@@ -71,7 +70,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
             {
               code: metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               timestamp: Time.current.to_i,
               properties: {
                 foo: 'bar'
@@ -82,7 +81,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
       end.to change(Event, :count).by(1)
 
       expect(response).to have_http_status(:ok)
-      expect(json[:events].first[:external_customer_id]).to eq(customer.external_id)
+      expect(json[:events].first[:external_subscription_id]).to eq(subscription.external_id)
     end
   end
 

--- a/spec/scenarios/billable_metrics/sum_spec.rb
+++ b/spec/scenarios/billable_metrics/sum_spec.rb
@@ -44,7 +44,6 @@ describe 'Aggregation - Sum Scenarios', :scenarios, type: :request, transaction:
           {
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription.external_id,
             properties: {
               'item_id' => 10,
@@ -67,7 +66,6 @@ describe 'Aggregation - Sum Scenarios', :scenarios, type: :request, transaction:
           {
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription.external_id,
             properties: {
               'item_id' => -5,
@@ -90,7 +88,6 @@ describe 'Aggregation - Sum Scenarios', :scenarios, type: :request, transaction:
           {
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription.external_id,
             properties: {
               'item_id' => 2,
@@ -155,7 +152,6 @@ describe 'Aggregation - Sum Scenarios', :scenarios, type: :request, transaction:
           {
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription1.external_id,
             properties: {
               'item_id' => 10,
@@ -178,7 +174,6 @@ describe 'Aggregation - Sum Scenarios', :scenarios, type: :request, transaction:
           {
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription1.external_id,
             properties: {
               'item_id' => -5,
@@ -201,7 +196,6 @@ describe 'Aggregation - Sum Scenarios', :scenarios, type: :request, transaction:
           {
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription1.external_id,
             properties: {
               'item_id' => 2,
@@ -224,7 +218,6 @@ describe 'Aggregation - Sum Scenarios', :scenarios, type: :request, transaction:
           {
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription2.external_id,
             properties: {
               'item_id' => 10,
@@ -245,7 +238,6 @@ describe 'Aggregation - Sum Scenarios', :scenarios, type: :request, transaction:
           {
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription2.external_id,
             properties: {
               'item_id' => -5,
@@ -266,7 +258,6 @@ describe 'Aggregation - Sum Scenarios', :scenarios, type: :request, transaction:
           {
             code: billable_metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription2.external_id,
             properties: {
               'item_id' => 2,

--- a/spec/scenarios/billable_metrics/weighted_sum_spec.rb
+++ b/spec/scenarios/billable_metrics/weighted_sum_spec.rb
@@ -30,7 +30,7 @@ describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request, tra
         {
           code: billable_metric.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
           properties: {value: '2500'}
         }
       )
@@ -64,7 +64,7 @@ describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request, tra
         {
           code: billable_metric.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
           properties: {value: '-2000'}
         }
       )
@@ -75,7 +75,7 @@ describe 'Aggregation - Weighted Sum Scenarios', :scenarios, type: :request, tra
         {
           code: billable_metric.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: subscription.external_id,
           properties: {value: '-200'}
         }
       )

--- a/spec/scenarios/charge_models/percentage_spec.rb
+++ b/spec/scenarios/charge_models/percentage_spec.rb
@@ -40,7 +40,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '10'}
             }
           )
@@ -53,7 +53,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '10'}
             }
           )
@@ -65,7 +65,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '10'}
             }
           )
@@ -77,7 +77,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '10'}
             }
           )
@@ -113,7 +113,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '4'}
             }
           )
@@ -128,7 +128,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '4'}
             }
           )
@@ -142,7 +142,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '4'}
             }
           )
@@ -156,7 +156,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '4'}
             }
           )
@@ -171,7 +171,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '10'}
             }
           )
@@ -212,7 +212,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '1'}
             }
           )
@@ -225,7 +225,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '1'}
             }
           )
@@ -237,7 +237,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '1'}
             }
           )
@@ -249,7 +249,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '1'}
             }
           )
@@ -290,7 +290,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '10'}
             }
           )
@@ -303,7 +303,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '10'}
             }
           )
@@ -316,7 +316,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '10'}
             }
           )
@@ -359,7 +359,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '100'}
             }
           )
@@ -373,7 +373,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '1000'}
             }
           )
@@ -387,7 +387,7 @@ describe 'Charge Models - Percentage Scenarios', :scenarios, type: :request do
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '10000'}
             }
           )

--- a/spec/scenarios/charge_models/prorated_graduated_spec.rb
+++ b/spec/scenarios/charge_models/prorated_graduated_spec.rb
@@ -70,7 +70,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '2'}
             }
           )
@@ -86,7 +86,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '5'}
             }
           )
@@ -102,7 +102,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '-6'}
             }
           )
@@ -118,7 +118,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '10'}
             }
           )
@@ -134,7 +134,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '4'}
             }
           )
@@ -150,7 +150,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '60'}
             }
           )
@@ -187,7 +187,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '20'}
             }
           )
@@ -292,7 +292,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: customer.external_id,
                 properties: {amount: '2'}
               }
             )
@@ -461,7 +461,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: customer.external_id,
                 properties: {amount: '2'}
               }
             )
@@ -472,7 +472,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: customer.external_id,
                 properties: {amount: '5'}
               }
             )
@@ -483,7 +483,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: customer.external_id,
                 properties: {amount: '-6'}
               }
             )
@@ -494,7 +494,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: customer.external_id,
                 properties: {amount: '10'}
               }
             )
@@ -505,7 +505,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: customer.external_id,
                 properties: {amount: '4'}
               }
             )
@@ -516,7 +516,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: customer.external_id,
                 properties: {amount: '60'}
               }
             )
@@ -553,7 +553,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: customer.external_id,
                 properties: {amount: '20'}
               }
             )
@@ -687,7 +687,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '1111', operation_type: 'add'}
             }
           )
@@ -703,7 +703,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '1111', operation_type: 'remove'}
             }
           )
@@ -719,7 +719,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '1111', operation_type: 'add'}
             }
           )
@@ -735,7 +735,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '2222', operation_type: 'add'}
             }
           )
@@ -751,7 +751,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '2222', operation_type: 'add'}
             }
           )
@@ -767,7 +767,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '3333', operation_type: 'add'}
             }
           )
@@ -804,7 +804,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '4444', operation_type: 'add'}
             }
           )
@@ -860,7 +860,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '1111', operation_type: 'add'}
             }
           )
@@ -876,7 +876,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '2222', operation_type: 'add'}
             }
           )
@@ -892,7 +892,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '3333', operation_type: 'add'}
             }
           )
@@ -908,7 +908,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '4444', operation_type: 'add'}
             }
           )
@@ -924,7 +924,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '5555', operation_type: 'add'}
             }
           )
@@ -940,7 +940,7 @@ describe 'Charge Models - Prorated Graduated Scenarios', :scenarios, type: :requ
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {amount: '6666', operation_type: 'add'}
             }
           )

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/monthly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '15'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '25'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '30'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/quarterly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '15'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '25'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '30'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/weekly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '15'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '25'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '30'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_advance/anniversary/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/anniversary/yearly_spec.rb
@@ -110,7 +110,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '2'}
         }
       )
@@ -119,7 +119,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '1'}
         }
       )
@@ -128,7 +128,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '30'}
         }
       )
@@ -158,7 +158,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
                 {
                   code: billable_metric_advance_metered.code,
                   transaction_id: SecureRandom.uuid,
-                  external_customer_id: customer.external_id,
+                  external_subscription_id: customer.external_id,
                   properties: {total: '55'}
                 }
               )
@@ -169,7 +169,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
                 {
                   code: billable_metric_metered.code,
                   transaction_id: SecureRandom.uuid,
-                  external_customer_id: customer.external_id,
+                  external_subscription_id: customer.external_id,
                   properties: {total: '1'}
                 }
               )

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/monthly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '15'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '25'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '30'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/quarterly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '15'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '25'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '30'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/weekly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '15'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '25'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '30'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_advance/calendar/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance/calendar/yearly_spec.rb
@@ -110,7 +110,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '2'}
         }
       )
@@ -119,7 +119,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '1'}
         }
       )
@@ -128,7 +128,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
         {
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '30'}
         }
       )
@@ -156,7 +156,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
             {
               code: billable_metric_advance_metered.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {total: '55'}
             }
           )
@@ -167,7 +167,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
             {
               code: billable_metric_metered.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {total: '1'}
             }
           )

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/monthly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/quarterly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/weekly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_arrears/anniversary/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/anniversary/yearly_spec.rb
@@ -110,7 +110,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '2'}
         }
       )
@@ -119,7 +119,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '1'}
         }
       )
@@ -128,7 +128,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '30'}
         }
       )
@@ -158,7 +158,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
                 {
                   code: billable_metric_advance_metered.code,
                   transaction_id: SecureRandom.uuid,
-                  external_customer_id: customer.external_id,
+                  external_subscription_id: customer.external_id,
                   properties: {total: '55'}
                 }
               )
@@ -169,7 +169,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
                 {
                   code: billable_metric_metered.code,
                   transaction_id: SecureRandom.uuid,
-                  external_customer_id: customer.external_id,
+                  external_subscription_id: customer.external_id,
                   properties: {total: '1'}
                 }
               )

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/monthly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/monthly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/quarterly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/quarterly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/weekly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/weekly_spec.rb
@@ -107,7 +107,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_recurring_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -116,7 +116,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )
@@ -125,7 +125,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered_advance.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '10'}
         }
       )

--- a/spec/scenarios/commitments/minimum/in_arrears/calendar/yearly_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_arrears/calendar/yearly_spec.rb
@@ -110,7 +110,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '2'}
         }
       )
@@ -119,7 +119,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '1'}
         }
       )
@@ -128,7 +128,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
         {
           code: billable_metric_advance_metered.code,
           transaction_id: SecureRandom.uuid,
-          external_customer_id: customer.external_id,
+          external_subscription_id: customer.external_id,
           properties: {total: '30'}
         }
       )
@@ -158,7 +158,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
             {
               code: billable_metric_advance_metered.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {total: '55'}
             }
           )
@@ -169,7 +169,7 @@ describe 'Billing Minimum Commitments In Arrears Scenario', :scenarios, type: :r
             {
               code: billable_metric_metered.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: customer.external_id,
               properties: {total: '1'}
             }
           )

--- a/spec/scenarios/invoices/invoices_spec.rb
+++ b/spec/scenarios/invoices/invoices_spec.rb
@@ -572,7 +572,6 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription.external_id,
             properties: {amount: '5'}
           }
@@ -662,7 +661,6 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription.external_id,
             properties: {amount: '5'}
           }
@@ -750,7 +748,6 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription.external_id,
             properties: {amount: '10'}
           }
@@ -794,7 +791,6 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: active_subscription.external_id,
             properties: {amount: '10000'}
           }
@@ -879,7 +875,6 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription.external_id,
             properties: {amount: '5'}
           }
@@ -969,7 +964,7 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
               code: metric.code,
               transaction_id: SecureRandom.uuid,
               organization_id: organization.id,
-              external_customer_id: customer.external_id
+              external_subscription_id: subscription.external_id
             }
           )
         end
@@ -1039,7 +1034,6 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription.external_id,
             properties: {amount: '5'}
           }
@@ -1305,7 +1299,6 @@ describe 'Invoices Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
             external_subscription_id: subscription.external_id,
             properties: {amount: '5'}
           }

--- a/spec/scenarios/pay_in_advance_charges_spec.rb
+++ b/spec/scenarios/pay_in_advance_charges_spec.rb
@@ -46,7 +46,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id
+              external_subscription_id: subscription.external_id
             }
           )
         end.to change { subscription.reload.fees.count }.from(0).to(1)
@@ -70,7 +70,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id
+              external_subscription_id: subscription.external_id
             }
           )
         end.to change { subscription.reload.fees.count }.from(1).to(2)
@@ -125,7 +125,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {unique_id: 'id_1'}
             }
           )
@@ -150,7 +150,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {unique_id: 'id_1', operation_type: 'remove'}
             }
           )
@@ -175,7 +175,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {unique_id: 'id_1'}
             }
           )
@@ -200,7 +200,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {unique_id: 'id_2'}
             }
           )
@@ -224,7 +224,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {unique_id: 'id_2'}
             }
           )
@@ -249,7 +249,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {unique_id: 'id_3'}
             }
           )
@@ -274,7 +274,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {unique_id: 'id_3', operation_type: 'remove'}
             }
           )
@@ -330,7 +330,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '10'}
             }
           )
@@ -352,7 +352,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '-4'}
             }
           )
@@ -370,7 +370,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '8'}
             }
           )
@@ -424,7 +424,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id:,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '10', region: 'europe'}
             }
           )
@@ -491,7 +491,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id:,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '10', region: 'africa', cloud: 'AWS'}
             }
           )
@@ -552,7 +552,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '3'}
             }
           )
@@ -574,7 +574,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '1'}
             }
           )
@@ -592,7 +592,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '2'}
             }
           )
@@ -659,7 +659,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '3'}
             }
           )
@@ -681,7 +681,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '1'}
             }
           )
@@ -699,7 +699,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '2'}
             }
           )
@@ -753,7 +753,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '8'}
             }
           )
@@ -768,7 +768,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: subscription.external_id,
                 properties: {amount: '5'}
               }
             )
@@ -791,7 +791,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '3'}
             }
           )
@@ -846,7 +846,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '2'}
             }
           )
@@ -861,7 +861,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: subscription.external_id,
                 properties: {amount: '1'}
               }
             )
@@ -921,7 +921,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: subscription.external_id,
                 properties: {amount: '100'}
               }
             )
@@ -948,7 +948,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: subscription.external_id,
                 properties: {amount: '1000'}
               }
             )
@@ -975,7 +975,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: subscription.external_id,
                 properties: {amount: '10000'}
               }
             )
@@ -1036,7 +1036,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '5'}
             }
           )
@@ -1058,7 +1058,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
             {
               code: billable_metric.code,
               transaction_id: SecureRandom.uuid,
-              external_customer_id: customer.external_id,
+              external_subscription_id: subscription.external_id,
               properties: {amount: '1'}
             }
           )
@@ -1115,7 +1115,7 @@ describe 'Pay in advance charges Scenarios', :scenarios, type: :request, transac
               {
                 code: billable_metric.code,
                 transaction_id: SecureRandom.uuid,
-                external_customer_id: customer.external_id,
+                external_subscription_id: subscription.external_id,
                 properties: {amount: '5'}
               }
             )

--- a/spec/scenarios/spending_minimum_spec.rb
+++ b/spec/scenarios/spending_minimum_spec.rb
@@ -53,7 +53,7 @@ describe 'Spending Minimum Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id
+            external_subscription_id: subscription.external_id
           }
         )
 
@@ -173,7 +173,7 @@ describe 'Spending Minimum Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
             properties: {
               region: 'usa'
             }
@@ -184,7 +184,7 @@ describe 'Spending Minimum Scenarios', :scenarios, type: :request do
           {
             code: metric.code,
             transaction_id: SecureRandom.uuid,
-            external_customer_id: customer.external_id,
+            external_subscription_id: subscription.external_id,
             properties: {
               region: 'europe'
             }

--- a/spec/scenarios/subscriptions/free_trial_billing_spec.rb
+++ b/spec/scenarios/subscriptions/free_trial_billing_spec.rb
@@ -30,7 +30,11 @@ describe 'Free Trial Billing Subscriptions Scenario', :scenarios, type: :request
 
   def create_usage_event!
     create_event(
-      {code: billable_metric.code, transaction_id: SecureRandom.uuid, external_customer_id: customer.external_id}
+      {
+        code: billable_metric.code,
+        transaction_id: SecureRandom.uuid,
+        external_subscription_id: customer.external_id
+      }
     )
   end
 

--- a/spec/serializers/v1/event_error_serializer_spec.rb
+++ b/spec/serializers/v1/event_error_serializer_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe ::V1::EventErrorSerializer do
         'lago_id' => event_error.event.id,
         'transaction_id' => event_error.event.transaction_id,
         'lago_customer_id' => nil,
-        'external_customer_id' => event_error.event.external_customer_id,
         'code' => event_error.event.code,
         'timestamp' => event_error.event.timestamp.iso8601(3),
         'properties' => event_error.event.properties,

--- a/spec/serializers/v1/event_serializer_spec.rb
+++ b/spec/serializers/v1/event_serializer_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe ::V1::EventSerializer do
         'lago_id' => event.id,
         'transaction_id' => event.transaction_id,
         'lago_customer_id' => event.customer_id,
-        'external_customer_id' => event.external_customer_id,
         'code' => event.code,
         'timestamp' => event.timestamp.iso8601(3),
         'properties' => event.properties,

--- a/spec/services/events/create_service_spec.rb
+++ b/spec/services/events/create_service_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Events::CreateService, type: :service do
   let(:organization) { create(:organization) }
 
   let(:code) { 'sum_agg' }
-  let(:external_customer_id) { SecureRandom.uuid }
   let(:external_subscription_id) { SecureRandom.uuid }
   let(:timestamp) { Time.current.to_f }
   let(:transaction_id) { SecureRandom.uuid }
@@ -24,7 +23,6 @@ RSpec.describe Events::CreateService, type: :service do
 
   let(:create_args) do
     {
-      external_customer_id:,
       external_subscription_id:,
       code:,
       transaction_id:,
@@ -44,7 +42,6 @@ RSpec.describe Events::CreateService, type: :service do
 
         expect(result).to be_success
         expect(result.event).to have_attributes(
-          external_customer_id:,
           external_subscription_id:,
           transaction_id:,
           code:,

--- a/spec/services/events/post_process_service_spec.rb
+++ b/spec/services/events/post_process_service_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Events::PostProcessService, type: :service do
   let(:billable_metric) { create(:billable_metric, organization:) }
 
   let(:started_at) { Time.current - 3.days }
-  let(:external_customer_id) { customer.external_id }
   let(:external_subscription_id) { subscription.external_id }
   let(:code) { billable_metric&.code }
   let(:timestamp) { Time.current - 1.second }
@@ -22,7 +21,6 @@ RSpec.describe Events::PostProcessService, type: :service do
     create(
       :event,
       organization_id: organization.id,
-      external_customer_id:,
       external_subscription_id:,
       timestamp:,
       code:,
@@ -31,68 +29,12 @@ RSpec.describe Events::PostProcessService, type: :service do
   end
 
   describe '#call' do
-    context 'without external customer id' do
-      let(:external_customer_id) { nil }
+    it 'assigns the customer external_id' do
+      result = process_service.call
 
-      it 'assigns the customer external_id' do
-        result = process_service.call
-
-        aggregate_failures do
-          expect(result).to be_success
-
-          expect(event.external_customer_id).to eq(customer.external_id)
-        end
-      end
-
-      context 'with multiple active subscription' do
-        let(:second_subscription) { create(:subscription, organization:, customer:, started_at:) }
-
-        before { second_subscription }
-
-        it 'assigns the subscription external_id' do
-          result = process_service.call
-
-          aggregate_failures do
-            expect(result).to be_success
-
-            expect(event.external_customer_id).to eq(customer.external_id)
-          end
-        end
-      end
-    end
-
-    context 'without external subscription id' do
-      let(:external_subscription_id) { nil }
-
-      before { subscription }
-
-      context 'with a single customer subscription' do
-        it 'assigns the subscription external_id' do
-          result = process_service.call
-
-          aggregate_failures do
-            expect(result).to be_success
-
-            expect(event.external_subscription_id).to eq(subscription.external_id)
-          end
-        end
-      end
-
-      context 'with multiple active subscription' do
-        let(:second_subscription) { create(:subscription, organization:, customer:, started_at:) }
-
-        before { second_subscription }
-
-        it 'does not assigns the subscription external_id' do
-          result = process_service.call
-
-          aggregate_failures do
-            expect(result).to be_success
-
-            expect(event.external_customer_id).to eq(customer.external_id)
-            expect(event.external_subscription_id).to be_nil
-          end
-        end
+      aggregate_failures do
+        expect(result).to be_success
+        expect(event.external_customer_id).to eq(customer.external_id)
       end
     end
 


### PR DESCRIPTION
## Context

Related to https://docs.getlago.com/guide/migration/migration-to-v1.2.0#2-mandatory-external-subscription-id-field-in-event-payloads

## Description

This PR forces `external_subscription_id` when creating events