### PR TITLE
Feat (anrok): display special provider rules in pdf

### DIFF
--- a/app/models/invoice/applied_tax.rb
+++ b/app/models/invoice/applied_tax.rb
@@ -15,7 +15,8 @@ class Invoice
 
     validates :amount_cents, numericality: {greater_than_or_equal_to: 0}
 
-    TAX_CODES_APPLICABLE_ON_WHOLE_INVOICE = %w[not_collecting juris_not_taxed reverse_charge customer_exempt transaction_exempt]
+    TAX_CODES_APPLICABLE_ON_WHOLE_INVOICE = %w[not_collecting juris_not_taxed reverse_charge customer_exempt
+      transaction_exempt].freeze
 
     def applied_on_whole_invoice?
       TAX_CODES_APPLICABLE_ON_WHOLE_INVOICE.include?(tax_code)

--- a/app/models/invoice/applied_tax.rb
+++ b/app/models/invoice/applied_tax.rb
@@ -14,6 +14,12 @@ class Invoice
       with_model_currency: :amount_currency
 
     validates :amount_cents, numericality: {greater_than_or_equal_to: 0}
+
+    TAX_CODES_APPLICABLE_ON_WHOLE_INVOICE = %w[not_collecting juris_not_taxed reverse_charge customer_exempt transaction_exempt]
+
+    def applied_on_whole_invoice?
+      TAX_CODES_APPLICABLE_ON_WHOLE_INVOICE.include?(tax_code)
+    end
   end
 end
 

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -160,8 +160,11 @@
             - applied_taxes.order(tax_rate: :desc).each do |applied_tax|
               tr
                 td.body-2
-                td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.fees_amount))
-                td.body-2 = MoneyHelper.format(applied_tax.amount)
+                - if applied_tax.applied_on_whole_invoice?
+                  td.body-2 = I18n.t('invoice.tax_name_only.' + applied_tax.tax_code)
+                - else
+                  td.body-2 = I18n.t('invoice.tax_name', name: applied_tax.tax_name, rate: applied_tax.tax_rate, amount: MoneyHelper.format(applied_tax.fees_amount))
+                  td.body-2 = MoneyHelper.format(applied_tax.amount)
           - else
             tr
               td.body-2

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -63,13 +63,13 @@ de:
     tax: Steuern
     tax_identification_number: 'Steuer ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% on %{amount})"
-    tax_name_with_details: "%{name} (%{rate}%)"
     tax_name_only:
-      not_collecting: Keine Steuer
-      juris_not_taxed: Keine Steuer
-      reverse_charge: Reverse-Charge-Verfahren - Steuerschuldnerschaft auf den Kunden übertragen
       customer_exempt: Der Kunde ist von der Umsatzsteuer befreit
+      juris_not_taxed: Keine Steuer
+      not_collecting: Keine Steuer
+      reverse_charge: Reverse-Charge-Verfahren - Steuerschuldnerschaft auf den Kunden übertragen
       transaction_exempt: Der Kunde ist von der Umsatzsteuer befreit
+    tax_name_with_details: "%{name} (%{rate}%)"
     tax_rate: Steuersatz
     taxes:
       fr_tax_exempt: Kunde ist gemäß Artikel 259-1 des französischen Allgemeinen Steuergesetzbuchs von der Steuer befreit.

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -64,6 +64,12 @@ de:
     tax_identification_number: 'Steuer ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% on %{amount})"
     tax_name_with_details: "%{name} (%{rate}%)"
+    tax_name_only:
+      not_collecting: Keine Steuer
+      juris_not_taxed: Keine Steuer
+      reverse_charge: Reverse-Charge-Verfahren - Steuerschuldnerschaft auf den Kunden übertragen
+      customer_exempt: Der Kunde ist von der Umsatzsteuer befreit
+      transaction_exempt: Der Kunde ist von der Umsatzsteuer befreit
     tax_rate: Steuersatz
     taxes:
       fr_tax_exempt: Kunde ist gemäß Artikel 259-1 des französischen Allgemeinen Steuergesetzbuchs von der Steuer befreit.

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -63,13 +63,13 @@ en:
     tax: Tax
     tax_identification_number: 'Tax ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% on %{amount})"
