### PR TITLE
misc: Add LAGO_CLICKHOUSE_MIGRATIONS_ENABLED env

### DIFF
--- a/.github/workflows/migrations-test.yml
+++ b/.github/workflows/migrations-test.yml
@@ -31,6 +31,7 @@ jobs:
       SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
       LAGO_FROM_EMAIL: noreply@getlago.com
       LAGO_CLICKHOUSE_ENABLED: true
+      LAGO_CLICKHOUSE_MIGRATIONS_ENABLED: true
       LAGO_CLICKHOUSE_HOST: localhost
       LAGO_CLICKHOUSE_DATABASE: default
       LAGO_CLICKHOUSE_USERNAME: ""

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -39,6 +39,7 @@ jobs:
       SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
       LAGO_FROM_EMAIL: noreply@getlago.com
       LAGO_CLICKHOUSE_ENABLED: true
+      LAGO_CLICKHOUSE_MIGRATIONS_ENABLED: true
       LAGO_CLICKHOUSE_HOST: localhost
       LAGO_CLICKHOUSE_DATABASE: default
       LAGO_CLICKHOUSE_USERNAME: ""

--- a/config/database.yml
+++ b/config/database.yml
@@ -26,7 +26,7 @@ development:
     password: default
     migrations_paths: db/clickhouse_migrate
     debug: true
-    database_tasks: <% if ENV['LAGO_CLICKHOUSE_ENABLED'].present? %> true <% else %> false <% end %>
+    database_tasks: <% if ENV['LAGO_CLICKHOUSE_MIGRATIONS_ENABLED'].present? %> true <% else %> false <% end %>
 
 test:
   primary:
@@ -46,7 +46,7 @@ test:
     password: <%= ENV.fetch('LAGO_CLICKHOUSE_PASSWORD', 'default') %>
     migrations_paths: db/clickhouse_migrate
     debug: true
-    database_tasks: <% if ENV['LAGO_CLICKHOUSE_ENABLED'].present? %> true <% else %> false <% end %>
+    database_tasks: <% if ENV['LAGO_CLICKHOUSE_MIGRATIONS_ENABLED'].present? %> true <% else %> false <% end %>
     schema_dump: <% if ENV['LAGO_DISABLE_SCHEMA_DUMP'].present? %> false <% else %> clickhouse_schema.rb <% end %>
 
 staging:
@@ -66,7 +66,7 @@ staging:
     password: <%= ENV['LAGO_CLICKHOUSE_PASSWORD'] %>
     migrations_paths: db/clickhouse_migrate
     debug: false
-    database_tasks: <% if ENV['LAGO_CLICKHOUSE_ENABLED'].present? %> true <% else %> false <% end %>
+    database_tasks: <% if ENV['LAGO_CLICKHOUSE_MIGRATIONS_ENABLED'].present? %> true <% else %> false <% end %>
 
 production:
   primary:
@@ -92,4 +92,4 @@ production:
     ssl: <%= ENV.fetch('LAGO_CLICKHOUSE_SSL', false) %>
     migrations_paths: db/clickhouse_migrate
     debug: false
-    database_tasks: <% if ENV['LAGO_CLICKHOUSE_ENABLED'].present? %> true <% else %> false <% end %>
+    database_tasks: <% if ENV['LAGO_CLICKHOUSE_MIGRATIONS_ENABLED'].present? %> true <% else %> false <% end %>

--- a/lib/tasks/lago.rake
+++ b/lib/tasks/lago.rake
@@ -9,7 +9,7 @@ namespace :lago do
       schema_version: ApplicationRecord.connection.migration_context.current_version
     }
 
-    if ENV['LAGO_CLICKHOUSE_ENABLED'] == "true"
+    if ENV['LAGO_CLICKHOUSE_MIGRATIONS_ENABLED'] == "true"
       output[:clickhouse_schema_version] = Clickhouse::BaseRecord.connection.migration_context.current_version
     end
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,10 +7,10 @@ fi
 
 rm -f ./tmp/pids/server.pid
 
-if [ -v LAGO_CLICKHOUSE_ENABLED ] && [ "$LAGO_CLICKHOUSE_ENABLED" == "true" ]
+if [ -v LAGO_CLICKHOUSE_MIGRATIONS_ENABLED ] && [ "$LAGO_CLICKHOUSE_MIGRATIONS_ENABLED" == "true" ]
 then
   bundle exec rails db:migrate:primary
-  bundle exec rake db:migrate:clickhouse
+  bundle exec rails db:migrate:clickhouse
 else
   bundle exec rails db:migrate
 fi


### PR DESCRIPTION
## Description

This PR introduce a new  `LAGO_CLICKHOUSE_MIGRATIONS_ENABLED` environment variable to enable or disable the Clickhouse migration. This variable completes the existing `LAGO_CLICKHOUSE_ENABLED` that enable the Clickhouse event stores in API

It should fix some issue we had recently in deploy on US/EU clusters with migration performed at startup

