### PR TITLE
feat(tax-integrations): update provider tax core logic

### DIFF
--- a/app/services/fees/apply_provider_taxes_service.rb
+++ b/app/services/fees/apply_provider_taxes_service.rb
@@ -28,7 +28,7 @@ module Fees
         )
         fee.applied_taxes << applied_tax
 
-        tax_amount_cents = tax.tax_amount
+        tax_amount_cents = (fee.sub_total_excluding_taxes_amount_cents * tax_rate).fdiv(100)
         applied_tax.amount_cents = tax_amount_cents.round
         applied_tax.save! if fee.persisted?
 

--- a/app/services/integrations/aggregator/taxes/invoices/base_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/base_service.rb
@@ -63,12 +63,21 @@ module Integrations
 
           def tax_breakdown(breakdown)
             breakdown.map do |b|
-              OpenStruct.new(
-                name: b['name'],
-                rate: b['rate'],
-                tax_amount: b['tax_amount'],
-                type: b['type']
-              )
+              if b['type'] == 'exempt'
+                OpenStruct.new(
+                  name: b['reason'],
+                  rate: '0.00',
+                  tax_amount: 0,
+                  type: b['type']
+                )
+              else
+                OpenStruct.new(
+                  name: b['name'],
+                  rate: b['rate'],
+                  tax_amount: b['tax_amount'],
+                  type: b['type']
+                )
+              end
             end
           end
         end

--- a/app/services/integrations/aggregator/taxes/invoices/payload.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payload.rb
@@ -47,7 +47,7 @@ module Integrations
             {
               'item_id' => fee.item_id,
               'item_code' => mapped_item.external_id,
-              'amount_cents' => fee.amount_cents
+              'amount_cents' => fee.sub_total_excluding_taxes_amount_cents
             }
           end
 

--- a/app/services/integrations/aggregator/taxes/invoices/payload.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payload.rb
@@ -34,8 +34,15 @@ module Integrations
           end
 
           def fee_item(fee)
-            # TODO: Update later with other fee types
-            mapped_item = add_on_item(fee)
+            mapped_item = if fee.charge?
+              billable_metric_item(fee)
+            elsif fee.add_on_id.present?
+              add_on_item(fee)
+            elsif fee.commitment?
+              commitment_item
+            elsif fee.subscription?
+              subscription_item
+            end
 
             {
               'item_id' => fee.item_id,

--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -2,15 +2,21 @@
 
 module Invoices
   class ComputeAmountsFromFees < BaseService
-    def initialize(invoice:)
+    def initialize(invoice:, provider_taxes: nil)
       @invoice = invoice
+      @provider_taxes = provider_taxes
+
       super
     end
 
     def call
       unless invoice.one_off?
         invoice.fees.each do |fee|
-          taxes_result = Fees::ApplyTaxesService.call(fee:)
+          taxes_result = if provider_taxes && customer_provider_taxation?
+            Fees::ApplyProviderTaxesService.call(fee:, fee_taxes: fee_taxes(fee))
+          else
+            Fees::ApplyTaxesService.call(fee:)
+          end
           taxes_result.raise_if_error!
           fee.save!
         end
@@ -22,7 +28,11 @@ module Invoices
         invoice.fees_amount_cents - invoice.coupons_amount_cents
       )
 
-      taxes_result = Invoices::ApplyTaxesService.call(invoice:)
+      taxes_result = if provider_taxes && customer_provider_taxation?
+        Invoices::ApplyProviderTaxesService.call(invoice:, provider_taxes:)
+      else
+        Invoices::ApplyTaxesService.call(invoice:)
+      end
       taxes_result.raise_if_error!
 
       invoice.sub_total_including_taxes_amount_cents = (
@@ -38,6 +48,14 @@ module Invoices
 
     private
 
-    attr_reader :invoice
+    attr_reader :invoice, :provider_taxes
+
+    def customer_provider_taxation?
+      @customer_provider_taxation ||= invoice.customer.anrok_customer
+    end
+
+    def fee_taxes(fee)
+      provider_taxes.find { |item| item.item_id == fee.item_id }
+    end
   end
 end

--- a/spec/fixtures/integration_aggregator/taxes/invoices/success_response.json
+++ b/spec/fixtures/integration_aggregator/taxes/invoices/success_response.json
@@ -23,6 +23,10 @@
               "rate": "0.10",
               "tax_amount": 990,
               "type": "tax_exempt"
+            },
+            {
+              "reason": "reverseCharge",
+              "type": "exempt"
             }
           ]
         }

