### PR TITLE
Feat clean expired topup invoices

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -53,7 +53,8 @@ module Api
           :wallet_id,
           :paid_credits,
           :granted_credits,
-          :voided_credits
+          :voided_credits,
+          :invoice_require_successful_payment
         )
       end
     end

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -80,6 +80,7 @@ module Api
           :paid_credits,
           :granted_credits,
           :expiration_at,
+          :invoice_require_successful_payment,
           recurring_transaction_rules: [
             :granted_credits,
             :interval,
@@ -88,7 +89,8 @@ module Api
             :started_at,
             :target_ongoing_balance,
             :threshold_credits,
-            :trigger
+            :trigger,
+            :invoice_require_successful_payment
           ]
         )
       end
@@ -101,6 +103,7 @@ module Api
         params.require(:wallet).permit(
           :name,
           :expiration_at,
+          :invoice_require_successful_payment,
           recurring_transaction_rules: [
             :lago_id,
             :interval,
@@ -110,7 +113,8 @@ module Api
             :threshold_credits,
             :trigger,
             :paid_credits,
-            :granted_credits
+            :granted_credits,
+            :invoice_require_successful_payment
           ]
         )
       end

--- a/app/graphql/mutations/wallet_transactions/create.rb
+++ b/app/graphql/mutations/wallet_transactions/create.rb
@@ -14,6 +14,7 @@ module Mutations
       argument :wallet_id, ID, required: true
 
       argument :granted_credits, String, required: false
+      argument :invoice_require_successful_payment, Boolean, required: false
       argument :paid_credits, String, required: false
       argument :voided_credits, String, required: false
 

--- a/app/graphql/types/wallet_transactions/object.rb
+++ b/app/graphql/types/wallet_transactions/object.rb
@@ -10,6 +10,7 @@ module Types
 
       field :amount, String, null: false
       field :credit_amount, String, null: false
+      field :invoice_require_successful_payment, Boolean, null: false
       field :status, Types::WalletTransactions::StatusEnum, null: false
       field :transaction_status, Types::WalletTransactions::TransactionStatusEnum, null: false
       field :transaction_type, Types::WalletTransactions::TransactionTypeEnum, null: false

--- a/app/graphql/types/wallets/object.rb
+++ b/app/graphql/types/wallets/object.rb
@@ -31,6 +31,8 @@ module Types
 
       field :recurring_transaction_rules, [Types::Wallets::RecurringTransactionRules::Object], null: true
 
+      field :invoice_require_successful_payment, Boolean, null: false
+
       field :created_at, GraphQL::Types::ISO8601DateTime, null: false
       field :expiration_at, GraphQL::Types::ISO8601DateTime, null: true
       field :terminated_at, GraphQL::Types::ISO8601DateTime, null: true

--- a/app/jobs/clock/expired_invoices_cleanup_job.rb
+++ b/app/jobs/clock/expired_invoices_cleanup_job.rb
@@ -1,0 +1,13 @@
+# app/jobs/expired_invoices_cleanup_job.rb
+class ExpiredInvoicesCleanupJob < ApplicationJob
+  queue_as :default
+
+  def perform()
+    expired_invoices = Invoice.open.where('created_at < ?', 90.days.ago)
+    expired_invoices.find_each do |invoice|
+      invoice.destroy
+    end
+
+    # delete the wallet transaction
+  end
+end

--- a/app/jobs/invoices/prepaid_credit_job.rb
+++ b/app/jobs/invoices/prepaid_credit_job.rb
@@ -8,6 +8,7 @@ module Invoices
 
     def perform(invoice)
       Wallets::ApplyPaidCreditsService.new.call(invoice)
+      Invoices::FinalizeOpenCreditService.call(invoice:)
     end
   end
 end

--- a/app/serializers/v1/wallet_serializer.rb
+++ b/app/serializers/v1/wallet_serializer.rb
@@ -22,7 +22,8 @@ module V1
         expiration_at: model.expiration_at&.iso8601,
         last_balance_sync_at: model.last_balance_sync_at&.iso8601,
         last_consumed_credit_at: model.last_consumed_credit_at&.iso8601,
