### PR TITLE
feat: add email validation

### DIFF
--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -9,6 +9,13 @@ module Customers
       new_customer = customer.new_record?
       shipping_address = params[:shipping_address] ||= {}
 
+      unless valid_email?(params[:email])
+        return result.single_validation_failure!(
+          field: :email,
+          error_code: 'invalid_format'
+        )
+      end
+
       unless valid_metadata_count?(metadata: params[:metadata])
         return result.single_validation_failure!(
           field: :metadata,
@@ -186,6 +193,13 @@ module Customers
     end
 
     private
+
+    def valid_email?(email)
+      return true if email.nil?
+
+      email_regex = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+      email_regex.match?(email).present?
+    end
 
     def valid_metadata_count?(metadata:)
       return true if metadata.blank?

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -197,8 +197,8 @@ module Customers
     def valid_email?(email)
       return true if email.nil?
 
-      email_regex = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
-      email_regex.match?(email).present?
+      email_regexp = /\A[^@\s]+@[^@\s]+\z/
+      email_regexp.match?(email).present?
     end
 
     def valid_metadata_count?(metadata:)

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe Customers::CreateService, type: :service do
           external_id:,
           name: 'Foo Bar',
           currency: 'EUR',
-          email: 'not_valid@not_valid.valid',
+          email: '@missingusername.com',
           tax_identification_number: '123456789',
           billing_configuration: {
             document_locale: 'fr'

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -104,6 +104,43 @@ RSpec.describe Customers::CreateService, type: :service do
       )
     end
 
+    context 'with invalid email' do
+      let(:create_args) do
+        {
+          external_id:,
+          name: 'Foo Bar',
+          currency: 'EUR',
+          email: 'not_valid@not_valid.valid',
+          tax_identification_number: '123456789',
+          billing_configuration: {
+            document_locale: 'fr'
+          },
+          shipping_address: {
+            address_line1: 'line1',
+            address_line2: 'line2',
+            city: 'Paris',
+            zipcode: '123456',
+            state: 'foobar',
+            country: 'FR'
+          }
+        }
+      end
+
+      it 'fails to create customer with wrong email' do
+        result = customers_service.create_from_api(
+          organization:,
+          params: create_args
+        )
+
+        aggregate_failures do
+          expect(result).not_to be_success
+          expect(result.error).to be_a(BaseService::ValidationFailure)
+          expect(result.error.messages.keys).to include(:email)
+          expect(result.error.messages[:email]).to include('invalid_format')
+        end
+      end
+    end
+
     context 'with external_id already used by a deleted customer' do
       it 'creates a customer with the same external_id' do
         create(:customer, :deleted, organization:, external_id:)


### PR DESCRIPTION
## Context

This pull request changes Customers::CreateService adding email validation to ensure only valid email addresses are accepted when creating or updating customer records.

This is particularly important because we sync these emails with Stripe, which enforces strict email validation. Without this check, invalid emails could cause the Stripe synchronization process to fail