### PR TITLE
feat(event): Compute aggregation using Clickhouse pre-aggregation

### DIFF
--- a/app/services/events/stores/clickhouse/pre_aggregated/base.rb
+++ b/app/services/events/stores/clickhouse/pre_aggregated/base.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module PreAggregated
+        class Base
+          def initialize(subscription:, boundaries:)
+            @subscription = subscription
+            @boundaries = boundaries
+          end
+
+          def call
+            result.charge_results = {}
+
+            append_to_result(pre_aggregated_query, initial_result: result.charge_results)
+            append_to_result(enriched_events_query, initial_result: result.charge_results)
+
+            result
+          end
+
+          protected
+
+          attr_reader :subscription, :boundaries
+
+          delegate :organization, to: :subscription
+
+          def aggregation_type
+            # NOTE: override in subclasses
+            raise NotImplementedError
+          end
+
+          def pre_aggregated_model
+            # NOTE: override in subclasses
+            raise NotImplementedError
+          end
+
+          def clickhouse_aggregation
+            # NOTE: override in subclasses
+            raise NotImplementedError
+          end
+
+          def from_datetime
+            @from_datetime ||= boundaries[:from_datetime]
+          end
+
+          def to_datetime
+            @to_datetime ||= boundaries[:to_datetime]
+          end
+
+          def check_before_boundaries?
+            from_datetime.beginning_of_hour != from_datetime
+          end
+
+          def check_after_boundaries?
+            to_datetime.end_of_hour != to_datetime # TODO: check for miliseconds
+          end
+
+          def charge_ids
+            @charge_ids ||= subscription.plan.charges.joins(:billable_metric)
+              .merge(BillableMetric.where(aggregation_type: aggregation_type))
+              .pluck(:id)
+          end
+
+          def pre_aggregated_counts_query
+            sql = pre_aggregated_model.where(organization_id: organization.id)
+              .where(external_subscription_id: subscription.external_id)
+              .where(charge_id: charge_ids)
+              .where(timestamp: from_datetime...)
+              .where(timestamp: ..to_datetime.beginning_of_hour)
+              .group(:charge_id, :grouped_by, :filters)
+              .select("#{clickhouse_aggregation}(value) as units, charge_id, grouped_by, filters")
+              .to_sql
+
+            pre_aggregated_model.connection.select_all(sql)
+          end
+
+          def enriched_events_query
+            return [] if !check_before_boundaries? && !check_after_to_boundaries?
+
+            base_scope = Clickhouse::EventsEnriched
+              .where(organization_id: organization.id)
+              .where(external_subscription_id: subscription.external_id)
+              .where(charge_id: charge_ids)
+              .group(:charge_id, :grouped_by, :filters)
+              .select("#{clickhouse_aggregation}(toDecimal128(value, #{ClickhouseStore::DECIMAL_SCALE})) as units, charge_id, grouped_by, filters")
+
+            if check_before_boundaries?
+              base_scope = base_scope.where(timestamp: from_datetime...from_datetime.end_of_hour)
+            end
+
+            if check_after_boundaries?
+              base_scope = base_scope.or(Clickhouse::EventsEnriched.where(timestamp: to_datetime.beginning_of_hour...to_datetime.end_of_hour))
+            end
+
+            Clickhouse::EventsEnriched.connection.select_all(base_scope.to_sql)
+          end
+
+          # NOTE: Build a list of units indexed by charge_id, filters and or grouped_by
+          #       The format of the result is similar to the following:
+          #
+          #         {
+          #           "XXXXX" => {
+          #             filters: {
+          #               '{"key1":"value","key2":"value"}' => {grouped_by: {}, units: 12.0}
+          #               '{"key5":"value","key3":"value"}' => {grouped_by: {'{"group_1":"value1","group2":"value2"}' => {units: 12.0}}}, units: 0.0}
+          #             }
+          #             grouped_by: {'{"group_1":"value1","group2":"value2"}' => {units: 12.0}}}
+          #             units: 12.0
+          #           }
+          #           #...
+          #         }
+          def append_to_result(grouped_rows, initial_result: {})
+            grouped_rows.each_with_object(initial_result) do |row, result|
+              charge_id = row['charge_id']
+              units = row['units']
+
+              result[charge_id] ||= {filters: {}, grouped_by: {}, units: 0}
+
+              if row['filters'].present?
+                result[charge_id][:filters][row['filters'].to_s] ||= {grouped_by: {}, units: 0}
+
+                if row['grouped_by'].present?
+                  result[charge_id][:filters][row['filters'].to_s][:grouped_by][row['grouped_by'].to_s] || {units: 0}
+                  assign_units(result[charge_id][:filters][row['filters'].to_s][:grouped_by][row['grouped_by'].to_s][:units], units)
+                else
+                  assign_units(result[charge_id][:filters][row['filters'].to_s][:units], units)
+                end
+              elsif row['grouped_by'].present?
+                result[charge_id][:grouped_by][row['grouped_by'].to_s] ||= {units: 0}
+                assign_units(result[charge_id][:grouped_by][row['grouped_by'].to_s], units)
+              else
+                assign_units(result[charge_id][:units], units)
+              end
+            end
+          end
+
+          def assign_units(bucket, units)
+            # NOTE: override in subclasses
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/events/stores/clickhouse/pre_aggregated/count_query.rb
+++ b/app/services/events/stores/clickhouse/pre_aggregated/count_query.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module PreAggregated
+        class CountQuery < Base
+          protected
+
+          def aggregation_type
+            @aggregation_type ||= 'count_agg'
+          end
+
+          def pre_aggregated_model
+            @pre_aggregated_model ||= Clickhouse::EventsCountAgg
+          end
+
+          def clickhouse_aggregation
+            @clickhouse_aggregation ||= 'sum'
+          end
+
+          def assign_units(bucket, units)
+            bucket[:units] += units
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/events/stores/clickhouse/pre_aggregated/count_query.rb
+++ b/app/services/events/stores/clickhouse/pre_aggregated/count_query.rb
@@ -12,7 +12,7 @@ module Events
           end
 
           def pre_aggregated_model
-            @pre_aggregated_model ||= Clickhouse::EventsCountAgg
+            @pre_aggregated_model ||= ::Clickhouse::EventsCountAgg
           end
 
           def clickhouse_aggregation

