### PR TITLE
feat (tax-integrations): Use Anrok taxes in subscription invoices flow

### DIFF
--- a/app/jobs/bill_subscription_job.rb
+++ b/app/jobs/bill_subscription_job.rb
@@ -14,6 +14,9 @@ class BillSubscriptionJob < ApplicationJob
       skip_charges:
     )
     return if result.success?
+    # NOTE: We don't want a dead job for failed invoice due to the tax reason.
+    #       This invoice should be in failed status and can be retried.
+    return if result.error.messages.dig(:tax_error)
 
     # If the invoice was passed as an argument, it means the job was already retried (see end of function)
     result.raise_if_error! if invoice

--- a/app/jobs/invoices/finalize_all_job.rb
+++ b/app/jobs/invoices/finalize_all_job.rb
@@ -6,7 +6,13 @@ module Invoices
 
     def perform(organization:, invoice_ids:)
       result = Invoices::FinalizeBatchService.new(organization:).call(invoice_ids)
-      result.raise_if_error!
+      result.raise_if_error! unless tax_error?(result)
+    end
+
+    private
+
+    def tax_error?(result)
+      result.error&.messages&.dig(:tax_error)
     end
   end
 end

--- a/app/services/fees/commitments/minimum/create_service.rb
+++ b/app/services/fees/commitments/minimum/create_service.rb
@@ -35,9 +35,6 @@ module Fees
             taxes_amount_cents: 0
           )
 
-          taxes_result = Fees::ApplyTaxesService.call(fee: new_fee)
-          taxes_result.raise_if_error!
-
           new_fee.save!
           result.fee = new_fee
 

--- a/app/services/invoices/apply_provider_taxes_service.rb
+++ b/app/services/invoices/apply_provider_taxes_service.rb
@@ -116,7 +116,11 @@ module Invoices
     end
 
     def fetch_provider_taxes_result
-      taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:)
+      taxes_result = if invoice.draft?
+        Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:)
+      else
+        Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:)
+      end
       taxes_result.raise_if_error!
     end
 

--- a/app/services/invoices/calculate_fees_service.rb
+++ b/app/services/invoices/calculate_fees_service.rb
@@ -46,7 +46,23 @@ module Invoices
 
         Credits::ProgressiveBillingService.call(invoice:)
         Credits::AppliedCouponsService.call(invoice:) if should_create_coupon_credit?
-        Invoices::ComputeAmountsFromFees.call(invoice:)
+
+        if customer_provider_taxation?
+          taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: invoice.fees)
+
+          unless taxes_result.success?
+            create_error_detail(taxes_result.error.code)
+
+            # Draft invoice needs to stay in draft status
+            invoice.failed! if invoice.finalized?
+
+            return result.service_failure!(code: 'tax_error', message: taxes_result.error.code)
+          end
+
+          Invoices::ComputeAmountsFromFees.call(invoice:, provider_taxes: taxes_result.fees)
+        else
+          Invoices::ComputeAmountsFromFees.call(invoice:)
+        end
 
         create_credit_note_credit if should_create_credit_note_credit?
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
@@ -315,6 +331,24 @@ module Invoices
       tz = subscription.customer.applicable_timezone
 
       timestamp.in_time_zone(tz).to_date != subscription.trial_end_datetime.in_time_zone(tz).to_date
+    end
+
+    def customer_provider_taxation?
+      @customer_provider_taxation ||= invoice.customer.anrok_customer
+    end
+
+    def create_error_detail(code)
+      error_result = ErrorDetails::CreateService.call(
+        owner: invoice,
+        organization: invoice.organization,
+        params: {
+          error_code: :tax_error,
+          details: {
+            tax_error: code
+          }
+        }
+      )
+      error_result.raise_if_error!
     end
   end
 end

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -17,7 +17,7 @@ module Invoices
         refresh_result = Invoices::RefreshDraftService.call(invoice:, context: :finalize)
         if tax_error?(refresh_result.error)
           invoice.update!(issuing_date: drafted_issuing_date)
-          return result.validation_failure!(errors: {tax_error: [refresh_result.error.error_message]})
+          return refresh_result
         end
         refresh_result.raise_if_error!
 
@@ -76,7 +76,7 @@ module Invoices
     end
 
     def tax_error?(error)
-      error&.code == 'tax_error'
+      error&.messages&.dig(:tax_error)
     end
   end
 end

--- a/app/services/invoices/refresh_draft_and_finalize_service.rb
+++ b/app/services/invoices/refresh_draft_and_finalize_service.rb
@@ -10,13 +10,19 @@ module Invoices
     def call
       return result.not_found_failure!(resource: 'invoice') if invoice.nil?
       return result unless invoice.draft?
