### PR TITLE
Fix(anrok): no fallback_item mapping is found

### DIFF
--- a/app/services/integrations/aggregator/taxes/invoices/base_service.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/base_service.rb
@@ -55,9 +55,7 @@ module Integrations
                 )
               end
             else
-              code = body['failedInvoices'].first['validation_errors']['type']
-              message = 'Service failure'
-
+              code, message = retrieve_error_details(body['failedInvoices'].first['validation_errors'])
               deliver_tax_error_webhook(customer:, code:, message:)
 
               result.service_failure!(code:, message:)
@@ -70,9 +68,7 @@ module Integrations
             if invoice_id
               result.invoice_id = invoice_id
             else
-              code = body['failedInvoices'].first['validation_errors']['type']
-              message = 'Service failure'
-
+              code, message = retrieve_error_details(body['failedInvoices'].first['validation_errors'])
               deliver_tax_error_webhook(customer:, code:, message:)
 
               result.service_failure!(code:, message:)
@@ -97,6 +93,18 @@ module Integrations
                 )
               end
             end
+          end
+
+          def retrieve_error_details(validation_error)
+            if validation_error.is_a?(Hash)
+              code = validation_error['type']
+              message = 'Service failure'
+              return [code, message]
+            end
+
+            code = 'validationError'
+            message = validation_error
+            [code, message]
           end
 
           def humanize_tax_name(camelized_name)

--- a/app/services/integrations/aggregator/taxes/invoices/payload.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payload.rb
@@ -57,7 +57,7 @@ module Integrations
           attr_reader :customer, :invoice, :fees
 
           def empty_struct
-            @empty_struct ||= OpenStruct.new()
+            @empty_struct ||= OpenStruct.new
           end
         end
       end

--- a/app/services/integrations/aggregator/taxes/invoices/payload.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payload.rb
@@ -43,6 +43,7 @@ module Integrations
             elsif fee.subscription?
               subscription_item
             end
+            mapped_item ||= empty_struct
 
             {
               'item_id' => fee.item_id,
@@ -54,6 +55,10 @@ module Integrations
           private
 
           attr_reader :customer, :invoice, :fees
+
+          def empty_struct
+            @empty_struct ||= OpenStruct.new()
+          end
         end
       end
     end

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -211,6 +211,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
             body_string = File.read(path)
             body = JSON.parse(body_string)
             body['failedInvoices'].first['validation_errors'] = "Request body: \"lineItems\": 0: \"productExternalId\": String must contain at least 1 character(s)."
+            body.to_json
           end
 
           before do
@@ -224,7 +225,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
               expect(result).not_to be_success
               expect(result.fees).to be(nil)
               expect(result.error).to be_a(BaseService::ServiceFailure)
-              expect(result.error.code).to eq('taxDateTooFarInFuture')
+              expect(result.error.code).to eq('validationError')
             end
           end
         end

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -229,7 +229,6 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
             end
           end
         end
-
       end
     end
 


### PR DESCRIPTION
## Context

Now if user doesn't have a fallback item set up and tries to fetch taxes for item without product_mapping provided, we'd fail with `undefined method 'external_id' for nil (NoMethodError)` and will return server error. Instead we should process it as any other tax_integration error, because it's an incomplete integration set up

## Description

in case when no mapped_item is found for the fee, we provide an empty open_struct, so calling any method on it returns nil. It allows us to send request to anrok with empty external_product_id, and then anrok can return us validation error with message `"Request body: \"lineItems\": 0: \"productExternalId\": String must contain at least 1 character(s)."` which indicates, that product_external_id to fetch taxes is missing
