### PR TITLE
fix(export-invoices): Namespace DataExports graphQL enum types

### DIFF
--- a/app/graphql/types/data_exports/format_type_enum.rb
+++ b/app/graphql/types/data_exports/format_type_enum.rb
@@ -3,6 +3,8 @@
 module Types
   module DataExports
     class FormatTypeEnum < Types::BaseEnum
+      graphql_name 'DataExportFormatTypeEnum'
+
       DataExport::EXPORT_FORMATS.each do |format|
         value format
       end

--- a/app/graphql/types/data_exports/status_enum.rb
+++ b/app/graphql/types/data_exports/status_enum.rb
@@ -3,6 +3,8 @@
 module Types
   module DataExports
     class StatusEnum < Types::BaseEnum
+      graphql_name 'DataExportStatusEnum'
+
       DataExport::STATUSES.each do |status|
         value status
       end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1909,7 +1909,7 @@ input CreateDataExportsInvoicesInput {
   """
   clientMutationId: String
   filters: FiltersInput!
-  format: FormatTypeEnum!
+  format: DataExportFormatTypeEnum!
   resourceType: ExportTypeEnum!
 }
 
@@ -3119,7 +3119,18 @@ type CustomerUsage {
 
 type DataExport {
   id: ID!
-  status: StatusEnum!
+  status: DataExportStatusEnum!
+}
+
+enum DataExportFormatTypeEnum {
+  csv
+}
+
+enum DataExportStatusEnum {
+  completed
+  failed
+  pending
+  processing
 }
 
 """
@@ -3651,10 +3662,6 @@ type FinalizedInvoiceCollection {
 type FinalizedInvoiceCollectionCollection {
   collection: [FinalizedInvoiceCollection!]!
   metadata: CollectionMetadata!
-}
-
-enum FormatTypeEnum {
-  csv
 }
 
 """
@@ -5985,13 +5992,6 @@ input RevokeMembershipInput {
   """
   clientMutationId: String
   id: ID!
-}
-
-enum StatusEnum {
-  completed
-  failed
-  pending
-  processing
 }
 
 enum StatusTypeEnum {

--- a/schema.json
+++ b/schema.json
@@ -7714,7 +7714,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "FormatTypeEnum",
+                  "name": "DataExportFormatTypeEnum",
                   "ofType": null
                 }
               },
@@ -13412,7 +13412,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "ENUM",
-                  "name": "StatusEnum",
+                  "name": "DataExportStatusEnum",
                   "ofType": null
                 }
               },
@@ -13425,6 +13425,58 @@
           ],
           "inputFields": null,
           "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "DataExportFormatTypeEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "csv",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "DataExportStatusEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "pending",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "processing",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "completed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "failed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
         },
         {
           "kind": "INPUT_OBJECT",
@@ -16729,23 +16781,6 @@
           "fields": null,
           "inputFields": null,
           "enumValues": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "FormatTypeEnum",
-          "description": null,
-          "interfaces": null,
-          "possibleTypes": null,
-          "fields": null,
-          "inputFields": null,
-          "enumValues": [
-            {
-              "name": "csv",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ]
         },
         {
           "kind": "INPUT_OBJECT",
@@ -31052,41 +31087,6 @@
             }
           ],
           "enumValues": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "StatusEnum",
-          "description": null,
-          "interfaces": null,
-          "possibleTypes": null,
-          "fields": null,
-          "inputFields": null,
-          "enumValues": [
-            {
-              "name": "pending",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "processing",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "completed",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "failed",
-              "description": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ]
         },
         {
           "kind": "ENUM",

--- a/spec/graphql/types/data_exports/object_spec.rb
+++ b/spec/graphql/types/data_exports/object_spec.rb
@@ -6,5 +6,5 @@ RSpec.describe Types::DataExports::Object do
   subject { described_class }
 
   it { is_expected.to have_field(:id).of_type('ID!') }
-  it { is_expected.to have_field(:status).of_type('StatusEnum!') }
+  it { is_expected.to have_field(:status).of_type('DataExportStatusEnum!') }
 end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/ability-to-export-data-from-the-user-interface


## Description

namespace graphQL data export types