### PR TITLE
fix(anrok): add error_details include to invoice serialization

### DIFF
--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -221,7 +221,7 @@ module Api
           json: ::V1::InvoiceSerializer.new(
             invoice,
             root_name: 'invoice',
-            includes: %i[customer subscriptions fees credits metadata applied_taxes]
+            includes: %i[customer subscriptions fees credits metadata applied_taxes error_details]
           )
         )
       end

--- a/app/serializers/v1/invoices/error_detail_serializer.rb
+++ b/app/serializers/v1/invoices/error_detail_serializer.rb
@@ -7,7 +7,7 @@ module V1
         {
           lago_id: model.id,
           error_code: model.error_code,
-          error_details: model.error_details
+          details: model.details
         }
       end
     end

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -3,12 +3,18 @@
 require 'rails_helper'
 
 RSpec.describe ::V1::InvoiceSerializer do
-  subject(:serializer) { described_class.new(invoice, root_name: 'invoice', includes: %i[metadata]) }
+  subject(:serializer) { described_class.new(invoice, root_name: 'invoice', includes: %i[metadata error_details]) }
 
   let(:invoice) { create(:invoice) }
   let(:metadata) { create(:invoice_metadata, invoice:) }
+  let(:error_details1) { create(:error_detail, owner: invoice) }
+  let(:error_details2) { create(:error_detail, owner: invoice, deleted_at: Time.current) }
 
-  before { metadata }
+  before do
+    metadata
+    error_details1
+    error_details2
+  end
 
   it 'serializes the object' do
     result = JSON.parse(serializer.to_json)
@@ -36,6 +42,13 @@ RSpec.describe ::V1::InvoiceSerializer do
         'sub_total_including_taxes_amount_cents' => invoice.sub_total_including_taxes_amount_cents,
         'total_amount_cents' => invoice.total_amount_cents,
         'file_url' => invoice.file_url,
+        'error_details' => [
+          {
+            'lago_id' => error_details1.id,
+            'error_code' => error_details1.error_code,
+            'details' => error_details1.details
+          }
+        ],
         'version_number' => 4
       )
 


### PR DESCRIPTION
## Context

when serializing invoice we want to include error_details

## Description

add error_details to include into invoice payload