### PR TITLE
misc(tracing) - add trace_id and span_id to lograge custom_options

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -6,10 +6,15 @@ Rails.application.configure do
   config.colorize_logging = false
 
   config.lograge.custom_options = lambda do |event|
+    # If ENV[OTEL_EXPORTER] is not set, the span context will have all zero values.
+    span = OpenTelemetry::Trace.current_span
+
     {
       ddsource: 'ruby',
       params: event.payload[:params].reject { |k| %w[controller action].include?(k) },
-      organization_id: event.payload[:organization_id]
+      organization_id: event.payload[:organization_id],
+      trace_id: span.context.hex_trace_id,
+      span_id: span.context.hex_span_id
     }
   end
 end


### PR DESCRIPTION
## Description

Make sure we can correlate logs with traces by including the OpenTelemetry trace_id and span_id in the logs.
