### PR TITLE
feat(ProgressiveBilling): Update PDF template

### DIFF
--- a/app/models/fee.rb
+++ b/app/models/fee.rb
@@ -66,6 +66,7 @@ class Fee < ApplicationRecord
     return billable_metric.id if charge?
     return add_on.id if add_on?
     return invoiceable_id if credit?
+    return usage_threshold_id if progressive_billing?
 
     subscription_id
   end
@@ -74,6 +75,7 @@ class Fee < ApplicationRecord
     return BillableMetric.name if charge?
     return AddOn.name if add_on?
     return WalletTransaction.name if credit?
+    return UsageThreshold.name if progressive_billing?
 
     Subscription.name
   end
@@ -81,7 +83,7 @@ class Fee < ApplicationRecord
   def item_code
     return billable_metric.code if charge?
     return add_on.code if add_on?
-    return fee_type if credit?
+    return fee_type if credit? || progressive_billing?
 
     subscription.plan.code
   end
@@ -89,7 +91,7 @@ class Fee < ApplicationRecord
   def item_name
     return billable_metric.name if charge?
     return add_on.name if add_on?
-    return fee_type if credit?
+    return fee_type if credit? || progressive_billing?
 
     subscription.plan.name
   end
@@ -97,7 +99,7 @@ class Fee < ApplicationRecord
   def item_description
     return billable_metric.description if charge?
     return add_on.description if add_on?
-    return fee_type if credit?
+    return fee_type if credit? || progressive_billing?
 
     subscription.plan.description
   end
@@ -107,6 +109,7 @@ class Fee < ApplicationRecord
     return charge.invoice_display_name.presence || billable_metric.name if charge?
     return add_on.invoice_name if add_on?
     return fee_type if credit?
+    return usage_threshold.invoice_name if progressive_billing?
 
     subscription.plan.invoice_display_name
   end

--- a/app/models/usage_threshold.rb
+++ b/app/models/usage_threshold.rb
@@ -18,4 +18,8 @@ class UsageThreshold < ApplicationRecord
   scope :not_recurring, -> { where(recurring: false) }
 
   default_scope -> { kept }
+
+  def invoice_name
+    threshold_display_name || I18n.t('invoice.usage_threshold')
+  end
 end

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -99,7 +99,7 @@ module Invoices
       @invoiced_amount_cents ||= subscription.invoices
         .finalized
         .where(invoice_type: %w[subscription progressive_billing])
-        .sum(:fees_amount_cents)
+        .sum { |invoice| invoice.fees.where(fee_type: %w[charge progressive_billing]).sum(:amount_cents) }
     end
 
     # NOTE: Current lifetime usage amount

--- a/app/views/helpers/fee_display_helper.rb
+++ b/app/views/helpers/fee_display_helper.rb
@@ -11,6 +11,7 @@ class FeeDisplayHelper
 
   def self.should_display_subscription_fee?(invoice_subscription)
     return false if invoice_subscription.blank?
+    return false if invoice_subscription.invoice.progressive_billing?
     return true if invoice_subscription.charge_amount_cents.zero?
 
     invoice_subscription.subscription_amount_cents.positive?

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -1,4 +1,4 @@
-- if subscription?
+- if subscription? || progressive_billing?
   - subscriptions.each do |subscription|
     - invoice_subscription = invoice_subscription(subscription.id)
     - subscription_fee = invoice_subscription.subscription_fee
@@ -51,6 +51,16 @@
               - else
                 - fees.sort_by { |f| f.invoice_sorting_clause }.each do |fee|
                   == SlimHelper.render('templates/invoices/v4/_fees_without_filters', fee)