--- a/app/services/events/stores/clickhouse/pre_aggregated/latest_query.rb
+++ b/app/services/events/stores/clickhouse/pre_aggregated/latest_query.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module PreAggregated
+        class LatestQuery < Base
+          protected
+
+          def aggregation_type
+            @aggregation_type ||= 'latest_agg'
+          end
+
+          def pre_aggregated_model
+            nil
+          end
+
+          def clickhouse_aggregation
+            nil
+          end
+
+          def assign_units(bucket, units)
+            bucket[:units] = units
+          end
+
+          def enriched_events_query
+            query = ::Clickhouse::EventsEnriched
+              .where(organization_id: organization.id)
+              .where(external_subscription_id: subscription.external_id)
+              .where(charge_id: charge_ids)
+              .where(timestamp: from_datetime...to_datetime) # TODO: check for miliseconds
+              .select(
+                [
+                  'DISTINCT ON (events_enriched.charge_id, events_enriched.grouped_by, events_enriched.filters) events_enriched.charge_id',
+                  'events_enriched.grouped_by',
+                  'events_enriched.filters',
+                  'events_enriched.timestamp',
+                  "toDecimal128(events_enriched.value, #{ClickhouseStore::DECIMAL_SCALE}) as units"
+                ].join(', ')
+              )
+              .order('events_enriched.charge_id, events_enriched.grouped_by, events_enriched.filters, events_enriched.timestamp DESC')
+
+            ::Clickhouse::EventsEnriched.connection.select_all(query.to_sql)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/events/stores/clickhouse/pre_aggregated/max_query.rb
+++ b/app/services/events/stores/clickhouse/pre_aggregated/max_query.rb
@@ -12,7 +12,7 @@ module Events
           end
 
           def pre_aggregated_model
-            @pre_aggregated_model ||= Clickhouse::EventsMaxAgg
+            @pre_aggregated_model ||= ::Clickhouse::EventsMaxAgg
           end
 
           def clickhouse_aggregation
@@ -20,7 +20,7 @@ module Events
           end
 
           def assign_units(bucket, units)
-            hash[:units] = value if value > hash[:units]
+            bucket[:units] = units if units > bucket[:units]
           end
         end
       end

--- a/app/services/events/stores/clickhouse/pre_aggregated/max_query.rb
+++ b/app/services/events/stores/clickhouse/pre_aggregated/max_query.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module PreAggregated
+        class MaxQuery < Base
+          protected
+
+          def aggregation_type
+            @aggregation_type ||= 'max_agg'
+          end
+
+          def pre_aggregated_model
+            @pre_aggregated_model ||= Clickhouse::EventsMaxAgg
+          end
+
+          def clickhouse_aggregation
+            @clickhouse_aggregation ||= 'max'
+          end
+
+          def assign_units(bucket, units)
+            hash[:units] = value if value > hash[:units]
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/events/stores/clickhouse/pre_aggregated/sum_query.rb
+++ b/app/services/events/stores/clickhouse/pre_aggregated/sum_query.rb
@@ -12,7 +12,7 @@ module Events
           end
 
           def pre_aggregated_model
-            @pre_aggregated_model ||= Clickhouse::EventsSumAgg
+            @pre_aggregated_model ||= ::Clickhouse::EventsSumAgg
           end
 
           def clickhouse_aggregation

--- a/app/services/events/stores/clickhouse/pre_aggregated/sum_query.rb
+++ b/app/services/events/stores/clickhouse/pre_aggregated/sum_query.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Events
+  module Stores
+    module Clickhouse
+      module PreAggregated
+        class SumQuery < Base
+          protected
+
+          def aggregation_type
+            @aggregation_type ||= 'sum_agg'
+          end
+
+          def pre_aggregated_model
+            @pre_aggregated_model ||= Clickhouse::EventsSumAgg
+          end
+
+          def clickhouse_aggregation
+            @clickhouse_aggregation ||= 'sum'
+          end
+
+          def assign_units(bucket, units)
+            bucket[:units] += units
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -108,7 +108,7 @@ module Invoices
         current_usage: true
       )
 
