### PR TITLE
feat(netsuite): Do not send line items with 0 amount cents

### DIFF
--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -26,7 +26,9 @@ module Integrations
               'lines' => [
                 {
                   'sublistId' => 'item',
-                  'lineItems' => invoice.fees.order(created_at: :asc).map { |fee| item(fee) } + discounts
+                  'lineItems' => invoice.fees.where('amount_cents > ?', 0).order(created_at: :asc).map do |fee|
+                    item(fee)
+                  end + discounts
                 }
               ],
               'options' => {

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -132,6 +132,18 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
       )
     end
 
+    let(:charge_fee2) do
+      create(
+        :charge_fee,
+        invoice:,
+        charge:,
+        units: 0,
+        precise_unit_amount: 0.0,
+        amount_cents: 0,
+        created_at: current_time
+      )
+    end
+
     let(:invoice_link) do
       url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"
 
@@ -219,6 +231,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
       fee_sub
       minimum_commitment_fee
       charge_fee
+      charge_fee2
     end
 
     it 'returns payload body' do


### PR DESCRIPTION
## Context

Customers do not want Lago to sync 0 amount line item to NetSuite.

## Description

Do not sync line items in NetSuite if Lago's `fees.amount_cents` is equal to `0`.