### PR TITLE
feat(tresholds): Add serializers

### DIFF
--- a/app/serializers/v1/plan_serializer.rb
+++ b/app/serializers/v1/plan_serializer.rb
@@ -23,6 +23,7 @@ module V1
       }
 
       payload.merge!(charges) if include?(:charges)
+      payload.merge!(progressive_billing_tresholds) if include?(:progressive_billing_tresholds)
       payload.merge!(taxes) if include?(:taxes)
       payload.merge!(minimum_commitment) if include?(:minimum_commitment) && model.minimum_commitment
 
@@ -37,6 +38,14 @@ module V1
         ::V1::ChargeSerializer,
         collection_name: 'charges',
         includes: include?(:taxes) ? %i[taxes] : []
+      ).serialize
+    end
+
+    def progressive_billing_tresholds
+      ::CollectionSerializer.new(
+        model.progressive_billing_tresholds,
+        ::V1::ProgressiveBillingTresholdSerializer,
+        collection_name: 'progressive_billing_tresholds'
       ).serialize
     end
 

--- a/app/serializers/v1/progressive_billing_treshold_serializer.rb
+++ b/app/serializers/v1/progressive_billing_treshold_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module V1
+  class ProgressiveBillingTresholdSerializer < ModelSerializer
+    def serialize
+      {
+        lago_id: model.id,
+        treshold_display_name: model.treshold_display_name,
+        amount_cents: model.amount_cents,
+        amount_currency: model.amount_currency,
+        recurring: model.recurring,
+        created_at: model.created_at.iso8601,
+        updated_at: model.updated_at.iso8601
+      }
+    end
+  end
+end

--- a/spec/serializers/v1/plan_serializer_spec.rb
+++ b/spec/serializers/v1/plan_serializer_spec.rb
@@ -3,14 +3,21 @@
 require 'rails_helper'
 
 RSpec.describe ::V1::PlanSerializer do
-  subject(:serializer) { described_class.new(plan, root_name: 'plan', includes: %i[charges taxes minimum_commitment]) }
+  subject(:serializer) do
+    described_class.new(
+      plan,
+      root_name: 'plan',
+      includes: %i[charges taxes minimum_commitment progressive_billing_tresholds]
+    )
+  end
 
   let(:plan) { create(:plan) }
   let(:customer) { create(:customer, organization: plan.organization) }
   let(:subscription) { create(:subscription, customer:, plan:) }
   let(:charge) { create(:standard_charge, plan:) }
+  let(:progressive_billing_treshold) { create(:progressive_billing_treshold, plan:) }
 
-  before { subscription && charge }
+  before { subscription && charge && progressive_billing_treshold }
 
   context 'when plan has one minimium commitment' do
     let(:commitment) { create(:commitment, plan:) }
@@ -46,6 +53,16 @@ RSpec.describe ::V1::PlanSerializer do
 
       expect(result['plan']['charges'].first).to include(
         'lago_id' => charge.id
+      )
+
+      expect(result['plan']['progressive_billing_tresholds'].first).to include(
+        'lago_id' => progressive_billing_treshold.id,
+        'treshold_display_name' => progressive_billing_treshold.treshold_display_name,
+        'amount_cents' => progressive_billing_treshold.amount_cents,
+        'amount_currency' => progressive_billing_treshold.amount_currency,
+        'recurring' => progressive_billing_treshold.recurring?,
+        'created_at' => progressive_billing_treshold.created_at.iso8601,
+        'updated_at' => progressive_billing_treshold.updated_at.iso8601
       )
 
       expect(result['plan']['minimum_commitment']).to include(
@@ -94,6 +111,16 @@ RSpec.describe ::V1::PlanSerializer do
 
       expect(result['plan']['charges'].first).to include(
         'lago_id' => charge.id
+      )
+
+      expect(result['plan']['progressive_billing_tresholds'].first).to include(
+        'lago_id' => progressive_billing_treshold.id,
+        'treshold_display_name' => progressive_billing_treshold.treshold_display_name,
+        'amount_cents' => progressive_billing_treshold.amount_cents,
+        'amount_currency' => progressive_billing_treshold.amount_currency,
+        'recurring' => progressive_billing_treshold.recurring?,
+        'created_at' => progressive_billing_treshold.created_at.iso8601,
+        'updated_at' => progressive_billing_treshold.updated_at.iso8601
       )
 
       expect(result['plan']['minimum_commitment']).to be_nil

--- a/spec/serializers/v1/progressive_billing_treshold_serializer_spec.rb
+++ b/spec/serializers/v1/progressive_billing_treshold_serializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ::V1::ProgressiveBillingTresholdSerializer do
+  subject(:serializer) { described_class.new(progressive_billing_treshold, root_name: 'progressive_billing_treshold') }
+
+  let(:progressive_billing_treshold) { create(:progressive_billing_treshold) }
+
+  it 'serializes the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['progressive_billing_treshold']).to include(
+        'lago_id' => progressive_billing_treshold.id,
+        'treshold_display_name' => progressive_billing_treshold.treshold_display_name,
+        'amount_cents' => progressive_billing_treshold.amount_cents,
+        'amount_currency' => progressive_billing_treshold.amount_currency,
+        'recurring' => progressive_billing_treshold.recurring?,
+        'created_at' => progressive_billing_treshold.created_at.iso8601,
+        'updated_at' => progressive_billing_treshold.updated_at.iso8601
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/progressive-billing

## Context

There's always a risk of customers not paying invoices generated at the end of a billing period. It would be beneficial to bill customers at given thresholds (units vs. amount) rather than waiting until the end of the period. This approach would allow for removing customer access if invoices are not paid and prevent having a highest amount of unpaid invoices.

## Description

- Add `ProgressiveBillingTresholdSerializer`
- Update PlanSerializer wtih `progressive_billing_tresholds`