### PR TITLE
fix: Remove conflict with a built-in method on graphql

### DIFF
--- a/app/graphql/types/wallets/recurring_transaction_rules/object.rb
+++ b/app/graphql/types/wallets/recurring_transaction_rules/object.rb
@@ -12,14 +12,16 @@ module Types
         field :granted_credits, String, null: false
         field :interval, Types::Wallets::RecurringTransactionRules::IntervalEnum, null: true
         field :invoice_requires_successful_payment, Boolean, null: false
-        field :method, Types::Wallets::RecurringTransactionRules::MethodEnum, null: false
+        field :method, Types::Wallets::RecurringTransactionRules::MethodEnum, null: false, resolver_method: :resolver_method
         field :paid_credits, String, null: false
         field :started_at, GraphQL::Types::ISO8601DateTime, null: true
         field :target_ongoing_balance, String, null: true
         field :threshold_credits, String, null: true
         field :trigger, Types::Wallets::RecurringTransactionRules::TriggerEnum, null: false
 
-        delegate :method, to: :object
+        def resolver_method
+          object.method
+        end
       end
     end
   end


### PR DESCRIPTION
The goal of this PR is to remove the following warning:

```
RecurringTransactionRule's `field :method` conflicts with a built-in method, use `resolver_method:` to pick a different resolver method for this field (for example, `resolver_method: :resolve_method` and `def resolve_method`). Or use `method_conflict_warning: false` to suppress this warning.
```