### PR TITLE
feat(dunning): Ability to fetch payment requests from API

### DIFF
--- a/app/controllers/api/v1/payment_requests_controller.rb
+++ b/app/controllers/api/v1/payment_requests_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class PaymentRequestsController < Api::BaseController
+      def index
+        result = PaymentRequestsQuery.call(
+          organization: current_organization,
+          pagination: {
+            page: params[:page],
+            limit: params[:per_page] || PER_PAGE
+          },
+          filters: index_filters
+        )
+
+        if result.success?
+          render(
+            json: ::CollectionSerializer.new(
+              result.payment_requests.preload(:customer, payment_requestable: :invoices),
+              ::V1::PaymentRequestSerializer,
+              collection_name: "payment_requests",
+              meta: pagination_metadata(result.payment_requests),
+              includes: %i[customer invoices]
+            )
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
+      private
+
+      def index_filters
+        params.permit(:external_customer_id)
+      end
+    end
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -25,7 +25,9 @@ class Organization < ApplicationRecord
   has_many :add_ons
   has_many :invites
   has_many :integrations, class_name: 'Integrations::BaseIntegration'
+  has_many :payable_groups
   has_many :payment_providers, class_name: 'PaymentProviders::BaseProvider'
+  has_many :payment_requests
   has_many :taxes
   has_many :wallets, through: :customers
   has_many :wallet_transactions, through: :wallets

--- a/app/models/payable_group.rb
+++ b/app/models/payable_group.rb
@@ -3,6 +3,7 @@
 class PayableGroup < ApplicationRecord
   include PaperTrailTraceable
 
+  belongs_to :organization
   belongs_to :customer, -> { with_discarded }
 
   has_many :invoices

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -4,7 +4,8 @@ class PaymentRequest < ApplicationRecord
   include PaperTrailTraceable
 
   has_many :payments
-  belongs_to :customer
+  belongs_to :organization
+  belongs_to :customer, -> { with_discarded }
   belongs_to :payment_requestable, polymorphic: true
 
   validates :email, presence: true

--- a/app/queries/payment_requests_query.rb
+++ b/app/queries/payment_requests_query.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class PaymentRequestsQuery < BaseQuery
+  def call
+    payment_requests = PaymentRequest.where(organization:)
+    payment_requests = paginate(payment_requests)
+    payment_requests = payment_requests.order(created_at: :desc)
+
+    payment_requests = with_external_customer(payment_requests) if filters.external_customer_id
+
+    result.payment_requests = payment_requests
+    result
+  end
+
+  private
+
+  def with_external_customer(scope)
+    scope.joins(:customer).where(customers: {external_id: filters.external_customer_id})
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
         put :refresh, on: :member
         put :finalize, on: :member
       end
+      resources :payment_requests, only: %i[index]
       resources :plans, param: :code
       resources :taxes, param: :code
       resources :wallet_transactions, only: :create

--- a/db/migrate/20240814144137_add_organization_id_to_payment_requests_and_payable_groups.rb
+++ b/db/migrate/20240814144137_add_organization_id_to_payment_requests_and_payable_groups.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class AddOrganizationIdToPaymentRequestsAndPayableGroups < ActiveRecord::Migration[7.1]
+  def change
+    change_table :payment_requests, bulk: true do |t|
+      t.uuid :organization_id
+    end
+
+    change_table :payable_groups, bulk: true do |t|
+      t.uuid :organization_id
+    end
+
+    # NOTE: Set organization_id for existing records based on customer_id
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE payment_requests
+          SET organization_id = (
+            SELECT organization_id
+            FROM customers
+            WHERE customers.id = payment_requests.customer_id
+          );
+
+          UPDATE payable_groups
+          SET organization_id = (
+            SELECT organization_id
+            FROM customers
+            WHERE customers.id = payable_groups.customer_id
+          )
+        SQL
+      end
+    end
+
+    change_column_null :payment_requests, :organization_id, false
+    change_column_null :payable_groups, :organization_id, false
+    add_index :payment_requests, :organization_id
+    add_index :payable_groups, :organization_id
+    add_foreign_key :payment_requests, :organizations
+    add_foreign_key :payable_groups, :organizations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_12_130655) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_14_144137) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -862,7 +862,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_12_130655) do
     t.integer "payment_status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "organization_id", null: false
     t.index ["customer_id"], name: "index_payable_groups_on_customer_id"
+    t.index ["organization_id"], name: "index_payable_groups_on_organization_id"
   end
 
   create_table "payment_provider_customers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -900,7 +902,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_12_130655) do
     t.string "email", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "organization_id", null: false
     t.index ["customer_id"], name: "index_payment_requests_on_customer_id"
+    t.index ["organization_id"], name: "index_payment_requests_on_organization_id"
     t.index ["payment_requestable_type", "payment_requestable_id"], name: "idx_on_payment_requestable_type_payment_requestable_b151968780"
   end
 
@@ -1236,10 +1240,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_12_130655) do
   add_foreign_key "memberships", "users"
   add_foreign_key "password_resets", "users"
   add_foreign_key "payable_groups", "customers"
+  add_foreign_key "payable_groups", "organizations"
   add_foreign_key "payment_provider_customers", "customers"
   add_foreign_key "payment_provider_customers", "payment_providers"
   add_foreign_key "payment_providers", "organizations"
   add_foreign_key "payment_requests", "customers"
