### PR TITLE
feat (tax-integrations): Use Anrok taxes in pay in advance flow

### DIFF
--- a/app/jobs/fees/create_pay_in_advance_job.rb
+++ b/app/jobs/fees/create_pay_in_advance_job.rb
@@ -9,6 +9,8 @@ module Fees
     def perform(charge:, event:, billing_at: nil)
       result = Fees::CreatePayInAdvanceService.call(charge:, event:, billing_at:)
 
+      return if !result.success? && result.error.messages.dig(:tax_error)
+
       result.raise_if_error!
     end
   end

--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -11,6 +11,9 @@ module Invoices
     def perform(charge:, event:, timestamp:, invoice: nil)
       result = Invoices::CreatePayInAdvanceChargeService.call(charge:, event:, timestamp:, invoice:)
       return if result.success?
+      # NOTE: We don't want a dead job for failed invoice due to the tax reason.
+      #       This invoice should be in failed status and can be retried.
+      return if result.error.messages.dig(:tax_error)
 
       result.raise_if_error! if invoice || result.invoice.nil? || !result.invoice.generating?
 

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -206,7 +206,7 @@ module Fees
 
       SendWebhookJob.perform_later(
         'fee.tax_provider_error',
-        integration: integration_customer.integration,
+        integration_customer.integration,
         event_transaction_id: event.transaction_id,
         lago_charge_id: charge.id,
         provider_error: {

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -20,9 +20,23 @@ module Fees
         else
           create_fee(properties: charge.properties)
         end
+
+        result.fees = fees.compact
+
+        if customer_provider_taxation?
+          fee_taxes_result = apply_provider_taxes(fees)
+
+          unless fee_taxes_result.success?
+            deliver_tax_error_webhook(code: 'tax_error', message: fee_taxes_result.error.code)
+
+            result.validation_failure!(errors: {tax_error: [fee_taxes_result.error.code]})
+            result.raise_if_error! unless charge.invoiceable?
+
+            return result
+          end
+        end
       end
 
-      result.fees = fees.compact
       deliver_webhooks
 
       result
@@ -70,8 +84,10 @@ module Fees
           grouped_by: format_grouped_by
         )
 
-        taxes_result = Fees::ApplyTaxesService.call(fee:)
-        taxes_result.raise_if_error!
+        unless customer_provider_taxation?
+          taxes_result = Fees::ApplyTaxesService.call(fee:)
+          taxes_result.raise_if_error!
+        end
 
         fee.save! unless estimate
 
@@ -154,6 +170,46 @@ module Fees
       return {} if charge.properties['grouped_by'].blank?
 
       charge.properties['grouped_by'].index_with { event.properties[_1] }
+    end
+
+    def customer_provider_taxation?
+      @apply_provider_taxes ||= integration_customer.present?
+    end
+
+    def integration_customer
+      @integration_customer ||= subscription.customer.anrok_customer
+    end
+
+    def apply_provider_taxes(fees_result)
+      taxes_result = Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:, fees: fees_result)
+
+      return taxes_result unless taxes_result.success?
+
+      result.fees_taxes = taxes_result.fees
+
+      fees_result.each do |fee|
+        fee_taxes = result.fees_taxes.find { |item| item.item_id == fee.item_id }
+
+        res = Fees::ApplyProviderTaxesService.call(fee:, fee_taxes:)
+        res.raise_if_error!
+      end
+
+      taxes_result
+    end
+
+    def deliver_tax_error_webhook(code:, message:)
+      return if charge.invoiceable?
+
+      SendWebhookJob.perform_later(
+        'fee.tax_provider_error',
+        integration: integration_customer.integration,
+        event_transaction_id: event.transaction_id,
+        lago_charge_id: charge.id,
+        provider_error: {
+          message:,
+          error_code: code
+        }
+      )
     end
   end
 end

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -217,7 +217,10 @@ module Fees
     end
 
     def invoice
