### PR TITLE
fix(export-invoices): allow no pagination for Query objects

### DIFF
--- a/app/controllers/api/v1/applied_coupons_controller.rb
+++ b/app/controllers/api/v1/applied_coupons_controller.rb
@@ -31,10 +31,10 @@ module Api
       def index
         result = AppliedCouponsQuery.call(
           organization: current_organization,
-          pagination: BaseQuery::Pagination.new(
+          pagination: {
             page: params[:page],
             limit: params[:per_page] || PER_PAGE
-          ),
+          },
           filters: BaseQuery::Filters.new(index_filters)
         )
 

--- a/app/controllers/api/v1/customers/usage_controller.rb
+++ b/app/controllers/api/v1/customers/usage_controller.rb
@@ -29,10 +29,10 @@ module Api
         def past
           result = PastUsageQuery.call(
             organization: current_organization,
-            pagination: BaseQuery::Pagination.new(
+            pagination: {
               page: params[:page],
               limit: params[:per_page] || PER_PAGE
-            ),
+            },
             filters: BaseQuery::Filters.new(past_usage_filters)
           )
 

--- a/app/controllers/api/v1/fees_controller.rb
+++ b/app/controllers/api/v1/fees_controller.rb
@@ -27,10 +27,10 @@ module Api
       def index
         result = FeesQuery.call(
           organization: current_organization,
-          pagination: BaseQuery::Pagination.new(
+          pagination: {
             page: params[:page],
             limit: params[:per_page] || PER_PAGE
-          ),
+          },
           filters: BaseQuery::Filters.new(index_filters)
         )
 

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -43,9 +43,13 @@ module Api
       end
 
       def index
-        result = InvoicesQuery.new(organization: current_organization).call(
-          page: params[:page],
-          limit: params[:per_page] || PER_PAGE,
+        result = InvoicesQuery.new(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          }
+        ).call(
           search_term: params[:search_term],
           payment_status: (params[:payment_status] if valid_payment_status?(params[:payment_status])),
           payment_dispute_lost: params[:payment_dispute_lost],

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -84,10 +84,10 @@ module Api
       def index
         result = SubscriptionsQuery.call(
           organization: current_organization,
-          pagination: BaseQuery::Pagination.new(
+          pagination: {
             page: params[:page],
             limit: params[:per_page] || PER_PAGE
-          ),
+          },
           filters: BaseQuery::Filters.new(index_filters)
         )
 

--- a/app/graphql/resolvers/customer_portal/invoices_resolver.rb
+++ b/app/graphql/resolvers/customer_portal/invoices_resolver.rb
@@ -15,12 +15,14 @@ module Resolvers
       type Types::Invoices::Object.collection_type, null: false
 
       def resolve(status: nil, page: nil, limit: nil, search_term: nil)
-        query = InvoicesQuery.new(organization: context[:customer_portal_user].organization)
+        query = InvoicesQuery.new(
+          organization: context[:customer_portal_user],
+          pagination: {page:, limit:}
+        )
+
         result = query.call(
           customer_id: context[:customer_portal_user].id,
           search_term:,
-          page:,
-          limit:,
           status:
         )
 

--- a/app/graphql/resolvers/customers/invoices_resolver.rb
+++ b/app/graphql/resolvers/customers/invoices_resolver.rb
@@ -19,12 +19,10 @@ module Resolvers
       type Types::Invoices::Object.collection_type, null: false
 
       def resolve(customer_id: nil, status: nil, page: nil, limit: nil, search_term: nil)
-        query = InvoicesQuery.new(organization: current_organization)
+        query = InvoicesQuery.new(organization: current_organization, pagination: {page:, limit:})
         result = query.call(
           search_term:,
           customer_id:,
-          page:,
-          limit:,
           status:
         )
 

--- a/app/graphql/resolvers/integration_collection_mappings_resolver.rb
+++ b/app/graphql/resolvers/integration_collection_mappings_resolver.rb
@@ -19,7 +19,7 @@ module Resolvers
     def resolve(page: nil, limit: nil, integration_id: nil, mapping_type: nil)
       result = ::IntegrationCollectionMappingsQuery.call(
         organization: current_organization,
-        pagination: BaseQuery::Pagination.new(page:, limit:),
+        pagination: {page:, limit:},
         filters: BaseQuery::Filters.new({integration_id:, mapping_type:})
       )
 

--- a/app/graphql/resolvers/integration_mappings_resolver.rb
+++ b/app/graphql/resolvers/integration_mappings_resolver.rb
@@ -19,7 +19,7 @@ module Resolvers
     def resolve(page: nil, limit: nil, integration_id: nil, mappable_type: nil)
       result = ::IntegrationMappingsQuery.call(
         organization: current_organization,
-        pagination: BaseQuery::Pagination.new(page:, limit:),
+        pagination: {page:, limit:},
         filters: BaseQuery::Filters.new({integration_id:, mappable_type:})
       )
 

--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -38,11 +38,9 @@ module Resolvers
       payment_dispute_lost: nil,
       payment_overdue: nil
     )
