### PR TITLE
feat(invoices): Add open status

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -52,7 +52,7 @@ class Invoice < ApplicationRecord
   PAYMENT_STATUS = %i[pending succeeded failed].freeze
 
   VISIBLE_STATUS = {draft: 0, finalized: 1, voided: 2, failed: 4}.freeze
-  INVISIBLE_STATUS = {generating: 3}.freeze
+  INVISIBLE_STATUS = {generating: 3, open: 5}.freeze
   STATUS = VISIBLE_STATUS.merge(INVISIBLE_STATUS).freeze
 
   enum invoice_type: INVOICE_TYPES
@@ -62,6 +62,7 @@ class Invoice < ApplicationRecord
   aasm column: 'status', timestamps: true do
     state :generating
     state :draft
+    state :open
     state :finalized
     state :voided
     state :failed
@@ -381,6 +382,7 @@ class Invoice < ApplicationRecord
   def status_changed_to_finalized?
     status_changed?(from: 'draft', to: 'finalized') ||
       status_changed?(from: 'generating', to: 'finalized') ||
+      status_changed?(from: 'open', to: 'finalized') ||
       status_changed?(from: 'failed', to: 'finalized')
   end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Invoice, type: :model do
 
   it 'has fixed status mapping' do
     expect(described_class::VISIBLE_STATUS).to match(draft: 0, finalized: 1, voided: 2, failed: 4)
-    expect(described_class::INVISIBLE_STATUS).to match(generating: 3)
-    expect(described_class::STATUS).to match(draft: 0, finalized: 1, voided: 2, generating: 3, failed: 4)
+    expect(described_class::INVISIBLE_STATUS).to match(generating: 3, open: 5)
+    expect(described_class::STATUS).to match(draft: 0, finalized: 1, voided: 2, generating: 3, failed: 4, open: 5)
   end
 
   describe 'validation' do


### PR DESCRIPTION
## Description

The open status is a technical status just like `generating`. It's used in different upcoming feature.

`open` invoices means:
* invoice cannot be edited (unlike `draft`)
* invoice is not visible (not via API nor GQL)
* invoice is payable