### PR TITLE
feat(billing): Retry finalize jobs on Sequence error

### DIFF
--- a/app/jobs/invoices/finalize_job.rb
+++ b/app/jobs/invoices/finalize_job.rb
@@ -4,6 +4,8 @@ module Invoices
   class FinalizeJob < ApplicationJob
     queue_as 'invoices'
 
+    retry_on Sequenced::SequenceError, wait: :polynomially_longer
+
     def perform(invoice)
       Invoices::RefreshDraftAndFinalizeService.call(invoice:)
     end


### PR DESCRIPTION
## Description

When finalizing an invoice, we need to assign an invoice number, following a sequence. This requires a lock on the database which can fail. Other similar jobs already retry on this error.

Maybe we should even retry any jobs with this error. 🤔 