### PR TITLE
fix(data-exports): Improve CSV export memory usage

### DIFF
--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -9,10 +9,10 @@ module DataExports
       extend Forwardable
 
       def call
-        ::CSV.generate(headers: true) do |csv|
+        ::CSV.open(output, 'wb', headers: true) do |csv|
           csv << headers
 
-          query.invoices.find_each do |invoice|
+          invoices.find_each do |invoice|
             serialized_invoice = serializer_klass
               .new(invoice, includes: %i[fees subscriptions])
               .serialize
@@ -30,13 +30,13 @@ module DataExports
                 serialized_invoice[:number],
                 serialized_invoice[:issuing_date],
                 serialized_fee[:lago_id],
-                serialized_fee[:item][:type],
-                serialized_fee[:item][:code],
-                serialized_fee[:item][:name],
-                serialized_fee[:item][:description],
-                serialized_fee[:item][:invoice_display_name],
-                serialized_fee[:item][:filter_invoice_display_name],
-                serialized_fee[:item][:grouped_by],
+                serialized_fee.dig(:item, :type),
+                serialized_fee.dig(:item, :code),
+                serialized_fee.dig(:item, :name),
+                serialized_fee.dig(:item, :description),
+                serialized_fee.dig(:item, :invoice_display_name),
+                serialized_fee.dig(:item, :filter_invoice_display_name),
+                serialized_fee.dig(:item, :grouped_by),
                 serialized_subscription&.dig(:external_id),
                 serialized_subscription&.dig(:plan_code),
                 serialized_fee[:from_date],

--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -12,7 +12,7 @@ module DataExports
         ::CSV.open(output, 'wb', headers: true) do |csv|
           csv << headers
 
-          invoices.find_each do |invoice|
+          invoices.find_each(batch_size:) do |invoice|
             serialized_invoice = serializer_klass
               .new(invoice, includes: %i[fees subscriptions])
               .serialize

--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -6,24 +6,50 @@ require 'forwardable'
 module DataExports
   module Csv
     class InvoiceFees < Invoices
+      DEFAULT_BATCH_SIZE = 50
+
       extend Forwardable
+
+      def initialize(
+        data_export:,
+        invoice_serializer_klass: V1::InvoiceSerializer,
+        fee_serializer_klass: V1::FeeSerializer,
+        subscription_serializer_klass: V1::SubscriptionSerializer,
+        output: Tempfile.create
+      )
+
+        @data_export = data_export
+        @invoice_serializer_klass = invoice_serializer_klass
+        @fee_serializer_klass = fee_serializer_klass
+        @subscription_serializer_klass = subscription_serializer_klass
+        @output = output
+        @batch_size = DEFAULT_BATCH_SIZE
+      end
 
       def call
         ::CSV.open(output, 'wb', headers: true) do |csv|
           csv << headers
 
           invoices.find_each(batch_size:).lazy.each do |invoice|
-            serialized_invoice = serializer_klass
-              .new(invoice, includes: %i[fees subscriptions])
-              .serialize
+            serialized_invoice = invoice_serializer_klass.new(invoice).serialize
 
-            subscriptions = serialized_invoice[:subscriptions].index_by do |sub|
-              sub[:lago_id]
-            end
+            invoice
+              .fees
+              .includes(
+                :invoice,
+                :subscription,
+                :charge,
+                :true_up_fee,
+                :customer,
+                :billable_metric,
+                {charge_filter: {values: :billable_metric_filter}}
+              )
+              .find_each(batch_size:)
+              .lazy
+              .each do |fee|
+              serialized_fee = fee_serializer_klass.new(fee).serialize
 
