### PR TITLE
🐛 bug(ProgressiveBilling) Don't set recalculation flags to true when creating LifetimeUsage

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -55,8 +55,8 @@ class Subscription < ApplicationRecord
     self.started_at ||= timestamp
     self.lifetime_usage ||= previous_subscription&.lifetime_usage || build_lifetime_usage(
       organization:,
-      recalculate_current_usage: true,
-      recalculate_invoiced_usage: true
+      recalculate_current_usage: false,
+      recalculate_invoiced_usage: false
     )
     active!
   end

--- a/spec/services/subscriptions/create_service_spec.rb
+++ b/spec/services/subscriptions/create_service_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe Subscriptions::CreateService, type: :service do
         expect(subscription.external_id).to eq(external_id)
         expect(subscription).to be_anniversary
         expect(subscription.lifetime_usage).to be_present
-        expect(subscription.lifetime_usage.recalculate_invoiced_usage).to be_truthy
-        expect(subscription.lifetime_usage.recalculate_current_usage).to be_truthy
+        expect(subscription.lifetime_usage.recalculate_invoiced_usage).to eq(false)
+        expect(subscription.lifetime_usage.recalculate_current_usage).to eq(false)
       end
     end
 
@@ -353,8 +353,8 @@ RSpec.describe Subscriptions::CreateService, type: :service do
           expect(subscription.external_id).to eq(external_id)
           expect(subscription).to be_anniversary
           expect(subscription.lifetime_usage).to be_present
-          expect(subscription.lifetime_usage.recalculate_invoiced_usage).to be_truthy
-          expect(subscription.lifetime_usage.recalculate_current_usage).to be_truthy
+          expect(subscription.lifetime_usage.recalculate_invoiced_usage).to eq(false)
+          expect(subscription.lifetime_usage.recalculate_current_usage).to eq(false)
         end
       end
     end
@@ -635,8 +635,6 @@ RSpec.describe Subscriptions::CreateService, type: :service do
               expect(result.subscription).to be_active
               expect(result.subscription.next_subscription).to be_present
               expect(result.subscription.lifetime_usage).to be_present
-              expect(result.subscription.lifetime_usage.recalculate_invoiced_usage).to be_truthy
-              expect(result.subscription.lifetime_usage.recalculate_current_usage).to be_truthy
             end
           end
 


### PR DESCRIPTION
## Description

as we activate a subscription, we assumed we'd have to flag the life-time usage for recalculation. This is incorrect, and causes unneeded calculations. These flags should be set when an invoice is generated or an event is processed.