### PR TITLE
feat(dunning): Create stripe payment

### DIFF
--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -20,6 +20,10 @@ class PaymentRequest < ApplicationRecord
 
   alias_attribute :total_amount_cents, :amount_cents
   alias_attribute :currency, :amount_currency
+
+  def invoice_ids
+    applied_invoices.pluck(:invoice_id)
+  end
 end
 
 # == Schema Information

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -26,15 +26,17 @@ end
 #
 # Table name: payment_requests
 #
-#  id              :uuid             not null, primary key
-#  amount_cents    :bigint           default(0), not null
-#  amount_currency :string           not null
-#  email           :string           not null
-#  payment_status  :integer          default("pending"), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  customer_id     :uuid             not null
-#  organization_id :uuid             not null
+#  id                           :uuid             not null, primary key
+#  amount_cents                 :bigint           default(0), not null
+#  amount_currency              :string           not null
+#  email                        :string           not null
+#  payment_attempts             :integer          default(0), not null
+#  payment_status               :integer          default("pending"), not null
+#  ready_for_payment_processing :boolean          default(TRUE), not null
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  customer_id                  :uuid             not null
+#  organization_id              :uuid             not null
 #
 # Indexes
 #

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -17,6 +17,9 @@ class PaymentRequest < ApplicationRecord
   PAYMENT_STATUS = %i[pending succeeded failed].freeze
 
   enum payment_status: PAYMENT_STATUS, _prefix: :payment
+
+  alias_attribute :total_amount_cents, :amount_cents
+  alias_attribute :currency, :amount_currency
 end
 
 # == Schema Information

--- a/app/services/payment_requests/payments/deliver_error_webhook_service.rb
+++ b/app/services/payment_requests/payments/deliver_error_webhook_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module PaymentRequests
+  module Payments
+    class DeliverErrorWebhookService < BaseService
+      def initialize(payment_request, params)
+        @payment_request = payment_request
+        @params = params
+      end
+
+      def call_async
+        SendWebhookJob.perform_later('payment_request.payment_failure', payment_request, params)
+
+        result
+      end
+
+      private
+
+      attr_reader :payment_request, :params
+    end
+  end
+end