-            serialized_invoice[:fees].each do |serialized_fee|
-              subscription_id = serialized_fee[:lago_subscription_id]
-              serialized_subscription = subscriptions[subscription_id]
+              serialized_subscription = fee.subscription ? subscription_serializer_klass.new(fee.subscription).serialize : {}
 
               csv << [
                 serialized_invoice[:lago_id],
@@ -37,8 +63,8 @@ module DataExports
                 serialized_fee.dig(:item, :invoice_display_name),
                 serialized_fee.dig(:item, :filter_invoice_display_name),
                 serialized_fee.dig(:item, :grouped_by),
-                serialized_subscription&.dig(:external_id),
-                serialized_subscription&.dig(:plan_code),
+                serialized_subscription[:external_id],
+                serialized_subscription[:plan_code],
                 serialized_fee[:from_date],
                 serialized_fee[:to_date],
                 serialized_fee[:total_amount_currency],
@@ -53,6 +79,8 @@ module DataExports
       end
 
       private
+
+      attr_reader :invoice_serializer_klass, :fee_serializer_klass, :subscription_serializer_klass
 
       def headers
         %w[

--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -12,7 +12,7 @@ module DataExports
         ::CSV.open(output, 'wb', headers: true) do |csv|
           csv << headers
 
-          invoices.find_each(batch_size:) do |invoice|
+          invoices.find_each(batch_size:).lazy.each do |invoice|
             serialized_invoice = serializer_klass
               .new(invoice, includes: %i[fees subscriptions])
               .serialize

--- a/app/services/data_exports/csv/invoice_fees.rb
+++ b/app/services/data_exports/csv/invoice_fees.rb
@@ -76,6 +76,8 @@ module DataExports
             end
           end
         end
+
+        output.rewind
       end
 
       private

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -21,7 +21,7 @@ module DataExports
         ::CSV.open(output, 'wb', headers: true) do |csv|
           csv << headers
 
-          invoices.find_each(batch_size:) do |invoice|
+          invoices.find_each(batch_size:).lazy.each do |invoice|
             csv << serialized_invoice(invoice)
           end
         end

--- a/app/services/data_exports/csv/invoices.rb
+++ b/app/services/data_exports/csv/invoices.rb
@@ -8,52 +8,27 @@ module DataExports
     class Invoices < BaseService
       extend Forwardable
 
-      def initialize(data_export:, serializer_klass: V1::InvoiceSerializer)
+      def initialize(data_export:, serializer_klass: V1::InvoiceSerializer, output: Tempfile.create)
         @data_export = data_export
         @serializer_klass = serializer_klass
+        @output = output
       end
 
       def call
-        ::CSV.generate(headers: true) do |csv|
+        ::CSV.open(output, 'wb', headers: true) do |csv|
           csv << headers
 
-          query.invoices.find_each do |invoice|
-            serialized_invoice = serializer_klass
-              .new(invoice, includes: %i[customer])
-              .serialize
-
-            csv << [
-              serialized_invoice[:lago_id],
-              serialized_invoice[:sequential_id],
-              serialized_invoice[:issuing_date],
-              serialized_invoice[:customer][:lago_id],
-              serialized_invoice[:customer][:external_id],
-              serialized_invoice[:customer][:name],
-              serialized_invoice[:customer][:country],
-              serialized_invoice[:customer][:tax_identification_number],
-              serialized_invoice[:number],
-              serialized_invoice[:invoice_type],
-              serialized_invoice[:payment_status],
-              serialized_invoice[:status],
-              serialized_invoice[:file_url],
-              serialized_invoice[:currency],
-              serialized_invoice[:fees_amount_cents],
-              serialized_invoice[:coupons_amount_cents],
-              serialized_invoice[:taxes_amount_cents],
-              serialized_invoice[:credit_notes_amount_cents],
-              serialized_invoice[:prepaid_credit_amount_cents],
-              serialized_invoice[:total_amount_cents],
-              serialized_invoice[:payment_due_date],
-              serialized_invoice[:payment_dispute_lost_at],
-              serialized_invoice[:payment_overdue]
-            ]
+          invoices.find_each do |invoice|
+            csv << serialized_invoice(invoice)
           end
         end
+
+        output.rewind
       end
 
       private
 
-      attr_reader :data_export, :serializer_klass
+      attr_reader :data_export, :serializer_klass, :output
 
       def_delegators :data_export, :organization, :resource_query
 
@@ -85,7 +60,39 @@ module DataExports
         ]
       end
 
-      def query
+      def serialized_invoice(invoice)
+        serialized_invoice = serializer_klass
+          .new(invoice, includes: %i[customer])
+          .serialize
+
+        [
+          serialized_invoice[:lago_id],
+          serialized_invoice[:sequential_id],
+          serialized_invoice[:issuing_date],
+          serialized_invoice.dig(:customer, :lago_id),
+          serialized_invoice.dig(:customer, :external_id),
+          serialized_invoice.dig(:customer, :name),
+          serialized_invoice.dig(:customer, :country),
+          serialized_invoice.dig(:customer, :tax_identification_number),
+          serialized_invoice[:number],
+          serialized_invoice[:invoice_type],
+          serialized_invoice[:payment_status],
+          serialized_invoice[:status],
+          serialized_invoice[:file_url],
+          serialized_invoice[:currency],
+          serialized_invoice[:fees_amount_cents],
+          serialized_invoice[:coupons_amount_cents],
+          serialized_invoice[:taxes_amount_cents],
+          serialized_invoice[:credit_notes_amount_cents],
+          serialized_invoice[:prepaid_credit_amount_cents],
+          serialized_invoice[:total_amount_cents],
+          serialized_invoice[:payment_due_date],
+          serialized_invoice[:payment_dispute_lost_at],
+          serialized_invoice[:payment_overdue]
+        ]
+      end
+
+      def invoices
         search_term = resource_query["search_term"]
         filters = resource_query.except("search_term")
 
@@ -94,7 +101,7 @@ module DataExports
           pagination: nil,
           search_term:,
           filters:
-        )
+        ).invoices
       end
     end
   end

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -51,9 +51,20 @@ RSpec.describe DataExports::Csv::InvoiceFees do
   end
 
   let(:tempfile) { Tempfile.create("test_export") }
