### PR TITLE
Feat(anrok): add handling discarded errors when retrying invoice

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -78,6 +78,10 @@ module Types
           resource_type: :invoice
         )&.external_id
       end
+
+      def error_details
+        object.error_details.kept
+      end
     end
   end
 end

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -92,7 +92,7 @@ module V1
 
     def error_details
       ::CollectionSerializer.new(
-        model.error_details,
+        model.error_details.kept,
         ::V1::Invoices::ErrorDetailSerializer,
         collection_name: 'error_details'
       ).serialize

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -17,7 +17,7 @@ module Invoices
 
       unless taxes_result.success?
         create_error_detail(taxes_result.error.code)
-        return result.service_failure!(code: 'tax_error', message: taxes_result.error.code)
+        return result.validation_failure!(errors: {tax_error: [taxes_result.error.code]})
       end
 
       provider_taxes = taxes_result.fees

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -12,6 +12,7 @@ module Invoices
       return result.not_found_failure!(resource: 'invoice') unless invoice
       return result.not_allowed_failure!(code: 'invalid_status') unless invoice.failed?
 
+      invoice.error_details.kept.update(deleted_at: Time.current)
       taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: invoice.fees)
 
       unless taxes_result.success?

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -12,7 +12,7 @@ module Invoices
       return result.not_found_failure!(resource: 'invoice') unless invoice
       return result.not_allowed_failure!(code: 'invalid_status') unless invoice.failed?
 
-      invoice.error_details.kept.update_all(deleted_at: Time.current)
+      invoice.error_details.tax_error.kept.update_all(deleted_at: Time.current)
       taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: invoice.fees)
 
       unless taxes_result.success?

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -12,7 +12,7 @@ module Invoices
       return result.not_found_failure!(resource: 'invoice') unless invoice
       return result.not_allowed_failure!(code: 'invalid_status') unless invoice.failed?
 
-      invoice.error_details.kept.update(deleted_at: Time.current)
+      invoice.error_details.kept.update_all(deleted_at: Time.current)
       taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: invoice.fees)
 
       unless taxes_result.success?

--- a/app/services/invoices/retry_service.rb
+++ b/app/services/invoices/retry_service.rb
@@ -12,7 +12,7 @@ module Invoices
       return result.not_found_failure!(resource: 'invoice') unless invoice
       return result.not_allowed_failure!(code: 'invalid_status') unless invoice.failed?
 
-      invoice.error_details.tax_error.kept.update_all(deleted_at: Time.current)
+      invoice.error_details.tax_error.kept.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
       taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: invoice.fees)
 
       unless taxes_result.success?

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -24,9 +24,9 @@ FactoryBot.define do
       payment_dispute_lost_at { DateTime.current - 1.day }
     end
 
-    trait :with_error do
+    trait :with_tax_error do
       after :create do |i|
-        create(:error_detail, owner: i)
+        create(:error_detail, owner: i, error_code: 'tax_error')
       end
     end
 

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Invoices::RetryService, type: :service do
       create(
         :invoice,
         :failed,
-        :with_error,
+        :with_tax_error,
         customer:,
         organization:,
         subscriptions: [subscription],
@@ -127,9 +127,9 @@ RSpec.describe Invoices::RetryService, type: :service do
           .to change(invoice, :status).from('failed').to('finalized')
       end
 
-      it 'discards previous errors' do
+      it 'discards previous tax errors' do
         expect { retry_service.call }
-          .to change(invoice.error_details.kept, :count).from(1).to(0)
+          .to change(invoice.error_details.tax_error.kept, :count).from(1).to(0)
       end
 
       it 'updates the issuing date and payment due date' do

--- a/spec/services/invoices/retry_service_spec.rb
+++ b/spec/services/invoices/retry_service_spec.rb
@@ -299,6 +299,7 @@ RSpec.describe Invoices::RetryService, type: :service do
         result = retry_service.call
 
         expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
         expect(invoice.reload.status).to eq('failed')
       end
 


### PR DESCRIPTION
## Context

When retrying an invoice we want to mark all previous errors as discarded, so if the invoice succeeded these errors will not be shown

## Description

- Update deleted_at for existing tax_error error_details  when retrying fetch taxes for the invoice
- Create new errors when retrying invoice fetching taxes failed
- Serialize only error_details that are not discarded 
