### PR TITLE
POC: Custom configuration for model

### DIFF
--- a/app/models/config.rb
+++ b/app/models/config.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class Config
+  def self.load(value)
+    new(value || {})
+  end
+
+  def self.dump(value)
+    DottedHash.new(value.to_h).to_h
+  end
+
+  def initialize(hash)
+    @hash = DottedHash.new(default).merge(DottedHash.new(hash)).to_h
+  end
+
+  def [](key)
+    @hash[key]
+  end
+
+  def to_h
+    @hash.dup
+  end
+
+  def inspect
+    "(#{self.class.name}) \n\t #{to_h.inspect}\n"
+  end
+
+  def default
+    {}
+  end
+
+  def reset
+    @hash = DottedHash.new(default).to_h
+  end
+end

--- a/app/models/recurring_transaction_rule.rb
+++ b/app/models/recurring_transaction_rule.rb
@@ -5,6 +5,8 @@ class RecurringTransactionRule < ApplicationRecord
 
   belongs_to :wallet
 
+  serialize :config, coder: ::Wallet::Config
+
   INTERVALS = [
     :weekly,
     :monthly,

--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -1,6 +1,24 @@
 # frozen_string_literal: true
 
 class Wallet < ApplicationRecord
+  class Config < ::Config
+    def invoice_require_successful_payment?
+      @hash["invoice.require_successful_payment"]
+    end
+
+    def invoice_require_successful_payment=(value)
+      @hash["invoice.require_successful_payment"] = value
+    end
+
+    def default
+      {
+        invoice: {
+          require_successful_payment: false
+        }
+      }
+    end
+  end
+
   include PaperTrailTraceable
 
   belongs_to :customer, -> { with_discarded }
@@ -9,6 +27,8 @@ class Wallet < ApplicationRecord
 
   has_many :wallet_transactions
   has_many :recurring_transaction_rules
+
+  serialize :config, coder: ::Wallet::Config
 
   monetize :balance_cents, :ongoing_balance_cents, :ongoing_usage_balance_cents
   monetize :consumed_amount_cents

--- a/app/models/wallet_transaction.rb
+++ b/app/models/wallet_transaction.rb
@@ -6,6 +6,8 @@ class WalletTransaction < ApplicationRecord
   belongs_to :wallet
   belongs_to :invoice, optional: true
 
+  serialize :config, coder: ::Wallet::Config
+
   STATUSES = [
     :pending,
     :settled

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -85,7 +85,8 @@ module WalletTransactions
           status: :settled,
           settled_at: Time.current,
           source:,
-          transaction_status: :granted
+          transaction_status: :granted,
+          config: {invoice: {require_successful_payment: wallet.config.invoice_require_successful_payment?}}
         )
 
         Wallets::Balance::IncreaseService.new(

--- a/db/migrate/20240715190427_add_wallet_config.rb
+++ b/db/migrate/20240715190427_add_wallet_config.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddWalletConfig < ActiveRecord::Migration[7.1]
+  def change
+    add_column :wallets, :config, :jsonb, default: {}, null: false
+    add_column :wallet_transactions, :config, :jsonb, default: {}, null: false
+    add_column :recurring_transaction_rules, :config, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_12_090133) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_15_190427) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -928,6 +928,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_12_090133) do
     t.integer "method", default: 0, null: false
     t.decimal "target_ongoing_balance", precision: 30, scale: 5
     t.datetime "started_at"
+    t.jsonb "config", default: {}, null: false
     t.index ["started_at"], name: "index_recurring_transaction_rules_on_started_at"
     t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
   end
@@ -1018,6 +1019,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_12_090133) do
     t.uuid "invoice_id"
     t.integer "source", default: 0, null: false
     t.integer "transaction_status", default: 0, null: false
+    t.jsonb "config", default: {}, null: false
     t.index ["invoice_id"], name: "index_wallet_transactions_on_invoice_id"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
   end
@@ -1044,6 +1046,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_12_090133) do
     t.decimal "credits_ongoing_balance", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "credits_ongoing_usage_balance", precision: 30, scale: 5, default: "0.0", null: false
     t.boolean "depleted_ongoing_balance", default: false, null: false
+    t.jsonb "config", default: {}, null: false
     t.index ["customer_id"], name: "index_wallets_on_customer_id"
   end
 


### PR DESCRIPTION
# Summary

Instead of constantly adding new columns for very specific feature, we could add a `config` object to models and store a json object in the database. It avoid running so many migrations and it's easy to configure defaults. 
It can be turned into a proper object with methods, instead of dealing with a hash.

**Not everything should go there, there are still plenty of good reasons to use a proper dedicated column.**

### Pros

* No database migration to add new fields easily
* Postgres is good enough to make queries in `jsonb` columns
* Same specific object (like `Wallet::Config`) for many similar model

### Cons

* Not as nice as a proper ActiveRecord attribute
* Could be abused and used for the wrong reasons

## Details

### Custom `Config` object

Using a dedicated `Wallet::Confg` here allows us to create custom helper method to avoid using the hash.
It also avoid for the forever issue of symbol vs string in the hash. Remember that once loaded from the database (via `JSON.parse`, all symbols are turned to strings.

```
wt.config.invoice_require_successful_payment?
# VS
wt.config["invoice.require_successful_payment"]
```

### Query

If you often need to retrieve all models via a field, like `Wallet.where(something: '234')` it's probably not the best to put it in the config. If you sometimes add some where statement on the config, Postgres should handle that well.

```ruby
WalletTransaction.where(
  wallet_id: id,
  status: :settled
).where(
  "config->>'invoice.require_successful_payment' = ?", true
).count
```

### DottedHash

`DottedHash` was introduced for Permissions. It flattens a complex hash to a 1-level hash with dots separating the keys.

```ruby
h = {
    invoice: {
        retry: true,
        notify: [:email, :slack]
    },
    taxes: :skip
}

dotted_h = {
    "invoice.retry" => true, 
    "invoice.notify" => [:email, :slack], 
    "taxes" => :skip
}
```

# Example

![CleanShot 2024-07-16 at 10 56 49@2x](https://github.com/user-attachments/assets/37c0c7d7-ee3a-4835-9426-07db6cc3ed8c)

![CleanShot 2024-07-16 at 10 58 09@2x](https://github.com/user-attachments/assets/e185f32c-62d5-4da8-b780-04ba2c82a030)

![CleanShot 2024-07-16 at 10 58 19@2x](https://github.com/user-attachments/assets/4a5dc917-e405-41a5-8bfb-35b6fe72eaac)

# Other possible improvements

* We could store some sort of schema along with defaults to generate the GrapgQL types
* Add data validation (using the same schema?)

Actually the best evolution is that Config becomes a proper `ActiveRecord::Model` with attribute, validation, and such, but backed by one json column, not a full table. 😎 

In this case, we should get rid of the DottedHash thing 👍 

* https://evilmartians.com/chronicles/wrapping-json-based-active-record-attributes-with-classes
* https://github.com/palkan/store_attribute
* https://github.com/madeintandem/jsonb_accessor