-  let(:serializer_klass) { class_double('V1::InvoiceSerializer') }
+  let(:invoice_serializer_klass) { class_double('V1::InvoiceSerializer') }
+  let(:fee_serializer_klass) { class_double('V1::FeeSerializer') }
+  let(:subscription_serializer_klass) { class_double('V1::SubscriptionSerializer') }
+
   let(:invoice_serializer) do
     instance_double('V1::InvoiceSerializer', serialize: serialized_invoice)
+  end
+
+  let(:fee_serializer) do
+    instance_double('V1::FeeSerializer', serialize: serialized_fee)
+  end
+
+  let(:subscription_serializer) do
+    instance_double('V1::SubscriptionSerializer', serialize: serialized_subscription)
   end
 
   let(:invoices_query_results) do
@@ -63,155 +74,61 @@ RSpec.describe DataExports::Csv::InvoiceFees do
   end
 
   let(:invoice) { create :invoice }
+  let(:fee) { create :fee, invoice: }
+
   let(:serialized_invoice) do
     {
       lago_id: "292ef60b-9e0c-42e7-9f50-44d5af4162ec",
       number: "TWI-2B86-170-001",
-      issuing_date: "2024-06-06",
-      subscriptions: [
-        {
-          lago_id: "80ebcc26-3703-4577-b13e-765591255df4",
-          external_id: "ff6c279c-9f6c-4962-987e-270936d52310",
-          plan_code: "all_charges"
-        }
-      ],
-      fees: [
-        {
-          lago_id: "cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302",
-          lago_subscription_id: "80ebcc26-3703-4577-b13e-765591255df4",
-          item: {
-            type: "charge",
-            code: "group",
-            name: "group",
-            description: "charge 1 description",
-            invoice_display_name: "group",
-            filter_invoice_display_name: "Converted to EUR",
-            grouped_by: {
-              models: "model_1"
-            }
-          },
-          taxes_amount_cents: 50,
-          total_amount_cents: 10000,
-          total_amount_currency: "USD",
-          units: "100.0",
-          precise_unit_amount: "10.0",
-          from_date: "2024-05-08T00:00:00+00:00",
-          to_date: "2024-06-06T12:48:59+00:00"
-        },
-        {
-          lago_id: "5277b901-3da6-4a55-974a-ee1295978e98",
-          lago_subscription_id: "80ebcc26-3703-4577-b13e-765591255df4",
-          item: {
-            type: "charge",
-            code: "group",
-            name: "group",
-            description: "charge 2 description",
-            invoice_display_name: "group",
-            filter_invoice_display_name: nil,
-            grouped_by: {
-              models: "model_2"
-            }
-          },
-          taxes_amount_cents: 1000,
-          total_amount_cents: 20000,
-          total_amount_currency: "USD",
-          units: "200.0",
-          precise_unit_amount: "1.0",
-          from_date: "2024-05-08T00:00:00+00:00",
-          to_date: "2024-06-06T12:48:59+00:00"
-        },
-        {
-          lago_id: "86d3515f-2c4e-49de-9e81-99f8c22f38ad",
-          lago_subscription_id: "80ebcc26-3703-4577-b13e-765591255df4",
-          item: {
-            type: "charge",
-            code: "group",
-            name: "group",
-            description: "charge 3 description",
-            invoice_display_name: "group",
-            filter_invoice_display_name: nil,
-            grouped_by: {
-              models: "model_3"
-            }
-          },
-          taxes_amount_cents: 0,
-          total_amount_cents: 30000,
-          total_amount_currency: "USD",
-          units: "300.0",
-          precise_unit_amount: "1.0",
-          from_date: "2024-05-08T00:00:00+00:00",
-          to_date: "2024-06-06T12:48:59+00:00"
-        },
-        {
-          lago_id: "203e6d6b-a5ff-4eb5-bbb9-01bfdf4f8d22",
-          lago_subscription_id: "80ebcc26-3703-4577-b13e-765591255df4",
-          item: {
-            type: "charge",
-            code: "filters",
-            name: "filters",
-            description: "charge 4 description",
-            invoice_display_name: "filters",
-            filter_invoice_display_name: "model_1, input",
-            grouped_by: {}
-          },
-          taxes_amount_cents: 0,
-          total_amount_cents: 0,
-          total_amount_currency: "USD",
-          units: "0.0",
-          precise_unit_amount: "0.0",
-          from_date: "2024-05-08T00:00:00+00:00",
-          to_date: "2024-06-06T12:48:59+00:00"
-        },
-        {
-          lago_id: "af3b0a41-33c3-4f2c-a6e4-62402df59ee3",
-          lago_subscription_id: "80ebcc26-3703-4577-b13e-765591255df4",
-          item: {
-            type: "charge",
-            code: "filters",
-            name: "filters",
-            description: "charge 5 description",
-            invoice_display_name: "filters",
-            filter_invoice_display_name: "model_2, output",
-            grouped_by: {}
-          },
-          taxes_amount_cents: 0,
-          total_amount_cents: 0,
-          total_amount_currency: "EUR",
-          units: "0.0",
-          precise_unit_amount: "0.0",
-          from_date: "2024-05-08T00:00:00+00:00",
-          to_date: "2024-06-06T12:48:59+00:00"
-        },
-        {
-          lago_id: "282867c6-fa26-4c08-82b4-42d4128d4627",
-          lago_subscription_id: nil,
-          item: {
-            type: "charge",
-            code: "filters",
-            name: "filters",
-            description: "charge 6 description",
-            invoice_display_name: "filters",
-            filter_invoice_display_name: nil,
-            grouped_by: {}
-          },
-          taxes_amount_cents: 0,
-          total_amount_cents: 0,
-          total_amount_currency: "USD",
-          units: "0.0",
-          precise_unit_amount: "0.0",
-          from_date: "2024-05-08T00:00:00+00:00",
-          to_date: "2024-06-06T12:48:59+00:00"
-        }
-      ]
+      issuing_date: "2024-06-06"
+    }
+  end
+
+  let(:serialized_fee) do
+    {
+      lago_id: "cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302",
+      item: {
+        type: "charge",
+        code: "group",
+        name: "group",
+        description: "charge 1 description",
+        invoice_display_name: "group",
+        filter_invoice_display_name: "Converted to EUR",
+        grouped_by: {models: "model_1"}
+      },
+      taxes_amount_cents: 50,
+      total_amount_cents: 10000,
+      total_amount_currency: "USD",
+      units: "100.0",
+      precise_unit_amount: "10.0",
+      from_date: "2024-05-08T00:00:00+00:00",
+      to_date: "2024-06-06T12:48:59+00:00"
+    }
+  end
+
+  let(:serialized_subscription) do
+    {
+      lago_id: "80ebcc26-3703-4577-b13e-765591255df4",
+      external_id: "ff6c279c-9f6c-4962-987e-270936d52310",
+      plan_code: "all_charges"
     }
   end
 
   before do
     invoice
