### PR TITLE
feat(invoice): Introduce visible/invisible invoice status

### DIFF
--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -5,7 +5,7 @@ module Api
     class CreditNotesController < Api::BaseController
       def create
         service = CreditNotes::CreateService.new(
-          invoice: current_organization.invoices.not_generating.find_by(id: input_params[:invoice_id]),
+          invoice: current_organization.invoices.visible.find_by(id: input_params[:invoice_id]),
           **input_params
         )
         result = service.call
@@ -116,7 +116,7 @@ module Api
 
       def estimate
         result = CreditNotes::EstimateService.call(
-          invoice: current_organization.invoices.not_generating.find_by(id: estimate_params[:invoice_id]),
+          invoice: current_organization.invoices.visible.find_by(id: estimate_params[:invoice_id]),
           items: estimate_params[:items]
         )
 

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -19,7 +19,7 @@ module Api
       end
 
       def update
-        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
+        invoice = current_organization.invoices.visible.find_by(id: params[:id])
 
         result = Invoices::UpdateService.new(
           invoice:,
@@ -35,7 +35,7 @@ module Api
       end
 
       def show
-        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
+        invoice = current_organization.invoices.visible.find_by(id: params[:id])
 
         return not_found_error(resource: 'invoice') unless invoice
 
@@ -99,7 +99,7 @@ module Api
       end
 
       def refresh
-        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
+        invoice = current_organization.invoices.visible.find_by(id: params[:id])
         return not_found_error(resource: 'invoice') unless invoice
 
         result = Invoices::RefreshDraftService.call(invoice:)
@@ -123,7 +123,7 @@ module Api
       end
 
       def void
-        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
+        invoice = current_organization.invoices.visible.find_by(id: params[:id])
 
         result = Invoices::VoidService.call(invoice:)
         if result.success?
@@ -134,7 +134,7 @@ module Api
       end
 
       def lose_dispute
-        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
+        invoice = current_organization.invoices.visible.find_by(id: params[:id])
 
         result = Invoices::LoseDisputeService.call(invoice:, payment_dispute_lost_at: DateTime.current)
         if result.success?
@@ -145,7 +145,7 @@ module Api
       end
 
       def retry_payment
-        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
+        invoice = current_organization.invoices.visible.find_by(id: params[:id])
         return not_found_error(resource: 'invoice') unless invoice
 
         result = Invoices::Payments::RetryService.new(invoice:).call
@@ -155,7 +155,7 @@ module Api
       end
 
       def retry
-        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
+        invoice = current_organization.invoices.visible.find_by(id: params[:id])
         return not_found_error(resource: 'invoice') unless invoice
 
         result = Invoices::RetryService.new(invoice:).call
@@ -167,7 +167,7 @@ module Api
       end
 
       def payment_url
-        invoice = current_organization.invoices.not_generating.includes(:customer).find_by(id: params[:id])
+        invoice = current_organization.invoices.visible.includes(:customer).find_by(id: params[:id])
         return not_found_error(resource: 'invoice') unless invoice
 
         result = ::Invoices::Payments::GeneratePaymentUrlService.call(invoice:)

--- a/app/graphql/mutations/credit_notes/create.rb
+++ b/app/graphql/mutations/credit_notes/create.rb
@@ -27,7 +27,7 @@ module Mutations
 
         result = ::CreditNotes::CreateService
           .new(
-            invoice: current_organization.invoices.not_generating.find_by(id: args[:invoice_id]),
+            invoice: current_organization.invoices.visible.find_by(id: args[:invoice_id]),
             **args
           )
           .call

--- a/app/graphql/mutations/customer_portal/download_invoice.rb
+++ b/app/graphql/mutations/customer_portal/download_invoice.rb
@@ -13,7 +13,7 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(id:)
-        invoice = context[:customer_portal_user].invoices.not_generating.find_by(id:)
+        invoice = context[:customer_portal_user].invoices.visible.find_by(id:)
         result = ::Invoices::GeneratePdfService.call(invoice:)
         result.success? ? result.invoice : result_error(result)
       end

--- a/app/graphql/mutations/invoices/download.rb
+++ b/app/graphql/mutations/invoices/download.rb
@@ -16,7 +16,7 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(id:)
-        invoice = Invoice.not_generating.find_by(id:, organization_id: current_organization.id)
+        invoice = Invoice.visible.find_by(id:, organization_id: current_organization.id)
         result = ::Invoices::GeneratePdfService.call(invoice:)
         result.success? ? result.invoice : result_error(result)
       end

--- a/app/graphql/mutations/invoices/lose_dispute.rb
+++ b/app/graphql/mutations/invoices/lose_dispute.rb
@@ -17,7 +17,7 @@ module Mutations
 
       def resolve(**args)
         result = ::Invoices::LoseDisputeService.call(
-          invoice: current_organization.invoices.not_generating.find_by(id: args[:id]),
+          invoice: current_organization.invoices.visible.find_by(id: args[:id]),
           payment_dispute_lost_at: DateTime.current
         )
         result.success? ? result.invoice : result_error(result)

--- a/app/graphql/mutations/invoices/refresh.rb
+++ b/app/graphql/mutations/invoices/refresh.rb
@@ -17,7 +17,7 @@ module Mutations
 
       def resolve(**args)
         result = ::Invoices::RefreshDraftService.call(
-          invoice: current_organization.invoices.not_generating.find_by(id: args[:id])
+          invoice: current_organization.invoices.visible.find_by(id: args[:id])
         )
         result.success? ? result.invoice : result_error(result)
       end

--- a/app/graphql/mutations/invoices/retry.rb
+++ b/app/graphql/mutations/invoices/retry.rb
@@ -16,7 +16,7 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(**args)
-        invoice = current_organization.invoices.not_generating.find_by(id: args[:id])
+        invoice = current_organization.invoices.visible.find_by(id: args[:id])
         result = ::Invoices::RetryService.new(invoice:).call
 
         result.success? ? result.invoice : result_error(result)

--- a/app/graphql/mutations/invoices/retry_payment.rb
+++ b/app/graphql/mutations/invoices/retry_payment.rb
@@ -16,7 +16,7 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(**args)
-        invoice = current_organization.invoices.not_generating.find_by(id: args[:id])
+        invoice = current_organization.invoices.visible.find_by(id: args[:id])
         result = ::Invoices::Payments::RetryService.new(invoice:).call
 
         result.success? ? result.invoice : result_error(result)

--- a/app/graphql/mutations/invoices/update.rb
+++ b/app/graphql/mutations/invoices/update.rb
@@ -15,7 +15,7 @@ module Mutations
       type Types::Invoices::Object
 
       def resolve(**args)
-        invoice = context[:current_organization].invoices.not_generating.find_by(id: args[:id])
+        invoice = context[:current_organization].invoices.visible.find_by(id: args[:id])
         result = ::Invoices::UpdateService.new(invoice:, params: args, webhook_notification: true).call
 
         result.success? ? result.invoice : result_error(result)

--- a/app/graphql/mutations/invoices/void.rb
+++ b/app/graphql/mutations/invoices/void.rb
@@ -17,7 +17,7 @@ module Mutations
 
       def resolve(**args)
         result = ::Invoices::VoidService.call(
-          invoice: current_organization.invoices.not_generating.find_by(id: args[:id])
+          invoice: current_organization.invoices.visible.find_by(id: args[:id])
         )
         result.success? ? result.invoice : result_error(result)
       end

--- a/app/graphql/resolvers/credit_notes/estimate_resolver.rb
+++ b/app/graphql/resolvers/credit_notes/estimate_resolver.rb
@@ -15,7 +15,7 @@ module Resolvers
 
       def resolve(invoice_id:, items:)
         result = ::CreditNotes::EstimateService.call(
-          invoice: current_organization.invoices.not_generating.find_by(id: invoice_id),
+          invoice: current_organization.invoices.visible.find_by(id: invoice_id),
           items:
         )
 

--- a/app/graphql/resolvers/invoice_resolver.rb
+++ b/app/graphql/resolvers/invoice_resolver.rb
@@ -14,7 +14,7 @@ module Resolvers
     type Types::Invoices::Object, null: true
 
     def resolve(id:)
-      current_organization.invoices.not_generating.find(id)
+      current_organization.invoices.visible.find(id)
     rescue ActiveRecord::RecordNotFound
       not_found_error(resource: 'invoice')
     end

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -79,7 +79,7 @@ module Types
       end
 
       def invoices
-        object.invoices.not_generating.order(created_at: :desc)
+        object.invoices.visible.order(created_at: :desc)
       end
 
       def applied_coupons

--- a/app/graphql/types/invoices/status_type_enum.rb
+++ b/app/graphql/types/invoices/status_type_enum.rb
@@ -5,7 +5,7 @@ module Types
     class StatusTypeEnum < Types::BaseEnum
       graphql_name 'InvoiceStatusTypeEnum'
 
-      Invoice::STATUS.reject { |k| k == :generating }.each do |type|
+      Invoice::VISIBLE_STATUS.keys.each do |type|
         value type
       end
     end

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -30,7 +30,7 @@ class InvoicesQuery < BaseQuery
   attr_reader :search_term, :filters
 
   def base_scope
-    organization.invoices.not_generating.ransack(search_params)
+    organization.invoices.visible.ransack(search_params)
   end
 
   def search_params

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe Invoice, type: :model do
 
   it { is_expected.to have_many(:integration_resources) }
 
+  it 'has fixed status mapping' do
+    expect(described_class::VISIBLE_STATUS).to match(draft: 0, finalized: 1, voided: 2, failed: 4)
+    expect(described_class::INVISIBLE_STATUS).to match(generating: 3)
+    expect(described_class::STATUS).to match(draft: 0, finalized: 1, voided: 2, generating: 3, failed: 4)
+  end
+
   describe 'validation' do
     describe 'of payment dispute lost absence' do
       context 'when invoice is not voided' do


### PR DESCRIPTION
## Description

We're splitting invoices statuses into 2 categories:
* **Visible:** show up in the UI (via graphQL) and available via the rest API
* **Invisible:** cannot be retrieved via API or UI, never trigger webhook. They are purely technical, waiting to move to a visible status