### PR TITLE
feat(ProgressiveBilling) - Add support for LAGO_LIFETIME_USAGE_REFRESH_INTERVAL_SECONDS 

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -30,9 +30,10 @@ module Clockwork
       .perform_later
   end
 
-  every(5.minutes, 'schedule:refresh_lifetime_usages') do
+  lifetime_usage_refresh_interval = ENV["LAGO_LIFETIME_USAGE_REFRESH_INTERVAL_SECONDS"].presence || 5.minutes
+  every(lifetime_usage_refresh_interval.to_i.seconds, 'schedule:refresh_lifetime_usages') do
     Clock::RefreshLifetimeUsagesJob
-      .set(sentry: {"slug" => 'lago_refresh_lifetime_usages', "cron" => '*/5 * * * *'})
+      .set(sentry: {"slug" => 'lago_refresh_lifetime_usages', "cron" => "#{lifetime_usage_refresh_interval} interval"})
       .perform_later
   end
 

--- a/spec/clockwork_spec.rb
+++ b/spec/clockwork_spec.rb
@@ -89,5 +89,29 @@ describe Clockwork do
       Clockwork::Test.block_for(job).call
       expect(Clock::RefreshLifetimeUsagesJob).to have_been_enqueued
     end
+
+    context "with a custom refresh interval configured" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with('LAGO_LIFETIME_USAGE_REFRESH_INTERVAL_SECONDS').and_return('150')
+      end
+
+      it 'uses the ENV["LAGO_LIFETIME_USAGE_REFRESH_INTERVAL_SECONDS"] to set a custom period' do
+        Clockwork::Test.run(
+          file: clock_file,
+          start_time:,
+          end_time:,
+          tick_speed: 1.second
+        )
+
+        expect(Clockwork::Test).to be_ran_job(job)
+        expect(Clockwork::Test.times_run(job)).to eq(12)
+
+        Clockwork::Test.block_for(job).call
+        expect(Clock::RefreshLifetimeUsagesJob).to have_been_enqueued
+
+        expect(ENV).to have_received(:[]).with('LAGO_LIFETIME_USAGE_REFRESH_INTERVAL_SECONDS')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

There's always a risk of customers not paying invoices generated at the end of a billing period. It would be beneficial to bill customers at given thresholds (units vs. amount) rather than waiting until the end of the period. This approach would allow for removing customer access if invoices are not paid and prevent having a highest amount of unpaid invoices.

## Description

Allows configuring the refresh interval via an ENV variable. 