### PR TITLE
Feat(invoice.payment_status): add prefix to invoice payment status enum

### DIFF
--- a/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
+++ b/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb
@@ -9,7 +9,7 @@ module Clock
     def perform
       Invoice
         .finalized
-        .not_succeeded
+        .not_payment_succeeded
         .where(payment_overdue: false)
         .where(payment_dispute_lost_at: nil)
         .where(payment_due_date: ...Time.current)

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -245,7 +245,7 @@ class Invoice < ApplicationRecord
   end
 
   def refundable_amount_cents
-    return 0 if version_number < CREDIT_NOTES_MIN_VERSION || credit? || draft? || !succeeded?
+    return 0 if version_number < CREDIT_NOTES_MIN_VERSION || credit? || draft? || !payment_succeeded?
 
     amount = creditable_amount_cents -
       credits.where(before_taxes: false).sum(:amount_cents) -

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -53,7 +53,7 @@ class Invoice < ApplicationRecord
   STATUS = %i[draft finalized voided generating].freeze
 
   enum invoice_type: INVOICE_TYPES
-  enum payment_status: PAYMENT_STATUS
+  enum payment_status: PAYMENT_STATUS, _prefix: :payment
   enum status: STATUS
 
   aasm column: 'status', timestamps: true do
@@ -260,7 +260,7 @@ class Invoice < ApplicationRecord
   def voidable?
     return false if payment_dispute_lost_at? || credit_notes.where.not(credit_status: :voided).any?
 
-    finalized? && (pending? || failed?)
+    finalized? && (payment_pending? || payment_failed?)
   end
 
   def different_boundaries_for_subscription_and_charges(subscription)

--- a/app/services/credit_notes/create_service.rb
+++ b/app/services/credit_notes/create_service.rb
@@ -170,7 +170,7 @@ module CreditNotes
 
     def should_handle_refund?
       return false unless credit_note.refunded?
-      return false unless credit_note.invoice.succeeded?
+      return false unless credit_note.invoice.payment_succeeded?
 
       invoice_payment.present?
     end

--- a/app/services/credit_notes/validate_service.rb
+++ b/app/services/credit_notes/validate_service.rb
@@ -51,7 +51,7 @@ module CreditNotes
 
     def valid_invoice_status?
       if credit_note.refund_amount_cents.positive?
-        return true if invoice.succeeded?
+        return true if invoice.payment_succeeded?
 
         add_error(field: :refund_amount_cents, error_code: 'cannot_refund_unpaid_invoice')
         return false

--- a/app/services/invoices/payments/adyen_service.rb
+++ b/app/services/invoices/payments/adyen_service.rb
@@ -63,7 +63,7 @@ module Invoices
 
         result.payment = payment
         result.invoice = payment.invoice
-        return result if payment.invoice.succeeded?
+        return result if payment.invoice.payment_succeeded?
 
         payment.update!(status:)
 
@@ -115,7 +115,7 @@ module Invoices
       end
 
       def should_process_payment?
-        return false if invoice.succeeded? || invoice.voided?
+        return false if invoice.payment_succeeded? || invoice.voided?
         return false if adyen_payment_provider.blank?
 
         customer&.adyen_customer&.provider_customer_id

--- a/app/services/invoices/payments/generate_payment_url_service.rb
+++ b/app/services/invoices/payments/generate_payment_url_service.rb
@@ -15,7 +15,7 @@ module Invoices
         return result.single_validation_failure!(error_code: 'no_linked_payment_provider') unless provider
         return result.single_validation_failure!(error_code: 'invalid_payment_provider') if provider == 'gocardless'
 
-        if invoice.succeeded? || invoice.voided? || invoice.draft?
+        if invoice.payment_succeeded? || invoice.voided? || invoice.draft?
           return result.single_validation_failure!(error_code: 'invalid_invoice_status_or_payment_status')
         end
 

--- a/app/services/invoices/payments/gocardless_service.rb
+++ b/app/services/invoices/payments/gocardless_service.rb
@@ -55,7 +55,7 @@ module Invoices
 
         result.payment = payment
         result.invoice = payment.invoice
-        return result if payment.invoice.succeeded?
+        return result if payment.invoice.payment_succeeded?
 
         payment.update!(status:)
 
@@ -74,7 +74,7 @@ module Invoices
       delegate :organization, :customer, to: :invoice
 
       def should_process_payment?
-        return false if invoice.succeeded? || invoice.voided?
+        return false if invoice.payment_succeeded? || invoice.voided?
         return false if gocardless_payment_provider.blank?
 
         customer&.gocardless_customer&.provider_customer_id

