### PR TITLE
feat(dunning): Generate PDF files for payment request invoices

### DIFF
--- a/app/mailers/payment_request_mailer.rb
+++ b/app/mailers/payment_request_mailer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PaymentRequestMailer < ApplicationMailer
+  before_action :ensure_invoices_pdf
+
   def requested
     @payment_request = params[:payment_request]
     @organization = @payment_request.organization
@@ -17,6 +19,14 @@ class PaymentRequestMailer < ApplicationMailer
           organization_name: @organization.name
         )
       )
+    end
+  end
+
+  private
+
+  def ensure_invoices_pdf
+    params[:payment_request].invoices.each do |invoice|
+      Invoices::GeneratePdfService.new(invoice:).call
     end
   end
 end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

## Description

The goal of this change is to ensure invoices pdf are generated before sending the payment request email.