### PR TITLE
feat (tax-integration): add new webhook type for fee tax failure

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -22,6 +22,7 @@ class SendWebhookJob < ApplicationJob
     'event.error' => Webhooks::Events::ErrorService,
     'events.errors' => Webhooks::Events::ValidationErrorsService,
     'fee.created' => Webhooks::Fees::PayInAdvanceCreatedService,
+    'fee.tax_provider_error' => Webhooks::Integrations::Taxes::FeeErrorService,
     'customer.accounting_provider_created' => Webhooks::Integrations::CustomerCreatedService,
     'customer.accounting_provider_error' => Webhooks::Integrations::CustomerErrorService,
     'customer.payment_provider_created' => Webhooks::PaymentProviders::CustomerCreatedService,

--- a/app/serializers/v1/integrations/taxes/fee_error_serializer.rb
+++ b/app/serializers/v1/integrations/taxes/fee_error_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module V1
+  module Integrations
+    module Taxes
+      class FeeErrorSerializer < ModelSerializer
+        def serialize
+          {
+            lago_integration_id: model.id,
+            tax_provider_code: model.code,
+            lago_charge_id: options[:lago_charge_id],
+            event_transaction_id: options[:event_transaction_id],
+            provider_error: options[:provider_error]
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/webhooks/integrations/taxes/fee_error_service.rb
+++ b/app/services/webhooks/integrations/taxes/fee_error_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Integrations
+    module Taxes
+      class FeeErrorService < Webhooks::BaseService
+        private
+
+        def current_organization
+          @current_organization ||= object.organization
+        end
+
+        def object_serializer
+          ::V1::Integrations::Taxes::FeeErrorSerializer.new(
+            object,
+            root_name: object_type,
+            event_transaction_id: options[:event_transaction_id],
+            lago_charge_id: options[:lago_charge_id],
+            provider_error: options[:provider_error]
+          )
+        end
+
+        def webhook_type
+          'fee.tax_provider_error'
+        end
+
+        def object_type
+          'tax_provider_fee_error'
+        end
+      end
+    end
+  end
+end

--- a/spec/serializers/v1/integrations/taxes/fee_error_serializer_spec.rb
+++ b/spec/serializers/v1/integrations/taxes/fee_error_serializer_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::Integrations::Taxes::FeeErrorSerializer do
+  subject(:serializer) { described_class.new(integration, options) }
+
+  let(:integration) { create(:anrok_integration) }
+  let(:options) do
+    {
+      'provider_error' => {
+        'error_message' => 'message',
+        'error_code' => 'code'
+      },
+      'event_transaction_id' => '123',
+      'lago_charge_id' => '456'
+    }.with_indifferent_access
+  end
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['data']['lago_integration_id']).to eq(integration.id)
+      expect(result['data']['tax_provider_code']).to eq(integration.code)
+      expect(result['data']['lago_charge_id']).to eq('456')
+      expect(result['data']['event_transaction_id']).to eq('123')
+      expect(result['data']['provider_error']).to eq(options[:provider_error])
+    end
+  end
+end

--- a/spec/services/webhooks/integrations/taxes/fee_error_service_spec.rb
+++ b/spec/services/webhooks/integrations/taxes/fee_error_service_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Integrations::Taxes::FeeErrorService do
+  subject(:webhook_service) { described_class.new(object: integration, options: webhook_options) }
+
+  let(:integration) { create(:anrok_integration, organization:) }
+  let(:organization) { create(:organization) }
+  let(:webhook_options) do
+    {
+      provider_error: {message: 'message', error_code: 'code'},
+      event_transaction_id: '123',
+      lago_charge_id: '456'
+    }
+  end
+
+  describe '.call' do
+    it_behaves_like 'creates webhook', 'fee.tax_provider_error', 'tax_provider_fee_error'
+  end
+end


### PR DESCRIPTION
## Context

Currently Lago is adding Anrok tax integration.

## Description

If there is error while fetching taxes for fees pay in advance, we want to have dedicated webhook.

This PR creates new webhook type for described case and adds related tests.