--- a/app/services/payment_requests/payments/payment_providers/factory.rb
+++ b/app/services/payment_requests/payments/payment_providers/factory.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module PaymentRequests
+  module Payments
+    module PaymentProviders
+      class Factory
+        def self.new_instance(payable:)
+          service_class(payable.customer&.payment_provider).new(payable)
+        end
+
+        def self.service_class(payment_provider)
+          case payment_provider&.to_s
+          when 'stripe'
+            PaymentRequests::Payments::StripeService
+          # when 'adyen'
+          #   PaymentRequests::Payments::AdyenService
+          # when 'gocardless'
+          #   PaymentRequests::Payments::GocardlessService
+          else
+            raise(NotImplementedError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+module PaymentRequests
+  module Payments
+    class StripeService < BaseService
+      include Customers::PaymentProviderFinder
+
+      PENDING_STATUSES = %w[processing requires_capture requires_action requires_confirmation requires_payment_method]
+        .freeze
+      SUCCESS_STATUSES = %w[succeeded].freeze
+      FAILED_STATUSES = %w[canceled].freeze
+
+      def initialize(payable = nil)
+        @payable = payable
+
+        super(nil)
+      end
+
+      def create
+        result.payable = payable
+        return result unless should_process_payment?
+
+        unless payable.total_amount_cents.positive?
+          update_payable_payment_status(payment_status: :succeeded)
+          return result
+        end
+
+        increment_payment_attempts
+
+        stripe_result = create_stripe_payment
+        # NOTE: return if payment was not processed
+        return result unless stripe_result
+
+        payment = Payment.new(
+          payable: payable,
+          payment_provider_id: stripe_payment_provider.id,
+          payment_provider_customer_id: customer.stripe_customer.id,
+          amount_cents: stripe_result.amount,
+          amount_currency: stripe_result.currency&.upcase,
+          provider_payment_id: stripe_result.id,
+          status: stripe_result.status
+        )
+        payment.save!
+
+        update_payable_payment_status(
+          payment_status: payable_payment_status(payment.status),
+          processing: payment.status == 'processing'
+        )
+
+        Integrations::Aggregator::Payments::CreateJob.perform_later(payment:) if payment.should_sync_payment?
+
+        result.payment = payment
+        result
+      rescue Stripe::AuthenticationError, Stripe::CardError, Stripe::InvalidRequestError, Stripe::PermissionError => e
+        # NOTE: Do not mark the payable as failed if the amount is too small for Stripe
+        #       For now we keep it as pending, the user can still update it manually
+        return result if e.code == 'amount_too_small'
+
+        #deliver_error_webhook(e)
+        update_payable_payment_status(payment_status: :failed, deliver_webhook: false)
+        result
+      rescue Stripe::RateLimitError, Stripe::APIConnectionError
+        raise # Let the auto-retry process do its own job
+      rescue Stripe::StripeError => e
+        #deliver_error_webhook(e)
+        raise
+      end
+
+      private
+
+      attr_accessor :payable
+
+      delegate :organization, :customer, to: :payable
+
+      def success_redirect_url
+        stripe_payment_provider.success_redirect_url.presence ||
+          ::PaymentProviders::StripeProvider::SUCCESS_REDIRECT_URL
+      end
+
+      def should_process_payment?
+        return false if payable.payment_succeeded?
+        return false if stripe_payment_provider.blank?
+
+        customer&.stripe_customer&.provider_customer_id
+      end
+
+      def stripe_api_key
+        stripe_payment_provider.secret_key
+      end
+
+      def stripe_payment_method
+        payment_method_id = customer.stripe_customer.payment_method_id
+
+        if payment_method_id
+          # NOTE: Check if payment method still exists
+          customer_service = PaymentProviderCustomers::StripeService.new(customer.stripe_customer)
+          customer_service_result = customer_service.check_payment_method(payment_method_id)
+          return customer_service_result.payment_method.id if customer_service_result.success?
+        end
+
+        # NOTE: Retrieve list of existing payment_methods
+        payment_method = Stripe::PaymentMethod.list(
+          {
+            customer: customer.stripe_customer.provider_customer_id
+          },
+          {
+            api_key: stripe_api_key
+          }
+        ).first
+        customer.stripe_customer.payment_method_id = payment_method&.id
+        customer.stripe_customer.save!
+
+        payment_method&.id
+      end
+
+      def update_payment_method_id
+        result = Stripe::Customer.retrieve(
+          customer.stripe_customer.provider_customer_id,
+          {
+            api_key: stripe_api_key
+          }
+        )
+        # TODO: stripe customer should be updated/deleted
+        return if result.deleted?
+
+        if (payment_method_id = result.invoice_settings.default_payment_method || result.default_source)
+          customer.stripe_customer.update!(payment_method_id:)
+        end
+      end
+
+      def create_stripe_payment
+        update_payment_method_id
+
+        Stripe::PaymentIntent.create(
+          stripe_payment_payload,
+          {
+            api_key: stripe_api_key,
+            idempotency_key: "#{payable.id}/#{payable.payment_attempts}"
+          }
+        )
+      end
+
+      def stripe_payment_payload
+        {
+          amount: payable.total_amount_cents,
+          currency: payable.currency.downcase,
+          customer: customer.stripe_customer.provider_customer_id,
+          payment_method: stripe_payment_method,
+          payment_method_types: customer.stripe_customer.provider_payment_methods,
+          confirm: true,
+          off_session: true,
+          error_on_requires_action: true,
+          description:,
+          metadata: {
+            lago_customer_id: customer.id,
+            lago_invoice_id: payable.id,
+            #invoice_issuing_date: payable.issuing_date.iso8601,
+            #invoice_type: invoice.invoice_type
+          }
+        }
+      end
+
+      def description
+        "#{organization.name} - PaymentRequest 123" #TODO: #{invoice.number}"
+      end
+
+      def payable_payment_status(payment_status)
+        return :pending if PENDING_STATUSES.include?(payment_status)
+        return :succeeded if SUCCESS_STATUSES.include?(payment_status)
+        return :failed if FAILED_STATUSES.include?(payment_status)
+
+        payment_status&.to_sym
+      end
+
+      def update_payable_payment_status(payment_status:, deliver_webhook: true, processing: false)
+        payable.update!(
+          payment_status:,
+          ready_for_payment_processing: !processing && payment_status.to_sym != :succeeded
+        )
+      end
+
+      def update_invoice_payment_status(payment_status:, deliver_webhook: true, processing: false)
+        result = Invoices::UpdateService.call(
+          invoice: payable.presence || @result.payable,
+          params: {
+            payment_status:,
+            # NOTE: A proper `processing` payment status should be introduced for payables
+            ready_for_payment_processing: !processing && payment_status.to_sym != :succeeded
+          },
+          webhook_notification: deliver_webhook
+        )
+        result.raise_if_error!
+      end
+
+      def increment_payment_attempts
+        payable.increment!(:payment_attempts)
+      end
+
+      def deliver_error_webhook(stripe_error)
+        DeliverErrorWebhookService.call_async(payable, {
+          provider_customer_id: customer.stripe_customer.provider_customer_id,
+          provider_error: {
+            message: stripe_error.message,
+            error_code: stripe_error.code
+          }
+        })
+      end
+
+      def stripe_payment_provider
+        @stripe_payment_provider ||= payment_provider(customer)
+      end
+    end
+  end
+end

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -191,7 +191,8 @@ module PaymentRequests
       end
 
       def increment_payment_attempts
-        payable.increment!(:payment_attempts)
+        payable.increment(:payment_attempts)
+        payable.save!
       end
 
       def deliver_error_webhook(stripe_error)

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -182,7 +182,7 @@ module PaymentRequests
       def update_payable_payment_status(payment_status:, deliver_webhook: true, processing: false)
         payable.update!(
           payment_status:,
-            # NOTE: A proper `processing` payment status should be introduced for payment_requests
+          # NOTE: A proper `processing` payment status should be introduced for payment_requests
           ready_for_payment_processing: !processing && payment_status.to_sym != :succeeded
         )
       end

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -20,6 +20,11 @@ module PaymentRequests
         result.payable = payable
         return result unless should_process_payment?
 
+        if payable.invoices.empty?
+          update_payable_payment_status(payment_status: :succeeded)
+          return result
+        end
+
         unless payable.total_amount_cents.positive?
           update_payable_payment_status(payment_status: :succeeded)
           return result

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -79,7 +79,7 @@ module PaymentRequests
         return false if payable.payment_succeeded?
         return false if stripe_payment_provider.blank?
 
-        customer&.stripe_customer&.provider_customer_id
+        !!customer&.stripe_customer&.provider_customer_id
       end
 
       def stripe_api_key

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -47,8 +47,6 @@ module PaymentRequests
           processing: payment.status == 'processing'
         )
 
