### PR TITLE
feature(ProgressiveBilling) - Add lifetime usage model

### DIFF
--- a/app/models/lifetime_usage.rb
+++ b/app/models/lifetime_usage.rb
@@ -6,23 +6,14 @@ class LifetimeUsage < ApplicationRecord
   self.discard_column = :deleted_at
 
   belongs_to :organization
-
-  validates :currency, inclusion: {in: currency_list}
+  belongs_to :subscription
 
   validates :current_usage_amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :invoiced_usage_amount_cents, numericality: {greater_than_or_equal_to: 0}
 
   monetize :current_usage_amount_cents,
     :invoiced_usage_amount_cents,
-    with_model_currency: :currency
+    with_currency: ->(lifetime_usage) { lifetime_usage.subscription.plan.amount_currency }
 
   default_scope -> { kept }
-
-  def subscription
-    Subscription.active
-      .joins(:organization)
-      .where(organizations: {id: organization_id})
-      .where(external_id: external_subscription_id)
-      .sole
-  end
 end

--- a/app/models/lifetime_usage.rb
+++ b/app/models/lifetime_usage.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class LifetimeUsage < ApplicationRecord
+  include Currencies
+  include Discard::Model
+  self.discard_column = :deleted_at
+
+  belongs_to :organization
+
+  validates :currency, inclusion: {in: currency_list}
+
+  validates :current_usage_amount_cents, numericality: {greater_than_or_equal_to: 0}
+  validates :invoiced_usage_amount_cents, numericality: {greater_than_or_equal_to: 0}
+
+  monetize :current_usage_amount_cents,
+    :invoiced_usage_amount_cents,
+    with_model_currency: :currency
+
+  default_scope -> { kept }
+
+  def subscription
+    Subscription.active
+      .joins(:organization)
+      .where(organizations: {id: organization_id})
+      .where(external_id: external_subscription_id)
+      .sole
+  end
+end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -53,7 +53,7 @@ class Subscription < ApplicationRecord
 
   def mark_as_active!(timestamp = Time.current)
     self.started_at ||= timestamp
-    self.lifetime_usage = previous_subscription&.lifetime_usage || build_lifetime_usage(organization: organization)
+    self.lifetime_usage ||= previous_subscription&.lifetime_usage || build_lifetime_usage(organization: organization)
     active!
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -158,4 +158,11 @@ class Subscription < ApplicationRecord
 
     number_od_days.negative? ? 0 : number_od_days
   end
+
+  def lifetime_usage
+    LifetimeUsage.find_by(
+      organization_id: organization.id,
+      external_subscription_id: external_id
+    )
+  end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -13,6 +13,7 @@ class Subscription < ApplicationRecord
   has_many :invoice_subscriptions
   has_many :invoices, through: :invoice_subscriptions
   has_many :fees
+  has_one :lifetime_usage, autosave: true
 
   validates :external_id, :billing_time, presence: true
   validate :validate_external_id, on: :create
@@ -52,6 +53,7 @@ class Subscription < ApplicationRecord
 
   def mark_as_active!(timestamp = Time.current)
     self.started_at ||= timestamp
+    self.lifetime_usage = previous_subscription&.lifetime_usage || build_lifetime_usage(organization: organization)
     active!
   end
 
@@ -157,12 +159,5 @@ class Subscription < ApplicationRecord
     number_od_days -= 1
 
     number_od_days.negative? ? 0 : number_od_days
-  end
-
-  def lifetime_usage
-    LifetimeUsage.find_by(
-      organization_id: organization.id,
-      external_subscription_id: external_id
-    )
   end
 end

--- a/db/migrate/20240808132042_create_lifetime_usage.rb
+++ b/db/migrate/20240808132042_create_lifetime_usage.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreateLifetimeUsage < ActiveRecord::Migration[7.1]
+  def change
+    create_table :lifetime_usages, id: :uuid do |t|
+      t.references :organization, null: false, index: true, foreign_key: true, type: :uuid
+      t.belongs_to :subscription, null: false, index: {unique: true}, foreign_key: true, type: :uuid
+      t.bigint :current_usage_amount_cents, null: false, default: 0
+      t.bigint :invoiced_usage_amount_cents, null: false, default: 0
+      t.boolean :recalculate_current_usage, null: false, default: false
+      t.boolean :recalculate_invoiced_usage, null: false, default: false
+      t.timestamp :current_usage_amount_refreshed_at
+      t.timestamp :invoiced_usage_amount_refreshed_at
+
+      t.timestamps
+      t.datetime :deleted_at
+    end
+
+    add_index :lifetime_usages, %i[recalculate_current_usage], where: "deleted_at IS NULL and recalculate_current_usage = 't'"
+    add_index :lifetime_usages, %i[recalculate_invoiced_usage], where: "deleted_at IS NULL and recalculate_invoiced_usage = 't'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_08_080611) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_08_132042) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -777,6 +777,24 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_080611) do
     t.index ["tax_id"], name: "index_invoices_taxes_on_tax_id"
   end
 
