### PR TITLE
feat(tresholds): Add usage tresholds params to controllers

### DIFF
--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -40,7 +40,7 @@ module Api
 
       def show
         plan = current_organization.plans.parents
-          .includes(charges: {filters: {values: :billable_metric_filter}})
+          .includes(:usage_thresholds, charges: {filters: {values: :billable_metric_filter}})
           .find_by(code: params[:code])
         return not_found_error(resource: 'plan') unless plan
 
@@ -55,11 +55,11 @@ module Api
 
         render(
           json: ::CollectionSerializer.new(
-            plans.includes(charges: {filters: {values: :billable_metric_filter}}),
+            plans.includes(:usage_thresholds, charges: {filters: {values: :billable_metric_filter}}),
             ::V1::PlanSerializer,
             collection_name: 'plans',
             meta: pagination_metadata(plans),
-            includes: %i[charges taxes minimum_commitment]
+            includes: %i[charges usage_thresholds taxes minimum_commitment]
           )
         )
       end
@@ -108,6 +108,12 @@ module Api
               ]
             },
             {tax_codes: []}
+          ],
+          usage_thresholds: [
+            :id,
+            :threshold_display_name,
+            :amount_cents,
+            :recurring
           ]
         )
       end
@@ -117,7 +123,7 @@ module Api
           json: ::V1::PlanSerializer.new(
             plan,
             root_name: 'plan',
-            includes: %i[charges taxes minimum_commitment]
+            includes: %i[charges usage_thresholds taxes minimum_commitment]
           )
         )
       end

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -165,6 +165,12 @@ module Api
                 ]
               },
               {tax_codes: []}
+            ],
+            usage_thresholds: [
+              :id,
+              :threshold_display_name,
+              :amount_cents,
+              :recurring
             ]
           }
         ]

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -39,7 +39,7 @@ module V1
     def plan
       ::V1::PlanSerializer.new(
         model.plan,
-        includes: %i[charges taxes minimum_commitment]
+        includes: %i[charges usage_thresholds taxes minimum_commitment]
       ).serialize
     end
   end


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/progressive-billing

## Context

There's always a risk of customers not paying invoices generated at the end of a billing period. It would be beneficial to bill customers at given thresholds (units vs. amount) rather than waiting until the end of the period. This approach would allow for removing customer access if invoices are not paid and prevent having a highest amount of unpaid invoices.

## Description

This PR adds and modifies controllers that handle creating, updating and overriding plans/subscriptions with usage tresholds. 