### PR TITLE
feat(tresholds): Add GraphQL for usage thresholds

### DIFF
--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -25,6 +25,7 @@ module Mutations
 
       argument :charges, [Types::Charges::Input]
       argument :minimum_commitment, Types::Commitments::Input, required: false
+      argument :usage_thresholds, [Types::UsageThresholds::Input], required: false
 
       type Types::Plans::Object
 

--- a/app/graphql/mutations/plans/update.rb
+++ b/app/graphql/mutations/plans/update.rb
@@ -25,6 +25,7 @@ module Mutations
 
       argument :charges, [Types::Charges::Input]
       argument :minimum_commitment, Types::Commitments::Input, required: false
+      argument :usage_thresholds, [Types::UsageThresholds::Input], required: false
 
       type Types::Plans::Object
 

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -20,6 +20,7 @@ module Types
       field :parent, Types::Plans::Object, null: true
       field :pay_in_advance, Boolean, null: false
       field :trial_period, Float
+      field :usage_thresholds, [Types::UsageThresholds::Object]
 
       field :charges, [Types::Charges::Object]
       field :taxes, [Types::Taxes::Object]

--- a/app/graphql/types/subscriptions/plan_overrides_input.rb
+++ b/app/graphql/types/subscriptions/plan_overrides_input.rb
@@ -12,6 +12,7 @@ module Types
       argument :name, String, required: false
       argument :tax_codes, [String], required: false
       argument :trial_period, Float, required: false
+      argument :usage_thresholds, [Types::Subscriptions::UsageThresholdOverridesInput], required: false
     end
   end
 end

--- a/app/graphql/types/subscriptions/usage_threshold_overrides_input.rb
+++ b/app/graphql/types/subscriptions/usage_threshold_overrides_input.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Types
+  module Subscriptions
+    class UsageThresholdOverridesInput < Types::BaseInputObject
+      argument :id, ID, required: true
+
+      argument :amount_cents, GraphQL::Types::BigInt, required: false
+      argument :recurring, Boolean, required: false
+      argument :threshold_display_name, String, required: false
+    end
+  end
+end

--- a/app/graphql/types/subscriptions/usage_threshold_overrides_input.rb
+++ b/app/graphql/types/subscriptions/usage_threshold_overrides_input.rb
@@ -3,9 +3,7 @@
 module Types
   module Subscriptions
     class UsageThresholdOverridesInput < Types::BaseInputObject
-      argument :id, ID, required: true
-
-      argument :amount_cents, GraphQL::Types::BigInt, required: false
+      argument :amount_cents, GraphQL::Types::BigInt, required: true
       argument :recurring, Boolean, required: false
       argument :threshold_display_name, String, required: false
     end

--- a/app/graphql/types/usage_thresholds/input.rb
+++ b/app/graphql/types/usage_thresholds/input.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module UsageThresholds
+    class Input < BaseInputObject
+      graphql_name 'UsageThresholdInput'
+
+      argument :id, ID, required: false
+
+      argument :amount_cents, GraphQL::Types::BigInt, required: false
+      argument :recurring, Boolean, required: false
+      argument :threshold_display_name, String, required: false
+    end
+  end
+end

--- a/app/graphql/types/usage_thresholds/object.rb
+++ b/app/graphql/types/usage_thresholds/object.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Types
+  module UsageThresholds
+    class Object < Types::BaseObject
+      graphql_name 'UsageThreshold'
+
+      field :id, ID, null: false
+
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :recurring, Boolean, null: false
+      field :threshold_display_name, String, null: true
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    end
+  end
+end

--- a/app/services/plans/override_service.rb
+++ b/app/services/plans/override_service.rb
@@ -36,14 +36,11 @@ module Plans
           Charges::OverrideService.call(charge:, params: charge_params)
         end
 
-        if License.premium? && plan.organization.premium_integrations.include?('progressive_billing')
-          plan.usage_thresholds.find_each do |threshold|
-            threshold_params = (
-              params[:usage_thresholds]&.find { |p| p[:id] == threshold.id } || {}
-            ).merge(plan_id: new_plan.id)
+        if params[:usage_thresholds].present? &&
+            License.premium? &&
+            plan.organization.premium_integrations.include?('progressive_billing')
 
-            UsageThresholds::OverrideService.call(threshold:, params: threshold_params)
-          end
+          UsageThresholds::OverrideService.call(usage_thresholds_params: params[:usage_thresholds], new_plan: new_plan)
         end
 
         if params[:minimum_commitment].present? && License.premium?

