### PR TITLE
fix(wrong-month-abbreviation): Do not prepend day number by 0 for fr and es locales

### DIFF
--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -32,7 +32,7 @@ es:
     - Viernes
     - Sábado
     formats:
-      default: "%d de %b de %Y"
+      default: "%-d de %b de %Y"
     month_names:
     -
     - Enero

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -32,7 +32,7 @@ fr:
     - Vendredi
     - Samedi
     formats:
-      default: "%d %b %Y"
+      default: "%-d %b %Y"
     month_names:
     -
     - Janvier


### PR DESCRIPTION
We don't want to prepend the month name by `0` if less than `10` for `es` and `fr` locales.

---

Example before:
<img width="290" alt="Screenshot 2024-08-06 at 12 49 54" src="https://github.com/user-attachments/assets/c5813457-c710-4148-a19f-34a5b3b87307">


Example after:
<img width="290" alt="Screenshot 2024-08-06 at 12 43 09" src="https://github.com/user-attachments/assets/9da395ee-bd31-491b-b64d-04e1229ffcdd">
