### PR TITLE
misc(netsuite): Process payload errors

### DIFF
--- a/app/services/integrations/aggregator/base_service.rb
+++ b/app/services/integrations/aggregator/base_service.rb
@@ -92,12 +92,14 @@ module Integrations
 
       def code(error)
         json = error.json_message
-        json['type'].presence || json.dig('error', 'code')
+        json['type'].presence || json.dig('error', 'payload', 'name').presence || json.dig('error', 'code')
       end
 
       def message(error)
         json = error.json_message
-        json.dig('payload', 'message').presence || json.dig('error', 'message')
+        json.dig('payload', 'message').presence ||
+          json.dig('error', 'payload', 'message').presence ||
+          json.dig('error', 'message')
       end
     end
   end

--- a/spec/fixtures/integration_aggregator/error_payload_response.json
+++ b/spec/fixtures/integration_aggregator/error_payload_response.json
@@ -1,0 +1,9 @@
+{
+  "error": {
+    "code": "action_script_runtime_error",
+    "payload": {
+      "name": "TypeError",
+      "message": "Please enter value(s) for: Company Name"
+    }
+  }
+}

--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -255,6 +255,41 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
         end
       end
 
+      context 'when it is a server payload error' do
+        let(:error_code) { Faker::Number.between(from: 500, to: 599) }
+        let(:code) { 'TypeError' }
+        let(:message) { 'Please enter value(s) for: Company Name' }
+
+        let(:body) do
+          path = Rails.root.join('spec/fixtures/integration_aggregator/error_payload_response.json')
+          File.read(path)
+        end
+
+        it 'returns an error' do
+          result = service_call
+
+          aggregate_failures do
+            expect(result).not_to be_success
+            expect(result.error.code).to eq(code)
+            expect(result.error.message).to eq("#{code}: #{message}")
+          end
+        end
+
+        it 'delivers an error webhook' do
+          expect { service_call }.to enqueue_job(SendWebhookJob)
+            .with(
+              'customer.accounting_provider_error',
+              customer,
+              provider: 'netsuite',
+              provider_code: integration.code,
+              provider_error: {
+                message:,
+                error_code: code
+              }
+            )
+        end
+      end
+
       context 'when it is a client error' do
         let(:error_code) { 404 }
         let(:code) { 'invalid_secret_key_format' }


### PR DESCRIPTION
## Context

Return Nango's error as a webhook message. Some error payloads have different json format as we expected.

## Description

Catch all the error formats that Netsuite/Nango returns and send a webhook.
