### PR TITLE
🐛 bug(ProgressiveBilling) - Only perform calculations for active subscriptions

### DIFF
--- a/app/services/lifetime_usages/calculate_service.rb
+++ b/app/services/lifetime_usages/calculate_service.rb
@@ -8,6 +8,14 @@ module LifetimeUsages
     end
 
     def call
+      result.lifetime_usage = lifetime_usage
+
+      # clear boolean flags without recalculating if the subscription is not active.
+      if !lifetime_usage.subscription.active?
+        lifetime_usage.update!(recalculate_current_usage: false, recalculate_invoiced_usage: false)
+        return result
+      end
+
       if lifetime_usage.recalculate_current_usage
         lifetime_usage.current_usage_amount_cents = calculate_current_usage_amount_cents
         lifetime_usage.recalculate_current_usage = false
@@ -20,7 +28,6 @@ module LifetimeUsages
       end
       lifetime_usage.save!
 
-      result.lifetime_usage = lifetime_usage
       result
     end
 

--- a/spec/services/lifetime_usages/calculate_service_spec.rb
+++ b/spec/services/lifetime_usages/calculate_service_spec.rb
@@ -108,6 +108,21 @@ RSpec.describe LifetimeUsages::CalculateService, type: :service do
       expect { service.call }.not_to change(lifetime_usage, :invoiced_usage_amount_refreshed_at)
     end
 
+    context "with terminated subscription" do
+      before do
+        lifetime_usage.subscription.mark_as_terminated!(20.seconds.ago)
+      end
+
+      it "clears the recalculate_current_usage flag" do
+        result = service.call
+        expect(result.lifetime_usage.recalculate_current_usage).to eq(false)
+      end
+
+      it "does not update the current_usage_amount_refreshed_at" do
+        expect { service.call }.not_to change(lifetime_usage, :current_usage_amount_refreshed_at)
+      end
+    end
+
     context 'with usage' do
       before do
         events


### PR DESCRIPTION
## Description

If the subscription is no active, we don't have to recalculate anything. This prevents us from calculating current usage for past subscriptions
