### PR TITLE
feat(ProgressiveBilling) -  add `LifetimeUsages::CalculateService`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,9 +13,9 @@ AllCops:
   NewCops: disable
   DisplayStyleGuide: true
   Exclude:
-    - 'bin/**/*'
-    - 'db/schema.rb'
-    - 'db/*_schema.rb'
+    - "bin/**/*"
+    - "db/schema.rb"
+    - "db/*_schema.rb"
 
 # TODO: Enable when we have time to fix all the offenses
 Style/StringLiterals:
@@ -23,16 +23,17 @@ Style/StringLiterals:
 
 Style/FrozenStringLiteralComment:
   Enabled: true
+  SafeAutoCorrect: true
 
 Performance/CaseWhenSplat:
   Enabled: true
 
 Rails/InverseOf:
-  Description: 'Checks for associations where the inverse cannot be determined automatically.'
+  Description: "Checks for associations where the inverse cannot be determined automatically."
   Enabled: false
 
 Rails/HttpStatus:
-  Description: 'Enforces use of symbolic or numeric value to describe HTTP status.'
+  Description: "Enforces use of symbolic or numeric value to describe HTTP status."
   Enabled: false
 
 Rails/HasManyOrHasOneDependent:
@@ -40,11 +41,11 @@ Rails/HasManyOrHasOneDependent:
   Enabled: false
 
 RSpec/ExampleLength:
-  Description: 'Checks for long examples.'
+  Description: "Checks for long examples."
   Enabled: false
 
 RSpec/MultipleExpectations:
-  Description: 'Checks if examples contain too many expect calls.'
+  Description: "Checks if examples contain too many expect calls."
   Enabled: false
 
 RSpec/MultipleMemoizedHelpers:
@@ -72,10 +73,10 @@ GraphQL/ExtractType:
 
 GraphQL/ExtractInputType:
   Exclude:
-    - 'app/graphql/mutations/applied_coupons/create.rb'
-    - 'app/graphql/mutations/credit_notes/create.rb'
-    - 'app/graphql/mutations/invites/accept.rb'
-    - 'app/graphql/mutations/plans/create.rb'
-    - 'app/graphql/mutations/plans/update.rb'
-    - 'app/graphql/mutations/register_user.rb'
-    - 'app/graphql/mutations/wallet_transactions/create.rb'
+    - "app/graphql/mutations/applied_coupons/create.rb"
+    - "app/graphql/mutations/credit_notes/create.rb"
+    - "app/graphql/mutations/invites/accept.rb"
+    - "app/graphql/mutations/plans/create.rb"
+    - "app/graphql/mutations/plans/update.rb"
+    - "app/graphql/mutations/register_user.rb"
+    - "app/graphql/mutations/wallet_transactions/create.rb"

--- a/app/controllers/api/v1/customers/usage_controller.rb
+++ b/app/controllers/api/v1/customers/usage_controller.rb
@@ -6,12 +6,11 @@ module Api
       class UsageController < Api::BaseController
         def current
           result = ::Invoices::CustomerUsageService
