### PR TITLE
feat: add the source to the serializer

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -56,7 +56,8 @@ module Api
           :paid_credits,
           :granted_credits,
           :voided_credits,
-          :invoice_requires_successful_payment
+          :invoice_requires_successful_payment,
+          metadata: {}
         )
       end
     end

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -81,6 +81,7 @@ module Api
           :granted_credits,
           :expiration_at,
           :invoice_requires_successful_payment,
+          transaction_metadata: {},
           recurring_transaction_rules: [
             :granted_credits,
             :interval,
@@ -90,7 +91,8 @@ module Api
             :target_ongoing_balance,
             :threshold_credits,
             :trigger,
-            :invoice_requires_successful_payment
+            :invoice_requires_successful_payment,
+            metadata: {}
           ]
         )
       end
@@ -114,7 +116,8 @@ module Api
             :trigger,
             :paid_credits,
             :granted_credits,
-            :invoice_requires_successful_payment
+            :invoice_requires_successful_payment,
+            metadata: {}
           ]
         )
       end

--- a/app/serializers/v1/wallet_transaction_serializer.rb
+++ b/app/serializers/v1/wallet_transaction_serializer.rb
@@ -7,13 +7,15 @@ module V1
         lago_id: model.id,
         lago_wallet_id: model.wallet_id,
         status: model.status,
+        source: model.source,
         transaction_status: model.transaction_status,
         transaction_type: model.transaction_type,
         amount: model.amount,
         credit_amount: model.credit_amount,
         settled_at: model.settled_at&.iso8601,
         created_at: model.created_at.iso8601,
-        invoice_requires_successful_payment: model.invoice_requires_successful_payment?
+        invoice_requires_successful_payment: model.invoice_requires_successful_payment?,
+        metadata: model.metadata
       }
     end
   end

--- a/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
+++ b/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
@@ -15,7 +15,8 @@ module V1
           threshold_credits: model.threshold_credits,
           trigger: model.trigger,
           created_at: model.created_at.iso8601,
-          invoice_requires_successful_payment: model.invoice_requires_successful_payment?
+          invoice_requires_successful_payment: model.invoice_requires_successful_payment?,
+          metadata: model.metadata
         }
       end
     end

--- a/app/services/validators/metadata_validator.rb
+++ b/app/services/validators/metadata_validator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Validators
+  class MetadataValidator
+    DEFAULT_CONFIG = {
+      max_keys: 10,
+      max_key_length: 20,
+      max_value_length: 100
+    }.freeze
+
+    attr_reader :metadata, :errors, :config
+
+    def initialize(metadata, config = {})
+      @metadata = metadata
+      @errors = {}
+      @config = DEFAULT_CONFIG.merge(config)
+    end
+
+    def valid?
+      return true if metadata.blank?
+
+      validate_size
+      validate_keys_and_values
+      validate_structure
+
+      errors.empty?
+    end
+
+    private
+
+    def validate_size
+      if metadata.size > config[:max_keys]
+        errors[:metadata] = 'too_many_keys'
+      end
+    end
+
+    def validate_keys_and_values
+      metadata.each do |key, value|
+        if key.length > config[:max_key_length]
+          errors[:metadata] = 'key_too_long'
+        end
+        if value.is_a?(String) && value.length > config[:max_value_length]
+          errors[:metadata] = 'value_too_long'
+        end
+      end
+    end
+
+    def validate_structure
+      metadata.each do |_, value|
+        if value.is_a?(Hash) || value.is_a?(Array)
+          errors[:metadata] = 'nested_structure_not_allowed'
+        end
+      end
+    end
+  end
+end

--- a/app/services/wallet_transactions/validate_service.rb
+++ b/app/services/wallet_transactions/validate_service.rb
@@ -7,6 +7,7 @@ module WalletTransactions
       valid_paid_credits_amount? if args[:paid_credits]
       valid_granted_credits_amount? if args[:granted_credits]
       valid_voided_credits_amount? if args[:voided_credits] && result.current_wallet
+      valid_metadata? if args[:metadata]
 
       if errors?
         result.validation_failure!(errors:)
@@ -48,6 +49,18 @@ module WalletTransactions
 
       if BigDecimal(args[:voided_credits]) > result.current_wallet.credits_balance
         return add_error(field: :voided_credits, error_code: 'insufficient_credits')
+      end
+
+      true
+    end
+
+    def valid_metadata?
+      validator = ::Validators::MetadataValidator.new(args[:metadata])
+      unless validator.valid?
+        validator.errors.each do |field, error_code|
+          add_error(field: field, error_code: error_code)
+        end
+        return false
       end
 
       true

