### PR TITLE
fix(netsuite): Do not send taxes columns if tax not mapped

### DIFF
--- a/app/services/integrations/aggregator/base_payload.rb
+++ b/app/services/integrations/aggregator/base_payload.rb
@@ -24,7 +24,7 @@ module Integrations
       end
 
       def tax_item
-        @tax_item ||= collection_mapping(:tax) || fallback_item
+        @tax_item ||= collection_mapping(:tax)
       end
 
       def commitment_item

--- a/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/invoices/payloads/netsuite.rb
@@ -11,18 +11,7 @@ module Integrations
             {
               'type' => type,
               'isDynamic' => true,
-              'columns' => {
-                'tranid' => invoice.id,
-                'entity' => integration_customer.external_customer_id,
-                'istaxable' => true,
-                'taxitem' => tax_item&.external_id,
-                'taxamountoverride' => amount(invoice.taxes_amount_cents, resource: invoice),
-                'otherrefnum' => invoice.number,
-                'custbody_lago_id' => invoice.id,
-                'custbody_ava_disable_tax_calculation' => true,
-                'custbody_lago_invoice_link' => invoice_url,
-                'duedate' => due_date
-              },
+              'columns' => columns,
               'lines' => [
                 {
                   'sublistId' => 'item',
@@ -38,6 +27,26 @@ module Integrations
           end
 
           private
+
+          def columns
+            result = {
+              'tranid' => invoice.id,
+              'entity' => integration_customer.external_customer_id,
+              'istaxable' => true,
+              'otherrefnum' => invoice.number,
+              'custbody_lago_id' => invoice.id,
+              'custbody_ava_disable_tax_calculation' => true,
+              'custbody_lago_invoice_link' => invoice_url,
+              'duedate' => due_date
+            }
+
+            if tax_item
+              result['taxitem'] = tax_item.external_id
+              result['taxamountoverride'] = amount(invoice.taxes_amount_cents, resource: invoice)
+            end
+
+            result
+          end
 
           def invoice_url
             url = ENV["LAGO_FRONT_URL"].presence || "https://app.getlago.com"

--- a/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
+++ b/spec/services/integrations/aggregator/invoices/payloads/netsuite_spec.rb
@@ -156,18 +156,7 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
       {
         'type' => 'invoice',
         'isDynamic' => true,
-        'columns' => {
-          'tranid' => invoice.id,
-          'entity' => integration_customer.external_customer_id,
-          'istaxable' => true,
-          'taxitem' => integration_collection_mapping5.external_id,
-          'taxamountoverride' => 2.0,
-          'otherrefnum' => invoice.number,
-          'custbody_lago_id' => invoice.id,
-          'custbody_ava_disable_tax_calculation' => true,
-          'custbody_lago_invoice_link' => invoice_link,
-          'duedate' => due_date
-        },
+        'columns' => columns,
         'lines' => [
           {
             'sublistId' => 'item',
@@ -224,7 +213,6 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
       integration_collection_mapping2
       integration_collection_mapping3
       integration_collection_mapping4
-      integration_collection_mapping5
       integration_collection_mapping6
       integration_mapping_add_on
       integration_mapping_bm
@@ -234,8 +222,48 @@ RSpec.describe Integrations::Aggregator::Invoices::Payloads::Netsuite do
       charge_fee2
     end
 
-    it 'returns payload body' do
-      expect(subject).to eq(body)
+    context 'when tax item is mapped' do
+      let(:columns) do
+        {
+          'tranid' => invoice.id,
+          'entity' => integration_customer.external_customer_id,
+          'istaxable' => true,
+          'taxitem' => integration_collection_mapping5.external_id,
+          'taxamountoverride' => 2.0,
+          'otherrefnum' => invoice.number,
+          'custbody_lago_id' => invoice.id,
+          'custbody_ava_disable_tax_calculation' => true,
+          'custbody_lago_invoice_link' => invoice_link,
+          'duedate' => due_date
+        }
+      end
+
+      before do
+        integration_collection_mapping5
+      end
+
+      it 'returns payload body with tax columns' do
+        expect(subject).to eq(body)
+      end
+    end
+
+    context 'when tax item is not mapped' do
+      let(:columns) do
+        {
+          'tranid' => invoice.id,
+          'entity' => integration_customer.external_customer_id,
+          'istaxable' => true,
+          'otherrefnum' => invoice.number,
+          'custbody_lago_id' => invoice.id,
+          'custbody_ava_disable_tax_calculation' => true,
+          'custbody_lago_invoice_link' => invoice_link,
+          'duedate' => due_date
+        }
+      end
+
+      it 'returns payload body without tax columns' do
+        expect(subject).to eq(body)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

In our NetSuite integration, if the tax_item mapping is not set, do not block the invoice from being synced to NetSuite. In that case, simply remove the taxitem and the taxamountoverride from the POST invoice request.

## Description

Remove`taxitem` and `taxamountoverride` columns from invoice payload if tax item is not mapped.