-        terminated_at: model.terminated_at
+        terminated_at: model.terminated_at,
+        invoice_require_successful_payment: model.invoice_require_successful_payment?
       }
 
       payload.merge!(recurring_transaction_rules) if include?(:recurring_transaction_rules)

--- a/app/serializers/v1/wallet_transaction_serializer.rb
+++ b/app/serializers/v1/wallet_transaction_serializer.rb
@@ -12,7 +12,8 @@ module V1
         amount: model.amount,
         credit_amount: model.credit_amount,
         settled_at: model.settled_at&.iso8601,
-        created_at: model.created_at.iso8601
+        created_at: model.created_at.iso8601,
+        invoice_require_successful_payment: model.invoice_require_successful_payment?
       }
     end
   end

--- a/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
+++ b/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
@@ -14,7 +14,8 @@ module V1
           target_ongoing_balance: model.target_ongoing_balance,
           threshold_credits: model.threshold_credits,
           trigger: model.trigger,
-          created_at: model.created_at.iso8601
+          created_at: model.created_at.iso8601,
+          invoice_require_successful_payment: model.invoice_require_successful_payment?
         }
       end
     end

--- a/app/services/invoices/finalize_open_credit_service.rb
+++ b/app/services/invoices/finalize_open_credit_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Invoices
+  class FinalizeOpenCreditService < BaseService
+    def initialize(invoice:)
+      @invoice = invoice
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: 'invoice') if invoice.nil?
+
+      result.invoice = invoice
+      return result if invoice.finalized?
+
+      ActiveRecord::Base.transaction do
+        invoice.issuing_date = today_in_tz
+        invoice.payment_due_date = today_in_tz
+        invoice.status = :finalized
+        invoice.save!
+      end
+
+      SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice)
+      GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
+      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+      Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
+      Utils::SegmentTrack.invoice_created(result.invoice)
+
+      result
+    end
+
+    private
+
+    attr_accessor :invoice, :result
+
+    def today_in_tz
+      @today_in_tz ||= Time.current.in_time_zone(invoice.customer.applicable_timezone).to_date
+    end
+
+    def should_deliver_email?
+      License.premium? &&
+        invoice.organization.email_settings.include?('invoice.finalized')
+    end
+  end
+end

--- a/app/services/invoices/paid_credit_service.rb
+++ b/app/services/invoices/paid_credit_service.rb
@@ -23,14 +23,20 @@ module Invoices
         create_credit_fee(invoice)
         compute_amounts(invoice)
 
-        invoice.finalized!
+        if License.premium? && wallet_transaction.invoice_require_successful_payment?
+          invoice.open!
+        else
+          invoice.finalized!
+        end
       end
 
-      Utils::SegmentTrack.invoice_created(result.invoice)
-      SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice)
-      GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
-      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-      Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
+      if invoice.finalized?
+        Utils::SegmentTrack.invoice_created(result.invoice)
+        SendWebhookJob.perform_later('invoice.paid_credit_added', result.invoice)
+        GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
+        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+        Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
+      end
 
       create_payment(result.invoice)
 

--- a/app/services/plans/create_service.rb
+++ b/app/services/plans/create_service.rb
@@ -102,7 +102,7 @@ module Plans
 
       if License.premium?
         charge.invoiceable = args[:invoiceable] unless args[:invoiceable].nil?
-        charge.regroup_paid_fees = args[:regroup_paid_fees] if args.has_key?(:regroup_paid_fees)
+        charge.regroup_paid_fees = args[:regroup_paid_fees] if args.key?(:regroup_paid_fees)
         charge.min_amount_cents = args[:min_amount_cents] || 0
       end
 

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -100,7 +100,7 @@ module Plans
 
       if License.premium?
         charge.invoiceable = params[:invoiceable] unless params[:invoiceable].nil?
-        charge.regroup_paid_fees = params[:regroup_paid_fees] if params.has_key?(:regroup_paid_fees)
+        charge.regroup_paid_fees = params[:regroup_paid_fees] if params.key?(:regroup_paid_fees)
         charge.min_amount_cents = params[:min_amount_cents] || 0
       end
 

--- a/app/services/wallet_transactions/void_service.rb
+++ b/app/services/wallet_transactions/void_service.rb
@@ -11,7 +11,7 @@ module WalletTransactions
     end
 
     def call