-    tax_name_with_details: "%{name} (%{rate}%)"
     tax_name_only:
-      not_collecting: No tax
-      juris_not_taxed: No tax
-      reverse_charge: Reverse charge - Tax liability shifted to customer
       customer_exempt: Customer is tax exempt
+      juris_not_taxed: No tax
+      not_collecting: No tax
+      reverse_charge: Reverse charge - Tax liability shifted to customer
       transaction_exempt: Customer is tax exempt
+    tax_name_with_details: "%{name} (%{rate}%)"
     tax_rate: Tax rate
     taxes:
       fr_tax_exempt: Customer is tax exempt according to article 259-1 of the French Tax General Code.

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -65,10 +65,10 @@ en:
     tax_name: "%{name} (%{rate}% on %{amount})"
     tax_name_with_details: "%{name} (%{rate}%)"
     tax_name_only:
-      not_collecting: Not collecting
-      juris_not_taxed: Juris not taxed
+      not_collecting: No tax
+      juris_not_taxed: No tax
       reverse_charge: Reverse charge - Tax liability shifted to customer
-      customer_exempt: Customer Exempt
+      customer_exempt: Customer is tax exempt
       transaction_exempt: Customer is tax exempt
     tax_rate: Tax rate
     taxes:

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -64,6 +64,12 @@ en:
     tax_identification_number: 'Tax ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% on %{amount})"
     tax_name_with_details: "%{name} (%{rate}%)"
+    tax_name_only:
+      not_collecting: Not collecting
+      juris_not_taxed: Juris not taxed
+      reverse_charge: Reverse charge - Tax liability shifted to customer
+      customer_exempt: Customer Exempt
+      transaction_exempt: Customer is tax exempt
     tax_rate: Tax rate
     taxes:
       fr_tax_exempt: Customer is tax exempt according to article 259-1 of the French Tax General Code.

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -63,6 +63,12 @@ es:
     tax_identification_number: 'ID del impuesto: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% sobre %{amount})"
     tax_name_with_details: "%{name} (%{rate}%)"
+    tax_name_only:
+      not_collecting: Sin impuesto
+      juris_not_taxed: Sin impuesto
+      reverse_charge: Inversión del sujeto pasivo - Responsabilidad fiscal trasladada al cliente
+      customer_exempt: El cliente está exento de impuestos
+      transaction_exempt: El cliente está exento de impuestos
     tax_rate: Tasas de impuestos
     taxes:
       fr_tax_exempt: El cliente está exento de impuestos según el artículo 259-1 del Código General de Impuestos francés.

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -62,13 +62,13 @@ es:
     tax: Impuesto
     tax_identification_number: 'ID del impuesto: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% sobre %{amount})"
-    tax_name_with_details: "%{name} (%{rate}%)"
     tax_name_only:
-      not_collecting: Sin impuesto
-      juris_not_taxed: Sin impuesto
-      reverse_charge: Inversión del sujeto pasivo - Responsabilidad fiscal trasladada al cliente
       customer_exempt: El cliente está exento de impuestos
+      juris_not_taxed: Sin impuesto
+      not_collecting: Sin impuesto
+      reverse_charge: Inversión del sujeto pasivo - Responsabilidad fiscal trasladada al cliente
       transaction_exempt: El cliente está exento de impuestos
+    tax_name_with_details: "%{name} (%{rate}%)"
     tax_rate: Tasas de impuestos
     taxes:
       fr_tax_exempt: El cliente está exento de impuestos según el artículo 259-1 del Código General de Impuestos francés.

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -64,6 +64,12 @@ fr:
     tax_identification_number: 'ID fiscal: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% sur %{amount})"
     tax_name_with_details: "%{name} (%{rate}%)"
