### PR TITLE
feat(dunning): Send email reminder when creating a payment request

### DIFF
--- a/app/controllers/api/v1/payment_requests_controller.rb
+++ b/app/controllers/api/v1/payment_requests_controller.rb
@@ -47,7 +47,7 @@ module Api
         params.require(:payment_request).permit(
           :email,
           :external_customer_id,
-          :lago_invoice_ids
+          lago_invoice_ids: []
         )
       end
 

--- a/app/mailers/payment_request_mailer.rb
+++ b/app/mailers/payment_request_mailer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class PaymentRequestMailer < ApplicationMailer
+  def requested
+    @payment_request = params[:payment_request]
+    @organization = @payment_request.organization
+    @customer = @payment_request.customer
+    @invoices = @payment_request.invoices
+
+    I18n.with_locale(@customer.preferred_document_locale) do
+      mail(
+        to: @payment_request.email,
+        from: email_address_with_name(ENV["LAGO_FROM_EMAIL"], @organization.name),
+        reply_to: email_address_with_name(@organization.email, @organization.name),
+        subject: I18n.t(
+          "email.payment_request.requested.subject",
+          organization_name: @organization.name
+        )
+      )
+    end
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -424,7 +424,6 @@ end
 #  file                                    :string
 #  invoice_type                            :integer          default("subscription"), not null
 #  issuing_date                            :date
-#  negative_amount_cents                   :bigint           default(0), not null
 #  net_payment_term                        :integer          default(0), not null
 #  number                                  :string           default(""), not null
 #  payment_attempts                        :integer          default(0), not null

--- a/app/models/payment_request.rb
+++ b/app/models/payment_request.rb
@@ -21,6 +21,8 @@ class PaymentRequest < ApplicationRecord
   alias_attribute :total_amount_cents, :amount_cents
   alias_attribute :currency, :amount_currency
 
+  monetize :amount_cents
+
   def invoice_ids
     applied_invoices.pluck(:invoice_id)
   end

--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -20,6 +20,8 @@ module PaymentRequests
         when :stripe
           PaymentRequests::Payments::StripeCreateJob.perform_later(payable)
         end
+
+        result
       rescue ActiveJob::Uniqueness::JobNotUnique => e
         Sentry.capture_exception(e)
       end

--- a/app/services/payment_requests/payments/create_service.rb
+++ b/app/services/payment_requests/payments/create_service.rb
@@ -10,6 +10,8 @@ module PaymentRequests
       end
 
       def call
+        return result.not_found_failure!(resource: "payment_provider") unless payment_provider
+
         case payment_provider
         when :adyen
           PaymentRequests::Payments::AdyenCreateJob.perform_later(payable)
@@ -18,8 +20,6 @@ module PaymentRequests
         when :stripe
           PaymentRequests::Payments::StripeCreateJob.perform_later(payable)
         end
-      # TODO: Do something when no payment provider is set
-      #       or leave it to the caller
       rescue ActiveJob::Uniqueness::JobNotUnique => e
         Sentry.capture_exception(e)
       end

--- a/app/views/payment_request_mailer/requested.slim
+++ b/app/views/payment_request_mailer/requested.slim
@@ -3,7 +3,7 @@ div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16
 div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
   = I18n.t('email.payment_request.requested.reminder_overdue_balance', organization_name: @organization.name)
 div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
-  = I18n.t('email.payment_request.requested.total_amount_due', amount: @invoices.sum(&:total_amount))
+  = I18n.t('email.payment_request.requested.total_amount_due', amount: MoneyHelper.format(@payment_request.amount))
 div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
   - if @customer.applicable_net_payment_term > 0
     = I18n.t('email.payment_request.requested.payment_terms', count: @customer.applicable_net_payment_term)
