### PR TITLE
feat(analytics): Ability to expire cache when fetching customer analytics

### DIFF
--- a/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
+++ b/app/graphql/resolvers/analytics/gross_revenues_resolver.rb
@@ -13,6 +13,8 @@ module Resolvers
       argument :currency, Types::CurrencyEnum, required: false
       argument :external_customer_id, String, required: false
 
+      argument :expire_cache, Boolean, required: false
+
       type Types::Analytics::GrossRevenues::Object.collection_type, null: false
 
       def resolve(**args)

--- a/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
+++ b/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
@@ -14,6 +14,8 @@ module Resolvers
       argument :external_customer_id, String, required: false
       argument :months, Integer, required: false
 
+      argument :expire_cache, Boolean, required: false
+
       type Types::Analytics::OverdueBalances::Object.collection_type, null: false
 
       def resolve(**args)

--- a/app/graphql/resolvers/customer_portal/analytics/invoice_collections_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/analytics/invoice_collections_resolver.rb
@@ -10,6 +10,8 @@ module Resolvers
 
         argument :months, Integer, required: false
 
+        argument :expire_cache, Boolean, required: false
+
         type Types::Analytics::InvoiceCollections::Object.collection_type, null: false
 
         def resolve(**args)

--- a/app/graphql/resolvers/customer_portal/analytics/overdue_balances_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/analytics/overdue_balances_resolver.rb
@@ -10,6 +10,8 @@ module Resolvers
 
         argument :months, Integer, required: false
 
+        argument :expire_cache, Boolean, required: false
+
         type Types::Analytics::OverdueBalances::Object.collection_type, null: false
 
         def resolve(**args)

--- a/app/models/analytics/base.rb
+++ b/app/models/analytics/base.rb
@@ -5,6 +5,10 @@ module Analytics
     self.abstract_class = true
 
     def self.find_all_by(organization_id, **args)
+      if args[:expire_cache] == true && args[:external_customer_id].present?
+        expire_cache_for_customer(organization_id, args[:external_customer_id])
+      end
+
       Rails.cache.fetch(cache_key(organization_id, **args), expires_in: cache_expiration) do
         sql = query(organization_id, **args)
 
@@ -15,6 +19,10 @@ module Analytics
 
     def self.cache_expiration
       4.hours
+    end
+
+    def self.expire_cache_for_customer(organization_id, external_customer_id)
+      raise NotImplementedError
     end
   end
 end

--- a/app/models/analytics/gross_revenue.rb
+++ b/app/models/analytics/gross_revenue.rb
@@ -121,6 +121,12 @@ module Analytics
           args[:months]
         ].join('/')
       end
+
+      def expire_cache_for_customer(organization_id, external_customer_id)
+        Rails.cache.delete_matched(
+          "gross-revenue/#{Date.current.strftime("%Y-%m-%d")}/#{organization_id}*#{external_customer_id}*"
+        )
+      end
     end
   end
 end

--- a/app/models/analytics/invoice_collection.rb
+++ b/app/models/analytics/invoice_collection.rb
@@ -88,6 +88,12 @@ module Analytics
           args[:months]
         ].join('/')
       end
+
+      def expire_cache_for_customer(organization_id, external_customer_id)
+        Rails.cache.delete_matched(
+          "invoice-collection/#{Date.current.strftime("%Y-%m-%d")}/#{organization_id}*#{external_customer_id}*"
+        )
+      end
     end
   end
 end

--- a/app/models/analytics/overdue_balance.rb
+++ b/app/models/analytics/overdue_balance.rb
@@ -5,6 +5,19 @@ module Analytics
     self.abstract_class = true
 
     class << self
+      def find_all_by(organization_id, **args)
+        if args[:expire_cache] == true && args[:external_customer_id].present?
+          expire_cache_for_customer(organization_id, args[:external_customer_id])
+        end
+
+        Rails.cache.fetch(cache_key(organization_id, **args), expires_in: cache_expiration) do
+          sql = query(organization_id, **args)
+
+          result = ActiveRecord::Base.connection.exec_query(sql)
+          result.to_a
+        end
+      end
+
       def query(organization_id, **args)
         if args[:external_customer_id].present?
           and_external_customer_id_sql = sanitize_sql(
@@ -86,6 +99,10 @@ module Analytics
           args[:currency],
           args[:months]
         ].join("/")