-        Integrations::Aggregator::Payments::CreateJob.perform_later(payment:) if payment.should_sync_payment?
-
         result.payment = payment
         result
       rescue Stripe::AuthenticationError, Stripe::CardError, Stripe::InvalidRequestError, Stripe::PermissionError => e

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -20,11 +20,6 @@ module PaymentRequests
         result.payable = payable
         return result unless should_process_payment?
 
-        if payable.invoices.empty?
-          update_payable_payment_status(payment_status: :succeeded)
-          return result
-        end
-
         unless payable.total_amount_cents.positive?
           update_payable_payment_status(payment_status: :succeeded)
           return result

--- a/db/migrate/20240822142524_add_payment_retry_columns_to_payment_requests.rb
+++ b/db/migrate/20240822142524_add_payment_retry_columns_to_payment_requests.rb
@@ -1,8 +1,10 @@
 class AddPaymentRetryColumnsToPaymentRequests < ActiveRecord::Migration[7.1]
   def change
-    change_table :payment_requests, bulk: true do |t|
-      t.integer :payment_attempts, default: 0, null: false
-      t.boolean :ready_for_payment_processing, default: true, null: false
+    safety_assured do
+      change_table :payment_requests, bulk: true do |t|
+        t.integer :payment_attempts, default: 0, null: false
+        t.boolean :ready_for_payment_processing, default: true, null: false
+      end
     end
   end
 end