@@ -17,7 +17,7 @@ div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16
 div style='padding-top: 32px;font-style: normal;font-weight: 400;font-size: 14px;line-height: 20px;color: #66758F;border-top: 1px solid #d9dee7;'
   = I18n.t('email.payment_request.requested.remaining_amount')
 div style='margin-bottom: 16px;font-style: normal;font-weight: 700;font-size: 32px;line-height: 40px;color: #19212E;'
-  = @invoices.sum(&:total_amount).format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+  = MoneyHelper.format(@payment_request.amount)
 
 /! TODO: Do not display the button unless payment url is present
 table style='margin-bottom: 32px' width="100%" cellspacing="0" cellpadding="0"
@@ -41,4 +41,4 @@ table style="width: 100%; border-collapse: collapse;"
       td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: left; padding-right: 16px; white-space: nowrap; padding: 16px 0;"
         = link_to invoice.number, invoice.file_url, {style: "text-decoration: none; color: #006cfa"}
       td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: right; color: #19212e; white-space: nowrap; padding: 16px 0;"
-        = invoice.total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+        = MoneyHelper.format(invoice.total_amount)

--- a/app/views/payment_request_mailer/requested.slim
+++ b/app/views/payment_request_mailer/requested.slim
@@ -1,0 +1,44 @@
+div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
+  = I18n.t('email.payment_request.requested.hello', customer_name: @customer.name)
+div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
+  = I18n.t('email.payment_request.requested.reminder_overdue_balance', organization_name: @organization.name)
+div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
+  = I18n.t('email.payment_request.requested.total_amount_due', amount: @invoices.sum(&:total_amount))
+div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
+  - if @customer.applicable_net_payment_term > 0
+    = I18n.t('email.payment_request.requested.payment_terms', count: @customer.applicable_net_payment_term)
+  - else
+    = I18n.t('email.payment_request.requested.upon_invoice_generation')
+div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
+  = I18n.t('email.payment_request.requested.already_paid')
+div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
+  = I18n.t('email.payment_request.requested.thank_you')
+
+div style='padding-top: 32px;font-style: normal;font-weight: 400;font-size: 14px;line-height: 20px;color: #66758F;border-top: 1px solid #d9dee7;'
+  = I18n.t('email.payment_request.requested.remaining_amount')
+div style='margin-bottom: 16px;font-style: normal;font-weight: 700;font-size: 32px;line-height: 40px;color: #19212E;'
+  = @invoices.sum(&:total_amount).format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))
+
+/! TODO: Do not display the button unless payment url is present
+table style='margin-bottom: 32px' width="100%" cellspacing="0" cellpadding="0"
+  tr
+    td
+      table cellspacing="0" cellpadding="0"
+        tr
+          td style="border-radius: 12px;" bgcolor="#006CFA"
+            a href="#" style="padding: 10px 16px;font-size: 16px; color: #ffffff;text-decoration: none;font-weight:bold;display: inline-block;font-weight: 400;font-style: normal;line-height: 24px;"
+              = I18n.t('email.payment_request.requested.pay_amount')
+
+table style="width: 100%; border-collapse: collapse;"
+  tr
+  tr style="border-bottom: 1px solid #d9dee7;"
+    td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: left; color: #66758F; white-space: nowrap; padding: 16px 0;"
+      = I18n.t('email.credit_note.created.invoice_number')
+    td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: right; color: #66758F; white-space: nowrap; padding: 16px 0;"
+      = I18n.t('invoice.amount')
+  - @invoices.each do |invoice|
+    tr style="border-bottom: 1px solid #d9dee7;"
+      td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: left; padding-right: 16px; white-space: nowrap; padding: 16px 0;"
+        = link_to invoice.number, invoice.file_url, {style: "text-decoration: none; color: #006cfa"}
+      td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: right; color: #19212e; white-space: nowrap; padding: 16px 0;"
+        = invoice.total_amount.format(format: I18n.t('money.format'), decimal_mark: I18n.t('money.decimal_mark'), thousands_separator: I18n.t('money.thousands_separator'))