+    fee
 
-    allow(serializer_klass)
+    allow(invoice_serializer_klass)
       .to receive(:new)
       .and_return(invoice_serializer)
+
+    allow(fee_serializer_klass)
+      .to receive(:new)
+      .and_return(fee_serializer)
+
+    allow(subscription_serializer_klass)
+      .to receive(:new)
+      .and_return(subscription_serializer)
 
     allow(InvoicesQuery)
       .to receive(:call)
@@ -226,18 +143,19 @@ RSpec.describe DataExports::Csv::InvoiceFees do
 
   describe '#call' do
     subject(:call) do
-      described_class.new(data_export:, serializer_klass:, output: tempfile).call
+      described_class.new(
+        data_export:,
+        invoice_serializer_klass:,
+        fee_serializer_klass:,
+        subscription_serializer_klass:,
+        output: tempfile
+      ).call
     end
 
     it 'generates the correct CSV output' do
       expected_csv = <<~CSV
         invoice_lago_id,invoice_number,invoice_issuing_date,fee_lago_id,fee_item_type,fee_item_code,fee_item_name,fee_item_description,fee_item_invoice_display_name,fee_item_filter_invoice_display_name,fee_item_grouped_by,subscription_external_id,subscription_plan_code,fee_from_date_utc,fee_to_date_utc,fee_amount_currency,fee_units,fee_precise_unit_amount,fee_taxes_amount_cents,fee_total_amount_cents
         292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,cc16e6d5-b5e1-4e2c-9ad3-62b3ee4be302,charge,group,group,charge 1 description,group,Converted to EUR,"{:models=>""model_1""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,100.0,10.0,50,10000
