### PR TITLE
feat (tax-integrations): add api support for failed invoice retry

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -154,6 +154,18 @@ module Api
         head(:ok)
       end
 
+      def retry
+        invoice = current_organization.invoices.not_generating.find_by(id: params[:id])
+        return not_found_error(resource: 'invoice') unless invoice
+
+        result = Invoices::RetryService.new(invoice:).call
+        if result.success?
+          render_invoice(result.invoice)
+        else
+          render_error_response(result)
+        end
+      end
+
       def payment_url
         invoice = current_organization.invoices.not_generating.includes(:customer).find_by(id: params[:id])
         return not_found_error(resource: 'invoice') unless invoice

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
         post :download, on: :member
         post :void, on: :member
         post :lose_dispute, on: :member
+        post :retry, on: :member
         post :retry_payment, on: :member
         post :payment_url, on: :member
         put :refresh, on: :member

--- a/spec/requests/api/v1/invoices_controller_spec.rb
+++ b/spec/requests/api/v1/invoices_controller_spec.rb
@@ -654,17 +654,56 @@ RSpec.describe Api::V1::InvoicesController, type: :request do
 
     context 'when invoice does not exist' do
       it 'returns not found' do
-        get_with_token(organization, '/api/v1/invoices/555/retry_payment')
+        post_with_token(organization, '/api/v1/invoices/555/retry_payment')
 
         expect(response).to have_http_status(:not_found)
       end
     end
 
     context 'when invoices belongs to an other organization' do
-      let(:invoice) { create(:invoice, organization:) }
+      let(:invoice) { create(:invoice) }
 
       it 'returns not found' do
-        get_with_token(organization, "/api/v1/invoices/#{invoice.id}/retry_payment")
+        post_with_token(organization, "/api/v1/invoices/#{invoice.id}/retry_payment")
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  describe 'GET /invoices/:id/retry' do
+    let(:retry_service) { instance_double(Invoices::RetryService) }
+    let(:result) { BaseService::Result.new }
+
+    before do
+      result.invoice = invoice
+
+      allow(Invoices::RetryService).to receive(:new).and_return(retry_service)
+      allow(retry_service).to receive(:call).and_return(result)
+    end
+
+    it 'calls retry service' do
+      post_with_token(organization, "/api/v1/invoices/#{invoice.id}/retry")
+
+      aggregate_failures do
+        expect(response).to have_http_status(:success)
+        expect(retry_service).to have_received(:call)
+      end
+    end
+
+    context 'when invoice does not exist' do
+      it 'returns not found' do
+        post_with_token(organization, '/api/v1/invoices/555/retry')
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when invoices belongs to an other organization' do
+      let(:invoice) { create(:invoice) }
+
+      it 'returns not found' do
+        post_with_token(organization, "/api/v1/invoices/#{invoice.id}/retry")
 
         expect(response).to have_http_status(:not_found)
       end


### PR DESCRIPTION
## Context

Currently Lago is adding Anrok tax integration.

## Description

During invoice generation process, invoice can end up in failed status if fetching taxes fails.

This PR adds API support for retrying failed invoice.
