### PR TITLE
misc - Missing gemfile.lock update after ruby upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -947,7 +947,7 @@ DEPENDENCIES
   with_advisory_lock
 
 RUBY VERSION
-   ruby 3.3.0p0
+   ruby 3.3.4p94
 
 BUNDLED WITH
    2.5.5


### PR DESCRIPTION
## description

Forgotten `Gemfile.lock` update after ruby 3.3.4 upgrade
