### PR TITLE
misc: change format of error_details description we send to FE

### DIFF
--- a/app/graphql/types/error_details/object.rb
+++ b/app/graphql/types/error_details/object.rb
@@ -6,8 +6,12 @@ module Types
       graphql_name 'ErrorDetail'
 
       field :error_code, Types::ErrorDetails::ErrorCodesEnum, null: false
-      field :error_details, GraphQL::Types::JSON, null: true
+      field :error_details, String, null: true
       field :id, ID, null: false
+
+      def error_details
+        object.error_details.values&.first
+      end
     end
   end
 end

--- a/app/graphql/types/error_details/object.rb
+++ b/app/graphql/types/error_details/object.rb
@@ -10,7 +10,7 @@ module Types
       field :id, ID, null: false
 
       def error_details
-        object.error_details.values&.first
+        object.error_details[object.error_code]
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -3465,7 +3465,7 @@ enum ErrorCodesEnum {
 
 type ErrorDetail {
   errorCode: ErrorCodesEnum!
-  errorDetails: JSON
+  errorDetails: String
   id: ID!
 }
 

--- a/schema.json
+++ b/schema.json
@@ -14691,7 +14691,7 @@
               "description": null,
               "type": {
                 "kind": "SCALAR",
-                "name": "JSON",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/spec/services/error_details/create_service_spec.rb
+++ b/spec/services/error_details/create_service_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe ErrorDetails::CreateService, type: :service do
 
     let(:params) do
       {
-        error_code: 'not_provided',
-        details: {'error_code' => 'taxDateTooFarInFuture'}
+        error_code: 'tax_error',
+        details: {'tax_error' => 'taxDateTooFarInFuture'}
       }
     end
 
@@ -61,7 +61,7 @@ RSpec.describe ErrorDetails::CreateService, type: :service do
         let(:params) do
           {
             error_code: 'this_error_code_will_never_achieve_its_goal',
-            details: {'error_received' => 'taxDateTooFarInFuture'}
+            details: {'this_error_code_will_never_achieve_its_goal' => 'does not matter what we send here'}
           }
         end
 


### PR DESCRIPTION
## Context

When adding error_details to the invoices [PR](https://github.com/getlago/lago-api/pull/2329), we added details of the errors as a jsonb object, while for now we'll be only storing there the error_code / error clarification and FE doesn't need the whole object for this

## Description

Updated error_detail type to send only first value of it's detils