--- a/app/services/invoices/payments/retry_service.rb
+++ b/app/services/invoices/payments/retry_service.rb
@@ -19,7 +19,7 @@ module Invoices
       def call
         return result.not_found_failure!(resource: 'invoice') if invoice.blank?
 
-        if invoice.draft? || invoice.voided? || invoice.succeeded?
+        if invoice.draft? || invoice.voided? || invoice.payment_succeeded?
           return result.not_allowed_failure!(code: 'invalid_status')
         end
 

--- a/app/services/invoices/payments/stripe_service.rb
+++ b/app/services/invoices/payments/stripe_service.rb
@@ -76,7 +76,7 @@ module Invoices
 
         result.payment = payment
         result.invoice = payment.invoice
-        return result if payment.invoice.succeeded?
+        return result if payment.invoice.payment_succeeded?
 
         payment.update!(status:)
 
@@ -140,7 +140,7 @@ module Invoices
       end
 
       def should_process_payment?
-        return false if invoice.succeeded? || invoice.voided?
+        return false if invoice.payment_succeeded? || invoice.voided?
         return false if stripe_payment_provider.blank?
 
         customer&.stripe_customer&.provider_customer_id
@@ -305,8 +305,8 @@ module Invoices
         invoice = Invoice.find_by(id: metadata[:lago_invoice_id], organization_id:)
         return result if invoice.nil?
 
-        # NOTE: Invoice exists but status is failed
-        return result if invoice.failed?
+        # NOTE: Invoice exists but payment status is failed
+        return result if invoice.payment_failed?
 
         result.not_found_failure!(resource: 'stripe_payment')
       end

--- a/app/services/invoices/update_service.rb
+++ b/app/services/invoices/update_service.rb
@@ -40,7 +40,7 @@ module Invoices
       end
 
       ActiveRecord::Base.transaction do
-        invoice.payment_overdue = false if invoice.payment_overdue? && invoice.payment_status == 'succeeded'
+        invoice.payment_overdue = false if invoice.payment_overdue? && invoice.payment_succeeded?
         invoice.save!
 
         Invoices::Metadata::UpdateService.call(invoice:, params: params[:metadata]) if params[:metadata]

--- a/app/services/payment_provider_customers/stripe_service.rb
+++ b/app/services/payment_provider_customers/stripe_service.rb
@@ -252,7 +252,7 @@ module PaymentProviderCustomers
 
     def reprocess_pending_invoices(customer)
       invoices = customer.invoices
-        .pending
+        .payment_pending
         .where(ready_for_payment_processing: true)
         .where(status: 'finalized')
 

--- a/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
+++ b/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
@@ -14,8 +14,7 @@ describe Clock::MarkInvoicesAsPaymentOverdueJob, job: true do
 
     it "marks expected invoices as payment overdue" do
       create(:invoice, :draft, payment_due_date: 1.day.ago)
-      # This shouldn't work after adding the prefix :thinking: - play with this later
-      create(:invoice, :succeeded, payment_due_date: 1.day.ago)
+      create(:invoice, payment_status: :succeeded, payment_due_date: 1.day.ago)
       create(:invoice, payment_due_date: 1.day.ago, payment_dispute_lost_at: 1.day.ago)
       create(:invoice, payment_due_date: nil)
       create(:invoice, payment_due_date: 1.day.from_now)

--- a/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
+++ b/spec/jobs/clock/mark_invoices_as_payment_overdue_job_spec.rb
@@ -14,6 +14,7 @@ describe Clock::MarkInvoicesAsPaymentOverdueJob, job: true do
 
     it "marks expected invoices as payment overdue" do
       create(:invoice, :draft, payment_due_date: 1.day.ago)
+      # This shouldn't work after adding the prefix :thinking: - play with this later
       create(:invoice, :succeeded, payment_due_date: 1.day.ago)
       create(:invoice, payment_due_date: 1.day.ago, payment_dispute_lost_at: 1.day.ago)
       create(:invoice, payment_due_date: nil)

--- a/spec/jobs/invoices/update_fees_payment_status_job_spec.rb
+++ b/spec/jobs/invoices/update_fees_payment_status_job_spec.rb
@@ -3,7 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Invoices::UpdateFeesPaymentStatusJob, type: :job do
-  let(:invoice) { create(:invoice, payment_status: 'succeeded') }
+  # Still investigating why this trait didn't get renamed
+  let(:invoice) { create(:invoice, :succeeded) }
   let(:fee) { create(:fee, invoice:) }
 
   before { fee }