+      drafted_issuing_date = invoice.issuing_date
 
       ActiveRecord::Base.transaction do
-        Invoices::RefreshDraftService.call(invoice:, context: :finalize).raise_if_error!
-
-        invoice.status = :finalized
         invoice.issuing_date = issuing_date
+        refresh_result = Invoices::RefreshDraftService.call(invoice:, context: :finalize)
+        if tax_error?(refresh_result.error)
+          invoice.update!(issuing_date: drafted_issuing_date)
+          return result.validation_failure!(errors: {tax_error: [refresh_result.error.error_message]})
+        end
+        refresh_result.raise_if_error!
+
         invoice.payment_due_date = payment_due_date
+        invoice.status = :finalized
         invoice.save!
 
         invoice.credit_notes.each(&:finalized!)
@@ -67,6 +73,10 @@ module Invoices
     def should_deliver_email?
       License.premium? &&
         invoice.organization.email_settings.include?('invoice.finalized')
+    end
+
+    def tax_error?(error)
+      error&.code == 'tax_error'
     end
   end
 end

--- a/app/services/invoices/refresh_draft_service.rb
+++ b/app/services/invoices/refresh_draft_service.rb
@@ -62,7 +62,9 @@ module Invoices
           CreditNotes::RefreshDraftService.call(credit_note:, fee:, old_fee_values:)
         end
 
-        return calculate_result if tax_error?(calculate_result.error)
+        if tax_error?(calculate_result.error)
+          return result.validation_failure!(errors: {tax_error: [calculate_result.error.error_message]})
+        end
         calculate_result.raise_if_error!
 
         flag_lifetime_usage_for_refresh

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -56,7 +56,7 @@ module Invoices
       if tax_error?(fee_result)
         SendWebhookJob.perform_later('invoice.drafted', invoice) if grace_period?
 
-        return fee_result
+        return result.validation_failure!(errors: {tax_error: [fee_result.error.error_message]})
       end
 
       if grace_period?

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -28,7 +28,6 @@ module Invoices
 
       fee_result = ActiveRecord::Base.transaction do
         invoice.status = invoice_status
-        invoice.save!
 
         fee_result = Invoices::CalculateFeesService.call(
           invoice:,

--- a/spec/jobs/bill_subscription_job_spec.rb
+++ b/spec/jobs/bill_subscription_job_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe BillSubscriptionJob, type: :job do
       expect(Invoices::SubscriptionService).to have_received(:call)
     end
 
+    context 'when there is tax error' do
+      let(:result) do
+        BaseService::Result.new.validation_failure!(errors: {tax_error: ['invalidMapping']})
+      end
+
+      it 'does not throw an error' do
+        expect do
+          described_class.perform_now(subscriptions, timestamp, invoicing_reason:)
+        end.not_to raise_error
+      end
+    end
+
     context 'with a previously created invoice' do
       let(:invoice) { create(:invoice, :generating) }
 

--- a/spec/jobs/invoices/finalize_all_job_spec.rb
+++ b/spec/jobs/invoices/finalize_all_job_spec.rb
@@ -8,17 +8,51 @@ RSpec.describe Invoices::FinalizeAllJob, type: :job do
   let(:finalize_batch_service) { instance_double(Invoices::FinalizeBatchService) }
   let(:result) { BaseService::Result.new }
   let(:organization) { create(:organization) }
-  let(:invoice) { create(:invoice, organization:) }
+  let(:invoice) { create(:invoice, :draft, organization:) }
 
-  before do
-    allow(Invoices::FinalizeBatchService).to receive(:new).and_return(finalize_batch_service)
-    allow(finalize_batch_service).to receive(:call).and_return(result)
+  context 'when succesfully fetching taxes' do
+    before do
+      allow(Invoices::FinalizeBatchService).to receive(:new).and_return(finalize_batch_service)
+      allow(finalize_batch_service).to receive(:call).and_return(result)
+    end
+
+    it 'calls the retry batch service' do
+      finalize_all_job.perform_now(organization:, invoice_ids: [invoice.id])
+
+      expect(Invoices::FinalizeBatchService).to have_received(:new)
+      expect(finalize_batch_service).to have_received(:call)
+    end
   end
 
-  it 'calls the retry batch service' do
-    finalize_all_job.perform_now(organization:, invoice_ids: [invoice.id])
+  context 'when there was a tax fetching error in FinalizeBatch service' do
+    let(:integration_customer) { create(:anrok_customer, customer: invoice.customer) }
+    let(:response) { instance_double(Net::HTTPOK) }
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+    let(:integration_collection_mapping) do
+      create(
+        :netsuite_collection_mapping,
+        integration: integration_customer.integration,
+        mapping_type: :fallback_item,
+        settings: {external_id: '1', external_account_code: '11', external_name: ''}
+      )
+    end
+    let(:body) do
+      p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+      File.read(p)
+    end
 
-    expect(Invoices::FinalizeBatchService).to have_received(:new)
-    expect(finalize_batch_service).to have_received(:call)
+    before do
+      integration_collection_mapping
+
+      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response).and_return(response)
+      allow(response).to receive(:body).and_return(body)
+    end
+
+    it 'does not throw an error when it is a tax error' do
+      expect { described_class.perform_now(organization: invoice.organization, invoice_ids: [invoice.id]) }
+        .not_to raise_error
+    end
   end
 end

