### PR TITLE
Feat(anrok): add enumed_tax_code to tax breakdown serialization

### DIFF
--- a/app/graphql/types/integrations/anrok_objects/breakdown_object.rb
+++ b/app/graphql/types/integrations/anrok_objects/breakdown_object.rb
@@ -6,6 +6,7 @@ module Types
       class BreakdownObject < Types::BaseObject
         graphql_name 'AnrokBreakdownObject'
 
+        field :enumed_tax_code, Types::Invoices::AppliedTaxes::WholeInvoiceApplicableTaxCodeEnum, null: true
         field :name, String, null: true
         field :rate, GraphQL::Types::Float, null: true
         field :tax_amount, GraphQL::Types::BigInt, null: true
@@ -13,6 +14,14 @@ module Types
 
         def rate
           BigDecimal(object.rate)
+        end
+
+        def tax_code
+          object.name&.parameterize(separator: '_')
+        end
+
+        def enumed_tax_code
+          tax_code if Invoice::AppliedTax::TAX_CODES_APPLICABLE_ON_WHOLE_INVOICE.include?(tax_code)
         end
       end
     end

--- a/app/graphql/types/integrations/anrok_objects/breakdown_object.rb
+++ b/app/graphql/types/integrations/anrok_objects/breakdown_object.rb
@@ -19,7 +19,7 @@ module Types
         end
 
         def tax_code
-          object.name&.parameterize(separator: '_')
+          @tax_code ||= object.name&.parameterize(separator: '_')
         end
 
         def enumed_tax_code

--- a/app/graphql/types/integrations/anrok_objects/breakdown_object.rb
+++ b/app/graphql/types/integrations/anrok_objects/breakdown_object.rb
@@ -6,6 +6,8 @@ module Types
       class BreakdownObject < Types::BaseObject
         graphql_name 'AnrokBreakdownObject'
 
+        # we need to show how this tax will behave when invoice is generated - will it be applied
+        # on whole invoice specific rule or just a normal tax
         field :enumed_tax_code, Types::Invoices::AppliedTaxes::WholeInvoiceApplicableTaxCodeEnum, null: true
         field :name, String, null: true
         field :rate, GraphQL::Types::Float, null: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -126,6 +126,7 @@ enum AggregationTypeEnum {
 }
 
 type AnrokBreakdownObject {
+  enumedTaxCode: InvoiceAppliedTaxOnWholeInvoiceCodeEnum
   name: String
   rate: Float
   taxAmount: BigInt

--- a/schema.json
+++ b/schema.json
@@ -927,6 +927,20 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "enumedTaxCode",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "InvoiceAppliedTaxOnWholeInvoiceCodeEnum",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "name",
               "description": null,
               "type": {

--- a/spec/graphql/mutations/integrations/anrok/fetch_draft_invoice_taxes_spec.rb
+++ b/spec/graphql/mutations/integrations/anrok/fetch_draft_invoice_taxes_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Mutations::Integrations::Anrok::FetchDraftInvoiceTaxes, type: :gr
               rate
               taxAmount
               type
+              enumedTaxCode
             }
           }
         }
@@ -120,6 +121,7 @@ RSpec.describe Mutations::Integrations::Anrok::FetchDraftInvoiceTaxes, type: :gr
       expect(breakdown1['rate']).to eq(0.1)
       expect(breakdown1['taxAmount']).to eq('990')
       expect(breakdown1['type']).to eq('tax_exempt')
+      expect(breakdown1['enumedTaxCode']).to eq(nil)
 
       breakdown2 = fee['taxBreakdown'].last
 
@@ -127,6 +129,7 @@ RSpec.describe Mutations::Integrations::Anrok::FetchDraftInvoiceTaxes, type: :gr
       expect(breakdown2['rate']).to eq(0.0)
       expect(breakdown2['taxAmount']).to eq('0')
       expect(breakdown2['type']).to eq('exempt')
+      expect(breakdown2['enumedTaxCode']).to eq('reverse_charge')
     end
   end
 


### PR DESCRIPTION
to display addon taxes the same way when creating a one-off invoice as when we show fee taxes in all the other invoices, FE needs enumed_tax_code to be sent in the same format as for Invoice::AppliedTax (which is usually created when creating an invoice)