--- a/app/services/wallet_transactions/void_service.rb
+++ b/app/services/wallet_transactions/void_service.rb
@@ -2,10 +2,11 @@
 
 module WalletTransactions
   class VoidService < BaseService
-    def initialize(wallet:, credits:, from_source: :manual)
+    def initialize(wallet:, credits:, from_source: :manual, metadata: {})
       @wallet = wallet
       @credits = credits
       @from_source = from_source
+      @metadata = metadata
 
       super
     end
@@ -21,7 +22,8 @@ module WalletTransactions
           status: :settled,
           settled_at: Time.current,
           source: from_source,
-          transaction_status: :voided
+          transaction_status: :voided,
+          metadata: metadata
         )
         Wallets::Balance::DecreaseService.new(wallet:, credits_amount:).call
         result.wallet_transaction = wallet_transaction
@@ -32,7 +34,7 @@ module WalletTransactions
 
     private
 
-    attr_reader :wallet, :credits, :from_source
+    attr_reader :wallet, :credits, :from_source, :metadata
 
     def credits_amount
       @credits_amount ||= BigDecimal(credits)

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -6,7 +6,7 @@ module Wallets
       recurring_transaction_rules.each do |recurring_transaction_rule|
         wallet = recurring_transaction_rule.wallet
 
-        WalletTransactions::CreateJob.perform_later(
+        job_params = {
           organization_id: wallet.organization.id,
           params: {
             wallet_id: wallet.id,
@@ -15,7 +15,10 @@ module Wallets
             source: :interval,
             invoice_requires_successful_payment: recurring_transaction_rule.invoice_requires_successful_payment?
           }
-        )
+        }
+        job_params[:params][:metadata] = recurring_transaction_rule.metadata unless recurring_transaction_rule.metadata.empty?
+
+        WalletTransactions::CreateJob.perform_later(job_params)
       end
     end
 

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -47,7 +47,8 @@ module Wallets
           wallet_id: wallet.id,
           paid_credits: params[:paid_credits],
           granted_credits: params[:granted_credits],
-          source: :manual
+          source: :manual,
+          metadata: params[:transaction_metadata]
         }
       )
 

--- a/app/services/wallets/recurring_transaction_rules/create_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/create_service.rb
@@ -26,7 +26,8 @@ module Wallets
           method:,
           started_at: rule_params[:started_at],
           target_ongoing_balance: rule_params[:target_ongoing_balance],
-          trigger: rule_params[:trigger].to_s
+          trigger: rule_params[:trigger].to_s,
+          metadata: rule_params[:metadata] || {}
         }
 
         attributes[:invoice_requires_successful_payment] = if rule_params.key?(:invoice_requires_successful_payment)

--- a/app/services/wallets/recurring_transaction_rules/validate_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/validate_service.rb
@@ -12,6 +12,7 @@ module Wallets
         return false unless valid_trigger?
         return false unless valid_method?
         return false unless valid_credits?
+        return false unless valid_metadata?
 
         true
       end
@@ -55,6 +56,10 @@ module Wallets
 
       def valid_decimal?(value)
         ::Validators::DecimalAmountService.new(value).valid_decimal?
+      end
+
+      def valid_metadata?
+        ::Validators::MetadataValidator.new(params[:metadata]).valid?
       end
     end
   end

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -8,6 +8,7 @@ module Wallets
       valid_granted_credits_amount? if args[:granted_credits]
       valid_expiration_at? if args[:expiration_at]
       valid_recurring_transaction_rules? if args[:recurring_transaction_rules].present?
+      valid_metadata? if args[:transaction_metadata]
 
       if errors?
         result.validation_failure!(errors:)
@@ -73,6 +74,18 @@ module Wallets
       unless Wallets::RecurringTransactionRules::ValidateService.call(params: args[:recurring_transaction_rules].first)
         add_error(field: :recurring_transaction_rules, error_code: "invalid_recurring_rule")
       end
+    end
+
+    def valid_metadata?
+      validator = ::Validators::MetadataValidator.new(args[:transaction_metadata])
+      unless validator.valid?
+        validator.errors.each do |field, error_code|
+          add_error(field: field, error_code: error_code)
+        end
+        return false
+      end
+
+      true
     end
   end
 end

--- a/db/migrate/20240807100609_add_metadata_to_wallet_transactions.rb
+++ b/db/migrate/20240807100609_add_metadata_to_wallet_transactions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMetadataToWalletTransactions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :wallet_transactions, :metadata, :jsonb, default: {}
+  end
+end