--- a/schema.graphql
+++ b/schema.graphql
@@ -2044,6 +2044,7 @@ input CreatePlanInput {
   payInAdvance: Boolean!
   taxCodes: [String!]
   trialPeriod: Float
+  usageThresholds: [UsageThresholdInput!]
 }
 
 input CreateRecurringTransactionRuleInput {
@@ -5333,6 +5334,7 @@ type Plan {
   taxes: [Tax!]
   trialPeriod: Float
   updatedAt: ISO8601DateTime!
+  usageThresholds: [UsageThreshold!]
 }
 
 type PlanCollection {
@@ -5357,6 +5359,7 @@ input PlanOverridesInput {
   name: String
   taxCodes: [String!]
   trialPeriod: Float
+  usageThresholds: [UsageThresholdOverridesInput!]
 }
 
 type Properties {
@@ -7232,6 +7235,7 @@ input UpdatePlanInput {
   payInAdvance: Boolean!
   taxCodes: [String!]
   trialPeriod: Float
+  usageThresholds: [UsageThresholdInput!]
 }
 
 input UpdateRecurringTransactionRuleInput {
@@ -7291,6 +7295,29 @@ input UpdateXeroIntegrationInput {
   syncCreditNotes: Boolean
   syncInvoices: Boolean
   syncPayments: Boolean
+}
+
+type UsageThreshold {
+  amountCents: BigInt!
+  createdAt: ISO8601DateTime!
+  id: ID!
+  recurring: Boolean!
+  thresholdDisplayName: String
+  updatedAt: ISO8601DateTime!
+}
+
+input UsageThresholdInput {
+  amountCents: BigInt
+  id: ID
+  recurring: Boolean
+  thresholdDisplayName: String
+}
+
+input UsageThresholdOverridesInput {
+  amountCents: BigInt
+  id: ID!
+  recurring: Boolean
+  thresholdDisplayName: String
 }
 
 type User {

--- a/schema.graphql
+++ b/schema.graphql
@@ -7314,8 +7314,7 @@ input UsageThresholdInput {
 }
 
 input UsageThresholdOverridesInput {
-  amountCents: BigInt
-  id: ID!
+  amountCents: BigInt!
   recurring: Boolean
   thresholdDisplayName: String
 }

--- a/schema.json
+++ b/schema.json
@@ -8612,6 +8612,26 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "usageThresholds",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UsageThresholdInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "enumValues": null
@@ -26765,6 +26785,28 @@
               "args": [
 
               ]
+            },
+            {
+              "name": "usageThresholds",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UsageThreshold",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
             }
           ],
           "inputFields": null,
@@ -26989,6 +27031,26 @@
                 "kind": "SCALAR",
                 "name": "Float",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "usageThresholds",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UsageThresholdOverridesInput",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -35988,6 +36050,26 @@
               "defaultValue": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "usageThresholds",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "UsageThresholdInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "enumValues": null
@@ -36380,6 +36462,245 @@
             {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UsageThreshold",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "recurring",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "thresholdDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UsageThresholdInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "recurring",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "thresholdDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UsageThresholdOverridesInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "recurring",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "thresholdDisplayName",
+              "description": null,
               "type": {
                 "kind": "SCALAR",
                 "name": "String",

--- a/schema.json
+++ b/schema.json
@@ -36659,28 +36659,16 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "id",
+              "name": "amountCents",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "ID",
+                  "name": "BigInt",
                   "ofType": null
                 }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "amountCents",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "BigInt",
-                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
   let(:organization) { membership.organization }
   let(:plan) { create(:plan, organization:) }
   let(:charge) { create(:standard_charge, plan:) }
+  let(:threshold) { create(:usage_threshold, plan:) }
   let(:ending_at) { Time.current.beginning_of_day + 1.year }
   let(:customer) { create(:customer, organization:) }
   let(:mutation) do
@@ -28,6 +29,11 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
           plan {
             id
             amountCents
+            usageThresholds {
+              id
+              amountCents
+              thresholdDisplayName
+            }
           }
         }
       }
@@ -35,6 +41,8 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
   end
 
   around { |test| lago_premium!(&test) }
+
+  before { organization.update!(premium_integrations: ['progressive_billing']) }
 
   it_behaves_like 'requires current user'
   it_behaves_like 'requires current organization'
@@ -60,6 +68,10 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
               id: charge.id,
               billableMetricId: charge.billable_metric_id,
               invoiceDisplayName: 'invoice display name'
+            ],
+            usageThresholds: [
+              id: threshold.id,
+              thresholdDisplayName: 'threshold display name'
             ]
           }
         }
@@ -82,6 +94,10 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
     )
     expect(result_data['plan']).to include(
       'id' => String,
+      'amountCents' => '100'
+    )
+    expect(result_data['plan']['usageThresholds'].first).to include(
+      'thresholdDisplayName' => 'threshold display name',
       'amountCents' => '100'
     )
   end

--- a/spec/graphql/mutations/subscriptions/create_spec.rb
+++ b/spec/graphql/mutations/subscriptions/create_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
             id
             amountCents
             usageThresholds {
-              id
               amountCents
               thresholdDisplayName
             }
@@ -70,7 +69,7 @@ RSpec.describe Mutations::Subscriptions::Create, type: :graphql do
               invoiceDisplayName: 'invoice display name'
             ],
             usageThresholds: [
-              id: threshold.id,
+              amountCents: 100,
               thresholdDisplayName: 'threshold display name'
             ]
           }

