### PR TITLE
feat(ProgressiveBilling): Apply credit notes, coupons and prepaid credits to invoice

### DIFF
--- a/app/services/credits/credit_note_service.rb
+++ b/app/services/credits/credit_note_service.rb
@@ -2,9 +2,8 @@
 
 module Credits
   class CreditNoteService < BaseService
-    def initialize(invoice:, credit_notes:)
+    def initialize(invoice:)
       @invoice = invoice
-      @credit_notes = credit_notes
 
       super(nil)
     end
@@ -48,9 +47,17 @@ module Credits
 
     private
 
-    attr_accessor :invoice, :credit_notes
+    attr_accessor :invoice
 
     delegate :customer, to: :invoice
+
+    def credit_notes
+      @credit_notes ||= customer.credit_notes
+        .finalized
+        .available
+        .where.not(invoice_id: invoice.id)
+        .order(created_at: :asc)
+    end
 
     def already_applied?
       invoice.credits.where.not(credit_note_id: nil).exists?

--- a/spec/services/credits/credit_note_service_spec.rb
+++ b/spec/services/credits/credit_note_service_spec.rb
@@ -3,12 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Credits::CreditNoteService do
-  subject(:credit_service) do
-    described_class.new(
-      invoice:,
-      credit_notes: [credit_note1, credit_note2]
-    )
-  end
+  subject(:credit_service) { described_class.new(invoice:) }
 
   let(:invoice) do
     create(
@@ -40,6 +35,11 @@ RSpec.describe Credits::CreditNoteService do
       credit_amount_cents: 50,
       customer:
     )
+  end
+
+  before do
+    credit_note1
+    credit_note2
   end
 
   describe '.call' do

--- a/spec/services/invoices/progressive_billing_service_spec.rb
+++ b/spec/services/invoices/progressive_billing_service_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe Invoices::ProgressiveBillingService, type: :service do
           organization:,
           customer:,
           status: 'finalized',
-          invoice_type: :subscription,
+          invoice_type: :progressive_billing,
           fees_amount_cents: 7,
           subscriptions: [subscription]
         )


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR makes sure that coupons, prepaid credits and credit notes are applied to progressive billing invoices