### PR TITLE
feat(dunning): Add resolver for payment requests

### DIFF
--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -84,3 +84,5 @@ organization:
     create:
     update:
     delete:
+payment_requests:
+  view: true

--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -60,3 +60,5 @@ organization:
     create: false
     update: false
     delete: false
+payment_requests:
+  view: true

--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -60,3 +60,5 @@ organization:
     create: false
     update: false
     delete: false
+payment_requests:
+  view: true

--- a/app/graphql/resolvers/payment_requests_resolver.rb
+++ b/app/graphql/resolvers/payment_requests_resolver.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Resolvers
+  class PaymentRequestsResolver < Resolvers::BaseResolver
+    include AuthenticableApiUser
+    include RequiredOrganization
+
+    REQUIRED_PERMISSION = "payment_requests:view"
+
+    description "Query payment requests of an organization"
+
+    argument :external_customer_id, String, required: false
+    argument :limit, Integer, required: false
+    argument :page, Integer, required: false
+
+    type Types::PaymentRequests::Object.collection_type, null: false
+
+    def resolve(page: nil, limit: nil, external_customer_id: nil)
+      result = PaymentRequestsQuery.call(
+        organization: current_organization,
+        filters: {
+          external_customer_id:
+        },
+        pagination: {
+          page:,
+          limit:
+        }
+      )
+
+      result.payment_requests
+    end
+  end
+end

--- a/app/graphql/types/payment_requests/object.rb
+++ b/app/graphql/types/payment_requests/object.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Types
+  module PaymentRequests
+    class Object < Types::BaseObject
+      graphql_name "PaymentRequest"
+
+      field :id, ID, null: false
+
+      field :amount_cents, GraphQL::Types::BigInt, null: false
+      field :amount_currency, Types::CurrencyEnum, null: false
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :email, String, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      field :customer, Types::Customers::Object, null: false
+      field :invoices, [Types::Invoices::Object], null: false
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -53,6 +53,7 @@ module Types
     field :password_reset, resolver: Resolvers::PasswordResetResolver
     field :payment_provider, resolver: Resolvers::PaymentProviderResolver
     field :payment_providers, resolver: Resolvers::PaymentProvidersResolver
+    field :payment_requests, resolver: Resolvers::PaymentRequestsResolver
     field :plan, resolver: Resolvers::PlanResolver
     field :plans, resolver: Resolvers::PlansResolver
     field :subscription, resolver: Resolvers::SubscriptionResolver

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -11,4 +11,8 @@ class PaymentRequest < ApplicationRecord
   validates :email, presence: true
   validates :amount_cents, presence: true
   validates :amount_currency, presence: true
+
+  def invoices
+    payment_requestable.is_a?(Invoice) ? [payment_requestable] : payment_requestable.invoices
+  end
 end

--- a/app/serializers/v1/payment_request_serializer.rb
+++ b/app/serializers/v1/payment_request_serializer.rb
@@ -26,10 +26,8 @@ module V1
     end
 
     def invoices
-      invoices = model.payment_requestable.is_a?(Invoice) ? [model.payment_requestable] : model.payment_requestable.invoices
-
       ::CollectionSerializer.new(
-        invoices,
+        model.invoices,
         ::V1::InvoiceSerializer,
         collection_name: "invoices"
       ).serialize

--- a/schema.graphql
+++ b/schema.graphql
@@ -5231,6 +5231,22 @@ type PaymentProviderCollection {
   metadata: CollectionMetadata!
 }
 
+type PaymentRequest {
+  amountCents: BigInt!
+  amountCurrency: CurrencyEnum!
+  createdAt: ISO8601DateTime!
+  customer: Customer!
+  email: String!
+  id: ID!
+  invoices: [Invoice!]!
+  updatedAt: ISO8601DateTime!
+}
+
+type PaymentRequestCollection {
+  collection: [PaymentRequest!]!
+  metadata: CollectionMetadata!
+}
+
 """
 Permissions Type
 """