--- a/db/migrate/20240822142524_add_payment_retry_columns_to_payment_requests.rb
+++ b/db/migrate/20240822142524_add_payment_retry_columns_to_payment_requests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPaymentRetryColumnsToPaymentRequests < ActiveRecord::Migration[7.1]
   def change
     safety_assured do

--- a/db/migrate/20240822142524_add_payment_retry_columns_to_payment_requests.rb
+++ b/db/migrate/20240822142524_add_payment_retry_columns_to_payment_requests.rb
@@ -1,0 +1,8 @@
+class AddPaymentRetryColumnsToPaymentRequests < ActiveRecord::Migration[7.1]
+  def change
+    change_table :payment_requests, bulk: true do |t|
+      t.integer :payment_attempts, default: 0, null: false
+      t.boolean :ready_for_payment_processing, default: true, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_22_082727) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_22_142524) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -905,6 +905,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_22_082727) do
     t.datetime "updated_at", null: false
     t.uuid "organization_id", null: false
     t.integer "payment_status", default: 0, null: false
+    t.integer "payment_attempts", default: 0, null: false
+    t.boolean "ready_for_payment_processing", default: true, null: false
     t.index ["customer_id"], name: "index_payment_requests_on_customer_id"
     t.index ["organization_id"], name: "index_payment_requests_on_organization_id"
   end

--- a/spec/factories/payment_requests.rb
+++ b/spec/factories/payment_requests.rb
@@ -9,5 +9,7 @@ FactoryBot.define do
     amount_currency { "EUR" }
     email { Faker::Internet.email }
     payment_status { "pending" }
+    ready_for_payment_processing { true }
+    payment_attempts { 0 }
   end
 end

--- a/spec/models/payment_request_spec.rb
+++ b/spec/models/payment_request_spec.rb
@@ -46,4 +46,16 @@ RSpec.describe PaymentRequest, type: :model do
       expect(payment_request).not_to be_valid
     end
   end
+
+  describe "#total_amount_cents" do
+    it "aliases amount_cents" do
+      expect(payment_request.total_amount_cents).to eq(payment_request.amount_cents)
+    end
+  end
+
+  describe "#currency" do
+    it "aliases amount_currency" do
+      expect(payment_request.currency).to eq(payment_request.amount_currency)
+    end
+  end
 end

--- a/spec/models/payment_request_spec.rb
+++ b/spec/models/payment_request_spec.rb
@@ -58,4 +58,18 @@ RSpec.describe PaymentRequest, type: :model do
       expect(payment_request.currency).to eq(payment_request.amount_currency)
     end
   end
+
+  describe "#invoice_ids" do
+    let(:payment_request) do
+      create(:payment_request, invoices:)
+    end
+
+    let(:invoices) do
+      create_list(:invoice, 2)
+    end
+
+    it "returns a list with the applied invoice ids" do
+      expect(payment_request.invoice_ids).to eq(invoices.map(&:id))
+    end
+  end
 end

