### PR TITLE
Fix export invoices query object filters

### DIFF
--- a/app/queries/base_query.rb
+++ b/app/queries/base_query.rb
@@ -39,7 +39,7 @@ class BaseQuery < BaseService
     value = filters[field_name]
     return value if [Time, ActiveSupport::TimeWithZone, Date, DateTime].include?(value.class)
 
-    DateTime.strptime(value)
+    DateTime.iso8601(value)
   rescue Date::Error
     result.single_validation_failure!(field: field_name.to_sym, error_code: 'invalid_date')
       .raise_if_error!

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -4,14 +4,14 @@ class InvoicesQuery < BaseQuery
   def call(search_term: nil, status: nil, filters: {}, customer_id: nil, payment_status: nil, payment_dispute_lost: nil, payment_overdue: nil) # rubocop:disable Metrics/ParameterLists
     @search_term = search_term
     @customer_id = customer_id
-    @filters = filters
+    @filters = filters = BaseQuery::Filters.new(filters)
 
     invoices = base_scope.result.includes(:customer)
-    invoices = invoices.where(currency: filters[:currency]) if filters[:currency]
-    invoices = with_customer_external_id(invoices) if filters[:customer_external_id]
+    invoices = invoices.where(currency: filters.currency) if filters.currency
+    invoices = with_customer_external_id(invoices) if filters.customer_external_id
     invoices = invoices.where(customer_id:) if customer_id.present?
-    invoices = invoices.where(invoice_type: filters[:invoice_type]) if filters[:invoice_type]
-    invoices = with_issuing_date_range(invoices) if filters[:issuing_date_from] || filters[:issuing_date_to]
+    invoices = invoices.where(invoice_type: filters.invoice_type) if filters.invoice_type
+    invoices = with_issuing_date_range(invoices) if filters.issuing_date_from || filters.issuing_date_to
     invoices = invoices.where(status:) if status.present?
     invoices = invoices.where(payment_status:) if payment_status.present?
     invoices = invoices.where.not(payment_dispute_lost_at: nil) unless payment_dispute_lost.nil?
@@ -51,12 +51,12 @@ class InvoicesQuery < BaseQuery
   end
 
   def with_customer_external_id(scope)
-    scope.joins(:customer).where(customer: {external_id: filters[:customer_external_id]})
+    scope.joins(:customer).where(customer: {external_id: filters.customer_external_id})
   end
 
   def with_issuing_date_range(scope)
-    scope = scope.where(issuing_date: issuing_date_from..) if filters[:issuing_date_from]
-    scope = scope.where(issuing_date: ..issuing_date_to) if filters[:issuing_date_to]
+    scope = scope.where(issuing_date: issuing_date_from..) if filters.issuing_date_from
+    scope = scope.where(issuing_date: ..issuing_date_to) if filters.issuing_date_to
     scope
   end
 

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -82,14 +82,23 @@ module DataExports
       end
 
       def query
-        search_term = resource_query["search_term"]
-        status = resource_query["status"]
-        filters = resource_query.except("search_term", "status")
+        filters = resource_query.except(
+        "search_term",
+        "customer_id",
+        "payment_dispute_lost",
+        "payment_overdue",
+        "payment_status",
+        "status"
+        )
 
         InvoicesQuery.new(organization: organization, pagination: nil).call(
-          search_term:,
-          status:,
-          filters:
+          search_term: resource_query["search_term"],
+          filters:,
+          customer_id: resource_query["customer_id"],
+          payment_dispute_lost: resource_query["payment_dispute_lost"],
+          payment_overdue: resource_query["payment_overdue"],
+          payment_status: resource_query["payment_status"],
+          status: resource_query["status"]
         )
       end
     end

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -83,12 +83,12 @@ module DataExports
 
       def query
         filters = resource_query.except(
-        "search_term",
-        "customer_id",
-        "payment_dispute_lost",
-        "payment_overdue",
-        "payment_status",
-        "status"
+          "search_term",
+          "customer_id",
+          "payment_dispute_lost",
+          "payment_overdue",
+          "payment_status",
+          "status"
         )
 
         InvoicesQuery.new(organization: organization, pagination: nil).call(

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -83,22 +83,22 @@ module DataExports
 
       def query
         filters = resource_query.except(
-          "search_term",
-          "customer_id",
-          "payment_dispute_lost",
-          "payment_overdue",
-          "payment_status",
-          "status"
+          'search_term',
+          'customer_id',
+          'payment_dispute_lost',
+          'payment_overdue',
+          'payment_status',
+          'status'
         )
 
         InvoicesQuery.new(organization: organization, pagination: nil).call(
-          search_term: resource_query["search_term"],
+          search_term: resource_query['search_term'],
           filters:,
-          customer_id: resource_query["customer_id"],
-          payment_dispute_lost: resource_query["payment_dispute_lost"],
-          payment_overdue: resource_query["payment_overdue"],
-          payment_status: resource_query["payment_status"],
-          status: resource_query["status"]
+          customer_id: resource_query['customer_id'],
+          payment_dispute_lost: resource_query['payment_dispute_lost'],
+          payment_overdue: resource_query['payment_overdue'],
+          payment_status: resource_query['payment_status'],
+          status: resource_query['status']
         )
       end
     end

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe InvoicesQuery, type: :query do
         search_term: nil,
         status: nil,
         filters: {
-          issuing_date_from: 2.days.ago.iso8601
+          issuing_date_from: 2.days.ago.iso8601.to_date.to_s
         }
       )
 
