### PR TITLE
feat(ProgressiveBilling): Usage threshold should be soft deleted

### DIFF
--- a/app/models/usage_threshold.rb
+++ b/app/models/usage_threshold.rb
@@ -3,6 +3,8 @@
 class UsageThreshold < ApplicationRecord
   include PaperTrailTraceable
   include Currencies
+  include Discard::Model
+  self.discard_column = :deleted_at
 
   belongs_to :plan
 
@@ -14,4 +16,6 @@ class UsageThreshold < ApplicationRecord
 
   scope :recurring, -> { where(recurring: true) }
   scope :not_recurring, -> { where(recurring: false) }
+
+  default_scope -> { kept }
 end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -262,7 +262,7 @@ module Plans
     def sanitize_thresholds(plan, args_thresholds, created_thresholds_ids)
       args_thresholds_ids = args_thresholds.map { |c| c[:id] }.compact
       thresholds_ids = plan.usage_thresholds.pluck(:id) - args_thresholds_ids - created_thresholds_ids
-      plan.usage_thresholds.where(id: thresholds_ids).destroy_all
+      plan.usage_thresholds.where(id: thresholds_ids).discard_all
     end
 
     def discard_charge!(charge)

--- a/db/migrate/20240819092354_add_deleted_at_to_usage_thresholds.rb
+++ b/db/migrate/20240819092354_add_deleted_at_to_usage_thresholds.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToUsageThresholds < ActiveRecord::Migration[7.1]
+  def change
+    add_column :usage_thresholds, :deleted_at, :datetime
+
+    remove_index :usage_thresholds, %i[amount_cents plan_id recurring], unique: true
+    remove_index :usage_thresholds, %i[plan_id recurring], unique: true, where: "recurring is true"
+
+    add_index :usage_thresholds, %i[amount_cents plan_id recurring], unique: true, where: 'deleted_at IS NULL'
+    add_index :usage_thresholds, %i[plan_id recurring], unique: true, where: "recurring is true and deleted_at IS NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_14_144137) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_19_092354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -1068,8 +1068,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_14_144137) do
     t.boolean "recurring", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["amount_cents", "plan_id", "recurring"], name: "idx_on_amount_cents_plan_id_recurring_888044d66b", unique: true
-    t.index ["plan_id", "recurring"], name: "index_usage_thresholds_on_plan_id_and_recurring", unique: true, where: "(recurring IS TRUE)"
+    t.datetime "deleted_at"
+    t.index ["amount_cents", "plan_id", "recurring"], name: "idx_on_amount_cents_plan_id_recurring_888044d66b", unique: true, where: "(deleted_at IS NULL)"
+    t.index ["plan_id", "recurring"], name: "index_usage_thresholds_on_plan_id_and_recurring", unique: true, where: "((recurring IS TRUE) AND (deleted_at IS NULL))"
     t.index ["plan_id"], name: "index_usage_thresholds_on_plan_id"
   end
 

--- a/spec/models/usage_threshold_spec.rb
+++ b/spec/models/usage_threshold_spec.rb
@@ -6,4 +6,13 @@ RSpec.describe UsageThreshold, type: :model do
   subject(:usage_threshold) { build(:usage_threshold) }
 
   it { is_expected.to validate_numericality_of(:amount_cents).is_greater_than(0) }
+
+  describe 'default scope' do
+    let!(:deleted_usage_threshold) { create(:usage_threshold, :deleted) }
+
+    it "only returns non-deleted usage_threshold objects" do
+      expect(described_class.all).to eq([])
+      expect(described_class.unscoped.discarded).to eq([deleted_usage_threshold])
+    end
+  end
 end


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR updates the `usage_threshold` model to allow soft deletion.