### PR TITLE
feat(dunning): Create payment request

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -34,6 +34,7 @@ class SendWebhookJob < ApplicationJob
     'credit_note.generated' => Webhooks::CreditNotes::GeneratedService,
     'credit_note.provider_refund_failure' => Webhooks::CreditNotes::PaymentProviderRefundFailureService,
     'payment_provider.error' => Webhooks::PaymentProviders::ErrorService,
+    'payment_request.created' => Webhooks::PaymentRequests::CreatedService,
     'subscription.terminated' => Webhooks::Subscriptions::TerminatedService,
     'subscription.started' => Webhooks::Subscriptions::StartedService,
     'subscription.termination_alert' => Webhooks::Subscriptions::TerminationAlertService,

--- a/app/services/payment_requests/create_service.rb
+++ b/app/services/payment_requests/create_service.rb
@@ -17,14 +17,21 @@ module PaymentRequests
         payable_group = customer.payable_groups.create!(organization:)
         invoices.each { |i| i.update!(payable_group:) }
 
-        # TODO: Create payment request for the payable group
+        # NOTE: Create payment request for the payable group
+        payment_request = payable_group.payment_requests.create!(
+          organization:,
+          customer:,
+          amount_cents: invoices.sum(:total_amount_cents),
+          amount_currency: invoices.first.currency,
+          email:
+        )
 
         # TODO: Send payment_request.created webhook
 
         # TODO: When payment provider is set: Create payment intent for the overdue invoices
         # TODO: When payment provider is not set: Send email to the customer
 
-        # result.payment_request = payment_request
+        result.payment_request = payment_request
       end
 
       result
@@ -40,6 +47,10 @@ module PaymentRequests
 
     def invoices
       @invoices ||= customer.invoices.where(id: params[:lago_invoice_ids])
+    end
+
+    def email
+      @email ||= params[:email] || customer.email
     end
   end
 end

--- a/app/services/payment_requests/create_service.rb
+++ b/app/services/payment_requests/create_service.rb
@@ -13,7 +13,9 @@ module PaymentRequests
       return result.not_found_failure!(resource: "customer") unless customer
 
       ActiveRecord::Base.transaction do
-        # TODO: Create payable group for the overdue invoices
+        # NOTE: Create payable group for the overdue invoices
+        payable_group = customer.payable_groups.create!(organization:)
+        invoices.each { |i| i.update!(payable_group:) }
 
         # TODO: Create payment request for the payable group
 
@@ -34,6 +36,10 @@ module PaymentRequests
 
     def customer
       @customer ||= organization.customers.find_by(external_id: params[:external_customer_id])
+    end
+
+    def invoices
+      @invoices ||= customer.invoices.where(id: params[:lago_invoice_ids])
     end
   end
 end

--- a/app/services/webhooks/payment_requests/created_service.rb
+++ b/app/services/webhooks/payment_requests/created_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module PaymentRequests
+    class CreatedService < Webhooks::BaseService
+      private
+
+      def current_organization
+        @current_organization ||= object.customer.organization
+      end
+
+      def object_serializer
+        ::V1::PaymentRequestSerializer.new(
+          object,
+          root_name: "payment_request",
+          includes: %i[customer invoices]
+        )
+      end
+
+      def webhook_type
+        "payment_request.created"
+      end
+
+      def object_type
+        "payment_request"
+      end
+    end
+  end
+end

--- a/spec/jobs/send_webhook_job_spec.rb
+++ b/spec/jobs/send_webhook_job_spec.rb
@@ -454,4 +454,23 @@ RSpec.describe SendWebhookJob, type: :job do
       expect(webhook_service).to have_received(:call)
     end
   end
+
+  context 'when webhook_type is payment_request.created' do
+    let(:webhook_service) { instance_double(Webhooks::PaymentRequests::CreatedService) }
+    let(:payment_request) { create(:payment_request) }
+
+    before do
+      allow(Webhooks::PaymentRequests::CreatedService).to receive(:new)
+        .with(object: payment_request, options: {})
+        .and_return(webhook_service)
+      allow(webhook_service).to receive(:call)
+    end
+
+    it 'calls the webhook payment_request service' do
+      send_webhook_job.perform_now('payment_request.created', payment_request)
+
+      expect(Webhooks::PaymentRequests::CreatedService).to have_received(:new)
+      expect(webhook_service).to have_received(:call)
+    end
+  end
 end

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
   let(:params) do
     {
       external_customer_id: customer.external_id,
+      email: "john.doe@example.com",
       lago_invoice_ids: [first_invoice.id, second_invoice.id]
     }
   end
@@ -27,6 +28,23 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
       expect { create_service.call }
         .to change { first_invoice.reload.payable_group }.from(nil).to(be_a(PayableGroup))
         .and change { second_invoice.reload.payable_group }.from(nil).to(be_a(PayableGroup))
+    end
+
+    it "creates a payment request" do
+      expect { create_service.call }.to change { customer.payment_requests.count }.by(1)
+    end
+
+    it "returns the payment request", :aggregate_failures do
+      result = create_service.call
+
+      expect(result.payment_request).to be_a(PaymentRequest)
+      expect(result.payment_request).to have_attributes(
+        organization:,
+        customer:,
+        amount_cents: first_invoice.total_amount_cents + second_invoice.total_amount_cents,
+        amount_currency: "EUR",
+        email: "john.doe@example.com"
+      )
     end
   end
 end

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentRequests::CreateService, type: :service do
+  subject(:create_service) { described_class.new(organization:, params:) }
+
+  let(:membership) { create(:membership) }
+  let(:organization) { membership.organization }
+  let(:customer) { create(:customer, organization:) }
+
+  let(:first_invoice) { create(:invoice, customer:) }
+  let(:second_invoice) { create(:invoice, customer:) }
+  let(:params) do
+    {
+      external_customer_id: customer.external_id,
+      lago_invoice_ids: [first_invoice.id, second_invoice.id]
+    }
+  end
+
+  describe "#call" do
+    it "creates a payable group for the customer" do
+      expect { create_service.call }.to change { customer.payable_groups.count }.by(1)
+    end
+
+    it "assigns the payable group to the invoices" do
+      expect { create_service.call }
+        .to change { first_invoice.reload.payable_group }.from(nil).to(be_a(PayableGroup))
+        .and change { second_invoice.reload.payable_group }.from(nil).to(be_a(PayableGroup))
+    end
+  end
+end

--- a/spec/services/webhooks/payment_requests/created_service_spec.rb
+++ b/spec/services/webhooks/payment_requests/created_service_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Webhooks::PaymentRequests::CreatedService do
+  subject(:webhook_service) { described_class.new(object: payment_request) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:) }
+  let(:payment_request) { create(:payment_request, customer:, organization:) }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "payment_request.created", "payment_request", {"customer" => Hash, "invoices" => Array}
+  end
+end


### PR DESCRIPTION
## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

## Description

The goal of this PR is to:

- create the payable group for the overdue invoices
- create the payment request for the payable group
- send the payment_request.created webhook

on the payment request creation service