### PR TITLE
fix: disable transaction on migration

### DIFF
--- a/db/migrate/20240701184757_add_deleted_at_to_fees.rb
+++ b/db/migrate/20240701184757_add_deleted_at_to_fees.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDeletedAtToFees < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 

--- a/db/migrate/20240701184757_add_deleted_at_to_fees.rb
+++ b/db/migrate/20240701184757_add_deleted_at_to_fees.rb
@@ -1,8 +1,8 @@
-# frozen_string_literal: true
-
 class AddDeletedAtToFees < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
   def change
     add_column :fees, :deleted_at, :datetime
-    add_index :fees, :deleted_at
+    add_index :fees, :deleted_at, algorithm: :concurrently
   end
 end


### PR DESCRIPTION
## Context
Uses disable_ddl_transaction! to execute the migration outside of a transaction, allowing for concurrent index creation.