### PR TITLE
fix(analytics): Prevent fetching deleted customer analytics

### DIFF
--- a/app/models/analytics/gross_revenue.rb
+++ b/app/models/analytics/gross_revenue.rb
@@ -8,7 +8,7 @@ module Analytics
       def query(organization_id, **args)
         if args[:external_customer_id].present?
           and_external_customer_id_sql = sanitize_sql(
-            ['AND c.external_id = :external_customer_id', args[:external_customer_id]]
+            ["AND c.external_id = :external_customer_id AND c.deleted_at IS NULL", args[:external_customer_id]]
           )
         end
 

--- a/app/models/analytics/invoice_collection.rb
+++ b/app/models/analytics/invoice_collection.rb
@@ -8,7 +8,7 @@ module Analytics
       def query(organization_id, **args)
         if args[:external_customer_id].present?
           and_external_customer_id_sql = sanitize_sql(
-            ["AND c.external_id = :external_customer_id", args[:external_customer_id]]
+            ["AND c.external_id = :external_customer_id AND c.deleted_at IS NULL", args[:external_customer_id]]
           )
         end
 

--- a/app/models/analytics/overdue_balance.rb
+++ b/app/models/analytics/overdue_balance.rb
@@ -8,7 +8,7 @@ module Analytics
       def query(organization_id, **args)
         if args[:external_customer_id].present?
           and_external_customer_id_sql = sanitize_sql(
-            ["AND c.external_id = :external_customer_id", args[:external_customer_id]]
+            ["AND c.external_id = :external_customer_id AND c.deleted_at IS NULL", args[:external_customer_id]]
           )
         end
 


### PR DESCRIPTION
On the customer page, we don't want to include analytics of deleted customers having the same `external_id`.