### PR TITLE
Fix(anrok): Paginate collections in graphQL mutations when sending collection_type

### DIFF
--- a/app/graphql/mutations/invoices/finalize_all.rb
+++ b/app/graphql/mutations/invoices/finalize_all.rb
@@ -16,7 +16,7 @@ module Mutations
       def resolve
         result = ::Invoices::FinalizeBatchService.new(organization: current_organization).call_async
 
-        result.success? ? result.invoices : result_error(result)
+        result.success? ? Kaminari.paginate_array(result.invoices) : result_error(result)
       end
     end
   end

--- a/app/graphql/mutations/invoices/retry_all.rb
+++ b/app/graphql/mutations/invoices/retry_all.rb
@@ -16,7 +16,7 @@ module Mutations
       def resolve
         result = ::Invoices::RetryBatchService.new(organization: current_organization).call_async
 
-        result.success? ? result.invoices : result_error(result)
+        result.success? ? Kaminari.paginate_array(result.invoices) : result_error(result)
       end
     end
   end

--- a/app/graphql/mutations/invoices/retry_all_payments.rb
+++ b/app/graphql/mutations/invoices/retry_all_payments.rb
@@ -16,7 +16,7 @@ module Mutations
       def resolve
         result = ::Invoices::Payments::RetryBatchService.new(organization_id: current_organization.id).call_async
 
-        result.success? ? result.invoices : result_error(result)
+        result.success? ? Kaminari.paginate_array(result.invoices) : result_error(result)
       end
     end
   end


### PR DESCRIPTION
Kaminari doesn't wrap by default response from mutations, so our collections were send as plain arrays instead of array with metadata, and FE needed to request collection to see that request succeeded. Instead now they can request metadata: :total_count