### PR TITLE
feat(ProgressiveBilling): Expose Invoice#AppliedUsageThresholds in REST API

### DIFF
--- a/app/serializers/v1/applied_usage_threshold_serializer.rb
+++ b/app/serializers/v1/applied_usage_threshold_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module V1
+  class AppliedUsageThresholdSerializer < ModelSerializer
+    def serialize
+      payload = {
+        lifetime_usage_amount_cents: model.lifetime_usage_amount_cents,
+        created_at: model.created_at.iso8601
+      }
+
+      payload.merge!(usage_treshold)
+      payload
+    end
+
+    private
+
+    def usage_treshold
+      {
+        usage_threshold: ::V1::UsageThresholdSerializer.new(model.usage_threshold).serialize
+      }
+    end
+  end
+end

--- a/app/serializers/v1/invoice_serializer.rb
+++ b/app/serializers/v1/invoice_serializer.rb
@@ -36,6 +36,7 @@ module V1
       payload.merge!(metadata) if include?(:metadata)
       payload.merge!(applied_taxes) if include?(:applied_taxes)
       payload.merge!(error_details) if include?(:error_details)
+      payload.merge!(applied_usage_thresholds) if model.progressive_billing?
 
       payload
     end
@@ -96,6 +97,14 @@ module V1
         model.error_details,
         ::V1::Invoices::ErrorDetailSerializer,
         collection_name: 'error_details'
+      ).serialize
+    end
+
+    def applied_usage_thresholds
+      ::CollectionSerializer.new(
+        model.applied_usage_thresholds,
+        ::V1::AppliedUsageThresholdSerializer,
+        collection_name: 'applied_usage_thresholds'
       ).serialize
     end
   end

--- a/spec/serializers/v1/applied_usage_threshold_serializer_spec.rb
+++ b/spec/serializers/v1/applied_usage_threshold_serializer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_String_literal: true
+
+require 'rails_helper'
+
+RSpec.describe V1::AppliedUsageThresholdSerializer do
+  subject(:serializer) { described_class.new(applied_usage_threshold, root_name: 'applied_usage_threshold') }
+
+  let(:applied_usage_threshold) { create(:applied_usage_threshold) }
+
+  it 'serialize the object' do
+    result = JSON.parse(serializer.to_json)
+
+    aggregate_failures do
+      expect(result['applied_usage_threshold']).to include(
+        'lifetime_usage_amount_cents' => applied_usage_threshold.lifetime_usage_amount_cents,
+        'created_at' => applied_usage_threshold.created_at.iso8601
+      )
+
+      expect(result['applied_usage_threshold']['usage_threshold']).to include(
+        'lago_id' => applied_usage_threshold.usage_threshold.id,
+        'threshold_display_name' => applied_usage_threshold.usage_threshold.threshold_display_name,
+        'amount_cents' => applied_usage_threshold.usage_threshold.amount_cents,
+        'recurring' => applied_usage_threshold.usage_threshold.recurring
+      )
+    end
+  end
+end

--- a/spec/serializers/v1/invoice_serializer_spec.rb
+++ b/spec/serializers/v1/invoice_serializer_spec.rb
@@ -60,4 +60,17 @@ RSpec.describe ::V1::InvoiceSerializer do
       )
     end
   end
+
+  context 'when invoice is a progressive_billing invoice' do
+    let(:invoice) { create(:invoice, invoice_type: :progressive_billing) }
+    let(:applied_usage_threshold) { create(:applied_usage_threshold, invoice:) }
+
+    before { applied_usage_threshold }
+
+    it 'serializes the object' do
+      result = JSON.parse(serializer.to_json)
+
+      expect(result['invoice']['applied_usage_thresholds'].count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR adds adds the new `applied_usage_thresholds` in `V1::InvoiceSerializer`