--- a/spec/jobs/invoices/update_fees_payment_status_job_spec.rb
+++ b/spec/jobs/invoices/update_fees_payment_status_job_spec.rb
@@ -3,8 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Invoices::UpdateFeesPaymentStatusJob, type: :job do
-  # Still investigating why this trait didn't get renamed
-  let(:invoice) { create(:invoice, :succeeded) }
+  let(:invoice) { create(:invoice, payment_status: :succeeded) }
   let(:fee) { create(:fee, invoice:) }
 
   before { fee }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -630,7 +630,7 @@ RSpec.describe Invoice, type: :model do
         context 'when invoice is finalized' do
           let(:status) { :finalized }
 
-          context 'when invoice is pending' do
+          context 'when invoice is payment_pending' do
             let(:payment_status) { :pending }
 
             it 'returns false' do
@@ -638,7 +638,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is failed' do
+          context 'when invoice is payment_failed' do
             let(:payment_status) { :failed }
 
             it 'returns false' do
@@ -646,7 +646,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is succeeded' do
+          context 'when invoice is payment_succeeded' do
             let(:payment_status) { :succeeded }
 
             it 'returns false' do
@@ -664,7 +664,7 @@ RSpec.describe Invoice, type: :model do
         context 'when invoice is finalized' do
           let(:status) { :finalized }
 
-          context 'when invoice is pending' do
+          context 'when invoice is payment_pending' do
             let(:payment_status) { :pending }
 
             it 'returns false' do
@@ -672,7 +672,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is failed' do
+          context 'when invoice is payment_failed' do
             let(:payment_status) { :failed }
 
             it 'returns false' do
@@ -680,7 +680,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is succeeded' do
+          context 'when invoice is payment_succeeded' do
             let(:payment_status) { :succeeded }
 
             it 'returns false' do
@@ -696,7 +696,7 @@ RSpec.describe Invoice, type: :model do
         context 'when invoice is not finalized' do
           let(:status) { :draft }
 
-          context 'when invoice is pending' do
+          context 'when invoice is payment_pending' do
             let(:payment_status) { :pending }
 
             it 'returns false' do
@@ -704,7 +704,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is failed' do
+          context 'when invoice is payment_failed' do
             let(:payment_status) { :failed }
 
             it 'returns false' do
@@ -712,7 +712,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is succeeded' do
+          context 'when invoice is payment_succeeded' do
             let(:payment_status) { :succeeded }
 
             it 'returns false' do
@@ -724,7 +724,7 @@ RSpec.describe Invoice, type: :model do
         context 'when invoice is finalized' do
           let(:status) { :finalized }
 
-          context 'when invoice is pending' do
+          context 'when invoice is payment_pending' do
             let(:payment_status) { :pending }
 
             it 'returns false' do
@@ -732,7 +732,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is failed' do
+          context 'when invoice is payment_failed' do
             let(:payment_status) { :failed }
 
             it 'returns false' do
@@ -740,7 +740,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is succeeded' do
+          context 'when invoice is payment_succeeded' do
             let(:payment_status) { :succeeded }
 
             it 'returns false' do
@@ -762,7 +762,7 @@ RSpec.describe Invoice, type: :model do
         context 'when invoice is not finalized' do
           let(:status) { [:draft, :voided].sample }
 
-          context 'when invoice is pending' do
+          context 'when invoice is payment_pending' do
             let(:payment_status) { :pending }
 
             it 'returns false' do
@@ -770,7 +770,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is failed' do
+          context 'when invoice is payment_failed' do
             let(:payment_status) { :failed }
 
             it 'returns false' do
@@ -778,7 +778,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is succeeded' do
+          context 'when invoice is payment_succeeded' do
             let(:payment_status) { :succeeded }
 
             it 'returns false' do
@@ -790,7 +790,7 @@ RSpec.describe Invoice, type: :model do
         context 'when invoice is finalized' do
           let(:status) { :finalized }
 
-          context 'when invoice is pending' do
+          context 'when invoice is payment_pending' do
             let(:payment_status) { :pending }
 
             it 'returns true' do
@@ -798,7 +798,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is failed' do
+          context 'when invoice is payment_failed' do
             let(:payment_status) { :failed }
 
             it 'returns true' do
@@ -806,7 +806,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is succeeded' do
+          context 'when invoice is payment_succeeded' do
             let(:payment_status) { :succeeded }
 
             it 'returns false' do
@@ -824,7 +824,7 @@ RSpec.describe Invoice, type: :model do
         context 'when invoice is not finalized' do
           let(:status) { [:draft, :voided].sample }
 
-          context 'when invoice is pending' do
+          context 'when invoice is payment_pending' do
             let(:payment_status) { :pending }
 
             it 'returns false' do
