### PR TITLE
fix(wrong-month-abbreviation): Change abbreviation month names

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -10,18 +10,19 @@ de:
     - Fr
     - Sa
     abbr_month_names:
-    - Jan
-    - Feb
-    - Mär
-    - Apr
+    -
+    - Jan.
+    - Feb.
+    - Mär.
+    - Apr.
     - Mai
-    - Jun
-    - Jul
-    - Aug
-    - Sep
-    - Okt
-    - Nov
-    - Dez
+    - Jun.
+    - Jul.
+    - Aug.
+    - Sep.
+    - Okt.
+    - Nov.
+    - Dez.
     day_names:
     - Sonntag
     - Montag
@@ -31,8 +32,9 @@ de:
     - Freitag
     - Samstag
     formats:
-      default: "%d. %B %Y"
+      default: "%d. %b %Y"
     month_names:
+    -
     - Januar
     - Februar
     - März

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
         value_already_exist: value_already_exist
   date:
     formats:
-      default: "%B %d, %Y"
+      default: "%b %d, %Y"
   money:
     decimal_mark: "."
     format: "%u%n"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -10,6 +10,7 @@ es:
     - Vie
     - Sáb
     abbr_month_names:
+    -
     - ene.
     - feb.
     - mar.
@@ -31,8 +32,9 @@ es:
     - Viernes
     - Sábado
     formats:
-      default: "%d de %B de %Y"
+      default: "%d de %b de %Y"
     month_names:
+    -
     - Enero
     - Febrero
     - Marzo

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -10,6 +10,7 @@ fr:
     - Ven
     - Sam
     abbr_month_names:
+    -
     - janv.
     - févr.
     - mars
@@ -31,8 +32,9 @@ fr:
     - Vendredi
     - Samedi
     formats:
-      default: "%d %B %Y"
+      default: "%d %b %Y"
     month_names:
+    -
     - Janvier
     - Février
     - Mars

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -10,6 +10,7 @@ it:
     - Ven
     - Sab
     abbr_month_names:
+    -
     - gen
     - feb
     - mar
@@ -31,8 +32,9 @@ it:
     - Venerdì
     - Sabato
     formats:
-      default: "%d %B %Y"
+      default: "%d %b %Y"
     month_names:
+    -
     - Gennaio
     - Febbraio
     - Marzo

--- a/config/locales/nb.yml
+++ b/config/locales/nb.yml
@@ -10,6 +10,7 @@ nb:
     - Fre
     - Lør
     abbr_month_names:
+    -
     - jan.
     - feb.
     - mars
@@ -31,8 +32,9 @@ nb:
     - Fredag
     - Lørdag
     formats:
-      default: "%d. %B %Y"
+      default: "%d. %b %Y"
     month_names:
+    -
     - Januar
     - Februar
     - Mars

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -10,6 +10,7 @@ sv:
     - fre
     - lör
     abbr_month_names:
+    -
     - jan.
     - feb.
     - mars
@@ -31,8 +32,9 @@ sv:
     - fredag
     - lördag
     formats:
-      default: "%d %B %Y"
+      default: "%d %b %Y"
     month_names:
+    -
     - januari
     - februari
     - mars


### PR DESCRIPTION
The goal of this PR is to change how we're aggregating months by default for all available locales.