### PR TITLE
feat(dunning): Generate Payment url for stripe and adyen

### DIFF
--- a/app/services/payment_requests/payments/generate_payment_url_service.rb
+++ b/app/services/payment_requests/payments/generate_payment_url_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module PaymentRequests
+  module Payments
+    class GeneratePaymentUrlService < BaseService
+      PROVIDER_GOCARDLESS = "gocardless"
+
+      def initialize(payable:)
+        @payable = payable
+        @provider = payable.customer.payment_provider.to_s
+
+        super
+      end
+
+      def call
+        return result.single_validation_failure!(error_code: "no_linked_payment_provider") if provider.blank?
+        return result.single_validation_failure!(error_code: "invalid_payment_provider") if gocardless_provider?
+        return result.single_validation_failure!(error_code: "invalid_payment_status") if payable.payment_succeeded?
+
+        payment_url_result = PaymentRequests::Payments::PaymentProviders::Factory.new_instance(payable:).generate_payment_url
+
+        return payment_url_result unless payment_url_result.success?
+
+        return result.single_validation_failure!(error_code: "payment_provider_error") if payment_url_result.payment_url.blank?
+
+        payment_url_result
+      end
+
+      private
+
+      attr_reader :payable, :provider
+
+      def gocardless_provider?
+        provider == PROVIDER_GOCARDLESS
+      end
+    end
+  end
+end

--- a/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
+++ b/spec/services/payment_requests/payments/generate_payment_url_service_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentRequests::Payments::GeneratePaymentUrlService, type: :service do
+  subject(:generate_payment_url_service) { described_class.new(payable: payment_request) }
+
+  let(:organization) { create(:organization) }
+  let(:customer) { create(:customer, organization:, payment_provider:, payment_provider_code: code) }
+  let(:payment_request) { create(:payment_request, customer:) }
+  let(:payment_provider) { "stripe" }
+  let(:code) { "stripe_1" }
+
+  describe ".call" do
+    let(:stripe_provider) { create(:stripe_provider, organization:, code:) }
+
+    before do
+      create(
+        :stripe_customer,
+        customer_id: customer.id,
+        payment_provider: stripe_provider
+      )
+
+      allow(Stripe::Checkout::Session).to receive(:create)
+        .and_return({"url" => "https://example55.com"})
+    end
+
+    it "returns the generated payment url" do
+      result = generate_payment_url_service.call
+
+      expect(result.payment_url).to eq("https://example55.com")
+    end
+
+    context "when payment provider is blank" do
+      let(:payment_provider) { nil }
+
+      it "returns an error", :aggregate_failures do
+        result = generate_payment_url_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:base]).to eq(["no_linked_payment_provider"])
+      end
+    end
+
+    context "when payment provider is gocardless" do
+      let(:payment_provider) { "gocardless" }
+
+      it "returns an error", :aggregate_failures do
+        result = generate_payment_url_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:base]).to eq(["invalid_payment_provider"])
+      end
+    end
+
+    context "when payment request's payment status is invalid" do
+      before { payment_request.payment_succeeded! }
+
+      it "returns an error", :aggregate_failures do
+        result = generate_payment_url_service.call
+
+        expect(result).not_to be_success
+        expect(result.error).to be_a(BaseService::ValidationFailure)
+        expect(result.error.messages[:base]).to eq(["invalid_payment_status"])
+      end
+    end
+  end
+end

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -365,4 +365,30 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
       end
     end
   end
+
+  describe "#generate_payment_url" do
+    before do
+      stripe_payment_provider
+      stripe_customer
+
+      allow(Stripe::Checkout::Session).to receive(:create)
+        .and_return({"url" => "https://example.com"})
+    end
+
+    it "generates payment url" do
+      stripe_service.generate_payment_url
+
+      expect(Stripe::Checkout::Session).to have_received(:create)
+    end
+
+    context "when payment_request is payment_succeeded" do
+      before { payment_request.payment_succeeded! }
+
+      it "does not generate payment url" do
+        stripe_service.generate_payment_url
+
+        expect(Stripe::Checkout::Session).not_to have_received(:create)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

## Description

The goal of this change is to allow payment requests for stripe and adyen payment providers to generate payment urls