-      return if credits_amount.zero?
+      return result if credits_amount.zero?
 
       ActiveRecord::Base.transaction do
         wallet_transaction = wallet.wallet_transactions.create!(

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -12,7 +12,8 @@ module Wallets
             wallet_id: wallet.id,
             paid_credits: paid_credits(recurring_transaction_rule),
             granted_credits: granted_credits(recurring_transaction_rule),
-            source: :interval
+            source: :interval,
+            invoice_require_successful_payment: recurring_transaction_rule.invoice_require_successful_payment?
           }
         )
       end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -10,13 +10,19 @@ module Wallets
     def call
       return result unless valid?
 
-      wallet = Wallet.new(
+      attributes = {
         customer_id: result.current_customer.id,
         name: params[:name],
         rate_amount: params[:rate_amount],
         expiration_at: params[:expiration_at],
         status: :active
-      )
+      }
+
+      if params.key?(:invoice_require_successful_payment)
+        attributes[:invoice_require_successful_payment] = ActiveModel::Type::Boolean.new.cast(params[:invoice_require_successful_payment])
+      end
+
+      wallet = Wallet.new(attributes)
 
       ActiveRecord::Base.transaction do
         currency_result = Customers::UpdateService.new(nil).update_currency(

--- a/app/services/wallets/recurring_transaction_rules/create_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/create_service.rb
@@ -18,7 +18,7 @@ module Wallets
           granted_credits = wallet_params[:granted_credits]
         end
 
-        rule = wallet.recurring_transaction_rules.create!(
+        attributes = {
           paid_credits: rule_params[:paid_credits] || paid_credits || 0.0,
           granted_credits: rule_params[:granted_credits] || granted_credits || 0.0,
           threshold_credits: rule_params[:threshold_credits] || 0.0,
@@ -27,7 +27,15 @@ module Wallets
           started_at: rule_params[:started_at],
           target_ongoing_balance: rule_params[:target_ongoing_balance],
           trigger: rule_params[:trigger].to_s
-        )
+        }
+
+        attributes[:invoice_require_successful_payment] = if rule_params.key?(:invoice_require_successful_payment)
+          ActiveModel::Type::Boolean.new.cast(rule_params[:invoice_require_successful_payment])
+        else
+          wallet.invoice_require_successful_payment?
+        end
+
+        rule = wallet.recurring_transaction_rules.create!(attributes)
 
         result.recurring_transaction_rule = rule
         result

--- a/app/services/wallets/recurring_transaction_rules/update_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/update_service.rb
@@ -25,6 +25,10 @@ module Wallets
             next
           end
 
+          # NOTE: on creation, we follow the wallet configuration if not set
+          unless rule.key?(:invoice_require_successful_payment)
+            rule[:invoice_require_successful_payment] = wallet.invoice_require_successful_payment
+          end
           created_recurring_rule = wallet.recurring_transaction_rules.create!(rule)
           created_recurring_rules_ids.push(created_recurring_rule.id)
         end

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -18,7 +18,8 @@ module Wallets
           wallet_id: wallet.id,
           paid_credits:,
           granted_credits:,
-          source: :threshold
+          source: :threshold,
+          invoice_require_successful_payment: threshold_rule.invoice_require_successful_payment?
         }
       )
     end

--- a/app/services/wallets/update_service.rb
+++ b/app/services/wallets/update_service.rb
@@ -17,7 +17,9 @@ module Wallets
       ActiveRecord::Base.transaction do
         wallet.name = params[:name] if params.key?(:name)
         wallet.expiration_at = params[:expiration_at] if params.key?(:expiration_at)
-
+        if params.key?(:invoice_require_successful_payment)
+          wallet.invoice_require_successful_payment = ActiveModel::Type::Boolean.new.cast(params[:invoice_require_successful_payment])
+        end
         if params[:recurring_transaction_rules] && License.premium?
           Wallets::RecurringTransactionRules::UpdateService.call(wallet:, params: params[:recurring_transaction_rules])
         end

--- a/clock.rb
+++ b/clock.rb
@@ -100,6 +100,12 @@ module Clockwork
       .perform_later
   end
 
