### PR TITLE
Feat(Wallet):  Add metadata to wallet transactions

### DIFF
--- a/app/controllers/api/v1/wallet_transactions_controller.rb
+++ b/app/controllers/api/v1/wallet_transactions_controller.rb
@@ -56,7 +56,11 @@ module Api
           :paid_credits,
           :granted_credits,
           :voided_credits,
-          :invoice_requires_successful_payment
+          :invoice_requires_successful_payment,
+          metadata: [
+            :key,
+            :value
+          ]
         )
       end
     end

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -81,6 +81,10 @@ module Api
           :granted_credits,
           :expiration_at,
           :invoice_requires_successful_payment,
+          transaction_metadata: [
+            :key,
+            :value
+          ],
           recurring_transaction_rules: [
             :granted_credits,
             :interval,

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -95,7 +95,7 @@ module Api
             :threshold_credits,
             :trigger,
             :invoice_requires_successful_payment,
-            metadata: [
+            transaction_metadata: [
               :key,
               :value
             ]
@@ -123,7 +123,7 @@ module Api
             :paid_credits,
             :granted_credits,
             :invoice_requires_successful_payment,
-            metadata: [
+            transaction_metadata: [
               :key,
               :value
             ]

--- a/app/controllers/api/v1/wallets_controller.rb
+++ b/app/controllers/api/v1/wallets_controller.rb
@@ -94,7 +94,11 @@ module Api
             :target_ongoing_balance,
             :threshold_credits,
             :trigger,
-            :invoice_requires_successful_payment
+            :invoice_requires_successful_payment,
+            metadata: [
+              :key,
+              :value
+            ]
           ]
         )
       end
@@ -118,7 +122,11 @@ module Api
             :trigger,
             :paid_credits,
             :granted_credits,
-            :invoice_requires_successful_payment
+            :invoice_requires_successful_payment,
+            metadata: [
+              :key,
+              :value
+            ]
           ]
         )
       end

--- a/app/serializers/v1/wallet_transaction_serializer.rb
+++ b/app/serializers/v1/wallet_transaction_serializer.rb
@@ -7,13 +7,15 @@ module V1
         lago_id: model.id,
         lago_wallet_id: model.wallet_id,
         status: model.status,
+        source: model.source,
         transaction_status: model.transaction_status,
         transaction_type: model.transaction_type,
         amount: model.amount,
         credit_amount: model.credit_amount,
         settled_at: model.settled_at&.iso8601,
         created_at: model.created_at.iso8601,
-        invoice_requires_successful_payment: model.invoice_requires_successful_payment?
+        invoice_requires_successful_payment: model.invoice_requires_successful_payment?,
+        metadata: model.metadata
       }
     end
   end

--- a/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
+++ b/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
@@ -16,7 +16,7 @@ module V1
           trigger: model.trigger,
           created_at: model.created_at.iso8601,
           invoice_requires_successful_payment: model.invoice_requires_successful_payment?,
-          metadata: model.metadata
+          transaction_metadata: model.transaction_metadata
         }
       end
     end

--- a/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
+++ b/app/serializers/v1/wallets/recurring_transaction_rule_serializer.rb
@@ -15,7 +15,8 @@ module V1
           threshold_credits: model.threshold_credits,
           trigger: model.trigger,
           created_at: model.created_at.iso8601,
-          invoice_requires_successful_payment: model.invoice_requires_successful_payment?
+          invoice_requires_successful_payment: model.invoice_requires_successful_payment?,
+          metadata: model.metadata
         }
       end
     end

--- a/app/services/validators/metadata_validator.rb
+++ b/app/services/validators/metadata_validator.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Validators
+  class MetadataValidator
+    DEFAULT_CONFIG = {
+      max_keys: 5,
+      max_key_length: 20,
+      max_value_length: 40
+    }.freeze
+
+    attr_reader :metadata, :errors, :config
+
+    def initialize(metadata, config = {})
+      @metadata = metadata || []
+      @errors = {}
+      @config = DEFAULT_CONFIG.merge(config)
+    end
+
+    def valid?
+      return true if metadata.empty?
+
+      validate_size
+      metadata.each { |item| validate_item(item) }
+
+      errors.empty?
+    end
+
+    private
+
+    def validate_size
+      errors[:metadata] = 'too_many_keys' if metadata.size > config[:max_keys]
+    end
+
+    def validate_item(item)
+      unless item.is_a?(Hash) && item.keys.sort == [:key, :value] && item[:key] && item[:value]
+        errors[:metadata] = 'invalid_key_value_pair'
+        return
+      end
+
+      validate_key_length(item[:key])
+      validate_value_length(item[:value])
+      validate_structure(item[:value])
+    end
+
+    def validate_key_length(key)
+      errors[:metadata] = 'key_too_long' if key.length > config[:max_key_length]
+    end
+
+    def validate_value_length(value)
+      errors[:metadata] = 'value_too_long' if value.is_a?(String) && value.length > config[:max_value_length]
+    end
+
+    def validate_structure(value)
+      errors[:metadata] = 'nested_structure_not_allowed' if value.is_a?(Hash) || value.is_a?(Array)
+    end
+  end
+end

--- a/app/services/validators/metadata_validator.rb
+++ b/app/services/validators/metadata_validator.rb
@@ -32,14 +32,14 @@ module Validators
     end
 
     def validate_item(item)
-      unless item.is_a?(Hash) && item.keys.sort == [:key, :value] && item[:key] && item[:value]
+      unless item.is_a?(Hash) && item.keys.sort == %w[key value] && item['key'] && item['value']
         errors[:metadata] = 'invalid_key_value_pair'
         return
       end
 