--- a/spec/jobs/invoices/finalize_job_spec.rb
+++ b/spec/jobs/invoices/finalize_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Invoices::FinalizeJob, type: :job do
     instance_double(Invoices::RefreshDraftAndFinalizeService)
   end
 
-  it 'delegates to the Generate service' do
+  it 'delegates to the RefreshDraftAndFinalizeService service' do
     allow(Invoices::RefreshDraftAndFinalizeService).to receive(:new)
       .with(invoice:)
       .and_return(finalize_service)
@@ -22,5 +22,36 @@ RSpec.describe Invoices::FinalizeJob, type: :job do
 
     expect(Invoices::RefreshDraftAndFinalizeService).to have_received(:new)
     expect(finalize_service).to have_received(:call)
+  end
+
+  context 'when there was a tax fetching error in RefreshDraftAndFinalize service' do
+    let(:integration_customer) { create(:anrok_customer, customer: invoice.customer) }
+    let(:response) { instance_double(Net::HTTPOK) }
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+    let(:integration_collection_mapping) do
+      create(
+        :netsuite_collection_mapping,
+        integration: integration_customer.integration,
+        mapping_type: :fallback_item,
+        settings: {external_id: '1', external_account_code: '11', external_name: ''}
+      )
+    end
+    let(:body) do
+      p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+      File.read(p)
+    end
+
+    before do
+      integration_collection_mapping
+
+      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response).and_return(response)
+      allow(response).to receive(:body).and_return(body)
+    end
+
+    it 'does not throw an error when it is a tax error' do
+      expect { described_class.perform_now(invoice) }.not_to raise_error
+    end
   end
 end

--- a/spec/jobs/invoices/refresh_draft_job_spec.rb
+++ b/spec/jobs/invoices/refresh_draft_job_spec.rb
@@ -19,4 +19,35 @@ RSpec.describe Invoices::RefreshDraftJob, type: :job do
     expect(Invoices::RefreshDraftService).to have_received(:new)
     expect(refresh_service).to have_received(:call)
   end
+
+  context 'when there was a tax fetching error in RefreshDraft service' do
+    let(:integration_customer) { create(:anrok_customer, customer: invoice.customer) }
+    let(:response) { instance_double(Net::HTTPOK) }
+    let(:lago_client) { instance_double(LagoHttpClient::Client) }
+    let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+    let(:integration_collection_mapping) do
+      create(
+        :netsuite_collection_mapping,
+        integration: integration_customer.integration,
+        mapping_type: :fallback_item,
+        settings: {external_id: '1', external_account_code: '11', external_name: ''}
+      )
+    end
+    let(:body) do
+      p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+      File.read(p)
+    end
+
+    before do
+      integration_collection_mapping
+
+      allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+      allow(lago_client).to receive(:post_with_response).and_return(response)
+      allow(response).to receive(:body).and_return(body)
+    end
+
+    it 'does not throw an error when it is a tax error' do
+      expect { described_class.perform_now(invoice) }.not_to raise_error
+    end
+  end
 end

--- a/spec/services/fees/commitments/minimum/create_service_spec.rb
+++ b/spec/services/fees/commitments/minimum/create_service_spec.rb
@@ -66,12 +66,6 @@ RSpec.describe Fees::Commitments::Minimum::CreateService do
             service_call
           end.to change(Fee.commitment_kind, :count).by(1)
         end
-
-        it 'saves taxes amount cents' do
-          service_call
-
-          expect(commitment_fee.taxes_amount_cents).to eq(taxes_amount_cents)
-        end
       end
     end
 

--- a/spec/services/invoices/apply_provider_taxes_service_spec.rb
+++ b/spec/services/invoices/apply_provider_taxes_service_spec.rb
@@ -39,15 +39,174 @@ RSpec.describe Invoices::ApplyProviderTaxesService, type: :service do
   end
 
   describe 'call' do