@@ -5288,6 +5304,7 @@ type Permissions {
   organizationTaxesView: Boolean!
   organizationUpdate: Boolean!
   organizationView: Boolean!
+  paymentRequestsView: Boolean!
   plansCreate: Boolean!
   plansDelete: Boolean!
   plansUpdate: Boolean!
@@ -5717,6 +5734,11 @@ type Query {
   Query organization's payment providers
   """
   paymentProviders(limit: Int, page: Int, type: ProviderTypeEnum): PaymentProviderCollection
+
+  """
+  Query payment requests of an organization
+  """
+  paymentRequests(externalCustomerId: String, limit: Int, page: Int): PaymentRequestCollection!
 
   """
   Query a single plan of an organization

--- a/schema.json
+++ b/schema.json
@@ -25200,6 +25200,228 @@
         },
         {
           "kind": "OBJECT",
+          "name": "PaymentRequest",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "amountCurrency",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CurrencyEnum",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "customer",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Customer",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "email",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoices",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Invoice",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PaymentRequestCollection",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "collection",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "PaymentRequest",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "metadata",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Permissions",
           "description": "Permissions Type",
           "interfaces": [
@@ -26145,6 +26367,24 @@
             },
             {
               "name": "organizationView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "paymentRequestsView",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -29663,6 +29903,59 @@
                   "type": {
                     "kind": "ENUM",
                     "name": "ProviderTypeEnum",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
+              "name": "paymentRequests",
+              "description": "Query payment requests of an organization",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PaymentRequestCollection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "externalCustomerId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "page",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
                     "ofType": null
                   },
                   "defaultValue": null,

--- a/spec/graphql/resolvers/payment_requests_resolver_spec.rb
+++ b/spec/graphql/resolvers/payment_requests_resolver_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Resolvers::PaymentRequestsResolver, type: :graphql do
+  let(:required_permission) { "payment_requests:view" }
+  let(:query) do
+    <<~GQL
+      query {
+        paymentRequests(limit: 5) {
+          collection {
+            id
+            amountCents
+            customer { id }
+            invoices { id }
+          }
+          metadata { currentPage, totalCount }
+        }
+      }
+    GQL
+  end
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+  let(:payment_request) { create(:payment_request, organization:, customer:) }
+
+  before do
+    payment_request
+  end
+
+  it_behaves_like "requires current user"
+  it_behaves_like "requires current organization"
+  it_behaves_like "requires permission", "payment_requests:view"
+
+  it "returns a list of payment_requests", :aggregate_failures do
+    result = execute_graphql(
+      current_user: membership.user,
+      current_organization: organization,
+      permissions: required_permission,
+      query:
+    )
+
+    payment_requests_response = result["data"]["paymentRequests"]
+
+    expect(payment_requests_response["collection"].count).to eq(organization.payment_requests.count)
+    expect(payment_requests_response["collection"].first["id"]).to eq(payment_request.id)
+    expect(payment_requests_response["collection"].first["amountCents"]).to eq(payment_request.amount_cents.to_s)
+    expect(payment_requests_response["collection"].first["customer"]["id"]).to eq(customer.id)
+    expect(payment_requests_response["collection"].first["invoices"]).to eq([])
+  end
+end

--- a/spec/models/payment_request_spec.rb
+++ b/spec/models/payment_request_spec.rb
@@ -45,4 +45,25 @@ RSpec.describe PaymentRequest, type: :model do
       expect(payment_request).not_to be_valid
     end
   end
+
+  describe "#invoices" do
+    context "when payment_requestable is an invoice" do
+      let(:invoice) { create(:invoice) }
+      let(:payment_request) { create(:payment_request, payment_requestable: invoice) }
+
+      it "returns an array with the invoice" do
+        expect(payment_request.invoices).to eq([invoice])
+      end
+    end
+
+    context "when payment_requestable is a payable_group" do
+      let(:payable_group) { create(:payable_group) }
+      let(:payment_request) { create(:payment_request, payment_requestable: payable_group) }
+
+      it "returns the invoices from the payable_group" do
+        invoice = create(:invoice, payable_group:)
+        expect(payment_request.invoices).to eq([invoice])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

## Description

The goal of this PR is to add the graphql resolver for fetching payment requests.