### PR TITLE
feat(gql): Add regroup_paid_fees to ChargeInput

### DIFF
--- a/app/graphql/types/charges/input.rb
+++ b/app/graphql/types/charges/input.rb
@@ -13,6 +13,7 @@ module Types
       argument :min_amount_cents, GraphQL::Types::BigInt, required: false
       argument :pay_in_advance, Boolean, required: false
       argument :prorated, Boolean, required: false
+      argument :regroup_paid_fees, Types::Charges::RegroupPaidFeesEnum, required: false
 
       argument :filters, [Types::ChargeFilters::Input], required: false
       argument :properties, Types::Charges::PropertiesInput, required: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -323,6 +323,7 @@ input ChargeInput {
   payInAdvance: Boolean
   properties: PropertiesInput
   prorated: Boolean
+  regroupPaidFees: RegroupPaidFeesEnum
   taxCodes: [String!]
 }
 

--- a/schema.json
+++ b/schema.json
@@ -3234,6 +3234,18 @@
               "deprecationReason": null
             },
             {
+              "name": "regroupPaidFees",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "RegroupPaidFeesEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "filters",
               "description": null,
               "type": {

--- a/spec/graphql/types/charges/input_spec.rb
+++ b/spec/graphql/types/charges/input_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Types::Charges::Input do
   it { is_expected.to accept_argument(:min_amount_cents).of_type('BigInt') }
   it { is_expected.to accept_argument(:pay_in_advance).of_type('Boolean') }
   it { is_expected.to accept_argument(:prorated).of_type('Boolean') }
+  it { is_expected.to accept_argument(:regroup_paid_fees).of_type('RegroupPaidFeesEnum') }
 
   it { is_expected.to accept_argument(:filters).of_type('[ChargeFilterInput!]') }
   it { is_expected.to accept_argument(:properties).of_type('PropertiesInput') }


### PR DESCRIPTION
## Description

`regroup_paid_fees` was missing from ChargeInput. You can read the data but not edit it. This makes it editable.