### PR TITLE
fix(export invoices): multi value invoices filters and improve graphql type name

### DIFF
--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -11,7 +11,7 @@ module Resolvers
 
     argument :currency, Types::CurrencyEnum, required: false
     argument :customer_external_id, String, required: false
-    argument :invoice_type, Types::Invoices::InvoiceTypeEnum, required: false
+    argument :invoice_type, [Types::Invoices::InvoiceTypeEnum], required: false
     argument :issuing_date_from, GraphQL::Types::ISO8601Date, required: false
     argument :issuing_date_to, GraphQL::Types::ISO8601Date, required: false
     argument :limit, Integer, required: false
@@ -20,7 +20,7 @@ module Resolvers
     argument :payment_overdue, Boolean, required: false
     argument :payment_status, [Types::Invoices::PaymentStatusTypeEnum], required: false
     argument :search_term, String, required: false
-    argument :status, Types::Invoices::StatusTypeEnum, required: false
+    argument :status, [Types::Invoices::StatusTypeEnum], required: false
 
     type Types::Invoices::Object.collection_type, null: false
 

--- a/app/graphql/types/data_exports/invoices/filters_input.rb
+++ b/app/graphql/types/data_exports/invoices/filters_input.rb
@@ -4,18 +4,19 @@ module Types
   module DataExports
     module Invoices
       class FiltersInput < BaseInputObject
+        graphql_name 'DataExportInvoiceFiltersInput'
         description 'Export Invoices search query and filters input argument'
 
         argument :currency, Types::CurrencyEnum, required: false
         argument :customer_external_id, String, required: false
-        argument :invoice_type, Types::Invoices::InvoiceTypeEnum, required: false
+        argument :invoice_type, [Types::Invoices::InvoiceTypeEnum], required: false
         argument :issuing_date_from, GraphQL::Types::ISO8601Date, required: false
         argument :issuing_date_to, GraphQL::Types::ISO8601Date, required: false
         argument :payment_dispute_lost, Boolean, required: false
         argument :payment_overdue, Boolean, required: false
         argument :payment_status, [Types::Invoices::PaymentStatusTypeEnum], required: false
         argument :search_term, String, required: false
-        argument :status, Types::Invoices::StatusTypeEnum, required: false
+        argument :status, [Types::Invoices::StatusTypeEnum], required: false
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1908,7 +1908,7 @@ input CreateDataExportsInvoicesInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  filters: FiltersInput!
+  filters: DataExportInvoiceFiltersInput!
   format: DataExportFormatTypeEnum!
   resourceType: ExportTypeEnum!
 }
@@ -3126,6 +3126,22 @@ enum DataExportFormatTypeEnum {
   csv
 }
 