--- a/spec/graphql/types/plans/object_spec.rb
+++ b/spec/graphql/types/plans/object_spec.rb
@@ -28,4 +28,5 @@ RSpec.describe Types::Plans::Object do
   it { is_expected.to have_field(:customers_count).of_type('Int!') }
   it { is_expected.to have_field(:draft_invoices_count).of_type('Int!') }
   it { is_expected.to have_field(:subscriptions_count).of_type('Int!') }
+  it { is_expected.to have_field(:usage_thresholds).of_type('[UsageThreshold!]') }
 end

--- a/spec/graphql/types/subscriptions/plan_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/plan_overrides_input_spec.rb
@@ -14,4 +14,5 @@ RSpec.describe Types::Subscriptions::PlanOverridesInput do
   it { is_expected.to accept_argument(:name).of_type('String') }
   it { is_expected.to accept_argument(:tax_codes).of_type('[String!]') }
   it { is_expected.to accept_argument(:trial_period).of_type('Float') }
+  it { is_expected.to accept_argument(:usage_thresholds).of_type('[UsageThresholdOverridesInput!]') }
 end

--- a/spec/graphql/types/subscriptions/usage_threshold_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/usage_threshold_overrides_input_spec.rb
@@ -5,8 +5,7 @@ require 'rails_helper'
 RSpec.describe Types::Subscriptions::UsageThresholdOverridesInput do
   subject { described_class }
 
-  it { is_expected.to accept_argument(:id).of_type('ID!') }
-  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt') }
+  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt!') }
   it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
   it { is_expected.to accept_argument(:threshold_display_name).of_type('String') }
 end

--- a/spec/graphql/types/subscriptions/usage_threshold_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/usage_threshold_overrides_input_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Subscriptions::UsageThresholdOverridesInput do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:id).of_type('ID!') }
+  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt') }
+  it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
+  it { is_expected.to accept_argument(:threshold_display_name).of_type('String') }
+end

--- a/spec/graphql/types/usage_thresholds/input_spec.rb
+++ b/spec/graphql/types/usage_thresholds/input_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::UsageThresholds::Input do
+  subject { described_class }
+
+  it { is_expected.to accept_argument(:id).of_type('ID') }
+  it { is_expected.to accept_argument(:amount_cents).of_type('BigInt') }
+  it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
+  it { is_expected.to accept_argument(:threshold_display_name).of_type('String') }
+end

--- a/spec/graphql/types/usage_thresholds/object_spec.rb
+++ b/spec/graphql/types/usage_thresholds/object_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::UsageThresholds::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:id).of_type('ID!') }
+  it { is_expected.to have_field(:amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:threshold_display_name).of_type('String') }
+  it { is_expected.to have_field(:recurring).of_type('Boolean!') }
+  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+end

--- a/spec/requests/api/v1/subscriptions_controller_spec.rb
+++ b/spec/requests/api/v1/subscriptions_controller_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
             amount_cents: commitment_amount_cents
           },
           usage_thresholds: [
-            id: usage_threshold.id,
             amount_cents: override_amount_cents,
             threshold_display_name: override_display_name
           ]
@@ -43,9 +42,6 @@ RSpec.describe Api::V1::SubscriptionsController, type: :request do
 
     let(:override_amount_cents) { 777 }
     let(:override_display_name) { 'Overriden Threshold 12' }
-    let(:usage_threshold) { create(:usage_threshold, plan:) }
-
-    before { usage_threshold }
 
     it 'returns a success', :aggregate_failures do
       create(:plan, code: plan.code, parent_id: plan.id, organization:, description: 'foo')

--- a/spec/services/usage_thresholds/override_service_spec.rb
+++ b/spec/services/usage_thresholds/override_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe UsageThresholds::OverrideService, type: :service do
-  subject(:override_service) { described_class.new(threshold:, params:) }
+  subject(:override_service) { described_class.new(usage_thresholds_params:, new_plan: plan) }
 
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
@@ -12,13 +12,14 @@ RSpec.describe UsageThresholds::OverrideService, type: :service do
     let(:threshold) { create(:usage_threshold, plan:) }
     let(:plan) { create(:plan, organization:) }
 
-    let(:params) do
-      {
-        id: threshold.id,
-        plan_id: plan.id,
-        threshold_display_name: 'Overriden threshold',
-        amount_cents: 1000
-      }
+    let(:usage_thresholds_params) do
+      [
+        {
+          plan_id: plan.id,
+          threshold_display_name: 'Overriden threshold',
+          amount_cents: 1000
+        }
+      ]
     end
 
     before { threshold }


### PR DESCRIPTION
## Roadmap Task

👉  https://getlago.canny.io/feature-requests/p/progressive-billing

## Context

There's always a risk of customers not paying invoices generated at the end of a billing period. It would be beneficial to bill customers at given thresholds (units vs. amount) rather than waiting until the end of the period. This approach would allow for removing customer access if invoices are not paid and prevent having a highest amount of unpaid invoices.

## Description

Add GraphQL for usage thresholds.