### PR TITLE
fix (tax-integrations): do not call update integration customer external service for anrok

### DIFF
--- a/app/services/integration_customers/update_service.rb
+++ b/app/services/integration_customers/update_service.rb
@@ -11,6 +11,7 @@ module IntegrationCustomers
       result = super
       return result if result.error
 
+      return result if integration_customer.type == 'IntegrationCustomers::AnrokCustomer'
       return result.not_found_failure!(resource: 'integration_customer') unless integration_customer
 
       integration_customer.update!(external_customer_id:) if external_customer_id.present?

--- a/spec/services/integration_customers/update_service_spec.rb
+++ b/spec/services/integration_customers/update_service_spec.rb
@@ -107,6 +107,23 @@ RSpec.describe IntegrationCustomers::UpdateService, type: :service do
             expect(result.integration_customer.subsidiary_id).to eq(subsidiary_id)
           end
         end
+
+        context 'with anrok customer' do
+          let(:external_customer_id) { SecureRandom.uuid }
+          let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
+
+          it 'does not calls aggregator update service' do
+            service_call
+
+            expect(aggregator_contacts_update_service).not_to have_received(:call)
+          end
+
+          it 'does not update integration customer' do
+            service_call
+
+            expect(integration_customer.reload.external_customer_id).not_to eq(external_customer_id)
+          end
+        end
       end
 
       context 'when sync with provider is false' do


### PR DESCRIPTION
## Context

For Anrok, we should not call the service that updates integration customer data in external service