### PR TITLE
feat(ProgressiveBilling): create an invoice for a threshold

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -13,6 +13,7 @@ class Fee < ApplicationRecord
   belongs_to :subscription, optional: true
   belongs_to :charge_filter, -> { with_discarded }, optional: true
   belongs_to :group, -> { with_discarded }, optional: true
+  belongs_to :usage_threshold, -> { with_discarded }, optional: true
   belongs_to :invoiceable, polymorphic: true, optional: true
   belongs_to :true_up_parent_fee, class_name: 'Fee', optional: true
 
@@ -34,7 +35,7 @@ class Fee < ApplicationRecord
   monetize :unit_amount_cents, disable_validation: true, allow_nil: true, with_model_currency: :currency
 
   # TODO: Deprecate add_on type in the near future
-  FEE_TYPES = %i[charge add_on subscription credit commitment].freeze
+  FEE_TYPES = %i[charge add_on subscription credit commitment progressive_billing].freeze
   PAYMENT_STATUS = %i[pending succeeded failed refunded].freeze
 
   enum fee_type: FEE_TYPES

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -51,7 +51,7 @@ class Invoice < ApplicationRecord
     allow_nil: true,
     with_model_currency: :currency
 
-  INVOICE_TYPES = %i[subscription add_on credit one_off advance_charges].freeze
+  INVOICE_TYPES = %i[subscription add_on credit one_off advance_charges progressive_billing].freeze
   PAYMENT_STATUS = %i[pending succeeded failed].freeze
 
   VISIBLE_STATUS = {draft: 0, finalized: 1, voided: 2, failed: 4}.freeze

--- a/app/models/invoice_subscription.rb
+++ b/app/models/invoice_subscription.rb
@@ -18,7 +18,8 @@ class InvoiceSubscription < ApplicationRecord
     subscription_periodic: 'subscription_periodic',
     subscription_terminating: 'subscription_terminating',
     in_advance_charge: 'in_advance_charge',
-    in_advance_charge_periodic: 'in_advance_charge_periodic'
+    in_advance_charge_periodic: 'in_advance_charge_periodic',
+    progressive_billing: 'progressive_billing'
   }.freeze
 
   enum invoicing_reason: INVOICING_REASONS

--- a/app/services/fees/apply_taxes_service.rb
+++ b/app/services/fees/apply_taxes_service.rb
@@ -59,7 +59,7 @@ module Fees
       return fee.add_on.taxes if fee.add_on? && fee.add_on.taxes.any?
       return fee.charge.taxes if fee.charge? && fee.charge.taxes.any?
       return fee.invoiceable.taxes if fee.commitment? && fee.invoiceable.taxes.any?
-      if (fee.charge? || fee.subscription? || fee.commitment?) && fee.subscription.plan.taxes.any?
+      if (fee.charge? || fee.subscription? || fee.commitment? || fee.progressive_billing?) && fee.subscription.plan.taxes.any?
         return fee.subscription.plan.taxes
       end
       return customer.taxes if customer.taxes.any?

--- a/app/services/fees/create_from_usage_threshold_service.rb
+++ b/app/services/fees/create_from_usage_threshold_service.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Fees
+  class CreateFromUsageThresholdService < BaseService
+    def initialize(usage_threshold:, invoice:, amount_cents:)
+      @usage_threshold = usage_threshold
+      @invoice = invoice
+      @amount_cents = amount_cents
+
+      super
+    end
+
+    def call
+      fee = Fee.new(
+        subscription: invoice.subscriptions.first,
+        invoice:,
+        usage_threshold:,
+        invoice_display_name: usage_threshold.threshold_display_name,
+        invoiceable: usage_threshold,
+        amount_cents: amount_cents,
+        amount_currency: invoice.currency,
+        fee_type: :progressive_billing,
+        units:,
+        unit_amount_cents: unit_amount_cents,
+        payment_status: :pending,
+        taxes_amount_cents: 0,
+        properties: {
+          charges_from_datetime: invoice.invoice_subscriptions.first.charges_from_datetime,
+          charges_to_datetime: invoice.invoice_subscriptions.first.charges_to_datetime,
+          timestamp: invoice.invoice_subscriptions.first.timestamp
+        }
+      )
+
+      taxes_result = Fees::ApplyTaxesService.call(fee:)
+      taxes_result.raise_if_error!
+
+      fee.save!
+      result.fee = fee
+
+      result
+    end
+
+    private
+
+    attr_reader :usage_threshold, :invoice, :amount_cents
+
+    def units
+      return 1 unless usage_threshold.recurring?
+
+      amount_cents.fdiv(usage_threshold.amount_cents)
+    end
+
+    def unit_amount_cents
+      return amount_cents unless usage_threshold.recurring?
+
+      usage_threshold.amount_cents
+    end
+  end
+end

