### PR TITLE
feat(dunning): Add customerId to invoices graphql resolver

### DIFF
--- a/app/graphql/resolvers/invoices_resolver.rb
+++ b/app/graphql/resolvers/invoices_resolver.rb
@@ -11,6 +11,7 @@ module Resolvers
 
     argument :currency, Types::CurrencyEnum, required: false
     argument :customer_external_id, String, required: false
+    argument :customer_id, ID, required: false, description: 'Uniq ID of the customer'
     argument :invoice_type, [Types::Invoices::InvoiceTypeEnum], required: false
     argument :issuing_date_from, GraphQL::Types::ISO8601Date, required: false
     argument :issuing_date_to, GraphQL::Types::ISO8601Date, required: false
@@ -27,6 +28,7 @@ module Resolvers
     def resolve( # rubocop:disable Metrics/ParameterLists
       currency: nil,
       customer_external_id: nil,
+      customer_id: nil,
       invoice_type: nil,
       issuing_date_from: nil,
       issuing_date_to: nil,
@@ -49,6 +51,7 @@ module Resolvers
           status:,
           currency:,
           customer_external_id:,
+          customer_id:,
           invoice_type:,
           issuing_date_from:,
           issuing_date_to:

--- a/schema.graphql
+++ b/schema.graphql
@@ -5995,7 +5995,25 @@ type Query {
   """
   Query invoices
   """
-  invoices(currency: CurrencyEnum, customerExternalId: String, invoiceType: [InvoiceTypeEnum!], issuingDateFrom: ISO8601Date, issuingDateTo: ISO8601Date, limit: Int, page: Int, paymentDisputeLost: Boolean, paymentOverdue: Boolean, paymentStatus: [InvoicePaymentStatusTypeEnum!], searchTerm: String, status: [InvoiceStatusTypeEnum!]): InvoiceCollection!
+  invoices(
+    currency: CurrencyEnum
+    customerExternalId: String
+
+    """
+    Uniq ID of the customer
+    """
+    customerId: ID
+    invoiceType: [InvoiceTypeEnum!]
+    issuingDateFrom: ISO8601Date
+    issuingDateTo: ISO8601Date
+    limit: Int
+    page: Int
+    paymentDisputeLost: Boolean
+    paymentOverdue: Boolean
+    paymentStatus: [InvoicePaymentStatusTypeEnum!]
+    searchTerm: String
+    status: [InvoiceStatusTypeEnum!]
+  ): InvoiceCollection!
 
   """
   Query memberships of an organization

--- a/schema.json
+++ b/schema.json
@@ -29872,6 +29872,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "customerId",
+                  "description": "Uniq ID of the customer",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "invoiceType",
                   "description": null,
                   "type": {


### PR DESCRIPTION
## Description

When fetching invoices, we can filter by `external_id` but it's not currently possible to filter by `id`. 

In the case of deleted customers with the same external id, it will return all the related invoices as well.
We want to be able to only return invoices for the active customer.
