### PR TITLE
fix: GoCardless payment creation exception when no mandate available

### DIFF
--- a/app/services/invoices/payments/gocardless_service.rb
+++ b/app/services/invoices/payments/gocardless_service.rb
@@ -6,7 +6,7 @@ module Invoices
       include Customers::PaymentProviderFinder
 
       class MandateNotFoundError < StandardError
-        DEFAULT_MESSAGE = 'No mandate avaiable for payment'
+        DEFAULT_MESSAGE = 'No mandate available for payment'
 
         attr_reader :code
 

--- a/app/services/invoices/payments/gocardless_service.rb
+++ b/app/services/invoices/payments/gocardless_service.rb
@@ -6,14 +6,15 @@ module Invoices
       include Customers::PaymentProviderFinder
 
       class MandateNotFoundError < StandardError
-        DEFAULT_MESSAGE = 'No mandate available for payment'
-
-        attr_reader :code
+        DEFAULT_MESSAGE = "No mandate available for payment"
+        ERROR_CODE = "no_mandate_error"
 
         def initialize(msg = DEFAULT_MESSAGE)
-          @code = '999'
-
           super
+        end
+
+        def code
+          ERROR_CODE
         end
       end
 

--- a/spec/services/invoices/payments/gocardless_service_spec.rb
+++ b/spec/services/invoices/payments/gocardless_service_spec.rb
@@ -177,36 +177,36 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
 
     context "when customer has no mandate to make a payment" do
       let(:customer) { create(:customer, organization:, payment_provider_code: code) }
-      let(:organization) { create(:organization, webhook_url: 'https://webhook.com') }
+      let(:organization) { create(:organization, webhook_url: "https://webhook.com") }
 
       before do
         allow(gocardless_list_response).to receive(:records)
           .and_return([])
 
         allow(gocardless_payments_service).to receive(:create)
-          .and_raise(GoCardlessPro::Error.new('code' => 'code', 'message' => 'error'))
+          .and_raise(GoCardlessPro::Error.new("code" => "code", "message" => "error"))
       end
 
-      it 'delivers an error webhook' do
+      it "delivers an error webhook" do
         result = gocardless_service.create
 
         aggregate_failures do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ServiceFailure)
-          expect(result.error.code).to eq('999')
-          expect(result.error.error_message).to eq('No mandate available for payment')
+          expect(result.error.code).to eq("no_mandate_error")
+          expect(result.error.error_message).to eq("No mandate available for payment")
           expect(result.invoice.reload).to have_attributes(
-            payment_status: 'failed',
+            payment_status: "failed",
             ready_for_payment_processing: true
           )
           expect(SendWebhookJob).to have_been_enqueued
             .with(
-              'invoice.payment_failure',
+              "invoice.payment_failure",
               invoice,
               provider_customer_id: gocardless_customer.provider_customer_id,
               provider_error: {
-                message: 'No mandate available for payment',
-                error_code: '999'
+                message: "No mandate available for payment",
+                error_code: "no_mandate_error"
               }
             )
         end

--- a/spec/services/invoices/payments/gocardless_service_spec.rb
+++ b/spec/services/invoices/payments/gocardless_service_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
           expect(result).not_to be_success
           expect(result.error).to be_a(BaseService::ServiceFailure)
           expect(result.error.code).to eq('999')
-          expect(result.error.error_message).to eq('No mandate avaiable for payment')
+          expect(result.error.error_message).to eq('No mandate available for payment')
           expect(result.invoice.reload).to have_attributes(
             payment_status: 'failed',
             ready_for_payment_processing: true
@@ -205,7 +205,7 @@ RSpec.describe Invoices::Payments::GocardlessService, type: :service do
               invoice,
               provider_customer_id: gocardless_customer.provider_customer_id,
               provider_error: {
-                message: 'No mandate avaiable for payment',
+                message: 'No mandate available for payment',
                 error_code: '999'
               }
             )


### PR DESCRIPTION
GoCardless payment creation does not raise error when no mandate available

Instead of raising an error when a mandate is not available at GoCardless to create a new payment,

We notify the client with a meaningful error message, flag the invoice as payment failed and return a failure result.

## Context

Given a customer does not have a GoCardless mandate available to process an invoice payment, `Invoices::Payments::GocardlessCreateJob` was raising an exception, moving the job to sidekiq dead jobs queue and notifying the client with not helpful information `"One of your parameters was incorrectly typed"`.

```
job_name: "Invoices::Payments::GocardlessCreateJob"
error_class: "GoCardlessPro::InvalidApiUsageError"
error_message: "One of your parameters was incorrectly typed"
```

## Description

This change fixes this issue exiting the job with a service failure result, notifying the client pointing the customer has no available mandate for the payment and updates the invoice as payment failed.