--- a/spec/services/payment_requests/payments/deliver_error_webhook_service_spec.rb
+++ b/spec/services/payment_requests/payments/deliver_error_webhook_service_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentRequests::Payments::DeliverErrorWebhookService, type: :service do
+  subject(:webhook_service) { described_class.new(payment_request, params) }
+
+  let(:payment_request) { create(:payment_request) }
+  let(:params) do
+    {
+      'provider_customer_id' => 'customer',
+      'provider_error' => {
+        'error_message' => 'message',
+        'error_code' => 'code'
+      }
+    }.with_indifferent_access
+  end
+
+  describe '.call_async' do
+    it 'enqueues a job to send an payment request payment failure webhook' do
+      expect do
+        webhook_service.call_async
+      end.to have_enqueued_job(SendWebhookJob).with('payment_request.payment_failure', payment_request, params)
+    end
+  end
+end

--- a/spec/services/payment_requests/payments/payment_providers/factory_spec.rb
+++ b/spec/services/payment_requests/payments/payment_providers/factory_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PaymentRequests::Payments::PaymentProviders::Factory, type: :service do
+  subject(:factory_service) { described_class.new_instance(payable:) }
+
+  let(:payment_provider) { 'stripe' }
+  let(:payable) { create(:payment_request, customer:) }
+  let(:customer) { create(:customer, payment_provider:) }
+
+  describe '#self.new_instance' do
+    context 'when stripe' do
+      it 'returns correct class' do
+        expect(factory_service.class.to_s).to eq('PaymentRequests::Payments::StripeService')
+      end
+    end
+
+    context 'when adyen' do
+      let(:payment_provider) { 'adyen' }
+
+      xit 'returns correct class' do
+        expect(factory_service.class.to_s).to eq('PaymentRequests::Payments::AdyenService')
+      end
+    end
+
+    context 'when gocardless' do
+      let(:payment_provider) { 'gocardless' }
+
+      xit 'returns correct class' do
+        expect(factory_service.class.to_s).to eq('PaymentRequests::Payments::GocardlessService')
+      end
+    end
+  end
+end

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -1,0 +1,356 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
+  subject(:stripe_service) { described_class.new(payment_request) }
+
+  let(:customer) { create(:customer, payment_provider_code: code) }
+  let(:organization) { customer.organization }
+  let(:stripe_payment_provider) { create(:stripe_provider, organization:, code:) }
+  let(:stripe_customer) { create(:stripe_customer, customer:, payment_method_id: "pm_123456") }
+  let(:code) { "stripe_1" }
+
+  let(:payment_request) do
+    create(
+      :payment_request,
+      organization:,
+      customer:,
+      amount_cents: 799,
+      amount_currency: "EUR",
+      invoices: [invoice_1, invoice_2]
+    )
+  end
+
+  let(:invoice_1) do
+    create(
+      :invoice,
+      organization:,
+      customer:,
+      total_amount_cents: 200,
+      currency: 'EUR',
+      ready_for_payment_processing: true
+    )
+  end
+
+  let(:invoice_2) do
+    create(
+      :invoice,
+      organization:,
+      customer:,
+      total_amount_cents: 599,
+      currency: 'EUR',
+      ready_for_payment_processing: true
+    )
+  end
+
+  describe ".create" do
+    let(:provider_customer_service) { instance_double(PaymentProviderCustomers::StripeService) }
+
+    let(:provider_customer_service_result) do
+      BaseService::Result.new.tap do |result|
+        result.payment_method = Stripe::PaymentMethod.new(id: "pm_123456")
+      end
+    end
+
+    let(:customer_response) do
+      File.read(Rails.root.join("spec/fixtures/stripe/customer_retrieve_response.json"))
+    end
+
+    let(:payment_status) { "succeeded" }
+
+    before do
+      stripe_payment_provider
+      stripe_customer
+
+      allow(Stripe::PaymentIntent).to receive(:create)
+        .and_return(
+          Stripe::PaymentIntent.construct_from(
+            id: "ch_123456",
+            status: payment_status,
+            amount: payment_request.total_amount_cents,
+            currency: payment_request.currency
+          )
+        )
+      allow(SegmentTrackJob).to receive(:perform_later)
+      #allow(PaymentRequests::PrepaidCreditJob).to receive(:perform_later)
+
+      allow(PaymentProviderCustomers::StripeService).to receive(:new)
+        .and_return(provider_customer_service)
+      allow(provider_customer_service).to receive(:check_payment_method)
+        .and_return(provider_customer_service_result)
+
+      stub_request(:get, "https://api.stripe.com/v1/customers/#{stripe_customer.provider_customer_id}")
+        .to_return(status: 200, body: customer_response, headers: {})
+    end
+
+    it "creates a stripe payment and a payment", :aggregate_failures do
+      result = stripe_service.create
+
+      expect(result).to be_success
+
+      expect(result.payable).to be_payment_succeeded
+      expect(result.payable.payment_attempts).to eq(1)
+      expect(result.payable.ready_for_payment_processing).to eq(false)
+
+      expect(result.payment.id).to be_present
+      expect(result.payment.payable).to eq(payment_request)
+      expect(result.payment.payment_provider).to eq(stripe_payment_provider)
+      expect(result.payment.payment_provider_customer).to eq(stripe_customer)
+      expect(result.payment.amount_cents).to eq(payment_request.total_amount_cents)
+      expect(result.payment.amount_currency).to eq(payment_request.currency)
+      expect(result.payment.status).to eq("succeeded")
+
+      expect(Stripe::PaymentIntent).to have_received(:create)
+    end
+
+    it_behaves_like "syncs payment" do
+      let(:service_call) { stripe_service.create }
+    end
+
+    context "with no payment provider" do
+      let(:stripe_payment_provider) { nil }
+
+      it "does not creates a stripe payment" do
+        result = stripe_service.create
+
+        expect(result).to be_success
+
+        aggregate_failures do
+          expect(result.payable).to eq(payment_request)
+          expect(result.payment).to be_nil
+
+          expect(Stripe::PaymentIntent).not_to have_received(:create)
+        end
+      end
+    end
+
+    context "with no invoices" do
+      let(:payment_request) do
+        create(:payment_request, organization:, customer:, invoices: [])
+      end
+
+      it 'does not creates a stripe payment', :aggregate_failures do
+        result = stripe_service.create
+
+        expect(result).to be_success
+
+        expect(result.payable).to eq(payment_request)
+        expect(result.payment).to be_nil
+        expect(result.payable).to be_payment_succeeded
+        expect(Stripe::PaymentIntent).not_to have_received(:create)
+      end
+    end
+
+    context 'with 0 amount' do
+      let(:payable) do
+        create(
+          :payment_request,
+          organization:,
+          customer:,
+          amount_cents: 0,
+          amount_currency: "EUR",
+          invoices: [invoice]
+        )
+      end
+
+      let(:invoice) do
+        create(
+          :invoice,
+          organization:,
+          customer:,
+          total_amount_cents: 0,
+          currency: 'EUR'
+        )
+      end
+
+      it 'does not creates a stripe payment', :aggregate_failures do
+        result = stripe_service.create
+
+        expect(result).to be_success
+        expect(result.payable).to eq(payment_request)
+        expect(result.payment).to be_nil
+        expect(result.payable).to be_payment_succeeded
+        expect(Stripe::PaymentIntent).not_to have_received(:create)
+      end
+    end
+
+    context "when customer does not have a provider customer id" do
+      before { stripe_customer.update!(provider_customer_id: nil) }
+
+      it "does not creates a stripe payment", :aggregate_failures  do
+        result = stripe_service.create
+
+        expect(result).to be_success
+
+        expect(result.payable).to eq(payment_request)
+        expect(result.payment).to be_nil
+
+        expect(Stripe::PaymentIntent).not_to have_received(:create)
+      end
+    end
+
+    context "when customer does not have a payment method" do
+      let(:stripe_customer) { create(:stripe_customer, customer:) }
+
+      before do
+        allow(Stripe::Customer).to receive(:retrieve)
+          .and_return(Stripe::StripeObject.construct_from(
+            {
+              invoice_settings: {
+                default_payment_method: nil
+              },
+              default_source: nil
+            }
+          ))
+
+        allow(Stripe::PaymentMethod).to receive(:list)
+          .and_return(Stripe::ListObject.construct_from(
+            data: [
+              {
+                id: "pm_123456",
+                object: "payment_method",
+                card: {brand: "visa"},
+                created: 1_656_422_973,
+                customer: "cus_123456",
+                livemode: false,
+                metadata: {},
+                type: "card"
+              }
+            ]
+          ))
+      end
+
+      it "retrieves the payment method" do
+        result = stripe_service.create
+
+        expect(result).to be_success
+        expect(customer.stripe_customer.reload).to be_present
+        expect(customer.stripe_customer.provider_customer_id).to eq(stripe_customer.provider_customer_id)
+        expect(customer.stripe_customer.payment_method_id).to eq("pm_123456")
+
+        expect(Stripe::PaymentMethod).to have_received(:list)
+        expect(Stripe::PaymentIntent).to have_received(:create)
+      end
+    end
+
+    context "with card error on stripe" do
+      let(:customer) { create(:customer, organization:, payment_provider_code: code) }
+
+      #let(:subscription) do
+      #  create(:subscription, organization:, customer:)
+      #end
+
+      let(:organization) do
+        create(:organization, webhook_url: "https://webhook.com")
+      end
+
+      before do
+      #  subscription
+
+        allow(Stripe::PaymentIntent).to receive(:create)
+          .and_raise(Stripe::CardError.new("error", {}))
+      end
+
+      it "delivers an error webhook" do
+        #allow(PaymentRequests::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
+
+        stripe_service.create
+
+        #expect(PaymentRequests::Payments::DeliverErrorWebhookService).to have_received(:call_async)
+        expect(SendWebhookJob).to have_been_enqueued
+          .with(
+            "payment_request.payment_failure",
+            payment_request,
+            provider_customer_id: stripe_customer.provider_customer_id,
+            provider_error: {
+              message: "error",
+              error_code: nil
+            }
+          )
+      end
+
+      #context "when invoice is credit? and open?" do
+      #  let(:wallet_transaction) { create(:wallet_transaction) }
+
+      #  before do
+      #    create(:fee, fee_type: :credit, invoice: invoice, invoiceable: wallet_transaction)
+      #    invoice.update! status: :open, invoice_type: :credit
+      #  end
+
+      #  it "delivers an error webhook" do
+      #    allow(PaymentRequests::Payments::DeliverErrorWebhookService).to receive(:call_async).and_call_original
+
+      #    stripe_service.create
+
+      #    expect(PaymentRequests::Payments::DeliverErrorWebhookService).to have_received(:call_async)
+      #    expect(SendWebhookJob).to have_been_enqueued
+      #      .with(
+      #        "wallet_transaction.payment_failure",
+      #        wallet_transaction,
+      #        provider_customer_id: stripe_customer.provider_customer_id,
+      #        provider_error: {
+      #          message: "error",
+      #          error_code: nil
+      #        }
+      #      )
+      #  end
+      #end
+    end
+
+    #context "when invoice has a too small amount" do
+    #  let(:organization) { create(:organization) }
+    #  let(:customer) { create(:customer, organization:) }
+    #  let(:subscription) { create(:subscription, organization:, customer:) }
+
+    #  let(:invoice) do
+    #    create(
+    #      :invoice,
+    #      organization:,
+    #      customer:,
+    #      total_amount_cents: 20,
+    #      currency: "EUR",
+    #      ready_for_payment_processing: true
+    #    )
+    #  end
+
+    #  before do
+    #    subscription
+
+    #    allow(Stripe::PaymentIntent).to receive(:create)
+    #      .and_raise(Stripe::InvalidRequestError.new("amount_too_small", {}, code: "amount_too_small"))
+    #  end
+
+    #  it "does not send mark the invoice as failed" do
+    #    stripe_service.create
+    #    invoice.reload
+
+    #    expect(invoice).to be_payment_pending
+    #  end
+    #end
+
+    context "when payment status is processing" do
+      let(:payment_status) { "processing" }
+
+      it "creates a stripe payment and a payment", :aggregate_failures do
+        result = stripe_service.create
+
+        expect(result).to be_success
+
+        expect(result.payable).to be_payment_pending
+        expect(result.payable.payment_attempts).to eq(1)
+        expect(result.payable.ready_for_payment_processing).to eq(false)
+
+        expect(result.payment.id).to be_present
+        expect(result.payment.payable).to eq(payment_request)
+        expect(result.payment.payment_provider).to eq(stripe_payment_provider)
+        expect(result.payment.payment_provider_customer).to eq(stripe_customer)
+        expect(result.payment.amount_cents).to eq(payment_request.total_amount_cents)
+        expect(result.payment.amount_currency).to eq(payment_request.currency)
+        expect(result.payment.status).to eq("processing")
+
+        expect(Stripe::PaymentIntent).to have_received(:create)
+      end
+    end
+  end
+end

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
       end
     end
 
