### PR TITLE
fix: Set ready_to_be_refreshed only when updating a plan

### DIFF
--- a/app/services/charges/apply_taxes_service.rb
+++ b/app/services/charges/apply_taxes_service.rb
@@ -21,8 +21,6 @@ module Charges
         charge.applied_taxes.find_or_create_by!(tax: taxes.find_by(code: tax_code))
       end
 
-      charge.plan.invoices.draft.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
-
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/plans/apply_taxes_service.rb
+++ b/app/services/plans/apply_taxes_service.rb
@@ -21,8 +21,6 @@ module Plans
         plan.applied_taxes.find_or_create_by!(tax: taxes.find_by(code: tax_code))
       end
 
-      plan.invoices.draft.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
-
       result
     rescue ActiveRecord::RecordInvalid => e
       result.record_validation_failure!(record: e.record)

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -52,6 +52,8 @@ module Plans
         end
       end
 
+      plan.invoices.draft.update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+
       result.plan = plan.reload
       result
     rescue ActiveRecord::RecordInvalid => e
@@ -206,15 +208,10 @@ module Plans
     end
 
     def discard_charge!(charge)
-      draft_invoice_ids = Invoice.draft.joins(plans: [:charges])
-        .where(charges: {id: charge.id}).distinct.pluck(:id)
-
       charge.discard!
 
       charge.filter_values.discard_all
       charge.filters.discard_all
-
-      Invoice.where(id: draft_invoice_ids).update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
     end
 
     # NOTE: We should remove pending subscriptions

--- a/spec/services/charges/apply_taxes_service_spec.rb
+++ b/spec/services/charges/apply_taxes_service_spec.rb
@@ -22,14 +22,6 @@ RSpec.describe Charges::ApplyTaxesService, type: :service do
       expect(Charge::AppliedTax.find_by(id: existing.id)).to be_nil
     end
 
-    it 'marks invoices as ready to be refreshed' do
-      subscription = create(:subscription, plan:)
-      invoice = create(:invoice, :draft, organization: plan.organization)
-      create(:invoice_subscription, invoice:, subscription:)
-
-      expect { apply_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
-    end
-
     it 'returns applied taxes' do
       result = apply_service.call
       expect(result.applied_taxes.count).to eq(2)

--- a/spec/services/plans/apply_taxes_service_spec.rb
+++ b/spec/services/plans/apply_taxes_service_spec.rb
@@ -16,14 +16,6 @@ RSpec.describe Plans::ApplyTaxesService, type: :service do
       expect { apply_service.call }.to change { plan.applied_taxes.count }.from(0).to(2)
     end
 
-    it 'marks invoices as ready to be refreshed' do
-      subscription = create(:subscription, organization:, plan:)
-      invoice = create(:invoice, :draft)
-      create(:invoice_subscription, invoice:, subscription:)
-
-      expect { apply_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
-    end
-
     it 'returns applied taxes' do
       result = apply_service.call
       expect(result.applied_taxes.count).to eq(2)

--- a/spec/services/plans/update_service_spec.rb
+++ b/spec/services/plans/update_service_spec.rb
@@ -93,6 +93,14 @@ RSpec.describe Plans::UpdateService, type: :service do
       end
     end
 
+    it 'marks invoices as ready to be refreshed' do
+      subscription = create(:subscription, organization:, plan:)
+      invoice = create(:invoice, :draft)
+      create(:invoice_subscription, invoice:, subscription:)
+
+      expect { plans_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
+    end
+
     context 'when charges are not passed' do
       let(:charge) { create(:standard_charge, plan:) }
       let(:update_args) do
@@ -670,13 +678,6 @@ RSpec.describe Plans::UpdateService, type: :service do
           expect { plans_service.call }
             .to change { charge.reload.deleted_at }.from(nil).to(Time.current)
         end
-      end
-
-      it 'marks invoices as ready to be refreshed' do
-        invoice = create(:invoice, :draft)
-        create(:invoice_subscription, subscription:, invoice:)
-
-        expect { plans_service.call }.to change { invoice.reload.ready_to_be_refreshed }.to(true)
       end
     end
 


### PR DESCRIPTION
Currently, we're setting `ready_to_be_refreshed` on invoices when applying taxes to the plan or a charge.

As it's only used when updating a plan, we want to change this behavior and only set `ready_to_be_refreshed: true` once at this moment.