### PR TITLE
fix: add disable_ddl_transaction

### DIFF
--- a/db/migrate/20240611074215_add_payment_overdue_to_invoices.rb
+++ b/db/migrate/20240611074215_add_payment_overdue_to_invoices.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
 class AddPaymentOverdueToInvoices < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
   def change
     add_column :invoices, :payment_overdue, :boolean, default: false
-    add_index :invoices, :payment_overdue
+    add_index :invoices, :payment_overdue, algorithm: :concurrently
 
     reversible do |dir|
       dir.up do
         # Set existing invoices as payment_overdue
         execute <<-SQL
           UPDATE invoices
-            SET payment_overdue = true
-            WHERE status = 1 -- finalized
+          SET payment_overdue = true
+          WHERE status = 1 -- finalized
             AND payment_status != 1 -- not succeeded
             AND payment_dispute_lost_at IS NULL -- not lost dispute
             AND payment_due_date < NOW(); -- due date is in the past

--- a/db/migrate/20240619082054_add_in_advance_charge_periodic_invoicing_reason.rb
+++ b/db/migrate/20240619082054_add_in_advance_charge_periodic_invoicing_reason.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AddInAdvanceChargePeriodicInvoicingReason < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
   def up
     execute <<-SQL
       ALTER TYPE subscription_invoicing_reason ADD VALUE IF NOT EXISTS 'in_advance_charge_periodic';


### PR DESCRIPTION
## Context
Uses disable_ddl_transaction! to execute the migration outside of a transaction, allowing for concurrent index creation.