-      validate_key_length(item[:key])
-      validate_value_length(item[:value])
-      validate_structure(item[:value])
+      validate_key_length(item['key'])
+      validate_value_length(item['value'])
+      validate_structure(item['value'])
     end
 
     def validate_key_length(key)

--- a/app/services/wallet_transactions/create_service.rb
+++ b/app/services/wallet_transactions/create_service.rb
@@ -14,6 +14,7 @@ module WalletTransactions
 
       wallet_transactions = []
       @source = params[:source] || :manual
+      @metadata = params[:metadata] || {}
       invoice_requires_successful_payment = if params.key?(:invoice_requires_successful_payment)
         ActiveModel::Type::Boolean.new.cast(params[:invoice_requires_successful_payment])
       else
@@ -43,7 +44,7 @@ module WalletTransactions
         void_result = WalletTransactions::VoidService.call(
           wallet: result.current_wallet,
           credits: params[:voided_credits],
-          from_source: source
+          from_source: source, metadata:
         )
         wallet_transactions << void_result.wallet_transaction
       end
@@ -58,7 +59,7 @@ module WalletTransactions
 
     private
 
-    attr_reader :organization, :params, :source
+    attr_reader :organization, :params, :source, :metadata
 
     def handle_paid_credits(wallet:, paid_credits:, invoice_requires_successful_payment:)
       paid_credits_amount = BigDecimal(paid_credits)
@@ -73,7 +74,8 @@ module WalletTransactions
         status: :pending,
         source:,
         transaction_status: :purchased,
-        invoice_requires_successful_payment:
+        invoice_requires_successful_payment:,
+        metadata:
       )
 
       BillPaidCreditJob.perform_later(wallet_transaction, Time.current.to_i)
@@ -96,7 +98,8 @@ module WalletTransactions
           settled_at: Time.current,
           source:,
           transaction_status: :granted,
-          invoice_requires_successful_payment:
+          invoice_requires_successful_payment:,
+          metadata:
         )
 
         Wallets::Balance::IncreaseService.new(

--- a/app/services/wallet_transactions/validate_service.rb
+++ b/app/services/wallet_transactions/validate_service.rb
@@ -7,6 +7,7 @@ module WalletTransactions
       valid_paid_credits_amount? if args[:paid_credits]
       valid_granted_credits_amount? if args[:granted_credits]
       valid_voided_credits_amount? if args[:voided_credits] && result.current_wallet
+      valid_metadata? if args[:metadata]
 
       if errors?
         result.validation_failure!(errors:)
@@ -48,6 +49,18 @@ module WalletTransactions
 
       if BigDecimal(args[:voided_credits]) > result.current_wallet.credits_balance
         return add_error(field: :voided_credits, error_code: 'insufficient_credits')
+      end
+
+      true
+    end
+
+    def valid_metadata?
+      validator = ::Validators::MetadataValidator.new(args[:metadata])
+      unless validator.valid?
+        validator.errors.each do |field, error_code|
+          add_error(field: field, error_code: error_code)
+        end
+        return false
       end
 
       true

--- a/app/services/wallet_transactions/void_service.rb
+++ b/app/services/wallet_transactions/void_service.rb
@@ -2,10 +2,11 @@
 
 module WalletTransactions
   class VoidService < BaseService
-    def initialize(wallet:, credits:, from_source: :manual)
+    def initialize(wallet:, credits:, from_source: :manual, metadata: {})
       @wallet = wallet
       @credits = credits
       @from_source = from_source
+      @metadata = metadata
 
       super
     end
@@ -21,7 +22,8 @@ module WalletTransactions
           status: :settled,
           settled_at: Time.current,
           source: from_source,
-          transaction_status: :voided
+          transaction_status: :voided,
+          metadata:
         )
         Wallets::Balance::DecreaseService.new(wallet:, credits_amount:).call
         result.wallet_transaction = wallet_transaction
@@ -32,7 +34,7 @@ module WalletTransactions
 
     private
 
-    attr_reader :wallet, :credits, :from_source
+    attr_reader :wallet, :credits, :from_source, :metadata
 
     def credits_amount
       @credits_amount ||= BigDecimal(credits)

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -13,7 +13,8 @@ module Wallets
             paid_credits: paid_credits(recurring_transaction_rule),
             granted_credits: granted_credits(recurring_transaction_rule),
             source: :interval,
-            invoice_requires_successful_payment: recurring_transaction_rule.invoice_requires_successful_payment?
+            invoice_requires_successful_payment: recurring_transaction_rule.invoice_requires_successful_payment?,
+            metadata: recurring_transaction_rule.metadata
           }
         )
       end

--- a/app/services/wallets/create_interval_wallet_transactions_service.rb
+++ b/app/services/wallets/create_interval_wallet_transactions_service.rb
@@ -14,7 +14,7 @@ module Wallets
             granted_credits: granted_credits(recurring_transaction_rule),
             source: :interval,
             invoice_requires_successful_payment: recurring_transaction_rule.invoice_requires_successful_payment?,
-            metadata: recurring_transaction_rule.metadata
+            metadata: recurring_transaction_rule.transaction_metadata
           }
         )
       end

--- a/app/services/wallets/create_service.rb
+++ b/app/services/wallets/create_service.rb
@@ -47,7 +47,8 @@ module Wallets
           wallet_id: wallet.id,
           paid_credits: params[:paid_credits],
           granted_credits: params[:granted_credits],
-          source: :manual
+          source: :manual,
+          metadata: params[:transaction_metadata]
         }
       )
 

--- a/app/services/wallets/recurring_transaction_rules/create_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/create_service.rb
@@ -27,7 +27,7 @@ module Wallets
           started_at: rule_params[:started_at],
           target_ongoing_balance: rule_params[:target_ongoing_balance],
           trigger: rule_params[:trigger].to_s,
