### PR TITLE
Increase default pool size to 10 for staging databases

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,7 +9,7 @@ development:
     password: changeme
     database: lago
     port: 5432
-    schema_search_path: "public"
+    schema_search_path: 'public'
   events:
     <<: *default
     host: db
@@ -53,9 +53,11 @@ staging:
   primary:
     <<: *default
     url: <%= ENV['DATABASE_URL'] %>
+    pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
   events:
     <<: *default
     url: <%= ENV['DATABASE_URL'] %>
+    pool: <%= ENV.fetch('DATABASE_POOL', 10) %>
     database_tasks: false
   clickhouse:
     adapter: clickhouse


### PR DESCRIPTION
## Description

Our staging workers are run with a concurrency of 10 but the connection pools are the default size of 5. In order to increase reliability when running high amount of jobs, we bump the limit to 10.