### PR TITLE
feat(ProgressiveBilling): expose SubscriptionLifetimeUsage in GraphQL

### DIFF
--- a/app/graphql/types/subscriptions/lifetime_usage_object.rb
+++ b/app/graphql/types/subscriptions/lifetime_usage_object.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Types
+  module Subscriptions
+    class LifetimeUsageObject < Types::BaseObject
+      graphql_name "SubscriptionLifetimeUsage"
+
+      field :total_usage_amount_cents, GraphQL::Types::BigInt, null: false
+      field :total_usage_from_datetime, GraphQL::Types::ISO8601DateTime, null: false
+      field :total_usage_to_datetime, GraphQL::Types::ISO8601DateTime, null: false
+
+      field :last_threshold_amount_cents, GraphQL::Types::BigInt, null: true
+      field :next_threshold_amount_cents, GraphQL::Types::BigInt, null: true
+      field :next_treshold_ratio, GraphQL::Types::Float, null: true
+
+      def total_usage_from_datetime
+        object.subscription.subscription_at
+      end
+
+      def total_usage_to_datetime
+        Time.current
+      end
+
+      private
+
+      delegate :last_threshold_amount_cents,
+        :next_threshold_amount_cents,
+        :next_treshold_ratio,
+        to: :last_and_next_thresholds
+
+      def last_and_next_thresholds
+        @last_and_next_thresholds ||= LifetimeUsages::FindLastAndNextThresholdsService.call(lifetime_usage: object)
+      end
+    end
+  end
+end

--- a/app/graphql/types/subscriptions/object.rb
+++ b/app/graphql/types/subscriptions/object.rb
@@ -31,6 +31,8 @@ module Types
 
       field :fees, [Types::Fees::Object], null: true
 
+      field :lifetime_usage, Types::Subscriptions::LifetimeUsageObject, null: true
+
       def next_plan
         object.next_subscription&.plan
       end
@@ -42,6 +44,12 @@ module Types
       def period_end_date
         ::Subscriptions::DatesService.new_instance(object, Time.current)
           .next_end_of_period
+      end
+
+      def lifetime_usage
+        return nil unless object.plan.usage_thresholds.any?
+
+        object.lifetime_usage
       end
     end
   end

