### PR TITLE
Fix: fix flaky test for eu_auto_taxes_service_spec

### DIFF
--- a/spec/services/customers/eu_auto_taxes_service_spec.rb
+++ b/spec/services/customers/eu_auto_taxes_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Customers::EuAutoTaxesService, type: :service do
   subject(:eu_tax_service) { described_class.new(customer:) }
 
   let(:organization) { create(:organization, country: 'FR') }
-  let(:customer) { create(:customer, organization:) }
+  let(:customer) { create(:customer, organization:, zipcode: nil) }
 
   describe '.call' do
     context 'with B2B organization' do


### PR DESCRIPTION
## Context

As customer is created with Factorybot and for zipcode we generate `zipcode: Faker::Address.zip_code `, we can accidentally generate a zipcode in france for a customer with special rules. This introduces a flaky test, as happened here:
https://github.com/getlago/lago-api/actions/runs/10451847578/job/28939063361

## Description

as in the tests we're assuming that customer's zipcode is empty unless actively set (https://github.com/getlago/lago-api/blob/bc8193366e63c1dadbbfaaffcc5d6ee9258eafc7/spec/services/customers/eu_auto_taxes_service_spec.rb#L63), the fix is to explicitly create customer with empty zipcode
