### PR TITLE
feat (tax-integrations): Add invoice retry service

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -374,6 +374,8 @@ class Invoice < ApplicationRecord
   end
 
   def status_changed_to_finalized?
-    status_changed?(from: 'draft', to: 'finalized') || status_changed?(from: 'generating', to: 'finalized')
+    status_changed?(from: 'draft', to: 'finalized') ||
+      status_changed?(from: 'generating', to: 'finalized') ||
+      status_changed?(from: 'failed', to: 'finalized')
   end
 end

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Invoices
+  class RetryService < BaseService
+    def initialize(invoice:)
+      @invoice = invoice
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'invoice') unless invoice
+      #return result.not_allowed_failure!(code: 'invalid_status') unless invoice.failed?
+
+      taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: invoice.fees)
+
+      unless taxes_result.success?
+        return result.service_failure!(code: 'taxes', message: 'fetching failed')
+      end
+
+      @taxes_fees = taxes_result.fees
+
+      ActiveRecord::Base.transaction do
+        invoice.status = :finalized
+
+        # TODO: pass provider taxes
+        Invoices::ComputeAmountsFromFees.call(invoice:)
+
+        create_credit_note_credit if should_create_credit_note_credit?
+        create_applied_prepaid_credit if should_create_applied_prepaid_credit?
+
+        invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
+        invoice.save!
+
+        invoice.reload
+
+        result.invoice = invoice
+      end
+
+      SendWebhookJob.perform_later('invoice.created', invoice) if invoice.organization.webhook_endpoints.any?
+      GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
+      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+      Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
+      Invoices::Payments::CreateService.new(invoice).call
+      Utils::SegmentTrack.invoice_created(invoice)
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue BaseService::FailedResult => e
+      e.result
+    rescue => e
+      result.fail_with_error!(e)
+    end
+
+    private
+
+    attr_accessor :invoice, :taxes_fees
+
+    def should_deliver_email?
+      License.premium? &&
+        invoice.organization.email_settings.include?('invoice.finalized')
+    end
+
+    def wallet
+      return @wallet if @wallet
+
+      @wallet = customer.wallets.active.first
+    end
+
+    def credit_notes
+      @credit_notes ||= customer.credit_notes
+        .finalized
+        .available
+        .where.not(invoice_id: invoice.id)
+        .order(created_at: :asc)
+    end
+
+    def should_create_credit_note_credit?
+      credit_notes.any?
+    end
+
+    def should_create_applied_prepaid_credit?
+      return false unless wallet&.active?
+      return false unless invoice.total_amount_cents&.positive?
+
+      wallet.balance.positive?
+    end
+
+    def create_credit_note_credit
+      credit_result = Credits::CreditNoteService.new(invoice:, credit_notes:).call
+      credit_result.raise_if_error!
+
+      invoice.total_amount_cents -= credit_result.credits.sum(&:amount_cents) if credit_result.credits
+    end
+
+    def create_applied_prepaid_credit
+      prepaid_credit_result = Credits::AppliedPrepaidCreditService.call(invoice:, wallet:)
+      prepaid_credit_result.raise_if_error!
+
+      invoice.total_amount_cents -= prepaid_credit_result.prepaid_credit_amount_cents
+    end
+  end
+end

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -18,13 +18,12 @@ module Invoices
         return result.service_failure!(code: 'taxes', message: 'fetching failed')
       end
 
-      @taxes_fees = taxes_result.fees
+      provider_taxes = taxes_result.fees
 
       ActiveRecord::Base.transaction do
         invoice.status = :finalized
 
-        # TODO: pass provider taxes
-        Invoices::ComputeAmountsFromFees.call(invoice:)
+        Invoices::ComputeAmountsFromFees.call(invoice:, provider_taxes:)
 
         create_credit_note_credit if should_create_credit_note_credit?
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
@@ -55,7 +54,7 @@ module Invoices
 
     private
 
-    attr_accessor :invoice, :taxes_fees
+    attr_accessor :invoice
 
     def should_deliver_email?
       License.premium? &&

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -23,5 +23,9 @@ FactoryBot.define do
     trait :dispute_lost do
       payment_dispute_lost_at { DateTime.current - 1.day }
     end
+
+    trait :failed do
+      status { :failed }
+    end
   end
 end

