### PR TITLE
feat(ProgressiveBilling) - add negative_amount_cents to invoices

### DIFF
--- a/db/migrate/20240816075711_add_negative_amount_cents_to_invoice.rb
+++ b/db/migrate/20240816075711_add_negative_amount_cents_to_invoice.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNegativeAmountCentsToInvoice < ActiveRecord::Migration[7.1]
+  def change
+    add_column :invoices, :negative_amount_cents, :bigint, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -754,6 +754,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_19_092354) do
     t.boolean "skip_charges", default: false, null: false
     t.boolean "payment_overdue", default: false
     t.uuid "payable_group_id"
+    t.bigint "negative_amount_cents", default: 0, null: false
     t.index ["customer_id", "sequential_id"], name: "index_invoices_on_customer_id_and_sequential_id", unique: true
     t.index ["customer_id"], name: "index_invoices_on_customer_id"
     t.index ["number"], name: "index_invoices_on_number"


### PR DESCRIPTION
## Context

With the addition of progressive billing we might have negative invoices when subtracting already progressively billed invoices. This MR sets up the DB to store that field. 


The logic will be added later on top of the invoicing code. 

