### PR TITLE
Feat(anrok): add fields to graphql response on applied taxes

### DIFF
--- a/app/graphql/types/invoices/applied_taxes/object.rb
+++ b/app/graphql/types/invoices/applied_taxes/object.rb
@@ -7,9 +7,10 @@ module Types
         graphql_name 'InvoiceAppliedTax'
         implements Types::Taxes::AppliedTax
 
-        field :invoice, Types::Invoices::Object, null: false
-
+        field :applied_on_whole_invoice?, GraphQL::Types::Boolean, null: false
         field :fees_amount_cents, GraphQL::Types::BigInt, null: false
+        field :invoice, Types::Invoices::Object, null: false
+        field :tax_code, String, null: false
       end
     end
   end

--- a/app/graphql/types/invoices/applied_taxes/object.rb
+++ b/app/graphql/types/invoices/applied_taxes/object.rb
@@ -7,7 +7,7 @@ module Types
         graphql_name 'InvoiceAppliedTax'
         implements Types::Taxes::AppliedTax
 
-        field :applied_on_whole_invoice?, GraphQL::Types::Boolean, null: false
+        field :applied_on_whole_invoice, GraphQL::Types::Boolean, null: false, method: :applied_on_whole_invoice?
         field :fees_amount_cents, GraphQL::Types::BigInt, null: false
         field :invoice, Types::Invoices::Object, null: false
       end

--- a/app/graphql/types/invoices/applied_taxes/object.rb
+++ b/app/graphql/types/invoices/applied_taxes/object.rb
@@ -10,7 +10,6 @@ module Types
         field :applied_on_whole_invoice?, GraphQL::Types::Boolean, null: false
         field :fees_amount_cents, GraphQL::Types::BigInt, null: false
         field :invoice, Types::Invoices::Object, null: false
-        field :tax_code, String, null: false
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -4068,6 +4068,7 @@ type Invoice {
 type InvoiceAppliedTax implements AppliedTax {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
+  appliedOnWholeInvoice?: Boolean!
   createdAt: ISO8601DateTime!
   feesAmountCents: BigInt!
   id: ID!

--- a/schema.graphql
+++ b/schema.graphql
@@ -4068,7 +4068,7 @@ type Invoice {
 type InvoiceAppliedTax implements AppliedTax {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
-  appliedOnWholeInvoice?: Boolean!
+  appliedOnWholeInvoice: Boolean!
   createdAt: ISO8601DateTime!
   feesAmountCents: BigInt!
   id: ID!

--- a/schema.json
+++ b/schema.json
@@ -19288,7 +19288,7 @@
               ]
             },
             {
-              "name": "appliedOnWholeInvoice?",
+              "name": "appliedOnWholeInvoice",
               "description": null,
               "type": {
                 "kind": "NON_NULL",

--- a/schema.json
+++ b/schema.json
@@ -19288,6 +19288,24 @@
               ]
             },
             {
+              "name": "appliedOnWholeInvoice?",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "createdAt",
               "description": null,
               "type": {


### PR DESCRIPTION
## Context

On FE to be able to show differently taxes applied on all line items vs on few only within the invoice, we need to specify on the applied_tax if it's applicable on the whole invoice
and to be able to show different translation for the taxes depending on their code, we want to send tax_cod with applied tax as well

## Description

- added tax_code
- and applied_on_whole_invoice

to Invoice::AppliedTax graphql type