+      end
+
+      def expire_cache_for_customer(organization_id, external_customer_id)
+        Rails.cache.delete_matched("overdue-balance*#{organization_id}*#{external_customer_id}*")
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -5549,7 +5549,7 @@ type Query {
   """
   Query gross revenue of an organization
   """
-  grossRevenues(currency: CurrencyEnum, externalCustomerId: String): GrossRevenueCollection!
+  grossRevenues(currency: CurrencyEnum, expireCache: Boolean, externalCustomerId: String): GrossRevenueCollection!
 
   """
   Query a single integration

--- a/schema.graphql
+++ b/schema.graphql
@@ -5681,7 +5681,7 @@ type Query {
   """
   Query overdue balances of an organization
   """
-  overdueBalances(currency: CurrencyEnum, externalCustomerId: String, months: Int): OverdueBalanceCollection!
+  overdueBalances(currency: CurrencyEnum, expireCache: Boolean, externalCustomerId: String, months: Int): OverdueBalanceCollection!
 
   """
   Query a password reset by token

--- a/schema.graphql
+++ b/schema.graphql
@@ -5496,7 +5496,7 @@ type Query {
   """
   Query invoice collections of a customer portal user
   """
-  customerPortalInvoiceCollections(months: Int): FinalizedInvoiceCollectionCollection!
+  customerPortalInvoiceCollections(expireCache: Boolean, months: Int): FinalizedInvoiceCollectionCollection!
 
   """
   Query invoices of a customer
@@ -5511,7 +5511,7 @@ type Query {
   """
   Query overdue balances of a customer portal user
   """
-  customerPortalOverdueBalances(months: Int): OverdueBalanceCollection!
+  customerPortalOverdueBalances(expireCache: Boolean, months: Int): OverdueBalanceCollection!
 
   """
   Query a customer portal user

--- a/schema.json
+++ b/schema.json
@@ -28137,6 +28137,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "expireCache",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },
@@ -28248,6 +28260,18 @@
                   "type": {
                     "kind": "SCALAR",
                     "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "expireCache",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/schema.json
+++ b/schema.json
@@ -29382,6 +29382,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "expireCache",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },

--- a/schema.json
+++ b/schema.json
@@ -28505,6 +28505,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "expireCache",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ]
             },

--- a/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/gross_revenues_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::Analytics::GrossRevenuesResolver, type: :graphql do
   let(:required_permission) { 'analytics:view' }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum, $externalCustomerId: String) {
-        grossRevenues(currency: $currency, externalCustomerId: $externalCustomerId) {
+      query($currency: CurrencyEnum, $externalCustomerId: String, $expireCache: Boolean) {
+        grossRevenues(currency: $currency, externalCustomerId: $externalCustomerId, expireCache: $expireCache) {
           collection {
             month
             amountCents

--- a/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Resolvers::Analytics::OverdueBalancesResolver, type: :graphql do
   let(:required_permission) { 'analytics:view' }
   let(:query) do
     <<~GQL
-      query($currency: CurrencyEnum, $externalCustomerId: String, $months: Int) {
-        overdueBalances(currency: $currency, externalCustomerId: $externalCustomerId, months: $months) {
+      query($currency: CurrencyEnum, $externalCustomerId: String, $months: Int, $expireCache: Boolean) {
+        overdueBalances(currency: $currency, externalCustomerId: $externalCustomerId, months: $months, expireCache: $expireCache) {
           collection {
             amountCents
             currency


### PR DESCRIPTION
We want to be able to refresh analytics on the customer section:
<img width="450" alt="Screenshot 2024-07-18 at 10 45 40" src="https://github.com/user-attachments/assets/ea7bc336-0eae-406e-b5c2-058e4b7532e3">

And the customer portal:
<img width="683" alt="Screenshot 2024-07-18 at 10 46 43" src="https://github.com/user-attachments/assets/2a1a238a-ee61-4b15-8e9b-668dac49d18f">
