### PR TITLE
fix(export invoices): Re arrange CSV column order, add new columns and fix row order by issuing date

### DIFF
--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -90,7 +90,7 @@ module DataExports
         filters = resource_query.except("search_term")
 
         InvoicesQuery.call(
-          organization: organization,
+          organization:,
           pagination: nil,
           search_term:,
           filters:

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -31,16 +31,17 @@ module DataExports
               serialized_invoice[:customer][:country],
               serialized_invoice[:customer][:tax_identification_number],
               serialized_invoice[:number],
-              serialized_invoice[:total_amount_cents],
-              serialized_invoice[:currency],
               serialized_invoice[:invoice_type],
               serialized_invoice[:payment_status],
               serialized_invoice[:status],
               serialized_invoice[:file_url],
+              serialized_invoice[:currency],
+              serialized_invoice[:fees_amount_cents],
+              serialized_invoice[:coupons_amount_cents],
               serialized_invoice[:taxes_amount_cents],
               serialized_invoice[:credit_notes_amount_cents],
               serialized_invoice[:prepaid_credit_amount_cents],
-              serialized_invoice[:coupons_amount_cents],
+              serialized_invoice[:total_amount_cents],
               serialized_invoice[:payment_due_date],
               serialized_invoice[:payment_dispute_lost_at],
               serialized_invoice[:payment_overdue]
@@ -65,16 +66,17 @@ module DataExports
           customer_country
           customer_tax_identification_number
           invoince_number
-          total_amount_cents
-          currency
           invoice_type
           payment_status
           status
           file_url
+          currency
+          fees_amount_cents
+          coupons_amount_cents
           taxes_amount_cents
           credit_notes_amount_cents
           prepaid_credit_amount_cents
-          coupons_amount_cents
+          total_amount_cents
           payment_due_date
           payment_dispute_lost_at
           payment_overdue

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -65,7 +65,7 @@ module DataExports
           customer_external_id
           customer_country
           customer_tax_identification_number
-          invoince_number
+          invoice_number
           invoice_type
           payment_status
           status

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -17,7 +17,7 @@ module DataExports
         ::CSV.generate(headers: true) do |csv|
           csv << headers
 
-          query.invoices.find_each do |invoice|
+          query.invoices.each do |invoice|
             serialized_invoice = serializer_klass
               .new(invoice, includes: %i[customer])
               .serialize

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -28,6 +28,7 @@ module DataExports
               serialized_invoice[:issuing_date],
               serialized_invoice[:customer][:lago_id],
               serialized_invoice[:customer][:external_id],
+              serialized_invoice[:customer][:name],
               serialized_invoice[:customer][:country],
               serialized_invoice[:customer][:tax_identification_number],
               serialized_invoice[:number],
@@ -63,6 +64,7 @@ module DataExports
           issuing_date
           customer_lago_id
           customer_external_id
+          customer_name
           customer_country
           customer_tax_identification_number
           invoice_number

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -72,18 +72,19 @@ RSpec.describe DataExports::Csv::Invoices do
         tax_identification_number: '123456789'
       },
       number: 'INV123',
-      total_amount_cents: 1000,
-      currency: 'USD',
       invoice_type: 'credit',
       payment_status: 'pending',
       status: 'finalized',
       file_url: 'http://api.lago.com/invoice.pdf',
-      taxes_amount_cents: 200,
-      credit_notes_amount_cents: 100,
-      prepaid_credit_amount_cents: 50,
-      coupons_amount_cents: 25,
+      currency: 'USD',
+      fees_amount_cents: 70000,
+      coupons_amount_cents: 1655,
+      taxes_amount_cents: 10500,
+      credit_notes_amount_cents: 334,
+      prepaid_credit_amount_cents: 1000,
+      total_amount_cents: 77511,
       payment_due_date: '2023-02-01',
-      payment_dispute_lost_at: nil,
+      payment_dispute_lost_at: '2023-12-22',
       payment_overdue: false
     }
   end
@@ -116,8 +117,8 @@ RSpec.describe DataExports::Csv::Invoices do
 
     it 'generates the correct CSV output' do
       expected_csv = <<~CSV
