### PR TITLE
feat(ProgressiveBilling) - Add historical_usage_amount_cents to LifetimeUsage

### DIFF
--- a/app/models/lifetime_usage.rb
+++ b/app/models/lifetime_usage.rb
@@ -10,6 +10,7 @@ class LifetimeUsage < ApplicationRecord
 
   validates :current_usage_amount_cents, numericality: {greater_than_or_equal_to: 0}
   validates :invoiced_usage_amount_cents, numericality: {greater_than_or_equal_to: 0}
+  validates :historical_usage_amount_cents, numericality: {greater_than_or_equal_to: 0}
 
   monetize :current_usage_amount_cents,
     :invoiced_usage_amount_cents,
@@ -28,6 +29,7 @@ end
 #  current_usage_amount_cents         :bigint           default(0), not null
 #  current_usage_amount_refreshed_at  :datetime
 #  deleted_at                         :datetime
+#  historical_usage_amount_cents      :bigint           default(0), not null
 #  invoiced_usage_amount_cents        :bigint           default(0), not null
 #  invoiced_usage_amount_refreshed_at :datetime
 #  recalculate_current_usage          :boolean          default(FALSE), not null

--- a/app/services/lifetime_usages/usage_thresholds/check_service.rb
+++ b/app/services/lifetime_usages/usage_thresholds/check_service.rb
@@ -22,7 +22,7 @@ module LifetimeUsages
         actual_current_usage = lifetime_usage.current_usage_amount_cents - progressive_billed_amount
         # we can end up in a situation where this goes below zero, in that case no thresholds are passed
         return result if actual_current_usage.negative?
-        invoiced_usage = lifetime_usage.invoiced_usage_amount_cents + progressive_billed_amount
+        invoiced_usage = lifetime_usage.historical_usage_amount_cents + lifetime_usage.invoiced_usage_amount_cents + progressive_billed_amount
 
         # Get the largest threshold amount
         # in case there are no fixed_thresholds, this will return nil which to_i will convert to 0

--- a/db/migrate/20240822080031_add_historical_usage_to_lifetime_usage.rb
+++ b/db/migrate/20240822080031_add_historical_usage_to_lifetime_usage.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHistoricalUsageToLifetimeUsage < ActiveRecord::Migration[7.1]
+  def change
+    add_column :lifetime_usages, :historical_usage_amount_cents, :bigint, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_20_125840) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_22_080031) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -798,6 +798,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_20_125840) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.bigint "historical_usage_amount_cents", default: 0, null: false
     t.index ["organization_id"], name: "index_lifetime_usages_on_organization_id"
     t.index ["recalculate_current_usage"], name: "index_lifetime_usages_on_recalculate_current_usage", where: "((deleted_at IS NULL) AND (recalculate_current_usage = true))"
     t.index ["recalculate_invoiced_usage"], name: "index_lifetime_usages_on_recalculate_invoiced_usage", where: "((deleted_at IS NULL) AND (recalculate_invoiced_usage = true))"

--- a/spec/models/lifetime_usage_spec.rb
+++ b/spec/models/lifetime_usage_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe LifetimeUsage, type: :model do
       lifetime_usage.invoiced_usage_amount_cents = 1
       expect(lifetime_usage).to be_valid
     end
+
+    it 'requires that historical_usage_amount_cents is positive' do
+      lifetime_usage.historical_usage_amount_cents = -1
+      expect(lifetime_usage).not_to be_valid
+
+      lifetime_usage.historical_usage_amount_cents = 0
+      expect(lifetime_usage).to be_valid
+
+      lifetime_usage.historical_usage_amount_cents = 1
+      expect(lifetime_usage).to be_valid
+    end
   end
 
   describe ".needs_recalculation scope" do


### PR DESCRIPTION
## Context

There's always a risk of customers not paying invoices generated at the end of a billing period. It would be beneficial to bill customers at given thresholds (units vs. amount) rather than waiting until the end of the period. This approach would allow for removing customer access if invoices are not paid and prevent having a highest amount of unpaid invoices.

## Description

Add a `historical_usage_amount_cents` column to `LifetimeUsage`, this column can be filled in with usage coming from an external system. 

We take the historical usage into account when checking if thresholds have been passed.