+  create_table "lifetime_usages", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "organization_id", null: false
+    t.uuid "subscription_id", null: false
+    t.bigint "current_usage_amount_cents", default: 0, null: false
+    t.bigint "invoiced_usage_amount_cents", default: 0, null: false
+    t.boolean "recalculate_current_usage", default: false, null: false
+    t.boolean "recalculate_invoiced_usage", default: false, null: false
+    t.datetime "current_usage_amount_refreshed_at", precision: nil
+    t.datetime "invoiced_usage_amount_refreshed_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
+    t.index ["organization_id"], name: "index_lifetime_usages_on_organization_id"
+    t.index ["recalculate_current_usage"], name: "index_lifetime_usages_on_recalculate_current_usage", where: "((deleted_at IS NULL) AND (recalculate_current_usage = true))"
+    t.index ["recalculate_invoiced_usage"], name: "index_lifetime_usages_on_recalculate_invoiced_usage", where: "((deleted_at IS NULL) AND (recalculate_invoiced_usage = true))"
+    t.index ["subscription_id"], name: "index_lifetime_usages_on_subscription_id", unique: true
+  end
+
   create_table "memberships", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "organization_id", null: false
     t.uuid "user_id", null: false
@@ -1181,6 +1199,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_080611) do
   add_foreign_key "invoices", "organizations"
   add_foreign_key "invoices_taxes", "invoices"
   add_foreign_key "invoices_taxes", "taxes"
+  add_foreign_key "lifetime_usages", "organizations"
+  add_foreign_key "lifetime_usages", "subscriptions"
   add_foreign_key "memberships", "organizations"
   add_foreign_key "memberships", "users"
   add_foreign_key "password_resets", "users"

--- a/spec/factories/lifetime_usage.rb
+++ b/spec/factories/lifetime_usage.rb
@@ -2,14 +2,9 @@
 
 FactoryBot.define do
   factory :lifetime_usage do
-    transient do
-      customer { create(:customer, organization:) }
-      subscription { create(:subscription, customer:) }
-    end
+    organization
+    subscription
 
-    organization { subscription.organization }
-    external_subscription_id { subscription.external_id }
-    currency { "EUR" }
     current_usage_amount_cents { 0 }
     invoiced_usage_amount_cents { 0 }
     recalculate_current_usage { false }

--- a/spec/factories/lifetime_usage.rb
+++ b/spec/factories/lifetime_usage.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :lifetime_usage do
+    transient do
+      customer { create(:customer, organization:) }
+      subscription { create(:subscription, customer:) }
+    end
+
+    organization { subscription.organization }
+    external_subscription_id { subscription.external_id }
+    currency { "EUR" }
+    current_usage_amount_cents { 0 }
+    invoiced_usage_amount_cents { 0 }
+    recalculate_current_usage { false }
+    recalculate_invoiced_usage { false }
+  end
+end

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     customer
     plan
     status { :active }
+    lifetime_usage { build :lifetime_usage, subscription: instance }
     external_id { SecureRandom.uuid }
     started_at { 1.day.ago }
 

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     customer
     plan
     status { :active }
-    lifetime_usage { build :lifetime_usage, subscription: instance }
     external_id { SecureRandom.uuid }
     started_at { 1.day.ago }
 

--- a/spec/models/lifetime_usage_spec.rb
+++ b/spec/models/lifetime_usage_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LifetimeUsage, type: :model do
+  subject(:lifetime_usage) { create(:lifetime_usage) }
+
+  it { is_expected.to belong_to(:organization) }
+  it { is_expected.to monetize(:current_usage_amount_cents) }
+  it { is_expected.to monetize(:invoiced_usage_amount_cents) }
+
+  describe 'default scope' do
+    let(:deleted_lifetime_usage) { create(:lifetime_usage, :deleted) }
+
+    it "only returns non-deleted lifetime-usage objects" do
+      expect(LifetimeUsage.all).to eq([lifetime_usage])
+      expect(LifetimeUsage.unscoped.discarded).to eq([deleted_lifetime_usage])
+    end
+  end
+
+  describe 'Validations' do
+    it 'requires that current_usage_amount_cents is postive' do
+      lifetime_usage.current_usage_amount_cents = -1
+      expect(lifetime_usage).not_to be_valid
+
+      lifetime_usage.current_usage_amount_cents = 1
+      expect(lifetime_usage).to be_valid
+    end
+
+    it 'requires that invoiced_usage_amount_cents is postive' do
+      lifetime_usage.invoiced_usage_amount_cents = -1
+      expect(lifetime_usage).not_to be_valid
+
+      lifetime_usage.invoiced_usage_amount_cents = 1
+      expect(lifetime_usage).to be_valid
+    end
+  end
+
+  describe 'Uniqueness constraints' do
+    it "can have only 1 lifetime_usage with the same external_subscription_id within an organization" do
+      expect do
+        LifetimeUsage.create(organization: lifetime_usage.organization,
+          external_subscripton_id: lifetime_usage.external_subscription_id)
+      end.to raise_error
+    end
+  end
+
+  describe "#subscription" do
+    it "returns the subscription" do
+      expected_subscription = Subscription.active.where(external_id: lifetime_usage.external_subscription_id).sole
+      expect(lifetime_usage.subscription).to eq(expected_subscription)
+    end
+  end
+end

