### PR TITLE
feat(webhook): Always dispatch webhook job

### DIFF
--- a/app/jobs/clock/subscriptions_to_be_terminated_job.rb
+++ b/app/jobs/clock/subscriptions_to_be_terminated_job.rb
@@ -18,9 +18,7 @@ module Clock
         )
         .where('webhooks.id IS NULL OR webhooks.created_at::date != ?', Time.current.to_date)
         .find_each do |subscription|
-          if subscription.customer.organization.webhook_endpoints.any?
-            SendWebhookJob.perform_later('subscription.termination_alert', subscription)
-          end
+          SendWebhookJob.perform_later('subscription.termination_alert', subscription)
         end
     end
 

--- a/app/services/credit_notes/refunds/adyen_service.rb
+++ b/app/services/credit_notes/refunds/adyen_service.rb
@@ -110,8 +110,6 @@ module CreditNotes
       end
 
       def deliver_error_webhook(message:, code:)
-        return unless organization.webhook_endpoints.any?
-
         SendWebhookJob.perform_later(
           'credit_note.provider_refund_failure',
           credit_note,

--- a/app/services/credit_notes/refunds/gocardless_service.rb
+++ b/app/services/credit_notes/refunds/gocardless_service.rb
@@ -114,8 +114,6 @@ module CreditNotes
       end
 
       def deliver_error_webhook(message:, code:)
-        return unless organization.webhook_endpoints.any?
-
         SendWebhookJob.perform_later(
           'credit_note.provider_refund_failure',
           credit_note,

--- a/app/services/credit_notes/refunds/stripe_service.rb
+++ b/app/services/credit_notes/refunds/stripe_service.rb
@@ -118,8 +118,6 @@ module CreditNotes
       end
 
       def deliver_error_webhook(message:, code:)
-        return unless organization.webhook_endpoints.any?
-
         SendWebhookJob.perform_later(
           'credit_note.provider_refund_failure',
           credit_note,

--- a/app/services/events/post_process_service.rb
+++ b/app/services/events/post_process_service.rb
@@ -110,8 +110,6 @@ module Events
     end
 
     def deliver_error_webhook(error:)
-      return unless organization.webhook_endpoints.any?
-
       SendWebhookJob.perform_later('event.error', event, {error:})
     end
   end

--- a/app/services/invoices/add_on_service.rb
+++ b/app/services/invoices/add_on_service.rb
@@ -33,7 +33,7 @@ module Invoices
       end
 
       Utils::SegmentTrack.invoice_created(result.invoice)
-      SendWebhookJob.perform_later('invoice.add_on_added', result.invoice) if should_deliver_webhook?
+      SendWebhookJob.perform_later('invoice.add_on_added', result.invoice)
       GeneratePdfAndNotifyJob.perform_later(invoice: result.invoice, email: should_deliver_email?)
 
       if result.invoice.should_sync_invoice?
@@ -76,10 +76,6 @@ module Invoices
       fee_result = Fees::AddOnService
         .new(invoice:, applied_add_on:).create
       fee_result.raise_if_error!
-    end
-
-    def should_deliver_webhook?
-      customer.organization.webhook_endpoints.any?
     end
 
     def create_payment(invoice)

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -29,7 +29,7 @@ module Invoices
       end
 
       Utils::SegmentTrack.invoice_created(invoice)
-      SendWebhookJob.perform_later('invoice.one_off_created', invoice) if should_deliver_webhook?
+      SendWebhookJob.perform_later('invoice.one_off_created', invoice)
       GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
       Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
       Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
@@ -66,10 +66,6 @@ module Invoices
     def create_one_off_fees(invoice)
       fee_result = Fees::OneOffService.new(invoice:, fees:).create
       fee_result.raise_if_error!
-    end
-
-    def should_deliver_webhook?
-      customer.organization.webhook_endpoints.any?
     end
 
     def should_deliver_email?

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -39,7 +39,7 @@ module Invoices
 
       Utils::SegmentTrack.invoice_created(invoice)
 
-      deliver_webhooks if should_deliver_webhook?
+      deliver_webhooks
       GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
       Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
       Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
@@ -82,10 +82,6 @@ module Invoices
       fee_result = Fees::CreatePayInAdvanceService.call(charge:, event:, estimate: true)
       fee_result.raise_if_error!
       fee_result.fees
-    end
-
-    def should_deliver_webhook?
-      customer.organization.webhook_endpoints.any?
     end
 
     def deliver_webhooks

--- a/app/services/invoices/finalize_service.rb
+++ b/app/services/invoices/finalize_service.rb
@@ -22,7 +22,7 @@ module Invoices
         invoice.credit_notes.each(&:finalized!)
       end
 
-      SendWebhookJob.perform_later('invoice.created', result.invoice) if invoice.organization.webhook_endpoints.any?
+      SendWebhookJob.perform_later('invoice.created', result.invoice)
       GeneratePdfAndNotifyJob.perform_later(invoice: invoice.reload, email: should_deliver_email?)
       Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
       Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?

--- a/app/services/invoices/lose_dispute_service.rb
+++ b/app/services/invoices/lose_dispute_service.rb
@@ -16,9 +16,7 @@ module Invoices
 
       invoice.mark_as_dispute_lost!(payment_dispute_lost_at)
 
-      if invoice.organization.webhook_endpoints.any?
-        SendWebhookJob.perform_later('invoice.payment_dispute_lost', result.invoice, provider_error: reason)
-      end
+      SendWebhookJob.perform_later('invoice.payment_dispute_lost', result.invoice, provider_error: reason)
 
       result
     rescue ActiveRecord::RecordInvalid => _e

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -27,7 +27,7 @@ module Invoices
       end
 
       Utils::SegmentTrack.invoice_created(result.invoice)
-      SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice) if should_deliver_webhook?
+      SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice)
       GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
       Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
       Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
@@ -81,10 +81,6 @@ module Invoices
         .new(invoice:, wallet_transaction:, customer:).create
 
       fee_result.raise_if_error!
-    end
-
-    def should_deliver_webhook?
-      customer.organization.webhook_endpoints.any?
     end
 
     def create_payment(invoice)

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -237,8 +237,6 @@ module Invoices
       end
 
       def deliver_error_webhook(adyen_error)
-        return unless invoice.organization.webhook_endpoints.any?
-
         SendWebhookJob.perform_later(
           'invoice.payment_failure',
           invoice,

--- a/app/services/invoices/payments/gocardless_service.rb
+++ b/app/services/invoices/payments/gocardless_service.rb
@@ -158,8 +158,6 @@ module Invoices
       end
 
       def deliver_error_webhook(gocardless_error)
-        return unless invoice.organization.webhook_endpoints.any?
-
         SendWebhookJob.perform_later(
           'invoice.payment_failure',
           invoice,

--- a/app/services/invoices/payments/retry_service.rb
+++ b/app/services/invoices/payments/retry_service.rb
@@ -27,7 +27,7 @@ module Invoices
           return result.not_allowed_failure!(code: 'payment_processor_is_currently_handling_payment')
         end
 
-        deliver_webhook if customer&.organization&.webhook_endpoints&.any?
+        deliver_webhook
         Invoices::Payments::CreateService.new(invoice).call
 
         result.invoice = invoice

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -283,8 +283,6 @@ module Invoices
       end
 
       def deliver_error_webhook(stripe_error)
-        return unless invoice.organization.webhook_endpoints.any?
-
         SendWebhookJob.perform_later(
           'invoice.payment_failure',
           invoice,

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -38,7 +38,7 @@ module Invoices
         result.invoice = invoice
       end
 
-      SendWebhookJob.perform_later('invoice.created', invoice) if invoice.organization.webhook_endpoints.any?
+      SendWebhookJob.perform_later('invoice.created', invoice)
       GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
       Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
       Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?

--- a/app/services/invoices/void_service.rb
+++ b/app/services/invoices/void_service.rb
@@ -30,7 +30,7 @@ module Invoices
         end
       end
 
-      SendWebhookJob.perform_later('invoice.voided', result.invoice) if invoice.organization.webhook_endpoints.any?
+      SendWebhookJob.perform_later('invoice.voided', result.invoice)
 
       result
     rescue AASM::InvalidTransition => _e

--- a/app/services/payment_provider_customers/adyen_service.rb
+++ b/app/services/payment_provider_customers/adyen_service.rb
@@ -65,9 +65,7 @@ module PaymentProviderCustomers
       if event['success'] == 'true'
         adyen_customer.update!(payment_method_id:, provider_customer_id: shopper_reference)
 
-        if organization.webhook_endpoints.any?
-          SendWebhookJob.perform_later('customer.payment_provider_created', customer)
-        end
+        SendWebhookJob.perform_later('customer.payment_provider_created', customer)
       else
         deliver_error_webhook(Adyen::AdyenError.new(nil, nil, event['reason'], event['eventCode']))
       end
@@ -126,8 +124,6 @@ module PaymentProviderCustomers
     end
 
     def deliver_error_webhook(adyen_error)
-      return unless organization.webhook_endpoints.any?
-
       SendWebhookJob.perform_later(
         'customer.payment_provider_error',
         customer,

--- a/app/services/payment_provider_customers/gocardless_service.rb
+++ b/app/services/payment_provider_customers/gocardless_service.rb
@@ -83,8 +83,6 @@ module PaymentProviderCustomers
     end
 
     def deliver_success_webhook
-      return unless organization.webhook_endpoints.any?
-
       SendWebhookJob.perform_later(
         'customer.payment_provider_created',
         customer
@@ -92,8 +90,6 @@ module PaymentProviderCustomers
     end
 
     def deliver_error_webhook(gocardless_error)
-      return unless organization.webhook_endpoints.any?
-
       SendWebhookJob.perform_later(
         'customer.payment_provider_error',
         customer,

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -229,8 +229,6 @@ module PaymentProviderCustomers
     end
 
     def deliver_success_webhook
-      return unless customer.organization.webhook_endpoints.any?
-
       SendWebhookJob.perform_later(
         'customer.payment_provider_created',
         customer
@@ -238,8 +236,6 @@ module PaymentProviderCustomers
     end
 
     def deliver_error_webhook(stripe_error)
-      return unless customer.organization.webhook_endpoints.any?
-
       SendWebhookJob.perform_later(
         'customer.payment_provider_error',
         customer,

--- a/app/services/payment_providers/stripe/base_service.rb
+++ b/app/services/payment_providers/stripe/base_service.rb
@@ -20,8 +20,6 @@ module PaymentProviders
       end
 
       def deliver_error_webhook(action:, error:)
-        return unless organization.webhook_endpoints.any?
-
         SendWebhookJob.perform_later(
           'payment_provider.error',
           payment_provider,

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -39,9 +39,8 @@ module WalletTransactions
       end
 
       transactions = wallet_transactions.compact
-      if organization.webhook_endpoints.any?
-        transactions.each { |wt| SendWebhookJob.perform_later('wallet_transaction.created', wt.reload) }
-      end
+
+      transactions.each { |wt| SendWebhookJob.perform_later('wallet_transaction.created', wt.reload) }
 
       result.wallet_transactions = transactions
       result

--- a/spec/services/events/post_process_service_spec.rb
+++ b/spec/services/events/post_process_service_spec.rb
@@ -49,5 +49,13 @@ RSpec.describe Events::PostProcessService, type: :service do
         expect { process_service.call }.to have_enqueued_job(Events::PayInAdvanceJob)
       end
     end
+
+    context 'when there is an error' do
+      it 'delivers an error webhook' do
+        allow(event).to receive(:save!).and_raise(ActiveRecord::RecordInvalid.new(event))
+
+        expect { process_service.call }.to have_enqueued_job(SendWebhookJob)
+      end
+    end
   end
 end

--- a/spec/services/invoices/add_on_service_spec.rb
+++ b/spec/services/invoices/add_on_service_spec.rb
@@ -115,16 +115,6 @@ RSpec.describe Invoices::AddOnService, type: :service do
       let(:service_call) { invoice_service.create }
     end
 
-    context 'when organization does not have a webhook endpoint' do
-      before { applied_add_on.customer.organization.webhook_endpoints.destroy_all }
-
-      it 'does not enqueues a SendWebhookJob' do
-        expect do
-          invoice_service.create
-        end.not_to have_enqueued_job(SendWebhookJob)
-      end
-    end
-
     context 'with customer timezone' do
       before { applied_add_on.customer.update!(timezone: 'America/Los_Angeles') }
 

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -163,16 +163,6 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
       end
     end
 
-    context 'when organization does not have a webhook endpoint' do
-      before { customer.organization.webhook_endpoints.destroy_all }
-
-      it 'does not enqueues a SendWebhookJob' do
-        expect do
-          create_service.call
-        end.not_to have_enqueued_job(SendWebhookJob)
-      end
-    end
-
     context 'with customer timezone' do
       before { customer.update!(timezone: 'America/Los_Angeles') }
 

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -179,16 +179,6 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
       end
     end
 
-    context 'when organization does not have a webhook endpoint' do
-      before { organization.webhook_endpoints.destroy_all }
-
-      it 'does not enqueues a SendWebhookJob' do
-        expect do
-          invoice_service.call
-        end.not_to have_enqueued_job(SendWebhookJob).with('invoice.created', Invoice)
-      end
-    end
-
     context 'with customer timezone' do
       let(:customer) { create(:customer, organization:, timezone: 'America/Los_Angeles') }
       let(:timestamp) { DateTime.parse('2022-11-25 01:00:00') }

--- a/spec/services/invoices/finalize_service_spec.rb
+++ b/spec/services/invoices/finalize_service_spec.rb
@@ -136,16 +136,6 @@ RSpec.describe Invoices::FinalizeService, type: :service do
       expect(payment_create_service).to have_received(:call)
     end
 
-    context 'when organization does not have a webhook endpoint' do
-      before { invoice.organization.webhook_endpoints.destroy_all }
-
-      it 'does not enqueue a SendWebhookJob' do
-        expect do
-          finalize_service.call
-        end.not_to have_enqueued_job(SendWebhookJob)
-      end
-    end
-
     context 'when invoice does not exist' do
       it 'returns an error' do
         result = described_class.new(invoice: nil).call

--- a/spec/services/invoices/paid_credit_service_spec.rb
+++ b/spec/services/invoices/paid_credit_service_spec.rb
@@ -119,16 +119,6 @@ RSpec.describe Invoices::PaidCreditService, type: :service do
       expect(payment_create_service).to have_received(:call)
     end
 
-    context 'when organization does not have a webhook endpoint' do
-      before { customer.organization.webhook_endpoints.destroy_all }
-
-      it 'does not enqueues a SendWebhookJob' do
-        expect do
-          invoice_service.call
-        end.not_to have_enqueued_job(SendWebhookJob)
-      end
-    end
-
     context 'with customer timezone' do
       before { customer.update!(timezone: 'America/Los_Angeles') }
 

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -230,16 +230,6 @@ RSpec.describe Invoices::RetryService, type: :service do
       expect(payment_create_service).to have_received(:call)
     end
 
-    context 'when organization does not have a webhook endpoint' do
-      before { invoice.organization.webhook_endpoints.destroy_all }
-
-      it 'does not enqueue a SendWebhookJob' do
-        expect do
-          retry_service.call
-        end.not_to have_enqueued_job(SendWebhookJob)
-      end
-    end
-
     context 'with credit notes' do
       let(:credit_note) do
         create(

--- a/spec/services/invoices/subscription_service_spec.rb
+++ b/spec/services/invoices/subscription_service_spec.rb
@@ -151,16 +151,6 @@ RSpec.describe Invoices::SubscriptionService, type: :service do
       end
     end
 
-    context 'when organization does not have a webhook endpoint' do
-      before { subscription.customer.organization.webhook_endpoints.destroy_all }
-
-      it 'does not enqueue a SendWebhookJob' do
-        expect do
-          invoice_service.call
-        end.not_to have_enqueued_job(SendWebhookJob)
-      end
-    end
-
     context 'with customer timezone' do
       before { subscription.customer.update!(timezone: 'America/Los_Angeles', invoice_grace_period: 3) }
 

--- a/spec/services/webhooks/base_service_spec.rb
+++ b/spec/services/webhooks/base_service_spec.rb
@@ -13,10 +13,6 @@ RSpec.describe Webhooks::BaseService, type: :service do
   let(:previous_webhook) { nil }
 
   describe '.call' do
-    before do
-      allow(SendHttpWebhookJob).to receive(:perform_later)
-    end
-
     it 'creates a pending webhook' do
       webhook_service.call
 
@@ -39,7 +35,7 @@ RSpec.describe Webhooks::BaseService, type: :service do
       it 'enqueues one http job' do
         webhook_service.call
 
-        expect(SendHttpWebhookJob).to have_received(:perform_later).once
+        expect(SendHttpWebhookJob).to have_been_enqueued.once
       end
     end
 
@@ -49,7 +45,7 @@ RSpec.describe Webhooks::BaseService, type: :service do
         object.reload
         webhook_service.call
 
-        expect(SendHttpWebhookJob).to have_received(:perform_later).twice
+        expect(SendHttpWebhookJob).to have_been_enqueued.twice
       end
     end
 
@@ -63,6 +59,7 @@ RSpec.describe Webhooks::BaseService, type: :service do
       it 'does not create the webhook model' do
         webhook_service.call
 
+        expect(SendHttpWebhookJob).not_to have_been_enqueued
         expect(Webhook.where(object: invoice)).not_to exist
       end
     end


### PR DESCRIPTION
## Description

Currently, we often make a query to the DB to figure if we should enqueue a job to send the webhooks.

As discussed during our tech meeting about a month ago, we're moving to always enqueuing a job. The job will simply do nothing if there is no webhook_endpoint configured for the given organization.

It doesn't show in the the diff but the orgs without endpoints won't receive any webhook.

https://github.com/getlago/lago-api/blob/b615f63a405efe81990436667f99c6ee34b408e6/app/services/webhooks/base_service.rb#L24-L27

### Benefits

* Centralized logic of _"should we send webhook?"_ in the job (easier if want to [subscribe to only a subset of webhooks](https://github.com/getlago/lago-api/pull/1993))
* Saves a query during the main tasks

### Down sides

* Enqueues more jobs (very small jobs)