### PR TITLE
fix(redis): Timeout error on unique jobs

### DIFF
--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -12,5 +12,9 @@ ActiveJob::Uniqueness.configure do |config|
     end
 
     config.redlock_servers = ["#{uri.scheme}://:#{ENV["REDIS_PASSWORD"]}@#{host}:#{uri.port}"]
+    config.redlock_options = {
+      retry_count: 0,
+      redis_timeout: 5
+    }
   end
 end


### PR DESCRIPTION
## Context

- We often have an error message about redis timeout (0.1 seconds)
- After investigation, its coming from the uniqueness job configuration

## Description

- Update the `redis_timeout` value to the same as redis, `5 second` . It's a lot but it will cover cases where redis can be slower (self hosted).


https://github.com/getlago/lago/issues/188#issuecomment-2229508006