-      query = InvoicesQuery.new(organization: current_organization)
+      query = InvoicesQuery.new(organization: current_organization, pagination: {page:, limit:})
       result = query.call(
         search_term:,
-        page:,
-        limit:,
         payment_status:,
         payment_dispute_lost:,
         payment_overdue:,

--- a/app/graphql/resolvers/subscriptions_resolver.rb
+++ b/app/graphql/resolvers/subscriptions_resolver.rb
@@ -19,7 +19,7 @@ module Resolvers
     def resolve(page: nil, limit: nil, plan_code: nil, status: nil)
       result = SubscriptionsQuery.call(
         organization: current_organization,
-        pagination: BaseQuery::Pagination.new(page:, limit:),
+        pagination: {page:, limit:},
         filters: BaseQuery::Filters.new({plan_code:, status:})
       )
 

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 
 class BaseQuery < BaseService
-  PER_PAGE = 100
-
-  Pagination = Struct.new(:page, :limit, keyword_init: true) do
-    def initialize(page: 0, limit: PER_PAGE)
-      super
-    end
-  end
+  Pagination = Struct.new(:page, :limit, keyword_init: true)
 
   class Filters < OpenStruct; end
 
-  def initialize(organization:, pagination: Pagination.new, filters: Filters.new)
+  def initialize(organization:, pagination: nil, filters: Filters.new)
     @organization = organization
-    @pagination = pagination
+    @pagination_params = pagination
     @filters = filters
 
     super
@@ -21,9 +15,20 @@ class BaseQuery < BaseService
 
   private
 
-  attr_reader :organization, :pagination, :filters
+  attr_reader :organization, :pagination_params, :filters
+
+  def pagination
+    return if pagination_params.blank?
+
+    @pagination ||= Pagination.new(
+      page: pagination_params[:page],
+      limit: pagination_params[:limit]
+    )
+  end
 
   def paginate(scope)
+    return scope unless pagination
+
     scope.page(pagination.page).per(pagination.limit)
   end
 

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -2,7 +2,7 @@
 
 class BaseQuery < BaseService
   # nil values force Kaminari to apply its default values for page and limit.
-  DEFAULT_PAGINATION_PARAMS = { page: nil, limit: nil }
+  DEFAULT_PAGINATION_PARAMS = {page: nil, limit: nil}
 
   Pagination = Struct.new(:page, :limit, keyword_init: true)
 

--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class BaseQuery < BaseService
+  # nil values force Kaminari to apply its default values for page and limit.
+  DEFAULT_PAGINATION_PARAMS = { page: nil, limit: nil }
+
   Pagination = Struct.new(:page, :limit, keyword_init: true)
 
   class Filters < OpenStruct; end
 
-  def initialize(organization:, pagination: nil, filters: Filters.new)
+  def initialize(organization:, pagination: DEFAULT_PAGINATION_PARAMS, filters: Filters.new)
     @organization = organization
     @pagination_params = pagination
     @filters = filters

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class InvoicesQuery < BaseQuery
-  def call(search_term:, status:, page:, limit:, filters: {}, customer_id: nil, payment_status: nil, payment_dispute_lost: nil, payment_overdue: nil) # rubocop:disable Metrics/ParameterLists
+  def call(search_term: nil, status: nil, filters: {}, customer_id: nil, payment_status: nil, payment_dispute_lost: nil, payment_overdue: nil) # rubocop:disable Metrics/ParameterLists
     @search_term = search_term
     @customer_id = customer_id
     @filters = filters
@@ -16,7 +16,8 @@ class InvoicesQuery < BaseQuery
     invoices = invoices.where(payment_status:) if payment_status.present?
     invoices = invoices.where.not(payment_dispute_lost_at: nil) unless payment_dispute_lost.nil?
     invoices = invoices.where(payment_overdue:) if payment_overdue.present?
-    invoices = invoices.order(issuing_date: :desc, created_at: :desc).page(page).per(limit)
+    invoices = invoices.order(issuing_date: :desc, created_at: :desc)
+    invoices = paginate(invoices)
 
     result.invoices = invoices
     result

--- a/app/queries/past_usage_query.rb
+++ b/app/queries/past_usage_query.rb
@@ -14,11 +14,13 @@ class PastUsageQuery < BaseQuery
     end
 
     # NOTE: Pagination attributes
-    result.current_page = query_result.current_page
-    result.next_page = query_result.next_page
-    result.prev_page = query_result.prev_page
-    result.total_pages = query_result.total_pages
-    result.total_count = query_result.total_count
+    if pagination
+      result.current_page = query_result.current_page
+      result.next_page = query_result.next_page
+      result.prev_page = query_result.prev_page
+      result.total_pages = query_result.total_pages
+      result.total_count = query_result.total_count
+    end
 
     result
   end

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -86,7 +86,7 @@ module DataExports
         status = resource_query["status"]
         filters = resource_query.except("search_term", "status")
 
-        InvoicesQuery.new(organization: organization).call(
+        InvoicesQuery.new(organization: organization, pagination: nil).call(
           search_term:,
           status:,
           filters:

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -89,8 +89,6 @@ module DataExports
         InvoicesQuery.new(organization: organization).call(
           search_term:,
           status:,
-          page: nil,
-          limit: nil,
           filters:
         )
       end

--- a/spec/queries/applied_coupons_query_spec.rb
+++ b/spec/queries/applied_coupons_query_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AppliedCouponsQuery, type: :query do
   end
 
   let(:organization) { create(:organization) }
-  let(:pagination) { BaseQuery::Pagination.new }
+  let(:pagination) { nil }
   let(:filters) { BaseQuery::Filters.new(query_filters) }
 
   let(:query_filters) { {} }
@@ -40,7 +40,7 @@ RSpec.describe AppliedCouponsQuery, type: :query do
   end
 
   context 'with pagination' do
-    let(:pagination) { BaseQuery::Pagination.new(page: 2, limit: 10) }
+    let(:pagination) { {page: 2, limit: 10} }
 
     it 'applies the pagination' do
       aggregate_failures do

--- a/spec/queries/applied_coupons_query_spec.rb
+++ b/spec/queries/applied_coupons_query_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe AppliedCouponsQuery, type: :query do
-  subject(:applied_coupons_query) { described_class.new(organization:, pagination:, filters:) }
+  subject(:result) do
+    described_class.call(organization:, pagination:, filters:)
+  end
 
   let(:organization) { create(:organization) }
   let(:pagination) { BaseQuery::Pagination.new }
@@ -18,67 +20,55 @@ RSpec.describe AppliedCouponsQuery, type: :query do
 
   before { applied_coupon }
 
-  describe 'call' do
-    it 'returns a list of applied_coupons' do
-      result = applied_coupons_query.call
+  it 'returns a list of applied_coupons' do
+    aggregate_failures do
+      expect(result).to be_success
+      expect(result.applied_coupons.count).to eq(1)
+      expect(result.applied_coupons).to eq([applied_coupon])
+    end
+  end
 
+  context 'when customer is deleted' do
+    let(:customer) { create(:customer, :deleted, organization:) }
+
+    it 'filters the applied_coupons' do
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.applied_coupons.count).to eq(0)
+      end
+    end
+  end
+
+  context 'with pagination' do
+    let(:pagination) { BaseQuery::Pagination.new(page: 2, limit: 10) }
+
+    it 'applies the pagination' do
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.applied_coupons.count).to eq(0)
+        expect(result.applied_coupons.current_page).to eq(2)
+      end
+    end
+  end
+
+  context 'with customer filter' do
+    let(:query_filters) { {external_customer_id: customer.external_id} }
+
+    it 'applies the filter' do
       aggregate_failures do
         expect(result).to be_success
         expect(result.applied_coupons.count).to eq(1)
-        expect(result.applied_coupons).to eq([applied_coupon])
       end
     end
+  end
 
-    context 'when customer is deleted' do
-      let(:customer) { create(:customer, :deleted, organization:) }
+  context 'with status filter' do
+    let(:query_filters) { {status: 'terminated'} }
 
-      it 'filters the applied_coupons' do
-        result = applied_coupons_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.applied_coupons.count).to eq(0)
-        end
-      end
-    end
-
-    context 'with pagination' do
-      let(:pagination) { BaseQuery::Pagination.new(page: 2, limit: 10) }
-
-      it 'applies the pagination' do
-        result = applied_coupons_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.applied_coupons.count).to eq(0)
-          expect(result.applied_coupons.current_page).to eq(2)
-        end
-      end
-    end
-
-    context 'with customer filter' do
-      let(:query_filters) { {external_customer_id: customer.external_id} }
-
-      it 'applies the filter' do
-        result = applied_coupons_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.applied_coupons.count).to eq(1)
-        end
-      end
-    end
-
-    context 'with status filter' do
-      let(:query_filters) { {status: 'terminated'} }
-
-      it 'applies the filter' do
-        result = applied_coupons_query.call
-
-        aggregate_failures do
-          expect(result).to be_success
-          expect(result.applied_coupons.count).to eq(0)
-        end
+    it 'applies the filter' do
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.applied_coupons.count).to eq(0)
       end
     end
   end