-    before do
-      result.fees = fee_taxes
-      allow(Integrations::Aggregator::Taxes::Invoices::CreateService).to receive(:call)
-        .with(invoice:)
-        .and_return(result)
+    context 'when applying taxes for non-draft invoice' do
+      before do
+        result.fees = fee_taxes
+        allow(Integrations::Aggregator::Taxes::Invoices::CreateService).to receive(:call)
+          .with(invoice:)
+          .and_return(result)
+      end
+
+      context 'with non zero fees amount' do
+        context 'with non-zero taxes' do
+          before do
+            fee1 = create(:fee, invoice:, amount_cents: 1000, precise_coupons_amount_cents: 0)
+            create(
+              :fee_applied_tax,
+              fee: fee1,
+              amount_cents: 100,
+              tax_name: 'tax 1',
+              tax_code: 'tax_1',
+              tax_rate: 10.0,
+              tax_description: 'type1'
+            )
+
+            fee2 = create(:fee, invoice:, amount_cents: 2000, precise_coupons_amount_cents: 0)
+
+            create(
+              :fee_applied_tax,
+              fee: fee2,
+              amount_cents: 200,
+              tax_name: 'tax 1',
+              tax_code: 'tax_1',
+              tax_rate: 10.0,
+              tax_description: 'type1'
+            )
+            create(
+              :fee_applied_tax,
+              fee: fee2,
+              amount_cents: 240,
+              tax_name: 'tax 2',
+              tax_code: 'tax_2',
+              tax_rate: 12.0,
+              tax_description: 'type2'
+            )
+          end
+
+          it 'creates applied taxes' do
+            result = apply_service.call
+
+            aggregate_failures do
+              expect(result).to be_success
+
+              applied_taxes = result.applied_taxes
+              expect(applied_taxes.count).to eq(2)
+
+              expect(applied_taxes.find { |item| item.tax_code == 'tax_1' }).to have_attributes(
+                invoice:,
+                tax_description: 'type1',
+                tax_code: 'tax_1',
+                tax_name: 'tax 1',
+                tax_rate: 10,
+                amount_currency: invoice.currency,
+                amount_cents: 300,
+                fees_amount_cents: 3000
+              )
+
+              expect(applied_taxes.find { |item| item.tax_code == 'tax_2' }).to have_attributes(
+                invoice:,
+                tax_description: 'type2',
+                tax_code: 'tax_2',
+                tax_name: 'tax 2',
+                tax_rate: 12,
+                amount_currency: invoice.currency,
+                amount_cents: 240,
+                fees_amount_cents: 2000
+              )
+
+              expect(invoice).to have_attributes(
+                taxes_amount_cents: 540,
+                taxes_rate: 18,
+                fees_amount_cents: 3000
+              )
+            end
+          end
+        end
+
+        context 'with special provider rules' do
+          special_rules =
+            [
+              {received_type: 'notCollecting', expected_name: 'Not collecting', tax_code: 'not_collecting'},
+              {received_type: 'productNotTaxed', expected_name: 'Product not taxed', tax_code: 'product_not_taxed'},
+              {received_type: 'jurisNotTaxed', expected_name: 'Juris not taxed', tax_code: 'juris_not_taxed'}
+            ]
+          special_rules.each do |applied_rule|
+            context "when tax provider returned specific rule applied to fees - #{applied_rule[:expected_name]}" do
+              let(:fee_taxes) do
+                [
+                  OpenStruct.new(
+                    tax_breakdown: [
+                      OpenStruct.new(name: applied_rule[:expected_name], type: applied_rule[:received_type],
+                        rate: '0.00', tax_amount: 0)
+                    ]
+                  ),
+                  OpenStruct.new(
+                    tax_breakdown: [
+                      OpenStruct.new(name: applied_rule[:expected_name], type: applied_rule[:received_type],
+                        rate: '0.00', tax_amount: 0)
+                    ]
+                  )
+                ]
+              end
+              let(:fee1) { create(:fee, invoice:, amount_cents: 1000, precise_coupons_amount_cents: 0) }
+              let(:fee2) { create(:fee, invoice:, amount_cents: 2000, precise_coupons_amount_cents: 0) }
+              let(:fee1_applied_tax) do
+                create(:fee_applied_tax, fee: fee1, amount_cents: 0, tax_name: applied_rule[:expected_name],
+                  tax_code: applied_rule[:tax_code], tax_rate: 0.0, tax_description: applied_rule[:received_type])
+              end
+              let(:fee2_applied_tax) do
+                create(:fee_applied_tax, fee: fee2, amount_cents: 0, tax_name: applied_rule[:expected_name],
+                  tax_code: applied_rule[:tax_code], tax_rate: 0.0, tax_description: applied_rule[:received_type])
+              end
+
+              before do
+                fee1_applied_tax
+                fee2_applied_tax
+              end
+
+              it "creates applied taxes with #{applied_rule[:expected_name]} params" do
+                result = apply_service.call
+
+                aggregate_failures do
+                  expect(result).to be_success
+
+                  applied_taxes = result.applied_taxes
+                  expect(applied_taxes.count).to eq(1)
+                  applied_taxes.each do |applied_tax|
+                    expect(applied_tax.tax_description).to eq(applied_rule[:received_type])
+                    expect(applied_tax.tax_code).to eq(applied_rule[:tax_code])
+                    expect(applied_tax.tax_name).to eq(applied_rule[:expected_name])
+                    expect(applied_tax.tax_rate).to eq(0.0)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
     end
 