-          metadata: rule_params[:metadata] || {}
+          transaction_metadata: rule_params[:transaction_metadata] || {}
         }
 
         attributes[:invoice_requires_successful_payment] = if rule_params.key?(:invoice_requires_successful_payment)

--- a/app/services/wallets/recurring_transaction_rules/create_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/create_service.rb
@@ -26,7 +26,8 @@ module Wallets
           method:,
           started_at: rule_params[:started_at],
           target_ongoing_balance: rule_params[:target_ongoing_balance],
-          trigger: rule_params[:trigger].to_s
+          trigger: rule_params[:trigger].to_s,
+          metadata: rule_params[:metadata] || {}
         }
 
         attributes[:invoice_requires_successful_payment] = if rule_params.key?(:invoice_requires_successful_payment)

--- a/app/services/wallets/recurring_transaction_rules/validate_service.rb
+++ b/app/services/wallets/recurring_transaction_rules/validate_service.rb
@@ -12,6 +12,7 @@ module Wallets
         return false unless valid_trigger?
         return false unless valid_method?
         return false unless valid_credits?
+        return false unless valid_metadata?
 
         true
       end
@@ -55,6 +56,10 @@ module Wallets
 
       def valid_decimal?(value)
         ::Validators::DecimalAmountService.new(value).valid_decimal?
+      end
+
+      def valid_metadata?
+        ::Validators::MetadataValidator.new(params[:metadata]).valid?
       end
     end
   end

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -19,7 +19,8 @@ module Wallets
           paid_credits:,
           granted_credits:,
           source: :threshold,
-          invoice_requires_successful_payment: threshold_rule.invoice_requires_successful_payment?
+          invoice_requires_successful_payment: threshold_rule.invoice_requires_successful_payment?,
+          metadata: threshold_rule.metadata
         }
       )
     end

--- a/app/services/wallets/threshold_top_up_service.rb
+++ b/app/services/wallets/threshold_top_up_service.rb
@@ -20,7 +20,7 @@ module Wallets
           granted_credits:,
           source: :threshold,
           invoice_requires_successful_payment: threshold_rule.invoice_requires_successful_payment?,
-          metadata: threshold_rule.metadata
+          metadata: threshold_rule.transaction_metadata
         }
       )
     end

--- a/app/services/wallets/validate_service.rb
+++ b/app/services/wallets/validate_service.rb
@@ -8,6 +8,7 @@ module Wallets
       valid_granted_credits_amount? if args[:granted_credits]
       valid_expiration_at? if args[:expiration_at]
       valid_recurring_transaction_rules? if args[:recurring_transaction_rules].present?
+      valid_metadata? if args[:transaction_metadata]
 
       if errors?
         result.validation_failure!(errors:)
@@ -73,6 +74,18 @@ module Wallets
       unless Wallets::RecurringTransactionRules::ValidateService.call(params: args[:recurring_transaction_rules].first)
         add_error(field: :recurring_transaction_rules, error_code: "invalid_recurring_rule")
       end
+    end
+
+    def valid_metadata?
+      validator = ::Validators::MetadataValidator.new(args[:transaction_metadata])
+      unless validator.valid?
+        validator.errors.each do |field, error_code|
+          add_error(field: field, error_code: error_code)
+        end
+        return false
+      end
+
+      true
     end
   end
 end

--- a/db/migrate/20240807100609_add_metadata_to_wallet_transactions.rb
+++ b/db/migrate/20240807100609_add_metadata_to_wallet_transactions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMetadataToWalletTransactions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :wallet_transactions, :metadata, :jsonb, default: {}
+  end
+end

--- a/db/migrate/20240808085506_add_metadata_to_recurring_transaction_rules.rb
+++ b/db/migrate/20240808085506_add_metadata_to_recurring_transaction_rules.rb
@@ -2,6 +2,6 @@
 
 class AddMetadataToRecurringTransactionRules < ActiveRecord::Migration[7.1]
   def change
-    add_column :recurring_transaction_rules, :metadata, :jsonb, default: {}
+    add_column :recurring_transaction_rules, :transaction_metadata, :jsonb, default: {}
   end
 end

--- a/db/migrate/20240808085506_add_metadata_to_recurring_transaction_rules.rb
+++ b/db/migrate/20240808085506_add_metadata_to_recurring_transaction_rules.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMetadataToRecurringTransactionRules < ActiveRecord::Migration[7.1]
+  def change
+    add_column :recurring_transaction_rules, :metadata, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -966,7 +966,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_12_130655) do
     t.decimal "target_ongoing_balance", precision: 30, scale: 5
     t.datetime "started_at"
     t.boolean "invoice_requires_successful_payment", default: false, null: false
-    t.jsonb "metadata", default: {}
+    t.jsonb "transaction_metadata", default: {}
     t.index ["started_at"], name: "index_recurring_transaction_rules_on_started_at"
     t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -966,6 +966,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_12_130655) do
     t.decimal "target_ongoing_balance", precision: 30, scale: 5
     t.datetime "started_at"
     t.boolean "invoice_requires_successful_payment", default: false, null: false
+    t.jsonb "metadata", default: {}
     t.index ["started_at"], name: "index_recurring_transaction_rules_on_started_at"
     t.index ["wallet_id"], name: "index_recurring_transaction_rules_on_wallet_id"
   end
@@ -1070,6 +1071,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_12_130655) do
     t.integer "source", default: 0, null: false
     t.integer "transaction_status", default: 0, null: false
     t.boolean "invoice_requires_successful_payment", default: false, null: false
+    t.jsonb "metadata", default: {}
     t.index ["invoice_id"], name: "index_wallet_transactions_on_invoice_id"
     t.index ["wallet_id"], name: "index_wallet_transactions_on_wallet_id"
   end

