### PR TITLE
fix: Correct computation for paid in advance events

### DIFF
--- a/app/services/billable_metrics/aggregations/base_service.rb
+++ b/app/services/billable_metrics/aggregations/base_service.rb
@@ -36,9 +36,9 @@ module BillableMetrics
         raise NotImplementedError
       end
 
-      def per_event_aggregation
+      def per_event_aggregation(exclude_event: false)
         Result.new.tap do |result|
-          result.event_aggregation = compute_per_event_aggregation
+          result.event_aggregation = compute_per_event_aggregation(exclude_event:)
         end
       end
 

--- a/app/services/billable_metrics/aggregations/count_service.rb
+++ b/app/services/billable_metrics/aggregations/count_service.rb
@@ -47,7 +47,7 @@ module BillableMetrics
         (1..result.aggregation).to_a
       end
 
-      def compute_per_event_aggregation
+      def compute_per_event_aggregation(exclude_event:)
         (0...event_store.count).map { |_| 1 }
       end
     end

--- a/app/services/billable_metrics/aggregations/custom_service.rb
+++ b/app/services/billable_metrics/aggregations/custom_service.rb
@@ -66,7 +66,7 @@ module BillableMetrics
         result
       end
 
-      def compute_per_event_aggregation
+      def compute_per_event_aggregation(exclude_event:)
         # TODO: Implement custom aggregation logic returning 1 value per event
         event_store.events_properties
       end

--- a/app/services/billable_metrics/aggregations/max_service.rb
+++ b/app/services/billable_metrics/aggregations/max_service.rb
@@ -42,7 +42,7 @@ module BillableMetrics
         result.service_failure!(code: 'aggregation_failure', message: e.message)
       end
 
-      def compute_per_event_aggregation
+      def compute_per_event_aggregation(exclude_event:)
         max_value = event_store.max || 0
         event_values = event_store.events_values
         max_value_seen = false

--- a/app/services/billable_metrics/aggregations/sum_service.rb
+++ b/app/services/billable_metrics/aggregations/sum_service.rb
@@ -127,8 +127,8 @@ module BillableMetrics
         BigDecimal(result)
       end
 
-      def compute_per_event_aggregation
-        event_store.events_values(force_from: true)
+      def compute_per_event_aggregation(exclude_event:)
+        event_store.events_values(force_from: true, exclude_event:)
       end
 
       def handle_event_metadata(current_aggregation: nil, max_aggregation: nil, units_applied: nil)

--- a/app/services/billable_metrics/aggregations/unique_count_service.rb
+++ b/app/services/billable_metrics/aggregations/unique_count_service.rb
@@ -115,7 +115,7 @@ module BillableMetrics
         (1..result.aggregation).to_a
       end
 
-      def compute_per_event_aggregation
+      def compute_per_event_aggregation(exclude_event:)
         (0...event_store.events_values(force_from: true).count).map { |_| 1 }
       end
 

--- a/app/services/billable_metrics/prorated_aggregations/sum_service.rb
+++ b/app/services/billable_metrics/prorated_aggregations/sum_service.rb
@@ -99,13 +99,13 @@ module BillableMetrics
         event_store.prorated_events_values(period_duration)
       end
 
-      def per_event_aggregation
+      def per_event_aggregation(exclude_event: false)
         recurring_result = recurring_value
         recurring_aggregation = recurring_result ? [BigDecimal(recurring_result)] : []
         recurring_prorated_aggregation = recurring_result ? [BigDecimal(recurring_result) * persisted_pro_rata] : []
 
         Result.new.tap do |result|
-          result.event_aggregation = recurring_aggregation + base_aggregator.compute_per_event_aggregation
+          result.event_aggregation = recurring_aggregation + base_aggregator.compute_per_event_aggregation(exclude_event:)
           result.event_prorated_aggregation = recurring_prorated_aggregation + compute_per_event_prorated_aggregation
         end
       end

--- a/app/services/charges/apply_pay_in_advance_charge_model_service.rb
+++ b/app/services/charges/apply_pay_in_advance_charge_model_service.rb
@@ -53,20 +53,22 @@ module Charges
     end
 
     def amount_including_event
-      charge_model.apply(charge:, aggregation_result:, properties:).amount
+      @amount_including_event ||= charge_model.apply(charge:, aggregation_result:, properties:).amount
     end
 
     def amount_excluding_event
+      return @amount_excluding_event if defined?(@amount_excluding_event)
+
       previous_result = BaseService::Result.new
       previous_result.aggregation = aggregation_result.aggregation - aggregation_result.pay_in_advance_aggregation
       previous_result.count = aggregation_result.count - 1
       previous_result.options = aggregation_result.options
       previous_result.aggregator = aggregation_result.aggregator
 