--- a/spec/graphql/mutations/integrations/anrok/fetch_draft_invoice_taxes_spec.rb
+++ b/spec/graphql/mutations/integrations/anrok/fetch_draft_invoice_taxes_spec.rb
@@ -114,12 +114,19 @@ RSpec.describe Mutations::Integrations::Anrok::FetchDraftInvoiceTaxes, type: :gr
       expect(fee['amountCents']).to eq('9900')
       expect(fee['taxAmountCents']).to eq('990')
 
-      breakdown = fee['taxBreakdown'].first
+      breakdown1 = fee['taxBreakdown'].first
 
-      expect(breakdown['name']).to eq('GST/HST')
-      expect(breakdown['rate']).to eq(0.1)
-      expect(breakdown['taxAmount']).to eq('990')
-      expect(breakdown['type']).to eq('tax_exempt')
+      expect(breakdown1['name']).to eq('GST/HST')
+      expect(breakdown1['rate']).to eq(0.1)
+      expect(breakdown1['taxAmount']).to eq('990')
+      expect(breakdown1['type']).to eq('tax_exempt')
+
+      breakdown2 = fee['taxBreakdown'].last
+
+      expect(breakdown2['name']).to eq('reverseCharge')
+      expect(breakdown2['rate']).to eq(0.0)
+      expect(breakdown2['taxAmount']).to eq('0')
+      expect(breakdown2['type']).to eq('exempt')
     end
   end
 end

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -127,6 +127,10 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
           aggregate_failures do
             expect(result).to be_success
             expect(result.fees.first['tax_breakdown'].first['rate']).to eq('0.10')
+            expect(result.fees.first['tax_breakdown'].first['name']).to eq('GST/HST')
+            expect(result.fees.first['tax_breakdown'].last['name']).to eq('reverseCharge')
+            expect(result.fees.first['tax_breakdown'].last['type']).to eq('exempt')
+            expect(result.fees.first['tax_breakdown'].last['rate']).to eq('0.00')
           end
         end
       end

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -128,6 +128,10 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
           aggregate_failures do
             expect(result).to be_success
             expect(result.fees.first['tax_breakdown'].first['rate']).to eq('0.10')
+            expect(result.fees.first['tax_breakdown'].first['name']).to eq('GST/HST')
+            expect(result.fees.first['tax_breakdown'].last['name']).to eq('reverseCharge')
+            expect(result.fees.first['tax_breakdown'].last['type']).to eq('exempt')
+            expect(result.fees.first['tax_breakdown'].last['rate']).to eq('0.00')
           end
         end
       end

--- a/spec/services/invoices/compute_amounts_from_fees_spec.rb
+++ b/spec/services/invoices/compute_amounts_from_fees_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Invoices::ComputeAmountsFromFees, type: :service do
       aggregate_failures do
         expect(fee1.reload.applied_taxes.count).to eq(2)
         expect(fee1.taxes_rate).to eq(80)
-        expect(fee1.taxes_amount_cents).to eq(121) # 75 + 45
+        expect(fee1.taxes_amount_cents).to eq(121)
 
         expect(invoice.fees_amount_cents).to eq(151)
         expect(invoice.sub_total_excluding_taxes_amount_cents).to eq(151)


### PR DESCRIPTION
## Context

Lago is currently implementing integration with Anrok, the tax provider.

## Description

As part of the tax provider integration, Lago is building new action for retrying invoice that failed due to unsuccessful tax fetch.
Pre-requirement for this action is having some updates in core logic that works with provider taxes. Few small changes are added in this PR:

1. In the API response it changed a bit how tax exempts are returned -> small fix added - NOT USED YET
2. `Invoices::ApplyProviderTaxesService` is extended so that it can also take provider taxes as parameter, not only fetch it internally - NOT USED YET
3. `Invoices::ComputeAmountsFromFees` is extended so that it can call `Fees::ApplyProviderTaxesService` and `Invoices::ApplyProviderTaxesService` if customer has configured Anrok -> THIS SERVICE IS USED, BUT THIS CHANGE SHOULD NOT CHANGE ANY LOGIC IF THERE IS NO ANROK CONNECTED.