--- a/spec/requests/api/v1/wallet_transactions_controller_spec.rb
+++ b/spec/requests/api/v1/wallet_transactions_controller_spec.rb
@@ -62,6 +62,28 @@ RSpec.describe Api::V1::WalletTransactionsController, type: :request do
       end
     end
 
+    context 'when metadata is present' do
+      let(:params) do
+        {
+          wallet_id:,
+          paid_credits: '10',
+          granted_credits: '10',
+          metadata: [{'key' => 'valid_value', 'value' => 'also_valid'}]
+        }
+      end
+
+      it 'creates the wallet transactions with correct data' do
+        post_with_token(organization, '/api/v1/wallet_transactions', {wallet_transaction: params})
+
+        expect(response).to have_http_status(:success)
+        expect(json[:wallet_transactions].count).to eq(2)
+        expect(json[:wallet_transactions].first[:metadata]).to be_present
+        expect(json[:wallet_transactions].second[:metadata]).to be_present
+        expect(json[:wallet_transactions].first[:metadata]).to include(key: 'valid_value', value: 'also_valid')
+        expect(json[:wallet_transactions].second[:metadata]).to include(key: 'valid_value', value: 'also_valid')
+      end
+    end
+
     context 'when wallet does not exist' do
       let(:wallet_id) { "#{wallet.id}123" }
 

--- a/spec/requests/api/v1/wallets_controller_spec.rb
+++ b/spec/requests/api/v1/wallets_controller_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
         end
       end
 
-      context 'with metadata' do
+      context 'with transaction metadata' do
         let(:create_params) do
           {
             external_customer_id: customer.external_id,
@@ -192,13 +192,13 @@ RSpec.describe Api::V1::WalletsController, type: :request do
                 trigger: 'interval',
                 interval: 'monthly',
                 invoice_requires_successful_payment: true,
-                metadata:
+                transaction_metadata:
               }
             ]
           }
         end
 
-        let(:metadata) { [{key: 'valid_value', value: 'also_valid'}] }
+        let(:transaction_metadata) { [{key: 'valid_value', value: 'also_valid'}] }
 
         it 'create the rule with correct metadata' do
           post_with_token(organization, '/api/v1/wallets', {wallet: create_params})
@@ -208,7 +208,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           aggregate_failures do
             expect(response).to have_http_status(:success)
             expect(recurring_rules).to be_present
-            expect(recurring_rules.first[:metadata]).to eq(metadata)
+            expect(recurring_rules.first[:transaction_metadata]).to eq(transaction_metadata)
           end
         end
       end
@@ -301,7 +301,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
         end
       end
 
-      context 'when metadata is set' do
+      context 'when transaction metadata is set' do
         let(:update_params) do
           {
             name: 'wallet1',
@@ -314,13 +314,13 @@ RSpec.describe Api::V1::WalletsController, type: :request do
                 paid_credits: '105',
                 granted_credits: '105',
                 target_ongoing_balance: '300',
-                metadata: update_metadata
+                transaction_metadata: update_transaction_metadata
               }
             ]
           }
         end
 
-        let(:update_metadata) { [{key: 'update_key', value: 'update_value'}] }
+        let(:update_transaction_metadata) { [{key: 'update_key', value: 'update_value'}] }
 
         it 'updates the rule' do
           put_with_token(
@@ -333,7 +333,7 @@ RSpec.describe Api::V1::WalletsController, type: :request do
           aggregate_failures do
             expect(response).to have_http_status(:success)
             expect(recurring_rules).to be_present
-            expect(recurring_rules.first[:metadata]).to eq(update_metadata)
+            expect(recurring_rules.first[:transaction_metadata]).to eq(update_transaction_metadata)
           end
         end
       end

--- a/spec/serializers/v1/wallet_transaction_serializer_spec.rb
+++ b/spec/serializers/v1/wallet_transaction_serializer_spec.rb
@@ -17,13 +17,15 @@ RSpec.describe ::V1::WalletTransactionSerializer do
         'lago_id' => wallet_transaction.id,
         'lago_wallet_id' => wallet_transaction.wallet_id,
         'status' => wallet_transaction.status,
+        'source' => wallet_transaction.source,
         'transaction_status' => wallet_transaction.transaction_status,
         'transaction_type' => wallet_transaction.transaction_type,
         'amount' => wallet_transaction.amount.to_s,
         'credit_amount' => wallet_transaction.credit_amount.to_s,
         'settled_at' => wallet_transaction.settled_at&.iso8601,
         'created_at' => wallet_transaction.created_at.iso8601,
-        'invoice_requires_successful_payment' => wallet_transaction.invoice_requires_successful_payment
+        'invoice_requires_successful_payment' => wallet_transaction.invoice_requires_successful_payment,
+        'metadata' => wallet_transaction.metadata
       )
     end
   end

--- a/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
+++ b/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe ::V1::Wallets::RecurringTransactionRuleSerializer do
       "threshold_credits" => recurring_transaction_rule.threshold_credits.to_s,
       "granted_credits" => recurring_transaction_rule.granted_credits.to_s,
       "created_at" => recurring_transaction_rule.created_at.iso8601,
-      "invoice_requires_successful_payment" => recurring_transaction_rule.invoice_requires_successful_payment
+      "invoice_requires_successful_payment" => recurring_transaction_rule.invoice_requires_successful_payment,
+      "metadata" => recurring_transaction_rule.metadata
     )
   end
 end

--- a/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
+++ b/spec/serializers/v1/wallets/recurring_transaction_rule_serializer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ::V1::Wallets::RecurringTransactionRuleSerializer do
       "granted_credits" => recurring_transaction_rule.granted_credits.to_s,
       "created_at" => recurring_transaction_rule.created_at.iso8601,
       "invoice_requires_successful_payment" => recurring_transaction_rule.invoice_requires_successful_payment,
