### PR TITLE
refactor(wallet): change ApplyPaidCreditsService argument

### DIFF
--- a/app/jobs/invoices/prepaid_credit_job.rb
+++ b/app/jobs/invoices/prepaid_credit_job.rb
@@ -8,7 +8,7 @@ module Invoices
 
     def perform(invoice)
       wallet_transaction = invoice.fees.find_by(fee_type: 'credit')&.invoiceable
-      Wallets::ApplyPaidCreditsService.new.call(wallet_transaction)
+      Wallets::ApplyPaidCreditsService.call(wallet_transaction:)
     end
   end
 end

--- a/app/jobs/invoices/prepaid_credit_job.rb
+++ b/app/jobs/invoices/prepaid_credit_job.rb
@@ -7,7 +7,8 @@ module Invoices
     unique :until_executed, on_conflict: :log
 
     def perform(invoice)
-      Wallets::ApplyPaidCreditsService.new.call(invoice)
+      wallet_transaction = invoice.fees.find_by(fee_type: 'credit')&.invoiceable
+      Wallets::ApplyPaidCreditsService.new.call(wallet_transaction)
     end
   end
 end

--- a/app/services/wallets/apply_paid_credits_service.rb
+++ b/app/services/wallets/apply_paid_credits_service.rb
@@ -2,7 +2,12 @@
 
 module Wallets
   class ApplyPaidCreditsService < BaseService
-    def call(wallet_transaction)
+    def initialize(wallet_transaction:)
+      @wallet_transaction = wallet_transaction
+      super
+    end
+
+    def call
       return result unless wallet_transaction
       return result if wallet_transaction.status == 'settled'
 
@@ -13,5 +18,9 @@ module Wallets
       result.wallet_transaction = wallet_transaction
       result
     end
+
+    private
+
+    attr_reader :wallet_transaction
   end
 end

--- a/app/services/wallets/apply_paid_credits_service.rb
+++ b/app/services/wallets/apply_paid_credits_service.rb
@@ -2,15 +2,16 @@
 
 module Wallets
   class ApplyPaidCreditsService < BaseService
-    def call(invoice)
-      wallet_transaction = invoice.fees.find_by(fee_type: 'credit')&.invoiceable
-
-      return unless wallet_transaction
-      return if wallet_transaction.status == 'settled'
+    def call(wallet_transaction)
+      return result unless wallet_transaction
+      return result if wallet_transaction.status == 'settled'
 
       WalletTransactions::SettleService.new(wallet_transaction:).call
       Wallets::Balance::IncreaseService
         .new(wallet: wallet_transaction.wallet, credits_amount: wallet_transaction.credit_amount).call
+
+      result.wallet_transaction = wallet_transaction
+      result
     end
   end
 end

--- a/spec/services/wallets/apply_paid_credits_service_spec.rb
+++ b/spec/services/wallets/apply_paid_credits_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Wallets::ApplyPaidCreditsService, type: :service do
-  subject(:service) { described_class.new }
+  subject(:service) { described_class.new(wallet_transaction:) }
 
   describe '.call' do
     let(:wallet) { create(:wallet, balance_cents: 1000, credits_balance: 10.0) }
@@ -11,18 +11,14 @@ RSpec.describe Wallets::ApplyPaidCreditsService, type: :service do
       create(:wallet_transaction, wallet:, amount: 15.0, credit_amount: 15.0, status: 'pending')
     end
 
-    before do
-      wallet_transaction
-    end
-
     it 'updates wallet balance' do
-      service.call(wallet_transaction)
+      service.call
 
       expect(wallet.reload.balance_cents).to eq 2500
     end
 
     it 'settles the wallet transaction' do
-      result = service.call(wallet_transaction)
+      result = service.call
 
       expect(result.wallet_transaction.status).to eq('settled')
     end

--- a/spec/services/wallets/apply_paid_credits_service_spec.rb
+++ b/spec/services/wallets/apply_paid_credits_service_spec.rb
@@ -6,40 +6,25 @@ RSpec.describe Wallets::ApplyPaidCreditsService, type: :service do
   subject(:service) { described_class.new }
 
   describe '.call' do
-    let(:invoice) { create(:invoice, customer:, organization: customer.organization) }
-    let(:customer) { create(:customer) }
-    let(:subscription) { create(:subscription, customer:) }
-    let(:wallet) { create(:wallet, customer:, balance_cents: 1000, credits_balance: 10.0) }
+    let(:wallet) { create(:wallet, balance_cents: 1000, credits_balance: 10.0) }
     let(:wallet_transaction) do
       create(:wallet_transaction, wallet:, amount: 15.0, credit_amount: 15.0, status: 'pending')
-    end
-    let(:fee) do
-      create(
-        :fee,
-        fee_type: 'credit',
-        invoiceable_type: 'WalletTransaction',
-        invoiceable_id: wallet_transaction.id,
-        invoice:
-      )
     end
 
     before do
       wallet_transaction
-      fee
-      subscription
-      invoice.update(invoice_type: 'credit')
     end
 
     it 'updates wallet balance' do
-      service.call(invoice)
+      service.call(wallet_transaction)
 
       expect(wallet.reload.balance_cents).to eq 2500
     end
 
     it 'settles the wallet transaction' do
-      service.call(invoice)
+      result = service.call(wallet_transaction)
 
-      expect(wallet_transaction.reload.status).to eq('settled')
+      expect(result.wallet_transaction.status).to eq('settled')
     end
   end
 end


### PR DESCRIPTION
## Description

As we're working on some wallet improvements, I was looking at this service. I'd like to make some modification:

* `*Service.call` methods should return a result as much as possible to avoid calling `raise_if_error!` on nil
* The Service is under `Wallets` namespace and only need a wallet transaction so I change the params. The invoice was not needed. I think this makes the test more straight forward too.
