### PR TITLE
feat(ProgressiveBilling): Improvements on PDF and APIs

### DIFF
--- a/app/graphql/types/invoices/object.rb
+++ b/app/graphql/types/invoices/object.rb
@@ -29,6 +29,7 @@ module Types
       field :credit_notes_amount_cents, GraphQL::Types::BigInt, null: false
       field :fees_amount_cents, GraphQL::Types::BigInt, null: false
       field :prepaid_credit_amount_cents, GraphQL::Types::BigInt, null: false
+      field :progressive_billing_credit_amount_cents, GraphQL::Types::BigInt, null: false
       field :sub_total_excluding_taxes_amount_cents, GraphQL::Types::BigInt, null: false
       field :sub_total_including_taxes_amount_cents, GraphQL::Types::BigInt, null: false
       field :taxes_amount_cents, GraphQL::Types::BigInt, null: false

--- a/app/jobs/clock/refresh_lifetime_usages_job.rb
+++ b/app/jobs/clock/refresh_lifetime_usages_job.rb
@@ -8,6 +8,8 @@ module Clock
     unique :until_executed, on_conflict: :log
 
     def perform
+      return unless License.premium?
+
       LifetimeUsage.needs_recalculation.find_each do |ltu|
         LifetimeUsages::RecalculateAndCheckJob.perform_later(ltu)
       end

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -18,6 +18,7 @@ module V1
         currency: model.currency,
         fees_amount_cents: model.fees_amount_cents,
         taxes_amount_cents: model.taxes_amount_cents,
+        progressive_billing_credit_amount_cents: model.progressive_billing_credit_amount_cents,
         coupons_amount_cents: model.coupons_amount_cents,
         credit_notes_amount_cents: model.credit_notes_amount_cents,
         sub_total_excluding_taxes_amount_cents: model.sub_total_excluding_taxes_amount_cents,

--- a/app/views/templates/invoices/v4/_progressive_billing_details.slim
+++ b/app/views/templates/invoices/v4/_progressive_billing_details.slim
@@ -5,7 +5,7 @@
 .invoice-resume.overflow-auto
   table.invoice-resume-table width="100%"
     tr.first_child
-      td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(invoice_subscription.charges_from_datetime_in_customer_timezone&.to_date, format: :default), to_date: I18n.l(invoice_subscription.charges_to_datetime_in_customer_timezone&.to_date, format: :default))
+      td.body-2 = I18n.t('invoice.fees_from_to_date', from_date: I18n.l(invoice_subscription.charges_from_datetime_in_customer_timezone&.to_date, format: :default), to_date: I18n.l(issuing_date, format: :default))
       td.body-2 = I18n.t('invoice.units')
       td.body-2 = I18n.t('invoice.unit_price')
       td.body-2 = I18n.t('invoice.tax_rate')
@@ -43,13 +43,10 @@
 / Total section
 .invoice-resume.overflow-auto
   table.total-table width="100%"
-    - if progressive_billing_credit_amount_cents.positive?
-      - credits.progressive_billing_invoice_kind.order(created_at: :asc) do |credit|
-        tr
-          td.body-2
-          / TODO(ProgressiveBilling): apply the right label
-          td.body-2 #{credit.item_name}
-          td.body-2 = '-' + MoneyHelper.format(credit.amount)
+    tr
+      td.body-2
+      td.body-2 I18.t('invoice.progressive_billing_credit')
+      td.body-2 = '-' + MoneyHelper.format(progressive_billing_credit_amount)
 
     - if coupons_amount_cents.positive?
       - credits.coupon_kind.order(created_at: :asc).each do |credit|

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -137,12 +137,10 @@
         - if subscriptions.count == 1
           - unless credit?
             - if progressive_billing_credit_amount_cents.positive?
-              - credits.progressive_billing_invoice_kind.order(created_at: :asc) do |credit|
-                tr
-                  td.body-2
-                  / TODO(ProgressiveBilling): apply the right label
-                  td.body-2 #{credit.item_name}
-                  td.body-2 = '-' + MoneyHelper.format(credit.amount)
+              tr
+                td.body-2
+                td.body-2 I18.t('invoice.progressive_billing_credit')
+                td.body-2 = '-' + MoneyHelper.format(progressive_billing_credit_amount)
 
             - if coupons_amount_cents.positive?
               - credits.coupon_kind.order(created_at: :asc).each do |credit|
@@ -188,6 +186,13 @@
             td.body-1
               = MoneyHelper.format(total_amount)
         - else
+          - if progressive_billing_credit_amount_cents.positive?
+            - credits = progressice_billing_credits(invoice_subscription.subscription).all
+            - if credits.present?
+              tr
+                td.body-2
+                td.body-2 I18.t('invoice.progressive_billing_credit')
+                td.body-2 = '-' + MoneyHelper.format(credits.sum(&:amount))
           tr
             td.body-2
             td.body-1 = I18n.t('invoice.total')

