### PR TITLE
feat(dunning): define right description/reference/product name within stripe and adyen payloads

### DIFF
--- a/app/services/payment_requests/payments/adyen_service.rb
+++ b/app/services/payment_requests/payments/adyen_service.rb
@@ -137,7 +137,7 @@ module PaymentRequests
             currency: payable.currency.upcase,
             value: payable.total_amount_cents
           },
-          reference: payable.id, # TODO: invoice.number,
+          reference: "Overdue invoices",
           paymentMethod: {
             type: 'scheme',
             storedPaymentMethodId: customer.adyen_customer.payment_method_id
@@ -153,7 +153,7 @@ module PaymentRequests
 
       def payment_url_params
         prms = {
-          reference: payable.id, # TODO: invoice.number,
+          reference: "Overdue invoices",
           amount: {
             value: payable.total_amount_cents,
             currency: payable.currency.upcase
@@ -163,7 +163,7 @@ module PaymentRequests
           shopperReference: customer.external_id,
           storePaymentMethodMode: 'enabled',
           recurringProcessingModel: 'UnscheduledCardOnFile',
-          expiresAt: Time.current + 1.day, # TODO: what should we do with the expiration?
+          expiresAt: Time.current + 70.days, # max link TTL
           metadata: {
             lago_customer_id: customer.id,
             lago_payment_request_id: payable.id,

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -185,13 +185,7 @@ module PaymentRequests
       end
 
       def description
-        # TODO: for invoices we define the payment description with the
-        #       invoice number, however, we do no have this kind of identifiers
-        #       on payment requests...
-        #
-        # "#{organization.name} - PaymentRequest #{payable.number}"
-
-        "#{organization.name} - PaymentRequest 123"
+        "#{organization.name} - Overdue invoices"
       end
 
       def payable_payment_status(payment_status)
@@ -233,7 +227,7 @@ module PaymentRequests
                 currency: payable.currency.downcase,
                 unit_amount: payable.total_amount_cents,
                 product_data: {
-                  name: payable.id # TODO: invoice.number
+                  name: "Overdue invoices"
                 }
               }
             }

--- a/spec/services/payment_requests/payments/adyen_service_spec.rb
+++ b/spec/services/payment_requests/payments/adyen_service_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe PaymentRequests::Payments::AdyenService, type: :service do
               type: "scheme"
             },
             recurringProcessingModel: "UnscheduledCardOnFile",
-            reference: payment_request.id,
+            reference: "Overdue invoices",
             shopperEmail: customer.email,
             shopperInteraction: "ContAuth",
             shopperReference: adyen_customer.provider_customer_id
@@ -310,7 +310,7 @@ RSpec.describe PaymentRequests::Payments::AdyenService, type: :service do
                 externalPlatform: {integrator: "Lago", name: "Lago"},
                 merchantApplication: {name: "Lago"}
               },
-              expiresAt: Time.current + 1.day,
+              expiresAt: Time.current + 70.days,
               merchantAccount: adyen_payment_provider.merchant_account,
               metadata: {
                 lago_customer_id: customer.id,
@@ -319,7 +319,7 @@ RSpec.describe PaymentRequests::Payments::AdyenService, type: :service do
                 payment_type: "one-time"
               },
               recurringProcessingModel: "UnscheduledCardOnFile",
-              reference: payment_request.id,
+              reference: "Overdue invoices",
               returnUrl: adyen_payment_provider.success_redirect_url,
               shopperEmail: customer.email,
               shopperReference: customer.external_id,

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
           confirm: true,
           off_session: true,
           error_on_requires_action: true,
-          description: "#{organization.name} - PaymentRequest 123",
+          description: "#{organization.name} - Overdue invoices",
           metadata: {
             lago_customer_id: customer.id,
             lago_payment_request_id: payment_request.id,
@@ -389,7 +389,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
                   currency: payment_request.currency.downcase,
                   unit_amount: payment_request.total_amount_cents,
                   product_data: {
-                    name: payment_request.id
+                    name: "Overdue invoices"
                   }
                 }
               }
@@ -399,7 +399,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
             customer: customer.stripe_customer.provider_customer_id,
             payment_method_types: customer.stripe_customer.provider_payment_methods,
             payment_intent_data: {
-              description: "#{organization.name} - PaymentRequest 123",
+              description: "#{organization.name} - Overdue invoices",
               metadata: {
                 lago_customer_id: customer.id,
                 lago_payment_request_id: payment_request.id,


### PR DESCRIPTION
 ## Roadmap Task

👉
https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

 ## Description

The goal of this change is to define description/reference/product name for stripe and adyen payloads as agreed.

Also, sets adyen payment link TTL to the maximum allowed (70 days).