### PR TITLE
perf(active_storage) - add index that went missing when the record_id column changed type

### DIFF
--- a/db/migrate/20240812130655_re_add_unique_index_on_record_id.rb
+++ b/db/migrate/20240812130655_re_add_unique_index_on_record_id.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ReAddUniqueIndexOnRecordId < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :active_storage_attachments, [:record_type, :record_id, :name, :blob_id],
+      name: :index_active_storage_attachments_uniqueness,
+      unique: true,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+
+  def down
+    remove_index :active_storage_attachments, name: 'index_active_storage_attachments_uniqueness', algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_08_132042) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_12_130655) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_132042) do
     t.datetime "created_at", null: false
     t.uuid "record_id"
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
the `record_id` column was removed and re-added as a UUID (https://github.com/getlago/lago-api/commit/c36ce47a7ddf7c53eecfb9211c38c2bbe0ab6fe8) . This inadvertently removed the index that ActiveStorage adds when setting up the table. 

This MR adds that index again.