### PR TITLE
misc(tracing) - Capture and pass context inside Parallel execution blocks 

### DIFF
--- a/app/services/invoices/customer_usage_service.rb
+++ b/app/services/invoices/customer_usage_service.rb
@@ -66,9 +66,14 @@ module Invoices
         .includes(:taxes, billable_metric: :organization, filters: {values: :billable_metric_filter})
         .order(Arel.sql('lower(unaccent(billable_metrics.name)) ASC'))
 
+      # we're capturing the context here so we can re-use inside the threads. This will correctly propagate spans to this current span
+      context = OpenTelemetry::Context.current
+
       invoice.fees = Parallel.flat_map(query.all, in_threads: ENV['LAGO_PARALLEL_THREADS_COUNT']&.to_i || 1) do |charge|
-        ActiveRecord::Base.connection_pool.with_connection do
-          charge_usage(charge)
+        OpenTelemetry::Context.with_current(context) do
+          ActiveRecord::Base.connection_pool.with_connection do
+            charge_usage(charge)
+          end
         end
       end
     end


### PR DESCRIPTION
## Description

Given that spans and traces are thread-local, we need to capture the context and set it explicitly in the blocks executing in other threads. 

Inspired by https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/concurrent_ruby/lib/opentelemetry/instrumentation/concurrent_ruby/patches/thread_pool_executor.rb#L15
