### PR TITLE
fix: Serialize nested collections with a symbol key

### DIFF
--- a/app/serializers/collection_serializer.rb
+++ b/app/serializers/collection_serializer.rb
@@ -22,7 +22,7 @@ class CollectionSerializer
   end
 
   def collection_name
-    options.fetch(:collection_name, :data)
+    options.fetch(:collection_name, :data).to_sym
   end
 
   def meta?


### PR DESCRIPTION
## Context

Before, all item attributes are serialized with symbol keys but nested collections with strings. This incosistency caused bugs when using the serializer to export resources in CSV format.

## Description

Ensure the provided key is symbolized.