### PR TITLE
Remove casting in Event.{from|to}_datetime scopes

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,8 +13,8 @@ class Event < EventsRecord
   validates :code, presence: true
 
   default_scope -> { kept }
-  scope :from_datetime, ->(from_datetime) { where('events.timestamp::timestamp(0) >= ?', from_datetime) }
-  scope :to_datetime, ->(to_datetime) { where('events.timestamp::timestamp(0) <= ?', to_datetime) }
+  scope :from_datetime, ->(from_datetime) { where('events.timestamp >= ?', from_datetime) }
+  scope :to_datetime, ->(to_datetime) { where('events.timestamp <= ?', to_datetime) }
 
   def api_client
     metadata['user_agent']


### PR DESCRIPTION
## Description

These scopes prevent optimal index usage. Specifically any index that includes the `timestamp` cannot be used when we use this cast.