### PR TITLE
feat(ProgressiveBilling) add `LifetimeUsages::UsageThresholds::CheckService`

### DIFF
--- a/app/models/usage_threshold.rb
+++ b/app/models/usage_threshold.rb
@@ -11,4 +11,7 @@ class UsageThreshold < ApplicationRecord
   validates :amount_cents, numericality: {greater_than: 0}
   validates :amount_cents, uniqueness: {scope: %i[plan_id recurring]}
   validates :recurring, uniqueness: {scope: :plan_id}, if: -> { recurring? }
+
+  scope :recurring, -> { where(recurring: true) }
+  scope :not_recurring, -> { where(recurring: false) }
 end

--- a/app/services/lifetime_usages/usage_thresholds/check_service.rb
+++ b/app/services/lifetime_usages/usage_thresholds/check_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module LifetimeUsages
+  module UsageThresholds
+    class CheckService < BaseService
+      def initialize(lifetime_usage:)
+        @lifetime_usage = lifetime_usage
+        @thresholds = lifetime_usage.subscription.usage_thresholds
+        super
+      end
+
+      def call
+        result.passed_thresholds = []
+
+        fixed_thresholds = thresholds.not_recurring.order(:amount_cents)
+        # There is only 1 recurring threshold, `first` will return it or nil
+        recurring_threshold = thresholds.recurring.first
+
+        progressive_billed_amount = subscription.invoices.progressive_billing.sum(:amount_cents)
+
+        # Calculate the actual current usage, we need to substract the already billed progressive amount
+        # as we might be passing the threshold multiple times per period
+        actual_current_usage = lifetime_usage.current_usage_amount_cents - progressive_billed_amount
+        invoiced_usage = lifetime_usage.invoiced_usage_amount_cents
+
+        # Get the largest threshold amount
+        # in case there are no fixed_thresholds, this will return nil which to_i will convert to 0
+        largest_threshold_amount = fixed_thresholds.maximum(:amount_cents).to_i
+        total_usage = invoiced_usage + actual_current_usage
+
+        # First check the fixed thresholds
+        if invoiced_usage < largest_threshold_amount
+          # we're below some thresholds, filter out those that we've already invoiced.
+          # and keep those that we've passed based on total_usage.
+          result.passed_thresholds += fixed_thresholds.select do |threshold|
+            threshold.amount_cents > invoiced_usage && threshold.amount_cents <= total_usage
+          end
+        end
+
+        # Finally check the recurring threshold
+        if recurring_threshold && total_usage - largest_threshold_amount > recurring_threshold.amount_cents
+          result.passed_thresholds << recurring_threshold
+        end
+
+        result
+      end
+
+      private
+
+      attr_reader :lifetime_usage, :thresholds
+    end
+  end
+end

--- a/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
@@ -3,9 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe LifetimeUsages::UsageThresholds::CheckService, type: :service do
-  subject(:service) { described_class.new(lifetime_usage: lifetime_usage) }
+  subject(:service) { described_class.new(lifetime_usage:, progressive_billed_amount:) }
 
   let(:lifetime_usage) { create(:lifetime_usage, subscription:, recalculate_current_usage:, recalculate_invoiced_usage:) }
+  let(:progressive_billed_amount) { 0 }
   let(:recalculate_current_usage) { true }
   let(:recalculate_invoiced_usage) { true }
   let(:subscription) { create(:subscription, customer_id: customer.id) }
@@ -30,133 +31,266 @@ RSpec.describe LifetimeUsages::UsageThresholds::CheckService, type: :service do
       expect(result.passed_thresholds.map(&:amount_cents)).to eq(expected_threshold_amounts), "invoiced:#{invoiced} current:#{current} expected_thresholds: #{expected_threshold_amounts} got: #{result.passed_thresholds.map(&:amount_cents)}"
     end
   end