+  every(1.day, 'schedule:clean_expired_open_invoices', at: '03:00') do
+    Clock::ExpiredInvoicesCleanupJob
+      .set(sentry: {"slug" => 'lago_clean_expired_open_invoices', "cron" => '0 3 * * *'})
+      .perform_later
+  end
+
   unless ActiveModel::Type::Boolean.new.cast(ENV['LAGO_DISABLE_EVENTS_VALIDATION'])
     every(1.hour, 'schedule:post_validate_events', at: '*:05') do
       Clock::EventsValidationJob

--- a/db/migrate/20240723150304_add_invoice_require_successful_payment.rb
+++ b/db/migrate/20240723150304_add_invoice_require_successful_payment.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddInvoiceRequireSuccessfulPayment < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :wallets, :invoice_require_successful_payment, :boolean, default: false, null: false
+    add_column :wallet_transactions, :invoice_require_successful_payment, :boolean, default: false, null: false
+    add_column :recurring_transaction_rules, :invoice_require_successful_payment, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_23_150221) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_23_150304) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -944,6 +944,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_23_150221) do
     t.integer "method", default: 0, null: false
     t.decimal "target_ongoing_balance", precision: 30, scale: 5
     t.datetime "started_at"
+    t.boolean "invoice_require_successful_payment", default: false, null: false
     t.index ["started_at"], name: "index_recurring_transaction_rules_on_started_at"
     t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
   end
@@ -1035,6 +1036,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_23_150221) do
     t.uuid "invoice_id"
     t.integer "source", default: 0, null: false
     t.integer "transaction_status", default: 0, null: false
+    t.boolean "invoice_require_successful_payment", default: false, null: false
     t.index ["invoice_id"], name: "index_wallet_transactions_on_invoice_id"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
   end
@@ -1061,6 +1063,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_23_150221) do
     t.decimal "credits_ongoing_balance", precision: 30, scale: 5, default: "0.0", null: false
     t.decimal "credits_ongoing_usage_balance", precision: 30, scale: 5, default: "0.0", null: false
     t.boolean "depleted_ongoing_balance", default: false, null: false
