### PR TITLE
feat(ProgressiveBilling) - take draft invoices into account for LifetimeUsage refreshing

### DIFF
--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -19,8 +19,6 @@ module Invoices
         invoice.payment_due_date = payment_due_date
         invoice.save!
 
-        flag_lifetime_usage_for_refresh
-
         invoice.credit_notes.each(&:finalized!)
       end
 
@@ -69,10 +67,6 @@ module Invoices
     def should_deliver_email?
       License.premium? &&
         invoice.organization.email_settings.include?('invoice.finalized')
-    end
-
-    def flag_lifetime_usage_for_refresh
-      LifetimeUsages::FlagRefreshFromInvoiceService.call(invoice:).raise_if_error!
     end
   end
 end

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -69,6 +69,8 @@ module Invoices
 
         calculate_result.raise_if_error!
 
+        flag_lifetime_usage_for_refresh
+
         # NOTE: In case of a refresh the same day of the termination.
         invoice.fees.update_all(created_at: invoice.created_at) # rubocop:disable Rails/SkipsModelValidations
       end
@@ -94,6 +96,10 @@ module Invoices
       CreditNoteItem
         .joins(:credit_note)
         .where(credit_note: {invoice_id: invoice.id})
+    end
+
+    def flag_lifetime_usage_for_refresh
+      LifetimeUsages::FlagRefreshFromInvoiceService.call(invoice:).raise_if_error!
     end
   end
 end

--- a/app/services/lifetime_usages/flag_refresh_from_invoice_service.rb
+++ b/app/services/lifetime_usages/flag_refresh_from_invoice_service.rb
@@ -9,7 +9,6 @@ module LifetimeUsages
 
     def call
       return result unless invoice.subscription?
-      return result unless invoice.finalized? || invoice.voided?
       return result unless has_plan_usage_thresholds?
 
       result.lifetime_usages = []

--- a/spec/services/invoices/refresh_draft_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_service_spec.rb
@@ -153,5 +153,13 @@ RSpec.describe Invoices::RefreshDraftService, type: :service do
       expect { refresh_service.call }
         .to change { invoice.reload.taxes_rate }.from(0.0).to(15)
     end
+
+    it 'flags lifetime usage for refresh' do
+      create(:usage_threshold, plan: subscription.plan)
+
+      refresh_service.call
+
+      expect(subscription.reload.lifetime_usage.recalculate_invoiced_usage).to be(true)
+    end
   end
 end


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

Also flag draft invoices for LifetimeUsage recalculation. 