@@ -326,7 +326,7 @@ RSpec.describe InvoicesQuery, type: :query do
         search_term: nil,
         status: nil,
         filters: {
-          issuing_date_to: 2.weeks.ago.iso8601
+          issuing_date_to: 2.weeks.ago.iso8601.to_date.to_s
         }
       )
 

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DataExports::Csv::InvoiceFees do
       "customer_external_id" => customer_external_id,
       "invoice_type" => invoice_type,
       "issuing_date_from" => issuing_date_from,
-      "issuing_date_to" => issuing_date_to,
+      "issuing_date_to" => issuing_date_to
     }
   end
 
@@ -216,7 +216,7 @@ RSpec.describe DataExports::Csv::InvoiceFees do
         payment_dispute_lost:,
         payment_overdue:,
         payment_status:,
-        status:,
+        status:
       )
       .and_return(query_results)
   end

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe DataExports::Csv::InvoiceFees do
   let(:resource_query) do
     {
       currency:,
+      customer_id:,
       customer_external_id:,
       invoice_type:,
       issuing_date_from:,
@@ -24,6 +25,7 @@ RSpec.describe DataExports::Csv::InvoiceFees do
 
   let(:currency) { 'EUR' }
   let(:customer_external_id) { 'custext123' }
+  let(:customer_id) { 'customer-lago-id-123' }
   let(:invoice_type) { 'credit' }
   let(:issuing_date_from) { '2023-12-25' }
   let(:issuing_date_to) { '2024-07-01' }
@@ -40,9 +42,6 @@ RSpec.describe DataExports::Csv::InvoiceFees do
       "invoice_type" => invoice_type,
       "issuing_date_from" => issuing_date_from,
       "issuing_date_to" => issuing_date_to,
-      "payment_dispute_lost" => payment_dispute_lost,
-      "payment_overdue" => payment_overdue,
-      "payment_status" => payment_status
     }
   end
 
@@ -212,8 +211,12 @@ RSpec.describe DataExports::Csv::InvoiceFees do
       .to receive(:call)
       .with(
         search_term:,
+        filters:,
+        customer_id:,
+        payment_dispute_lost:,
+        payment_overdue:,
+        payment_status:,
         status:,
-        filters:
       )
       .and_return(query_results)
   end

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe DataExports::Csv::Invoices do
       "customer_external_id" => customer_external_id,
       "invoice_type" => invoice_type,
       "issuing_date_from" => issuing_date_from,
-      "issuing_date_to" => issuing_date_to,
+      "issuing_date_to" => issuing_date_to
     }
   end
 
@@ -105,7 +105,7 @@ RSpec.describe DataExports::Csv::Invoices do
         payment_dispute_lost:,
         payment_overdue:,
         payment_status:,
-        status:,
+        status:
       )
       .and_return(query_results)
   end

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe DataExports::Csv::Invoices do
     {
       currency:,
       customer_external_id:,
+      customer_id:,
       invoice_type:,
       issuing_date_from:,
       issuing_date_to:,
@@ -21,6 +22,7 @@ RSpec.describe DataExports::Csv::Invoices do
   end
 
   let(:currency) { 'EUR' }
+  let(:customer_id) { 'customer-lago-id-123' }
   let(:customer_external_id) { 'custext123' }
   let(:invoice_type) { 'credit' }
   let(:issuing_date_from) { '2023-12-25' }
@@ -38,9 +40,6 @@ RSpec.describe DataExports::Csv::Invoices do
       "invoice_type" => invoice_type,
       "issuing_date_from" => issuing_date_from,
       "issuing_date_to" => issuing_date_to,
-      "payment_dispute_lost" => payment_dispute_lost,
-      "payment_overdue" => payment_overdue,
-      "payment_status" => payment_status
     }
   end
 
@@ -101,8 +100,12 @@ RSpec.describe DataExports::Csv::Invoices do
       .to receive(:call)
       .with(
         search_term:,
+        filters:,
+        customer_id:,
+        payment_dispute_lost:,
+        payment_overdue:,
+        payment_status:,
         status:,
-        filters:
       )
       .and_return(query_results)
   end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/ability-to-export-data-from-the-user-interface


## Description

This change include a number of fixes related to query objects in general, the InvoicesQuery objects filters and how the invoices CSV export service uses the InvoicesQuery;

* Fixes query objects date parsing capabilities as original implementation was able to parse datetimes and failed with dates.
* Fix InvoicesQuery filters to ensure it works when keys are strings or symbols using the Filters object.
* Fix DataExports::CSV::Invoices service to use properly the current InvoicesQuery interface as it was missing some filters that are currently outside of the filters hash (will be fixed in https://github.com/getlago/lago-api/pull/2313)