### PR TITLE
fix(export-invoices): fix finalized data export email subject typo

### DIFF
--- a/config/locales/en/email.yml
+++ b/config/locales/en/email.yml
@@ -19,7 +19,7 @@ en:
         intro: Your %{resource_type} export is ready! You can download it using the link below, which will be available for 7 days.
         lago_team: The Lago Team
         main_cta_label: Download export
-        subject: Your Lago %{resource_type} export in ready!
+        subject: Your Lago %{resource_type} export is ready!
         thanks: Thanks,
     invoice:
       finalized:

--- a/spec/mailers/data_export_mailer_spec.rb
+++ b/spec/mailers/data_export_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DataExportMailer, type: :mailer do
 
     specify do
       expect(mailer.to).to eq([data_export.user.email])
-      expect(mailer.subject).to eq("Your Lago invoices export in ready!")
+      expect(mailer.subject).to eq("Your Lago invoices export is ready!")
       expect(mailer.body.encoded).to match("Your invoices export is ready!")
       expect(mailer.body.encoded).to match("will be available for 7 days")
       expect(mailer.body.encoded).to match(data_export.file_url)
@@ -27,7 +27,7 @@ RSpec.describe DataExportMailer, type: :mailer do
       let(:data_export) { create(:data_export, :completed, resource_type: 'invoice_fees') }
 
       specify do
-        expect(mailer.subject).to eq("Your Lago invoice fees export in ready!")
+        expect(mailer.subject).to eq("Your Lago invoice fees export is ready!")
         expect(mailer.body.encoded).to match("Your invoice fees export is ready!")
       end
     end


### PR DESCRIPTION
## Context

When a data export (invoices or fees) is completed an email is sent to the user... this email has a typo in the subject.

## Description

fix the typo.