### PR TITLE
feat(event): Add pay_in_advance flag in grouped charges view

### DIFF
--- a/db/migrate/20240718080929_update_billable_metrics_grouped_charges_to_version_3.rb
+++ b/db/migrate/20240718080929_update_billable_metrics_grouped_charges_to_version_3.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UpdateBillableMetricsGroupedChargesToVersion3 < ActiveRecord::Migration[7.1]
+  def change
+    drop_view :billable_metrics_grouped_charges
+    create_view :billable_metrics_grouped_charges, version: 3
+  end
+end

--- a/db/views/billable_metrics_grouped_charges_v03.sql
+++ b/db/views/billable_metrics_grouped_charges_v03.sql
@@ -1,0 +1,50 @@
+select
+    billable_metrics.organization_id,
+    billable_metrics.code,
+    billable_metrics.aggregation_type,
+    billable_metrics.field_name,
+    charges.plan_id,
+    charges.id as charge_id,
+    charges.pay_in_advance,
+    (
+        case when charges.charge_model = 0 -- Standard
+        then
+            charges.properties->'grouped_by'
+        else
+            null
+        end
+    ) as grouped_by,
+    charge_filters.id as charge_filter_id,
+    json_object_agg(
+        billable_metric_filters.key,
+        coalesce(charge_filter_values.values, '{}')
+        order by billable_metric_filters.key asc
+    ) FILTER (WHERE billable_metric_filters.key IS NOT NULL) AS filters,
+    (
+        case when charges.charge_model = 0 -- Standard
+        then
+            charge_filters.properties->'grouped_by'
+        else
+            null
+        end
+    ) AS filters_grouped_by
+
+from billable_metrics
+    inner join charges on charges.billable_metric_id = billable_metrics.id
+    left join charge_filters on charge_filters.charge_id = charges.id
+    left join charge_filter_values on charge_filter_values.charge_filter_id = charge_filters.id
+    left join billable_metric_filters on charge_filter_values.billable_metric_filter_id = billable_metric_filters.id
+where
+    billable_metrics.deleted_at is null
+    and charges.deleted_at is null
+    and charge_filters.deleted_at is null
+    and charge_filter_values.deleted_at is null
+    and billable_metric_filters.deleted_at is null
+group by
+    billable_metrics.organization_id,
+    billable_metrics.code,
+    billable_metrics.aggregation_type,
+    billable_metrics.field_name,
+    charges.plan_id,
+    charges.id,
+    charge_filters.id


### PR DESCRIPTION
## Context

This PR update the `billable_metrics_grouped_charges` view introduced in https://github.com/getlago/lago-api/pull/2231 to allow a better filtering of events related to in advance charges.

Today all event having the code of a billable metric related to an in advance charge is sent to the event_worker even if no subscription is attached to it leading to a lot of load on the worker for jobs that will in the end not be charged

## Description

This PR will allow us to the update the ingest service so that only event related to an in advance charge on a active subscription are sent to the event worker