### PR TITLE
fix: Fix flaky test for commitment fees amount sort

### DIFF
--- a/spec/scenarios/commitments/minimum/in_advance_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance_spec.rb
@@ -131,7 +131,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
                 expect(invoices.third.fees.commitment_kind.count).to eq(1)
                 expect(invoices.fourth.fees.commitment_kind.count).to eq(1)
 
-                expect(commitment_fees).to eq([642_857, 900_000, 328_571])
+                expect(commitment_fees.sort).to eq([328_571, 642_857, 900_000])
               end
             end
           end

--- a/spec/scenarios/commitments/minimum/in_advance_spec.rb
+++ b/spec/scenarios/commitments/minimum/in_advance_spec.rb
@@ -131,7 +131,7 @@ describe 'Billing Minimum Commitments In Advance Scenario', :scenarios, type: :r
                 expect(invoices.third.fees.commitment_kind.count).to eq(1)
                 expect(invoices.fourth.fees.commitment_kind.count).to eq(1)
 
-                expect(commitment_fees.sort).to eq([328_571, 642_857, 900_000])
+                expect(commitment_fees).to contain_exactly(328_571, 642_857, 900_000)
               end
             end
           end


### PR DESCRIPTION
## Context
This PR addresses a flaky test related to the sorting of commitment fees amounts.
<img width="1118" alt="Screenshot 2024-07-12 at 11 42 55" src="https://github.com/user-attachments/assets/1270c316-22ef-4934-a1ad-e64382893938">