-      "metadata" => recurring_transaction_rule.metadata
+      "transaction_metadata" => recurring_transaction_rule.transaction_metadata
     )
   end
 end

--- a/spec/services/validators/metadata_validator_spec.rb
+++ b/spec/services/validators/metadata_validator_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Validators::MetadataValidator, type: :validator do
   let(:max_value_length) { Validators::MetadataValidator::DEFAULT_CONFIG[:max_value_length] }
 
   describe '.valid?' do
-    let(:metadata) { [{key: 'valid_key', value: 'valid_value'}] }
+    let(:metadata) { [{'key' => 'valid_key', 'value' => 'valid_value'}] }
 
     it 'returns true for valid metadata' do
       expect(metadata_validator).to be_valid
     end
 
     context 'when metadata has too many key-value pairs' do
-      let(:metadata) { (1..max_keys + 1).map { |i| {key: "key#{i}", value: "value#{i}"} } }
+      let(:metadata) { (1..max_keys + 1).map { |i| {'key' => "key#{i}", 'value' => "value#{i}"} } }
 
       it 'returns false' do
         expect(metadata_validator).not_to be_valid
@@ -26,7 +26,7 @@ RSpec.describe Validators::MetadataValidator, type: :validator do
     end
 
     context 'when metadata contains a key that is too long' do
-      let(:metadata) { [{key: 'a' * (max_key_length + 1), value: 'valid'}] }
+      let(:metadata) { [{'key' => 'a' * (max_key_length + 1), 'value' => 'valid'}] }
 
       it 'returns false' do
         expect(metadata_validator).not_to be_valid
@@ -35,7 +35,7 @@ RSpec.describe Validators::MetadataValidator, type: :validator do
     end
 
     context 'when metadata contains a value that is too long' do
-      let(:metadata) { [{key: 'key', value: 'a' * (max_value_length + 1)}] }
+      let(:metadata) { [{'key' => 'key', 'value' => 'a' * (max_value_length + 1)}] }
 
       it 'returns false' do
         expect(metadata_validator).not_to be_valid
@@ -44,7 +44,7 @@ RSpec.describe Validators::MetadataValidator, type: :validator do
     end
 
     context 'when metadata contains nested structures as value' do
-      let(:metadata) { [{key: 'key', value: {key: 'nested_value'}}] }
+      let(:metadata) { [{'key' => 'key', 'value' => {'key' => 'nested_value'}}] }
 
       it 'returns false' do
         expect(metadata_validator).not_to be_valid
@@ -53,7 +53,7 @@ RSpec.describe Validators::MetadataValidator, type: :validator do
     end
 
     context 'when metadata is a single hash instead of an array' do
-      let(:metadata) { {key: 'fixed', value: '0'} }
+      let(:metadata) { {'key' => 'fixed', 'value' => '0'} }
 
       it 'returns false' do
         expect(metadata_validator).not_to be_valid
@@ -62,7 +62,7 @@ RSpec.describe Validators::MetadataValidator, type: :validator do
     end
 
     context 'when metadata contains a hash with invalid key-value pair structure' do
-      let(:metadata) { [{key1: 'value1', key2: 'value2'}] }
+      let(:metadata) { [{'key1' => 'value1', 'key2' => 'value2'}] }
 
       it 'returns false' do
         expect(metadata_validator).not_to be_valid

--- a/spec/services/validators/metadata_validator_spec.rb
+++ b/spec/services/validators/metadata_validator_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Validators::MetadataValidator, type: :validator do
+  subject(:metadata_validator) { described_class.new(metadata) }
+
+  let(:max_keys) { Validators::MetadataValidator::DEFAULT_CONFIG[:max_keys] }
+  let(:max_key_length) { Validators::MetadataValidator::DEFAULT_CONFIG[:max_key_length] }
+  let(:max_value_length) { Validators::MetadataValidator::DEFAULT_CONFIG[:max_value_length] }
+
+  describe '.valid?' do
+    let(:metadata) { [{key: 'valid_key', value: 'valid_value'}] }
+
+    it 'returns true for valid metadata' do
+      expect(metadata_validator).to be_valid
+    end
+
+    context 'when metadata has too many key-value pairs' do
+      let(:metadata) { (1..max_keys + 1).map { |i| {key: "key#{i}", value: "value#{i}"} } }
+
+      it 'returns false' do
+        expect(metadata_validator).not_to be_valid
+        expect(metadata_validator.errors[:metadata]).to include('too_many_keys')
+      end
+    end
+
+    context 'when metadata contains a key that is too long' do
+      let(:metadata) { [{key: 'a' * (max_key_length + 1), value: 'valid'}] }
+
+      it 'returns false' do
+        expect(metadata_validator).not_to be_valid
+        expect(metadata_validator.errors[:metadata]).to include('key_too_long')
+      end
+    end
+
+    context 'when metadata contains a value that is too long' do
+      let(:metadata) { [{key: 'key', value: 'a' * (max_value_length + 1)}] }
+
+      it 'returns false' do
+        expect(metadata_validator).not_to be_valid
+        expect(metadata_validator.errors[:metadata]).to include('value_too_long')
+      end
+    end
+
+    context 'when metadata contains nested structures as value' do
+      let(:metadata) { [{key: 'key', value: {key: 'nested_value'}}] }
+
+      it 'returns false' do
+        expect(metadata_validator).not_to be_valid
+        expect(metadata_validator.errors[:metadata]).to include('nested_structure_not_allowed')
+      end
+    end
+
+    context 'when metadata is a single hash instead of an array' do
+      let(:metadata) { {key: 'fixed', value: '0'} }
+
+      it 'returns false' do
+        expect(metadata_validator).not_to be_valid
+        expect(metadata_validator.errors[:metadata]).to include('invalid_key_value_pair')
+      end
+    end
+
+    context 'when metadata contains a hash with invalid key-value pair structure' do
+      let(:metadata) { [{key1: 'value1', key2: 'value2'}] }
+
+      it 'returns false' do
+        expect(metadata_validator).not_to be_valid
+        expect(metadata_validator.errors[:metadata]).to include('invalid_key_value_pair')
+      end
+    end
+
+    context 'when metadata is empty' do
+      let(:metadata) {}
+
+      it 'returns true' do
+        expect(metadata_validator).to be_valid
+      end
+    end
+
+    context 'when metadata is an empty array' do
+      let(:metadata) { [] }
+
+      it 'returns true' do
+        expect(metadata_validator).to be_valid
+      end
+    end
+  end
+end