+  context "without progressive_billed_amount" do
+    context "without recurring thresholds" do
+      context "with no fixed thresholds" do
+        before do
+          create_thresholds(subscription, amounts: [])
+        end
 
-  context "without recurring thresholds" do
-    context "with no fixed thresholds" do
-      before do
-        create_thresholds(subscription, amounts: [])
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [0, 7] => [],
+            [0, 10] => [],
+            [9, 2] => [],
+            [11, 1] => [],
+            [11, 10] => []
+          })
+        end
       end
 
-      it "calculates the passed thresholds correctly" do
-        validate_thresholds({
-          [0, 7] => [],
-          [0, 10] => [],
-          [9, 2] => [],
-          [11, 1] => [],
-          [11, 10] => []
-        })
+      context "with 1 fixed threshold" do
+        before do
+          create_thresholds(subscription, amounts: [10])
+        end
+
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [0, 7] => [],
+            [0, 10] => [10],
+            [9, 2] => [10],
+            [11, 1] => [],
+            [11, 10] => []
+          })
+        end
+      end
+
+      context "with multiple fixed thresholds" do
+        before do
+          create_thresholds(subscription, amounts: [10, 20, 31, 40])
+        end
+
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [0, 7] => [],
+            [0, 10] => [10],
+            [0, 31] => [10, 20, 31],
+            [9, 2] => [10],
+            [9, 20] => [10, 20],
+            [9, 31] => [10, 20, 31, 40],
+            [11, 1] => [],
+            [11, 10] => [20],
+            [21, 20] => [31, 40],
+            [40, 2] => [],
+            [50, 0] => []
+          })
+        end
       end
     end
 
-    context "with 1 fixed threshold" do
-      before do
-        create_thresholds(subscription, amounts: [10])
+    context "with recurring thresholds" do
+      context "with no fixed thresholds" do
+        before do
+          create_thresholds(subscription, amounts: [], recurring: 10)
+        end
+
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [0, 7] => [],
+            [0, 10] => [10],
+            [9, 2] => [10],
+            [11, 1] => [],
+            [11, 8] => [],
+            [11, 9] => [10],
+            [11, 10] => [10],
+            [11, 20] => [10],
+            [202, 7] => [],
+            [202, 8] => [10]
+          })
+        end
       end
 
-      it "calculates the passed thresholds correctly" do
-        validate_thresholds({
-          [0, 7] => [],
-          [0, 10] => [10],
-          [9, 2] => [10],
-          [11, 1] => [],
-          [11, 10] => []
-        })
-      end
-    end
+      context "with 1 fixed threshold" do
+        before do
+          create_thresholds(subscription, amounts: [10], recurring: 5)
+        end
 
-    context "with multiple fixed thresholds" do
-      before do
-        create_thresholds(subscription, amounts: [10, 20, 31, 40])
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [0, 7] => [],
+            [0, 10] => [10],
+            [0, 15] => [10, 5],
+            [0, 20] => [10, 5],
+            [9, 2] => [10],
+            [9, 6] => [10, 5],
+            [9, 20] => [10, 5],
+            [11, 3] => [],
+            [11, 4] => [5],
+            [11, 20] => [5]
+          })
+        end
       end
 
-      it "calculates the passed thresholds correctly" do
-        validate_thresholds({
-          [0, 7] => [],
-          [0, 10] => [10],
-          [0, 31] => [10, 20, 31],
-          [9, 2] => [10],
-          [9, 20] => [10, 20],
-          [9, 31] => [10, 20, 31, 40],
-          [11, 1] => [],
-          [11, 10] => [20],
-          [21, 20] => [31, 40],
-          [40, 2] => [],
-          [50, 0] => []
-        })
+      context "with multiple fixed thresholds" do
+        before do
+          create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5)
+        end
+
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [0, 7] => [],
+            [0, 10] => [10],
+            [0, 31] => [10, 20, 31],
+            [0, 44] => [10, 20, 31, 40],
+            [0, 45] => [10, 20, 31, 40, 5],
+            [9, 2] => [10],
+            [9, 20] => [10, 20],
+            [9, 31] => [10, 20, 31, 40],
+            [9, 37] => [10, 20, 31, 40, 5],
+            [11, 1] => [],
+            [11, 10] => [20],
+            [21, 20] => [31, 40],
+            [21, 24] => [31, 40, 5],
+            [40, 2] => [],
+            [40, 5] => [5],
+            [41, 4] => [5],
+            [49, 1] => [5],
+            [50, 0] => [],
+            [50, 5] => [5]
+          })
+        end
       end
     end
   end
 
