### PR TITLE
fix(plan): Add presence validation for plan interval

### DIFF
--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -36,7 +36,7 @@ class Plan < ApplicationRecord
 
   monetize :amount_cents
 
-  validates :name, :code, presence: true
+  validates :name, :code, :interval, presence: true
   validates :amount_currency, inclusion: {in: currency_list}
   validates :pay_in_advance, inclusion: {in: [true, false]}
   validate :validate_code_unique

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Plan, type: :model do
   it { is_expected.to have_one(:minimum_commitment) }
   it { is_expected.to have_many(:usage_thresholds) }
 
+  it { is_expected.to validate_presence_of(:interval) }
+  it { is_expected.to define_enum_for(:interval).with_values(Plan::INTERVALS) }
+
   it_behaves_like 'paper_trail traceable'
 
   describe 'Validations' do


### PR DESCRIPTION
## Context

We were getting 500's when trying to create a plan without an interval via the API.

## Description

This PR adds presence validation for plan's interval.