--- a/spec/services/wallet_transactions/create_service_spec.rb
+++ b/spec/services/wallet_transactions/create_service_spec.rb
@@ -80,6 +80,28 @@ RSpec.describe WalletTransactions::CreateService, type: :service do
       end.to have_enqueued_job(SendWebhookJob).thrice.with('wallet_transaction.created', WalletTransaction)
     end
 
+    context 'with valid metadata' do
+      let(:metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
+      let(:params) do
+        {
+          wallet_id: wallet.id,
+          paid_credits:,
+          granted_credits:,
+          voided_credits:,
+          source: :manual,
+          metadata: metadata
+        }
+      end
+
+      it 'processes the transaction normally and includes the metadata' do
+        expect(create_service).to be_success
+        transactions = WalletTransaction.where(wallet_id: wallet.id)
+        expect(transactions.first.metadata).to include('key' => 'valid_value', 'value' => 'also_valid')
+        expect(transactions.second.metadata).to include('key' => 'valid_value', 'value' => 'also_valid')
+        expect(transactions.third.metadata).to include('key' => 'valid_value', 'value' => 'also_valid')
+      end
+    end
+
     context 'with validation error' do
       let(:paid_credits) { '-15.00' }
 

--- a/spec/services/wallet_transactions/validate_service_spec.rb
+++ b/spec/services/wallet_transactions/validate_service_spec.rb
@@ -77,5 +77,24 @@ RSpec.describe WalletTransactions::ValidateService, type: :service do
         expect(result.error.messages[:voided_credits]).to eq(['insufficient_credits'])
       end
     end
+
+    context 'with invalid metadata' do
+      let(:args) do
+        {
+          wallet_id:,
+          customer_id: customer.external_id,
+          organization_id: organization.id,
+          paid_credits:,
+          granted_credits:,
+          voided_credits:,
+          metadata: [{'key' => 'key', 'value' => {'key' => 'nested_value'}}]
+        }
+      end
+
+      it 'returns false and result has errors for metadata' do
+        expect(validate_service).not_to be_valid
+        expect(result.error.messages[:metadata]).to eq(['nested_structure_not_allowed'])
+      end
+    end
   end
 end

--- a/spec/services/wallet_transactions/void_service_spec.rb
+++ b/spec/services/wallet_transactions/void_service_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe WalletTransactions::VoidService, type: :service do
       end
     end
 
+    context 'when transaction have metadata' do
+      subject(:void_service) { described_class.call(wallet:, credits:, metadata:) }
+
+      let(:metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
+
+      it 'sets expected attributes' do
+        expect(void_service.wallet_transaction).to have_attributes(
+          amount: 10,
+          credit_amount: 10,
+          transaction_type: 'outbound',
+          status: 'settled',
+          source: 'manual',
+          transaction_status: 'voided',
+          metadata: metadata
+        )
+      end
+    end
+
     it 'creates a wallet transaction' do
       expect { void_service }.to change(WalletTransaction, :count).by(1)
     end

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 paid_credits: recurring_transaction_rule.paid_credits.to_s,
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
-                invoice_requires_successful_payment: false
+                invoice_requires_successful_payment: false,
+                metadata: {}
               }
             )
         end
@@ -78,7 +79,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
-                  invoice_requires_successful_payment: false
+                  invoice_requires_successful_payment: false,
+                  metadata: {}
                 }
               )
           end
@@ -108,7 +110,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   paid_credits: "150.0",
                   granted_credits: "0.0",
                   source: :interval,
-                  invoice_requires_successful_payment: false
+                  invoice_requires_successful_payment: false,
+                  metadata: {}
                 }
               )
           end
@@ -132,7 +135,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 paid_credits: recurring_transaction_rule.paid_credits.to_s,
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
-                invoice_requires_successful_payment: false
+                invoice_requires_successful_payment: false,
+                metadata: {}
               }
             )
         end
@@ -160,7 +164,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
-                  invoice_requires_successful_payment: false
+                  invoice_requires_successful_payment: false,
+                  metadata: {}
                 }
               )
           end
@@ -193,7 +198,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
-                  invoice_requires_successful_payment: false
+                  invoice_requires_successful_payment: false,
+                  metadata: {}
                 }
               )
           end
@@ -217,7 +223,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 paid_credits: recurring_transaction_rule.paid_credits.to_s,
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
-                invoice_requires_successful_payment: false
+                invoice_requires_successful_payment: false,
+                metadata: {}
               }
             )
         end
@@ -245,7 +252,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
-                  invoice_requires_successful_payment: false
+                  invoice_requires_successful_payment: false,
+                  metadata: {}
                 }
               )
           end
@@ -268,7 +276,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
-                  invoice_requires_successful_payment: false
+                  invoice_requires_successful_payment: false,
+                  metadata: {}
                 }
               )
           end
