### PR TITLE
feat(tax-integration): add failed invoices count

### DIFF
--- a/app/graphql/types/integrations/anrok.rb
+++ b/app/graphql/types/integrations/anrok.rb
@@ -8,6 +8,7 @@ module Types
       field :api_key, String, null: false
       field :code, String, null: false
       field :external_account_id, String, null: true
+      field :failed_invoices_count, Integer, null: true
       field :has_mappings_configured, Boolean
       field :id, ID, null: false
       field :name, String, null: false
@@ -26,6 +27,10 @@ module Types
         return nil unless object.api_key.include?('/')
 
         object.api_key.split('/')[0]
+      end
+
+      def failed_invoices_count
+        object.error_details.where(owner_type: 'Invoice').kept.count
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -148,6 +148,7 @@ type AnrokIntegration {
   apiKey: String!
   code: String!
   externalAccountId: String
+  failedInvoicesCount: Int
   hasMappingsConfigured: Boolean
   id: ID!
   name: String!

--- a/schema.json
+++ b/schema.json
@@ -1295,6 +1295,20 @@
               ]
             },
             {
+              "name": "failedInvoicesCount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "hasMappingsConfigured",
               "description": null,
               "type": {

--- a/spec/graphql/types/integrations/anrok_spec.rb
+++ b/spec/graphql/types/integrations/anrok_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Types::Integrations::Anrok do
 
   it { is_expected.to have_field(:api_key).of_type('String!') }
   it { is_expected.to have_field(:code).of_type('String!') }
-  it { is_expected.to have_field(:failed_invoices_count).of_type('Integer') }
+  it { is_expected.to have_field(:failed_invoices_count).of_type('Int') }
   it { is_expected.to have_field(:has_mappings_configured).of_type('Boolean') }
   it { is_expected.to have_field(:name).of_type('String!') }
   it { is_expected.to have_field(:external_account_id).of_type('String') }

--- a/spec/graphql/types/integrations/anrok_spec.rb
+++ b/spec/graphql/types/integrations/anrok_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Types::Integrations::Anrok do
 
   it { is_expected.to have_field(:api_key).of_type('String!') }
   it { is_expected.to have_field(:code).of_type('String!') }
+  it { is_expected.to have_field(:failed_invoices_count).of_type('Integer') }
   it { is_expected.to have_field(:has_mappings_configured).of_type('Boolean') }
   it { is_expected.to have_field(:name).of_type('String!') }
   it { is_expected.to have_field(:external_account_id).of_type('String') }


### PR DESCRIPTION
## Context

Currently integration with tax provider Anrok is being added.

## Description

This PR adds total number of failed invoices to the Anrok Integration GQL response. It will allow FE to display this information.