-            .call(
-              nil,
-              customer_id: params[:customer_external_id],
-              subscription_id: params[:external_subscription_id],
+            .with_external_ids(
+              customer_external_id: params[:customer_external_id],
+              external_subscription_id: params[:external_subscription_id],
               organization_id: current_organization.id
-            )
+            ).call
 
           if result.success?
             render(

--- a/app/graphql/resolvers/customers/usage_resolver.rb
+++ b/app/graphql/resolvers/customers/usage_resolver.rb
@@ -15,7 +15,7 @@ module Resolvers
       type Types::Customers::Usage::Current, null: false
 
       def resolve(customer_id:, subscription_id:)
-        result = Invoices::CustomerUsageService.call(context[:current_user], customer_id:, subscription_id:)
+        result = Invoices::CustomerUsageService.with_ids(context[:current_user], customer_id:, subscription_id:).call
 
         result.success? ? result.usage : result_error(result)
       end

--- a/app/services/lifetime_usages/calculate_service.rb
+++ b/app/services/lifetime_usages/calculate_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module LifetimeUsages
+  class CalculateService < BaseService
+    def initialize(lifetime_usage:)
+      @lifetime_usage = lifetime_usage
+      super
+    end
+
+    def call
+      if lifetime_usage.recalculate_current_usage
+        lifetime_usage.current_usage_amount_cents = calculate_current_usage_amount_cents
+      end
+      if lifetime_usage.recalculate_invoiced_usage
+        lifetime_usage.invoiced_usage_amount_cents = calculate_invoiced_usage_amount_cents
+      end
+
+      result.lifetime_usage = lifetime_usage
+      result
+    end
+
+    private
+
+    def calculate_invoiced_usage_amount_cents
+      invoices = subscription.invoices.finalized
+      invoices.sum { |invoice| invoice.fees.charge.sum(:amount_cents) }
+    end
+
+    def calculate_current_usage_amount_cents
+      result = Invoices::CustomerUsageService.call(
+        nil,
+        customer_id: lifetime_usage.subscription.customer_id,
+        subscription_id: lifetime_usage.subscription_id
+      )
+      result.usage.amount_cents
+    end
+
+    attr_accessor :lifetime_usage
+  end
+end

--- a/app/services/lifetime_usages/calculate_service.rb
+++ b/app/services/lifetime_usages/calculate_service.rb
@@ -21,6 +21,8 @@ module LifetimeUsages
 
     private
 
+    delegate :subscription, to: :lifetime_usage
+
     def calculate_invoiced_usage_amount_cents
       invoices = subscription.invoices.finalized
       invoices.sum { |invoice| invoice.fees.charge.sum(:amount_cents) }
@@ -28,9 +30,9 @@ module LifetimeUsages
 
     def calculate_current_usage_amount_cents
       result = Invoices::CustomerUsageService.call(
-        nil,
-        customer_id: lifetime_usage.subscription.customer_id,
-        subscription_id: lifetime_usage.subscription_id
+        nil, # current_user
+        customer: subscription.customer,
+        subscription: subscription
       )
       result.usage.amount_cents
     end

--- a/app/services/wallets/balance/refresh_ongoing_service.rb
+++ b/app/services/wallets/balance/refresh_ongoing_service.rb
@@ -12,9 +12,8 @@ module Wallets
         total_amount = customer.active_subscriptions.sum do |subscription|
           ::Invoices::CustomerUsageService.call(
             nil, # current_user
-            customer_id: customer.external_id,
-            subscription_id: subscription.external_id,
-            organization_id: customer.organization_id
+            customer: customer,
+            subscription: subscription
           ).invoice.total_amount
         end
         usage_credits_amount = total_amount.to_f.fdiv(wallet.rate_amount)

--- a/spec/services/invoices/customer_usage_service_spec.rb
+++ b/spec/services/invoices/customer_usage_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Invoices::CustomerUsageService, type: :service, cache: :memory do
   subject(:usage_service) do
-    described_class.new(membership.user, customer_id:, subscription_id:)
+    described_class.with_ids(membership.user, customer_id:, subscription_id:)
   end
 
   let(:membership) { create(:membership) }

--- a/spec/services/lifetime_usages/calculate_service_spec.rb
+++ b/spec/services/lifetime_usages/calculate_service_spec.rb
@@ -9,15 +9,93 @@ RSpec.describe LifetimeUsages::CalculateService, type: :service do
   let(:recalculate_current_usage) { true }
   let(:recalculate_invoiced_usage) { true }
   let(:subscription) { create(:subscription, customer_id: customer.id) }
+  let(:organization) { subscription.organization }
   let(:customer) { create(:customer) }
-  let(:invoices) { create_list(:invoice, 2, :finalized, subscription:, amounts_cents: [1000, 2000]) }
 
-  describe '#call' do
+  let(:invoice_subscription) { create(:invoice_subscription, invoice: invoice, subscription: subscription) }
+  let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
+  let(:charge) { create(:standard_charge, plan: subscription.plan, billable_metric:, properties: {amount: '10'}) }
+  let(:timestamp) { Time.current }
+  let(:fees) do
+    create_list(
+      :charge_fee,
+      2,
+      invoice:,
+      charge:,
+      amount_cents: 100,
+      precise_coupons_amount_cents: 50
+    )
+  end
+
+  let(:events) do
+    create_list(
+      :event,
+      2,
+      organization:,
+      subscription:,
+      customer:,
+      code: billable_metric.code,
+      timestamp:
+    )
+  end
+
+  describe '#recalculate_invoiced_usage' do
     context "without previous invoices" do
-      it "recalculates the invoiced_usage as zero" do
+      it "calculates the invoiced_usage as zero" do
         result = service.call
-
         expect(result.lifetime_usage.invoiced_usage_amount_cents).to be_zero
+      end
+    end
+
+    context "with draft invoice" do
+      let(:invoice) { create(:invoice, :draft) }
+
+      before do
+        invoice
+        invoice_subscription
+        fees
+      end
+
+      it "calculates the invoiced_usage as zero" do
+        result = service.call
+        expect(result.lifetime_usage.invoiced_usage_amount_cents).to be_zero
+      end
+    end
+
+    context "with finalized invoice" do
+      let(:invoice) { create(:invoice, :finalized) }
+
+      before do
+        invoice
+        invoice_subscription
+        fees
+      end
+
+      it "calculates the invoiced_usage_amount_cents correctly" do
+        result = service.call
+        expect(result.lifetime_usage.invoiced_usage_amount_cents).to eq(200)
+      end
+    end
+  end
+
+  describe '#recalculate_current_usage' do
+    context 'without usage' do
+      it 'calculates the current_usage as zero' do
+        result = service.call
+        expect(result.lifetime_usage.current_usage_amount_cents).to be_zero
+      end
+    end
+
+    context 'with usage' do
+      before do
+        events
+        charge
+        Rails.cache.clear
+      end
+
+      it 'calculates the current_usage_amount_cents correctly' do
+        result = service.call
+        expect(result.lifetime_usage.current_usage_amount_cents).to eq(2000)
       end
     end
   end

--- a/spec/services/lifetime_usages/calculate_service_spec.rb
+++ b/spec/services/lifetime_usages/calculate_service_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LifetimeUsages::CalculateService, type: :service do
+  subject(:service) { described_class.new(lifetime_usage: lifetime_usage) }
+
+  let(:lifetime_usage) { create(:lifetime_usage, subscription:, recalculate_current_usage:, recalculate_invoiced_usage:) }
+  let(:recalculate_current_usage) { true }
+  let(:recalculate_invoiced_usage) { true }
+  let(:subscription) { create(:subscription, customer_id: customer.id) }
+  let(:customer) { create(:customer) }
+  let(:invoices) { create_list(:invoice, 2, :finalized, subscription:, amounts_cents: [1000, 2000]) }
+
+  describe '#call' do
+  end
+end

--- a/spec/services/lifetime_usages/calculate_service_spec.rb
+++ b/spec/services/lifetime_usages/calculate_service_spec.rb
@@ -13,5 +13,12 @@ RSpec.describe LifetimeUsages::CalculateService, type: :service do
   let(:invoices) { create_list(:invoice, 2, :finalized, subscription:, amounts_cents: [1000, 2000]) }
 
   describe '#call' do
+    context "without previous invoices" do
+      it "recalculates the invoiced_usage as zero" do
+        result = service.call
+
+        expect(result.lifetime_usage.invoiced_usage_amount_cents).to be_zero
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR add the `LifetimeUsages::CalculateService`. This service is responsible for correctly calculating the `invoiced_usage` and `current_usage` amounts. 

Secondly a small refactor to the `CustomerUsageService` to differentiate between the 2 use-cases and streamline usage in the newly added `CalculateService`
