### PR TITLE
feat(anrok): Add failed status to invoice

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -50,7 +50,7 @@ class Invoice < ApplicationRecord
 
   INVOICE_TYPES = %i[subscription add_on credit one_off advance_charges].freeze
   PAYMENT_STATUS = %i[pending succeeded failed].freeze
-  STATUS = %i[draft finalized voided generating].freeze
+  STATUS = %i[draft finalized voided generating status_failed].freeze
 
   enum invoice_type: INVOICE_TYPES
   enum payment_status: PAYMENT_STATUS, _prefix: :payment
@@ -61,6 +61,7 @@ class Invoice < ApplicationRecord
     state :draft
     state :finalized
     state :voided
+    state :failed
 
     event :finalize do
       transitions from: :draft, to: :finalized

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -50,7 +50,7 @@ class Invoice < ApplicationRecord
 
   INVOICE_TYPES = %i[subscription add_on credit one_off advance_charges].freeze
   PAYMENT_STATUS = %i[pending succeeded failed].freeze
-  STATUS = %i[draft finalized voided generating status_failed].freeze
+  STATUS = %i[draft finalized voided generating failed].freeze
 
   enum invoice_type: INVOICE_TYPES
   enum payment_status: PAYMENT_STATUS, _prefix: :payment

--- a/schema.graphql
+++ b/schema.graphql
@@ -3957,6 +3957,7 @@ enum InvoicePaymentStatusTypeEnum {
 
 enum InvoiceStatusTypeEnum {
   draft
+  failed
   finalized
   voided
 }

--- a/schema.json
+++ b/schema.json
@@ -19694,6 +19694,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "failed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },


### PR DESCRIPTION
## Context
https://www.notion.so/getlago/Dive-in-Calculate-taxes-info-for-finalized-invoices-subscription-58481b4c8a5c40b18cf86b8a800cf49d?pvs=4#255f83ec5c6a47b283ee5afda6d13df1
As part of processing errors from tax_provider, we want to be able to indicate that invoice failed to be generated

## Description

Added new status for invoices: `failed`
Added prefix to payment_statuses enum methods: `payment`


