### PR TITLE
fix: incorrect country on credit note template

### DIFF
--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -341,7 +341,7 @@ html
               = organization.city
           - if organization.state.present?
             .body-2 = organization.state
-          .body-2 = ISO3166::Country.new(customer.country)&.common_name
+          .body-2 = ISO3166::Country.new(organization.country)&.common_name
           .body-2 = organization.email
           - if organization.tax_identification_number.present?
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)


### PR DESCRIPTION
## Context

Wrong country is displayed on organization section of the credit note template. It always display the customer country instead of the organization one 

## Description

This PR makes sure that the organization country is rendered.