--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -88,11 +88,10 @@ module Invoices
     end
 
     def date_service(subscription)
-      Subscriptions::DatesService.new_instance(
-        subscription,
-        datetime,
-        current_usage: subscription.terminated? && subscription.upgraded?
-      )
+      current_usage = invoicing_reason.to_sym == :progressive_billing
+      current_usage ||= subscription.terminated? && subscription.upgraded?
+
+      Subscriptions::DatesService.new_instance(subscription, datetime, current_usage:)
     end
 
     # This method calculates boundaries for terminated subscription. If termination is happening on billing date

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Invoices
+  class ProgressiveBillingService < BaseService
+    def initialize(usage_thresholds:, lifetime_usage:, timestamp: Time.current)
+      @usage_thresholds = usage_thresholds
+      @lifetime_usage = lifetime_usage
+      @timestamp = timestamp
+
+      super
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        create_generating_invoice
+        create_threshold_fees
+        Invoices::ComputeAmountsFromFees.call(invoice:)
+        invoice.finalized!
+      end
+
+      Utils::SegmentTrack.invoice_created(invoice)
+      SendWebhookJob.perform_later('invoice.created', invoice)
+      GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
+      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+      Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
+      Invoices::Payments::CreateService.call(invoice)
+
+      result.invoice = invoice
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue Sequenced::SequenceError
+      raise
+    rescue => e
+      result.fail_with_error!(e)
+    end
+
+    private
+
+    attr_accessor :usage_thresholds, :lifetime_usage, :timestamp, :invoice
+
+    delegate :subscription, to: :lifetime_usage
+
+    def create_generating_invoice
+      invoice_result = CreateGeneratingService.call(
+        customer: subscription.customer,
+        invoice_type: :progressive_billing,
+        currency: usage_thresholds.first.plan.amount_currency,
+        datetime: Time.zone.at(timestamp)
+      ) do |invoice|
+        CreateInvoiceSubscriptionService
+          .call(invoice:, subscriptions: [subscription], timestamp:, invoicing_reason: :progressive_billing)
+          .raise_if_error!
+      end
+      invoice_result.raise_if_error!
+
+      @invoice = invoice_result.invoice
+    end
+
+    def sorted_thresholds
+      fixed = usage_thresholds.select { |t| !t.recurring }.sort_by(&:amount_cents)
+      recurring = usage_thresholds.select(&:recurring)
+      fixed + recurring
+    end
+
+    def create_threshold_fees
+      sorted_thresholds.each do |usage_threshold|
+        fee_result = Fees::CreateFromUsageThresholdService
+          .call(usage_threshold:, invoice:, amount_cents: amount_cents(usage_threshold))
+        fee_result.raise_if_error!
+        fee_result.fee
+      end
+    end
+
+    def should_deliver_email?
+      License.premium? && subscription.organization.email_settings.include?('invoice.finalized')
+    end
+
+    def amount_cents(usage_threshold)
+      if usage_threshold.recurring?
+        # NOTE: Recurring is always the last threshold.
+        #       Amount is the current lifetime usage without already invoiced thresholds
+        #       The recurring threshold can be reached multiple time, so we need to compute the number of times
+        units = (total_lifetime_usage_amount_cents - invoiced_amount_cents) / usage_threshold.amount_cents
+        units * usage_threshold.amount_cents
+      else
+        # NOTE: Amount to bill if the current threshold minus the usage that have already been invoiced
+        result_amount = usage_threshold.amount_cents - invoiced_amount_cents
+
+        # NOTE: Add the amount to the invoiced_amount_cents for next non recurring threshold
+        @invoiced_amount_cents += result_amount
+
+        result_amount
+      end
+    end
+
+    # NOTE: Sum of usage that have already been invoiced
+    def invoiced_amount_cents
+      @invoiced_amount_cents ||= subscription.invoices
+        .finalized
+        .where(invoice_type: %w[subscription progressive_billing])
+        .sum(:fees_amount_cents)
+    end
+
+    # NOTE: Current lifetime usage amount
+    def total_lifetime_usage_amount_cents
+      @total_lifetime_usage_amount_cents ||= lifetime_usage.invoiced_usage_amount_cents + lifetime_usage.current_usage_amount_cents
+    end
+  end
+end