-      {
+      @boundaries = {
         from_datetime: date_service.from_datetime,
         to_datetime: date_service.to_datetime,
         charges_from_datetime: date_service.charges_from_datetime,

--- a/spec/factories/clickhouse/events_count_aggs.rb
+++ b/spec/factories/clickhouse/events_count_aggs.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :clickhouse_events_count_agg, class: 'Clickhouse::EventsCountAgg' do
+    transient do
+      subscription { create(:subscription, customer:) }
+      customer { create(:customer) }
+      organization { customer.organization }
+      billable_metric { create(:billable_metric, organization:) }
+      plan { create(:plan, organization:) }
+      charge { create(:standard_charge, billable_metric:, plan:) }
+    end
+
+    organization_id { organization.id }
+    external_subscription_id { subscription.external_id }
+    code { billable_metric.code }
+    timestamp { Time.current.beginning_of_hour }
+    value { 1.0 }
+    charge_id { charge.id }
+
+    filters { {} }
+    grouped_by { {} }
+  end
+end

--- a/spec/factories/clickhouse/events_enriched.rb
+++ b/spec/factories/clickhouse/events_enriched.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :clickhouse_events_enriched, class: 'Clickhouse::EventsEnriched' do
+    transient do
+      subscription { create(:subscription, customer:) }
+      customer { create(:customer) }
+      organization { customer.organization }
+      billable_metric { create(:billable_metric, organization:) }
+      plan { create(:plan, organization:) }
+      charge { create(:standard_charge, billable_metric:, plan:) }
+    end
+
+    organization_id { organization.id }
+    external_subscription_id { subscription.external_id }
+    code { billable_metric.code }
+    timestamp { Time.current }
+    transaction_id { "tr_#{SecureRandom.hex}" }
+    properties { {} }
+    value { 21.0 }
+    charge_id { charge.id }
+    aggregation_type { billable_metric.aggregation_type }
+    filters { {} }
+    grouped_by { {} }
+  end
+end

--- a/spec/factories/clickhouse/events_max_aggs.rb
+++ b/spec/factories/clickhouse/events_max_aggs.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :clickhouse_events_max_agg, class: 'Clickhouse::EventsMaxAgg' do
+    transient do
+      subscription { create(:subscription, customer:) }
+      customer { create(:customer) }
+      organization { customer.organization }
+      billable_metric { create(:billable_metric, organization:) }
+      plan { create(:plan, organization:) }
+      charge { create(:standard_charge, billable_metric:, plan:) }
+    end
+
+    organization_id { organization.id }
+    external_subscription_id { subscription.external_id }
+    code { billable_metric.code }
+    timestamp { Time.current.beginning_of_hour }
+    value { 4.0 }
+    charge_id { charge.id }
+
+    filters { {} }
+    grouped_by { {} }
+  end
+end

--- a/spec/factories/clickhouse/events_sum_aggs.rb
+++ b/spec/factories/clickhouse/events_sum_aggs.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :clickhouse_events_sum_agg, class: 'Clickhouse::EventsSumAgg' do
+    transient do
+      subscription { create(:subscription, customer:) }
+      customer { create(:customer) }
+      organization { customer.organization }
+      billable_metric { create(:billable_metric, organization:) }
+      plan { create(:plan, organization:) }
+      charge { create(:standard_charge, billable_metric:, plan:) }
+    end
+
+    organization_id { organization.id }
+    external_subscription_id { subscription.external_id }
+    code { billable_metric.code }
+    timestamp { Time.current.beginning_of_hour }
+    value { 12.0 }
+    charge_id { charge.id }
+
+    filters { {} }
+    grouped_by { {} }
+  end
+end

--- a/spec/services/events/stores/clickhouse/pre_aggregated/count_query_spec.rb
+++ b/spec/services/events/stores/clickhouse/pre_aggregated/count_query_spec.rb
@@ -1,0 +1,484 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::Stores::Clickhouse::PreAggregated::CountQuery, type: :service, clickhouse: true do
+  subject(:pre_aggregated_query) { described_class.new(subscription:, boundaries:) }
+
+  let(:subscription) { create(:subscription, customer:, plan:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:billable_metric1) { create(:billable_metric, organization:) }
+  let(:billable_metric2) { create(:billable_metric, organization:) }
+
+  let(:plan) { create(:plan, organization:) }
+  let(:charge1) { create(:standard_charge, billable_metric: billable_metric1, plan:) }
+  let(:charge2) { create(:standard_charge, billable_metric: billable_metric2, plan:) }
+
+  let(:boundaries) { {from_datetime:, to_datetime:} }
+  let(:from_datetime) { Time.zone.parse('2024-07-01T03:42:00') }
+  let(:to_datetime) { Time.zone.parse('2024-07-31T22:47:00') }
+
+  let(:pre_aggregated_events1) do
+    [
+      create(
+        :clickhouse_events_count_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric1,
+        charge: charge1,
+        value: 3.0,
+        timestamp: Time.zone.parse('2024-07-07T00:00:00')
+      ),
+      create(
+        :clickhouse_events_count_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric1,
+        charge: charge1,
+        value: 2.0,
+        timestamp: Time.zone.parse('2024-07-09T00:00:00')
+      )
+    ]
+  end
+
+  let(:pre_aggregated_events2) do
+    [
+      create(
+        :clickhouse_events_count_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric2,
+        charge: charge2,
+        value: 4.0,
+        timestamp: Time.zone.parse('2024-07-04T00:00:00')
+      ),
+      create(
+        :clickhouse_events_count_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric2,
+        charge: charge2,
+        value: 8.0,
+        timestamp: Time.zone.parse('2024-07-10T00:00:00')
+      ),
+      create(
+        :clickhouse_events_count_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric2,
+        charge: charge2,
+        value: 2.0,
+        timestamp: Time.zone.parse('2024-07-16T00:00:00')
+      )
+    ]
+  end
+
+  before do
+    pre_aggregated_events1
+    pre_aggregated_events2
+  end
+
+  describe '.call' do
+    it 'returns the aggregated count units', aggregate_failures: true do
+      result = pre_aggregated_query.call
+
+      expect(result).to be_success
+      expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+      expect(result.charges_units[charge1.id]).to eq({units: 5.0, filters: {}, grouped_by: {}})
+      expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+    end
+
+    context 'with enriched events before and after the boundaries' do
+      let(:enriched_events1) do
+        [
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 1.0,
+            timestamp: Time.zone.parse('2024-07-01T03:45:50')
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 1.0,
+            timestamp: Time.zone.parse('2024-07-31T22:12:00')
+          )
+        ]
+      end
+
+      let(:enriched_events2) do
+        [
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge2,
+            value: 1.0,
+            # Ignored since it should be taken into account by the pre-aggregated query
+            timestamp: Time.zone.parse('2024-07-01T04:10:50')
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge2,
+            value: 1.0,
+            # Ignored since it should be taken into account by the pre-aggregated query
+            timestamp: Time.zone.parse('2024-07-31T23:10:00')
+          )
+        ]
+      end
+
+      before do
+        enriched_events1
+        enriched_events2
+      end
+
+      it 'returns the aggregated count units', aggregate_failures: true do
+        result = pre_aggregated_query.call
+
+        expect(result).to be_success
+        expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+        expect(result.charges_units[charge1.id]).to eq({units: 7.0, filters: {}, grouped_by: {}})
+        expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+      end
+    end
+
+    context 'with grouped_by' do
+      let(:charge1) do
+        create(
+          :charge,
+          billable_metric: billable_metric1,
+          plan:,
+          properties: {amount: 10.to_s, grouped_by: %w[cloud country]}
+        )
+      end
+
+      let(:pre_aggregated_events1) do
+        [
+          create(
+            :clickhouse_events_count_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 3.0,
+            timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'us'}
+          ),
+          create(
+            :clickhouse_events_count_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'us'}
+          ),
+          create(
+            :clickhouse_events_count_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00')
+          ),
+          create(
+            :clickhouse_events_count_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'canada'}
+          )
+        ]
+      end
+
+      it 'returns the aggregated count units', aggregate_failures: true do
+        result = pre_aggregated_query.call
+
+        expect(result).to be_success
+        expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+        expect(result.charges_units[charge1.id][:units]).to eq(2.0)
+        expect(result.charges_units[charge1.id][:grouped_by]).to eq({
+          "{\"cloud\":\"aws\",\"country\":\"canada\"}" => {units: 2.0},
+          "{\"cloud\":\"aws\",\"country\":\"us\"}" => {units: 5.0}
+        })
+
+        expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+      end
+
+      context 'with enriched events before and after the boundaries' do
+        let(:enriched_events1) do
+          [
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-01T03:45:50'),
+              grouped_by: {cloud: 'aws', country: 'canada'}
+            ),
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-31T22:12:00')
+            )
+          ]
+        end
+
+        before do
+          enriched_events1
+        end
+
+        it 'returns the aggregated count units', aggregate_failures: true do
+          result = pre_aggregated_query.call
+
+          expect(result).to be_success
+          expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+          expect(result.charges_units[charge1.id][:units]).to eq(3.0)
+          expect(result.charges_units[charge1.id][:grouped_by]).to eq({
+            "{\"cloud\":\"aws\",\"country\":\"canada\"}" => {units: 3.0},
+            "{\"cloud\":\"aws\",\"country\":\"us\"}" => {units: 5.0}
+          })
+
+          expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+        end
+      end
+    end
+
+    context 'with filters' do
+      let(:billable_metric_filter11) do
+        create(:billable_metric_filter, billable_metric: billable_metric1, key: 'cloud', values: %w[aws gcp azure])
+      end
+      let(:billable_metric_filter12) do
+        create(:billable_metric_filter, billable_metric: billable_metric1, key: 'country', values: %w[us canada france])
+      end
+
+      let(:charge_filter1) { create(:charge_filter, charge: charge1, properties: {amount: 10.to_s}) }
+      let(:charge_filter1_value1) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter11,
+          values: %w[aws]
+        )
+      end
+      let(:charge_filter1_value2) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter12,
+          values: %w[us canada]
+        )
+      end
+
+      let(:charge_filter2) { create(:charge_filter, charge: charge1, properties: {amount: 10.to_s}) }
+      let(:charge_filter2_value1) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter12,
+          values: %w[france]
+        )
+      end
+
+      let(:pre_aggregated_events1) do
+        [
+          create(
+            :clickhouse_events_count_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 3.0,
+            timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+            filters: {cloud: ['aws'], country: %w[us canada]}
+          ),
+          create(
+            :clickhouse_events_count_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            filters: {cloud: ['aws'], country: %w[us canada]}
+          ),
+          create(
+            :clickhouse_events_count_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00')
+          ),
+          create(
+            :clickhouse_events_count_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            filters: {country: %w[france]}
+          )
+        ]
+      end
+
+      it 'returns the aggregated count units', aggregate_failures: true do
+        result = pre_aggregated_query.call
+
+        expect(result).to be_success
+        expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+        expect(result.charges_units[charge1.id][:units]).to eq(2.0)
+        expect(result.charges_units[charge1.id][:filters]).to eq({
+          "{\"cloud\":[\"aws\"],\"country\":[\"us\",\"canada\"]}" => {units: 5.0, grouped_by: {}},
+          "{\"country\":[\"france\"]}" => {units: 2.0, grouped_by: {}}
+        })
+
+        expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+      end
+
+      context 'with enriched events before and after the boundaries' do
+        let(:enriched_events1) do
+          [
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-01T03:45:50'),
+              filters: {cloud: ['aws'], country: %w[us canada]}
+            ),
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-31T22:12:00')
+            )
+          ]
+        end
+
+        before do
+          enriched_events1
+        end
+
+        it 'returns the aggregated count units', aggregate_failures: true do
+          result = pre_aggregated_query.call
+
+          expect(result).to be_success
+          expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+          expect(result.charges_units[charge1.id][:units]).to eq(3.0)
+          expect(result.charges_units[charge1.id][:filters]).to eq({
+            "{\"cloud\":[\"aws\"],\"country\":[\"us\",\"canada\"]}" => {units: 6.0, grouped_by: {}},
+            "{\"country\":[\"france\"]}" => {units: 2.0, grouped_by: {}}
+          })
+
+          expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+        end
+      end
+
+      context 'with grouped_by and filters' do
+        let(:charge1) do
+          create(
+            :charge,
+            billable_metric: billable_metric1,
+            plan:,
+            properties: {amount: 10.to_s, grouped_by: %w[region]}
+          )
+        end
+
+        let(:pre_aggregated_events1) do
+          [
+            create(
+              :clickhouse_events_count_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 3.0,
+              timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_count_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_count_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_count_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-2'}
+            )
+          ]
+        end
+
+        it 'returns the aggregated count units', aggregate_failures: true do
+          result = pre_aggregated_query.call
+
+          expect(result).to be_success
+          expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+          expect(result.charges_units[charge1.id][:units]).to eq(0.0)
+          expect(result.charges_units[charge1.id][:grouped_by]).to eq(
+            {"{\"region\":\"us-east-1\"}" => {units: 2.0}}
+          )
+
+          expect(result.charges_units[charge1.id][:filters]).to eq({
+            "{\"cloud\":[\"aws\"],\"country\":[\"us\",\"canada\"]}" => {
+              units: 0.0,
+              grouped_by: {
+                "{\"region\":\"us-east-1\"}" => {units: 5.0},
+                "{\"region\":\"us-east-2\"}" => {units: 2.0}
+              }
+            }
+          })
+
+          expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+        end
+      end
+    end
+  end
+end