--- a/spec/queries/fees_query_spec.rb
+++ b/spec/queries/fees_query_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FeesQuery, type: :query do
   subject(:fees_query) { described_class.new(organization:, pagination:, filters:) }
 
   let(:organization) { create(:organization) }
-  let(:pagination) { BaseQuery::Pagination.new }
+  let(:pagination) { nil }
   let(:filters) { BaseQuery::Filters.new(query_filters) }
 
   let(:query_filters) { {} }
@@ -29,7 +29,7 @@ RSpec.describe FeesQuery, type: :query do
     end
 
     context 'with pagination' do
-      let(:pagination) { BaseQuery::Pagination.new(page: 2, limit: 10) }
+      let(:pagination) { {page: 2, limit: 10} }
 
       it 'applies the pagination' do
         result = fees_query.call

--- a/spec/queries/integration_collection_mappings_query_spec.rb
+++ b/spec/queries/integration_collection_mappings_query_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe IntegrationCollectionMappingsQuery, type: :query do
   subject(:collection_mappings_query) { described_class.new(organization:, pagination:, filters:) }
 
-  let(:pagination) { BaseQuery::Pagination.new }
+  let(:pagination) { nil }
   let(:filters) { BaseQuery::Filters.new(query_filters) }
   let(:query_filters) { {} }
   let(:membership) { create(:membership) }