--- a/db/migrate/20240808085506_add_metadata_to_recurring_transaction_rules.rb
+++ b/db/migrate/20240808085506_add_metadata_to_recurring_transaction_rules.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMetadataToRecurringTransactionRules < ActiveRecord::Migration[7.1]
+  def change
+    add_column :recurring_transaction_rules, :metadata, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_08_080611) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_08_085506) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -947,6 +947,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_080611) do
     t.decimal "target_ongoing_balance", precision: 30, scale: 5
     t.datetime "started_at"
     t.boolean "invoice_requires_successful_payment", default: false, null: false
+    t.jsonb "metadata", default: {}
     t.index ["started_at"], name: "index_recurring_transaction_rules_on_started_at"
     t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
   end
@@ -1051,6 +1052,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_080611) do
     t.integer "source", default: 0, null: false
     t.integer "transaction_status", default: 0, null: false
     t.boolean "invoice_requires_successful_payment", default: false, null: false
+    t.jsonb "metadata", default: {}
     t.index ["invoice_id"], name: "index_wallet_transactions_on_invoice_id"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
   end

--- a/spec/requests/api/v1/wallet_transactions_controller_spec.rb
+++ b/spec/requests/api/v1/wallet_transactions_controller_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
       {
         wallet_id:,
         paid_credits: '10',
-        granted_credits: '10'
+        granted_credits: '10',
+        metadata: {key1: 'valid_value', key2: 'also_valid'}
       }
     end
 
@@ -30,9 +31,13 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
 
       expect(json[:wallet_transactions].count).to eq(2)
       expect(json[:wallet_transactions].first[:lago_id]).to be_present
+      expect(json[:wallet_transactions].first[:metadata]).to be_present
       expect(json[:wallet_transactions].second[:lago_id]).to be_present
+      expect(json[:wallet_transactions].second[:metadata]).to be_present
       expect(json[:wallet_transactions].first[:status]).to eq('pending')
+      expect(json[:wallet_transactions].first[:metadata]).to include(key1: 'valid_value', key2: 'also_valid')
       expect(json[:wallet_transactions].second[:status]).to eq('settled')
+      expect(json[:wallet_transactions].second[:metadata]).to include(key1: 'valid_value', key2: 'also_valid')
       expect(json[:wallet_transactions].first[:lago_wallet_id]).to eq(wallet.id)
       expect(json[:wallet_transactions].second[:lago_wallet_id]).to eq(wallet.id)
     end
@@ -42,7 +47,8 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
       let(:params) do
         {
           wallet_id:,
-          voided_credits: '10'
+          voided_credits: '10',
+          metadata: {key1: 'valid_value', key2: 'also_valid'}
         }
       end
 
@@ -56,7 +62,8 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
           lago_id: String,
           status: 'settled',
           transaction_status: 'voided',
-          lago_wallet_id: wallet.id
+          lago_wallet_id: wallet.id,
+          metadata: {key1: 'valid_value', key2: 'also_valid'}
         )
         expect(wallet.reload.credits_balance).to eq(10)
       end

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -17,13 +17,15 @@ RSpec.describe ::V1::WalletTransactionSerializer do
         'lago_id' => wallet_transaction.id,
         'lago_wallet_id' => wallet_transaction.wallet_id,
         'status' => wallet_transaction.status,
+        'source' => wallet_transaction.source,
         'transaction_status' => wallet_transaction.transaction_status,
         'transaction_type' => wallet_transaction.transaction_type,
         'amount' => wallet_transaction.amount.to_s,
         'credit_amount' => wallet_transaction.credit_amount.to_s,
         'settled_at' => wallet_transaction.settled_at&.iso8601,
         'created_at' => wallet_transaction.created_at.iso8601,
-        'invoice_requires_successful_payment' => wallet_transaction.invoice_requires_successful_payment
+        'invoice_requires_successful_payment' => wallet_transaction.invoice_requires_successful_payment,
+        'metadata' => wallet_transaction.metadata
       )
     end
   end

--- a/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
+++ b/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe ::V1::Wallets::RecurringTransactionRuleSerializer do
       "threshold_credits" => recurring_transaction_rule.threshold_credits.to_s,
       "granted_credits" => recurring_transaction_rule.granted_credits.to_s,
       "created_at" => recurring_transaction_rule.created_at.iso8601,