--- a/spec/services/events/stores/clickhouse/pre_aggregated/latest_query_spec.rb
+++ b/spec/services/events/stores/clickhouse/pre_aggregated/latest_query_spec.rb
@@ -1,0 +1,323 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::Stores::Clickhouse::PreAggregated::LatestQuery, type: :service, clickhouse: true do
+  subject(:pre_aggregated_query) { described_class.new(subscription:, boundaries:) }
+
+  let(:subscription) { create(:subscription, customer:, plan:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:billable_metric1) { create(:latest_billable_metric, organization:) }
+  let(:billable_metric2) { create(:latest_billable_metric, organization:) }
+
+  let(:plan) { create(:plan, organization:) }
+  let(:charge1) { create(:standard_charge, billable_metric: billable_metric1, plan:) }
+  let(:charge2) { create(:standard_charge, billable_metric: billable_metric2, plan:) }
+
+  let(:boundaries) { {from_datetime:, to_datetime:} }
+  let(:from_datetime) { Time.zone.parse('2024-07-01T03:42:00') }
+  let(:to_datetime) { Time.zone.parse('2024-07-31T22:47:00') }
+
+  let(:enriched_events1) do
+    [
+      create(
+        :clickhouse_events_enriched,
+        subscription:,
+        organization:,
+        charge: charge1,
+        value: 2.0,
+        timestamp: Time.zone.parse('2024-07-01T03:45:50')
+      ),
+      create(
+        :clickhouse_events_enriched,
+        subscription:,
+        organization:,
+        charge: charge1,
+        value: 7.0,
+        timestamp: Time.zone.parse('2024-07-31T22:12:00')
+      )
+    ]
+  end
+
+  let(:enriched_events2) do
+    [
+      create(
+        :clickhouse_events_enriched,
+        subscription:,
+        organization:,
+        charge: charge2,
+        value: 4.0,
+        timestamp: Time.zone.parse('2024-07-04T00:00:00')
+      ),
+      create(
+        :clickhouse_events_enriched,
+        subscription:,
+        organization:,
+        charge: charge2,
+        value: 8.0,
+        timestamp: Time.zone.parse('2024-07-10T00:00:00')
+      ),
+      create(
+        :clickhouse_events_enriched,
+        subscription:,
+        organization:,
+        charge: charge2,
+        value: 2.0,
+        timestamp: Time.zone.parse('2024-07-16T00:00:00')
+      )
+    ]
+  end
+
+  before do
+    enriched_events1
+    enriched_events2
+  end
+
+  describe '.call' do
+    it 'returns the latest units', aggregate_failures: true do
+      result = pre_aggregated_query.call
+
+      expect(result).to be_success
+      expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+      expect(result.charges_units[charge1.id]).to eq({units: 7.0, filters: {}, grouped_by: {}})
+      expect(result.charges_units[charge2.id]).to eq({units: 2.0, filters: {}, grouped_by: {}})
+    end
+
+    context 'with grouped_by' do
+      let(:charge1) do
+        create(
+          :charge,
+          billable_metric: billable_metric1,
+          plan:,
+          properties: {amount: 10.to_s, grouped_by: %w[cloud country]}
+        )
+      end
+
+      let(:enriched_events1) do
+        [
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 3.0,
+            timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'us'}
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'us'}
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00')
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'canada'}
+          )
+        ]
+      end
+
+      it 'returns the latest units', aggregate_failures: true do
+        result = pre_aggregated_query.call
+
+        expect(result).to be_success
+        expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+        expect(result.charges_units[charge1.id][:units]).to eq(2.0)
+        expect(result.charges_units[charge1.id][:grouped_by]).to eq({
+          "{\"cloud\":\"aws\",\"country\":\"canada\"}" => {units: 2.0},
+          "{\"cloud\":\"aws\",\"country\":\"us\"}" => {units: 2.0}
+        })
+
+        expect(result.charges_units[charge2.id]).to eq({units: 2.0, filters: {}, grouped_by: {}})
+      end
+    end
+
+    context 'with filters' do
+      let(:billable_metric_filter11) do
+        create(:billable_metric_filter, billable_metric: billable_metric1, key: 'cloud', values: %w[aws gcp azure])
+      end
+      let(:billable_metric_filter12) do
+        create(:billable_metric_filter, billable_metric: billable_metric1, key: 'country', values: %w[us canada france])
+      end
+
+      let(:charge_filter1) { create(:charge_filter, charge: charge1, properties: {amount: 10.to_s}) }
+      let(:charge_filter1_value1) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter11,
+          values: %w[aws]
+        )
+      end
+      let(:charge_filter1_value2) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter12,
+          values: %w[us canada]
+        )
+      end
+
+      let(:charge_filter2) { create(:charge_filter, charge: charge1, properties: {amount: 10.to_s}) }
+      let(:charge_filter2_value1) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter12,
+          values: %w[france]
+        )
+      end
+
+      let(:enriched_events1) do
+        [
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 3.0,
+            timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+            filters: {cloud: ['aws'], country: %w[us canada]}
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            filters: {cloud: ['aws'], country: %w[us canada]}
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00')
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            filters: {country: %w[france]}
+          )
+        ]
+      end
+
+      it 'returns the latest units', aggregate_failures: true do
+        result = pre_aggregated_query.call
+
+        expect(result).to be_success
+        expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+        expect(result.charges_units[charge1.id][:units]).to eq(2.0)
+        expect(result.charges_units[charge1.id][:filters]).to eq({
+          "{\"cloud\":[\"aws\"],\"country\":[\"us\",\"canada\"]}" => {units: 2.0, grouped_by: {}},
+          "{\"country\":[\"france\"]}" => {units: 2.0, grouped_by: {}}
+        })
+
+        expect(result.charges_units[charge2.id]).to eq({units: 2.0, filters: {}, grouped_by: {}})
+      end
+
+      context 'with grouped_by and filters' do
+        let(:charge1) do
+          create(
+            :charge,
+            billable_metric: billable_metric1,
+            plan:,
+            properties: {amount: 10.to_s, grouped_by: %w[region]}
+          )
+        end
+
+        let(:enriched_events1) do
+          [
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 3.0,
+              timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-2'}
+            )
+          ]
+        end
+
+        it 'returns the latest units', aggregate_failures: true do
+          result = pre_aggregated_query.call
+
+          expect(result).to be_success
+          expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+          expect(result.charges_units[charge1.id][:units]).to eq(0.0)
+          expect(result.charges_units[charge1.id][:grouped_by]).to eq(
+            {"{\"region\":\"us-east-1\"}" => {units: 2.0}}
+          )
+
+          expect(result.charges_units[charge1.id][:filters]).to eq({
+            "{\"cloud\":[\"aws\"],\"country\":[\"us\",\"canada\"]}" => {
+              units: 0.0,
+              grouped_by: {
+                "{\"region\":\"us-east-1\"}" => {units: 2.0},
+                "{\"region\":\"us-east-2\"}" => {units: 2.0}
+              }
+            }
+          })
+
+          expect(result.charges_units[charge2.id]).to eq({units: 2.0, filters: {}, grouped_by: {}})
+        end
+      end
+    end
+  end
+end

