### PR TITLE
feat(ProgressiveBilling): Use draft invoices and previous subscriptions

### DIFF
--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -17,7 +17,7 @@ module Credits
           .invoices
           .progressive_billing
           .finalized
-          .where(issuing_date: invoice_subscription.charges_from_datetime...invoice_subscription.charges_to_datetime)
+          .where(created_at: invoice_subscription.charges_from_datetime...invoice_subscription.charges_to_datetime)
           .order(issuing_date: :asc)
 
         total_subscription_amount = invoice.fees.charge.where(subscription: subscription).sum(:amount_cents)
@@ -65,7 +65,7 @@ module Credits
       invoice.invoice_subscriptions.any? do |invoice_subscription|
         invoice_subscription.subscription.invoices.progressive_billing
           .finalized
-          .where(issuing_date: invoice_subscription.charges_from_datetime...invoice_subscription.charges_to_datetime)
+          .where(created_at: invoice_subscription.charges_from_datetime...invoice_subscription.charges_to_datetime)
           .exists?
       end
     end

--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -453,10 +453,10 @@ html
       .invoice-resume.mb-24.overflow-auto
         - if credit?
           == SlimHelper.render('templates/invoices/v4/_credit', self)
-        - elsif subscriptions.count == 1
-          == SlimHelper.render('templates/invoices/v4/_subscription_details', self)
         - elsif progressive_billing?
           == SlimHelper.render('templates/invoices/v4/_progressive_billing_details', self)
+        - elsif subscriptions.count == 1
+          == SlimHelper.render('templates/invoices/v4/_subscription_details', self)
         - else
           == SlimHelper.render('templates/invoices/v4/_subscriptions_summary', self)
 
@@ -465,7 +465,7 @@ html
       - if progressive_billing?
         p.body-3.mb-24
           - applied_usage_threshold = applied_usage_thresholds.order(created_at: :asc).last
-          = I18n.t('invoice.reached_usage_threshold', usage_amount: MoneyHelper. applied_usage_threshold.lifetime_usage_amount, threshold_amount: MoneyHelper.format(applied_usage_threshold.threshold.amount_cents))
+          = I18n.t('invoice.reached_usage_threshold', usage_amount: MoneyHelper.format(applied_usage_threshold.lifetime_usage_amount), threshold_amount: MoneyHelper.format(applied_usage_threshold.usage_threshold.amount))
 
       p.body-3.mb-24 = LineBreakHelper.break_lines(organization.invoice_footer)
 

--- a/app/views/templates/invoices/v4/_progressive_billing_details.slim
+++ b/app/views/templates/invoices/v4/_progressive_billing_details.slim
@@ -45,7 +45,7 @@
   table.total-table width="100%"
     tr
       td.body-2
-      td.body-2 I18.t('invoice.progressive_billing_credit')
+      td.body-2 = I18n.t('invoice.progressive_billing_credit')
       td.body-2 = '-' + MoneyHelper.format(progressive_billing_credit_amount)
 
     - if coupons_amount_cents.positive?

--- a/app/views/templates/invoices/v4/_subscription_details.slim
+++ b/app/views/templates/invoices/v4/_subscription_details.slim
@@ -139,7 +139,7 @@
             - if progressive_billing_credit_amount_cents.positive?
               tr
                 td.body-2
-                td.body-2 I18.t('invoice.progressive_billing_credit')
+                td.body-2 = I18n.t('invoice.progressive_billing_credit')
                 td.body-2 = '-' + MoneyHelper.format(progressive_billing_credit_amount)
 
             - if coupons_amount_cents.positive?
@@ -191,7 +191,7 @@
             - if credits.present?
               tr
                 td.body-2
-                td.body-2 I18.t('invoice.progressive_billing_credit')
+                td.body-2 = I18n.t('invoice.progressive_billing_credit')
                 td.body-2 = '-' + MoneyHelper.format(credits.sum(&:amount))
           tr
             td.body-2

--- a/app/views/templates/invoices/v4/_subscriptions_summary.slim
+++ b/app/views/templates/invoices/v4/_subscriptions_summary.slim
@@ -17,7 +17,7 @@ table.total-table width="100%"
     - if progressive_billing_credit_amount_cents.positive?
       tr
         td.body-2
-        td.body-2 I18.t('invoice.progressive_billing_credit')
+        td.body-2 = I18n.t('invoice.progressive_billing_credit')
         td.body-2 = '-' + MoneyHelper.format(progressive_billing_credit_amount)
 
     - if coupons_amount_cents.positive?

--- a/spec/services/credits/progressive_billing_service_spec.rb
+++ b/spec/services/credits/progressive_billing_service_spec.rb
@@ -49,6 +49,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
         invoice_type: :progressive_billing,
         subscriptions: [subscription],
         issuing_date: invoice.issuing_date - 1.day,
+        created_at: invoice.issuing_date - 1.day,
         fees_amount_cents: 20
       )
     end
@@ -84,6 +85,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
         invoice_type: :progressive_billing,
         subscriptions: [subscription],
         issuing_date: invoice.issuing_date - 2.days,
+        created_at: invoice.issuing_date - 2.days,
         fees_amount_cents: 20
       )
     end
@@ -97,6 +99,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
         invoice_type: :progressive_billing,
         subscriptions: [subscription],
         issuing_date: invoice.issuing_date - 1.day,
+        created_at: invoice.issuing_date - 1.day,
         fees_amount_cents: 200
       )
     end
@@ -134,6 +137,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
         invoice_type: :progressive_billing,
         subscriptions: [subscription],
         issuing_date: invoice.issuing_date - 3.days,
+        created_at: invoice.issuing_date - 3.days,
         fees_amount_cents: 20
       )
     end
@@ -147,6 +151,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
         invoice_type: :progressive_billing,
         subscriptions: [subscription],
         issuing_date: invoice.issuing_date - 2.days,
+        created_at: invoice.issuing_date - 2.days,
         fees_amount_cents: 1000
       )
     end
@@ -160,6 +165,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
         invoice_type: :progressive_billing,
         subscriptions: [subscription],
         issuing_date: invoice.issuing_date - 1.day,
+        created_at: invoice.issuing_date - 1.day,
         fees_amount_cents: 200
       )
     end
@@ -220,6 +226,7 @@ Rspec.describe Credits::ProgressiveBillingService, type: :service do
         invoice_type: :progressive_billing,
         subscriptions: [subscription],
         issuing_date: invoice.issuing_date - 1.day,
+        created_at: invoice.issuing_date - 1.day,
         fees_amount_cents: 20
       )
     end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -122,13 +122,16 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
       context "when a progressive_billing invoice is present" do
         let(:progressive_invoice) do
-          create(:invoice,
+          create(
+            :invoice,
             customer:,
             status: 'finalized',
             invoice_type: :progressive_billing,
             subscriptions: [subscription],
             fees_amount_cents: 50,
-            issuing_date: timestamp - 5.days)
+            issuing_date: timestamp - 5.days,
+            created_at: timestamp - 5.days
+          )
         end
 
         let(:progressive_fee) do


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR
- Includes draft invoices in the computation of `lifetime_usage#invoiced_usage_amount_cents` amount
- Makes sure that previous subscriptions are also taken into account