-      "invoice_requires_successful_payment" => recurring_transaction_rule.invoice_requires_successful_payment
+      "invoice_requires_successful_payment" => recurring_transaction_rule.invoice_requires_successful_payment,
+      "metadata" => recurring_transaction_rule.metadata
     )
   end
 end

--- a/spec/services/validators/metadata_validator_spec.rb
+++ b/spec/services/validators/metadata_validator_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Validators::MetadataValidator, type: :validator do
+  subject(:metadata_validator) { described_class.new(metadata) }
+
+  let(:max_keys) { Validators::MetadataValidator::DEFAULT_CONFIG[:max_keys] }
+  let(:max_key_length) { Validators::MetadataValidator::DEFAULT_CONFIG[:max_key_length] }
+  let(:max_value_length) { Validators::MetadataValidator::DEFAULT_CONFIG[:max_value_length] }
+
+  describe '.valid?' do
+    let(:metadata) { {key1: 'valid_value', key2: 'also_valid'} }
+
+    it 'returns true for valid metadata' do
+      expect(metadata_validator).to be_valid
+    end
+
+    context 'when metadata has too many keys' do
+      let(:metadata) { (1..max_keys + 1).map { |i| %W[key#{i} value#{i}] }.to_h }
+
+      it 'returns false' do
+        expect(metadata_validator).not_to be_valid
+        expect(metadata_validator.errors[:metadata]).to include('too_many_keys')
+      end
+    end
+
+    context 'when metadata contains a key that is too long' do
+      let(:metadata) { {'a' * (max_key_length + 1) => 'valid'} }
+
+      it 'returns false' do
+        expect(metadata_validator).not_to be_valid
+        expect(metadata_validator.errors[:metadata]).to include('key_too_long')
+      end
+    end
+
+    context 'when metadata contains a value that is too long' do
+      let(:metadata) { {'key' => 'a' * (max_value_length + 1)} }
+
+      it 'returns false' do
+        expect(metadata_validator).not_to be_valid
+        expect(metadata_validator.errors[:metadata]).to include('value_too_long')
+      end
+    end
+
+    context 'when metadata contains nested structures' do
+      let(:metadata) { {'key' => {'nested_key' => 'value'}} }
+
+      it 'returns false' do
+        expect(metadata_validator).not_to be_valid
+        expect(metadata_validator.errors[:metadata]).to include('nested_structure_not_allowed')
+      end
+    end
+
+    context 'when metadata is empty' do
+      let(:metadata) { {} }
+
+      it 'returns true' do
+        expect(metadata_validator).to be_valid
+      end
+    end
+  end
+end

--- a/spec/services/wallet_transactions/validate_service_spec.rb
+++ b/spec/services/wallet_transactions/validate_service_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
   let(:paid_credits) { '1.00' }
   let(:granted_credits) { '0.00' }
   let(:voided_credits) { '0.00' }
+  let(:metadata) { {key: 'value'} }
   let(:args) do
     {
       wallet_id:,
@@ -22,7 +23,8 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
       organization_id: organization.id,
       paid_credits:,
       granted_credits:,
-      voided_credits:
+      voided_credits:,
+      metadata:
     }
   end
 
@@ -75,6 +77,15 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
       it 'returns false and result has errors' do
         expect(validate_service).not_to be_valid
         expect(result.error.messages[:voided_credits]).to eq(['insufficient_credits'])
+      end
+    end
+
+    context 'with invalid metadata' do
+      let(:metadata) { {key: {nested_key: 'value'}} }
+
+      it 'returns false and result has errors for metadata' do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:metadata]).to eq(['nested_structure_not_allowed'])
       end
     end
   end

--- a/spec/services/wallet_transactions/void_service_spec.rb
+++ b/spec/services/wallet_transactions/void_service_spec.rb
@@ -3,12 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe WalletTransactions::VoidService, type: :service do
-  subject(:void_service) { described_class.call(wallet:, credits:) }
+  subject(:void_service) { described_class.call(wallet:, credits:, metadata:) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
   let(:customer) { create(:customer, organization:) }
   let(:subscription) { create(:subscription, customer:) }
+  let(:metadata) { {'key1' => 'valid_value', 'key2' => 'also_valid'} }
   let(:wallet) do
     create(
       :wallet,
@@ -48,7 +49,8 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
           status: 'settled',
           source: 'manual',
           transaction_status: 'voided',
-          settled_at: Time.current
+          settled_at: Time.current,
+          metadata:
         )
       end
     end

--- a/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Wallets::RecurringTransactionRules::CreateService do
     }
   end
 
+  let(:metadata) { {} }
   let(:rule_params) do
     {
       interval: "monthly",
@@ -22,7 +23,8 @@ RSpec.describe Wallets::RecurringTransactionRules::CreateService do
       granted_credits: "5.0",
       started_at: "2024-05-30T12:48:26Z",
       target_ongoing_balance: "100.0",
-      trigger: "interval"
+      trigger: "interval",
+      metadata:
     }
   end
 
@@ -88,6 +90,18 @@ RSpec.describe Wallets::RecurringTransactionRules::CreateService do
 
           expect(wallet.recurring_transaction_rules.first).to have_attributes(
             invoice_requires_successful_payment: true
+          )
+        end
+      end
+
+      context 'when metadata is present' do
+        let(:metadata) { {'key1' => 'valid_value', 'key2' => 'also_valid'} }
+
+        it "creates rule with expected attributes" do
+          expect { create_service.call }.to change { wallet.reload.recurring_transaction_rules.count }.by(1)
+
+          expect(wallet.recurring_transaction_rules.first).to have_attributes(
+            metadata: metadata
           )
         end
       end

--- a/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/update_service_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
 
   let(:wallet) { create(:wallet) }
   let(:recurring_transaction_rule) { create(:recurring_transaction_rule, wallet:) }
+  let(:metadata) { {'key1' => 'valid_value', 'key2' => 'also_valid'} }
   let(:params) do
     [
       {
@@ -15,7 +16,8 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
         interval: "weekly",
         paid_credits: "105",
         granted_credits: "105",
-        started_at: "2024-05-30T12:48:26Z"
+        started_at: "2024-05-30T12:48:26Z",
+        metadata:
       }
     ]
   end
@@ -38,7 +40,8 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
           paid_credits: 105.0,
           started_at: Time.parse("2024-05-30T12:48:26Z"),
           threshold_credits: 0.0,
-          trigger: "interval"
+          trigger: "interval",
+          metadata:
         )
       end
     end