@@ -292,7 +301,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 paid_credits: recurring_transaction_rule.paid_credits.to_s,
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
-                invoice_requires_successful_payment: false
+                invoice_requires_successful_payment: false,
+                metadata: {}
               }
             )
         end
@@ -320,7 +330,8 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                   paid_credits: recurring_transaction_rule.paid_credits.to_s,
                   granted_credits: recurring_transaction_rule.granted_credits.to_s,
                   source: :interval,
-                  invoice_requires_successful_payment: false
+                  invoice_requires_successful_payment: false,
+                  metadata: {}
                 }
               )
           end
@@ -414,7 +425,48 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 paid_credits: recurring_transaction_rule.paid_credits.to_s,
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
-                invoice_requires_successful_payment: true
+                invoice_requires_successful_payment: true,
+                metadata: {}
+              }
+            )
+        end
+      end
+    end
+
+    context 'when rule have medata' do
+      let(:recurring_transaction_rule) do
+        create(
+          :recurring_transaction_rule,
+          trigger: :interval,
+          wallet:,
+          interval:,
+          created_at: created_at + 1.second,
+          started_at:,
+          metadata:
+        )
+      end
+      let(:interval) { :weekly }
+
+      let(:metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
+
+      let(:current_date) do
+        DateTime.parse('20 Jun 2022').prev_occurring(created_at.strftime('%A').downcase.to_sym)
+      end
+
+      it 'enqueues a job with correct configuration' do
+        travel_to(current_date) do
+          create_interval_transactions_service.call
+
+          expect(WalletTransactions::CreateJob).to have_been_enqueued
+            .with(
+              organization_id: customer.organization_id,
+              params: {
+                wallet_id: wallet.id,
+                paid_credits: recurring_transaction_rule.paid_credits.to_s,
+                granted_credits: recurring_transaction_rule.granted_credits.to_s,
+                source: :interval,
+                invoice_requires_successful_payment: false,
+                metadata:
               }
             )
         end

--- a/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
+++ b/spec/services/wallets/create_interval_wallet_transactions_service_spec.rb
@@ -442,12 +442,12 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
           interval:,
           created_at: created_at + 1.second,
           started_at:,
-          metadata:
+          transaction_metadata:
         )
       end
       let(:interval) { :weekly }
 
-      let(:metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
+      let(:transaction_metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
 
       let(:current_date) do
         DateTime.parse('20 Jun 2022').prev_occurring(created_at.strftime('%A').downcase.to_sym)
@@ -466,7 +466,7 @@ RSpec.describe Wallets::CreateIntervalWalletTransactionsService, type: :service 
                 granted_credits: recurring_transaction_rule.granted_credits.to_s,
                 source: :interval,
                 invoice_requires_successful_payment: false,
-                metadata:
+                metadata: transaction_metadata
               }
             )
         end

--- a/spec/services/wallets/create_service_spec.rb
+++ b/spec/services/wallets/create_service_spec.rb
@@ -95,6 +95,30 @@ RSpec.describe Wallets::CreateService, type: :service do
       end
     end
 
+    context 'when wallet have transaction metadata' do
+      let(:params) do
+        {
+          name: 'New Wallet',
+          customer:,
+          organization_id: organization.id,
+          currency: 'EUR',
+          rate_amount: '1.00',
+          expiration_at:,
+          paid_credits: '10',
+          granted_credits: '10',
+          transaction_metadata: [{'key' => 'valid_value', 'value' => 'also_valid'}]
+        }
+      end
+
+      it 'enqueues the job with correct metadata' do
+        expect { service_result }.to have_enqueued_job(
+          WalletTransactions::CreateJob
+        ).with(hash_including(
+          params: hash_including(metadata: params[:transaction_metadata])
+        ))
+      end
+    end
+
     context 'with recurring transaction rules' do
       around { |test| lago_premium!(&test) }
 

--- a/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
@@ -92,22 +92,22 @@ RSpec.describe Wallets::RecurringTransactionRules::CreateService do
         end
       end
 
-      context "when metadata is present" do
+      context "when transaction metadata is present" do
         let(:rule_params) do
           {
             trigger: "threshold",
             threshold_credits: "1.0",
-            metadata:
+            transaction_metadata:
           }
         end
 
