### PR TITLE
feat(netsuite): Add lago customer link to netsuite

### DIFF
--- a/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
@@ -15,6 +15,7 @@ module Integrations
                 'custentity_lago_id' => customer.id,
                 'custentity_lago_sf_id' => customer.external_salesforce_id,
                 'custentity_form_activeprospect_customer' => customer.name, # TODO: Will be removed
+                'custentity_lago_customer_link' => customer_url,
                 'email' => customer.email,
                 'phone' => customer.phone
               },
@@ -33,6 +34,7 @@ module Integrations
                 'subsidiary' => integration_customer.subsidiary_id,
                 'custentity_lago_sf_id' => customer.external_salesforce_id,
                 'custentity_form_activeprospect_customer' => customer.name, # TODO: Will be removed
+                'custentity_lago_customer_link' => customer_url,
                 'email' => customer.email,
                 'phone' => customer.phone
               },
@@ -40,6 +42,14 @@ module Integrations
                 'isDynamic' => false
               }
             }
+          end
+
+          private
+
+          def customer_url
+            url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+
+            URI.join(url, "/customer/", customer.id).to_s
           end
         end
       end

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
     }
   end
 
+  let(:customer_link) do
+    url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+
+    URI.join(url, "/customer/", customer.id).to_s
+  end
+
   before do
     allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
   end
@@ -47,7 +53,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
               'custentity_lago_id' => customer.id,
               'custentity_lago_sf_id' => customer.external_salesforce_id,
               'custentity_form_activeprospect_customer' => customer.name,
-              'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
+              'custentity_lago_customer_link' => customer_link,
               'email' => customer.email,
               'phone' => customer.phone
             },
@@ -160,7 +166,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
             'custentity_lago_id' => customer.id,
             'custentity_lago_sf_id' => customer.external_salesforce_id,
             'custentity_form_activeprospect_customer' => customer.name,
-            'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
+            'custentity_lago_customer_link' => customer_link,
             'email' => customer.email,
             'phone' => customer.phone
           },

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
               'custentity_lago_id' => customer.id,
               'custentity_lago_sf_id' => customer.external_salesforce_id,
               'custentity_form_activeprospect_customer' => customer.name,
+              'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
               'email' => customer.email,
               'phone' => customer.phone
             },
@@ -159,6 +160,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
             'custentity_lago_id' => customer.id,
             'custentity_lago_sf_id' => customer.external_salesforce_id,
             'custentity_form_activeprospect_customer' => customer.name,
+            'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
             'email' => customer.email,
             'phone' => customer.phone
           },

--- a/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Netsuite do
   let(:integration_customer) { FactoryBot.create(:netsuite_customer) }
   let(:subsidiary_id) { Faker::Number.number(digits: 2) }
   let(:payload) { described_class.new(integration:, customer:, integration_customer:, subsidiary_id:) }
+  let(:customer_link) { payload.__send__(:customer_url) }
 
   describe "#create_body" do
     subject(:create_body_call) { payload.create_body }
@@ -22,7 +23,7 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Netsuite do
           'custentity_lago_id' => customer.id,
           'custentity_lago_sf_id' => customer.external_salesforce_id,
           'custentity_form_activeprospect_customer' => customer.name,
-          'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
+          'custentity_lago_customer_link' => customer_link,
           'email' => customer.email,
           'phone' => customer.phone
         },
@@ -49,7 +50,7 @@ RSpec.describe Integrations::Aggregator::Contacts::Payloads::Netsuite do
           'subsidiary' => integration_customer.subsidiary_id,
           'custentity_lago_sf_id' => customer.external_salesforce_id,
           'custentity_form_activeprospect_customer' => customer.name, # TODO: Will be removed
-          'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
+          'custentity_lago_customer_link' => customer_link,
           'email' => customer.email,
           'phone' => customer.phone
         },

--- a/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/payloads/netsuite_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::Contacts::Payloads::Netsuite do
+  let(:integration) { integration_customer.integration }
+  let(:customer) { integration_customer.customer }
+  let(:integration_customer) { FactoryBot.create(:netsuite_customer) }
+  let(:subsidiary_id) { Faker::Number.number(digits: 2) }
+  let(:payload) { described_class.new(integration:, customer:, integration_customer:, subsidiary_id:) }
+
+  describe "#create_body" do
+    subject(:create_body_call) { payload.create_body }
+
+    let(:payload_body) do
+      {
+        'type' => 'customer',
+        'isDynamic' => false,
+        'columns' => {
+          'companyname' => customer.name,
+          'subsidiary' => subsidiary_id,
+          'custentity_lago_id' => customer.id,
+          'custentity_lago_sf_id' => customer.external_salesforce_id,
+          'custentity_form_activeprospect_customer' => customer.name,
+          'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
+          'email' => customer.email,
+          'phone' => customer.phone
+        },
+        'options' => {
+          'ignoreMandatoryFields' => false
+        }
+      }
+    end
+
+    it "returns the payload body" do
+      expect(subject).to eq payload_body
+    end
+  end
+
+  describe "#update_body" do
+    subject(:update_body_call) { payload.update_body }
+
+    let(:payload_body) do
+      {
+        'type' => 'customer',
+        'recordId' => integration_customer.external_customer_id,
+        'values' => {
+          'companyname' => customer.name,
+          'subsidiary' => integration_customer.subsidiary_id,
+          'custentity_lago_sf_id' => customer.external_salesforce_id,
+          'custentity_form_activeprospect_customer' => customer.name, # TODO: Will be removed
+          'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
+          'email' => customer.email,
+          'phone' => customer.phone
+        },
+        'options' => {
+          'isDynamic' => false
+        }
+      }
+    end
+
+    it "returns the payload body" do
+      expect(subject).to eq payload_body
+    end
+  end
+end

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
     }
   end
 
+  let(:customer_link) do
+    url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
+
+    URI.join(url, "/customer/", customer.id).to_s
+  end
+
   before do
     allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
   end
@@ -42,7 +48,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
               'subsidiary' => integration_customer.subsidiary_id,
               'custentity_lago_sf_id' => customer.external_salesforce_id,
               'custentity_form_activeprospect_customer' => customer.name,
-              'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
+              'custentity_lago_customer_link' => customer_link,
               'email' => customer.email,
               'phone' => customer.phone
             },
@@ -129,7 +135,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
             'subsidiary' => integration_customer.subsidiary_id,
             'custentity_lago_sf_id' => customer.external_salesforce_id,
             'custentity_form_activeprospect_customer' => customer.name,
-            'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
+            'custentity_lago_customer_link' => customer_link,
             'email' => customer.email,
             'phone' => customer.phone
           },

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
               'subsidiary' => integration_customer.subsidiary_id,
               'custentity_lago_sf_id' => customer.external_salesforce_id,
               'custentity_form_activeprospect_customer' => customer.name,
+              'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
               'email' => customer.email,
               'phone' => customer.phone
             },
@@ -128,6 +129,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
             'subsidiary' => integration_customer.subsidiary_id,
             'custentity_lago_sf_id' => customer.external_salesforce_id,
             'custentity_form_activeprospect_customer' => customer.name,
+            'custentity_lago_customer_link' => "#{ENV["LAGO_FRONT_URL"]}/customer/#{customer.id}",
             'email' => customer.email,
             'phone' => customer.phone
           },


### PR DESCRIPTION
## Context

By creating or updating a customer from Lago to NetSuite, a client needs us to send a custom field with the hyperlink of our Lago customer.

## Description

Add `custentity_lago_customer_link` to payload body when saving a netsuite customer.