### PR TITLE
fix(rake): Skip gsub if no variable is defined

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -20,9 +20,13 @@ namespace :db do
     migration_file = 'db/clickhouse_schema.rb'
     text = File.read(migration_file)
 
-    text = text.gsub(ENV.fetch('LAGO_KAFKA_BOOTSTRAP_SERVERS', ''), '*****')
-    text = text.gsub(ENV.fetch('LAGO_KAFKA_RAW_EVENTS_TOPIC', ''), '*****')
-    text = text.gsub(ENV.fetch('LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP', ''), '*****')
+    [
+      ENV.fetch('LAGO_KAFKA_BOOTSTRAP_SERVERS', nil),
+      ENV.fetch('LAGO_KAFKA_RAW_EVENTS_TOPIC', nil),
+      ENV.fetch('LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP', nil)
+    ].compact.each do |value|
+      text = text.gsub(value, '*****')
+    end
 
     File.open(migration_file, 'w') { |file| file.puts text }
   end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -21,9 +21,9 @@ namespace :db do
     text = File.read(migration_file)
 
     [
-      ENV.fetch('LAGO_KAFKA_BOOTSTRAP_SERVERS', nil),
-      ENV.fetch('LAGO_KAFKA_RAW_EVENTS_TOPIC', nil),
-      ENV.fetch('LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP', nil)
+      ENV['LAGO_KAFKA_BOOTSTRAP_SERVERS'],
+      ENV['LAGO_KAFKA_RAW_EVENTS_TOPIC'],
+      ENV['LAGO_KAFKA_CLICKHOUSE_CONSUMER_GROUP']
     ].compact.each do |value|
       text = text.gsub(value, '*****')
     end


### PR DESCRIPTION
## Description

When not env variable is defined we end up with `gsub('', '*****')` which result in a segmentation fault. 😅