### PR TITLE
fix(anrok): renamed field error_details to details on error_details object

### DIFF
--- a/app/graphql/types/error_details/object.rb
+++ b/app/graphql/types/error_details/object.rb
@@ -10,7 +10,7 @@ module Types
       field :id, ID, null: false
 
       def error_details
-        object.error_details[object.error_code]
+        object.details[object.error_code]
       end
     end
   end


### PR DESCRIPTION
## Description

Fix serialization of error_details in graphql after error_details field on error_details model was renamed to details
