### PR TITLE
feat(ProgressiveBilling): Apply credit to progressive billing invoices

### DIFF
--- a/app/services/invoices/compute_amounts_from_fees.rb
+++ b/app/services/invoices/compute_amounts_from_fees.rb
@@ -24,8 +24,9 @@ module Invoices
 
       invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
       invoice.coupons_amount_cents = invoice.credits.coupon_kind.sum(:amount_cents)
+
       invoice.sub_total_excluding_taxes_amount_cents = (
-        invoice.fees_amount_cents - invoice.coupons_amount_cents
+        invoice.fees_amount_cents - invoice.progressive_billing_credit_amount_cents - invoice.coupons_amount_cents
       )
 
       taxes_result = if provider_taxes && customer_provider_taxation?

--- a/app/services/invoices/progressive_billing_service.rb
+++ b/app/services/invoices/progressive_billing_service.rb
@@ -17,9 +17,11 @@ module Invoices
 
         invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
         invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
-        Credits::AppliedCouponsService.call(invoice:) if invoice.fees_amount_cents&.positive?
 
+        Credits::ProgressiveBillingService.call(invoice:)
+        Credits::AppliedCouponsService.call(invoice:)
         Invoices::ComputeAmountsFromFees.call(invoice:)
+
         create_credit_note_credit
         create_applied_prepaid_credit
 

--- a/spec/services/credits/progressive_billing_service_spec.rb
+++ b/spec/services/credits/progressive_billing_service_spec.rb
@@ -19,15 +19,15 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
       subscriptions: subscriptions)
   end
 
+  let(:subscription_fees) { [subscription_fee1, subscription_fee2] }
+  let(:subscription_fee1) { create(:charge_fee, invoice:, subscription:, amount_cents: 500) }
+  let(:subscription_fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 500) }
+
   before do
     invoice
     invoice.invoice_subscriptions.each { |is| is.update!(charges_from_datetime: invoice.issuing_date - 1.month, charges_to_datetime: invoice.issuing_date) }
     subscription_fees
   end
-
-  let(:subscription_fees) { [subscription_fee1, subscription_fee2] }
-  let(:subscription_fee1) { create(:charge_fee, invoice:, subscription:, amount_cents: 500) }
-  let(:subscription_fee2) { create(:charge_fee, invoice:, subscription:, amount_cents: 500) }
 
   context "without progressive billing invoices" do
     describe "#call" do
@@ -67,6 +67,9 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
         credit = result.credits.sole
         expect(credit.amount_cents).to eq(20)
         expect(invoice.progressive_billing_credit_amount_cents).to eq(20)
+
+        expect(subscription_fee1.reload.precise_coupons_amount_cents).to eq(10)
+        expect(subscription_fee2.reload.precise_coupons_amount_cents).to eq(10)
       end
     end
   end


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR applies credits from the progressive_billing invoices to every new progressive billing invoice in the same period. It also makes sure that credits are well applied to fees and taken into account when computing taxes