### PR TITLE
fix: invoices query payment_dispute_lost filter

### DIFF
--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -14,7 +14,8 @@ class InvoicesQuery < BaseQuery
     invoices = with_issuing_date_range(invoices) if filters.issuing_date_from || filters.issuing_date_to
     invoices = invoices.where(status:) if status.present?
     invoices = invoices.where(payment_status:) if payment_status.present?
-    invoices = invoices.where.not(payment_dispute_lost_at: nil) unless payment_dispute_lost.nil?
+    invoices = invoices.where.not(payment_dispute_lost_at: nil) if payment_dispute_lost
+    invoices = invoices.where(payment_dispute_lost_at: nil) if payment_dispute_lost == false
     invoices = invoices.where(payment_overdue:) if payment_overdue.present?
     invoices = invoices.order(issuing_date: :desc, created_at: :desc)
     invoices = paginate(invoices)

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -211,6 +211,28 @@ RSpec.describe InvoicesQuery, type: :query do
     end
   end
 
+  context 'when filtering by payment dispute lost false' do
+    it 'returns 1 invoices' do
+      result = invoice_query.call(
+        search_term: nil,
+        status: nil,
+        payment_dispute_lost: false
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(returned_ids.count).to eq(5)
+        expect(returned_ids).to include(invoice_first.id)
+        expect(returned_ids).to include(invoice_second.id)
+        expect(returned_ids).to include(invoice_third.id)
+        expect(returned_ids).to include(invoice_fourth.id)
+        expect(returned_ids).to include(invoice_fifth.id)
+        expect(returned_ids).not_to include(invoice_sixth.id)
+      end
+    end
+  end
+
   context 'when filtering by payment overdue' do
     it 'returns expected invoices' do
       result = invoice_query.call(


### PR DESCRIPTION
## Context

Whenever `payment_dispute_lost` filter had a value other than `nil` it was returing only inovoices with `payment_dispute_lost`,

hence, when the filter had a `false` value, it still returns only invoices with a payment dispute lost.

## Description

This change fixes the filter by providing the proper scoping base on the value of the filter.
