### PR TITLE
feat(ProgressiveBilling): Add new threshold reached webhook

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -38,6 +38,7 @@ class SendWebhookJob < ApplicationJob
     'subscription.started' => Webhooks::Subscriptions::StartedService,
     'subscription.termination_alert' => Webhooks::Subscriptions::TerminationAlertService,
     'subscription.trial_ended' => Webhooks::Subscriptions::TrialEndedService,
+    'subscription.usage_threshold_reached' => Webhooks::Subscriptions::UsageThresholdsReachedService,
     'wallet.depleted_ongoing_balance' => Webhooks::Wallets::DepletedOngoingBalanceService,
     'wallet_transaction.created' => Webhooks::WalletTransactions::CreatedService,
     'wallet_transaction.updated' => Webhooks::WalletTransactions::UpdatedService,

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -26,6 +26,7 @@ module V1
 
       payload = payload.merge(customer:) if include?(:customer)
       payload = payload.merge(plan:) if include?(:plan)
+      payload = payload.merge(usage_threshold:) if include?(:usage_threshold)
 
       payload
     end
@@ -41,6 +42,10 @@ module V1
         model.plan,
         includes: %i[charges usage_thresholds taxes minimum_commitment]
       ).serialize
+    end
+
+    def usage_threshold
+      ::V1::UsageThresholdSerializer.new(options[:usage_threshold]).serialize
     end
   end
 end

--- a/app/services/webhooks/subscriptions/usage_thresholds_reached_service.rb
+++ b/app/services/webhooks/subscriptions/usage_thresholds_reached_service.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module Subscriptions
+    class UsageThresholdsReachedService < Webhooks::BaseService
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::SubscriptionSerializer.new(
+          object,
+          root_name: 'subscription',
+          includes: %i[plan customer usage_threshold],
+          usage_threshold: options[:usage_threshold]
+        )
+      end
+
+      def webhook_type
+        'subscription.usage_threshold_reached'
+      end
+
+      def object_type
+        'subscription'
+      end
+    end
+  end
+end

--- a/spec/serializers/v1/subscription_serializer_spec.rb
+++ b/spec/serializers/v1/subscription_serializer_spec.rb
@@ -73,4 +73,23 @@ RSpec.describe ::V1::SubscriptionSerializer do
       end
     end
   end
+
+  context 'when including usage threshold' do
+    subject(:serializer) do
+      described_class.new(
+        subscription,
+        root_name: 'subscription',
+        includes: %i[usage_threshold],
+        usage_threshold:
+      )
+    end
+
+    let(:usage_threshold) { create(:usage_threshold, plan: subscription.plan) }
+
+    it 'serializes the object' do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result['subscription']['usage_threshold']).to be_present
+    end
+  end
 end

--- a/spec/services/webhooks/subscriptions/usage_thresholds_reached_service_spec.rb
+++ b/spec/services/webhooks/subscriptions/usage_thresholds_reached_service_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::Subscriptions::UsageThresholdsReachedService do
+  subject(:webhook_service) { described_class.new(object: subscription, options: {usage_threshold:}) }
+
+  let(:organization) { create(:organization) }
+  let(:plan) { create(:plan, organization: organization) }
+  let(:customer) { create(:customer, organization: organization) }
+  let(:subscription) { create(:subscription, plan: plan, customer: customer) }
+  let(:usage_threshold) { create(:usage_threshold, plan: plan) }
+
+  describe '.call' do
+    it_behaves_like 'creates webhook', 'subscription.usage_threshold_reached', 'subscription', {'usage_threshold' => Hash}
+  end
+end


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR add a new `subscription.usage_threshold_reached` webhook to notify that a subscription reached a new  lifetime usage threshold