### PR TITLE
misc: add prefix to payment status enum on fee

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -38,7 +38,7 @@ class Fee < ApplicationRecord
   PAYMENT_STATUS = %i[pending succeeded failed refunded].freeze
 
   enum fee_type: FEE_TYPES
-  enum payment_status: PAYMENT_STATUS
+  enum payment_status: PAYMENT_STATUS, _prefix: :payment
 
   validates :amount_currency, inclusion: {in: currency_list}
   validates :units, numericality: {greated_than_or_equal_to: 0}


### PR DESCRIPTION
as second part of improvements introduced in this PR:
https://github.com/getlago/lago-api/pull/2299
we want to be more explicit when payment_status on a model actually relates to the payment, so following invoices we want to add `payment_` prefix to payment statuses on fees