### PR TITLE
feat(netsuite): Cleanup email and phone in contact payloads

### DIFF
--- a/app/services/integrations/aggregator/contacts/payloads/base_payload.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/base_payload.rb
@@ -17,12 +17,12 @@ module Integrations
             [
               {
                 'name' => customer.name,
-                'email' => customer.email,
                 'city' => customer.city,
                 'zip' => customer.zipcode,
                 'country' => customer.country,
                 'state' => customer.state,
-                'phone' => customer.phone
+                'email' => email,
+                'phone' => phone
               }
             ]
           end
@@ -32,12 +32,12 @@ module Integrations
               {
                 'id' => integration_customer.external_customer_id,
                 'name' => customer.name,
-                'email' => customer.email,
                 'city' => customer.city,
                 'zip' => customer.zipcode,
                 'country' => customer.country,
                 'state' => customer.state,
-                'phone' => customer.phone
+                'email' => email,
+                'phone' => phone
               }
             ]
           end
@@ -45,6 +45,14 @@ module Integrations
           private
 
           attr_reader :customer, :integration_customer, :subsidiary_id
+
+          def email
+            customer.email.to_s.split(',').first&.strip
+          end
+
+          def phone
+            customer.phone.to_s.split(',').first&.strip
+          end
         end
       end
     end

--- a/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
+++ b/app/services/integrations/aggregator/contacts/payloads/netsuite.rb
@@ -14,10 +14,9 @@ module Integrations
                 'subsidiary' => subsidiary_id,
                 'custentity_lago_id' => customer.id,
                 'custentity_lago_sf_id' => customer.external_salesforce_id,
-                'custentity_form_activeprospect_customer' => customer.name, # TODO: Will be removed
                 'custentity_lago_customer_link' => customer_url,
-                'email' => customer.email,
-                'phone' => customer.phone
+                'email' => email,
+                'phone' => phone
               },
               'options' => {
                 'ignoreMandatoryFields' => false # Fixed value
@@ -33,10 +32,9 @@ module Integrations
                 'companyname' => customer.name,
                 'subsidiary' => integration_customer.subsidiary_id,
                 'custentity_lago_sf_id' => customer.external_salesforce_id,
-                'custentity_form_activeprospect_customer' => customer.name, # TODO: Will be removed
                 'custentity_lago_customer_link' => customer_url,
-                'email' => customer.email,
-                'phone' => customer.phone
+                'email' => email,
+                'phone' => phone
               },
               'options' => {
                 'isDynamic' => false

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
               'subsidiary' => subsidiary_id,
               'custentity_lago_id' => customer.id,
               'custentity_lago_sf_id' => customer.external_salesforce_id,
-              'custentity_form_activeprospect_customer' => customer.name,
               'custentity_lago_customer_link' => customer_link,
               'email' => customer.email,
               'phone' => customer.phone
@@ -185,7 +184,6 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
             'subsidiary' => subsidiary_id,
             'custentity_lago_id' => customer.id,
             'custentity_lago_sf_id' => customer.external_salesforce_id,
-            'custentity_form_activeprospect_customer' => customer.name,
             'custentity_lago_customer_link' => customer_link,
             'email' => customer.email,
             'phone' => customer.phone

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
               'companyname' => customer.name,
               'subsidiary' => integration_customer.subsidiary_id,
               'custentity_lago_sf_id' => customer.external_salesforce_id,
-              'custentity_form_activeprospect_customer' => customer.name,
               'custentity_lago_customer_link' => customer_link,
               'email' => customer.email,
               'phone' => customer.phone
@@ -134,7 +133,6 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
             'companyname' => customer.name,
             'subsidiary' => integration_customer.subsidiary_id,
             'custentity_lago_sf_id' => customer.external_salesforce_id,
-            'custentity_form_activeprospect_customer' => customer.name,
             'custentity_lago_customer_link' => customer_link,
             'email' => customer.email,
             'phone' => customer.phone


### PR DESCRIPTION
## Context

Netsuite doesn't support comma-separated contacts emails, so we'll send only the first one.
Similar aplies for the phone number(s).

## Description

This PR adds methods for transforming email and phone in contact create and update payloads.
It also removes obsolete `custentity_form_activeprospect_customer` attribute.