-        lago_id,sequential_id,issuing_date,customer_lago_id,customer_external_id,customer_country,customer_tax_identification_number,invoince_number,total_amount_cents,currency,invoice_type,payment_status,status,file_url,taxes_amount_cents,credit_notes_amount_cents,prepaid_credit_amount_cents,coupons_amount_cents,payment_due_date,payment_dispute_lost_at,payment_overdue
-        invoice-lago-id-123,SEQ123,2023-01-01,customer-lago-id-456,CUST123,US,123456789,INV123,1000,USD,credit,pending,finalized,http://api.lago.com/invoice.pdf,200,100,50,25,2023-02-01,,false
+        lago_id,sequential_id,issuing_date,customer_lago_id,customer_external_id,customer_country,customer_tax_identification_number,invoince_number,invoice_type,payment_status,status,file_url,currency,fees_amount_cents,coupons_amount_cents,taxes_amount_cents,credit_notes_amount_cents,prepaid_credit_amount_cents,total_amount_cents,payment_due_date,payment_dispute_lost_at,payment_overdue
+        invoice-lago-id-123,SEQ123,2023-01-01,customer-lago-id-456,CUST123,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
       CSV
 
       expect(call).to eq(expected_csv)

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe DataExports::Csv::Invoices do
 
     it 'generates the correct CSV output' do
       expected_csv = <<~CSV
-        lago_id,sequential_id,issuing_date,customer_lago_id,customer_external_id,customer_country,customer_tax_identification_number,invoince_number,invoice_type,payment_status,status,file_url,currency,fees_amount_cents,coupons_amount_cents,taxes_amount_cents,credit_notes_amount_cents,prepaid_credit_amount_cents,total_amount_cents,payment_due_date,payment_dispute_lost_at,payment_overdue
+        lago_id,sequential_id,issuing_date,customer_lago_id,customer_external_id,customer_country,customer_tax_identification_number,invoice_number,invoice_type,payment_status,status,file_url,currency,fees_amount_cents,coupons_amount_cents,taxes_amount_cents,credit_notes_amount_cents,prepaid_credit_amount_cents,total_amount_cents,payment_due_date,payment_dispute_lost_at,payment_overdue
         invoice-lago-id-123,SEQ123,2023-01-01,customer-lago-id-456,CUST123,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
       CSV
 

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe DataExports::Csv::Invoices do
       sequential_id: 'SEQ123',
       issuing_date: '2023-01-01',
       customer: {
+        name: 'customer name',
         lago_id: 'customer-lago-id-456',
         external_id: 'CUST123',
         country: 'US',
@@ -117,8 +118,8 @@ RSpec.describe DataExports::Csv::Invoices do
 
     it 'generates the correct CSV output' do
       expected_csv = <<~CSV
-        lago_id,sequential_id,issuing_date,customer_lago_id,customer_external_id,customer_country,customer_tax_identification_number,invoice_number,invoice_type,payment_status,status,file_url,currency,fees_amount_cents,coupons_amount_cents,taxes_amount_cents,credit_notes_amount_cents,prepaid_credit_amount_cents,total_amount_cents,payment_due_date,payment_dispute_lost_at,payment_overdue
-        invoice-lago-id-123,SEQ123,2023-01-01,customer-lago-id-456,CUST123,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
+        lago_id,sequential_id,issuing_date,customer_lago_id,customer_external_id,customer_name,customer_country,customer_tax_identification_number,invoice_number,invoice_type,payment_status,status,file_url,currency,fees_amount_cents,coupons_amount_cents,taxes_amount_cents,credit_notes_amount_cents,prepaid_credit_amount_cents,total_amount_cents,payment_due_date,payment_dispute_lost_at,payment_overdue
+        invoice-lago-id-123,SEQ123,2023-01-01,customer-lago-id-456,CUST123,customer name,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
       CSV
 
       expect(call).to eq(expected_csv)


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/ability-to-export-data-from-the-user-interface

## Context

Customers need some extra data in the invoices export we did not anticipate.

## Description

- Add the `fees_amount_cents` column in the CSV export
- Fix the invoice header typo (invoice instead of `invoince`)
- Add a `customer_name` column, after the `customer_external_id` name
- Invoices list must be sorted by `issuing_date DESC` (newest invoice at the top)
- Adapt the order of columns (in the exact order). This list of columns must start after the file_url one:
1. `fees_amount_cents`
2. `coupons_amount_cents`
3. `taxes_amount_cents`
4. `credit_notes_amount_cents`
5. `prepaid_credit_amount_cents`
6. `total_amount_cents`

In order to achieve the CSV row order by `issuing_date DESC` we can not use rails `find_each` or `find_in_batches` as this batching solution limits the ordering by the records primary key (asc or desc). We will use `each` over the whole result, if workers are impacted with performance or memory usage we will have to implement pagination through the query object capabilities.