### PR TITLE
fix (tax-integrations): use billing address if there is no shipping address

### DIFF
--- a/app/services/integrations/aggregator/taxes/invoices/payload.rb
+++ b/app/services/integrations/aggregator/taxes/invoices/payload.rb
@@ -22,10 +22,10 @@ module Integrations
                 'contact' => {
                   'external_id' => integration_customer&.external_customer_id || customer.external_id,
                   'name' => customer.name,
-                  'address_line_1' => customer.shipping_address_line1,
-                  'city' => customer.shipping_city,
-                  'zip' => customer.shipping_zipcode,
-                  'country' => customer.shipping_country,
+                  'address_line_1' => customer.shipping_address_line1 || customer.address_line1,
+                  'city' => customer.shipping_city || customer.city,
+                  'zip' => customer.shipping_zipcode || customer.zipcode,
+                  'country' => customer.shipping_country || customer.country,
                   'taxable' => customer.tax_identification_number.present?,
                   'tax_number' => customer.tax_identification_number
                 },

--- a/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_draft_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateDraftService do
 
   let(:integration) { create(:anrok_integration, organization:) }
   let(:integration_customer) { create(:anrok_customer, integration:, customer:) }
-  let(:customer) { create(:customer, organization:) }
+  let(:customer) { create(:customer, :with_shipping_address, organization:) }
   let(:organization) { create(:organization) }
   let(:lago_client) { instance_double(LagoHttpClient::Client) }
   let(:endpoint) { 'https://api.nango.dev/v1/anrok/draft_invoices' }

--- a/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/taxes/invoices/create_service_spec.rb
@@ -74,10 +74,10 @@ RSpec.describe Integrations::Aggregator::Taxes::Invoices::CreateService do
         'contact' => {
           'external_id' => customer.external_id,
           'name' => customer.name,
-          'address_line_1' => customer.shipping_address_line1,
-          'city' => customer.shipping_city,
-          'zip' => customer.shipping_zipcode,
-          'country' => customer.shipping_country,
+          'address_line_1' => customer.address_line1,
+          'city' => customer.city,
+          'zip' => customer.zipcode,
+          'country' => customer.country,
           'taxable' => false,
           'tax_number' => nil
         },


### PR DESCRIPTION
## Context

If there is no shipping address, we should fallback to billing address