+
+        / Progressive billing fees
+        - if progressive_billing?
+          - fees.sort_by { |f| f.invoice_sorting_clause }.each do |fee|
+            tr
+              td.body-1 = fee.invoice_name
+              td.body-2 = fee.units
+              td.body-2 = MoneyHelper.format(fee.amount)
+              td.body-2 == TaxHelper.applied_taxes(fee)
+              td.body-2 = MoneyHelper.format(fee.amount)
 
     / Charge fees section for subscription invoice
     - if subscription? && subscription_fees(subscription.id).charge_kind.any?

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -83,6 +83,7 @@ de:
     units: Einheiten
     units_prorated_per_period: Einheiten anteilig pro Sekunde pro %{period}
     usage_based_fees: Nutzungsabhängige Gebühren
+    usage_threshold: Abrechnungsschwelle
     volume:
       fee_per_unit: Gebühr pro Einheit
       flat_fee_for_all_units: Pauschalgebühr für alle Einheiten

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -83,6 +83,7 @@ en:
     units: Units
     units_prorated_per_period: Units prorated per second per %{period}
     usage_based_fees: Usage based fees
+    usage_threshold: Billing threshold
     volume:
       fee_per_unit: Fee per unit
       flat_fee_for_all_units: Flat fee for all units

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -81,6 +81,7 @@ es:
     units: Unidades
     units_prorated_per_period: Unidades prorrateadas por segundo por %{period}
     usage_based_fees: Cargos basados en el uso
+    usage_threshold: Umbral de facturación
     volume:
       fee_per_unit: Tarifa por unidad
       flat_fee_for_all_units: Tarifa plana para todas las unidades

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -83,6 +83,7 @@ fr:
     units: Unités
     units_prorated_per_period: Unités proratisées par seconde par %{period}
     usage_based_fees: Frais de consommation
+    usage_threshold: Seuil de facturation
     volume:
       fee_per_unit: Frais par unité
       flat_fee_for_all_units: Frais fixes pour toutes les unités

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -83,6 +83,7 @@ it:
     units: Unità
     units_prorated_per_period: Unità proporzionate al secondo per %{period}
     usage_based_fees: Tariffe basate sull'utilizzo
+    usage_threshold: Soglia di fatturazione
     volume:
       fee_per_unit: Tassa per unità
       flat_fee_for_all_units: Canone forfettario per tutte le unità

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -83,6 +83,7 @@ nb:
     units: Enheter
     units_prorated_per_period: Enheter proratert per sekund per %{period}
     usage_based_fees: Bruksbaserte kostnader
+    usage_threshold: Faktureringsterskel
     volume:
       fee_per_unit: Gebyr per enhet
       flat_fee_for_all_units: Fast avgift for alle enheter

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -81,6 +81,7 @@ sv:
     units: Enheter
     units_prorated_per_period: Proportionella enheter per sekund per %{period}
     usage_based_fees: Avgifter baserade på användning
+    usage_threshold: Faktureringströskel
     volume:
       fee_per_unit: Avgift per enhet
       flat_fee_for_all_units: Fast avgift för alla enheter

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -106,7 +106,7 @@ FactoryBot.define do
   factory :progressive_billing_fee, class: 'Fee' do
     invoice
     fee_type { 'progressive_billing' }
-    subscription
+    subscription { create(:subscription) }
 
     amount_cents { 200 }
     amount_currency { 'EUR' }

--- a/spec/models/fee_spec.rb
+++ b/spec/models/fee_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe Fee, type: :model do
       end
     end
 
+    context 'when it is a progressive billing fee' do
+      it 'returns add on code' do
+        expect(fee_model.new(fee_type: 'progressive_billing').item_code).to eq('progressive_billing')
+      end
+    end
+
     context 'when it is an pay_in_advance charge fee' do
       let(:charge) { create(:standard_charge, :pay_in_advance) }
 
@@ -116,6 +122,14 @@ RSpec.describe Fee, type: :model do
         end
       end
 
