### PR TITLE
feat (tax-integrations): add new service for syncing void invoice with anrok

### DIFF
--- a/app/services/integrations/aggregator/taxes/invoices/base_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/base_service.rb
@@ -61,6 +61,19 @@ module Integrations
             end
           end
 
+          def process_void_response(body)
+            invoice_id = body['succeededInvoices']&.first.try(:[], 'id')
+
+            if invoice_id
+              result.invoice_id = invoice_id
+            else
+              code = body['failedInvoices'].first['validation_errors']['type']
+              message = 'Service failure'
+
+              result.service_failure!(code:, message:)
+            end
+          end
+
           def tax_breakdown(breakdown)
             breakdown.map do |b|
               if b['type'] == 'exempt'

--- a/app/services/integrations/aggregator/taxes/invoices/void_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/void_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Integrations
+  module Aggregator
+    module Taxes
+      module Invoices
+        class VoidService < BaseService
+          def action_path
+            "v1/#{provider}/void_invoices"
+          end
+
+          def call
+            return result unless integration
+            return result unless integration.type == 'Integrations::AnrokIntegration'
+
+            response = http_client.post_with_response(payload, headers)
+            body = JSON.parse(response.body)
+
+            process_void_response(body)
+
+            result
+          rescue LagoHttpClient::HttpError => e
+            code = code(e)
+            message = message(e)
+
+            result.service_failure!(code:, message:)
+          end
+
+          private
+
+          def payload
+            [
+              {
+                'id' => invoice.id
+              }
+            ]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/integration_aggregator/taxes/invoices/success_response_void.json
+++ b/spec/fixtures/integration_aggregator/taxes/invoices/success_response_void.json
@@ -1,0 +1,8 @@
+{
+  "succeededInvoices": [
+    {
+      "id": "f9cde4d6-3b79-4c44-89b5-d5a91e430054"
+    }
+  ],
+  "failedInvoices": []
+}

--- a/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/void_service_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Integrations::Aggregator::Taxes::Invoices::VoidService do
+  subject(:service_call) { described_class.call(invoice:) }
+
+  let(:integration) { create(:anrok_integration, organization:) }
+  let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+  let(:customer) { create(:customer, organization:) }
+  let(:organization) { create(:organization) }
+  let(:lago_client) { instance_double(LagoHttpClient::Client) }
+  let(:endpoint) { 'https://api.nango.dev/v1/anrok/void_invoices' }
+  let(:current_time) { Time.current }
+
+  let(:integration_collection_mapping1) do
+    create(
+      :netsuite_collection_mapping,
+      integration:,
+      mapping_type: :fallback_item,
+      settings: {external_id: '1', external_account_code: '11', external_name: ''}
+    )
+  end
+
+  let(:invoice) do
+    create(
+      :invoice,
+      customer:,
+      organization:
+    )
+  end
+
+  let(:headers) do
+    {
+      'Connection-Id' => integration.connection_id,
+      'Authorization' => "Bearer #{ENV["NANGO_SECRET_KEY"]}",
+      'Provider-Config-Key' => 'anrok'
+    }
+  end
+
+  let(:params) do
+    [
+      {
+        'id' => invoice.id
+      }
+    ]
+  end
+
+  before do
+    allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+
+    integration_customer
+    integration_collection_mapping1
+  end
+
+  describe '#call' do
+    context 'when service call is successful' do
+      let(:response) { instance_double(Net::HTTPOK) }
+
+      before do
+        allow(lago_client).to receive(:post_with_response).with(params, headers).and_return(response)
+        allow(response).to receive(:body).and_return(body)
+      end
+
+      context 'when void invoice sync is successful' do
+        let(:body) do
+          path = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response_void.json')
+          File.read(path)
+        end
+
+        it 'returns invoice_id' do
+          result = service_call
+
+          aggregate_failures do
+            expect(result).to be_success
+            expect(result.invoice_id).to be_present
+          end
+        end
+      end
+
+      context 'when void invoice sync is NOT successful' do
+        let(:body) do
+          path = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+          File.read(path)
+        end
+
+        it 'returns errors' do
+          result = service_call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ServiceFailure)
+            expect(result.error.code).to eq('taxDateTooFarInFuture')
+          end
+        end
+      end
+    end
+
+    context 'when service call is not successful' do
+      let(:body) do
+        path = Rails.root.join('spec/fixtures/integration_aggregator/error_response.json')
+        File.read(path)
+      end
+
+      let(:http_error) { LagoHttpClient::HttpError.new(error_code, body, nil) }
+
+      before do
+        allow(lago_client).to receive(:post_with_response).with(params, headers).and_raise(http_error)
+      end
+
+      context 'when it is a server error' do
+        let(:error_code) { Faker::Number.between(from: 500, to: 599) }
+
+        it 'returns an error' do
+          result = service_call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.fees).to be(nil)
+            expect(result.error).to be_a(BaseService::ServiceFailure)
+            expect(result.error.code).to eq('action_script_runtime_error')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Currently integration with tax provider Anrok is being added

## Description

This service adds logic for sending new request to Nango. This action notifies Anrok that invoice has been voided in Lago. 