### PR TITLE
chore(services): Rename FinalizeService to RefreshDraftAndFinalizeService

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -114,7 +114,7 @@ module Api
         invoice = current_organization.invoices.draft.find_by(id: params[:id])
         return not_found_error(resource: 'invoice') unless invoice
 
-        result = Invoices::FinalizeService.call(invoice:)
+        result = Invoices::RefreshDraftAndFinalizeService.call(invoice:)
         if result.success?
           render_invoice(result.invoice)
         else

--- a/app/graphql/mutations/invoices/finalize.rb
+++ b/app/graphql/mutations/invoices/finalize.rb
@@ -16,7 +16,7 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(**args)
-        result = ::Invoices::FinalizeService.call(
+        result = ::Invoices::RefreshDraftAndFinalizeService.call(
           invoice: current_organization.invoices.draft.find_by(id: args[:id])
         )
         result.success? ? result.invoice : result_error(result)

--- a/app/jobs/invoices/finalize_job.rb
+++ b/app/jobs/invoices/finalize_job.rb
@@ -5,7 +5,7 @@ module Invoices
     queue_as 'invoices'
 
     def perform(invoice)
-      Invoices::FinalizeService.call(invoice:)
+      Invoices::RefreshDraftAndFinalizeService.call(invoice:)
     end
   end
 end

--- a/app/services/customers/terminate_relations_service.rb
+++ b/app/services/customers/terminate_relations_service.rb
@@ -19,7 +19,7 @@ module Customers
       customer.subscriptions.pending.find_each(&:mark_as_canceled!)
 
       # NOTE: Finalize all draft invoices.
-      customer.invoices.draft.find_each { |invoice| Invoices::FinalizeService.call(invoice:) }
+      customer.invoices.draft.find_each { |invoice| Invoices::RefreshDraftAndFinalizeService.call(invoice:) }
 
       # NOTE: Terminate applied coupons
       customer.applied_coupons.active.find_each do |applied_coupon|

--- a/app/services/customers/update_invoice_grace_period_service.rb
+++ b/app/services/customers/update_invoice_grace_period_service.rb
@@ -15,7 +15,7 @@ module Customers
 
         # NOTE: Finalize related draft invoices.
         customer.invoices.ready_to_be_finalized.each do |invoice|
-          Invoices::FinalizeService.call(invoice:)
+          Invoices::RefreshDraftAndFinalizeService.call(invoice:)
         end
 
         # NOTE: Update issuing_date on draft invoices.

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Invoices
-  class FinalizeService < BaseService
+  class RefreshDraftAndFinalizeService < BaseService
     def initialize(invoice:)
       @invoice = invoice
       super

--- a/app/services/organizations/update_invoice_grace_period_service.rb
+++ b/app/services/organizations/update_invoice_grace_period_service.rb
@@ -15,7 +15,7 @@ module Organizations
 
         # NOTE: Finalize related draft invoices.
         organization.invoices.ready_to_be_finalized.each do |invoice|
-          Invoices::FinalizeService.call(invoice:)
+          Invoices::RefreshDraftAndFinalizeService.call(invoice:)
         end
 
         # NOTE: Update issuing_date on draft invoices.

--- a/app/services/plans/destroy_service.rb
+++ b/app/services/plans/destroy_service.rb
@@ -20,7 +20,7 @@ module Plans
 
       # NOTE: Finalize all draft invoices.
       invoices = Invoice.draft.joins(:plans).where(plans: {id: plan.id}).distinct
-      invoices.find_each { |invoice| Invoices::FinalizeService.call(invoice:) }
+      invoices.find_each { |invoice| Invoices::RefreshDraftAndFinalizeService.call(invoice:) }
 
       plan.pending_deletion = false
       plan.discard!

--- a/spec/jobs/clock/finalize_invoices_job_spec.rb
+++ b/spec/jobs/clock/finalize_invoices_job_spec.rb
@@ -29,7 +29,7 @@ describe Clock::FinalizeInvoicesJob, job: true do
     before do
       draft_invoice
       finalized_invoice
-      allow(Invoices::FinalizeService).to receive(:call)
+      allow(Invoices::RefreshDraftAndFinalizeService).to receive(:call)
     end
 
     context 'when during the grace period' do

--- a/spec/jobs/invoices/finalize_job_spec.rb
+++ b/spec/jobs/invoices/finalize_job_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Invoices::FinalizeJob, type: :job do
   let(:result) { BaseService::Result.new }
 
   let(:finalize_service) do
-    instance_double(Invoices::FinalizeService)
+    instance_double(Invoices::RefreshDraftAndFinalizeService)
   end
 
   it 'delegates to the Generate service' do
-    allow(Invoices::FinalizeService).to receive(:new)
+    allow(Invoices::RefreshDraftAndFinalizeService).to receive(:new)
       .with(invoice:)
       .and_return(finalize_service)
     allow(finalize_service).to receive(:call)
@@ -20,7 +20,7 @@ RSpec.describe Invoices::FinalizeJob, type: :job do
 
     described_class.perform_now(invoice)
 
-    expect(Invoices::FinalizeService).to have_received(:new)
+    expect(Invoices::RefreshDraftAndFinalizeService).to have_received(:new)
     expect(finalize_service).to have_received(:call)
   end
 end

--- a/spec/services/customers/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/customers/update_invoice_grace_period_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Customers::UpdateInvoiceGracePeriodService, type: :service do
     before do
       invoice_to_be_finalized
       invoice_to_not_be_finalized
-      allow(Invoices::FinalizeService).to receive(:call)
+      allow(Invoices::RefreshDraftAndFinalizeService).to receive(:call)
     end
 
     it 'updates invoice grace period on customer' do
@@ -36,8 +36,8 @@ RSpec.describe Customers::UpdateInvoiceGracePeriodService, type: :service do
         result = update_service.call
 
         expect(result.customer.invoice_grace_period).to eq(2)
-        expect(Invoices::FinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
-        expect(Invoices::FinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)
+        expect(Invoices::RefreshDraftAndFinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
+        expect(Invoices::RefreshDraftAndFinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Customers::UpdateInvoiceGracePeriodService, type: :service do
         travel_to(current_date) do
           update_service.call
 
-          expect(Invoices::FinalizeService).not_to have_received(:call)
+          expect(Invoices::RefreshDraftAndFinalizeService).not_to have_received(:call)
         end
       end
 

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Invoices::FinalizeService, type: :service do
+RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
   subject(:finalize_service) { described_class.new(invoice:) }
 
   describe '#call' do

--- a/spec/services/organizations/update_invoice_grace_period_service_spec.rb
+++ b/spec/services/organizations/update_invoice_grace_period_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Organizations::UpdateInvoiceGracePeriodService, type: :service do
     before do
       invoice_to_be_finalized
       invoice_to_not_be_finalized
-      allow(Invoices::FinalizeService).to receive(:call)
+      allow(Invoices::RefreshDraftAndFinalizeService).to receive(:call)
     end
 
     it 'updates invoice grace period on organization' do
@@ -36,8 +36,8 @@ RSpec.describe Organizations::UpdateInvoiceGracePeriodService, type: :service do
         result = update_service.call
 
         expect(result.organization.invoice_grace_period).to eq(2)
-        expect(Invoices::FinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
-        expect(Invoices::FinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)
+        expect(Invoices::RefreshDraftAndFinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
+        expect(Invoices::RefreshDraftAndFinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Organizations::UpdateInvoiceGracePeriodService, type: :service do
         travel_to(current_date) do
           update_service.call
 
-          expect(Invoices::FinalizeService).not_to have_received(:call)
+          expect(Invoices::RefreshDraftAndFinalizeService).not_to have_received(:call)
         end
       end
 

--- a/spec/services/organizations/update_service_spec.rb
+++ b/spec/services/organizations/update_service_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Organizations::UpdateService do
         before do
           invoice_to_be_finalized
           invoice_to_not_be_finalized
-          allow(Invoices::FinalizeService).to receive(:call)
+          allow(Invoices::RefreshDraftAndFinalizeService).to receive(:call)
         end
 
         it 'finalizes corresponding draft invoices' do
@@ -125,8 +125,8 @@ RSpec.describe Organizations::UpdateService do
 
             aggregate_failures do
               expect(result.organization.invoice_grace_period).to eq(2)
-              expect(Invoices::FinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
-              expect(Invoices::FinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)
+              expect(Invoices::RefreshDraftAndFinalizeService).not_to have_received(:call).with(invoice: invoice_to_not_be_finalized)
+              expect(Invoices::RefreshDraftAndFinalizeService).to have_received(:call).with(invoice: invoice_to_be_finalized)
             end
           end
         end

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -742,7 +742,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
 
       subscription.customer.update!(timezone: new_timezone)
 
-      finalized_result = Invoices::FinalizeService.call(invoice: result.invoice.reload)
+      finalized_result = Invoices::RefreshDraftAndFinalizeService.call(invoice: result.invoice.reload)
       invoice_sub = finalized_result.invoice.reload.invoice_subscriptions.first
 
       aggregate_failures do


### PR DESCRIPTION
## Description

As we're considering adding more Invoice state, we should specify what the current `FinalizeService` does. It not only finalize it, it takes a draft invoice, refresh it and finalize it.

We're also changing a little bit how invoice is set in result and reloaded, hoping to make it a little bit clearer.