--- a/spec/models/lifetime_usage_spec.rb
+++ b/spec/models/lifetime_usage_spec.rb
@@ -6,15 +6,13 @@ RSpec.describe LifetimeUsage, type: :model do
   subject(:lifetime_usage) { create(:lifetime_usage) }
 
   it { is_expected.to belong_to(:organization) }
-  it { is_expected.to monetize(:current_usage_amount_cents) }
-  it { is_expected.to monetize(:invoiced_usage_amount_cents) }
 
   describe 'default scope' do
-    let(:deleted_lifetime_usage) { create(:lifetime_usage, :deleted) }
+    let!(:deleted_lifetime_usage) { create(:lifetime_usage, :deleted) }
 
     it "only returns non-deleted lifetime-usage objects" do
-      expect(LifetimeUsage.all).to eq([lifetime_usage])
-      expect(LifetimeUsage.unscoped.discarded).to eq([deleted_lifetime_usage])
+      expect(described_class.all).to eq([lifetime_usage])
+      expect(described_class.unscoped.discarded).to eq([deleted_lifetime_usage])
     end
   end
 
@@ -33,22 +31,6 @@ RSpec.describe LifetimeUsage, type: :model do
 
       lifetime_usage.invoiced_usage_amount_cents = 1
       expect(lifetime_usage).to be_valid
-    end
-  end
-
-  describe 'Uniqueness constraints' do
-    it "can have only 1 lifetime_usage with the same external_subscription_id within an organization" do
-      expect do
-        LifetimeUsage.create(organization: lifetime_usage.organization,
-          external_subscripton_id: lifetime_usage.external_subscription_id)
-      end.to raise_error
-    end
-  end
-
-  describe "#subscription" do
-    it "returns the subscription" do
-      expected_subscription = Subscription.active.where(external_id: lifetime_usage.external_subscription_id).sole
-      expect(lifetime_usage.subscription).to eq(expected_subscription)
     end
   end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -462,4 +462,16 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe '#lifetime_usage' do
+    it 'returns nil if there is none' do
+      expect(subscription.lifetime_usage).to be_nil
+    end
+
+    it 'returns the single lifetime usage for this subscription' do
+      lifetime_usage = create(:lifetime_usage, subscription:)
+
+      expect(subscription.lifetime_usage).to eq(lifetime_usage)
+    end
+  end
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Subscription, type: :model do
   let(:plan) { create(:plan) }
 
   it_behaves_like 'paper_trail traceable'
+  it { is_expected.to have_one(:lifetime_usage) }
 
   describe '#upgraded?' do
     let(:previous_subscription) { nil }
@@ -460,18 +461,6 @@ RSpec.describe Subscription, type: :model do
       it 'takes the daylight saving time into account' do
         expect(result).to eq(29)
       end
-    end
-  end
-
-  describe '#lifetime_usage' do
-    it 'returns nil if there is none' do
-      expect(subscription.lifetime_usage).to be_nil
-    end
-
-    it 'returns the single lifetime usage for this subscription' do
-      lifetime_usage = create(:lifetime_usage, subscription:)
-
-      expect(subscription.lifetime_usage).to eq(lifetime_usage)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require_relative '../config/environment'
 
 require 'spec_helper'
 require 'simplecov'
+require 'money-rails/test_helpers'
 
 def pp(*args)
   # Uncomment the following line if you can't find where you left a `pp` call

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -432,6 +432,10 @@ RSpec.describe Subscriptions::CreateService, type: :service do
 
       context 'when plan is not the same' do
         context 'when we upgrade the plan' do
+          before do
+            subscription.mark_as_active!
+          end
+
           let(:plan) { create(:plan, amount_cents: 200, organization:) }
           let(:old_plan) { create(:plan, amount_cents: 100, organization:) }
           let(:name) { 'invoice display name new' }
@@ -593,6 +597,10 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         end
 
         context 'when we downgrade the plan' do
+          before do
+            subscription.mark_as_active!
+          end
+
           let(:plan) { create(:plan, amount_cents: 50, organization:) }
           let(:old_plan) { create(:plan, amount_cents: 100, organization:) }
           let(:name) { 'invoice display name new' }


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

Adds a LifetimeUsage model. sets up links between Subscription and LifetimeUsage.
