### PR TITLE
misc(events) - Setup more aggressive autovacuum_vacuum_scale_factor setting for events

### DIFF
--- a/db/migrate/20240801142242_alter_events_vacuum_settings.rb
+++ b/db/migrate/20240801142242_alter_events_vacuum_settings.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AlterEventsVacuumSettings < ActiveRecord::Migration[7.1]
+  def up
+    execute "ALTER TABLE events set (autovacuum_vacuum_scale_factor=0.005)"
+  end
+
+  def down
+    # revert to PG defaults
+    execute "ALTER TABLE events set (autovacuum_vacuum_scale_factor=0.1)"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_29_154334) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_01_142242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
## Description

Default postgres autovacuum settings are a bit too defensive for our use-cases. We require frequent vacuuming of the events table, mostly to keep the visibility map of the events table up to date. 