### PR TITLE
fix: Enhance Error Messaging for Validation Failures

### DIFF
--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -35,6 +35,18 @@ module ApiErrors
     )
   end
 
+  def service_validation_errors(code: ,errors:)
+    render(
+      json: {
+        status: 422,
+        error: 'Unprocessable Entity',
+        code: code,
+        error_details: errors
+      },
+      status: :unprocessable_entity
+    )
+  end
+
   def forbidden_error(code:)
     render(
       json: {
@@ -65,6 +77,8 @@ module ApiErrors
       method_not_allowed_error(code: error_result.error.code)
     when BaseService::ValidationFailure
       validation_errors(errors: error_result.error.messages)
+    when BaseService::ServiceFailure
+      service_validation_errors(code:error_result.error.code, errors: error_result.error.message)
     when BaseService::ForbiddenFailure
       forbidden_error(code: error_result.error.code)
     when BaseService::UnauthorizedFailure

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -35,6 +35,18 @@ module ApiErrors
     )
   end
 
+  def unprocessable_errors(errors:)
+    render(
+      json: {
+        status: 422,
+        error: 'Unprocessable Entity',
+        code: 'unprocessable_entity',
+        error_details: errors
+      },
+      status: :unprocessable_entity
+    )
+  end
+
   def forbidden_error(code:)
     render(
       json: {
@@ -65,6 +77,8 @@ module ApiErrors
       method_not_allowed_error(code: error_result.error.code)
     when BaseService::ValidationFailure
       validation_errors(errors: error_result.error.messages)
+    when BaseService::ServiceFailure
+      unprocessable_errors(errors: error_result.error.messages)
     when BaseService::ForbiddenFailure
       forbidden_error(code: error_result.error.code)
     when BaseService::UnauthorizedFailure

--- a/app/controllers/concerns/api_errors.rb
+++ b/app/controllers/concerns/api_errors.rb
@@ -35,18 +35,6 @@ module ApiErrors
     )
   end
 
-  def unprocessable_errors(errors:)
-    render(
-      json: {
-        status: 422,
-        error: 'Unprocessable Entity',
-        code: 'unprocessable_entity',
-        error_details: errors
-      },
-      status: :unprocessable_entity
-    )
-  end
-
   def forbidden_error(code:)
     render(
       json: {
@@ -77,8 +65,6 @@ module ApiErrors
       method_not_allowed_error(code: error_result.error.code)
     when BaseService::ValidationFailure
       validation_errors(errors: error_result.error.messages)
-    when BaseService::ServiceFailure
-      unprocessable_errors(errors: error_result.error.messages)
     when BaseService::ForbiddenFailure
       forbidden_error(code: error_result.error.code)
     when BaseService::UnauthorizedFailure

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -94,8 +94,6 @@ module Customers
 
       track_customer_created(customer)
       result
-    rescue BaseService::ServiceFailure => e
-      result.validation_failure!(errors: e.message)
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     rescue BaseService::FailedResult => e

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -95,7 +95,7 @@ module Customers
       track_customer_created(customer)
       result
     rescue BaseService::ServiceFailure => e
-      result.single_validation_failure!(error_code: e.code)
+      result.fail_with_error!(e)
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     rescue BaseService::FailedResult => e

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -95,7 +95,7 @@ module Customers
       track_customer_created(customer)
       result
     rescue BaseService::ServiceFailure => e
-      result.fail_with_error!(e)
+      result.validation_failure!(errors: e.message)
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)
     rescue BaseService::FailedResult => e


### PR DESCRIPTION
## Context

Previously, our application was returning a generic error message ("stripe_error") without specific details when encountering Stripe validation issues. This made debugging and user feedback less efficient and clear.

## Description
```
{
    "status": 422,
    "error": "Unprocessable Entity",
    "code": "validation_errors",
    "error_details": {
        "base": [
            "stripe_error"
        ]
    }
}
```
change to have more detailed message

```
{
    "status": 422,
    "error": "Unprocessable Entity",
    "code": "stripe_error",
    "error_details": "stripe_error: Invalid email address: potato"
}
```
```
{
    "status": 422,
    "error": "Unprocessable Entity",
    "code": "stripe_error",
    "error_details": "stripe_error: No such customer: 'cus_QTimv9ndM10QdY1'"
}
```


