### PR TITLE
fix(stripe): nil result on small amount

### DIFF
--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -54,7 +54,7 @@ module Invoices
       rescue Stripe::AuthenticationError, Stripe::CardError, Stripe::InvalidRequestError, Stripe::PermissionError => e
         # NOTE: Do not mark the invoice as failed if the amount is too small for Stripe
         #       For now we keep it as pending, the user can still update it manually
-        return if e.code == 'amount_too_small'
+        return result if e.code == 'amount_too_small'
 
         deliver_error_webhook(e)
         update_invoice_payment_status(payment_status: :failed, deliver_webhook: false)


### PR DESCRIPTION
## Context

In some cases on small invoice amount, the  `Invoices::Payments::StripeCreateJob` is raising a `NoMethodError: undefined method `raise_if_error!' for nil`

## Description

This PR fixes this issue ba ensuring that a `result` is returned by the `Invoices::Payments::StripeCreateService` 