--- a/app/services/lifetime_usages/find_last_and_next_thresholds_service.rb
+++ b/app/services/lifetime_usages/find_last_and_next_thresholds_service.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module LifetimeUsages
+  class FindLastAndNextThresholdsService < BaseService
+    def initialize(lifetime_usage:)
+      @lifetime_usage = lifetime_usage
+      @thresholds = lifetime_usage.subscription.plan.usage_thresholds
+
+      super
+    end
+
+    def call
+      result.last_threshold_amount_cents = last_threshold_amount_cents
+      result.next_threshold_amount_cents = next_threshold_amount_cents
+      result.next_treshold_ratio = next_treshold_ratio
+      result
+    end
+
+    private
+
+    attr_reader :lifetime_usage, :thresholds
+    delegate :organization, :subscription, to: :lifetime_usage
+
+    def last_applied_usage_threshold
+      return @last_applied_usage_threshold if defined?(@last_applied_usage_threshold)
+
+      subscription_ids = organization.subscriptions
+        .where(external_id: subscription.external_id, subscription_at: subscription.subscription_at)
+        .where(canceled_at: nil)
+        .select(:id)
+
+      @last_applied_usage_threshold = AppliedUsageThreshold
+        .joins(invoice: :invoice_subscriptions)
+        .where(invoice_subscriptions: {subscription_id: subscription_ids})
+        .order(created_at: :desc)
+        .first
+    end
+
+    def next_usage_threshold
+      return @next_usage_threshold if defined?(@next_usage_threshold)
+
+      @next_usage_threshold = thresholds
+        .not_recurring
+        .where('amount_cents > ?', lifetime_usage.total_amount_cents)
+        .order(amount_cents: :asc)
+        .first
+
+      @next_usage_threshold ||= thresholds.recurring.first
+    end
+
+    def largest_threshold
+      @largest_threshold ||= thresholds.not_recurring.order(amount_cents: :desc).first
+    end
+
+    def last_threshold_amount_cents
+      last_threshold = last_applied_usage_threshold&.usage_threshold
+      return unless last_threshold
+
+      if last_threshold.recurring?
+        recurring_amount = lifetime_usage.total_amount_cents - (largest_threshold.amount_cents || 0)
+        occurence = recurring_amount / last_threshold.amount_cents
+
+        largest_threshold.amount_cents + occurence * last_threshold.amount_cents
+      else
+        last_threshold.amount_cents
+      end
+    end
+
+    def next_threshold_amount_cents
+      return unless next_usage_threshold
+      return next_usage_threshold.amount_cents unless next_usage_threshold.recurring?
+
+      recurring_amount = lifetime_usage.total_amount_cents - (largest_threshold.amount_cents || 0)
+      occurence = recurring_amount.fdiv(next_usage_threshold.amount_cents).ceil
+
+      largest_threshold.amount_cents + occurence * next_usage_threshold.amount_cents
+    end
+
+    def next_treshold_ratio
+      return unless next_usage_threshold
+
+      base_amount_cents = lifetime_usage.total_amount_cents - (last_threshold_amount_cents || 0)
+      base_amount_cents.fdiv(next_threshold_amount_cents - (last_threshold_amount_cents || 0))
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -6385,6 +6385,7 @@ type Subscription {
   externalId: String!
   fees: [Fee!]
   id: ID!
+  lifetimeUsage: SubscriptionLifetimeUsage
   name: String
   nextName: String
   nextPendingStartDate: ISO8601Date
@@ -6412,6 +6413,15 @@ type SubscriptionCollection {
   Pagination Metadata for navigating the Pagination
   """
   metadata: CollectionMetadata!
+}
+
+type SubscriptionLifetimeUsage {
+  lastThresholdAmountCents: BigInt
+  nextThresholdAmountCents: BigInt
+  nextTresholdRatio: Float
+  totalUsageAmountCents: BigInt!
+  totalUsageFromDatetime: ISO8601DateTime!
+  totalUsageToDatetime: ISO8601DateTime!
 }
 
 type Subsidiary {

--- a/schema.json
+++ b/schema.json
@@ -32236,6 +32236,20 @@
               ]
             },
             {
+              "name": "lifetimeUsage",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "SubscriptionLifetimeUsage",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "name",
               "description": null,
               "type": {
@@ -32459,6 +32473,115 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "CollectionMetadata",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SubscriptionLifetimeUsage",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "lastThresholdAmountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "nextThresholdAmountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "nextTresholdRatio",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "totalUsageAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "totalUsageFromDatetime",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "totalUsageToDatetime",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
                   "ofType": null
                 }
               },

--- a/spec/graphql/types/subscriptions/lifetime_usage_object_spec.rb
+++ b/spec/graphql/types/subscriptions/lifetime_usage_object_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Subscriptions::LifetimeUsageObject do
+  subject { described_class }
+
+  it { is_expected.to have_field(:total_usage_amount_cents).of_type('BigInt!') }
+  it { is_expected.to have_field(:total_usage_from_datetime).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:total_usage_to_datetime).of_type('ISO8601DateTime!') }
+
+  it { is_expected.to have_field(:last_threshold_amount_cents).of_type('BigInt') }
+  it { is_expected.to have_field(:next_threshold_amount_cents).of_type('BigInt') }
+  it { is_expected.to have_field(:next_treshold_ratio).of_type('Float') }
+end

--- a/spec/graphql/types/subscriptions/object_spec.rb
+++ b/spec/graphql/types/subscriptions/object_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Types::Subscriptions::Object do
+  subject { described_class }
+
+  it { is_expected.to have_field(:customer).of_type('Customer!') }
+  it { is_expected.to have_field(:external_id).of_type('String!') }
+  it { is_expected.to have_field(:id).of_type('ID!') }
+  it { is_expected.to have_field(:plan).of_type('Plan!') }
+
+  it { is_expected.to have_field(:name).of_type('String') }
+  it { is_expected.to have_field(:next_name).of_type('String') }
+  it { is_expected.to have_field(:next_pending_start_date).of_type('ISO8601Date') }
+  it { is_expected.to have_field(:period_end_date).of_type('ISO8601Date') }
+  it { is_expected.to have_field(:status).of_type('StatusTypeEnum') }
+
+  it { is_expected.to have_field(:billing_time).of_type('BillingTimeEnum') }
+  it { is_expected.to have_field(:canceled_at).of_type('ISO8601DateTime') }
+  it { is_expected.to have_field(:ending_at).of_type('ISO8601DateTime') }
+  it { is_expected.to have_field(:started_at).of_type('ISO8601DateTime') }
+  it { is_expected.to have_field(:subscription_at).of_type('ISO8601DateTime') }
+  it { is_expected.to have_field(:terminated_at).of_type('ISO8601DateTime') }
+
+  it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
+  it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
+
+  it { is_expected.to have_field(:next_plan).of_type('Plan') }
+  it { is_expected.to have_field(:next_subscription).of_type('Subscription') }
+
+  it { is_expected.to have_field(:fees).of_type('[Fee!]') }
+
+  it { is_expected.to have_field(:lifetime_usage).of_type('SubscriptionLifetimeUsage') }
+end

--- a/spec/services/lifetime_usages/find_last_and_next_thresholds_service_spec.rb
+++ b/spec/services/lifetime_usages/find_last_and_next_thresholds_service_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LifetimeUsages::FindLastAndNextThresholdsService, type: :service do
+  subject(:lifetime_usage_result) { described_class.call(lifetime_usage:) }
+
+  let(:lifetime_usage) { create(:lifetime_usage, subscription:, organization:, current_usage_amount_cents:) }
+  let(:current_usage_amount_cents) { 0 }
+
+  let(:plan) { create(:plan) }
+  let(:organization) { plan.organization }
+
+  let(:customer) { create(:customer, organization:) }
+  let(:subscription) { create(:subscription, plan:, customer:) }
+
+  it 'computes the amounts' do
+    expect(lifetime_usage_result.last_threshold_amount_cents).to be_nil
+    expect(lifetime_usage_result.next_threshold_amount_cents).to be_nil
+    expect(lifetime_usage_result.next_treshold_ratio).to be_nil
+  end
+
+  context 'with a usage_threshold' do
+    let(:usage_threshold) { create(:usage_threshold, plan:, amount_cents: 100) }
+
+    before { usage_threshold }
+
+    it 'computes the amounts' do
+      expect(lifetime_usage_result.last_threshold_amount_cents).to be_nil
+      expect(lifetime_usage_result.next_threshold_amount_cents).to eq(100)
+      expect(lifetime_usage_result.next_treshold_ratio).to be_zero
+    end
+
+    context 'with a lifetime_usage' do
+      let(:current_usage_amount_cents) { 23 }
+
+      it 'computes the amounts' do
+        expect(lifetime_usage_result.last_threshold_amount_cents).to be_nil
+        expect(lifetime_usage_result.next_threshold_amount_cents).to eq(100)
+        expect(lifetime_usage_result.next_treshold_ratio).to eq(0.23)
+      end
+    end
+  end
+
+  context 'with a past threshold' do
+    let(:usage_threshold1) { create(:usage_threshold, plan:, amount_cents: 100) }
+    let(:usage_threshold2) { create(:usage_threshold, plan:, amount_cents: 200) }
+
+    let(:applied_usage_threshold) { create(:applied_usage_threshold, usage_threshold: usage_threshold1, invoice:) }
+
+    let(:invoice) { create(:invoice, organization:, customer:) }
+    let(:invoice_subscription) { create(:invoice_subscription, invoice:, subscription:) }
+
+    let(:current_usage_amount_cents) { 120 }
+
+    before do
+      usage_threshold1
+      usage_threshold2
+
+      invoice_subscription
+      applied_usage_threshold
+    end
+
+    it 'computes the amounts' do
+      expect(lifetime_usage_result.last_threshold_amount_cents).to eq(100)
+      expect(lifetime_usage_result.next_threshold_amount_cents).to eq(200)
+      expect(lifetime_usage_result.next_treshold_ratio).to eq(0.2)
+    end
+
+    context 'when lifetime_usage is above last threshold' do
+      let(:applied_usage_threshold) { create(:applied_usage_threshold, usage_threshold: usage_threshold2, invoice:) }
+      let(:current_usage_amount_cents) { 223 }
+
+      it 'computes the amounts' do
+        expect(lifetime_usage_result.last_threshold_amount_cents).to eq(200)
+        expect(lifetime_usage_result.next_threshold_amount_cents).to be_nil
+        expect(lifetime_usage_result.next_treshold_ratio).to be_nil
+      end
+    end
+
+    context 'when next threshold is recurring' do
+      let(:usage_threshold2) { create(:usage_threshold, :recurring, plan:, amount_cents: 200) }
+
+      it 'computes the amounts' do
+        expect(lifetime_usage_result.last_threshold_amount_cents).to eq(100)
+        expect(lifetime_usage_result.next_threshold_amount_cents).to eq(300)
+        expect(lifetime_usage_result.next_treshold_ratio).to eq(0.1)
+      end
+
+      context 'when lifetime_usage is above next threshold' do
+        let(:applied_usage_threshold) { create(:applied_usage_threshold, usage_threshold: usage_threshold2, invoice:) }
+        let(:current_usage_amount_cents) { 723 }
+
+        it 'computes the amounts' do
+          expect(lifetime_usage_result.last_threshold_amount_cents).to eq(700)
+          expect(lifetime_usage_result.next_threshold_amount_cents).to eq(900)
+          expect(lifetime_usage_result.next_treshold_ratio).to eq(0.115) # (723 - 700) / 200
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

AI companies want their users to pay before the end of a period if usage skyrockets. The problem being that self-serve companies can overuse their API without paying, triggering lots of costs on their side.

## Description

This PR exposes a new `SubscriptionLifetimeUsage` GraphQL type attached to the `Subscription` type. 