+"""
+Export Invoices search query and filters input argument
+"""
+input DataExportInvoiceFiltersInput {
+  currency: CurrencyEnum
+  customerExternalId: String
+  invoiceType: [InvoiceTypeEnum!]
+  issuingDateFrom: ISO8601Date
+  issuingDateTo: ISO8601Date
+  paymentDisputeLost: Boolean
+  paymentOverdue: Boolean
+  paymentStatus: [InvoicePaymentStatusTypeEnum!]
+  searchTerm: String
+  status: [InvoiceStatusTypeEnum!]
+}
+
 enum DataExportStatusEnum {
   completed
   failed
@@ -3621,22 +3637,6 @@ input FetchIntegrationTaxItemsInput {
   """
   clientMutationId: String
   integrationId: ID!
-}
-
-"""
-Export Invoices search query and filters input argument
-"""
-input FiltersInput {
-  currency: CurrencyEnum
-  customerExternalId: String
-  invoiceType: InvoiceTypeEnum
-  issuingDateFrom: ISO8601Date
-  issuingDateTo: ISO8601Date
-  paymentDisputeLost: Boolean
-  paymentOverdue: Boolean
-  paymentStatus: [InvoicePaymentStatusTypeEnum!]
-  searchTerm: String
-  status: InvoiceStatusTypeEnum
 }
 
 """
@@ -5661,7 +5661,7 @@ type Query {
   """
   Query invoices
   """
-  invoices(currency: CurrencyEnum, customerExternalId: String, invoiceType: InvoiceTypeEnum, issuingDateFrom: ISO8601Date, issuingDateTo: ISO8601Date, limit: Int, page: Int, paymentDisputeLost: Boolean, paymentOverdue: Boolean, paymentStatus: [InvoicePaymentStatusTypeEnum!], searchTerm: String, status: InvoiceStatusTypeEnum): InvoiceCollection!
+  invoices(currency: CurrencyEnum, customerExternalId: String, invoiceType: [InvoiceTypeEnum!], issuingDateFrom: ISO8601Date, issuingDateTo: ISO8601Date, limit: Int, page: Int, paymentDisputeLost: Boolean, paymentOverdue: Boolean, paymentStatus: [InvoicePaymentStatusTypeEnum!], searchTerm: String, status: [InvoiceStatusTypeEnum!]): InvoiceCollection!
 
   """
   Query memberships of an organization

--- a/schema.json
+++ b/schema.json
@@ -7698,7 +7698,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "FiltersInput",
+                  "name": "DataExportInvoiceFiltersInput",
                   "ofType": null
                 }
               },
@@ -13444,6 +13444,161 @@
           ]
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "DataExportInvoiceFiltersInput",
+          "description": "Export Invoices search query and filters input argument",
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "currency",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "CurrencyEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customerExternalId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoiceType",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "InvoiceTypeEnum",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "issuingDateFrom",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "issuingDateTo",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601Date",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentDisputeLost",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentOverdue",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentStatus",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "InvoicePaymentStatusTypeEnum",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "searchTerm",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "InvoiceStatusTypeEnum",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
           "kind": "ENUM",
           "name": "DataExportStatusEnum",
           "description": null,
@@ -16420,145 +16575,6 @@
                   "name": "ID",
                   "ofType": null
                 }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "enumValues": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "FiltersInput",
-          "description": "Export Invoices search query and filters input argument",
-          "interfaces": null,
-          "possibleTypes": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "currency",
-              "description": null,
-              "type": {
-                "kind": "ENUM",
-                "name": "CurrencyEnum",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "customerExternalId",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "invoiceType",
-              "description": null,
-              "type": {
-                "kind": "ENUM",
-                "name": "InvoiceTypeEnum",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "issuingDateFrom",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "issuingDateTo",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "ISO8601Date",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "paymentDisputeLost",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "paymentOverdue",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "paymentStatus",
-              "description": null,
-              "type": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "ENUM",
-                    "name": "InvoicePaymentStatusTypeEnum",
-                    "ofType": null
-                  }
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "searchTerm",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "status",
-              "description": null,
-              "type": {
-                "kind": "ENUM",
-                "name": "InvoiceStatusTypeEnum",
-                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -29122,9 +29138,17 @@
                   "name": "invoiceType",
                   "description": null,
                   "type": {
-                    "kind": "ENUM",
-                    "name": "InvoiceTypeEnum",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "InvoiceTypeEnum",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,
@@ -29238,9 +29262,17 @@
                   "name": "status",
                   "description": null,
                   "type": {
-                    "kind": "ENUM",
-                    "name": "InvoiceStatusTypeEnum",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "InvoiceStatusTypeEnum",
+                        "ofType": null
+                      }
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/spec/graphql/mutations/data_exports/invoices/create_spec.rb
+++ b/spec/graphql/mutations/data_exports/invoices/create_spec.rb
@@ -38,14 +38,14 @@ RSpec.describe Mutations::DataExports::Invoices::Create, type: :graphql do
           filters: {
             currency: 'USD',
             customerExternalId: 'abc123',
-            invoiceType: 'one_off',
+            invoiceType: ['one_off'],
             issuingDateFrom: '2024-05-23',
             issuingDateTo: '2024-07-01',
             paymentDisputeLost: false,
             paymentOverdue: true,
-            paymentStatus: 'pending',
+            paymentStatus: ['pending'],
             searchTerm: 'service ABC',
-            status: 'finalized'
+            status: ['finalized']
           }
         }
       }

--- a/spec/graphql/resolvers/invoices_resolver_spec.rb
+++ b/spec/graphql/resolvers/invoices_resolver_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
     let(:query) do
       <<~GQL
         query {
-          invoices(limit: 5, status: draft) {
+          invoices(limit: 5, status: [draft]) {
             collection { id }
             metadata { currentPage, totalCount }
           }
@@ -194,7 +194,7 @@ RSpec.describe Resolvers::InvoicesResolver, type: :graphql do
     let(:query) do
       <<~GQL
         query {
-          invoices(limit: 5, invoiceType: one_off) {
+          invoices(limit: 5, invoiceType: [one_off]) {
             collection { id }
             metadata { currentPage, totalCount }
           }

--- a/spec/graphql/types/data_exports/invoices/filters_input_spec.rb
+++ b/spec/graphql/types/data_exports/invoices/filters_input_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Types::DataExports::Invoices::FiltersInput do
 
   it { is_expected.to accept_argument(:currency).of_type('CurrencyEnum') }
   it { is_expected.to accept_argument(:customer_external_id).of_type('String') }
-  it { is_expected.to accept_argument(:invoice_type).of_type('InvoiceTypeEnum') }
+  it { is_expected.to accept_argument(:invoice_type).of_type('[InvoiceTypeEnum!]') }
   it { is_expected.to accept_argument(:issuing_date_from).of_type('ISO8601Date') }
   it { is_expected.to accept_argument(:issuing_date_to).of_type('ISO8601Date') }
   it { is_expected.to accept_argument(:payment_dispute_lost).of_type('Boolean') }
   it { is_expected.to accept_argument(:payment_overdue).of_type('Boolean') }
   it { is_expected.to accept_argument(:payment_status).of_type('[InvoicePaymentStatusTypeEnum!]') }
   it { is_expected.to accept_argument(:search_term).of_type('String') }
-  it { is_expected.to accept_argument(:status).of_type('InvoiceStatusTypeEnum') }
+  it { is_expected.to accept_argument(:status).of_type('[InvoiceStatusTypeEnum!]') }
 end

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -155,6 +155,29 @@ RSpec.describe InvoicesQuery, type: :query do
     end
   end
 
+  context 'when filtering by succeeded and failed payment_status' do
+    it 'returns 1 invoices' do
+      result = invoice_query.call(
+        search_term: nil,
+        status: nil,
+        payment_status: ['succeeded', 'failed'],
+        page: 1,
+        limit: 10
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(result.invoices.count).to eq(2)
+        expect(returned_ids).to include(invoice_first.id)
+        expect(returned_ids).not_to include(invoice_second.id)
+        expect(returned_ids).to include(invoice_third.id)
+        expect(returned_ids).not_to include(invoice_fourth.id)
+        expect(returned_ids).not_to include(invoice_fifth.id)
+      end
+    end
+  end
+
   context 'when filtering by payment dispute lost' do
     it 'returns 1 invoices' do
       result = invoice_query.call(


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/ability-to-export-data-from-the-user-interface


## Description

Accept a list of values for invoices type and status filters on invoices resolver and create data export mutation.

also;
assigns a meaningful name to data exports invoices filter input type