+    t.boolean "invoice_require_successful_payment", default: false, null: false
     t.index ["customer_id"], name: "index_wallets_on_customer_id"
   end
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1884,6 +1884,7 @@ input CreateCustomerWalletTransactionInput {
   """
   clientMutationId: String
   grantedCredits: String
+  invoiceRequireSuccessfulPayment: Boolean
   paidCredits: String
   voidedCredits: String
   walletId: ID!
@@ -7417,6 +7418,7 @@ type Wallet {
   customer: Customer
   expirationAt: ISO8601DateTime
   id: ID!
+  invoiceRequireSuccessfulPayment: Boolean!
   lastBalanceSyncAt: ISO8601DateTime
   lastConsumedCreditAt: ISO8601DateTime
   name: String
@@ -7444,6 +7446,7 @@ type WalletTransaction {
   createdAt: ISO8601DateTime!
   creditAmount: String!
   id: ID!
+  invoiceRequireSuccessfulPayment: Boolean!
   settledAt: ISO8601DateTime
   status: WalletTransactionStatusEnum!
   transactionStatus: WalletTransactionTransactionStatusEnum!

--- a/schema.json
+++ b/schema.json
@@ -7536,6 +7536,18 @@
               "deprecationReason": null
             },
             {
+              "name": "invoiceRequireSuccessfulPayment",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "paidCredits",
               "description": null,
               "type": {
@@ -37029,6 +37041,24 @@
               ]
             },
             {
+              "name": "invoiceRequireSuccessfulPayment",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "lastBalanceSyncAt",
               "description": null,
               "type": {
@@ -37352,6 +37382,24 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoiceRequireSuccessfulPayment",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
                   "ofType": null
                 }
               },

--- a/spec/graphql/mutations/wallet_transactions/create_spec.rb
+++ b/spec/graphql/mutations/wallet_transactions/create_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
     <<-GQL
       mutation($input: CreateCustomerWalletTransactionInput!) {
         createCustomerWalletTransaction(input: $input) {
-          collection { id, status }
+          collection { id, status, invoiceRequireSuccessfulPayment }
         }
       }
     GQL
@@ -38,7 +38,8 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
         input: {
           walletId: wallet.id,
           paidCredits: '5.00',
-          grantedCredits: '5.00'
+          grantedCredits: '5.00',
+          invoiceRequireSuccessfulPayment: true
         }
       }
     )
@@ -46,5 +47,6 @@ RSpec.describe Mutations::WalletTransactions::Create, type: :graphql do
     result_data = result['data']['createCustomerWalletTransaction']
     expect(result_data['collection'].map { |wt| wt['status'] })
       .to contain_exactly('pending', 'settled')
+    expect(result_data['collection'].map { |wt| wt['invoiceRequireSuccessfulPayment'] }).to all be true
   end
 end

--- a/spec/graphql/types/wallet_transactions/object_spec.rb
+++ b/spec/graphql/types/wallet_transactions/object_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Types::WalletTransactions::Object do
 
   it { is_expected.to have_field(:amount).of_type('String!') }
   it { is_expected.to have_field(:credit_amount).of_type('String!') }
+  it { is_expected.to have_field(:invoice_require_successful_payment).of_type('Boolean!') }
   it { is_expected.to have_field(:status).of_type('WalletTransactionStatusEnum!') }
   it { is_expected.to have_field(:transaction_status).of_type('WalletTransactionTransactionStatusEnum!') }
   it { is_expected.to have_field(:transaction_type).of_type('WalletTransactionTransactionTypeEnum!') }

--- a/spec/graphql/types/wallets/object_spec.rb
+++ b/spec/graphql/types/wallets/object_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Types::Wallets::Object do
 
   it { is_expected.to have_field(:recurring_transaction_rules).of_type('[RecurringTransactionRule!]') }
 
+  it { is_expected.to have_field(:invoice_require_successful_payment).of_type('Boolean!') }
+
   it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
   it { is_expected.to have_field(:expiration_at).of_type('ISO8601DateTime') }
   it { is_expected.to have_field(:terminated_at).of_type('ISO8601DateTime') }

--- a/spec/jobs/invoices/prepaid_credit_job_spec.rb
+++ b/spec/jobs/invoices/prepaid_credit_job_spec.rb
@@ -38,4 +38,10 @@ RSpec.describe Invoices::PrepaidCreditJob, type: :job do
 
     expect(wallet_transaction.reload.status).to eq('settled')
   end
+
+  it 'finalize the invoice' do
+    allow(Invoices::FinalizeOpenCreditService).to receive(:call)
+    described_class.perform_now(invoice)
+    expect(Invoices::FinalizeOpenCreditService).to have_received(:call).with(invoice:)
+  end
 end

--- a/spec/serializers/v1/wallet_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_serializer_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe ::V1::WalletSerializer do
         'credits_ongoing_usage_balance' => wallet.credits_ongoing_usage_balance.to_s,
         'ongoing_balance_cents' => wallet.ongoing_balance_cents,
         'ongoing_usage_balance_cents' => wallet.ongoing_usage_balance_cents,
-        'consumed_credits' => wallet.consumed_credits.to_s
+        'consumed_credits' => wallet.consumed_credits.to_s,
+        'invoice_require_successful_payment' => wallet.invoice_require_successful_payment
       )
     end
   end

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe ::V1::WalletTransactionSerializer do
         'amount' => wallet_transaction.amount.to_s,
         'credit_amount' => wallet_transaction.credit_amount.to_s,
         'settled_at' => wallet_transaction.settled_at&.iso8601,
-        'created_at' => wallet_transaction.created_at.iso8601
+        'created_at' => wallet_transaction.created_at.iso8601,
+        'invoice_require_successful_payment' => wallet_transaction.invoice_require_successful_payment
       )
     end
   end

--- a/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
+++ b/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe ::V1::Wallets::RecurringTransactionRuleSerializer do
       "target_ongoing_balance" => recurring_transaction_rule.target_ongoing_balance,
       "threshold_credits" => recurring_transaction_rule.threshold_credits.to_s,
       "granted_credits" => recurring_transaction_rule.granted_credits.to_s,
-      "created_at" => recurring_transaction_rule.created_at.iso8601
+      "created_at" => recurring_transaction_rule.created_at.iso8601,
+      "invoice_require_successful_payment" => recurring_transaction_rule.invoice_require_successful_payment
     )
   end
 end

--- a/spec/services/invoices/finalize_open_credit_service_spec.rb
+++ b/spec/services/invoices/finalize_open_credit_service_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::FinalizeOpenCreditService, type: :service do
+  let(:service) { described_class.new(invoice:) }
+
+  let(:organization) { create(:organization, email_settings: Organization::EMAIL_SETTINGS) }
+  let(:invoice) { create(:invoice, organization:, invoice_type: 'credit', status: :open, payment_due_date: 1.week.ago.to_date) }
+
+  before do
+    allow(invoice).to receive(:should_sync_invoice?).and_return(true)
+    allow(invoice).to receive(:should_sync_sales_order?).and_return(true)
+  end
+
+  describe '.call' do
+    around { |test| lago_premium!(&test) }
+
+    it 'updates invoice status and enqueues necessary jobs' do
+      result = service.call
+
+      expect(result.invoice.status).to eq('finalized')
+      expect(result.invoice.issuing_date).to be_today
+      expect(result.invoice.payment_due_date).to be_today
+
+      expect(SendWebhookJob).to have_been_enqueued.with('invoice.paid_credit_added', result.invoice)
+      expect(Invoices::GeneratePdfAndNotifyJob).to have_been_enqueued.with(invoice: result.invoice, email: true)
+      expect(Integrations::Aggregator::Invoices::CreateJob).to have_been_enqueued.with(invoice: result.invoice)
+      expect(Integrations::Aggregator::SalesOrders::CreateJob).to have_been_enqueued.with(invoice: result.invoice)
+      expect(SegmentTrackJob).to have_been_enqueued.with(membership_id: anything, event: 'invoice_created', properties: {
+        organization_id: result.invoice.organization.id,
+        invoice_id: result.invoice.id,
+        invoice_type: result.invoice.invoice_type
+      })
+    end
+
+    context 'when invoice is already finalized' do
+      let(:invoice) { create(:invoice, organization:, invoice_type: 'credit', status: :finalized) }
+
+      it 'does not update invoice status' do
+        result = service.call
+
+        expect(result.invoice.status).to eq('finalized')
+
+        expect(SendWebhookJob).not_to have_been_enqueued
+        expect(Invoices::GeneratePdfAndNotifyJob).not_to have_been_enqueued
+        expect(Integrations::Aggregator::Invoices::CreateJob).not_to have_been_enqueued
+        expect(Integrations::Aggregator::SalesOrders::CreateJob).not_to have_been_enqueued
+        expect(SegmentTrackJob).not_to have_been_enqueued
+      end
+    end
+
+    context 'when invoice is not found' do
+      let(:invoice) { nil }
+
+      it 'returns not found failure' do
+        result = service.call
+
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq('invoice_not_found')
+      end
+    end
+  end
+end

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 wallet_id: wallet.id,
                 paid_credits: recurring_transaction_rule.paid_credits.to_s,
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                source: :interval
+                source: :interval,
+                invoice_require_successful_payment: false
               }
             )
         end
@@ -76,7 +77,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   wallet_id: wallet.id,
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                  source: :interval
+                  source: :interval,
+                  invoice_require_successful_payment: false
                 }
               )
           end
@@ -105,7 +107,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   wallet_id: wallet.id,
                   paid_credits: "150.0",
                   granted_credits: "0.0",
-                  source: :interval
+                  source: :interval,
+                  invoice_require_successful_payment: false
                 }
               )
           end
@@ -128,7 +131,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 wallet_id: wallet.id,
                 paid_credits: recurring_transaction_rule.paid_credits.to_s,
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                source: :interval
+                source: :interval,
+                invoice_require_successful_payment: false
               }
             )
         end
@@ -155,7 +159,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   wallet_id: wallet.id,
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                  source: :interval
+                  source: :interval,
+                  invoice_require_successful_payment: false
                 }
               )
           end
@@ -187,7 +192,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   wallet_id: wallet.id,
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                  source: :interval
+                  source: :interval,
+                  invoice_require_successful_payment: false
                 }
               )
           end
@@ -210,7 +216,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 wallet_id: wallet.id,
                 paid_credits: recurring_transaction_rule.paid_credits.to_s,
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                source: :interval
+                source: :interval,
+                invoice_require_successful_payment: false
               }
             )
         end
@@ -237,7 +244,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   wallet_id: wallet.id,
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                  source: :interval
+                  source: :interval,
+                  invoice_require_successful_payment: false
                 }
               )
           end
@@ -259,7 +267,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   wallet_id: wallet.id,
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                  source: :interval
+                  source: :interval,
+                  invoice_require_successful_payment: false
                 }
               )
           end
@@ -282,7 +291,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 wallet_id: wallet.id,
                 paid_credits: recurring_transaction_rule.paid_credits.to_s,
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                source: :interval
+                source: :interval,
+                invoice_require_successful_payment: false
               }
             )
         end
@@ -309,7 +319,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   wallet_id: wallet.id,
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
-                  source: :interval
+                  source: :interval,
+                  invoice_require_successful_payment: false
                 }
               )
           end
@@ -369,6 +380,43 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
           travel_to(current_date + 10.hours) do
             expect { create_interval_transactions_service.call }.not_to have_enqueued_job
           end
+        end
+      end
+    end
+
+    context 'when rule requires successful payment' do
+      let(:recurring_transaction_rule) do
+        create(
+          :recurring_transaction_rule,
+          trigger: :interval,
+          wallet:,
+          interval:,
+          created_at: created_at + 1.second,
+          started_at:,
+          invoice_require_successful_payment: true
+        )
+      end
+      let(:interval) { :weekly }
+
+      let(:current_date) do
+        DateTime.parse('20 Jun 2022').prev_occurring(created_at.strftime('%A').downcase.to_sym)
+      end
+
+      it 'follows the rule configuration' do
+        travel_to(current_date) do
+          create_interval_transactions_service.call
+
+          expect(WalletTransactions::CreateJob).to have_been_enqueued
+            .with(
+              organization_id: customer.organization_id,
+              params: {
+                wallet_id: wallet.id,
+                paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                granted_credits: recurring_transaction_rule.granted_credits.to_s,
+                source: :interval,
+                invoice_require_successful_payment: true
+              }
+            )
         end
       end
     end

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Wallets::CreateService, type: :service do
         expect(wallet.rate_amount).to eq(1.0)
         expect(wallet.expiration_at.iso8601).to eq(expiration_at)
         expect(wallet.recurring_transaction_rules.count).to eq(0)
+        expect(wallet.invoice_require_successful_payment).to eq(false)
       end
     end
 
@@ -57,6 +58,31 @@ RSpec.describe Wallets::CreateService, type: :service do
       it 'returns an error' do
         expect(service_result).not_to be_success
         expect(service_result.error.messages[:paid_credits]).to eq(['invalid_paid_credits'])
+      end
+    end
+
+    context 'when invoice_require_successful_payment is set ' do
+      let(:params) do
+        {
+          name: 'New Wallet',
+          customer:,
+          organization_id: organization.id,
+          currency: 'EUR',
+          rate_amount: '1.00',
+          paid_credits:,
+          invoice_require_successful_payment: true
+        }
+      end
+
+      it 'follows the value' do
+        aggregate_failures do
+          expect { service_result }.to change(Wallet, :count).by(1)
+
+          expect(service_result).to be_success
+
+          wallet = service_result.wallet
+          expect(wallet.invoice_require_successful_payment).to eq(true)
+        end
       end
     end
 

--- a/spec/services/wallets/update_service_spec.rb
+++ b/spec/services/wallets/update_service_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Wallets::UpdateService, type: :service do
       {
         id: wallet&.id,
         name: 'new name',
-        expiration_at:
+        expiration_at:,
+        invoice_require_successful_payment: true
       }
     end
 
@@ -33,6 +34,7 @@ RSpec.describe Wallets::UpdateService, type: :service do
       aggregate_failures do
         expect(result.wallet.name).to eq('new name')
         expect(result.wallet.expiration_at.iso8601).to eq(expiration_at)
+        expect(result.wallet.invoice_require_successful_payment).to eq(true)
       end
     end
 


### PR DESCRIPTION
## Description

This PR introduces a scheduled cleanup job that automatically deletes pending wallet transactions and corresponding unpaid open invoices that are older than 90 days. 