--- a/app/views/templates/invoices/v4/_subscriptions_summary.slim
+++ b/app/views/templates/invoices/v4/_subscriptions_summary.slim
@@ -15,12 +15,10 @@ table.invoice-resume-table width="100%"
 table.total-table width="100%"
   - unless credit?
     - if progressive_billing_credit_amount_cents.positive?
-      - credits.progressive_billing_invoice_kind.order(created_at: :asc) do |credit|
-        tr
-          td.body-2
-          / TODO(ProgressiveBilling): apply the right label
-          td.body-2 #{credit.item_name}
-          td.body-2 = '-' + MoneyHelper.format(credit.amount)
+      tr
+        td.body-2
+        td.body-2 I18.t('invoice.progressive_billing_credit')
+        td.body-2 = '-' + MoneyHelper.format(progressive_billing_credit_amount)
 
     - if coupons_amount_cents.positive?
       - credits.coupon_kind.order(created_at: :asc).each do |credit|

--- a/config/locales/de/invoice.yml
+++ b/config/locales/de/invoice.yml
@@ -52,6 +52,7 @@ de:
     prepaid_credit_invoice: Anzahlungsrechnung
     prepaid_credits: Prepaid-Guthaben
     prepaid_credits_with_value: Prepaid-Guthaben - %{wallet_name}
+    progressive_billing_credit: Nutzung bereits abgerechnet
     quarter: quartal
     quarterly: Vierteljährlich
     see_breakdown: Siehe Aufschlüsselung für Gesamtübersicht
@@ -89,7 +90,6 @@ de:
     units: Einheiten
     units_prorated_per_period: Einheiten anteilig pro Sekunde pro %{period}
     usage_based_fees: Nutzungsabhängige Gebühren
-    usage_threshold: Abrechnungsschwelle
     volume:
       fee_per_unit: Gebühr pro Einheit
       flat_fee_for_all_units: Pauschalgebühr für alle Einheiten

--- a/config/locales/en/invoice.yml
+++ b/config/locales/en/invoice.yml
@@ -52,6 +52,7 @@ en:
     prepaid_credit_invoice: Advance invoice
     prepaid_credits: Prepaid credits
     prepaid_credits_with_value: Prepaid credits - %{wallet_name}
+    progressive_billing_credit: Usage already billed
     quarter: quarter
     quarterly: Quarterly
     see_breakdown: See breakdown for total unit
@@ -89,7 +90,6 @@ en:
     units: Units
     units_prorated_per_period: Units prorated per second per %{period}
     usage_based_fees: Usage based fees
-    usage_threshold: Billing threshold
     volume:
       fee_per_unit: Fee per unit
       flat_fee_for_all_units: Flat fee for all units

--- a/config/locales/es/invoice.yml
+++ b/config/locales/es/invoice.yml
@@ -51,6 +51,7 @@ es:
     prepaid_credit_invoice: Factura anticipada
     prepaid_credits: Créditos prepagados
     prepaid_credits_with_value: Créditos prepagados - %{wallet_name}
+    progressive_billing_credit: Uso ya facturado
     quarter: trimestre
     quarterly: Trimestral
     see_breakdown: Consulte el desglose a continuación
@@ -87,7 +88,6 @@ es:
     units: Unidades
     units_prorated_per_period: Unidades prorrateadas por segundo por %{period}
     usage_based_fees: Cargos basados en el uso
-    usage_threshold: Umbral de facturación
     volume:
       fee_per_unit: Tarifa por unidad
       flat_fee_for_all_units: Tarifa plana para todas las unidades

--- a/config/locales/fr/invoice.yml
+++ b/config/locales/fr/invoice.yml
@@ -52,6 +52,7 @@ fr:
     prepaid_credit_invoice: Facture d'acompte
     prepaid_credits: Crédit(s) prépayé(s)
     prepaid_credits_with_value: Crédit(s) prépayé(s) - %{wallet_name}
+    progressive_billing_credit: Usage déjà facturé
     quarter: trimestre
     quarterly: trimestriellement
     see_breakdown: Consultez le détail ci-après
@@ -89,7 +90,6 @@ fr:
     units: Unités
     units_prorated_per_period: Unités proratisées par seconde par %{period}
     usage_based_fees: Frais de consommation
-    usage_threshold: Seuil de facturation
     volume:
       fee_per_unit: Frais par unité
       flat_fee_for_all_units: Frais fixes pour toutes les unités

--- a/config/locales/it/invoice.yml
+++ b/config/locales/it/invoice.yml
@@ -52,6 +52,7 @@ it:
     prepaid_credit_invoice: Fattura anticipata
     prepaid_credits: Crediti prepagati
     prepaid_credits_with_value: Crediti prepagati - %{wallet_name}
+    progressive_billing_credit: Utilizzo già fatturato
     quarter: trimestre
     quarterly: Trimestrale
     see_breakdown: Vedere la ripartizione per l'unità totale
@@ -89,7 +90,6 @@ it:
     units: Unità
     units_prorated_per_period: Unità proporzionate al secondo per %{period}
     usage_based_fees: Tariffe basate sull'utilizzo