-        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,5277b901-3da6-4a55-974a-ee1295978e98,charge,group,group,charge 2 description,group,,"{:models=>""model_2""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,200.0,1.0,1000,20000
-        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,86d3515f-2c4e-49de-9e81-99f8c22f38ad,charge,group,group,charge 3 description,group,,"{:models=>""model_3""}",ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,300.0,1.0,0,30000
-        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,203e6d6b-a5ff-4eb5-bbb9-01bfdf4f8d22,charge,filters,filters,charge 4 description,filters,"model_1, input",{},ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,0.0,0.0,0,0
-        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,af3b0a41-33c3-4f2c-a6e4-62402df59ee3,charge,filters,filters,charge 5 description,filters,"model_2, output",{},ff6c279c-9f6c-4962-987e-270936d52310,all_charges,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,EUR,0.0,0.0,0,0
-        292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,282867c6-fa26-4c08-82b4-42d4128d4627,charge,filters,filters,charge 6 description,filters,,{},,,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,0.0,0.0,0,0
       CSV
 
       call

--- a/spec/services/data_exports/csv/invoice_fees_spec.rb
+++ b/spec/services/data_exports/csv/invoice_fees_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe DataExports::Csv::InvoiceFees do
     }
   end
 
+  let(:tempfile) { Tempfile.create("test_export") }
   let(:serializer_klass) { class_double('V1::InvoiceSerializer') }
   let(:invoice_serializer) do
     instance_double('V1::InvoiceSerializer', serialize: serialized_invoice)
@@ -224,7 +225,9 @@ RSpec.describe DataExports::Csv::InvoiceFees do
   end
 
   describe '#call' do
-    subject(:call) { described_class.new(data_export:, serializer_klass:).call }
+    subject(:call) do
+      described_class.new(data_export:, serializer_klass:, output: tempfile).call
+    end
 
     it 'generates the correct CSV output' do
       expected_csv = <<~CSV
@@ -237,7 +240,11 @@ RSpec.describe DataExports::Csv::InvoiceFees do
         292ef60b-9e0c-42e7-9f50-44d5af4162ec,TWI-2B86-170-001,2024-06-06,282867c6-fa26-4c08-82b4-42d4128d4627,charge,filters,filters,charge 6 description,filters,,{},,,2024-05-08T00:00:00+00:00,2024-06-06T12:48:59+00:00,USD,0.0,0.0,0,0
       CSV
 
-      expect(call).to eq(expected_csv)
+      call
+      tempfile.rewind
+      generated_csv = tempfile.read
+
+      expect(generated_csv).to eq(expected_csv)
     end
   end
 end

--- a/spec/services/data_exports/csv/invoices_spec.rb
+++ b/spec/services/data_exports/csv/invoices_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe DataExports::Csv::Invoices do
     }
   end
 
+  let(:tempfile) { Tempfile.create("test_export") }
   let(:serializer_klass) { class_double('V1::InvoiceSerializer') }
   let(:invoice_serializer) do
     instance_double('V1::InvoiceSerializer', serialize: serialized_invoice)
@@ -110,10 +111,7 @@ RSpec.describe DataExports::Csv::Invoices do
 
   describe '#call' do
     subject(:call) do
-      described_class.new(
-        data_export: data_export,
-        serializer_klass: serializer_klass
-      ).call
+      described_class.new(data_export:, serializer_klass:, output: tempfile).call
     end
 
     it 'generates the correct CSV output' do
@@ -122,7 +120,11 @@ RSpec.describe DataExports::Csv::Invoices do
         invoice-lago-id-123,SEQ123,2023-01-01,customer-lago-id-456,CUST123,customer name,US,123456789,INV123,credit,pending,finalized,http://api.lago.com/invoice.pdf,USD,70000,1655,10500,334,1000,77511,2023-02-01,2023-12-22,false
       CSV
 
-      expect(call).to eq(expected_csv)
+      call
+      tempfile.rewind
+      generated_csv = tempfile.read
+
+      expect(generated_csv).to eq(expected_csv)
     end
   end
 end


### PR DESCRIPTION
## Context

CSV content was generated in memory and then upload to file storage. This implies high memory requirements when the export contains a high number of records.

## Description

This change modifies the exporters to write the CSV content to disk (tempfile), then upload the file.

This should reduce the memory requirements of the worker processing the data exports and avoid sidekiq workers being restarted/killed.
