### PR TITLE
feat(dunning): Prevent creation of payment request

### DIFF
--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
       end
     end
 
+    context "when invoices have different currencies" do
+      before { second_invoice.update!(currency: "USD") }
+
+      it "returns not allowed failure", :aggregate_failures do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("invoices_have_different_currencies")
+      end
+    end
+
     it "creates a payment request" do
       expect { create_service.call }.to change { customer.payment_requests.count }.by(1)
     end

--- a/spec/services/payment_requests/create_service_spec.rb
+++ b/spec/services/payment_requests/create_service_spec.rb
@@ -100,6 +100,18 @@ RSpec.describe PaymentRequests::CreateService, type: :service do
       end
     end
 
+    context "when invoices are not ready for payment processing" do
+      before { first_invoice.update!(ready_for_payment_processing: false) }
+
+      it "returns not allowed failure", :aggregate_failures do
+        result = create_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::MethodNotAllowedFailure)
+        expect(result.error.code).to eq("invoices_not_ready_for_payment_processing")
+      end
+    end
+
     it "creates a payment request" do
       expect { create_service.call }.to change { customer.payment_requests.count }.by(1)
     end


### PR DESCRIPTION
## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

## Description

The goal of this PR is to return an error when trying to create a payment request with:
- invoices having different currencies
- invoices not ready for payment processing 
