### PR TITLE
feat(ProgressiveBilling): Add progressive billing invoice relation to credit

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -26,6 +26,7 @@ class Invoice < ApplicationRecord
   has_many :plans, through: :subscriptions
   has_many :metadata, class_name: 'Metadata::InvoiceMetadata', dependent: :destroy
   has_many :credit_notes
+  has_many :progressive_billing_credits, class_name: 'Credit', foreign_key: :progressive_billing_invoice_id
 
   has_many :applied_taxes, class_name: 'Invoice::AppliedTax', dependent: :destroy
   has_many :taxes, through: :applied_taxes

--- a/db/migrate/20240820090312_attach_progressive_billing_invoices_to_credits.rb
+++ b/db/migrate/20240820090312_attach_progressive_billing_invoices_to_credits.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AttachProgressiveBillingInvoicesToCredits < ActiveRecord::Migration[7.1]
+  def change
+    add_column :credits, :progressive_billing_invoice_id, :uuid
+    add_foreign_key :credits, :invoices, column: :progressive_billing_invoice_id
+    add_index :credits, :progressive_billing_invoice_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_19_092354) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_20_090312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -372,9 +372,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_19_092354) do
     t.datetime "updated_at", null: false
     t.uuid "credit_note_id"
     t.boolean "before_taxes", default: false, null: false
+    t.uuid "progressive_billing_invoice_id"
     t.index ["applied_coupon_id"], name: "index_credits_on_applied_coupon_id"
     t.index ["credit_note_id"], name: "index_credits_on_credit_note_id"
     t.index ["invoice_id"], name: "index_credits_on_invoice_id"
+    t.index ["progressive_billing_invoice_id"], name: "index_credits_on_progressive_billing_invoice_id"
   end
 
   create_table "customer_metadata", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1202,6 +1204,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_19_092354) do
   add_foreign_key "credits", "applied_coupons"
   add_foreign_key "credits", "credit_notes"
   add_foreign_key "credits", "invoices"
+  add_foreign_key "credits", "invoices", column: "progressive_billing_invoice_id"
   add_foreign_key "customer_metadata", "customers"
   add_foreign_key "customers", "organizations"
   add_foreign_key "customers_taxes", "customers"

--- a/spec/factories/credits.rb
+++ b/spec/factories/credits.rb
@@ -16,4 +16,12 @@ FactoryBot.define do
     amount_cents { 200 }
     amount_currency { 'EUR' }
   end
+
+  factory :progressive_billing_invoice_credit, class: 'Credit' do
+    invoice
+    progressive_billing_invoice factory: :invoice
+
+    amount_cents { 200 }
+    amount_currency { 'EUR' }
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Invoice, type: :model do
   it { is_expected.to have_many(:payment_requests) }
   it { is_expected.to belong_to(:payable_group).optional }
 
+  it { is_expected.to have_many(:progressive_billing_credits) }
+
   it 'has fixed status mapping' do
     expect(described_class::VISIBLE_STATUS).to match(draft: 0, finalized: 1, voided: 2, failed: 4)
     expect(described_class::INVISIBLE_STATUS).to match(generating: 3, open: 5)


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR adds the `progressive_billing_invoice_id` foreign key column to the `credits` table. It will allow us to take a progressive billing invoice into account when generating a subscription invoice