@@ -832,7 +832,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is failed' do
+          context 'when invoice is payment_failed' do
             let(:payment_status) { :failed }
 
             it 'returns false' do
@@ -840,7 +840,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is succeeded' do
+          context 'when invoice is payment_succeeded' do
             let(:payment_status) { :succeeded }
 
             it 'returns false' do
@@ -852,7 +852,7 @@ RSpec.describe Invoice, type: :model do
         context 'when invoice is finalized' do
           let(:status) { :finalized }
 
-          context 'when invoice is pending' do
+          context 'when invoice is payment_pending' do
             let(:payment_status) { :pending }
 
             it 'returns false' do
@@ -860,7 +860,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is failed' do
+          context 'when invoice is payment_failed' do
             let(:payment_status) { :failed }
 
             it 'returns false' do
@@ -868,7 +868,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is succeeded' do
+          context 'when invoice is payment_succeeded' do
             let(:payment_status) { :succeeded }
 
             it 'returns false' do
@@ -884,7 +884,7 @@ RSpec.describe Invoice, type: :model do
         context 'when invoice is not finalized' do
           let(:status) { [:draft, :voided].sample }
 
-          context 'when invoice is pending' do
+          context 'when invoice is payment_pending' do
             let(:payment_status) { :pending }
 
             it 'returns false' do
@@ -892,7 +892,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is failed' do
+          context 'when invoice is payment_failed' do
             let(:payment_status) { :failed }
 
             it 'returns false' do
@@ -900,7 +900,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is succeeded' do
+          context 'when invoice is payment_succeeded' do
             let(:payment_status) { :succeeded }
 
             it 'returns false' do
@@ -912,7 +912,7 @@ RSpec.describe Invoice, type: :model do
         context 'when invoice is finalized' do
           let(:status) { :finalized }
 
-          context 'when invoice is pending' do
+          context 'when invoice is payment_pending' do
             let(:payment_status) { :pending }
 
             it 'returns true' do
@@ -920,7 +920,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is failed' do
+          context 'when invoice is payment_failed' do
             let(:payment_status) { :failed }
 
             it 'returns true' do
@@ -928,7 +928,7 @@ RSpec.describe Invoice, type: :model do
             end
           end
 
-          context 'when invoice is succeeded' do
+          context 'when invoice is payment_succeeded' do
             let(:payment_status) { :succeeded }
 
             it 'returns false' do

--- a/spec/services/credit_notes/validate_service_spec.rb
+++ b/spec/services/credit_notes/validate_service_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
       let(:refund_amount_cents) { 200 }
 
       before do
-        invoice.succeeded!
+        invoice.payment_succeeded!
         create(:fee, invoice:, amount_cents: 100, taxes_rate: 20, taxes_amount_cents: 20)
       end
 
@@ -131,7 +131,7 @@ RSpec.describe CreditNotes::ValidateService, type: :service do
 
     context 'when reaching invoice refundable amount' do
       before do
-        invoice.succeeded!
+        invoice.payment_succeeded!
         create(:credit_note, invoice:, total_amount_cents: 119, refund_amount_cents: 199, credit_amount_cents: 0)
       end
 

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -943,7 +943,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             aggregate_failures do
               expect(result).to be_success
 
-              expect(invoice).to be_pending
+              expect(invoice).to be_payment_pending
               expect(invoice.fees.subscription_kind.count).to eq(1)
               expect(invoice).to have_empty_charge_fees
 
@@ -977,7 +977,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
             aggregate_failures do
               expect(result).to be_success
 
-              expect(invoice).to be_pending
+              expect(invoice).to be_payment_pending
               expect(invoice.fees.subscription_kind.count).to eq(1)
               expect(invoice).to have_empty_charge_fees
 

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
         ]
       end
 
-      it 'creates an succeeded invoice' do
+      it 'creates a payment_succeeded invoice' do
         result = create_service.call
 
         aggregate_failures do

--- a/spec/services/invoices/payments/adyen_service_spec.rb
+++ b/spec/services/invoices/payments/adyen_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
       expect(result).to be_success
 
       aggregate_failures do
-        expect(result.invoice).to be_succeeded
+        expect(result.invoice).to be_payment_succeeded
         expect(result.invoice.payment_attempts).to eq(1)
         expect(result.invoice.reload.ready_for_payment_processing).to eq(false)
 
@@ -113,7 +113,7 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
           expect(result.invoice).to eq(invoice)
           expect(result.payment).to be_nil
 
-          expect(result.invoice).to be_succeeded
+          expect(result.invoice).to be_payment_succeeded
 
           expect(payments_api).not_to have_received(:payments)
         end
@@ -315,8 +315,8 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
       end
     end
 