-      charge_model.apply(
+      @amount_excluding_event ||= charge_model.apply(
         charge:,
         aggregation_result: previous_result,
-        properties: (properties || {}).merge(ignore_last_event: true)
+        properties: (properties || {}).merge(exclude_event: true)
       ).amount
     end
 

--- a/app/services/events/stores/base_store.rb
+++ b/app/services/events/stores/base_store.rb
@@ -8,6 +8,8 @@ module Events
         @subscription = subscription
         @boundaries = boundaries
 
+        @filters = filters
+
         @grouped_by = filters[:grouped_by]
         @grouped_by_values = filters[:grouped_by_values]
 
@@ -113,7 +115,7 @@ module Events
 
       protected
 
-      attr_accessor :code, :subscription, :boundaries, :grouped_by_values, :matching_filters, :ignored_filters
+      attr_accessor :code, :subscription, :boundaries, :grouped_by_values, :filters, :matching_filters, :ignored_filters
 
       delegate :customer, to: :subscription
 

--- a/app/services/events/stores/clickhouse_store.rb
+++ b/app/services/events/stores/clickhouse_store.rb
@@ -22,9 +22,10 @@ module Events
         filters_scope(scope)
       end
 
-      def events_values(limit: nil, force_from: false)
+      def events_values(limit: nil, force_from: false, exclude_event: false)
         scope = events(force_from:).group(DEDUPLICATION_GROUP)
 
+        scope = scope.where('events_raw.transaction_id != ?', filters[:event].transaction_id) if exclude_event
         scope = scope.limit(limit) if limit
 
         scope.pluck(Arel.sql(sanitized_numeric_property))

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -21,11 +21,12 @@ module Events
         filters_scope(scope)
       end
 
-      def events_values(limit: nil, force_from: false)
+      def events_values(limit: nil, force_from: false, exclude_event: false)
         field_name = sanitized_property_name
         field_name = "(#{field_name})::numeric" if numeric_property
 
         scope = events(force_from:)
+        scope = scope.where.not(transaction_id: filters[:event].transaction_id) if exclude_event
         scope = scope.limit(limit) if limit
 
         scope.pluck(Arel.sql(field_name))

--- a/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
+++ b/spec/services/charges/apply_pay_in_advance_charge_model_service_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Charges::ApplyPayInAdvanceChargeModelService, type: :service do
           .and_return(BaseService::Result.new.tap { |r| r.amount = 10 })
 
         allow(charge_model_class).to receive(:apply)
-          .with(charge:, aggregation_result: previous_agg_result, properties: properties.merge(ignore_last_event: true))
+          .with(charge:, aggregation_result: previous_agg_result, properties: properties.merge(exclude_event: true))
           .and_return(BaseService::Result.new.tap { |r| r.amount = 8 })
 
         result = charge_service.call

--- a/spec/services/events/stores/clickhouse_store_spec.rb
+++ b/spec/services/events/stores/clickhouse_store_spec.rb
@@ -527,6 +527,43 @@ RSpec.describe Events::Stores::ClickhouseStore, type: :service, clickhouse: true
 
       expect(event_store.events_values).to eq([1, 2, 3, 4, 5])
     end
+
+    context 'when exclude_event is true' do
+      subject(:event_store) do
+        described_class.new(
+          code:,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by:,
+            grouped_by_values:,
+            matching_filters:,
+            ignored_filters:,
+            event:
+          }
+        )
+      end
+
+      let(:event) do
+        Clickhouse::EventsRaw.create!(
+          transaction_id: SecureRandom.uuid,
+          organization_id: organization.id,
+          external_subscription_id: subscription.external_id,
+          external_customer_id: customer.external_id,
+          code:,
+          timestamp: boundaries[:from_datetime] + 1.day,
+          properties: {billable_metric.field_name => 6}
+        )
+      end
+
+      it 'excludes current event but returns the value attached to other events' do
+        event
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
+
+        expect(event_store.events_values(exclude_event: true)).to eq([1, 2, 3, 4, 5])
+      end
+    end
   end
 
   describe '.last_event' do

--- a/spec/services/events/stores/postgres_store_spec.rb
+++ b/spec/services/events/stores/postgres_store_spec.rb
@@ -532,6 +532,42 @@ RSpec.describe Events::Stores::PostgresStore, type: :service do
 
       expect(event_store.events_values).to eq([1, 2, 3, 4, 5])
     end
+
+    context 'when exclude_event is true' do
+      subject(:event_store) do
+        described_class.new(
+          code:,
+          subscription:,
+          boundaries:,
+          filters: {
+            grouped_by:,
+            grouped_by_values:,
+            matching_filters:,
+            ignored_filters:,
+            event:
+          }
+        )
+      end
+
+      let(:event) do
+        create(
+          :event,
+          organization:,
+          external_subscription_id: subscription.external_id,
+          code:,
+          timestamp: boundaries[:from_datetime] + 1.day,
+          properties: {billable_metric.field_name => 6}
+        )
+      end
+
+      it 'excludes current event but returns the value attached to other events' do
+        event
+        event_store.aggregation_property = billable_metric.field_name
+        event_store.numeric_property = true
+
+        expect(event_store.events_values(exclude_event: true)).to eq([1, 2, 3, 4, 5])
+      end
+    end
   end
 
   describe '#last_event' do


### PR DESCRIPTION
When an event is created for a paid-in-advance charge, by regrouping all fees in a single invoice at the end of the period, we were excluding the last event for computing the amount.

In the case an event was created in the future, we should not remove the last event.

The goal of this PR is to fix this issue by excluding the appropriate event before doing the aggregation.

Example before:
![Screenshot 2024-08-12 at 18 25 10](https://github.com/user-attachments/assets/46820b59-ee12-4da1-a1de-446effc68a87)

Example after:
![Screenshot 2024-08-12 at 17 33 43](https://github.com/user-attachments/assets/ee7d8eb5-ac5b-4656-b77b-c15258dbcb10)