--- a/config/locales/de/email.yml
+++ b/config/locales/de/email.yml
@@ -20,5 +20,19 @@ de:
         invoice_number: Rechnungsnummer
         issue_date: Ausstellungsdatum
         subject: 'Deine Rechnung von %{organization_name} #%{invoice_number}'
+    payment_request:
+      requested:
+        already_paid: Wenn Sie die Zahlung bereits vorgenommen haben, ignorieren Sie bitte diese E-Mail.
+        hello: Hallo %{customer_name},
+        pay_amount": Restbetrag bezahlen
+        payment_terms:
+          one: Unsere vertraglich vereinbarten Zahlungsbedingungen sind %{count} Tag.
+          other: Unsere vertraglich vereinbarten Zahlungsbedingungen sind %{count} Tage.
+          zero: Unsere vertraglich vereinbarten Zahlungsbedingungen erfordern die Zahlung bei Rechnungserstellung.
+        remaining_amount: Restbetrag zu zahlen
+        reminder_overdue_balance: Dies ist eine Erinnerung des Finanzteams von %{organization_name}, dass einige Rechnungen überfällig sind.
+        subject: Ihr überfälliger Saldo von %{organization_name}
+        thank_you: Danke.
+        total_amount_due: Der insgesamt fällige Betrag beträgt %{amount}.
     powered_by: Bereitgestellt von
     questions: Fragen? Kontaktiere uns unter

--- a/config/locales/en/email.yml
+++ b/config/locales/en/email.yml
@@ -31,5 +31,20 @@ en:
         subject: 'Your Invoice from %{organization_name} #%{invoice_number}'
     password_reset:
       subject: Reset your Lago password
+    payment_request:
+      requested:
+        already_paid: If you have already made the payment, please disregard this email.
+        hello: Hello %{customer_name},
+        pay_amount: Pay balance
+        payment_terms:
+          one: Our contractually agreed payment terms is %{count} day.
+          other: Our contractually agreed payment terms are %{count} days.
+          zero: Our contractually agreed payment terms require payment upon invoice generation.
+        remaining_amount: Remaining amount to pay
+        reminder_overdue_balance: This is a reminder from the %{organization_name} finance team that some invoices are overdue.
+        subject: Your overdue balance from %{organization_name}
+        thank_you: Thank you.
+        total_amount_due: The total amount due is %{amount}.
+        upon_invoice_generation: Our contractually agreed payment terms require payment upon invoice generation.
     powered_by: Powered by
     questions: Questions? Contact us at

--- a/config/locales/es/email.yml
+++ b/config/locales/es/email.yml
@@ -20,5 +20,19 @@ es:
         invoice_number: Número de factura
         issue_date: Fecha de emisión
         subject: 'Tu factura de %{organization_name} #%{invoice_number}'
+      payment_request:
+        requested:
+          already_paid: Si ya ha realizado el pago, por favor ignore este correo electrónico.
+          hello: Hola %{customer_name},
+          pay_amount: Pagar el saldo
+          payment_terms:
+            one: Nuestros términos de pago acordados contractualmente son %{count} día.
+            other: Nuestros términos de pago acordados contractualmente son %{count} días.
+            zero: Nuestros términos de pago acordados contractualmente requieren el pago al generar la factura.
+          remaining_amount: Monto restante a pagar
+          reminder_overdue_balance: Este es un recordatorio del equipo financiero de %{organization_name} de que algunas facturas están vencidas.
+          subject: Su saldo vencido de %{organization_name}
+          thank_you: Gracias.
+          total_amount_due: El monto total adeudado es de %{amount}.
     powered_by_lago: Powered by
     questions: "¿Preguntas? Contáctanos en"

--- a/config/locales/fr/email.yml
+++ b/config/locales/fr/email.yml
@@ -20,5 +20,19 @@ fr:
         invoice_number: Nº de facture
         issue_date: Date d'émission
         subject: Votre facture nº %{invoice_number} de %{organization_name}
