### PR TITLE
Fix(anrok): make tax object on applied tax optional

### DIFF
--- a/app/graphql/types/taxes/applied_tax.rb
+++ b/app/graphql/types/taxes/applied_tax.rb
@@ -7,7 +7,7 @@ module Types
 
       field :id, ID, null: false
 
-      field :tax, Types::Taxes::Object, null: false
+      field :tax, Types::Taxes::Object, null: true
       field :tax_code, String, null: false
       field :tax_description, String, null: true
       field :tax_name, String, null: false

--- a/schema.graphql
+++ b/schema.graphql
@@ -202,7 +202,7 @@ interface AppliedTax {
   amountCurrency: CurrencyEnum!
   createdAt: ISO8601DateTime!
   id: ID!
-  tax: Tax!
+  tax: Tax
   taxCode: String!
   taxDescription: String
   taxName: String!
@@ -2210,7 +2210,7 @@ type CreditNoteAppliedTax implements AppliedTax {
   createdAt: ISO8601DateTime!
   creditNote: CreditNote!
   id: ID!
-  tax: Tax!
+  tax: Tax
   taxCode: String!
   taxDescription: String
   taxName: String!
@@ -3668,7 +3668,7 @@ type FeeAppliedTax implements AppliedTax {
   createdAt: ISO8601DateTime!
   fee: Fee!
   id: ID!
-  tax: Tax!
+  tax: Tax
   taxCode: String!
   taxDescription: String
   taxName: String!
@@ -4076,7 +4076,7 @@ type InvoiceAppliedTax implements AppliedTax {
   feesAmountCents: BigInt!
   id: ID!
   invoice: Invoice!
-  tax: Tax!
+  tax: Tax
   taxCode: String!
   taxDescription: String
   taxName: String!

--- a/schema.json
+++ b/schema.json
@@ -1767,13 +1767,9 @@
               "name": "tax",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Tax",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Tax",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -9663,13 +9659,9 @@
               "name": "tax",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Tax",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Tax",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -16214,13 +16206,9 @@
               "name": "tax",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Tax",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Tax",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -19415,13 +19403,9 @@
               "name": "tax",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Tax",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Tax",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,


### PR DESCRIPTION
Since applied taxes received from Anrok does not have relation to taxes saved in the DB, tax is no longer required on the Applied Tax