-    context "with no invoices" do
+    context "when payment request has no invoices" do
       let(:payment_request) do
         create(:payment_request, organization:, customer:, invoices: [])
       end
@@ -174,7 +174,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
     context "when customer does not have a provider customer id" do
       before { stripe_customer.update!(provider_customer_id: nil) }
 
-      it "does not creates a stripe payment", :aggregate_failures  do
+      it "does not creates a stripe payment", :aggregate_failures do
         result = stripe_service.create
 
         expect(result).to be_success

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -128,6 +128,13 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
       )
     end
 
+    it "updates invoice payment status to succeeded", :aggregate_failures do
+      stripe_service.create
+
+      expect(invoice_1.reload).to be_payment_succeeded
+      expect(invoice_2.reload).to be_payment_succeeded
+    end
+
     context "with no payment provider" do
       let(:stripe_payment_provider) { nil }
 

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -121,23 +121,6 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
       end
     end
 
-    context "when payment request has no invoices" do
-      let(:payment_request) do
-        create(:payment_request, organization:, customer:, invoices: [])
-      end
-
-      it 'does not creates a stripe payment', :aggregate_failures do
-        result = stripe_service.create
-
-        expect(result).to be_success
-
-        expect(result.payable).to eq(payment_request)
-        expect(result.payment).to be_nil
-        expect(result.payable).to be_payment_succeeded
-        expect(Stripe::PaymentIntent).not_to have_received(:create)
-      end
-    end
-
     context 'with 0 amount' do
       let(:payable) do
         create(

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
     end
 
     context 'with 0 amount' do
-      let(:payable) do
+      let(:payment_request) do
         create(
           :payment_request,
           organization:,

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -104,10 +104,6 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
       expect(Stripe::PaymentIntent).to have_received(:create)
     end
 
-    it_behaves_like "syncs payment" do
-      let(:service_call) { stripe_service.create }
-    end
-
     context "with no payment provider" do
       let(:stripe_payment_provider) { nil }
 

--- a/spec/support/matchers/negated_matchers.rb
+++ b/spec/support/matchers/negated_matchers.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+#
+RSpec::Matchers.define_negated_matcher :not_change, :change

--- a/spec/support/matchers/negated_matchers.rb
+++ b/spec/support/matchers/negated_matchers.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
-#
+
 RSpec::Matchers.define_negated_matcher :not_change, :change


### PR DESCRIPTION
## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

## Description

The goal of this PR is to create a stripe payment for customers this payment provider.