-        let(:metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
+        let(:transaction_metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
 
         it "creates rule with expected attributes" do
           expect { create_service.call }.to change { wallet.reload.recurring_transaction_rules.count }.by(1)
 
           expect(wallet.recurring_transaction_rules.first).to have_attributes(
-            metadata: metadata
+            transaction_metadata: transaction_metadata
           )
         end
       end

--- a/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/create_service_spec.rb
@@ -92,6 +92,26 @@ RSpec.describe Wallets::RecurringTransactionRules::CreateService do
         end
       end
 
+      context "when metadata is present" do
+        let(:rule_params) do
+          {
+            trigger: "threshold",
+            threshold_credits: "1.0",
+            metadata:
+          }
+        end
+
+        let(:metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
+
+        it "creates rule with expected attributes" do
+          expect { create_service.call }.to change { wallet.reload.recurring_transaction_rules.count }.by(1)
+
+          expect(wallet.recurring_transaction_rules.first).to have_attributes(
+            metadata: metadata
+          )
+        end
+      end
+
       context 'when invoice_requires_successful_payment is blank' do
         let(:wallet) { create(:wallet, invoice_requires_successful_payment: true) }
         let(:wallet_params) do

--- a/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
+++ b/spec/services/wallets/recurring_transaction_rules/validate_service_spec.rb
@@ -58,6 +58,20 @@ RSpec.describe Wallets::RecurringTransactionRules::ValidateService do
       end
     end
 
+    context "when invalid metadata" do
+      let(:params) do
+        {
+          trigger: "interval",
+          interval: "weekly",
+          metadata: [{'key' => 'valid_key', 'value_1' => 'invalid_value'}]
+        }
+      end
+
+      it "returns false" do
+        expect(validate_service.call).to eq false
+      end
+    end
+
     context "when invalid credits" do
       let(:params) do
         {

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
       end
     end
 
-    context 'when rule contains metadata' do
+    context 'when rule contains transaction metadata' do
       let(:recurring_transaction_rule) do
         create(
           :recurring_transaction_rule,
@@ -77,17 +77,17 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
           threshold_credits: "6.0",
           paid_credits: "10.0",
           granted_credits: "3.0",
-          metadata:
+          transaction_metadata:
         )
       end
 
-      let(:metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
+      let(:transaction_metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
 
       it "calls wallet transaction create job with expected params" do
         expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
           .with(
             organization_id: wallet.organization.id,
-            params: hash_including(metadata:)
+            params: hash_including(metadata: transaction_metadata)
           )
       end
     end

--- a/spec/services/wallets/threshold_top_up_service_spec.rb
+++ b/spec/services/wallets/threshold_top_up_service_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
             paid_credits: "10.0",
             granted_credits: "3.0",
             source: :threshold,
-            invoice_requires_successful_payment: false
+            invoice_requires_successful_payment: false,
+            metadata: {}
           }
         )
     end
@@ -63,6 +64,30 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
           .with(
             organization_id: wallet.organization.id,
             params: hash_including(invoice_requires_successful_payment: true)
+          )
+      end
+    end
+
+    context 'when rule contains metadata' do
+      let(:recurring_transaction_rule) do
+        create(
+          :recurring_transaction_rule,
+          wallet:,
+          trigger: "threshold",
+          threshold_credits: "6.0",
+          paid_credits: "10.0",
+          granted_credits: "3.0",
+          metadata:
+        )
+      end
+
+      let(:metadata) { [{'key' => 'valid_value', 'value' => 'also_valid'}] }
+
+      it "calls wallet transaction create job with expected params" do
+        expect { top_up_service.call }.to have_enqueued_job(WalletTransactions::CreateJob)
+          .with(
+            organization_id: wallet.organization.id,
+            params: hash_including(metadata:)
           )
       end
     end
@@ -106,7 +131,8 @@ RSpec.describe Wallets::ThresholdTopUpService, type: :service do
               paid_credits: "194.5",
               granted_credits: "0.0",
               source: :threshold,
-              invoice_requires_successful_payment: false
+              invoice_requires_successful_payment: false,
+              metadata: {}
             }
           )
       end

--- a/spec/services/wallets/validate_service_spec.rb
+++ b/spec/services/wallets/validate_service_spec.rb
@@ -101,6 +101,24 @@ RSpec.describe Wallets::ValidateService, type: :service do
           expect(result.error.messages[:expiration_at]).to eq(['invalid_date'])
         end
       end
+
+      context 'with invalid transaction metadata' do
+        let(:args) do
+          {
+            customer:,
+            organization_id: organization.id,
+            paid_credits:,
+            granted_credits:,
+            expiration_at:,
+            transaction_metadata: [{key: "valid key", value1: "invalid value"}]
+          }
+        end
+
+        it 'returns false and result has errors' do
+          expect(validate_service).not_to be_valid
+          expect(result.error.messages[:metadata]).to eq(['invalid_key_value_pair'])
+        end
+      end
     end
 
     context 'with recurring transaction rules' do


### PR DESCRIPTION
## Context

This PR introduces the functionality of attaching metadata to wallet transactions. 
Metadata can only be added through the API during the creation of a wallet or when topping up a wallet with a new transaction.

## Description

1. **Metadata on Wallet Creation:** Users can now assign metadata to a transaction at the point of wallet creation. This metadata is exclusive to the wallet transaction triggered during the creation process.
   
2. **Metadata on Wallet Top-Up:** Metadata can also be included when topping up a wallet to provide additional transaction details.

3. **Metadata on Wallet recurring rules:** Metadata can also be included on the recurring rules and will be used every time a rule is triggered to create a new wallet transaction 

**Limitations:**
- Metadata is not searchable.
- The number of metadata entries per transaction is capped at the same limit as customer-level metadata.(5)
- Metadata can be set only through API calls, not through the UI.
- Applicable for both initial wallet creation and subsequent top-up transactions.
- Add metadata to the rules can be done when creating the wallet or when updating the wallet inside the `recurring_transaction_rules` part 

**Top up a wallet:**

 ```json
 {
  "wallet_transaction": {
    "wallet_id": "4f771fe7-2f06-446c-95be-6c5bed80ea8a",
    "paid_credits": "10",
    "granted_credits": "10",
    "voided_credits": "1",
    "invoice_requires_successful_payment": false,
    "metadata": [
        {
            "key": "source",
            "value": "manual"
        }
    ]
  }
 ```
**Create a wallet:**
 ```json
{
  "wallet": {
    "name": "Prepaid",
    "rate_amount": "12",
    "currency": "USD",
    "external_customer_id": "customer_id",
    "paid_credits": "20.0",
    "granted_credits": "10.0",
    "invoice_require_successful_payment": true,
    "transaction_metadata": [
        {
            "key": "source", "value": "wallet creation" //This will be added to the wallet transactions of the wallet creation 
        }
    ],
    "recurring_transaction_rules": [
          {
            "method": "fixed",
            "paid_credits": "0",
            "granted_credits": "1000",
            "trigger": "threshold",
            "threshold_credits": "5",
            "invoice_require_successful_payment": true,
            "transaction_metadata":[
                {
                    "key": "source", "value": "rule" //This will be stored on the rules and will be used every time the rule triggers
                }
            ]
          }
        ]
  }
}

 ```