-    context 'with non zero fees amount' do
-      context 'with non-zero taxes' do
+    context 'when applying taxes for draft invoice' do
+      let(:invoice) do
+        create(
+          :invoice,
+          :draft,
+          organization:,
+          customer:,
+          fees_amount_cents:,
+          coupons_amount_cents:,
+          sub_total_excluding_taxes_amount_cents: fees_amount_cents - coupons_amount_cents
+        )
+      end
+
+      before do
+        result.fees = fee_taxes
+        allow(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to receive(:call)
+          .with(invoice:)
+          .and_return(result)
+      end
+
+      context 'with non zero fees amount' do
         before do
           fee1 = create(:fee, invoice:, amount_cents: 1000, precise_coupons_amount_cents: 0)
           create(
@@ -118,145 +277,8 @@ RSpec.describe Invoices::ApplyProviderTaxesService, type: :service do
               taxes_rate: 18,
               fees_amount_cents: 3000
             )
+            expect(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to have_received(:call)
           end
-        end
-      end
-
-      context 'with special provider rules' do
-        special_rules =
-          [
-            {received_type: 'notCollecting', expected_name: 'Not collecting', tax_code: 'not_collecting'},
-            {received_type: 'productNotTaxed', expected_name: 'Product not taxed', tax_code: 'product_not_taxed'},
-            {received_type: 'jurisNotTaxed', expected_name: 'Juris not taxed', tax_code: 'juris_not_taxed'}
-          ]
-        special_rules.each do |applied_rule|
-          context "when tax provider returned specific rule applied to fees - #{applied_rule[:expected_name]}" do
-            let(:fee_taxes) do
-              [
-                OpenStruct.new(
-                  tax_breakdown: [
-                    OpenStruct.new(name: applied_rule[:expected_name], type: applied_rule[:received_type],
-                      rate: '0.00', tax_amount: 0)
-                  ]
-                ),
-                OpenStruct.new(
-                  tax_breakdown: [
-                    OpenStruct.new(name: applied_rule[:expected_name], type: applied_rule[:received_type],
-                      rate: '0.00', tax_amount: 0)
-                  ]
-                )
-              ]
-            end
-            let(:fee1) { create(:fee, invoice:, amount_cents: 1000, precise_coupons_amount_cents: 0) }
-            let(:fee2) { create(:fee, invoice:, amount_cents: 2000, precise_coupons_amount_cents: 0) }
-            let(:fee1_applied_tax) do
-              create(:fee_applied_tax, fee: fee1, amount_cents: 0, tax_name: applied_rule[:expected_name],
-                tax_code: applied_rule[:tax_code], tax_rate: 0.0, tax_description: applied_rule[:received_type])
-            end
-            let(:fee2_applied_tax) do
-              create(:fee_applied_tax, fee: fee2, amount_cents: 0, tax_name: applied_rule[:expected_name],
-                tax_code: applied_rule[:tax_code], tax_rate: 0.0, tax_description: applied_rule[:received_type])
-            end
-
-            before do
-              fee1_applied_tax
-              fee2_applied_tax
-            end
-
-            it "creates applied taxes with #{applied_rule[:expected_name]} params" do
-              result = apply_service.call
-
-              aggregate_failures do
-                expect(result).to be_success
-
-                applied_taxes = result.applied_taxes
-                expect(applied_taxes.count).to eq(1)
-                applied_taxes.each do |applied_tax|
-                  expect(applied_tax.tax_description).to eq(applied_rule[:received_type])
-                  expect(applied_tax.tax_code).to eq(applied_rule[:tax_code])
-                  expect(applied_tax.tax_name).to eq(applied_rule[:expected_name])
-                  expect(applied_tax.tax_rate).to eq(0.0)
-                end
-              end
-            end
-          end
-        end
-      end
-    end
-
-    context 'when invoices fees_amount_cents is zero' do
-      let(:fees_amount_cents) { 0 }
-
-      before do
-        fee1 = create(:fee, invoice:, amount_cents: 0, precise_coupons_amount_cents: 0)
-        create(
-          :fee_applied_tax,
-          fee: fee1,
-          amount_cents: 0,
-          tax_name: 'tax 1',
-          tax_code: 'tax_1',
-          tax_rate: 10.0,
-          tax_description: 'type1'
-        )
-
-        fee2 = create(:fee, invoice:, amount_cents: 0, precise_coupons_amount_cents: 0)
-
-        create(
-          :fee_applied_tax,
-          fee: fee2,
-          amount_cents: 0,
-          tax_name: 'tax 1',
-          tax_code: 'tax_1',
-          tax_rate: 10.0,
-          tax_description: 'type1'
-        )
-        create(
-          :fee_applied_tax,
-          fee: fee2,
-          amount_cents: 0,
-          tax_name: 'tax 2',
-          tax_code: 'tax_2',
-          tax_rate: 12.0,
-          tax_description: 'type2'
-        )
-      end
-
-      it 'creates applied_taxes' do
-        result = apply_service.call
-
-        aggregate_failures do
-          expect(result).to be_success
-
-          applied_taxes = result.applied_taxes
-          expect(applied_taxes.count).to eq(2)
-
-          expect(applied_taxes.find { |item| item.tax_code == 'tax_1' }).to have_attributes(
-            invoice:,
-            tax_description: 'type1',
-            tax_code: 'tax_1',
-            tax_name: 'tax 1',
-            tax_rate: 10,
-            amount_currency: invoice.currency,
-            amount_cents: 0,
-            fees_amount_cents: 0
-          )
-
-          expect(applied_taxes.find { |item| item.tax_code == 'tax_2' }).to have_attributes(
-            invoice:,
-            tax_description: 'type2',
-            tax_code: 'tax_2',
-            tax_name: 'tax 2',
-            tax_rate: 12,
-            amount_currency: invoice.currency,
-            amount_cents: 0,
-            fees_amount_cents: 0
-          )
-
-          expect(invoice).to have_attributes(
-            taxes_amount_cents: 0,
-            taxes_rate: 16,
-            fees_amount_cents: 0
-          )
         end
       end
     end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -151,6 +151,76 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
         end
       end
 
+      context 'when there is tax provider integration' do
+        let(:integration) { create(:anrok_integration, organization:) }
+        let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+        let(:response) { instance_double(Net::HTTPOK) }
+        let(:lago_client) { instance_double(LagoHttpClient::Client) }
+        let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+        let(:body) do
+          p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response_multiple_fees.json')
+          json = File.read(p)
+
+          # setting item_id based on the test example
+          response = JSON.parse(json)
+          response['succeededInvoices'].first['fees'].first['item_id'] = subscription.id
+          response['succeededInvoices'].first['fees'].last['item_id'] = charge.billable_metric.id
+
+          response.to_json
+        end
+        let(:integration_collection_mapping) do
+          create(
+            :netsuite_collection_mapping,
+            integration:,
+            mapping_type: :fallback_item,
+            settings: {external_id: '1', external_account_code: '11', external_name: ''}
+          )
+        end
+
+        before do
+          integration_collection_mapping
+          integration_customer
+
+          allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+          allow(lago_client).to receive(:post_with_response).and_return(response)
+          allow(response).to receive(:body).and_return(body)
+        end
+
+        it 'creates fees' do
+          result = invoice_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            expect(result.invoice.fees_amount_cents).to eq(100)
+            expect(result.invoice.taxes_amount_cents).to eq(10)
+
+            expect(result.invoice.reload.error_details.count).to eq(0)
+          end
+        end
+
+        context 'when there is error received from the provider' do
+          let(:body) do
+            p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+            File.read(p)
+          end
+
+          it 'returns tax error' do
+            result = invoice_service.call
+
+            aggregate_failures do
+              expect(result).not_to be_success
+              expect(result.error.code).to eq('tax_error')
+              expect(result.error.error_message).to eq('taxDateTooFarInFuture')
+
+              expect(invoice.reload.status).to eq('failed')
+              expect(invoice.reload.error_details.count).to eq(1)
+              expect(invoice.reload.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
+            end
+          end
+        end
+      end
+
       context 'when charge is pay_in_advance, not recurring and invoiceable' do
         let(:charge) do
           create(

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
   subject(:invoice_service) do
     described_class.new(
       invoice:,
-      recurring:
+      recurring:,
+      context:
     )
   end
 
@@ -14,6 +15,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
   let(:customer) { create(:customer, organization:) }
   let(:tax) { create(:tax, organization:, rate: 20) }
   let(:recurring) { false }
+  let(:context) { nil }
 
   let(:invoice) do
     create(
@@ -184,6 +186,8 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
           allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
           allow(lago_client).to receive(:post_with_response).and_return(response)
           allow(response).to receive(:body).and_return(body)
+          allow(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to receive(:call).and_call_original
+          allow(Integrations::Aggregator::Taxes::Invoices::CreateService).to receive(:call).and_call_original
         end
 
         it 'creates fees' do
@@ -197,6 +201,11 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
             expect(result.invoice.reload.error_details.count).to eq(0)
           end
+        end
+
+        it 'fetches taxes using finalized invoices service' do
+          invoice_service.call
+          expect(Integrations::Aggregator::Taxes::Invoices::CreateService).to have_received(:call)
         end
 
         context 'when there is error received from the provider' do
@@ -216,6 +225,64 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
               expect(invoice.reload.status).to eq('failed')
               expect(invoice.reload.error_details.count).to eq(1)
               expect(invoice.reload.error_details.first.details['tax_error']).to eq('taxDateTooFarInFuture')
+            end
+          end
+        end
+
+        context 'when calculating fees for draft invoice' do
+          let(:invoice) do
+            create(
+              :invoice,
+              :draft,
+              organization:,
+              currency: 'EUR',
+              issuing_date: Time.zone.at(timestamp).to_date,
+              customer: subscription.customer
+            )
+          end
+
+          context 'when no context is passed' do
+            let(:endpoint) { 'https://api.nango.dev/v1/anrok/draft_invoices' }
+
+            it 'creates fees' do
+              result = invoice_service.call
+
+              aggregate_failures do
+                expect(result).to be_success
+
+                expect(result.invoice.fees_amount_cents).to eq(100)
+                expect(result.invoice.taxes_amount_cents).to eq(10)
+
+                expect(result.invoice.reload.error_details.count).to eq(0)
+              end
+            end
+
+            it 'fetches taxes using draft invoices service' do
+              invoice_service.call
+              expect(Integrations::Aggregator::Taxes::Invoices::CreateDraftService).to have_received(:call)
+            end
+          end
+
+          context 'when context is :finalize' do
+            let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+            let(:context) { :finalize }
+
+            it 'creates fees' do
+              result = invoice_service.call
+
+              aggregate_failures do
+                expect(result).to be_success
+
+                expect(result.invoice.fees_amount_cents).to eq(100)
+                expect(result.invoice.taxes_amount_cents).to eq(10)
+
+                expect(result.invoice.reload.error_details.count).to eq(0)
+              end
+            end
+
+            it 'fetches taxes using finalized invoices service' do
+              invoice_service.call
+              expect(Integrations::Aggregator::Taxes::Invoices::CreateService).to have_received(:call)
             end
           end
         end

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
         it 'does not send any updates' do
           finalize_service.call
           aggregate_failures do
-            expect(SendWebhookJob).not_to have_received(:perform_later)
+            expect(SendWebhookJob).not_to have_received(:perform_later).with('invoice.created', invoice)
             expect(Invoices::GeneratePdfAndNotifyJob).not_to have_received(:perform_later)
             expect(Integrations::Aggregator::Invoices::CreateJob).not_to have_received(:perform_later)
             expect(Integrations::Aggregator::SalesOrders::CreateJob).not_to have_received(:perform_later)

--- a/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
+++ b/spec/services/invoices/refresh_draft_and_finalize_service_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
       )
     end
 
-    let(:billable_metric) { create(:billable_metric, aggregation_type: 'count_agg') }
     let(:timestamp) { Time.zone.now - 1.year }
     let(:started_at) { Time.zone.now - 2.years }
     let(:fee) { create(:fee, invoice:, subscription:) }
@@ -195,6 +194,118 @@ RSpec.describe Invoices::RefreshDraftAndFinalizeService, type: :service do
         expect do
           finalize_service.call
         end.to have_enqueued_job(SendWebhookJob).with('credit_note.created', CreditNote)
+      end
+    end
+
+    context 'when tax integration is set up' do
+      let(:integration) { create(:anrok_integration, organization:) }
+      let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+      let(:response) { instance_double(Net::HTTPOK) }
+      let(:lago_client) { instance_double(LagoHttpClient::Client) }
+      let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+      let(:integration_collection_mapping) do
+        create(
+          :netsuite_collection_mapping,
+          integration:,
+          mapping_type: :fallback_item,
+          settings: {external_id: '1', external_account_code: '11', external_name: ''}
+        )
+      end
+
+      before do
+        integration_collection_mapping
+        integration_customer
+        invoice.update(issuing_date: Time.current + 3.months)
+
+        allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+        allow(lago_client).to receive(:post_with_response).and_return(response)
+        allow(response).to receive(:body).and_return(body)
+        allow(Invoices::ApplyProviderTaxesService).to receive(:call).and_call_original
+        allow(SendWebhookJob).to receive(:perform_later).and_call_original
+        allow(Invoices::GeneratePdfAndNotifyJob).to receive(:perform_later).and_call_original
+        allow(Integrations::Aggregator::Invoices::CreateJob).to receive(:perform_later).and_call_original
+        allow(Integrations::Aggregator::SalesOrders::CreateJob).to receive(:perform_later).and_call_original
+        allow(Invoices::Payments::CreateService).to receive(:new).and_call_original
+        allow(Utils::SegmentTrack).to receive(:invoice_created).and_call_original
+      end
+
+      context 'when taxes fetched correctly' do
+        let(:body) do
+          p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response_multiple_fees.json')
+          json = File.read(p)
+
+          response = JSON.parse(json)
+          response['succeededInvoices'].first['fees'].first['item_id'] = subscription.id
+          response['succeededInvoices'].first['fees'].last['item_id'] = plan.billable_metrics.first.id
+
+          response.to_json
+        end
+        let(:invoice_issuing_date) { Time.current.in_time_zone(invoice.customer.applicable_timezone).to_date }
+
+        it 'refreshes all data and applies fetched taxes' do
+          aggregate_failures do
+            expect { finalize_service.call }.to change { invoice.reload.taxes_rate }.from(0.0).to(10.0)
+              .and change { invoice.fees.count }.from(0).to(2)
+            expect(LagoHttpClient::Client).to have_received(:new).with(endpoint)
+            expect(Invoices::ApplyProviderTaxesService).to have_received(:call)
+          end
+        end
+
+        it 'finalizes the invoice' do
+          expect { finalize_service.call }.to change { invoice.reload.status }.from('draft').to('finalized')
+        end
+
+        it 'sends finalized invoice issuing date to tax_provider' do
+          finalize_service.call
+          expect(lago_client).to have_received(:post_with_response)
+            .with([hash_including('issuing_date' => invoice_issuing_date)], anything)
+        end
+      end
+
+      context 'when fetched taxes with errors' do
+        let(:body) do
+          p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+          File.read(p)
+        end
+
+        it 'returns error' do
+          result = finalize_service.call
+          aggregate_failures do
+            expect(invoice.reload.status).to eql('failed')
+            expect(result.success?).to be(false)
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:tax_error]).to eq(['taxDateTooFarInFuture'])
+          end
+        end
+
+        it 'moves invoice to failed state' do
+          expect { finalize_service.call }.to change(invoice.reload, :status).from('draft').to('failed')
+        end
+
+        it 'creates a new error_detail for the invoice' do
+          expect { finalize_service.call }.to change(invoice.error_details, :count).from(0).to(1)
+        end
+
+        it 'updates fees despite error result' do
+          expect { finalize_service.call }.to change(invoice.fees.charge_kind, :count).from(0).to(1)
+            .and change(invoice.fees.subscription_kind, :count).from(0).to(1)
+        end
+
+        it 'does not send any updates' do
+          finalize_service.call
+          aggregate_failures do
+            expect(SendWebhookJob).not_to have_received(:perform_later)
+            expect(Invoices::GeneratePdfAndNotifyJob).not_to have_received(:perform_later)
+            expect(Integrations::Aggregator::Invoices::CreateJob).not_to have_received(:perform_later)
+            expect(Integrations::Aggregator::SalesOrders::CreateJob).not_to have_received(:perform_later)
+            expect(Invoices::Payments::CreateService).not_to have_received(:new)
+            expect(Utils::SegmentTrack).not_to have_received(:invoice_created)
+          end
+        end
+
+        it 'does not change issuing_date on the invoice' do
+          expect { finalize_service.call }.not_to change(invoice, :issuing_date)
+        end
       end
     end
 


### PR DESCRIPTION
## Context

Currently integration with tax provider Anrok is being implemented.

## Description

This PR uses all existing Anrok logic on subscription and draft invoices. 

If customer is connected to Anrok, its taxes should be used. All services and Anrok core logic is already implemented and merged on main. This is just logic that consumes it for subscription and draft invoices
