### PR TITLE
deps: bump sidekiq from 7.1.4 to 7.1.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -772,7 +772,7 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (6.2.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.1.4)
+    sidekiq (7.1.5)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)


### PR DESCRIPTION
This is meant to fix the exception 
`super: no superclass method `broadcast' for class ActiveSupport::Logger` when running lago worker.

More details on the sidekiq issue can be found here https://github.com/sidekiq/sidekiq/issues/6063