--- a/spec/fixtures/integration_aggregator/taxes/invoices/success_response_multiple_fees.json
+++ b/spec/fixtures/integration_aggregator/taxes/invoices/success_response_multiple_fees.json
@@ -1,0 +1,45 @@
+{
+  "succeededInvoices": [
+    {
+      "issuing_date": "2024-03-07",
+      "sub_total_excluding_taxes": 9900,
+      "taxes_amount_cents": 99,
+      "currency": "USD",
+      "contact": {
+        "external_id": "cus_lago_12345",
+        "name": "John Doe",
+        "taxable": true,
+        "tax_number": "1234567890"
+      },
+      "fees": [
+        {
+          "item_id": "sub_fee_id-12345",
+          "item_code": "lago_default_b2b",
+          "amount_cents": 2000,
+          "tax_amount_cents": 200,
+          "tax_breakdown": [
+            {
+              "name": "GST/HST",
+              "rate": "0.10",
+              "tax_amount": 200
+            }
+          ]
+        },
+        {
+          "item_id": "charge_fee_id-12345",
+          "item_code": "lago_default_b2c",
+          "amount_cents": 1000,
+          "tax_amount_cents": 150,
+          "tax_breakdown": [
+            {
+              "name": "GST/HST",
+              "rate": "0.15",
+              "tax_amount": 150
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "failedInvoices": []
+}

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::RetryService, type: :service do
+  subject(:retry_service) { described_class.new(invoice:) }
+
+  describe '#call' do
+    let(:organization) { create(:organization) }
+    let(:customer) { create(:customer, organization:) }
+
+    let(:invoice) do
+      create(
+        :invoice,
+        :failed,
+        customer:,
+        organization:,
+        subscriptions: [subscription],
+        currency: 'EUR',
+        issuing_date: Time.zone.at(timestamp).to_date
+      )
+    end
+
+    let(:subscription) do
+      create(
+        :subscription,
+        plan:,
+        subscription_at: started_at,
+        started_at:,
+        created_at: started_at
+      )
+    end
+
+    let(:timestamp) { Time.zone.now - 1.year }
+    let(:started_at) { Time.zone.now - 2.years }
+    let(:plan) { create(:plan, organization:, interval: 'monthly') }
+    let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
+    let(:charge) { create(:standard_charge, plan: subscription.plan, charge_model: 'standard', billable_metric:) }
+
+    let(:fee_subscription) do
+      create(
+        :fee,
+        invoice:,
+        subscription:,
+        fee_type: :subscription,
+        amount_cents: 2_000
+      )
+    end
+    let(:fee_charge) do
+      create(
+        :fee,
+        invoice:,
+        charge:,
+        fee_type: :charge,
+        total_aggregated_units: 100,
+        amount_cents: 1_000
+      )
+    end
+
+    let(:integration) { create(:anrok_integration, organization:) }
+    let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+    let(:response) { instance_double(Net::HTTPOK) }
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+    let(:body) do
+      path = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response_multiple_fees.json')
+      json = File.read(path)
+
+      # setting item_id based on the test example
+      response = JSON.parse(json)
+      response['succeededInvoices'].first['fees'].first['item_id'] = subscription.id
+      response['succeededInvoices'].first['fees'].last['item_id'] = billable_metric.id
+
+      response.to_json
+    end
+    let(:integration_collection_mapping) do
+      create(
+        :netsuite_collection_mapping,
+        integration:,
+        mapping_type: :fallback_item,
+        settings: {external_id: '1', external_account_code: '11', external_name: ''}
+      )
+    end
+
+    before do
+      integration_collection_mapping
+      fee_subscription
+      fee_charge
+
+      allow(SegmentTrackJob).to receive(:perform_later)
+      allow(Invoices::Payments::StripeCreateJob).to receive(:perform_later).and_call_original
+      allow(Invoices::Payments::GocardlessCreateJob).to receive(:perform_later).and_call_original
+
+      integration_customer
+
+      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response).and_return(response)
+      allow(response).to receive(:body).and_return(body)
+    end
+
+    context 'when invoice does not exist' do
+      it 'returns an error' do
+        result = described_class.new(invoice: nil).call
+
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq('invoice_not_found')
+      end
+    end
+
+    context 'when invoice is in draft status' do
+      before do
+        invoice.update(status: :draft)
+      end
+
+      it 'returns an error' do
+        result = retry_service.call
+
+        expect(result).not_to be_success
+        expect(result.error.code).to eq('invalid_status')
+      end
+    end
+
+    it 'marks the invoice as finalized' do
+      expect { retry_service.call }
+        .to change(invoice, :status).from('failed').to('finalized')
+    end
+
+    it 'updates the issuing date and payment due date' do
+      invoice.customer.update(timezone: 'America/New_York')
+
+      freeze_time do
+        current_date = Time.current.in_time_zone('America/New_York').to_date
+
+        expect { retry_service.call }
+          .to change { invoice.reload.issuing_date }.to(current_date)
+          .and change { invoice.reload.payment_due_date }.to(current_date)
+      end
+    end
+
+    it 'generates invoice number' do
+      customer_slug = "#{organization.document_number_prefix}-#{format("%03d", customer.sequential_id)}"
+      sequential_id = customer.invoices.where.not(id: invoice.id).order(created_at: :desc).first&.sequential_id || 0
+
+      expect { retry_service.call }
+        .to change { invoice.reload.number }
+        .from("#{organization.document_number_prefix}-DRAFT")
+        .to("#{customer_slug}-#{format('%03d', sequential_id + 1)}")
+    end
+
+    it 'generates expected invoice totals' do
+      result = retry_service.call
+
+      aggregate_failures do
+        expect(result).to be_success
+        expect(result.invoice.fees.charge_kind.count).to eq(1)
+        expect(result.invoice.fees.subscription_kind.count).to eq(1)
+
+        expect(result.invoice.currency).to eq('EUR')
+        expect(result.invoice.fees_amount_cents).to eq(3_000)
+
+        expect(result.invoice.taxes_amount_cents).to eq(350)
+        expect(result.invoice.taxes_rate.round(2)).to eq(11.67) # (0.667 * 10) + (0.333 * 15)
+        expect(result.invoice.applied_taxes.count).to eq(2)
+
+        expect(result.invoice.total_amount_cents).to eq(3_350)
+      end
+    end
+
+    it_behaves_like 'syncs invoice' do
+      let(:service_call) { retry_service.call }
+    end
+
+    it_behaves_like 'syncs sales order' do
+      let(:service_call) { retry_service.call }
+    end
+
+    it 'enqueues a SendWebhookJob' do
+      expect do
+        retry_service.call
+      end.to have_enqueued_job(SendWebhookJob).with('invoice.created', Invoice)
+    end
+
+    it 'enqueues GeneratePdfAndNotifyJob with email false' do
+      expect do
+        retry_service.call
+      end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
+    end
+
+    context 'with lago_premium' do
+      around { |test| lago_premium!(&test) }
+
+      it 'enqueues GeneratePdfAndNotifyJob with email true' do
+        expect do
+          retry_service.call
+        end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: true))
+      end
+
+      context 'when organization does not have right email settings' do
+        before { invoice.organization.update!(email_settings: []) }
+
+        it 'enqueues GeneratePdfAndNotifyJob with email false' do
+          expect do
+            retry_service.call
+          end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
+        end
+      end
+    end
+
+    it 'calls SegmentTrackJob' do
+      invoice = retry_service.call.invoice
+
+      expect(SegmentTrackJob).to have_received(:perform_later).with(
+        membership_id: CurrentContext.membership,
+        event: 'invoice_created',
+        properties: {
+          organization_id: invoice.organization.id,
+          invoice_id: invoice.id,
+          invoice_type: invoice.invoice_type
+        }
+      )
+    end
+
+    it 'creates a payment' do
+      payment_create_service = instance_double(Invoices::Payments::CreateService)
+      allow(Invoices::Payments::CreateService).to receive(:new).and_return(payment_create_service)
+      allow(payment_create_service).to receive(:call)
+
+      retry_service.call
+      expect(Invoices::Payments::CreateService).to have_received(:new)
+      expect(payment_create_service).to have_received(:call)
+    end
+
+    context 'when organization does not have a webhook endpoint' do
+      before { invoice.organization.webhook_endpoints.destroy_all }
+
+      it 'does not enqueue a SendWebhookJob' do
+        expect do
+          retry_service.call
+        end.not_to have_enqueued_job(SendWebhookJob)
+      end
+    end
+
+    context 'with credit notes' do
+      let(:credit_note) do
+        create(
+          :credit_note,
+          customer:,
+          total_amount_cents: 10,
+          total_amount_currency: 'EUR',
+          balance_amount_cents: 10,
+          balance_amount_currency: 'EUR',
+          credit_amount_cents: 10,
+          credit_amount_currency: 'EUR'
+        )
+      end
+
+      before { credit_note }
+
+      it 'updates the invoice accordingly' do
+        result = retry_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+          expect(result.invoice.fees_amount_cents).to eq(3_000)
+          expect(result.invoice.taxes_amount_cents).to eq(350)
+          expect(result.invoice.total_amount_cents).to eq(3_340)
+          expect(result.invoice.credits.count).to eq(1)
+
+          credit = result.invoice.credits.first
+          expect(credit.credit_note).to eq(credit_note)
+          expect(credit.amount_cents).to eq(10)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -107,9 +107,9 @@ RSpec.describe Invoices::RetryService, type: :service do
       end
     end
 
-    context 'when invoice is in draft status' do
+    context 'when invoice is not failed' do
       before do
-        invoice.update(status: :draft)
+        invoice.update(status: %i[draft finalized voided generating].sample)
       end
 
       it 'returns an error' do

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Invoices::RetryService, type: :service do
       expect { retry_service.call }
         .to change { invoice.reload.number }
         .from("#{organization.document_number_prefix}-DRAFT")
-        .to("#{customer_slug}-#{format('%03d', sequential_id + 1)}")
+        .to("#{customer_slug}-#{format("%03d", sequential_id + 1)}")
     end
 
     it 'generates expected invoice totals' do


### PR DESCRIPTION
## Context

Currently Lago is adding Anrok tax integration

## Description

This PR adds new service for retrying failed invoice due to the tax integration errors.

Main goals of the service are:

1. Keep existing fees
2. Fetch tax based on the existing fees
3. Apply taxes on fees and invoice
4. Calculate totals
5. Generate invoice number and finalize invoice
6. Call all async actions: accounting integration syncs, trigger webhooks, payment...