+      result.invoice_id = SecureRandom.uuid
+
       OpenStruct.new(
+        id: result.invoice_id,
         issuing_date: Time.current.in_time_zone(customer.applicable_timezone).to_date,
         currency: subscription.plan.amount_currency,
         customer:

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -27,8 +27,6 @@ module Fees
           fee_taxes_result = apply_provider_taxes(fees)
 
           unless fee_taxes_result.success?
-            deliver_tax_error_webhook(code: 'tax_error', message: fee_taxes_result.error.code)
-
             result.validation_failure!(errors: {tax_error: [fee_taxes_result.error.code]})
             result.raise_if_error! unless charge.invoiceable?
 
@@ -199,21 +197,6 @@ module Fees
       end
 
       taxes_result
-    end
-
-    def deliver_tax_error_webhook(code:, message:)
-      return if charge.invoiceable?
-
-      SendWebhookJob.perform_later(
-        'fee.tax_provider_error',
-        integration_customer.integration,
-        event_transaction_id: event.transaction_id,
-        lago_charge_id: charge.id,
-        provider_error: {
-          message:,
-          error_code: code
-        }
-      )
     end
 
     def invoice

--- a/app/services/fees/create_pay_in_advance_service.rb
+++ b/app/services/fees/create_pay_in_advance_service.rb
@@ -177,7 +177,11 @@ module Fees
     end
 
     def integration_customer
-      @integration_customer ||= subscription.customer.anrok_customer
+      @integration_customer ||= customer.anrok_customer
+    end
+
+    def customer
+      @customer ||= subscription.customer
     end
 
     def apply_provider_taxes(fees_result)
@@ -209,6 +213,14 @@ module Fees
           message:,
           error_code: code
         }
+      )
+    end
+
+    def invoice
+      OpenStruct.new(
+        issuing_date: Time.current.in_time_zone(customer.applicable_timezone).to_date,
+        currency: subscription.plan.amount_currency,
+        customer:
       )
     end
   end

--- a/app/services/invoices/apply_provider_taxes_service.rb
+++ b/app/services/invoices/apply_provider_taxes_service.rb
@@ -116,7 +116,7 @@ module Invoices
     end
 
     def fetch_provider_taxes_result
-      taxes_result = if invoice.draft?
+      taxes_result = if invoice.draft? || invoice.advance_charges?
         Integrations::Aggregator::Taxes::Invoices::CreateDraftService.call(invoice:)
       else
         Integrations::Aggregator::Taxes::Invoices::CreateService.call(invoice:)

--- a/app/services/invoices/create_generating_service.rb
+++ b/app/services/invoices/create_generating_service.rb
@@ -2,13 +2,14 @@
 
 module Invoices
   class CreateGeneratingService < BaseService
-    def initialize(customer:, invoice_type:, datetime:, currency:, charge_in_advance: false, skip_charges: false) # rubocop:disable Metrics/ParameterLists
+    def initialize(customer:, invoice_type:, datetime:, currency:, charge_in_advance: false, skip_charges: false, invoice_id: nil) # rubocop:disable Metrics/ParameterLists
       @customer = customer
       @invoice_type = invoice_type
       @currency = currency
       @datetime = datetime
       @charge_in_advance = charge_in_advance
       @skip_charges = skip_charges
+      @invoice_id = invoice_id
 
       super
     end
@@ -16,6 +17,7 @@ module Invoices
     def call
       ActiveRecord::Base.transaction do
         invoice = Invoice.create!(
+          id: invoice_id || SecureRandom.uuid,
           organization:,
           customer:,
           invoice_type:,
@@ -37,7 +39,7 @@ module Invoices
 
     private
 
-    attr_accessor :customer, :invoice_type, :currency, :datetime, :charge_in_advance, :skip_charges
+    attr_accessor :customer, :invoice_type, :currency, :datetime, :charge_in_advance, :skip_charges, :invoice_id
 
     delegate :organization, to: :customer
 

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -16,7 +16,8 @@ module Invoices
     end
 
     def call
-      fees = generate_fees
+      fee_result = generate_fees
+      fees = fee_result.fees
       return Result.new if fees.none?
 
       create_generating_invoice unless invoice
@@ -29,7 +30,14 @@ module Invoices
         invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
         Credits::AppliedCouponsService.call(invoice:) if invoice.fees_amount_cents&.positive?
 
-        Invoices::ComputeAmountsFromFees.call(invoice:)
+        if tax_error?(fee_result)
+          invoice.failed!
+          create_error_detail(fee_result.error.messages.dig(:tax_error))
+
+          return fee_result
+        end
+
+        Invoices::ComputeAmountsFromFees.call(invoice:, provider_taxes: result.fees_taxes)
         create_credit_note_credit
         create_applied_prepaid_credit if should_create_applied_prepaid_credit?
 
@@ -80,8 +88,11 @@ module Invoices
 
     def generate_fees
       fee_result = Fees::CreatePayInAdvanceService.call(charge:, event:, estimate: true)
-      fee_result.raise_if_error!
-      fee_result.fees
+      fee_result.raise_if_error! unless tax_error?(fee_result)
+
+      result.fees_taxes = fee_result.fees_taxes
+
+      fee_result
     end
 
     def deliver_webhooks
@@ -122,6 +133,24 @@ module Invoices
 
     def refresh_amounts(credit_amount_cents:)
       invoice.total_amount_cents -= credit_amount_cents
+    end
+
+    def tax_error?(fee_result)
+      !fee_result.success? && fee_result.error.messages.dig(:tax_error)
+    end
+
+    def create_error_detail(code)
+      error_result = ErrorDetails::CreateService.call(
+        owner: invoice,
+        organization: invoice.organization,
+        params: {
+          error_code: :tax_error,
+          details: {
+            tax_error: code
+          }
+        }
+      )
+      error_result.raise_if_error!
     end
   end
 end

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -32,7 +32,8 @@ module Invoices
 
         if tax_error?(fee_result)
           invoice.failed!
-          create_error_detail(fee_result.error.messages.dig(:tax_error))
+          invoice.fees.each { |f| SendWebhookJob.perform_later('fee.created', f) }
+          create_error_detail(fee_result.error.messages.dig(:tax_error)&.first)
 
           return fee_result
         end

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -76,7 +76,8 @@ module Invoices
         invoice_type: :subscription,
         currency: customer.currency,
         datetime: Time.zone.at(timestamp),
-        charge_in_advance: true
+        charge_in_advance: true,
+        invoice_id: result.invoice_id
       ) do |invoice|
         Invoices::CreateInvoiceSubscriptionService
           .call(invoice:, subscriptions: [subscription], timestamp:, invoicing_reason: :in_advance_charge)