--- a/spec/services/events/stores/clickhouse/pre_aggregated/max_query_spec.rb
+++ b/spec/services/events/stores/clickhouse/pre_aggregated/max_query_spec.rb
@@ -1,0 +1,484 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::Stores::Clickhouse::PreAggregated::MaxQuery, type: :service, clickhouse: true do
+  subject(:pre_aggregated_query) { described_class.new(subscription:, boundaries:) }
+
+  let(:subscription) { create(:subscription, customer:, plan:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:billable_metric1) { create(:max_billable_metric, organization:) }
+  let(:billable_metric2) { create(:max_billable_metric, organization:) }
+
+  let(:plan) { create(:plan, organization:) }
+  let(:charge1) { create(:standard_charge, billable_metric: billable_metric1, plan:) }
+  let(:charge2) { create(:standard_charge, billable_metric: billable_metric2, plan:) }
+
+  let(:boundaries) { {from_datetime:, to_datetime:} }
+  let(:from_datetime) { Time.zone.parse('2024-07-01T03:42:00') }
+  let(:to_datetime) { Time.zone.parse('2024-07-31T22:47:00') }
+
+  let(:pre_aggregated_events1) do
+    [
+      create(
+        :clickhouse_events_max_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric1,
+        charge: charge1,
+        value: 3.0,
+        timestamp: Time.zone.parse('2024-07-07T00:00:00')
+      ),
+      create(
+        :clickhouse_events_max_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric1,
+        charge: charge1,
+        value: 2.0,
+        timestamp: Time.zone.parse('2024-07-09T00:00:00')
+      )
+    ]
+  end
+
+  let(:pre_aggregated_events2) do
+    [
+      create(
+        :clickhouse_events_max_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric2,
+        charge: charge2,
+        value: 4.0,
+        timestamp: Time.zone.parse('2024-07-04T00:00:00')
+      ),
+      create(
+        :clickhouse_events_max_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric2,
+        charge: charge2,
+        value: 8.0,
+        timestamp: Time.zone.parse('2024-07-10T00:00:00')
+      ),
+      create(
+        :clickhouse_events_max_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric2,
+        charge: charge2,
+        value: 2.0,
+        timestamp: Time.zone.parse('2024-07-16T00:00:00')
+      )
+    ]
+  end
+
+  before do
+    pre_aggregated_events1
+    pre_aggregated_events2
+  end
+
+  describe '.call' do
+    it 'returns the aggregated max units', aggregate_failures: true do
+      result = pre_aggregated_query.call
+
+      expect(result).to be_success
+      expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+      expect(result.charges_units[charge1.id]).to eq({units: 3.0, filters: {}, grouped_by: {}})
+      expect(result.charges_units[charge2.id]).to eq({units: 8.0, filters: {}, grouped_by: {}})
+    end
+
+    context 'with enriched events before and after the boundaries' do
+      let(:enriched_events1) do
+        [
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 1.0,
+            timestamp: Time.zone.parse('2024-07-01T03:45:50')
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 1.0,
+            timestamp: Time.zone.parse('2024-07-31T22:12:00')
+          )
+        ]
+      end
+
+      let(:enriched_events2) do
+        [
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge2,
+            value: 1.0,
+            # Ignored since it should be taken into account by the pre-aggregated query
+            timestamp: Time.zone.parse('2024-07-01T04:10:50')
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge2,
+            value: 1.0,
+            # Ignored since it should be taken into account by the pre-aggregated query
+            timestamp: Time.zone.parse('2024-07-31T23:10:00')
+          )
+        ]
+      end
+
+      before do
+        enriched_events1
+        enriched_events2
+      end
+
+      it 'returns the aggregated count units', aggregate_failures: true do
+        result = pre_aggregated_query.call
+
+        expect(result).to be_success
+        expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+        expect(result.charges_units[charge1.id]).to eq({units: 3.0, filters: {}, grouped_by: {}})
+        expect(result.charges_units[charge2.id]).to eq({units: 8.0, filters: {}, grouped_by: {}})
+      end
+    end
+
+    context 'with grouped_by' do
+      let(:charge1) do
+        create(
+          :charge,
+          billable_metric: billable_metric1,
+          plan:,
+          properties: {amount: 10.to_s, grouped_by: %w[cloud country]}
+        )
+      end
+
+      let(:pre_aggregated_events1) do
+        [
+          create(
+            :clickhouse_events_max_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 3.0,
+            timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'us'}
+          ),
+          create(
+            :clickhouse_events_max_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'us'}
+          ),
+          create(
+            :clickhouse_events_max_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00')
+          ),
+          create(
+            :clickhouse_events_max_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'canada'}
+          )
+        ]
+      end
+
+      it 'returns the aggregated max units', aggregate_failures: true do
+        result = pre_aggregated_query.call
+
+        expect(result).to be_success
+        expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+        expect(result.charges_units[charge1.id][:units]).to eq(2.0)
+        expect(result.charges_units[charge1.id][:grouped_by]).to eq({
+          "{\"cloud\":\"aws\",\"country\":\"canada\"}" => {units: 2.0},
+          "{\"cloud\":\"aws\",\"country\":\"us\"}" => {units: 3.0}
+        })
+
+        expect(result.charges_units[charge2.id]).to eq({units: 8.0, filters: {}, grouped_by: {}})
+      end
+
+      context 'with enriched events before and after the boundaries' do
+        let(:enriched_events1) do
+          [
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-01T03:45:50'),
+              grouped_by: {cloud: 'aws', country: 'canada'}
+            ),
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-31T22:12:00')
+            )
+          ]
+        end
+
+        before do
+          enriched_events1
+        end
+
+        it 'returns the aggregated count units', aggregate_failures: true do
+          result = pre_aggregated_query.call
+
+          expect(result).to be_success
+          expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+          expect(result.charges_units[charge1.id][:units]).to eq(2.0)
+          expect(result.charges_units[charge1.id][:grouped_by]).to eq({
+            "{\"cloud\":\"aws\",\"country\":\"canada\"}" => {units: 2.0},
+            "{\"cloud\":\"aws\",\"country\":\"us\"}" => {units: 3.0}
+          })
+
+          expect(result.charges_units[charge2.id]).to eq({units: 8.0, filters: {}, grouped_by: {}})
+        end
+      end
+    end
+
+    context 'with filters' do
+      let(:billable_metric_filter11) do
+        create(:billable_metric_filter, billable_metric: billable_metric1, key: 'cloud', values: %w[aws gcp azure])
+      end
+      let(:billable_metric_filter12) do
+        create(:billable_metric_filter, billable_metric: billable_metric1, key: 'country', values: %w[us canada france])
+      end
+
+      let(:charge_filter1) { create(:charge_filter, charge: charge1, properties: {amount: 10.to_s}) }
+      let(:charge_filter1_value1) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter11,
+          values: %w[aws]
+        )
+      end
+      let(:charge_filter1_value2) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter12,
+          values: %w[us canada]
+        )
+      end
+
+      let(:charge_filter2) { create(:charge_filter, charge: charge1, properties: {amount: 10.to_s}) }
+      let(:charge_filter2_value1) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter12,
+          values: %w[france]
+        )
+      end
+
+      let(:pre_aggregated_events1) do
+        [
+          create(
+            :clickhouse_events_max_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 3.0,
+            timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+            filters: {cloud: ['aws'], country: %w[us canada]}
+          ),
+          create(
+            :clickhouse_events_max_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            filters: {cloud: ['aws'], country: %w[us canada]}
+          ),
+          create(
+            :clickhouse_events_max_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00')
+          ),
+          create(
+            :clickhouse_events_max_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            filters: {country: %w[france]}
+          )
+        ]
+      end
+
+      it 'returns the aggregated max units', aggregate_failures: true do
+        result = pre_aggregated_query.call
+
+        expect(result).to be_success
+        expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+        expect(result.charges_units[charge1.id][:units]).to eq(2.0)
+        expect(result.charges_units[charge1.id][:filters]).to eq({
+          "{\"cloud\":[\"aws\"],\"country\":[\"us\",\"canada\"]}" => {units: 3.0, grouped_by: {}},
+          "{\"country\":[\"france\"]}" => {units: 2.0, grouped_by: {}}
+        })
+
+        expect(result.charges_units[charge2.id]).to eq({units: 8.0, filters: {}, grouped_by: {}})
+      end
+
+      context 'with enriched events before and after the boundaries' do
+        let(:enriched_events1) do
+          [
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-01T03:45:50'),
+              filters: {cloud: ['aws'], country: %w[us canada]}
+            ),
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-31T22:12:00')
+            )
+          ]
+        end
+
+        before do
+          enriched_events1
+        end
+
+        it 'returns the aggregated count units', aggregate_failures: true do
+          result = pre_aggregated_query.call
+
+          expect(result).to be_success
+          expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+          expect(result.charges_units[charge1.id][:units]).to eq(2.0)
+          expect(result.charges_units[charge1.id][:filters]).to eq({
+            "{\"cloud\":[\"aws\"],\"country\":[\"us\",\"canada\"]}" => {units: 3.0, grouped_by: {}},
+            "{\"country\":[\"france\"]}" => {units: 2.0, grouped_by: {}}
+          })
+
+          expect(result.charges_units[charge2.id]).to eq({units: 8.0, filters: {}, grouped_by: {}})
+        end
+      end
+
+      context 'with grouped_by and filters' do
+        let(:charge1) do
+          create(
+            :charge,
+            billable_metric: billable_metric1,
+            plan:,
+            properties: {amount: 10.to_s, grouped_by: %w[region]}
+          )
+        end
+
+        let(:pre_aggregated_events1) do
+          [
+            create(
+              :clickhouse_events_max_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 3.0,
+              timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_max_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_max_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_max_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-2'}
+            )
+          ]
+        end
+
+        it 'returns the aggregated max units', aggregate_failures: true do
+          result = pre_aggregated_query.call
+
+          expect(result).to be_success
+          expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+          expect(result.charges_units[charge1.id][:units]).to eq(0.0)
+          expect(result.charges_units[charge1.id][:grouped_by]).to eq(
+            {"{\"region\":\"us-east-1\"}" => {units: 2.0}}
+          )
+
+          expect(result.charges_units[charge1.id][:filters]).to eq({
+            "{\"cloud\":[\"aws\"],\"country\":[\"us\",\"canada\"]}" => {
+              units: 0.0,
+              grouped_by: {
+                "{\"region\":\"us-east-1\"}" => {units: 3.0},
+                "{\"region\":\"us-east-2\"}" => {units: 2.0}
+              }
+            }
+          })
+
+          expect(result.charges_units[charge2.id]).to eq({units: 8.0, filters: {}, grouped_by: {}})
+        end
+      end
+    end
+  end
+end

