### PR TITLE
feat(dunning): Add update_payment_status for gocardless payments

### DIFF
--- a/app/jobs/send_webhook_job.rb
+++ b/app/jobs/send_webhook_job.rb
@@ -36,6 +36,7 @@ class SendWebhookJob < ApplicationJob
     'payment_provider.error' => Webhooks::PaymentProviders::ErrorService,
     'payment_request.created' => Webhooks::PaymentRequests::CreatedService,
     "payment_request.payment_failure" => Webhooks::PaymentProviders::PaymentRequestPaymentFailureService,
+    "payment_request.payment_status_updated" => Webhooks::PaymentRequests::PaymentStatusUpdatedService,
     'subscription.terminated' => Webhooks::Subscriptions::TerminatedService,
     'subscription.started' => Webhooks::Subscriptions::StartedService,
     'subscription.termination_alert' => Webhooks::Subscriptions::TerminationAlertService,

--- a/app/services/payment_requests/payments/gocardless_service.rb
+++ b/app/services/payment_requests/payments/gocardless_service.rb
@@ -72,6 +72,25 @@ module PaymentRequests
         result
       end
 
+      def update_payment_status(provider_payment_id:, status:)
+        payment = Payment.find_by(provider_payment_id:)
+        return result.not_found_failure!(resource: 'gocardless_payment') unless payment
+
+        result.payment = payment
+        result.payable = payment.payable
+        return result if payment.payable.payment_succeeded?
+
+        payment.update!(status:)
+
+        payable_payment_status = payable_payment_status(status)
+        update_payable_payment_status(payment_status: payable_payment_status)
+        update_invoices_payment_status(payment_status: payable_payment_status)
+
+        result
+      rescue BaseService::FailedResult => e
+        result.fail_with_error!(e)
+      end
+
       private
 
       attr_accessor :payable
@@ -149,14 +168,18 @@ module PaymentRequests
       end
 
       def update_payable_payment_status(payment_status:, deliver_webhook: true)
-        payable.update!(
-          payment_status:,
-          ready_for_payment_processing: payment_status.to_sym != :succeeded
-        )
+        UpdateService.call(
+          payable: result.payable,
+          params: {
+            payment_status:,
+            ready_for_payment_processing: payment_status.to_sym != :succeeded
+          },
+          webhook_notification: deliver_webhook
+        ).raise_if_error!
       end
 
       def update_invoices_payment_status(payment_status:, deliver_webhook: true)
-        payable.invoices.each do |invoice|
+        result.payable.invoices.each do |invoice|
           Invoices::UpdateService.call(
             invoice:,
             params: {

--- a/app/services/payment_requests/update_service.rb
+++ b/app/services/payment_requests/update_service.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module PaymentRequests
+  class UpdateService < BaseService
+    def initialize(payable:, params:, webhook_notification: false)
+      @payable = payable
+      @params = params
+      @webhook_notification = webhook_notification
+
+      super
+    end
+
+    def call
+      return result.not_found_failure!(resource: "payment_request") unless payable
+
+      if params.key?(:payment_status) && !valid_payment_status?(params[:payment_status])
+        return result.single_validation_failure!(
+          field: :payment_status,
+          error_code: "value_is_invalid"
+        )
+      end
+
+      payable.payment_status = params[:payment_status] if params.key?(:payment_status)
+      payable.ready_for_payment_processing = params[:ready_for_payment_processing] if params.key?(:ready_for_payment_processing)
+      payable.save!
+
+      if payable.saved_change_to_payment_status?
+        track_payment_status_changed
+        deliver_webhook if webhook_notification
+      end
+
+      result.payable = payable
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+
+    private
+
+    attr_reader :payable, :params, :webhook_notification
+
+    def valid_payment_status?(payment_status)
+      PaymentRequest::PAYMENT_STATUS.include?(payment_status&.to_sym)
+    end
+
+    def track_payment_status_changed
+      SegmentTrackJob.perform_later(
+        membership_id: CurrentContext.membership,
+        event: "payment_status_changed",
+        properties: {
+          organization_id: payable.organization.id,
+          payment_request_id: payable.id,
+          payment_status: payable.payment_status
+        }
+      )
+    end
+
+    def deliver_webhook
+      return unless webhook_notification
+
+      SendWebhookJob.perform_later("payment_request.payment_status_updated", payable)
+    end
+  end
+end

--- a/app/services/webhooks/payment_requests/payment_status_updated_service.rb
+++ b/app/services/webhooks/payment_requests/payment_status_updated_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Webhooks
+  module PaymentRequests
+    class PaymentStatusUpdatedService < Webhooks::BaseService
+      def current_organization
+        @current_organization ||= object.organization
+      end
+
+      def object_serializer
+        ::V1::PaymentRequestSerializer.new(
+          object,
+          root_name: "payment_request",
+          includes: %i[customer invoices]
+        )
+      end
+
+      def webhook_type
+        'payment_request.payment_status_updated'
+      end
+
+      def object_type
+        'payment_request'
+      end
+    end
+  end
+end

--- a/spec/services/payment_requests/update_service_spec.rb
+++ b/spec/services/payment_requests/update_service_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PaymentRequests::UpdateService do
+  subject(:result) do
+    described_class.call(
+      payable: payment_request,
+      params: update_args,
+      webhook_notification:
+    )
+  end
+
+  let(:payment_request) { create :payment_request }
+  let(:webhook_notification) { false }
+  let(:update_args) { {payment_status: "succeeded"} }
+
+  describe "#call" do
+    before do
+      allow(SegmentTrackJob).to receive(:perform_later)
+    end
+
+    it "updates the invoice", :aggregate_failures do
+      expect(result).to be_success
+      expect(result.payable).to eq(payment_request)
+      expect(result.payable).to be_payment_succeeded
+    end
+
+    it "calls SegmentTrackJob" do
+      result
+
+      expect(SegmentTrackJob).to have_received(:perform_later).with(
+        membership_id: CurrentContext.membership,
+        event: "payment_status_changed",
+        properties: {
+          organization_id: payment_request.organization.id,
+          payment_request_id: payment_request.id,
+          payment_status: payment_request.payment_status
+        }
+      )
+    end
+
+    context "when payment_request does not exist" do
+      let(:payment_request) { nil }
+
+      it "returns an error" do
+        expect(result).not_to be_success
+        expect(result.error.error_code).to eq("payment_request_not_found")
+      end
+    end
+  end
+end

--- a/spec/services/webhooks/payment_requests/payment_status_updated_service_spec.rb
+++ b/spec/services/webhooks/payment_requests/payment_status_updated_service_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Webhooks::PaymentRequests::PaymentStatusUpdatedService do
+  subject(:webhook_service) { described_class.new(object: payment_request) }
+
+  let(:payment_request) { create(:payment_request) }
+
+  describe ".call" do
+    it_behaves_like "creates webhook", "payment_request.payment_status_updated", "payment_request"
+  end
+end


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

 ## Description

The goal of this change is to update the status of gocardless payments.

With this change we introduce a service to update payment requests, this will trigger a webhook when the payment status is updated.