-  context "with recurring thresholds" do
-    context "with no fixed thresholds" do
-      before do
-        create_thresholds(subscription, amounts: [], recurring: 10)
+  context "with progressive_billed_amount set to 10" do
+    let(:progressive_billed_amount) { 10 }
+
+    context "without recurring thresholds" do
+      context "with no fixed thresholds" do
+        before do
+          create_thresholds(subscription, amounts: [])
+        end
+
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [0, 7] => [],
+            [0, 10] => [],
+            [9, 2] => [],
+            [11, 1] => [],
+            [11, 10] => []
+          })
+        end
       end
 
-      it "calculates the passed thresholds correctly" do
-        validate_thresholds({
-          [0, 7] => [],
-          [0, 10] => [10],
-          [9, 2] => [10],
-          [11, 1] => [],
-          [11, 8] => [],
-          [11, 9] => [10],
-          [11, 10] => [10],
-          [11, 20] => [10],
-          [202, 7] => [],
-          [202, 8] => [10]
-        })
+      context "with 1 fixed threshold" do
+        before do
+          create_thresholds(subscription, amounts: [10])
+        end
+
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [9, 2] => [],
+            [9, 20] => [],
+            [11, 10] => [],
+            [11, 20] => []
+          })
+        end
+      end
+
+      context "with multiple fixed thresholds" do
+        before do
+          create_thresholds(subscription, amounts: [10, 20, 31, 40])
+        end
+
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [0, 10] => [],
+            [0, 31] => [20, 31],
+            [9, 10] => [],
+            [9, 12] => [20],
+            [9, 20] => [20],
+            [9, 31] => [20, 31, 40],
+            [11, 11] => [],
+            [11, 20] => [31],
+            [21, 20] => [40],
+            [30, 12] => [],
+            [50, 10] => []
+          })
+        end
       end
     end
 
-    context "with 1 fixed threshold" do
-      before do
-        create_thresholds(subscription, amounts: [10], recurring: 5)
+    context "with recurring thresholds" do
+      context "with no fixed thresholds" do
+        before do
+          create_thresholds(subscription, amounts: [], recurring: 10)
+        end
+
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [0, 10] => [],
+            [11, 10] => [],
+            [11, 19] => [10],
+            [202, 17] => [],
+            [202, 18] => [10],
+            [202, 28] => [10]
+          })
+        end
       end
 
-      it "calculates the passed thresholds correctly" do
-        validate_thresholds({
-          [0, 7] => [],
-          [0, 10] => [10],
-          [0, 15] => [10, 5],
-          [0, 20] => [10, 5],
-          [9, 2] => [10],
-          [9, 6] => [10, 5],
-          [9, 20] => [10, 5],
-          [11, 3] => [],
-          [11, 4] => [5],
-          [11, 20] => [5]
-        })
-      end
-    end
+      context "with 1 fixed threshold" do
+        before do
+          create_thresholds(subscription, amounts: [10], recurring: 5)
+        end
 
-    context "with multiple fixed thresholds" do
-      before do
-        create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5)
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [0, 7] => [],
+            [0, 10] => [],
+            [0, 15] => [5],
+            [0, 20] => [5],
+            [9, 2] => [],
+            [9, 6] => [],
+            [9, 16] => [5],
+            [11, 3] => [],
+            [11, 4] => [],
+            [11, 14] => [5],
+            [11, 24] => [5]
+          })
+        end
       end
 
