### PR TITLE
feat (tax-integrations): Use Anrok taxes for one off invoices

### DIFF
--- a/app/graphql/mutations/integrations/anrok/fetch_draft_invoice_taxes.rb
+++ b/app/graphql/mutations/integrations/anrok/fetch_draft_invoice_taxes.rb
@@ -26,7 +26,7 @@ module Mutations
             fees: fees(args)
           ).call
 
-          result.success? ? result.fees : validation_error(messages: {tax_error: result.error.code})
+          result.success? ? result.fees : validation_error(messages: {tax_error: [result.error.code]})
         end
 
         private

--- a/app/graphql/mutations/integrations/anrok/fetch_draft_invoice_taxes.rb
+++ b/app/graphql/mutations/integrations/anrok/fetch_draft_invoice_taxes.rb
@@ -26,7 +26,7 @@ module Mutations
             fees: fees(args)
           ).call
 
-          result.success? ? result.fees : result_error(result)
+          result.success? ? result.fees : validation_error(messages: result.error.code)
         end
 
         private

--- a/app/graphql/mutations/integrations/anrok/fetch_draft_invoice_taxes.rb
+++ b/app/graphql/mutations/integrations/anrok/fetch_draft_invoice_taxes.rb
@@ -26,7 +26,7 @@ module Mutations
             fees: fees(args)
           ).call
 
-          result.success? ? result.fees : validation_error(messages: result.error.code)
+          result.success? ? result.fees : validation_error(messages: {tax_error: result.error.code})
         end
 
         private

--- a/app/services/invoices/create_one_off_service.rb
+++ b/app/services/invoices/create_one_off_service.rb
@@ -28,7 +28,7 @@ module Invoices
           invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
           invoice.failed!
 
-          return fees_result
+          return result.validation_failure!(errors: {tax_error: [fees_result.error.error_message]})
         end
 
         Invoices::ComputeAmountsFromFees.call(invoice:, provider_taxes: result.fees_taxes)

--- a/spec/services/fees/one_off_service_spec.rb
+++ b/spec/services/fees/one_off_service_spec.rb
@@ -135,5 +135,104 @@ RSpec.describe Fees::OneOffService do
         end
       end
     end