--- a/spec/services/events/stores/clickhouse/pre_aggregated/sum_query_spec.rb
+++ b/spec/services/events/stores/clickhouse/pre_aggregated/sum_query_spec.rb
@@ -1,0 +1,484 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Events::Stores::Clickhouse::PreAggregated::SumQuery, type: :service, clickhouse: true do
+  subject(:pre_aggregated_query) { described_class.new(subscription:, boundaries:) }
+
+  let(:subscription) { create(:subscription, customer:, plan:) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:billable_metric1) { create(:sum_billable_metric, organization:) }
+  let(:billable_metric2) { create(:sum_billable_metric, organization:) }
+
+  let(:plan) { create(:plan, organization:) }
+  let(:charge1) { create(:standard_charge, billable_metric: billable_metric1, plan:) }
+  let(:charge2) { create(:standard_charge, billable_metric: billable_metric2, plan:) }
+
+  let(:boundaries) { {from_datetime:, to_datetime:} }
+  let(:from_datetime) { Time.zone.parse('2024-07-01T03:42:00') }
+  let(:to_datetime) { Time.zone.parse('2024-07-31T22:47:00') }
+
+  let(:pre_aggregated_events1) do
+    [
+      create(
+        :clickhouse_events_sum_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric1,
+        charge: charge1,
+        value: 3.0,
+        timestamp: Time.zone.parse('2024-07-07T00:00:00')
+      ),
+      create(
+        :clickhouse_events_sum_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric1,
+        charge: charge1,
+        value: 2.0,
+        timestamp: Time.zone.parse('2024-07-09T00:00:00')
+      )
+    ]
+  end
+
+  let(:pre_aggregated_events2) do
+    [
+      create(
+        :clickhouse_events_sum_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric2,
+        charge: charge2,
+        value: 4.0,
+        timestamp: Time.zone.parse('2024-07-04T00:00:00')
+      ),
+      create(
+        :clickhouse_events_sum_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric2,
+        charge: charge2,
+        value: 8.0,
+        timestamp: Time.zone.parse('2024-07-10T00:00:00')
+      ),
+      create(
+        :clickhouse_events_sum_agg,
+        subscription:,
+        organization:,
+        billable_metric: billable_metric2,
+        charge: charge2,
+        value: 2.0,
+        timestamp: Time.zone.parse('2024-07-16T00:00:00')
+      )
+    ]
+  end
+
+  before do
+    pre_aggregated_events1
+    pre_aggregated_events2
+  end
+
+  describe '.call' do
+    it 'returns the aggregated count units', aggregate_failures: true do
+      result = pre_aggregated_query.call
+
+      expect(result).to be_success
+      expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+      expect(result.charges_units[charge1.id]).to eq({units: 5.0, filters: {}, grouped_by: {}})
+      expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+    end
+
+    context 'with enriched events before and after the boundaries' do
+      let(:enriched_events1) do
+        [
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 1.0,
+            timestamp: Time.zone.parse('2024-07-01T03:45:50')
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge1,
+            value: 1.0,
+            timestamp: Time.zone.parse('2024-07-31T22:12:00')
+          )
+        ]
+      end
+
+      let(:enriched_events2) do
+        [
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge2,
+            value: 1.0,
+            # Ignored since it should be taken into account by the pre-aggregated query
+            timestamp: Time.zone.parse('2024-07-01T04:10:50')
+          ),
+          create(
+            :clickhouse_events_enriched,
+            subscription:,
+            organization:,
+            charge: charge2,
+            value: 1.0,
+            # Ignored since it should be taken into account by the pre-aggregated query
+            timestamp: Time.zone.parse('2024-07-31T23:10:00')
+          )
+        ]
+      end
+
+      before do
+        enriched_events1
+        enriched_events2
+      end
+
+      it 'returns the aggregated count units', aggregate_failures: true do
+        result = pre_aggregated_query.call
+
+        expect(result).to be_success
+        expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+        expect(result.charges_units[charge1.id]).to eq({units: 7.0, filters: {}, grouped_by: {}})
+        expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+      end
+    end
+
+    context 'with grouped_by' do
+      let(:charge1) do
+        create(
+          :charge,
+          billable_metric: billable_metric1,
+          plan:,
+          properties: {amount: 10.to_s, grouped_by: %w[cloud country]}
+        )
+      end
+
+      let(:pre_aggregated_events1) do
+        [
+          create(
+            :clickhouse_events_sum_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 3.0,
+            timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'us'}
+          ),
+          create(
+            :clickhouse_events_sum_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'us'}
+          ),
+          create(
+            :clickhouse_events_sum_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00')
+          ),
+          create(
+            :clickhouse_events_sum_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            grouped_by: {cloud: 'aws', country: 'canada'}
+          )
+        ]
+      end
+
+      it 'returns the aggregated count units', aggregate_failures: true do
+        result = pre_aggregated_query.call
+
+        expect(result).to be_success
+        expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+        expect(result.charges_units[charge1.id][:units]).to eq(2.0)
+        expect(result.charges_units[charge1.id][:grouped_by]).to eq({
+          "{\"cloud\":\"aws\",\"country\":\"canada\"}" => {units: 2.0},
+          "{\"cloud\":\"aws\",\"country\":\"us\"}" => {units: 5.0}
+        })
+
+        expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+      end
+
+      context 'with enriched events before and after the boundaries' do
+        let(:enriched_events1) do
+          [
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-01T03:45:50'),
+              grouped_by: {cloud: 'aws', country: 'canada'}
+            ),
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-31T22:12:00')
+            )
+          ]
+        end
+
+        before do
+          enriched_events1
+        end
+
+        it 'returns the aggregated count units', aggregate_failures: true do
+          result = pre_aggregated_query.call
+
+          expect(result).to be_success
+          expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+          expect(result.charges_units[charge1.id][:units]).to eq(3.0)
+          expect(result.charges_units[charge1.id][:grouped_by]).to eq({
+            "{\"cloud\":\"aws\",\"country\":\"canada\"}" => {units: 3.0},
+            "{\"cloud\":\"aws\",\"country\":\"us\"}" => {units: 5.0}
+          })
+
+          expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+        end
+      end
+    end
+
+    context 'with filters' do
+      let(:billable_metric_filter11) do
+        create(:billable_metric_filter, billable_metric: billable_metric1, key: 'cloud', values: %w[aws gcp azure])
+      end
+      let(:billable_metric_filter12) do
+        create(:billable_metric_filter, billable_metric: billable_metric1, key: 'country', values: %w[us canada france])
+      end
+
+      let(:charge_filter1) { create(:charge_filter, charge: charge1, properties: {amount: 10.to_s}) }
+      let(:charge_filter1_value1) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter11,
+          values: %w[aws]
+        )
+      end
+      let(:charge_filter1_value2) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter12,
+          values: %w[us canada]
+        )
+      end
+
+      let(:charge_filter2) { create(:charge_filter, charge: charge1, properties: {amount: 10.to_s}) }
+      let(:charge_filter2_value1) do
+        create(
+          :charge_filter_value,
+          charge_filter: charge_filter1,
+          billable_metric_filter: billable_metric_filter12,
+          values: %w[france]
+        )
+      end
+
+      let(:pre_aggregated_events1) do
+        [
+          create(
+            :clickhouse_events_sum_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 3.0,
+            timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+            filters: {cloud: ['aws'], country: %w[us canada]}
+          ),
+          create(
+            :clickhouse_events_sum_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            filters: {cloud: ['aws'], country: %w[us canada]}
+          ),
+          create(
+            :clickhouse_events_sum_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00')
+          ),
+          create(
+            :clickhouse_events_sum_agg,
+            subscription:,
+            organization:,
+            billable_metric: billable_metric1,
+            charge: charge1,
+            value: 2.0,
+            timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+            filters: {country: %w[france]}
+          )
+        ]
+      end
+
+      it 'returns the aggregated count units', aggregate_failures: true do
+        result = pre_aggregated_query.call
+
+        expect(result).to be_success
+        expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+        expect(result.charges_units[charge1.id][:units]).to eq(2.0)
+        expect(result.charges_units[charge1.id][:filters]).to eq({
+          "{\"cloud\":[\"aws\"],\"country\":[\"us\",\"canada\"]}" => {units: 5.0, grouped_by: {}},
+          "{\"country\":[\"france\"]}" => {units: 2.0, grouped_by: {}}
+        })
+
+        expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+      end
+
+      context 'with enriched events before and after the boundaries' do
+        let(:enriched_events1) do
+          [
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-01T03:45:50'),
+              filters: {cloud: ['aws'], country: %w[us canada]}
+            ),
+            create(
+              :clickhouse_events_enriched,
+              subscription:,
+              organization:,
+              charge: charge1,
+              value: 1.0,
+              timestamp: Time.zone.parse('2024-07-31T22:12:00')
+            )
+          ]
+        end
+
+        before do
+          enriched_events1
+        end
+
+        it 'returns the aggregated count units', aggregate_failures: true do
+          result = pre_aggregated_query.call
+
+          expect(result).to be_success
+          expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+          expect(result.charges_units[charge1.id][:units]).to eq(3.0)
+          expect(result.charges_units[charge1.id][:filters]).to eq({
+            "{\"cloud\":[\"aws\"],\"country\":[\"us\",\"canada\"]}" => {units: 6.0, grouped_by: {}},
+            "{\"country\":[\"france\"]}" => {units: 2.0, grouped_by: {}}
+          })
+
+          expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+        end
+      end
+
+      context 'with grouped_by and filters' do
+        let(:charge1) do
+          create(
+            :charge,
+            billable_metric: billable_metric1,
+            plan:,
+            properties: {amount: 10.to_s, grouped_by: %w[region]}
+          )
+        end
+
+        let(:pre_aggregated_events1) do
+          [
+            create(
+              :clickhouse_events_sum_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 3.0,
+              timestamp: Time.zone.parse('2024-07-07T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_sum_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_sum_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              grouped_by: {region: 'us-east-1'}
+            ),
+            create(
+              :clickhouse_events_sum_agg,
+              subscription:,
+              organization:,
+              billable_metric: billable_metric1,
+              charge: charge1,
+              value: 2.0,
+              timestamp: Time.zone.parse('2024-07-09T00:00:00'),
+              filters: {cloud: ['aws'], country: %w[us canada]},
+              grouped_by: {region: 'us-east-2'}
+            )
+          ]
+        end
+
+        it 'returns the aggregated count units', aggregate_failures: true do
+          result = pre_aggregated_query.call
+
+          expect(result).to be_success
+          expect(result.charges_units.keys).to match_array([charge1.id, charge2.id])
+          expect(result.charges_units[charge1.id][:units]).to eq(0.0)
+          expect(result.charges_units[charge1.id][:grouped_by]).to eq(
+            {"{\"region\":\"us-east-1\"}" => {units: 2.0}}
+          )
+
+          expect(result.charges_units[charge1.id][:filters]).to eq({
+            "{\"cloud\":[\"aws\"],\"country\":[\"us\",\"canada\"]}" => {
+              units: 0.0,
+              grouped_by: {
+                "{\"region\":\"us-east-1\"}" => {units: 5.0},
+                "{\"region\":\"us-east-2\"}" => {units: 2.0}
+              }
+            }
+          })
+
+          expect(result.charges_units[charge2.id]).to eq({units: 14.0, filters: {}, grouped_by: {}})
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, clickhouse: true) do
+    DatabaseCleaner.strategy = :deletion
     WebMock.disable_net_connect!(allow: ENV.fetch('LAGO_CLICKHOUSE_HOST', 'clickhouse'))
   end
 end


### PR DESCRIPTION
## Context

This PR is part of the real-time aggregation epic

## Description

This PRs uses previously added Clickhouse tables and materialized views for pre-aggregation of Max, Sum and Count billable metrics, to compute the number of units for a billing period.
It takes into account the `::Clickhouse::Events*Agg` as well as the `::Clickhouse::EventsEnriched` at the beginning and the end of the period