@@ -52,7 +55,8 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
             method: "target",
             paid_credits: "105",
             target_ongoing_balance: "300",
-            trigger: "interval"
+            trigger: "interval",
+            metadata:
           }
         ]
       end
@@ -71,7 +75,8 @@ RSpec.describe Wallets::RecurringTransactionRules::UpdateService do
             paid_credits: 105.0,
             target_ongoing_balance: 300.0,
             threshold_credits: 0.0,
-            trigger: "interval"
+            trigger: "interval",
+            metadata:
           )
           expect(rule.id).not_to eq(recurring_transaction_rule.id)
         end

--- a/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
@@ -17,6 +17,20 @@ RSpec.describe Wallets::RecurringTransactionRules::ValidateService do
       expect(validate_service.call).to be_truthy
     end
 
+    context "when invalid metadata" do
+      let(:params) do
+        {
+          trigger: "interval",
+          interval: "weekly",
+          metadata: {'key' => {'nested_key' => 'value'}}
+        }
+      end
+
+      it "returns false" do
+        expect(validate_service.call).to be_falsey
+      end
+    end
+
     context "when invalid interval" do
       let(:params) do
         {

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
         trigger: "threshold",
         threshold_credits: "6.0",
         paid_credits: "10.0",
-        granted_credits: "3.0"
+        granted_credits: "3.0",
+        metadata: {'key1' => 'valid_value', 'key2' => 'also_valid'}
       )
     end
 
@@ -40,7 +41,8 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
             paid_credits: "10.0",
             granted_credits: "3.0",
             source: :threshold,
-            invoice_requires_successful_payment: false
+            invoice_requires_successful_payment: false,
+            metadata: {'key1' => 'valid_value', 'key2' => 'also_valid'}
           }
         )
     end


### PR DESCRIPTION
## Context

This PR introduces the functionality to attach metadata to wallet transactions to differentiate between automated and manual top-ups. Metadata can only be added through the API during the creation of a wallet or when topping up a wallet with a new transaction.

## Description

1. **Metadata on Wallet Creation:** Users can now assign metadata to a transaction at the point of wallet creation. This metadata is exclusive to the wallet transaction triggered during the creation process.
   
2. **Metadata on Wallet Top-Up:** Metadata can also be included when topping up a wallet to provide additional transaction details.

**Limitations:**
- Metadata is not searchable.
- The number of metadata entries per transaction is capped at the same limit as customer-level metadata.
- Metadata can be set only through API calls, not through the UI.
- Applicable for both initial wallet creation and subsequent top-up transactions.