+
+    context 'when there is tax provider integration' do
+      let(:integration) { create(:anrok_integration, organization:) }
+      let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+      let(:response) { instance_double(Net::HTTPOK) }
+      let(:lago_client) { instance_double(LagoHttpClient::Client) }
+      let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+      let(:body) do
+        p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response_multiple_fees.json')
+        json = File.read(p)
+
+        # setting item_id based on the test example
+        response = JSON.parse(json)
+        response['succeededInvoices'].first['fees'].first['item_id'] = add_on_first.id
+        response['succeededInvoices'].first['fees'].last['item_id'] = add_on_second.id
+
+        response.to_json
+      end
+      let(:integration_collection_mapping) do
+        create(
+          :netsuite_collection_mapping,
+          integration:,
+          mapping_type: :fallback_item,
+          settings: {external_id: '1', external_account_code: '11', external_name: ''}
+        )
+      end
+
+      before do
+        integration_collection_mapping
+        integration_customer
+
+        allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+        allow(lago_client).to receive(:post_with_response).and_return(response)
+        allow(response).to receive(:body).and_return(body)
+      end
+
+      it 'creates fees' do
+        result = one_off_service.create
+
+        first_fee = result.fees[0]
+        second_fee = result.fees[1]
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(first_fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            add_on_id: add_on_first.id,
+            description: 'desc-123',
+            unit_amount_cents: 1200,
+            precise_unit_amount: 12,
+            units: 2,
+            amount_cents: 2400,
+            amount_currency: 'EUR',
+            fee_type: 'add_on',
+            payment_status: 'pending'
+          )
+          expect(first_fee.applied_taxes.first.amount_cents).to eq(240)
+
+          expect(second_fee).to have_attributes(
+            id: String,
+            invoice_id: invoice.id,
+            add_on_id: add_on_second.id,
+            description: add_on_second.description,
+            unit_amount_cents: 400,
+            precise_unit_amount: 4,
+            units: 1,
+            amount_cents: 400,
+            amount_currency: 'EUR',
+            fee_type: 'add_on',
+            payment_status: 'pending'
+          )
+          expect(second_fee.applied_taxes.first.amount_cents).to eq(60)
+
+          expect(invoice.reload.error_details.count).to eq(0)
+        end
+      end
+
+      context 'when there is error received from the provider' do
+        let(:body) do
+          p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+          File.read(p)
+        end
+
+        it 'returns tax error' do
+          result = one_off_service.create
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error.code).to eq('tax_error')
+            expect(result.error.error_message).to eq('taxDateTooFarInFuture')
+
+            expect(invoice.reload.error_details.count).to eq(1)
+            expect(invoice.reload.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -108,6 +108,92 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
       end.to have_enqueued_job(Invoices::GeneratePdfAndNotifyJob).with(hash_including(email: false))
     end
 
+    context 'when there is tax provider integration' do
+      let(:integration) { create(:anrok_integration, organization:) }
+      let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+      let(:response) { instance_double(Net::HTTPOK) }
+      let(:lago_client) { instance_double(LagoHttpClient::Client) }
+      let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+      let(:body) do
+        p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response_multiple_fees.json')
+        json = File.read(p)
+
+        # setting item_id based on the test example
+        response = JSON.parse(json)
+        response['succeededInvoices'].first['fees'].first['item_id'] = add_on_first.id
+        response['succeededInvoices'].first['fees'].last['item_id'] = add_on_second.id
+
+        response.to_json
+      end
+      let(:integration_collection_mapping) do
+        create(
+          :netsuite_collection_mapping,
+          integration:,
+          mapping_type: :fallback_item,
+          settings: {external_id: '1', external_account_code: '11', external_name: ''}
+        )
+      end
+
+      before do
+        integration_collection_mapping
+        integration_customer
+
+        allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+        allow(lago_client).to receive(:post_with_response).and_return(response)
+        allow(response).to receive(:body).and_return(body)
+      end
+
+      it 'creates an invoice' do
+        result = create_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.invoice.issuing_date.to_date).to eq(timestamp)
+          expect(result.invoice.invoice_type).to eq('one_off')
+          expect(result.invoice.payment_status).to eq('pending')
+          expect(result.invoice.fees.where(fee_type: :add_on).count).to eq(2)
+          expect(result.invoice.fees.pluck(:description)).to contain_exactly('desc-123', add_on_second.description)
+
+          expect(result.invoice.currency).to eq('EUR')
+          expect(result.invoice.fees_amount_cents).to eq(2800) # 2400 + 400
+
+          expect(result.invoice.taxes_amount_cents).to eq(300) # (2400 * 0.1) + (400 * 0.15)
+          expect(result.invoice.taxes_rate).to eq(10.71429)
+          expect(result.invoice.applied_taxes.count).to eq(2)
+
+          expect(result.invoice.total_amount_cents).to eq(3100)
+
+          expect(result.invoice).to be_finalized
+
+          expect(result.invoice.reload.error_details.count).to eq(0)
+        end
+      end
+
+      context 'when there is error received from the provider' do
+        let(:body) do
+          p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+          File.read(p)
+        end
+
+        it 'returns tax error' do
+          result = create_service.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:tax_error]).to eq(['taxDateTooFarInFuture'])
+
+            invoice = customer.invoices.order(created_at: :desc).first
+
+            expect(invoice.status).to eq('failed')
+            expect(invoice.error_details.count).to eq(1)
+            expect(invoice.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
+          end
+        end
+      end
+    end
+
     context 'when invoice amount in cents is zero' do
       let(:fees) do
         [

--- a/spec/services/invoices/create_one_off_service_spec.rb
+++ b/spec/services/invoices/create_one_off_service_spec.rb
@@ -180,15 +180,10 @@ RSpec.describe Invoices::CreateOneOffService, type: :service do
           result = create_service.call
 
           aggregate_failures do
-            expect(result).not_to be_success
-            expect(result.error).to be_a(BaseService::ValidationFailure)
-            expect(result.error.messages[:tax_error]).to eq(['taxDateTooFarInFuture'])
-
-            invoice = customer.invoices.order(created_at: :desc).first
-
-            expect(invoice.status).to eq('failed')
-            expect(invoice.error_details.count).to eq(1)
-            expect(invoice.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
+            expect(result).to be_success
+            expect(result.invoice.status).to eq('failed')
+            expect(result.invoice.error_details.count).to eq(1)
+            expect(result.invoice.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
           end
         end
       end


### PR DESCRIPTION
## Context

Currently integration with tax provider Anrok is being implemented.

## Description

This PR uses all existing Anrok logic on one-off invoices. 

If customer is connected to Anrok, its taxes should be used. All services and Anrok core logic is already implemented and merged on main. This is just logic that consumes it for one-off invoices
