### PR TITLE
fix: Bill subscription when created with subscription date in the past

### DIFF
--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -91,7 +91,9 @@ module Subscriptions
     end
 
     def should_be_billed_today?(sub)
-      sub.active? && sub.subscription_at.today? && plan.pay_in_advance? && !sub.in_trial_period?
+      return false unless sub.subscription_at.today? || sub.subscription_at.past?
+
+      sub.active? && plan.pay_in_advance? && !sub.in_trial_period?
     end
 
     def create_subscription

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -247,6 +247,15 @@ RSpec.describe Subscriptions::CreateService, type: :service do
       end
     end
 
+    context 'when plan is pay_in_advance and subscription_at is in the past' do
+      let(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true) }
+      let(:subscription_at) { 5.days.ago }
+
+      it 'enqueues a job to bill the subscription' do
+        expect { create_service.call }.to have_enqueued_job(BillSubscriptionJob)
+      end
+    end
+
     context 'when plan is pay_in_advance and subscription_at is in the future' do
       let(:plan) { create(:plan, amount_cents: 100, organization:, pay_in_advance: true) }
       let(:subscription_at) { Time.current + 5.days }


### PR DESCRIPTION
## Context

When a subscription is created with a subscription date in the past, for a paid-in-advance plan, we're not generating any invoices before the next billing cycle.

## Description

The goal of this PR is to be able to generate an invoice for the pay-in-advance subscription fee immediately when the subscription is created.
