### PR TITLE
perf(wallets): Improve job enqueuing

### DIFF
--- a/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
+++ b/app/jobs/clock/refresh_wallets_ongoing_balance_job.rb
@@ -14,7 +14,7 @@ module Clock
       jobs = []
       batch_size = 100
 
-      Wallet.active.select(:id).find_each do |wallet|
+      Wallet.active.where(updated_at: ..1.minute.ago).select(:id).find_each do |wallet|
         jobs << Wallets::RefreshOngoingBalanceJob.new(wallet)
 
         if jobs.size >= batch_size

--- a/app/jobs/wallets/refresh_ongoing_balance_job.rb
+++ b/app/jobs/wallets/refresh_ongoing_balance_job.rb
@@ -4,9 +4,14 @@ module Wallets
   class RefreshOngoingBalanceJob < ApplicationJob
     queue_as 'wallets'
 
-    unique :until_executed, on_conflict: :log
+    unique :while_executing, on_conflict: :log
 
     def perform(wallet)
+      # If the wallet was updated recently, it's probably because this same job was executed
+      # Since it runs every 5.minutes, even if the was was modified for other reasons and
+      # the balance wasn't updated, it will be updated in the next run.
+      return if wallet.updated_at < 1.minute.ago
+
       Wallets::Balance::RefreshOngoingService.call(wallet:)
     end
   end

--- a/spec/jobs/clock/refresh_wallets_ongoing_balance_job_spec.rb
+++ b/spec/jobs/clock/refresh_wallets_ongoing_balance_job_spec.rb
@@ -6,36 +6,35 @@ describe Clock::RefreshWalletsOngoingBalanceJob, job: true do
   subject { described_class }
 
   describe '.perform' do
-    let(:organization) { create(:organization) }
-    let(:customer) { create(:customer, organization:) }
-    let(:wallet) { create(:wallet, customer:) }
+    let(:wallets) { create_list(:wallet, 3) }
 
     before do
-      wallet
-      allow(Wallets::Balance::RefreshOngoingService).to receive(:call)
+      wallets
     end
 
     context 'when freemium' do
-      it 'does not call the refresh service' do
+      it 'does not enqueue a refresh job' do
         described_class.perform_now
-        expect(Wallets::RefreshOngoingBalanceJob).not_to have_been_enqueued.with(wallet)
+        expect(Wallets::RefreshOngoingBalanceJob).not_to have_been_enqueued
       end
     end
 
     context 'when premium' do
       around { |test| lago_premium!(&test) }
 
-      it 'calls the refresh service' do
+      it 'enqueues a refresh job for each wallets' do
         described_class.perform_now
-        expect(Wallets::RefreshOngoingBalanceJob).to have_been_enqueued.with(wallet)
+        expect(Wallets::RefreshOngoingBalanceJob).to have_been_enqueued.with(wallets.first)
+        expect(Wallets::RefreshOngoingBalanceJob).to have_been_enqueued.with(wallets.second)
+        expect(Wallets::RefreshOngoingBalanceJob).to have_been_enqueued.with(wallets.third)
       end
 
       context 'when not active' do
-        let(:wallet) { create(:wallet, :terminated) }
+        let(:wallets) { [create(:wallet, :terminated)] }
 
-        it 'does not call the refresh service' do
+        it 'does not enqueue a refresh job' do
           described_class.perform_now
-          expect(Wallets::RefreshOngoingBalanceJob).not_to have_been_enqueued.with(wallet)
+          expect(Wallets::RefreshOngoingBalanceJob).not_to have_been_enqueued
         end
       end
     end


### PR DESCRIPTION
## Context

Every 5 minutes, we enqueues a few thousands of jobs to update the wallet balance.

## Description

I'm proposing a few improvements to how we enqueue all the `Wallets::RefreshOngoingBalanceJob`s.

### 1. Use `select(:id)`

Instead of retrieving all the wallet columns and hydrated a full models, we'll only retrieve the ID because all we need is to be able to generate a Global ID for each model. When the job is executed, it retrieves the full model.

![CleanShot 2024-08-02 at 10 31 10@2x](https://github.com/user-attachments/assets/7dff66a5-4b31-4110-96e8-6ea772f6e964)


### 2. Use `perform_all_later`

Since we updated recently to Rails 7.1, we can now [use `perform_all_later`](https://blog.saeloun.com/2023/11/27/rails-7-1-adds-active-job-perform-all-later/). [Official docs](https://edgeguides.rubyonrails.org/active_job_basics.html#bulk-enqueuing).

With `perform_all_later`, a 1000 wallets to refresh will write 10 times to Redis, enqueuing 100 jobs each time.
With `perform_later`,  a 1000 wallets to refresh will write 1000 times to Redis, enqueuing 1 job at a time.


