### PR TITLE
fix(redis) - set redlock_options even if REDIS_PASSWORD is not provided

### DIFF
--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -3,6 +3,11 @@
 ActiveJob::Uniqueness.configure do |config|
   config.lock_ttl = 1.hour
 
+  config.redlock_options = {
+    retry_count: 0,
+    redis_timeout: 5
+  }
+
   if ENV['REDIS_PASSWORD'].present? && !ENV['REDIS_PASSWORD'].empty?
     uri = URI(ENV['REDIS_URL'])
     host = [uri.host, uri.path].join('')
@@ -12,9 +17,5 @@ ActiveJob::Uniqueness.configure do |config|
     end
 
     config.redlock_servers = ["#{uri.scheme}://:#{ENV["REDIS_PASSWORD"]}@#{host}:#{uri.port}"]
-    config.redlock_options = {
-      retry_count: 0,
-      redis_timeout: 5
-    }
   end
 end


### PR DESCRIPTION
## Description

We only passed in the `redlock_options` when we provided the `REDIS_PASSWORD` env var. We should set it in all cases.

