### PR TITLE
perf - fix N+1 queries on #index actions

### DIFF
--- a/app/controllers/api/v1/add_ons_controller.rb
+++ b/app/controllers/api/v1/add_ons_controller.rb
@@ -59,7 +59,7 @@ module Api
 
         render(
           json: ::CollectionSerializer.new(
-            add_ons,
+            add_ons.includes(:taxes),
             ::V1::AddOnSerializer,
             collection_name: 'add_ons',
             meta: pagination_metadata(add_ons),

--- a/app/controllers/api/v1/applied_coupons_controller.rb
+++ b/app/controllers/api/v1/applied_coupons_controller.rb
@@ -41,7 +41,7 @@ module Api
         if result.success?
           render(
             json: ::CollectionSerializer.new(
-              result.applied_coupons,
+              result.applied_coupons.includes(:credits),
               ::V1::AppliedCouponSerializer,
               collection_name: 'applied_coupons',
               meta: pagination_metadata(result.applied_coupons),

--- a/app/controllers/api/v1/credit_notes_controller.rb
+++ b/app/controllers/api/v1/credit_notes_controller.rb
@@ -105,7 +105,7 @@ module Api
 
         render(
           json: ::CollectionSerializer.new(
-            credit_notes,
+            credit_notes.includes(:items, :applied_taxes),
             ::V1::CreditNoteSerializer,
             collection_name: 'credit_notes',
             meta: pagination_metadata(credit_notes),

--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -42,7 +42,7 @@ module Api
 
         render(
           json: ::CollectionSerializer.new(
-            customers,
+            customers.includes(:taxes),
             ::V1::CustomerSerializer,
             collection_name: 'customers',
             meta: pagination_metadata(customers),

--- a/app/controllers/api/v1/fees_controller.rb
+++ b/app/controllers/api/v1/fees_controller.rb
@@ -37,7 +37,7 @@ module Api
         if result.success?
           render(
             json: ::CollectionSerializer.new(
-              result.fees,
+              result.fees.includes(:applied_taxes),
               ::V1::FeeSerializer,
               collection_name: 'fees',
               meta: pagination_metadata(result.fees),

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -66,7 +66,7 @@ module Api
         if result.success?
           render(
             json: ::CollectionSerializer.new(
-              result.invoices,
+              result.invoices.includes(:metadata, :applied_taxes),
               ::V1::InvoiceSerializer,
               collection_name: 'invoices',
               meta: pagination_metadata(result.invoices),

--- a/app/controllers/api/v1/plans_controller.rb
+++ b/app/controllers/api/v1/plans_controller.rb
@@ -55,7 +55,7 @@ module Api
 
         render(
           json: ::CollectionSerializer.new(
-            plans.includes(:usage_thresholds, charges: {filters: {values: :billable_metric_filter}}),
+            plans.includes(:usage_thresholds, :taxes, :minimum_commitment, charges: {filters: {values: :billable_metric_filter}}),
             ::V1::PlanSerializer,
             collection_name: 'plans',
             meta: pagination_metadata(plans),


### PR DESCRIPTION
## Description

Many #index actions include extra relations when serializing. If we don't include the associations we'll have N+1 queries in overview pages making them unnecessarily slow. 