-    context 'when invoice is already succeeded' do
-      before { invoice.succeeded! }
+    context 'when invoice is already payment_succeeded' do
+      before { invoice.payment_succeeded! }
 
       it 'does not update the status of invoice and payment' do
         result = adyen_service.update_payment_status(
@@ -393,8 +393,8 @@ RSpec.describe Invoices::Payments::AdyenService, type: :service do
       expect(payment_links_api).to have_received(:payment_links)
     end
 
-    context 'when invoice is succeeded' do
-      before { invoice.succeeded! }
+    context 'when invoice is payment_succeeded' do
+      before { invoice.payment_succeeded! }
 
       it 'does not generate payment url' do
         adyen_service.generate_payment_url

--- a/spec/services/invoices/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/invoices/payments/generate_payment_url_service_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Invoices::Payments::GeneratePaymentUrlService, type: :service do
     end
 
     context 'when invoice payment status is invalid' do
-      before { invoice.succeeded! }
+      before { invoice.payment_succeeded! }
 
       it 'returns an error' do
         result = generate_payment_url_service.call

--- a/spec/services/invoices/payments/gocardless_service_spec.rb
+++ b/spec/services/invoices/payments/gocardless_service_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
       expect(result).to be_success
 
       aggregate_failures do
-        expect(result.invoice).to be_succeeded
+        expect(result.invoice).to be_payment_succeeded
         expect(result.invoice.payment_attempts).to eq(1)
         expect(result.invoice.reload.ready_for_payment_processing).to eq(false)
 
@@ -116,7 +116,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
           expect(result.invoice).to eq(invoice)
           expect(result.payment).to be_nil
 
-          expect(result.invoice).to be_succeeded
+          expect(result.invoice).to be_payment_succeeded
 
           expect(gocardless_payments_service).not_to have_received(:create)
         end
@@ -221,8 +221,8 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
       end
     end
 
-    context 'when invoice is already succeeded' do
-      before { invoice.succeeded! }
+    context 'when invoice is already payment_succeeded' do
+      before { invoice.payment_succeeded! }
 
       it 'does not update the status of invoice and payment' do
         result = gocardless_service.update_payment_status(

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       expect(result).to be_success
 
       aggregate_failures do
-        expect(result.invoice).to be_succeeded
+        expect(result.invoice).to be_payment_succeeded
         expect(result.invoice.payment_attempts).to eq(1)
         expect(result.invoice.ready_for_payment_processing).to eq(false)
 
@@ -125,7 +125,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
           expect(result.invoice).to eq(invoice)
           expect(result.payment).to be_nil
 
-          expect(result.invoice).to be_succeeded
+          expect(result.invoice).to be_payment_succeeded
 
           expect(Stripe::PaymentIntent).not_to have_received(:create)
         end
@@ -300,8 +300,8 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       expect(Stripe::Checkout::Session).to have_received(:create)
     end
 
-    context 'when invoice is succeeded' do
-      before { invoice.succeeded! }
+    context 'when invoice is payment_succeeded' do
+      before { invoice.payment_succeeded! }
 
       it 'does not generate payment url' do
         stripe_service.generate_payment_url
@@ -430,8 +430,8 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
       end
     end
 
-    context 'when invoice is already succeeded' do
-      before { invoice.succeeded! }
+    context 'when invoice is already payment_succeeded' do
+      before { invoice.payment_succeeded! }
 
       it 'does not update the status of invoice and payment' do
         result = stripe_service.update_payment_status(

--- a/spec/services/invoices/payments/stripe_service_spec.rb
+++ b/spec/services/invoices/payments/stripe_service_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         stripe_service.create
         invoice.reload
 
-        expect(invoice).to be_pending
+        expect(invoice).to be_payment_pending
       end
     end
 
@@ -267,7 +267,7 @@ RSpec.describe Invoices::Payments::StripeService, type: :service do
         expect(result).to be_success
 
         aggregate_failures do
-          expect(result.invoice).to be_pending
+          expect(result.invoice).to be_payment_pending
           expect(result.invoice.payment_attempts).to eq(1)
           expect(result.invoice.ready_for_payment_processing).to eq(false)
 


### PR DESCRIPTION
As part of implementation error status for invoices, we got conflict between current `failed?` method on invoice that comes from payment_status and new `failed?` method that comes from invoice status itself, so it makes sense to make payment statuses explicitly payment's  statuses, introducing this prefix to payment_status enum, so it will be
`paymen_failed` instead (and other methods from the enum)
Also it will make it clearer that `invoice.pending?` does not mean that the invoice is pending because of something, instead we'll have now `invoice.payment_pending?` which is again more explicit