### PR TITLE
fix: Prevent creating subscription fee in advance for yearly plan started in the past

### DIFF
--- a/app/services/subscriptions/dates/yearly_service.rb
+++ b/app/services/subscriptions/dates/yearly_service.rb
@@ -9,6 +9,13 @@ module Subscriptions
         monthly_service.compute_from_date(billing_date).month == subscription_at.month
       end
 
+      def first_month_in_first_yearly_period?
+        return billing_date.month == 1 && billing_date.year == subscription_at.year if calendar?
+
+        billing_from_date = monthly_service.compute_from_date(billing_date)
+        billing_from_date.month == subscription_at.month && billing_from_date.year == subscription_at.year
+      end
+
       private
 
       def compute_base_date

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -236,6 +236,10 @@ module Subscriptions
       false
     end
 
+    def first_month_in_first_yearly_period?
+      false
+    end
+
     def compute_duration(from_date:)
       raise(NotImplementedError)
     end


### PR DESCRIPTION
Currently, we are not creating any subscription fee if the subscription is started in the past.
For yearly plan with monthly charges, that's not the case, the subscription is created on the next charges billing period.

The goal of this PR is to change that by not creating any subscription fee even if the plan is yearly with monthly charges.