### PR TITLE
feat(dunning): Prevent creating payment request when not overdue

### DIFF
--- a/app/services/payment_requests/create_service.rb
+++ b/app/services/payment_requests/create_service.rb
@@ -10,7 +10,9 @@ module PaymentRequests
     end
 
     def call
-      # TODO: Return error unless premium license
+      unless License.premium? && organization.premium_integrations.include?("dunning")
+        return result.not_allowed_failure!(code: "premium_addon_feature_missing")
+      end
 
       return result.not_found_failure!(resource: "customer") unless customer
       return result.not_found_failure!(resource: "invoice") if invoices.empty?

--- a/app/services/payment_requests/create_service.rb
+++ b/app/services/payment_requests/create_service.rb
@@ -17,7 +17,9 @@ module PaymentRequests
       return result.not_found_failure!(resource: "customer") unless customer
       return result.not_found_failure!(resource: "invoice") if invoices.empty?
 
-      # TODO: Return error if invoices are not overdue
+      if invoices.exists?(payment_overdue: false)
+        return result.not_allowed_failure!(code: "invoices_not_overdue")
+      end
 
       ActiveRecord::Base.transaction do
         # NOTE: Create payable group for the overdue invoices

--- a/spec/requests/api/v1/payment_requests_controller_spec.rb
+++ b/spec/requests/api/v1/payment_requests_controller_spec.rb
@@ -14,17 +14,6 @@ RSpec.describe Api::V1::PaymentRequestsController, type: :request do
       }
     end
 
-    context "when customer is not found" do
-      let(:params) do
-        {external_customer_id: "unknown"}
-      end
-
-      it "returns a not found error" do
-        post_with_token(organization, "/api/v1/payment_requests", {payment_request: params})
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-
     it "delegates to PaymentRequests::CreateService", :aggregate_failures do
       payment_request = create(:payment_request)
       allow(PaymentRequests::CreateService).to receive(:call).and_return(

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -19,7 +19,39 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
     }
   end
 
+  around { |test| lago_premium!(&test) }
+
+  before { organization.update!(premium_integrations: ["dunning"]) }
+
   describe "#call" do
+    context "when organization is not premium" do
+      before do
+        allow(License).to receive(:premium?).and_return(false)
+      end
+
+      it "returns not allowed failure", :aggregate_failures do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("premium_addon_feature_missing")
+      end
+    end
+
+    context "when organization does not have premium dunning integration" do
+      before do
+        allow(organization).to receive(:premium_integrations).and_return([])
+      end
+
+      it "returns not allowed failure", :aggregate_failures do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("premium_addon_feature_missing")
+      end
+    end
+
     context "when customer does not exist" do
       before { params[:external_customer_id] = "non-existing-id" }
 


### PR DESCRIPTION
## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

## Description

The goal of this PR is to prevent the creation of a payment request:

- when not premium
- when not having `dunning` add-on feature
- when invoices are not overdue