@@ -92,6 +93,7 @@ module Invoices
       fee_result.raise_if_error! unless tax_error?(fee_result)
 
       result.fees_taxes = fee_result.fees_taxes
+      result.invoice_id = fee_result.invoice_id
 
       fee_result
     end

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -100,6 +100,133 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
         .with('fee.created', Fee)
     end
 
+    context 'when there is tax provider integration' do
+      let(:integration) { create(:anrok_integration, organization:) }
+      let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+      let(:response) { instance_double(Net::HTTPOK) }
+      let(:lago_client) { instance_double(LagoHttpClient::Client) }
+      let(:endpoint) { 'https://api.nango.dev/v1/anrok/finalized_invoices' }
+      let(:body) do
+        p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/success_response.json')
+        json = File.read(p)
+
+        # setting item_id based on the test example
+        response = JSON.parse(json)
+        response['succeededInvoices'].first['fees'].first['item_id'] = billable_metric.id
+
+        response.to_json
+      end
+      let(:integration_collection_mapping) do
+        create(
+          :netsuite_collection_mapping,
+          integration:,
+          mapping_type: :fallback_item,
+          settings: {external_id: '1', external_account_code: '11', external_name: ''}
+        )
+      end
+
+      before do
+        integration_collection_mapping
+        integration_customer
+
+        allow(LagoHttpClient::Client).to receive(:new).with(endpoint).and_return(lago_client)
+        allow(lago_client).to receive(:post_with_response).and_return(response)
+        allow(response).to receive(:body).and_return(body)
+      end
+
+      it 'creates fees' do
+        result = fee_service.call
+
+        aggregate_failures do
+          expect(result).to be_success
+
+          expect(result.fees.count).to eq(1)
+          expect(result.fees.first).to have_attributes(
+            subscription:,
+            charge:,
+            amount_cents: 10,
+            amount_currency: 'EUR',
+            fee_type: 'charge',
+            pay_in_advance: true,
+            invoiceable: charge,
+            units: 9,
+            properties: Hash,
+            events_count: 1,
+            charge_filter: nil,
+            pay_in_advance_event_id: event.id,
+            pay_in_advance_event_transaction_id: event.transaction_id,
+            payment_status: 'pending',
+            unit_amount_cents: 1,
+            precise_unit_amount: 0.01111111111,
+            taxes_rate: 10.0,
+            taxes_amount_cents: 1
+         )
+          expect(result.fees.first.applied_taxes.count).to eq(2)
+        end
+      end
+
+      context 'when there is error received from the provider' do
+        let(:body) do
+          p = Rails.root.join('spec/fixtures/integration_aggregator/taxes/invoices/failure_response.json')
+          File.read(p)
+        end
+
+        it 'returns tax error' do
+          result = fee_service.call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error).to be_a(BaseService::ValidationFailure)
+            expect(result.error.messages[:tax_error]).to eq(['taxDateTooFarInFuture'])
+            expect(charge.reload.fees.count).to eq(1)
+          end
+        end
+
+        it 'does not deliver tax error webhook' do
+          expect { fee_service.call }.not_to enqueue_job(SendWebhookJob)
+            .with(
+              'fee.tax_provider_error',
+              customer.anrok_customer.integration,
+              event_transaction_id: event.transaction_id,
+              lago_charge_id: charge.id,
+              provider_error: {
+                message: 'taxDateTooFarInFuture',
+                error_code: 'tax_error'
+              }
+            )
+        end
+
+        context 'when invoiceable is false' do
+          let(:charge) { create(:standard_charge, :pay_in_advance, billable_metric:, plan:, invoiceable: false) }
+
+          it 'returns tax error and fee is not being stored' do
+            result = fee_service.call
+
+            aggregate_failures do
+              expect(result).not_to be_success
+              expect(result.error).to be_a(BaseService::ValidationFailure)
+              expect(result.error.messages[:tax_error]).to eq(['taxDateTooFarInFuture'])
+              expect(charge.reload.fees.count).to eq(0)
+            end
+          end
+
+          it 'delivers tax error webhook' do
+            expect { fee_service.call }.to enqueue_job(SendWebhookJob)
+              .with(
+                'fee.tax_provider_error',
+                customer.anrok_customer.integration,
+                event_transaction_id: event.transaction_id,
+                lago_charge_id: charge.id,
+                provider_error: {
+                  message: 'taxDateTooFarInFuture',
+                  error_code: 'tax_error'
+                }
+              )
+          end
+        end
+      end
+    end
+
     context 'when aggregation fails' do
       let(:aggregation_result) do
         BaseService::Result.new.service_failure!(code: 'failure', message: 'Failure')

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
             precise_unit_amount: 0.01111111111,
             taxes_rate: 10.0,
             taxes_amount_cents: 1
