### PR TITLE
feat(console): Hard delete invoice in console

### DIFF
--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -11,22 +11,34 @@ module Rails::ConsoleMethods
     end
   end
 
-  def delete_invoice(id)
+  def hard_delete_invoice(id)
     invoice = Invoice.find(id)
-    puts "Retrieved invoice #{invoice.id} from organization #{invoice.organization.name}"
+    puts "Going to hard delete invoice from org `#{invoice.organization.name}` (id: #{invoice.id})" # rubocop:disable Rails/Output
 
-    puts "Deleting invoice #{invoice.id}..."
+    puts "Press any key to confirm deletion or CTRL+C to cancel." # rubocop:disable Rails/Output
+    c = $stdin.getch
+
+    if c == "\u0003"
+      puts "Deletion cancelled." # rubocop:disable Rails/Output
+      return invoice
+    end
+
+    puts "Deleting invoice #{invoice.id}..." # rubocop:disable Rails/Output
     ActiveRecord::Base.transaction do
-      invoice.taxes.destroy_all
+      invoice.invoice_subscriptions.destroy_all
+      invoice.credit_notes.destroy_all
+      invoice.fees.each { |f| f.true_up_fee&.destroy! }
       invoice.fees.destroy_all
-      invoice.destroy
+      invoice.taxes.destroy_all
+      invoice.credits.destroy_all
+      invoice.destroy!
     end
 
     begin
       invoice.reload
-      puts "Invoice #{id} could not be deleted. Please try again."
+      puts "Invoice #{id} could not be deleted. Please try again." # rubocop:disable Rails/Output
     rescue ActiveRecord::RecordNotFound
-      puts "Invoice #{id} has been successfully deleted."
+      puts "Invoice #{id} has been successfully deleted." # rubocop:disable Rails/Output
     end
   end
 end

--- a/config/initializers/console.rb
+++ b/config/initializers/console.rb
@@ -10,4 +10,23 @@ module Rails::ConsoleMethods
       raise "Don't know how to resolve this ¯\\_(ツ)_/¯. Please provide a valid email or Global ID."
     end
   end
+
+  def delete_invoice(id)
+    invoice = Invoice.find(id)
+    puts "Retrieved invoice #{invoice.id} from organization #{invoice.organization.name}"
+
+    puts "Deleting invoice #{invoice.id}..."
+    ActiveRecord::Base.transaction do
+      invoice.taxes.destroy_all
+      invoice.fees.destroy_all
+      invoice.destroy
+    end
+
+    begin
+      invoice.reload
+      puts "Invoice #{id} could not be deleted. Please try again."
+    rescue ActiveRecord::RecordNotFound
+      puts "Invoice #{id} has been successfully deleted."
+    end
+  end
 end


### PR DESCRIPTION
## Description

Sometimes you created an invoice by mistake or there was a bug and it should be recreated. It's a rare operation that doesn't happen in the normal flow. The deletion must be done via the Rails console.

This helper allows you to delete it with a helper instead of trying to figure it out every time.

The helper will load the invoice, print the ID and the organization name, then wait for confirmation before deleting it.

```
irb(main):001:0> id = Invoice.first.id
=> "0df671da-c89b-4259-a822-1446bff8e570"
irb(main):002:0> hard_delete_invoice id
Going to hard delete invoice from org `Hooli` (id: 0df671da-c89b-4259-a822-1446bff8e570)
Press any key to confirm deletion or CTRL+C to cancel.
Deletion cancelled.
=>
#<Invoice:0x0000ffff99c74248
...
```

```
hard_delete_invoice id
  Invoice Load (2.3ms)  SELECT "invoices".* FROM "invoices" WHERE "invoices"."id" = $1 LIMIT $2  [["id", "f065ac80-5cfb-4b3e-95a8-91bedfff0258"], ["LIMIT", 1]]
  Organization Load (1.5ms)  SELECT "organizations".* FROM "organizations" WHERE "organizations"."id" = $1 LIMIT $2  [["id", "e2ecf765-4538-4d46-a9dd-c3cf70c37d4a"], ["LIMIT", 1]]
Going to hard delete invoice from org `Denesik-Harvey` (id: f065ac80-5cfb-4b3e-95a8-91bedfff0258)
Press any key to confirm deletion or CTRL+C to cancel.
Invoice f065ac80-5cfb-4b3e-95a8-91bedfff0258 has been successfully deleted.
=> nil
```