### PR TITLE
fix: invoices query payment_overdue filter

### DIFF
--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -16,7 +16,7 @@ class InvoicesQuery < BaseQuery
     invoices = invoices.where(payment_status:) if payment_status.present?
     invoices = invoices.where.not(payment_dispute_lost_at: nil) if payment_dispute_lost
     invoices = invoices.where(payment_dispute_lost_at: nil) if payment_dispute_lost == false
-    invoices = invoices.where(payment_overdue:) if payment_overdue.present?
+    invoices = invoices.where(payment_overdue:) unless payment_overdue.nil?
     invoices = invoices.order(issuing_date: :desc, created_at: :desc)
     invoices = paginate(invoices)
 

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -241,7 +241,39 @@ RSpec.describe InvoicesQuery, type: :query do
         payment_overdue: true
       )
 
-      expect(result.invoices.pluck(:id)).to eq([invoice_third.id])
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(returned_ids.count).to eq(1)
+        expect(returned_ids).not_to include(invoice_first.id)
+        expect(returned_ids).not_to include(invoice_second.id)
+        expect(returned_ids).to include(invoice_third.id)
+        expect(returned_ids).not_to include(invoice_fourth.id)
+        expect(returned_ids).not_to include(invoice_fifth.id)
+        expect(returned_ids).not_to include(invoice_sixth.id)
+      end
+    end
+  end
+
+  context 'when filtering by payment overdue false' do
+    it 'returns expected invoices' do
+      result = invoice_query.call(
+        search_term: nil,
+        status: nil,
+        payment_overdue: false
+      )
+
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(returned_ids.count).to eq(5)
+        expect(returned_ids).to include(invoice_first.id)
+        expect(returned_ids).to include(invoice_second.id)
+        expect(returned_ids).not_to include(invoice_third.id)
+        expect(returned_ids).to include(invoice_fourth.id)
+        expect(returned_ids).to include(invoice_fifth.id)
+        expect(returned_ids).to include(invoice_sixth.id)
+      end
     end
   end
 


### PR DESCRIPTION
## Context

Given `payment_overdue` filter is false, `InvoicesQuery` ignores the filter and return all invoices without consider their `payment_overdue` value, while it should only return `payment_overdue` == false invoices.

## Description

This change fixes the filter by providing the proper scoping base on the value of the filter.