-      it "calculates the passed thresholds correctly" do
-        validate_thresholds({
-          [0, 7] => [],
-          [0, 10] => [10],
-          [0, 31] => [10, 20, 31],
-          [0, 44] => [10, 20, 31, 40],
-          [0, 45] => [10, 20, 31, 40, 5],
-          [9, 2] => [10],
-          [9, 20] => [10, 20],
-          [9, 31] => [10, 20, 31, 40],
-          [9, 37] => [10, 20, 31, 40, 5],
-          [11, 1] => [],
-          [11, 10] => [20],
-          [21, 20] => [31, 40],
-          [21, 24] => [31, 40, 5],
-          [40, 2] => [],
-          [40, 5] => [5],
-          [41, 4] => [5],
-          [49, 1] => [5],
-          [50, 0] => [],
-          [50, 5] => [5]
-        })
+      context "with multiple fixed thresholds" do
+        before do
+          create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5)
+        end
+
+        it "calculates the passed thresholds correctly" do
+          validate_thresholds({
+            [0, 7] => [],
+            [0, 10] => [],
+            [0, 31] => [20, 31],
+            [0, 44] => [20, 31, 40],
+            [0, 45] => [20, 31, 40, 5],
+            [9, 2] => [],
+            [9, 20] => [20],
+            [9, 31] => [20, 31, 40],
+            [9, 37] => [20, 31, 40, 5],
+            [11, 1] => [],
+            [11, 10] => [],
+            [20, 20] => [31, 40],
+            [21, 20] => [40],
+            [21, 24] => [40, 5],
+            [40, 14] => [],
+            [40, 15] => [5],
+            [41, 14] => [5],
+            [49, 1] => [],
+            [49, 11] => [5],
+            [50, 5] => [],
+            [50, 15] => [5]
+          })
+        end
       end
     end
   end

--- a/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
@@ -11,4 +11,153 @@ RSpec.describe LifetimeUsages::UsageThresholds::CheckService, type: :service do
   let(:subscription) { create(:subscription, customer_id: customer.id) }
   let(:organization) { subscription.organization }
   let(:customer) { create(:customer) }