-    usage_threshold: Soglia di fatturazione
     volume:
       fee_per_unit: Tassa per unità
       flat_fee_for_all_units: Canone forfettario per tutte le unità

--- a/config/locales/nb/invoice.yml
+++ b/config/locales/nb/invoice.yml
@@ -52,6 +52,7 @@ nb:
     prepaid_credit_invoice: Forskuddsfaktura
     prepaid_credits: Forskuddsbetalte kreditter
     prepaid_credits_with_value: Forhåndsbetalte kreditter - %{wallet_name}
+    progressive_billing_credit: Bruk allerede fakturert
     quarter: kvartal
     quarterly: Kvartalsvis
     see_breakdown: Se oversikt for antall enheter
@@ -89,7 +90,6 @@ nb:
     units: Enheter
     units_prorated_per_period: Enheter proratert per sekund per %{period}
     usage_based_fees: Bruksbaserte kostnader
-    usage_threshold: Faktureringsterskel
     volume:
       fee_per_unit: Gebyr per enhet
       flat_fee_for_all_units: Fast avgift for alle enheter

--- a/config/locales/sv/invoice.yml
+++ b/config/locales/sv/invoice.yml
@@ -51,6 +51,7 @@ sv:
     prepaid_credit_invoice: Förskottsfaktura
     prepaid_credits: Förbetald kontobalans
     prepaid_credits_with_value: Förbetald kontobalans - %{wallet_name}
+    progressive_billing_credit: Användning redan fakturerad
     quarter: kvartal
     quarterly: Kvartalsvis
     see_breakdown: Se uppdelning nedan
@@ -87,7 +88,6 @@ sv:
     units: Enheter
     units_prorated_per_period: Proportionella enheter per sekund per %{period}
     usage_based_fees: Avgifter baserade på användning
-    usage_threshold: Faktureringströskel
     volume:
       fee_per_unit: Avgift per enhet
       flat_fee_for_all_units: Fast avgift för alla enheter

--- a/schema.graphql
+++ b/schema.graphql
@@ -4049,6 +4049,7 @@ type Invoice {
   paymentOverdue: Boolean!
   paymentStatus: InvoicePaymentStatusTypeEnum!
   prepaidCreditAmountCents: BigInt!
+  progressiveBillingCreditAmountCents: BigInt!
   refundableAmountCents: BigInt!
   sequentialId: ID!
   status: InvoiceStatusTypeEnum!

--- a/schema.json
+++ b/schema.json
@@ -18979,6 +18979,24 @@
               ]
             },
             {
+              "name": "progressiveBillingCreditAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "refundableAmountCents",
               "description": null,
               "type": {

--- a/spec/graphql/types/invoices/object_spec.rb
+++ b/spec/graphql/types/invoices/object_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Types::Invoices::Object do
   it { is_expected.to have_field(:credit_notes_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:fees_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:prepaid_credit_amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:progressive_billing_credit_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:sub_total_excluding_taxes_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:sub_total_including_taxes_amount_cents).of_type('BigInt!') }
   it { is_expected.to have_field(:taxes_amount_cents).of_type('BigInt!') }

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1073,6 +1073,7 @@ RSpec.describe Invoice, type: :model do
           :invoice,
           fees_amount_cents: 200,
           coupons_amount_cents: 20,
+          progressive_billing_credit_amount_cents:,
           taxes_amount_cents: 36,
           total_amount_cents: 216,
           taxes_rate: 20,
@@ -1092,10 +1093,20 @@ RSpec.describe Invoice, type: :model do
         create(:charge_fee, subscription:, invoice:, charge:, amount_cents: 200, taxes_rate: 20)
       end
 
+      let(:progressive_billing_credit_amount_cents) { 0 }
+
       before { fee }
 
       it 'returns the expected creditable amount in cents' do
         expect(invoice.creditable_amount_cents).to eq(216)
+      end
+
+      context 'with progressive billing credit' do
+        let(:progressive_billing_credit_amount_cents) { 2 }
+
+        it 'returns the expected creditable amount in cents' do
+          expect(invoice.creditable_amount_cents).to eq(214)
+        end
       end
     end
   end

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe ::V1::InvoiceSerializer do
         'payment_overdue' => invoice.payment_overdue,
         'currency' => invoice.currency,
         'fees_amount_cents' => invoice.fees_amount_cents,
+        'progressive_billing_credit_amount_cents' => invoice.progressive_billing_credit_amount_cents,
         'coupons_amount_cents' => invoice.coupons_amount_cents,
         'credit_notes_amount_cents' => invoice.credit_notes_amount_cents,
         'prepaid_credit_amount_cents' => invoice.prepaid_credit_amount_cents,


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR:
- Improves the PDF templates to render the previously billed progressive billing amount
- Exposes the `progressive_billing_credit_amount_cents` in REST and GraphQL APIs as well as in invoice related webhooks.
- Ensures that the `Clock::RefreshLifetimeUsagesJob` job is performed only in premium mode