--- a/spec/queries/integration_mappings_query_spec.rb
+++ b/spec/queries/integration_mappings_query_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe IntegrationMappingsQuery, type: :query do
   subject(:integration_mappings_query) { described_class.new(organization:, pagination:, filters:) }
 
-  let(:pagination) { BaseQuery::Pagination.new }
+  let(:pagination) { nil }
   let(:filters) { BaseQuery::Filters.new(query_filters) }
   let(:query_filters) { {} }
   let(:membership) { create(:membership) }

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -173,9 +173,7 @@ RSpec.describe InvoicesQuery, type: :query do
       result = invoice_query.call(
         search_term: nil,
         status: nil,
-        payment_status: ['succeeded', 'failed'],
-        page: 1,
-        limit: 10
+        payment_status: ['succeeded', 'failed']
       )
 
       returned_ids = result.invoices.pluck(:id)

--- a/spec/queries/subscriptions_query_spec.rb
+++ b/spec/queries/subscriptions_query_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe SubscriptionsQuery, type: :query do
   subject(:subscriptions_query) { described_class.new(organization:, pagination:, filters:) }
 
   let(:organization) { create(:organization) }
-  let(:pagination) { BaseQuery::Pagination.new }
+  let(:pagination) { nil }
   let(:filters) { BaseQuery::Filters.new(query_filters) }
 
   let(:query_filters) { {} }
@@ -29,7 +29,7 @@ RSpec.describe SubscriptionsQuery, type: :query do
     end
 
     context 'with pagination' do
-      let(:pagination) { BaseQuery::Pagination.new(page: 2, limit: 10) }
+      let(:pagination) { {page: 2, limit: 10} }
 
       it 'applies the pagination' do
         result = subscriptions_query.call

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -213,8 +213,6 @@ RSpec.describe DataExports::Csv::InvoiceFees do
       .with(
         search_term:,
         status:,
-        page: nil,
-        limit: nil,
         filters:
       )
       .and_return(query_results)

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe DataExports::Csv::InvoiceFees do
 
     allow(InvoicesQuery)
       .to receive(:new)
-      .with(organization: data_export.organization)
+      .with(organization: data_export.organization, pagination: nil)
       .and_return(invoices_query)
 
     allow(invoices_query)

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -102,8 +102,6 @@ RSpec.describe DataExports::Csv::Invoices do
       .with(
         search_term:,
         status:,
-        page: nil,
-        limit: nil,
         filters:
       )
       .and_return(query_results)

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe DataExports::Csv::Invoices do
 
     allow(InvoicesQuery)
       .to receive(:new)
-      .with(organization: data_export.organization)
+      .with(organization: data_export.organization, pagination: nil)
       .and_return(invoices_query)
 
     allow(invoices_query)


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/ability-to-export-data-from-the-user-interface

## Context

When exporting data (eg: invoices) we use query objects to fetch the records to export. However, the current implementation of query objects paginates to first page and limit results to 25 or 100 (depends on implementation) when no pagination information is provided.

We need the query object to allow no pagination and fetch all resources matching the search / filter criteria when no pagination is provided.

## Description

This change allows client code to call Query object with no pagination information to avoid pagination defaults (page: 1, limit: 25).

Also, it makes `BaseQuery::Pagination` internal knowledge of the query objects. As query objects expect pagination as a hash `{page: 1, limit: 50}`. The same will be applied to `BaseQuery::Filters` in a coming PR.

Updates the Query objects implementing the latest approach and updates `InvoicesQuery` object to allow no pagination and fix the CSV data export issues.

