### PR TITLE
🐛 bug(ProgressiveBilling) - Set refreshed_at timestamps for LifetimeUsage

### DIFF
--- a/app/services/lifetime_usages/calculate_service.rb
+++ b/app/services/lifetime_usages/calculate_service.rb
@@ -11,10 +11,12 @@ module LifetimeUsages
       if lifetime_usage.recalculate_current_usage
         lifetime_usage.current_usage_amount_cents = calculate_current_usage_amount_cents
         lifetime_usage.recalculate_current_usage = false
+        lifetime_usage.current_usage_amount_refreshed_at = Time.current
       end
       if lifetime_usage.recalculate_invoiced_usage
         lifetime_usage.invoiced_usage_amount_cents = calculate_invoiced_usage_amount_cents
         lifetime_usage.recalculate_invoiced_usage = false
+        lifetime_usage.invoiced_usage_amount_refreshed_at = Time.current
       end
       lifetime_usage.save!
 


### PR DESCRIPTION
## Description

The timestamp indicating when a calculation has been performed was not set. 