-         )
+          )
           expect(result.fees.first.applied_taxes.count).to eq(2)
         end
       end

--- a/spec/services/fees/create_pay_in_advance_service_spec.rb
+++ b/spec/services/fees/create_pay_in_advance_service_spec.rb
@@ -182,20 +182,6 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
           end
         end
 
-        it 'does not deliver tax error webhook' do
-          expect { fee_service.call }.not_to enqueue_job(SendWebhookJob)
-            .with(
-              'fee.tax_provider_error',
-              customer.anrok_customer.integration,
-              event_transaction_id: event.transaction_id,
-              lago_charge_id: charge.id,
-              provider_error: {
-                message: 'taxDateTooFarInFuture',
-                error_code: 'tax_error'
-              }
-            )
-        end
-
         context 'when invoiceable is false' do
           let(:charge) { create(:standard_charge, :pay_in_advance, billable_metric:, plan:, invoiceable: false) }
 
@@ -208,20 +194,6 @@ RSpec.describe Fees::CreatePayInAdvanceService, type: :service do
               expect(result.error.messages[:tax_error]).to eq(['taxDateTooFarInFuture'])
               expect(charge.reload.fees.count).to eq(0)
             end
-          end
-
-          it 'delivers tax error webhook' do
-            expect { fee_service.call }.to enqueue_job(SendWebhookJob)
-              .with(
-                'fee.tax_provider_error',
-                customer.anrok_customer.integration,
-                event_transaction_id: event.transaction_id,
-                lago_charge_id: charge.id,
-                provider_error: {
-                  message: 'taxDateTooFarInFuture',
-                  error_code: 'tax_error'
-                }
-              )
           end
         end
       end

--- a/spec/services/invoices/advance_charges_service_spec.rb
+++ b/spec/services/invoices/advance_charges_service_spec.rb
@@ -49,8 +49,10 @@ RSpec.describe Invoices::AdvanceChargesService, type: :service do
       before do
         tax
         charge = create(:standard_charge, :regroup_paid_fees, plan: subscription.plan)
-        create_list(:charge_fee, 3, :succeeded, invoice_id: nil, subscription:, charge:, amount_cents: 100, properties: fee_boundaries)
+        succeeded_fees = create_list(:charge_fee, 3, :succeeded, invoice_id: nil, subscription:, charge:, amount_cents: 100, properties: fee_boundaries)
         create_list(:charge_fee, 2, :failed, invoice_id: nil, subscription:, charge:, amount_cents: 100, properties: fee_boundaries)
+
+        succeeded_fees.each { |fee| Fees::ApplyTaxesService.call(fee:) }
       end
 
       it 'creates invoices' do

--- a/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
+++ b/spec/services/invoices/create_pay_in_advance_charge_service_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe Invoices::CreatePayInAdvanceChargeService, type: :service do
         allow(response).to receive(:body).and_return(body)
       end
 
-      it 'creates fees' do
+      it 'creates an invoice and fees' do
         result = invoice_service.call
 
         aggregate_failures do


### PR DESCRIPTION
## Context

Currently integration with tax provider Anrok is being implemented.

## Description

This PR uses all existing Anrok logic on pay in advance invoices

If customer is connected to Anrok, its taxes should be used. All services and Anrok core logic is already implemented and merged on main. This is just logic that consumes it for pay in advance invoices
