### PR TITLE
chore(ci): check if schema.rb is out of sync

### DIFF
--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -54,3 +54,12 @@ jobs:
         run: bin/rails db:migrate:primary
       - name: Perform Clickhouse database migrations
         run: bin/rails db:migrate:clickhouse
+      - name: Compare schema.rb with database
+        run: |
+          if git diff-index --quiet HEAD -- db/schema.rb; then
+            echo "The schema.rb is clean!"
+          else
+            echo "The schema.rb seems out of sync."
+            echo "Please run `lago exec api bin/rails db:drop db:create db:migrate:primary db:schema:dump RAILS_ENV=test` locally and commit the changes."
+            exit 1
+          fi


### PR DESCRIPTION
`schema.rb` easily gets out of sync.

I'm toying with the idea of testing it on CI but I'm afraid it would break too often and it would be annoying.

Ideally, I'd prefer to [make this work](https://github.com/getlago/lago-api/pull/1888) and stop committing the file.