### PR TITLE
Fix(anrok): return only number of failed invoices

### DIFF
--- a/app/graphql/types/integrations/anrok.rb
+++ b/app/graphql/types/integrations/anrok.rb
@@ -30,7 +30,8 @@ module Types
       end
 
       def failed_invoices_count
-        Invoice.where(id: object.error_details.where(owner_type: 'Invoice').select(:owner_id)).failed.count
+        Invoice.where(organization_id: object.organization_id, status: 'failed')
+          .joins(:error_details).where(error_details: {error_code: 'tax_error'}).count
       end
     end
   end

--- a/app/graphql/types/integrations/anrok.rb
+++ b/app/graphql/types/integrations/anrok.rb
@@ -30,7 +30,7 @@ module Types
       end
 
       def failed_invoices_count
-        object.error_details.where(owner_type: 'Invoice').kept.count
+        Invoice.where(id: object.error_details.where(owner_type: 'Invoice').select(:owner_id)).failed.count
       end
     end
   end


### PR DESCRIPTION
When returning amount of failed invoices for the anrok integration, filter invoices with only status 'failed'