--- a/db/migrate/20240813095718_add_usage_threshold_id_to_fees.rb
+++ b/db/migrate/20240813095718_add_usage_threshold_id_to_fees.rb
@@ -1,0 +1,7 @@
+# frozen_String_literal: true
+
+class AddUsageThresholdIdToFees < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :fees, :usage_threshold, type: :uuid, foreign_key: true, index: true
+  end
+end

--- a/db/migrate/20240813121307_add_progressive_billing_to_invoicing_reason.rb
+++ b/db/migrate/20240813121307_add_progressive_billing_to_invoicing_reason.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddProgressiveBillingToInvoicingReason < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    execute <<-SQL
+      ALTER TYPE subscription_invoicing_reason ADD VALUE IF NOT EXISTS 'progressive_billing';
+    SQL
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_14_144137) do
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "billable_metric_weighted_interval", ["seconds"]
-  create_enum "subscription_invoicing_reason", ["subscription_starting", "subscription_periodic", "subscription_terminating", "in_advance_charge", "in_advance_charge_periodic"]
+  create_enum "subscription_invoicing_reason", ["subscription_starting", "subscription_periodic", "subscription_terminating", "in_advance_charge", "in_advance_charge_periodic", "progressive_billing"]
 
   create_table "active_storage_attachments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
@@ -538,6 +538,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_14_144137) do
     t.jsonb "grouped_by", default: {}, null: false
     t.string "pay_in_advance_event_transaction_id"
     t.datetime "deleted_at"
+    t.uuid "usage_threshold_id"
     t.index ["add_on_id"], name: "index_fees_on_add_on_id"
     t.index ["applied_add_on_id"], name: "index_fees_on_applied_add_on_id"
     t.index ["charge_filter_id"], name: "index_fees_on_charge_filter_id"
@@ -550,6 +551,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_14_144137) do
     t.index ["pay_in_advance_event_transaction_id"], name: "index_fees_on_pay_in_advance_event_transaction_id", where: "(deleted_at IS NULL)"
     t.index ["subscription_id"], name: "index_fees_on_subscription_id"
     t.index ["true_up_parent_fee_id"], name: "index_fees_on_true_up_parent_fee_id"
+    t.index ["usage_threshold_id"], name: "index_fees_on_usage_threshold_id"
   end
 
   create_table "fees_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1212,6 +1214,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_14_144137) do
   add_foreign_key "fees", "groups"
   add_foreign_key "fees", "invoices"
   add_foreign_key "fees", "subscriptions"
+  add_foreign_key "fees", "usage_thresholds"
   add_foreign_key "fees_taxes", "fees"
   add_foreign_key "fees_taxes", "taxes"
   add_foreign_key "group_properties", "charges", on_delete: :cascade

--- a/schema.graphql
+++ b/schema.graphql
@@ -3593,6 +3593,7 @@ enum FeeTypesEnum {
   charge
   commitment
   credit
+  progressive_billing
   subscription
 }
 
@@ -3997,6 +3998,7 @@ enum InvoiceTypeEnum {
   advance_charges
   credit
   one_off
+  progressive_billing
   subscription
 }
 