+      context 'when it is a progressive billing fee' do
+        let(:fee) { build_stubbed(:progressive_billing_fee, invoice_display_name:) }
+
+        it 'returns add on name' do
+          expect(fee_invoice_name).to eq(fee.usage_threshold.invoice_name)
+        end
+      end
+
       context 'when it is an pay_in_advance charge fee' do
         let(:fee) { build_stubbed(:fee, charge:, fee_type: 'charge', invoice_display_name:) }
         let(:charge) { create(:standard_charge, :pay_in_advance, invoice_display_name: charge_invoice_display_name) }
@@ -173,6 +187,12 @@ RSpec.describe Fee, type: :model do
       end
     end
 
+    context 'when it is a progressive billing fee' do
+      it "returns 'credit'" do
+        expect(fee_model.new(fee_type: 'progressive_billing').item_name).to eq('progressive_billing')
+      end
+    end
+
     context 'when it is an pay_in_advance charge fee' do
       let(:charge) { create(:standard_charge, :pay_in_advance) }
 
@@ -214,6 +234,12 @@ RSpec.describe Fee, type: :model do
     context "when it is a credit fee" do
       it "returns 'credit'" do
         expect(fee_model.new(fee_type: "credit").item_description).to eq("credit")
+      end
+    end
+
+    context "when it is a progressive_billing fee" do
+      it "returns 'credit'" do
+        expect(fee_model.new(fee_type: "progressive_billing").item_description).to eq("progressive_billing")
       end
     end
 
@@ -261,6 +287,12 @@ RSpec.describe Fee, type: :model do
       end
     end
 
+    context 'when it is a progressive_billing fee' do
+      it 'returns wallet transaction' do
+        expect(fee_model.new(fee_type: 'progressive_billing').item_type).to eq('UsageThreshold')
+      end
+    end
+
     context 'when it is an pay_in_advance charge fee' do
       let(:charge) { create(:standard_charge, :pay_in_advance) }
 
@@ -305,6 +337,14 @@ RSpec.describe Fee, type: :model do
       it 'returns the wallet transaction id' do
         expect(fee_model.new(fee_type: 'credit', invoiceable: wallet_transaction).item_id)
           .to eq(wallet_transaction.id)
+      end
+    end
+
+    context 'when it is a progressive_billing fee' do
+      let(:fee) { create(:progressive_billing_fee) }
+
+      it 'returns the wallet transaction id' do
+        expect(fee.item_id).to eq(fee.usage_threshold_id)
       end
     end
 

--- a/spec/models/usage_threshold_spec.rb
+++ b/spec/models/usage_threshold_spec.rb
@@ -15,4 +15,18 @@ RSpec.describe UsageThreshold, type: :model do
       expect(described_class.unscoped.discarded).to eq([deleted_usage_threshold])
     end
   end
+
+  describe 'invoice_name' do
+    subject(:usage_threshold) { build(:usage_threshold, threshold_display_name:) }
+
+    let(:threshold_display_name) { 'Threshold Display Name' }
+
+    it { expect(usage_threshold.invoice_name).to eq(threshold_display_name) }
+
+    context 'when threshold display name is null' do
+      let(:threshold_display_name) { nil }
+
+      it { expect(usage_threshold.invoice_name).to eq(I18n.t('invoice.usage_threshold')) }
+    end
+  end
 end

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service do
 
     context 'when threashold was already billed' do
       before do
-        create(
+        invoice = create(
           :invoice,
           organization:,
           customer:,
@@ -133,6 +133,12 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service do
           invoice_type: :progressive_billing,
           fees_amount_cents: 20,
           subscriptions: [subscription]
+        )
+
+        create(
+          :charge_fee,
+          invoice:,
+          amount_cents: 20
         )
       end
 
@@ -165,7 +171,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service do
 
     context 'when usage was already billed' do
       before do
-        create(
+        invoice = create(
           :invoice,
           organization:,
           customer:,
@@ -173,6 +179,12 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service do
           invoice_type: :subscription,
           fees_amount_cents: 7,
           subscriptions: [subscription]
+        )
+
+        create(
+          :charge_fee,
+          invoice:,
+          amount_cents: 7
         )
       end
 


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR allows generating the PDF for progressive billing invoices