### PR TITLE
feat(events): Track event sent without external_subscription_id for /estimate_fees

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -61,6 +61,10 @@ module Api
       end
 
       def estimate_fees
+        if create_params[:external_subscription_id].blank?
+          Deprecation.report('estimate_fees_missing_external_subscription_id', current_organization.id)
+        end
+
         result = Fees::EstimatePayInAdvanceService.call(
           organization: current_organization,
           params: create_params

--- a/spec/requests/api/v1/events_controller_spec.rb
+++ b/spec/requests/api/v1/events_controller_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
     before do
       charge
       tax
+      allow(Deprecation).to receive(:report)
     end
 
     it 'returns a success' do
@@ -147,6 +148,8 @@ RSpec.describe Api::V1::EventsController, type: :request do
         expect(response).to have_http_status(:success)
 
         expect(json[:fees].count).to eq(1)
+
+        expect(Deprecation).to have_received(:report).with('estimate_fees_missing_external_subscription_id', organization.id)
 
         fee = json[:fees].first
         expect(fee[:lago_id]).to be_nil
@@ -171,7 +174,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
           '/api/v1/events/estimate_fees',
           event: {
             code: metric.code,
-            external_customer_id: nil,
+            external_subscription_id: nil,
             properties: {
               foo: 'bar'
             }
@@ -179,7 +182,29 @@ RSpec.describe Api::V1::EventsController, type: :request do
         )
 
         aggregate_failures do
+          expect(Deprecation).to have_received(:report).with('estimate_fees_missing_external_subscription_id', organization.id)
           expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context 'with external_subscription_id' do
+      it 'returns a success' do
+        post_with_token(
+          organization,
+          '/api/v1/events/estimate_fees',
+          event: {
+            code: metric.code,
+            external_subscription_id: subscription.external_id,
+            properties: {
+              foo: 'bar'
+            }
+          }
+        )
+
+        aggregate_failures do
+          expect(Deprecation).not_to have_received(:report)
+          expect(response).to have_http_status(:success)
         end
       end
     end
@@ -201,6 +226,7 @@ RSpec.describe Api::V1::EventsController, type: :request do
         )
 
         aggregate_failures do
+          expect(Deprecation).to have_received(:report).with('estimate_fees_missing_external_subscription_id', organization.id)
           expect(response).to have_http_status(:unprocessable_entity)
         end
       end


### PR DESCRIPTION
## Context

All events sent to Lago must include `external_subscription_id`.

## Description

Track event sent to `/api/v1/events/estimate_fees` without the `external_subscription_id`

See https://github.com/getlago/lago-api/pull/2056