--- a/schema.json
+++ b/schema.json
@@ -16423,6 +16423,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "progressive_billing",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },
@@ -20049,6 +20055,12 @@
             },
             {
               "name": "advance_charges",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "progressive_billing",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -102,4 +102,18 @@ FactoryBot.define do
     invoiceable_type { 'Commitment' }
     invoiceable_id { commitment.id }
   end
+
+  factory :progressive_billing_fee, class: 'Fee' do
+    invoice
+    fee_type { 'progressive_billing' }
+    subscription
+
+    amount_cents { 200 }
+    amount_currency { 'EUR' }
+    taxes_amount_cents { 2 }
+
+    usage_threshold { create(:usage_threshold, plan: subscription.plan) }
+    invoiceable_type { 'UsageThreshold' }
+    invoiceable_id { usage_threshold.id }
+  end
 end

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -5,6 +5,12 @@ require 'rails_helper'
 RSpec.describe Fee, type: :model do
   subject(:fee_model) { described_class }
 
+  describe 'associations' do
+    subject(:fee) { build(:fee) }
+
+    it { is_expected.to belong_to(:usage_threshold).optional }
+  end
+
   describe '.item_code' do
     context 'when it is a subscription fee' do
       let(:subscription) { create(:subscription) }

--- a/spec/services/fees/apply_taxes_service_spec.rb
+++ b/spec/services/fees/apply_taxes_service_spec.rb
@@ -199,6 +199,38 @@ RSpec.describe Fees::ApplyTaxesService, type: :service do
       end
     end
 
+    context 'when fee is a progressive_billing type with taxes applied to the plan' do
+      let(:plan) { create(:plan, organization:) }
+      let(:usage_threshold) { create(:usage_threshold, plan:) }
+      let(:subscription) { create(:subscription, organization:, customer:, plan:) }
+
+      let(:fee) { create(:progressive_billing_fee, invoice:, amount_cents: 1000, usage_threshold:, subscription:) }
+
+      let(:applied_tax) { create(:plan_applied_tax, plan:, tax: tax1) }
+
+      before { applied_tax }
+
+      it 'creates applied_taxes based on the plan taxes', aggregate_failures: true do
+        result = apply_service.call
+
+        expect(result).to be_success
+
+        applied_taxes = result.applied_taxes
+        expect(applied_taxes.count).to eq(1)
+
+        expect(applied_taxes[0]).to have_attributes(
+          fee:,
+          tax: tax1,
+          tax_description: tax1.description,
+          tax_code: tax1.code,
+          tax_name: tax1.name,
+          tax_rate: 10,
+          amount_currency: fee.currency,
+          amount_cents: 100
+        )
+      end
+    end
+
     context 'when customer has applied_taxes' do
       let(:applied_tax1) { create(:customer_applied_tax, customer:, tax: tax1) }
       let(:applied_tax2) { create(:customer_applied_tax, customer:, tax: tax2) }

--- a/spec/services/fees/create_from_usage_threshold_service_spec.rb
+++ b/spec/services/fees/create_from_usage_threshold_service_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fees::CreateFromUsageThresholdService, type: :service do
+  subject(:create_service) { described_class.new(usage_threshold:, invoice:, amount_cents:) }
+
+  let(:usage_threshold) { create(:usage_threshold, plan:) }
+  let(:invoice) { create(:invoice, organization: customer.organization, customer:) }
+
+  let(:invoice_subscription) { create(:invoice_subscription, invoice:, subscription:) }
+  let(:customer) { create(:customer) }
+  let(:plan) { create(:plan, organization: customer.organization) }
+  let(:subscription) { create(:subscription, plan:, customer:) }
+
+  let(:amount_cents) { 1000 }
+
+  let(:tax) { create(:tax, organization: customer.organization, rate: 20) }
+
+  before do
+    invoice_subscription
+    tax
+  end
+
+  it 'creates a fee from usage threshold', aggregate_failure: true do
+    fee_result = create_service.call
+
+    expect(fee_result).to be_success
+    expect(fee_result.fee).to be_present
+
+    fee = fee_result.fee
+    expect(fee).to be_persisted
+    expect(fee).to have_attributes(
+      subscription:,
+      invoice:,
+      usage_threshold:,
+      invoiceable: usage_threshold,
+      invoice_display_name: usage_threshold.threshold_display_name,
+      amount_cents: amount_cents,
+      amount_currency: invoice.currency,
+      fee_type: 'progressive_billing',
+      units: 1,
+      unit_amount_cents: amount_cents,
+      payment_status: 'pending',
+      taxes_amount_cents: amount_cents * tax.rate / 100,
+      properties: {
+        'charges_from_datetime' => invoice_subscription.charges_from_datetime,
+        'charges_to_datetime' => invoice_subscription.charges_to_datetime,
+        'timestamp' => invoice_subscription.timestamp
+      }
+    )
+  end
+
+  context 'when usage thresold is recurring' do
+    let(:usage_threshold) { create(:usage_threshold, :recurring, plan:) }
+    let(:amount_cents) { usage_threshold.amount_cents * 5 }
+
+    it 'creates a fee from usage threshold', aggregate_failure: true do
+      fee_result = create_service.call
+
+      expect(fee_result).to be_success
+      expect(fee_result.fee).to be_present
+
+      fee = fee_result.fee
+      expect(fee).to be_persisted
+      expect(fee).to have_attributes(
+        subscription:,
+        invoice:,
+        usage_threshold:,
+        invoiceable: usage_threshold,
+        invoice_display_name: usage_threshold.threshold_display_name,
+        amount_cents: amount_cents,
+        amount_currency: invoice.currency,
+        fee_type: 'progressive_billing',
+        units: 5,
+        unit_amount_cents: usage_threshold.amount_cents,
+        payment_status: 'pending',
+        taxes_amount_cents: amount_cents * tax.rate / 100,
+        properties: {
+          'charges_from_datetime' => invoice_subscription.charges_from_datetime,
+          'charges_to_datetime' => invoice_subscription.charges_to_datetime,
+          'timestamp' => invoice_subscription.timestamp
+        }
+      )
+    end
+  end
+end

--- a/spec/services/invoices/create_invoice_subscription_service_spec.rb
+++ b/spec/services/invoices/create_invoice_subscription_service_spec.rb
@@ -289,5 +289,28 @@ RSpec.describe Invoices::CreateInvoiceSubscriptionService do
         end
       end
     end
+
+    context 'when invoicing reason is progressive_billing' do
+      let(:invoicing_reason) { :progressive_billing }
+      let(:timestamp) { Time.zone.parse('2023-10-01T00:00:00') }
+
+      it 'creates an invoice subscription', aggregate_failure: true do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.invoice_subscriptions.count).to eq(1)
+
+        invoice_subscription = result.invoice_subscriptions.first
+        expect(invoice_subscription).to have_attributes(
+          invoice:,
+          subscription:,
+          timestamp: match_datetime(timestamp),
+          charges_from_datetime: match_datetime(Time.zone.parse('2023-09-06T00:00:00')),
+          charges_to_datetime: match_datetime('2023-10-05T23:59:59'),
+          recurring: false,
+          invoicing_reason: 'progressive_billing'
+        )
+      end
+    end
   end
 end

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Invoices::ProgressiveBillingService, type: :service do
+  subject(:create_service) { described_class.new(usage_thresholds:, lifetime_usage:, timestamp:) }
+
+  let(:usage_thresholds) { [create(:usage_threshold, plan:)] }
+  let(:plan) { create(:plan) }
+  let(:organization) { plan.organization }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, plan:, customer:) }
+  let(:lifetime_usage) { create(:lifetime_usage, subscription:) }
+
+  let(:timestamp) { Time.current.beginning_of_month }
+
+  let(:tax) { create(:tax, organization:, rate: 20) }
+
+  before do
+    allow(SegmentTrackJob).to receive(:perform_later)
+
+    tax
+  end
+
+  describe '#call' do
+    it 'creates a progressive billing invoice', aggregate_failures: true do
+      result = create_service.call
+
+      expect(result).to be_success
+      expect(result.invoice).to be_present
+
+      invoice = result.invoice
+      usage_threshold = usage_thresholds.first
+      expect(invoice).to be_persisted
+      expect(invoice).to have_attributes(
+        organization: organization,
+        customer: customer,
+        currency: plan.amount_currency,
+        status: 'finalized',
+        invoice_type: 'progressive_billing',
+        fees_amount_cents: usage_threshold.amount_cents,
+        taxes_amount_cents: usage_threshold.amount_cents * tax.rate / 100,
+        total_amount_cents: usage_threshold.amount_cents + usage_threshold.amount_cents * tax.rate / 100
+      )
+
+      expect(invoice.invoice_subscriptions.count).to eq(1)
+      expect(invoice.fees.count).to eq(1)
+    end
+
+    context 'with multiple thresholds' do
+      let(:usage_thresholds) do
+        [
+          create(:usage_threshold, plan:, amount_cents: 1000),
+          create(:usage_threshold, plan:, amount_cents: 2500)
+        ]
+      end
+
+      it 'creates a progressive billing invoice with two fees', aggregate_failures: true do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.invoice).to be_present
+
+        invoice = result.invoice
+        expect(invoice).to be_persisted
+        expect(invoice).to have_attributes(
+          organization: organization,
+          customer: customer,
+          currency: plan.amount_currency,
+          status: 'finalized',
+          invoice_type: 'progressive_billing',
+          fees_amount_cents: 2500,
+          taxes_amount_cents: 2500 * tax.rate / 100,
+          total_amount_cents: 2500 * (1 + tax.rate / 100)
+        )
+
+        expect(invoice.invoice_subscriptions.count).to eq(1)
+        expect(invoice.fees.count).to eq(2)
+
+        expect(invoice.fees.pluck(:amount_cents)).to match_array([1000, 1500])
+        expect(invoice.fees.pluck(:usage_threshold_id)).to match_array(usage_thresholds.map(&:id))
+      end
+
+      context 'with a recurring threshold' do
+        let(:usage_thresholds) do
+          # NOTE: the order is wrong on purpose to test the sorting
+          [
+            create(:usage_threshold, plan:, amount_cents: 2500),
+            create(:usage_threshold, :recurring, plan:, amount_cents: 500),
+            create(:usage_threshold, plan:, amount_cents: 1000)
+          ]
+        end
+
+        let(:lifetime_usage) { create(:lifetime_usage, subscription:, current_usage_amount_cents: 4300) }
+
+        it 'creates a progressive billing invoice with multiples fees', aggregate_failures: true do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.invoice).to be_present
+
+          invoice = result.invoice
+          expect(invoice).to be_persisted
+          expect(invoice).to have_attributes(
+            organization: organization,
+            customer: customer,
+            currency: plan.amount_currency,
+            status: 'finalized',
+            invoice_type: 'progressive_billing',
+            fees_amount_cents: 4000,
+            taxes_amount_cents: 4000 * tax.rate / 100,
+            total_amount_cents: 4000 * (1 + tax.rate / 100)
+          )
+
+          expect(invoice.invoice_subscriptions.count).to eq(1)
+          expect(invoice.fees.count).to eq(3)
+
+          expect(invoice.fees.pluck(:amount_cents)).to match_array([1000, 1500, 1500])
+          expect(invoice.fees.pluck(:usage_threshold_id)).to match_array(usage_thresholds.map(&:id))
+          expect(invoice.fees.pluck(:units)).to match_array([1, 1, 3])
+        end
+      end
+    end
+
+    context 'when threashold was already billed' do
+      before do
+        create(
+          :invoice,
+          organization:,
+          customer:,
+          status: 'finalized',
+          invoice_type: :progressive_billing,
+          fees_amount_cents: 20,
+          subscriptions: [subscription]
+        )
+      end
+
+      it 'creates a progressive billing invoice', aggregate_failures: true do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.invoice).to be_present
+
+        invoice = result.invoice
+        usage_threshold = usage_thresholds.first
+        amount_cents = usage_threshold.amount_cents - 20
+
+        expect(invoice).to be_persisted
+        expect(invoice).to have_attributes(
+          organization: organization,
+          customer: customer,
+          currency: plan.amount_currency,
+          status: 'finalized',
+          invoice_type: 'progressive_billing',
+          fees_amount_cents: amount_cents,
+          taxes_amount_cents: amount_cents * tax.rate / 100,
+          total_amount_cents: amount_cents * (1 + tax.rate / 100)
+        )
+
+        expect(invoice.invoice_subscriptions.count).to eq(1)
+        expect(invoice.fees.count).to eq(1)
+      end
+    end
+
+    context 'when usage was already billed' do
+      before do
+        create(
+          :invoice,
+          organization:,
+          customer:,
+          status: 'finalized',
+          invoice_type: :subscription,
+          fees_amount_cents: 7,
+          subscriptions: [subscription]
+        )
+      end
+
+      it 'creates a progressive billing invoice', aggregate_failures: true do
+        result = create_service.call
+
+        expect(result).to be_success
+        expect(result.invoice).to be_present
+
+        invoice = result.invoice
+        usage_threshold = usage_thresholds.first
+        amount_cents = usage_threshold.amount_cents - 7
+
+        expect(invoice).to be_persisted
+        expect(invoice).to have_attributes(
+          organization: organization,
+          customer: customer,
+          currency: plan.amount_currency,
+          status: 'finalized',
+          invoice_type: 'progressive_billing',
+          fees_amount_cents: amount_cents,
+          taxes_amount_cents: (amount_cents * tax.rate / 100).round,
+          total_amount_cents: (amount_cents * (1 + tax.rate / 100)).round
+        )
+
+        expect(invoice.invoice_subscriptions.count).to eq(1)
+        expect(invoice.fees.count).to eq(1)
+      end
+
+      context 'with a recurring threshold' do
+        let(:usage_thresholds) { [create(:usage_threshold, :recurring, plan:, amount_cents: 100)] }
+
+        let(:lifetime_usage) { create(:lifetime_usage, subscription:, current_usage_amount_cents: 215) }
+
+        it 'creates a progressive billing invoice', aggregate_failures: true do
+          result = create_service.call
+
+          expect(result).to be_success
+          expect(result.invoice).to be_present
+
+          invoice = result.invoice
+          usage_threshold = usage_thresholds.first
+          amount_cents = usage_threshold.amount_cents * 2
+
+          expect(invoice).to be_persisted
+          expect(invoice).to have_attributes(
+            organization: organization,
+            customer: customer,
+            currency: plan.amount_currency,
+            status: 'finalized',
+            invoice_type: 'progressive_billing',
+            fees_amount_cents: amount_cents,
+            taxes_amount_cents: amount_cents * tax.rate / 100,
+            total_amount_cents: amount_cents * (1 + tax.rate / 100)
+          )
+
+          expect(invoice.invoice_subscriptions.count).to eq(1)
+          expect(invoice.fees.count).to eq(1)
+
+          expect(invoice.fees.pluck(:units)).to match_array([2])
+        end
+      end
+    end
+
+    it 'enqueues a SendWebhookJob' do
+      expect { create_service.call }.to have_enqueued_job(SendWebhookJob)
+    end
+
+    it 'enqueue an GeneratePdfAndNotifyJob with email false' do
+      expect { create_service.call }
+        .to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
+    end
+
+    context 'with lago_premium' do
+      around { |test| lago_premium!(&test) }
+
+      it 'enqueues an GeneratePdfAndNotifyJob with email true' do
+        expect { create_service.call }
+          .to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: true))
+      end
+
+      context 'when organization does not have right email settings' do
+        before { organization.update!(email_settings: []) }
+
+        it 'enqueue an GeneratePdfAndNotifyJob with email false' do
+          expect { create_service.call }
+            .to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
+        end
+      end
+    end
+
+    it 'calls SegmentTrackJob' do
+      invoice = create_service.call.invoice
+
+      expect(SegmentTrackJob).to have_received(:perform_later).with(
+        membership_id: CurrentContext.membership,
+        event: 'invoice_created',
+        properties: {
+          organization_id: organization.id,
+          invoice_id: invoice.id,
+          invoice_type: invoice.invoice_type
+        }
+      )
+    end
+
+    it 'creates a payment' do
+      allow(Invoices::Payments::CreateService).to receive(:call)
+
+      create_service.call
+
+      expect(Invoices::Payments::CreateService).to have_received(:call)
+    end
+
+    it_behaves_like 'syncs invoice' do
+      let(:service_call) { create_service.call }
+    end
+
+    it_behaves_like 'syncs sales order' do
+      let(:service_call) { create_service.call }
+    end
+  end
+end


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR adds the services to create an invoice with a fee when a specific `usage_threshold` is reach by a subscription.

It creates:
- A `progressive_billing` invoice
- An `invoice_subscription` with the right period boundaries
- A `progressive_billing` fee

It also handles:
- PDF generation
- Tax computation
- Email delivery
- Tracking on Segment
- Payment
- Sync with integrations