### PR TITLE
fix(thresholds): Fix updating plan with deleted thresholds

### DIFF
--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -34,6 +34,10 @@ module Types
       field :draft_invoices_count, Integer, null: false
       field :subscriptions_count, Integer, null: false
 
+      def usage_thresholds
+        object.usage_thresholds.order(amount_cents: :asc)
+      end
+
       def charges
         object.charges.includes(filters: {values: :billable_metric_filter}).order(created_at: :asc)
       end

--- a/app/graphql/types/subscriptions/charge_overrides_input.rb
+++ b/app/graphql/types/subscriptions/charge_overrides_input.rb
@@ -4,7 +4,7 @@ module Types
   module Subscriptions
     class ChargeOverridesInput < Types::BaseInputObject
       argument :billable_metric_id, ID, required: true
-      argument :id, ID, required: true
+      argument :id, ID, required: false
 
       argument :filters, [Types::ChargeFilters::Input], required: false
       argument :invoice_display_name, String, required: false

--- a/app/graphql/types/subscriptions/usage_threshold_overrides_input.rb
+++ b/app/graphql/types/subscriptions/usage_threshold_overrides_input.rb
@@ -4,6 +4,7 @@ module Types
   module Subscriptions
     class UsageThresholdOverridesInput < Types::BaseInputObject
       argument :amount_cents, GraphQL::Types::BigInt, required: true
+      argument :id, ID, required: false
       argument :recurring, Boolean, required: false
       argument :threshold_display_name, String, required: false
     end

--- a/app/models/usage_threshold.rb
+++ b/app/models/usage_threshold.rb
@@ -14,8 +14,8 @@ class UsageThreshold < ApplicationRecord
   monetize :amount_cents, with_currency: ->(threshold) { threshold.plan.amount_currency }
 
   validates :amount_cents, numericality: {greater_than: 0}
-  validates :amount_cents, uniqueness: {scope: %i[plan_id recurring]}
-  validates :recurring, uniqueness: {scope: :plan_id}, if: -> { recurring? }
+  validates :amount_cents, uniqueness: {scope: %i[plan_id recurring deleted_at]}, if: -> { deleted_at.nil? }
+  validates :recurring, uniqueness: {scope: %i[plan_id deleted_at]}, if: -> { recurring? && deleted_at.nil? }
 
   scope :recurring, -> { where(recurring: true) }
   scope :not_recurring, -> { where(recurring: false) }

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -194,9 +194,15 @@ module Plans
             usage_threshold.recurring = payload_threshold[:recurring]
           end
 
-          usage_threshold.save!
-
-          next
+          # This means that in the UI we just removed an existing threshold
+          # and then just re-added a threshold (which no longer has an id) with the same amount
+          # so we discard the existing one and we're inserting a new one instead
+          if !usage_threshold.valid? && usage_threshold.errors.where(:amount_cents, :taken).present?
+            usage_threshold.discard!
+          else
+            usage_threshold.save!
+            next
+          end
         end
 
         plan = plan.reload

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -46,10 +46,15 @@ module Plans
 
         process_charges(plan, params[:charges]) if params[:charges]
 
-        if params[:usage_thresholds] &&
+        if params.key?(:usage_thresholds) &&
             License.premium? &&
             plan.organization.premium_integrations.include?('progressive_billing')
-          process_usage_thresholds(plan, params[:usage_thresholds])
+
+          if params[:usage_thresholds].empty?
+            plan.usage_thresholds.discard_all
+          else
+            process_usage_thresholds(plan, params[:usage_thresholds])
+          end
         end
 
         process_minimum_commitment(plan, params[:minimum_commitment]) if params[:minimum_commitment] && License.premium?
@@ -83,11 +88,17 @@ module Plans
     end
 
     def create_usage_threshold(plan, params)
-      usage_threshold = plan.usage_thresholds.new(
-        threshold_display_name: params[:threshold_display_name],
-        amount_cents: params[:amount_cents],
-        recurring: params[:recurring] || false
+      usage_threshold = plan.usage_thresholds.find_or_initialize_by(
+        recurring: params[:recurring] || false,
+        amount_cents: params[:amount_cents]
       )
+
+      existing_recurring_threshold = plan.usage_thresholds.recurring.first
+      if params[:recurring] && existing_recurring_threshold
+        usage_threshold = existing_recurring_threshold
+      end
+
+      usage_threshold.threshold_display_name = params[:threshold_display_name]
 
       usage_threshold.save!
       usage_threshold
@@ -185,6 +196,8 @@ module Plans
 
           next
         end
+
+        plan = plan.reload
 
         created_threshold = create_usage_threshold(plan, payload_threshold)
         created_thresholds_ids.push(created_threshold.id)

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -94,11 +94,13 @@ module Plans
       )
 
       existing_recurring_threshold = plan.usage_thresholds.recurring.first
+
       if params[:recurring] && existing_recurring_threshold
         usage_threshold = existing_recurring_threshold
       end
 
       usage_threshold.threshold_display_name = params[:threshold_display_name]
+      usage_threshold.amount_cents = params[:amount_cents]
 
       usage_threshold.save!
       usage_threshold

--- a/schema.graphql
+++ b/schema.graphql
@@ -361,7 +361,7 @@ enum ChargeModelEnum {
 input ChargeOverridesInput {
   billableMetricId: ID!
   filters: [ChargeFilterInput!]
-  id: ID!
+  id: ID
   invoiceDisplayName: String
   minAmountCents: BigInt
   properties: PropertiesInput
@@ -7687,6 +7687,7 @@ input UsageThresholdInput {
 
 input UsageThresholdOverridesInput {
   amountCents: BigInt!
+  id: ID
   recurring: Boolean
   thresholdDisplayName: String
 }

--- a/schema.json
+++ b/schema.json
@@ -3285,13 +3285,9 @@
               "name": "id",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -37297,6 +37293,18 @@
                   "name": "BigInt",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/spec/graphql/types/subscriptions/charge_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/charge_overrides_input_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Types::Subscriptions::ChargeOverridesInput do
   subject { described_class }
 
   it { is_expected.to accept_argument(:billable_metric_id).of_type('ID!') }
-  it { is_expected.to accept_argument(:id).of_type('ID!') }
+  it { is_expected.to accept_argument(:id).of_type('ID') }
   it { is_expected.to accept_argument(:filters).of_type('[ChargeFilterInput!]') }
   it { is_expected.to accept_argument(:invoice_display_name).of_type('String') }
   it { is_expected.to accept_argument(:min_amount_cents).of_type('BigInt') }

--- a/spec/graphql/types/subscriptions/usage_threshold_overrides_input_spec.rb
+++ b/spec/graphql/types/subscriptions/usage_threshold_overrides_input_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Types::Subscriptions::UsageThresholdOverridesInput do
   subject { described_class }
 
   it { is_expected.to accept_argument(:amount_cents).of_type('BigInt!') }
+  it { is_expected.to accept_argument(:id).of_type('ID') }
   it { is_expected.to accept_argument(:recurring).of_type('Boolean') }
   it { is_expected.to accept_argument(:threshold_display_name).of_type('String') }
 end


### PR DESCRIPTION
## Context

We were getting validation erros when updating a plan via the UI.
The problem was a specific combination of: removing and re-adding thresholds with the same amount because of a constraint. First we were creating a new threshold while the old one (with the same amount was still in the DB). Also there might have been the same threshold wtih that amount existing but soft deleted.

## Description

Refactor the validations, and saving logic of thresholds.