+
+  def create_thresholds(subscription, amounts:, recurring: nil)
+    amounts.each do |amount|
+      subscription.plan.usage_thresholds.create!(amount_cents: amount)
+    end
+    if recurring
+      subscription.plan.usage_thresholds.create!(amount_cents: recurring, recurring: true)
+    end
+  end
+
+  def validate_thresholds(mapping)
+    mapping.each do |(invoiced, current), expected_threshold_amounts|
+      lifetime_usage.invoiced_usage_amount_cents = invoiced
+      lifetime_usage.current_usage_amount_cents = current
+      result = service.call
+
+      expect(result.passed_thresholds.map(&:amount_cents)).to eq(expected_threshold_amounts), "invoiced:#{invoiced} current:#{current} expected_thresholds: #{expected_threshold_amounts} got: #{result.passed_thresholds.map(&:amount_cents)}"
+    end
+  end
+
+  context "without recurring thresholds" do
+    context "with no fixed thresholds" do
+      before do
+        create_thresholds(subscription, amounts: [])
+      end
+
+      it "calculates the passed thresholds correctly" do
+        validate_thresholds({
+          [0, 7] => [],
+          [0, 10] => [],
+          [9, 2] => [],
+          [11, 1] => [],
+          [11, 10] => []
+        })
+      end
+    end
+
+    context "with 1 fixed threshold" do
+      before do
+        create_thresholds(subscription, amounts: [10])
+      end
+
+      it "calculates the passed thresholds correctly" do
+        validate_thresholds({
+          [0, 7] => [],
+          [0, 10] => [10],
+          [9, 2] => [10],
+          [11, 1] => [],
+          [11, 10] => []
+        })
+      end
+    end
+
+    context "with multiple fixed thresholds" do
+      before do
+        create_thresholds(subscription, amounts: [10, 20, 31, 40])
+      end
+
+      it "calculates the passed thresholds correctly" do
+        validate_thresholds({
+          [0, 7] => [],
+          [0, 10] => [10],
+          [0, 31] => [10, 20, 31],
+          [9, 2] => [10],
+          [9, 20] => [10, 20],
+          [9, 31] => [10, 20, 31, 40],
+          [11, 1] => [],
+          [11, 10] => [20],
+          [21, 20] => [31, 40],
+          [40, 2] => [],
+          [50, 0] => []
+        })
+      end
+    end
+  end
+
+  context "with recurring thresholds" do
+    context "with no fixed thresholds" do
+      before do
+        create_thresholds(subscription, amounts: [], recurring: 10)
+      end
+
+      it "calculates the passed thresholds correctly" do
+        validate_thresholds({
+          [0, 7] => [],
+          [0, 10] => [10],
+          [9, 2] => [10],
+          [11, 1] => [],
+          [11, 8] => [],
+          [11, 9] => [10],
+          [11, 10] => [10],
+          [11, 20] => [10],
+          [202, 7] => [],
+          [202, 8] => [10]
+        })
+      end
+    end
+
+    context "with 1 fixed threshold" do
+      before do
+        create_thresholds(subscription, amounts: [10], recurring: 5)
+      end
+
+      it "calculates the passed thresholds correctly" do
+        validate_thresholds({
+          [0, 7] => [],
+          [0, 10] => [10],
+          [0, 15] => [10, 5],
+          [0, 20] => [10, 5],
+          [9, 2] => [10],
+          [9, 6] => [10, 5],
+          [9, 20] => [10, 5],
+          [11, 3] => [],
+          [11, 4] => [5],
+          [11, 20] => [5]
+        })
+      end
+    end
+
+    context "with multiple fixed thresholds" do
+      before do
+        create_thresholds(subscription, amounts: [10, 20, 31, 40], recurring: 5)
+      end
+
+      it "calculates the passed thresholds correctly" do
+        validate_thresholds({
+          [0, 7] => [],
+          [0, 10] => [10],
+          [0, 31] => [10, 20, 31],
+          [0, 44] => [10, 20, 31, 40],
+          [0, 45] => [10, 20, 31, 40, 5],
+          [9, 2] => [10],
+          [9, 20] => [10, 20],
+          [9, 31] => [10, 20, 31, 40],
+          [9, 37] => [10, 20, 31, 40, 5],
+          [11, 1] => [],
+          [11, 10] => [20],
+          [21, 20] => [31, 40],
+          [21, 24] => [31, 40, 5],
+          [40, 2] => [],
+          [40, 5] => [5],
+          [41, 4] => [5],
+          [49, 1] => [5],
+          [50, 0] => [],
+          [50, 5] => [5]
+        })
+      end
+    end
+  end
 end

--- a/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
+++ b/spec/services/lifetime_usages/usage_thresholds/check_service_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LifetimeUsages::UsageThresholds::CheckService, type: :service do
+  subject(:service) { described_class.new(lifetime_usage: lifetime_usage) }
+
+  let(:lifetime_usage) { create(:lifetime_usage, subscription:, recalculate_current_usage:, recalculate_invoiced_usage:) }
+  let(:recalculate_current_usage) { true }
+  let(:recalculate_invoiced_usage) { true }
+  let(:subscription) { create(:subscription, customer_id: customer.id) }
+  let(:organization) { subscription.organization }
+  let(:customer) { create(:customer) }
+end


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR adds the service responsible for checking if a threshold has been reached. It will return return all passed_thresholds as the result.