+    tax_name_only:
+      not_collecting: Pas de taxe
+      juris_not_taxed: Taxe non applicable
+      reverse_charge: Autoliquidation - Responsabilité fiscale transférée au client
+      customer_exempt: Le client est exonéré de taxe
+      transaction_exempt: Le client est exonéré de taxe
     tax_rate: Taux de taxe
     taxes:
       fr_tax_exempt: Le client est exonéré de taxe – art. 259-1 du CGI.

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -63,13 +63,13 @@ fr:
     tax: TVA
     tax_identification_number: 'ID fiscal: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% sur %{amount})"
-    tax_name_with_details: "%{name} (%{rate}%)"
     tax_name_only:
-      not_collecting: Pas de taxe
-      juris_not_taxed: Taxe non applicable
-      reverse_charge: Autoliquidation - Responsabilité fiscale transférée au client
       customer_exempt: Le client est exonéré de taxe
+      juris_not_taxed: Taxe non applicable
+      not_collecting: Pas de taxe
+      reverse_charge: Autoliquidation - Responsabilité fiscale transférée au client
       transaction_exempt: Le client est exonéré de taxe
+    tax_name_with_details: "%{name} (%{rate}%)"
     tax_rate: Taux de taxe
     taxes:
       fr_tax_exempt: Le client est exonéré de taxe – art. 259-1 du CGI.

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -63,13 +63,13 @@ it:
     tax: Tasse
     tax_identification_number: 'Identificativo fiscale: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% su %{amount})"
-    tax_name_with_details: "%{name} (%{rate}%)"
     tax_name_only:
-      not_collecting: Nessuna tassa
-      juris_not_taxed: Nessuna tassa
-      reverse_charge: Inversione contabile - Responsabilità fiscale trasferita al cliente
       customer_exempt: Il cliente è esente da tasse
+      juris_not_taxed: Nessuna tassa
+      not_collecting: Nessuna tassa
+      reverse_charge: Inversione contabile - Responsabilità fiscale trasferita al cliente
       transaction_exempt: Il cliente è esente da tasse
+    tax_name_with_details: "%{name} (%{rate}%)"
     tax_rate: Aliquota fiscale
     taxes:
       fr_tax_exempt: Il cliente è esente da tasse secondo l'articolo 259-1 del Codice Generale delle Imposte francese.

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -64,6 +64,12 @@ it:
     tax_identification_number: 'Identificativo fiscale: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% su %{amount})"
     tax_name_with_details: "%{name} (%{rate}%)"
+    tax_name_only:
+      not_collecting: Nessuna tassa
+      juris_not_taxed: Nessuna tassa
+      reverse_charge: Inversione contabile - Responsabilità fiscale trasferita al cliente
+      customer_exempt: Il cliente è esente da tasse
+      transaction_exempt: Il cliente è esente da tasse
     tax_rate: Aliquota fiscale
     taxes:
       fr_tax_exempt: Il cliente è esente da tasse secondo l'articolo 259-1 del Codice Generale delle Imposte francese.

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -63,13 +63,13 @@ nb:
     tax: Merverdiavgift
     tax_identification_number: 'Skatte-ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% on %{amount})"
-    tax_name_with_details: "%{name} (%{rate}%)"
     tax_name_only:
-      not_collecting: Ingen skatt
-      juris_not_taxed: Ingen skatt
-      reverse_charge: Omvendt avgiftsplikt - Skatteplikt overført til kunden
       customer_exempt: Kunden er fritatt for avgift
+      juris_not_taxed: Ingen skatt
+      not_collecting: Ingen skatt
+      reverse_charge: Omvendt avgiftsplikt - Skatteplikt overført til kunden
       transaction_exempt: Kunden er fritatt for avgift
+    tax_name_with_details: "%{name} (%{rate}%)"
     tax_rate: Skattesats
     taxes:
       fr_tax_exempt: Kunden er skattefri i henhold til artikkel 259-1 i den franske skatteforvaltningsloven.

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -64,6 +64,12 @@ nb:
     tax_identification_number: 'Skatte-ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% on %{amount})"
     tax_name_with_details: "%{name} (%{rate}%)"