+    payment_request:
+      requested:
+        already_paid: Si vous avez déjà effectué le paiement, veuillez ignorer cet e-mail.
+        hello: Bonjour %{customer_name},
+        pay_amount: Payer le solde
+        payment_terms:
+          one: Nos conditions de paiement convenues contractuellement sont de %{count} jour.
+          other: Nos conditions de paiement convenues contractuellement sont de %{count} jours.
+          zero: Nos conditions de paiement définies contractuellement exigent le paiement à la création de la facture.
+        remaining_amount: Montant restant à payer
+        reminder_overdue_balance: Ceci est un rappel de l'équipe financière de %{organization_name} que certaines de vos factures sont en retard.
+        subject: Votre solde impayé pour %{organization_name}
+        thank_you: Merci.
+        total_amount_due: Le montant total dû est de %{amount}.
     powered_by: Généré par
     questions: Questions? Contactez nous à

--- a/config/locales/it/email.yml
+++ b/config/locales/it/email.yml
@@ -20,5 +20,19 @@ it:
         invoice_number: Numero Fattura
         issue_date: Data Emissione
         subject: 'La tua fattura da %{organization_name} #%{invoice_number}'
+    payment_request:
+      requested:
+        already_paid: Se hai già effettuato il pagamento, ti preghiamo di ignorare questa email.
+        hello: Ciao %{customer_name},
+        pay_amount: Paga il saldo
+        payment_terms:
+          one: I nostri termini di pagamento contrattualmente concordati sono %{count} giorno.
+          other: I nostri termini di pagamento contrattualmente concordati sono %{count} giorni.
+          zero: I nostri termini di pagamento contrattualmente concordati richiedono il pagamento al momento della generazione della fattura.
+        remaining_amount: Importo residuo da pagare
+        reminder_overdue_balance: Questo è un promemoria del team finanziario di %{organization_name} che alcune fatture sono in ritardo.
+        subject: Il tuo saldo in ritardo da %{organization_name}
+        thank_you: Grazie.
+        total_amount_due: L'importo totale dovuto è di %{amount}.
     powered_by: Elaborato da
     questions: Domande? Contattaci all'indirizzo

--- a/config/locales/nb/email.yml
+++ b/config/locales/nb/email.yml
@@ -20,5 +20,19 @@ nb:
         invoice_number: Fakturanummer
         issue_date: Dato
         subject: 'Faktura fra %{organization_name} #%{invoice_number}'
+    payment_request:
+      requested:
+        already_paid: Hvis du allerede har foretatt betalingen, vennligst se bort fra denne e-posten.
+        hello: Hei %{customer_name},
+        pay_amount: Betal saldoen
+        payment_terms:
+          one: Våre avtalte betalingsbetingelser er %{count} dag.
+          other: Våre avtalte betalingsbetingelser er %{count} dager.
+          zero: Våre avtalte betalingsbetingelser krever betaling ved fakturautstedelse.
+        remaining_amount: Gjenstående beløp å betale
+        reminder_overdue_balance: Dette er en påminnelse fra økonomiavdelingen i %{organization_name} om at noen fakturaer er forfalt.
+        subject: Din forfalte saldo fra %{organization_name}
+        thank_you: Takk.
+        total_amount_due: Totalbeløpet som forfaller er %{amount}.
     powered_by: Fakturering drevet av
     questions: Har du spørsmål? Kontakt oss på

--- a/config/locales/sv/email.yml
+++ b/config/locales/sv/email.yml
@@ -20,5 +20,19 @@ sv:
         invoice_number: Fakturanummer
         issue_date: Fakturadatum
         subject: 'Din faktura från %{organization_name} #%{invoice_number}'
