### PR TITLE
Fix: Event ingestions when using a non default schema

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -80,6 +80,7 @@ production:
     url: <%= ENV['DATABASE_URL'] %>
     pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
     prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
+    schema_search_path: <%= ENV.fetch('POSTGRES_SCHEMA', 'public') %>
     database_tasks: false
   clickhouse:
     adapter: clickhouse


### PR DESCRIPTION
## Context

Currently the database configuration for production looks like so:
```
production:
  primary:
    <<: *default
    url: <%= ENV['DATABASE_URL'] %>
    pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
    prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
    schema_search_path: <%= ENV.fetch('POSTGRES_SCHEMA', 'public') %>
  events:
    <<: *default
    url: <%= ENV['DATABASE_URL'] %>
    pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
    prepared_statements: <%= ENV.fetch('DATABASE_PREPARED_STATEMENTS', true) %>
    database_tasks: false
```

As you can see, schema_search_path is configured for `primary` but missing for `events`. This means that migrations and all the main logic will run on POSTGRES_SCHEMA if configured, but events will still look for the tables in the `public` schema, which will not exist, causing an error and rendering Lago features such as events ingestion completely unusable.

This PR simply also adds the same `schema_search_path` directive to the events config, making them match and fixing the issue. I have extensively tested this code on my self deployed Lago over the past week.

## Description

Make the schema_search_path for `primary` and `events` match and be identical so they can find each other's data.