+    tax_name_only:
+      not_collecting: Ingen skatt
+      juris_not_taxed: Ingen skatt
+      reverse_charge: Omvendt avgiftsplikt - Skatteplikt overført til kunden
+      customer_exempt: Kunden er fritatt for avgift
+      transaction_exempt: Kunden er fritatt for avgift
     tax_rate: Skattesats
     taxes:
       fr_tax_exempt: Kunden er skattefri i henhold til artikkel 259-1 i den franske skatteforvaltningsloven.

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -63,6 +63,12 @@ sv:
     tax_identification_number: 'Skatte ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% på %{amount})"
     tax_name_with_details: "%{name} (%{rate}%)"
+    tax_name_only:
+      not_collecting: Ingen skatt
+      juris_not_taxed: Ingen skatt
+      reverse_charge: Omvänd skattskyldighet - Skatteskyldighet överförd till kunden
+      customer_exempt: Kunden är befriad från moms
+      transaction_exempt: Kunden är befriad från moms
     tax_rate: Momssats
     taxes:
       fr_tax_exempt: Kunden är skattebefriad enligt artikel 259-1 i den franska skatteförvaltningskoden.

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -62,13 +62,13 @@ sv:
     tax: Skatt
     tax_identification_number: 'Skatte ID: %{tax_identification_number}'
     tax_name: "%{name} (%{rate}% på %{amount})"
-    tax_name_with_details: "%{name} (%{rate}%)"
     tax_name_only:
-      not_collecting: Ingen skatt
-      juris_not_taxed: Ingen skatt
-      reverse_charge: Omvänd skattskyldighet - Skatteskyldighet överförd till kunden
       customer_exempt: Kunden är befriad från moms
+      juris_not_taxed: Ingen skatt
+      not_collecting: Ingen skatt
+      reverse_charge: Omvänd skattskyldighet - Skatteskyldighet överförd till kunden
       transaction_exempt: Kunden är befriad från moms
+    tax_name_with_details: "%{name} (%{rate}%)"
     tax_rate: Momssats
     taxes:
       fr_tax_exempt: Kunden är skattebefriad enligt artikel 259-1 i den franska skatteförvaltningskoden.

--- a/spec/models/invoice/applied_tax_spec.rb
+++ b/spec/models/invoice/applied_tax_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Invoice::AppliedTax, type: :model do
 
   it_behaves_like 'paper_trail traceable'
 
-  context '#applied_on_whole_invoice?' do
+  describe '#applied_on_whole_invoice?' do
     subject(:applicable_on_whole_invoice) { applied_tax.applied_on_whole_invoice? }
 
     context 'when applied tax represents special rule' do
@@ -23,6 +23,5 @@ RSpec.describe Invoice::AppliedTax, type: :model do
         expect(subject).to be(false)
       end
     end
-
   end
 end

--- a/spec/models/invoice/applied_tax_spec.rb
+++ b/spec/models/invoice/applied_tax_spec.rb
@@ -6,4 +6,23 @@ RSpec.describe Invoice::AppliedTax, type: :model do
   subject(:applied_tax) { create(:invoice_applied_tax) }
 
   it_behaves_like 'paper_trail traceable'
+
+  context '#applied_on_whole_invoice?' do
+    subject(:applicable_on_whole_invoice) { applied_tax.applied_on_whole_invoice? }
+
+    context 'when applied tax represents special rule' do
+      let(:applied_tax) { create(:invoice_applied_tax, tax_code: Invoice::AppliedTax::TAX_CODES_APPLICABLE_ON_WHOLE_INVOICE.sample) }
+
+      it 'is applicable on whole invoice' do
+        expect(subject).to be(true)
+      end
+    end
+
+    context 'when normal applied tax' do
+      it 'is not applicable on whole invoice' do
+        expect(subject).to be(false)
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
## Context

When saving applied taxes with received from Anrok special tax provider rules (types) we want to display them in invoice

## Description

added `applied_on_whole_invoice?` method to Invoice::AppliedTax
depending on if displayed tax is applicable on the whole invoice or no, show different name format for the tax name