+    payment_request:
+      requested:
+        already_paid: Om du redan har gjort betalningen, vänligen bortse från detta mejl.
+        hello: Hej %{customer_name},
+        pay_amount: Betala saldot
+        payment_terms:
+          one: Våra avtalsenliga betalningsvillkor är %{count} dag.
+          other: Våra avtalsenliga betalningsvillkor är %{count} dagar.
+          zero: Våra avtalsenliga betalningsvillkor kräver betalning vid fakturautställning.
+        remaining_amount: Återstående belopp att betala
+        reminder_overdue_balance: Detta är en påminnelse från ekonomiavdelningen på %{organization_name} om att vissa fakturor är förfallna.
+        subject: Din förfallna saldo från %{organization_name}
+        thank_you: Tack.
+        total_amount_due: Det totala förfallna beloppet är %{amount}.
     powered_by_lago: Powered by
     questions: Frågor? Kontakta oss på

--- a/spec/mailers/payment_request_mailer_spec.rb
+++ b/spec/mailers/payment_request_mailer_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentRequestMailer, type: :mailer do
+  subject(:payment_request_mailer) { described_class }
+
+  let(:first_invoice) { create(:invoice, total_amount_cents: 1000) }
+  let(:second_invoice) { create(:invoice, total_amount_cents: 2000) }
+  let(:payment_request) { create(:payment_request, invoices: [first_invoice, second_invoice]) }
+
+  before do
+    first_invoice.file.attach(
+      io: StringIO.new(File.read(Rails.root.join("spec/fixtures/blank.pdf"))),
+      filename: "invoice.pdf",
+      content_type: "application/pdf"
+    )
+    second_invoice.file.attach(
+      io: StringIO.new(File.read(Rails.root.join("spec/fixtures/blank.pdf"))),
+      filename: "invoice.pdf",
+      content_type: "application/pdf"
+    )
+  end
+
+  describe "#requested" do
+    specify do
+      mailer = payment_request_mailer.with(payment_request:).requested
+
+      expect(mailer.to).to eq([payment_request.email])
+      expect(mailer.reply_to).to eq([payment_request.organization.email])
+      expect(mailer.body.encoded).to include(first_invoice.number)
+      expect(mailer.body.encoded).to include(second_invoice.number)
+    end
+  end
+end

--- a/spec/mailers/previews/payment_request_mailer_preview.rb
+++ b/spec/mailers/previews/payment_request_mailer_preview.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class PaymentRequestMailerPreview < BasePreviewMailer
+  def requested
+    payment_request = FactoryBot.create(:payment_request)
+    first_invoice = FactoryBot.create(:invoice, total_amount_cents: 1000)
+    second_invoice = FactoryBot.create(:invoice, total_amount_cents: 2000)
+
+    first_invoice.file.attach(
+      io: StringIO.new(File.read(Rails.root.join("spec/fixtures/blank.pdf"))),
+      filename: "invoice.pdf",
+      content_type: "application/pdf"
+    )
+    second_invoice.file.attach(
+      io: StringIO.new(File.read(Rails.root.join("spec/fixtures/blank.pdf"))),
+      filename: "invoice.pdf",
+      content_type: "application/pdf"
+    )
+
+    FactoryBot.create(
+      :payment_request_applied_invoice,
+      invoice: first_invoice,
+      payment_request:
+    )
+    FactoryBot.create(
+      :payment_request_applied_invoice,
+      invoice: second_invoice,
+      payment_request:
+    )
+
+    PaymentRequestMailer.with(payment_request:).requested
+  end
+end

--- a/spec/mailers/previews/payment_request_mailer_preview.rb
+++ b/spec/mailers/previews/payment_request_mailer_preview.rb
@@ -2,7 +2,7 @@
 
 class PaymentRequestMailerPreview < BasePreviewMailer
   def requested
-    payment_request = FactoryBot.create(:payment_request)
+    payment_request = FactoryBot.create(:payment_request, amount_cents: 3000)
     first_invoice = FactoryBot.create(:invoice, total_amount_cents: 1000)
     second_invoice = FactoryBot.create(:invoice, total_amount_cents: 2000)
 


### PR DESCRIPTION
 ## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Description

The goal of this PR is to send an email reminder when creating a payment request without payment provider.