### PR TITLE
fix(wrong-month-abbreviation): use month full names instead

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -10,7 +10,6 @@ de:
     - Fr
     - Sa
     abbr_month_names:
-    -
     - Jan
     - Feb
     - Mär
@@ -32,9 +31,8 @@ de:
     - Freitag
     - Samstag
     formats:
-      default: "%d. %b. %Y"
+      default: "%d. %B %Y"
     month_names:
-    -
     - Januar
     - Februar
     - März

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
         value_already_exist: value_already_exist
   date:
     formats:
-      default: "%b %d, %Y"
+      default: "%B %d, %Y"
   money:
     decimal_mark: "."
     format: "%u%n"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -10,19 +10,18 @@ es:
     - Vie
     - Sáb
     abbr_month_names:
-    -
-    - Ene
-    - Feb
-    - Mar
-    - Abr
-    - May
-    - Jun
-    - Jul
-    - Ago
-    - Sep
-    - Oct
-    - Nov
-    - Dic
+    - ene.
+    - feb.
+    - mar.
+    - abr.
+    - may.
+    - jun.
+    - jul.
+    - ago.
+    - sep.
+    - oct.
+    - nov.
+    - dic.
     day_names:
     - Domingo
     - Lunes
@@ -32,9 +31,8 @@ es:
     - Viernes
     - Sábado
     formats:
-      default: "%d de %b. de %Y"
+      default: "%d de %B de %Y"
     month_names:
-    -
     - Enero
     - Febrero
     - Marzo

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -10,19 +10,18 @@ fr:
     - Ven
     - Sam
     abbr_month_names:
-    -
-    - Jan
-    - Fév
-    - Mar
-    - Avr
-    - Mai
-    - Juin
-    - Jui
-    - Aoû
-    - Sep
-    - Oct
-    - Nov
-    - Déc
+    - janv.
+    - févr.
+    - mars
+    - avr.
+    - mai
+    - juin
+    - juill.
+    - août
+    - sept.
+    - oct.
+    - nov.
+    - déc.
     day_names:
     - Dimanche
     - Lundi
@@ -32,9 +31,8 @@ fr:
     - Vendredi
     - Samedi
     formats:
-      default: "%d %b %Y"
+      default: "%d %B %Y"
     month_names:
-    -
     - Janvier
     - Février
     - Mars

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -10,19 +10,18 @@ it:
     - Ven
     - Sab
     abbr_month_names:
-    -
-    - Gen
-    - Feb
-    - Mar
-    - Apr
-    - Mag
-    - Giu
-    - Lug
-    - Ago
-    - Set
-    - Ott
-    - Nov
-    - Dic
+    - gen
+    - feb
+    - mar
+    - apr
+    - mag
+    - giu
+    - lug
+    - ago
+    - set
+    - ott
+    - nov
+    - dic
     day_names:
     - Domenica
     - Lunedì
@@ -32,9 +31,8 @@ it:
     - Venerdì
     - Sabato
     formats:
-      default: "%d %b. %Y"
+      default: "%d %B %Y"
     month_names:
-    -
     - Gennaio
     - Febbraio
     - Marzo

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -10,19 +10,18 @@ nb:
     - Fre
     - Lør
     abbr_month_names:
-    -
-    - Jan
-    - Feb
-    - Mar
-    - Apr
-    - Mai
-    - Jun
-    - Jul
-    - Aug
-    - Sep
-    - Okt
-    - Nov
-    - Des
+    - jan.
+    - feb.
+    - mars
+    - apr.
+    - mai
+    - juni
+    - juli
+    - aug.
+    - sep.
+    - okt.
+    - nov.
+    - des.
     day_names:
     - Søndag
     - Mandag
@@ -32,9 +31,8 @@ nb:
     - Fredag
     - Lørdag
     formats:
-      default: "%d %b, %Y"
+      default: "%d. %B %Y"
     month_names:
-    -
     - Januar
     - Februar
     - Mars

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -2,19 +2,18 @@
 sv:
   date:
     abbr_day_names:
-    - sön.
-    - mån.
-    - tis.
-    - ons.
-    - tor.
-    - fre.
-    - lör.
+    - sön
+    - mån
+    - tis
+    - ons
+    - tor
+    - fre
+    - lör
     abbr_month_names:
-    -
     - jan.
     - feb.
     - mars
-    - april
+    - apr.
     - maj
     - juni
     - juli
@@ -32,9 +31,8 @@ sv:
     - fredag
     - lördag
     formats:
-      default: "%d %b. %Y"
+      default: "%d %B %Y"
     month_names:
-    -
     - januari
     - februari
     - mars


### PR DESCRIPTION
 ## Context

 Invoices and emails have been sent with dates with month abbreviated,
 however the abbreviation was wrong for some months and languages, also
 the format was off in some cases.

related: https://github.com/getlago/lago/issues/386

 ## Description

 This change fixes this issue changing the date format with month full
 name.

 Also, correct the month name abbreviations