+  add_foreign_key "payment_requests", "organizations"
   add_foreign_key "payments", "invoices"
   add_foreign_key "payments", "payment_providers"
   add_foreign_key "payments", "payment_requests"

--- a/spec/factories/payable_groups.rb
+++ b/spec/factories/payable_groups.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :payable_group do
     customer
+    organization { customer.organization }
   end
 end

--- a/spec/factories/payment_requests.rb
+++ b/spec/factories/payment_requests.rb
@@ -3,7 +3,8 @@
 FactoryBot.define do
   factory :payment_request do
     customer
-    payment_requestable { create(:payable_group) }
+    organization { customer.organization }
+    payment_requestable { create(:payable_group, customer:) }
 
     amount_cents { 200 }
     amount_currency { "EUR" }

--- a/spec/models/payment_request_spec.rb
+++ b/spec/models/payment_request_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe PaymentRequest, type: :model do
   subject(:payment_request) do
     described_class.new(
+      organization:,
       customer:,
       payment_requestable: payable_group,
       email: Faker::Internet.email,
@@ -14,6 +15,7 @@ RSpec.describe PaymentRequest, type: :model do
   end
 
   let(:customer) { create(:customer) }
+  let(:organization) { customer.organization }
   let(:payment) { create(:payment) }
   let(:payable_group) { create(:payable_group) }
 

--- a/spec/queries/payment_requests_query_spec.rb
+++ b/spec/queries/payment_requests_query_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentRequestsQuery, type: :query do
+  subject(:result) do
+    described_class.call(organization:, pagination:, filters:)
+  end
+
+  let(:pagination) { nil }
+  let(:filters) { {} }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:payment_request_first) { create(:payment_request, organization:) }
+  let(:payment_request_second) { create(:payment_request, organization:, customer:) }
+
+  before do
+    payment_request_first
+    payment_request_second
+  end
+
+  it "returns all payment requests", :aggregate_failures do
+    expect(result).to be_success
+    expect(result.payment_requests.pluck(:id)).to contain_exactly(
+      payment_request_first.id,
+      payment_request_second.id
+    )
+  end
+
+  context "with pagination" do
+    let(:pagination) { {page: 2, limit: 1} }
+
+    it "applies the pagination", :aggregate_failures do
+      expect(result).to be_success
+      expect(result.payment_requests.count).to eq(1)
+      expect(result.payment_requests.current_page).to eq(2)
+      expect(result.payment_requests.prev_page).to eq(1)
+      expect(result.payment_requests.next_page).to be_nil
+      expect(result.payment_requests.total_pages).to eq(2)
+      expect(result.payment_requests.total_count).to eq(2)
+    end
+  end
+
+  context "when filtering by customer_id" do
+    let(:filters) { {external_customer_id: customer.external_id} }
+
+    it "returns all payment_requests of the customer", :aggregate_failures do
+      expect(result).to be_success
+      expect(result.payment_requests.pluck(:id)).to contain_exactly(
+        payment_request_second.id
+      )
+    end
+  end
+end

--- a/spec/requests/api/v1/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/payment_requests_controller_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Api::V1::PaymentRequestsController, type: :request do
+  let(:organization) { create(:organization) }
+
+  describe "index" do
+    it "returns organization's payment requests", :aggregate_failures do
+      first_customer = create(:customer, organization:)
+      second_customer = create(:customer, organization:)
+      first_payment_request = create(:payment_request, customer: first_customer)
+      second_payment_request = create(:payment_request, customer: second_customer)
+
+      get_with_token(organization, "/api/v1/payment_requests")
+
+      expect(response).to have_http_status(:success)
+      expect(json[:payment_requests].count).to eq(2)
+      expect(json[:payment_requests].map { |r| r[:lago_id] }).to contain_exactly(
+        first_payment_request.id,
+        second_payment_request.id
+      )
+    end
+
+    context "with a not found customer", :aggregate_failures do
+      it "returns an empty result" do
+        get_with_token(
+          organization,
+          "/api/v1/payment_requests?external_customer_id=unknown"
+        )
+
+        expect(response).to have_http_status(:success)
+        expect(json[:payment_requests]).to be_empty
+      end
+    end
+
+    context "with customer" do
+      let(:customer) { create(:customer, organization:) }
+
+      it "returns customer's payment requests", :aggregate_failures do
+        payable_group = create(:payable_group, customer:)
+        first_payment_request = create(:payment_request, customer:, payment_requestable: payable_group)
+        create(:payment_request)
+        invoice = create(:invoice, customer:, payable_group:)
+
+        get_with_token(
+          organization,
+          "/api/v1/payment_requests?external_customer_id=#{customer.external_id}"
+        )
+
+        expect(response).to have_http_status(:success)
+        expect(json[:payment_requests].map { |r| r[:lago_id] }).to contain_exactly(
+          first_payment_request.id
+        )
+        expect(json[:payment_requests].first[:customer][:lago_id]).to eq(customer.id)
+        expect(json[:payment_requests].first[:invoices].first[:lago_id]).to eq(invoice.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

## Description

The goal of this PR is to add an endpoint for fetching payment requests from the API.