### PR TITLE
feat(dunning): Add hasOverdueInvoices field to customer resolver

### DIFF
--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -73,6 +73,7 @@ module Types
         description: 'Number of available credits from credit notes per customer'
       field :has_active_wallet, Boolean, null: false, description: 'Define if a customer has an active wallet'
       field :has_credit_notes, Boolean, null: false, description: 'Define if a customer has any credit note'
+      field :has_overdue_invoices, Boolean, null: false, description: 'Define if a customer has overdue invoices'
 
       field :can_edit_attributes, Boolean, null: false, method: :editable? do
         description 'Check if customer attributes are editable'
@@ -96,6 +97,10 @@ module Types
 
       def has_credit_notes
         object.credit_notes.finalized.any?
+      end
+
+      def has_overdue_invoices
+        object.invoices.payment_overdue.any?
       end
 
       def active_subscriptions_count

--- a/schema.graphql
+++ b/schema.graphql
@@ -3082,6 +3082,11 @@ type Customer {
   Define if a customer has any credit note
   """
   hasCreditNotes: Boolean!
+
+  """
+  Define if a customer has overdue invoices
+  """
+  hasOverdueInvoices: Boolean!
   id: ID!
   invoiceGracePeriod: Int
   invoices: [Invoice!]

--- a/schema.json
+++ b/schema.json
@@ -12209,6 +12209,24 @@
               ]
             },
             {
+              "name": "hasOverdueInvoices",
+              "description": "Define if a customer has overdue invoices",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Types::Customers::Object do
   it { is_expected.to have_field(:credit_notes_credits_available_count).of_type('Int!') }
   it { is_expected.to have_field(:has_active_wallet).of_type('Boolean!') }
   it { is_expected.to have_field(:has_credit_notes).of_type('Boolean!') }
+  it { is_expected.to have_field(:has_overdue_invoices).of_type('Boolean!') }
 
   it { is_expected.to have_field(:can_edit_attributes).of_type('Boolean!') }
 end


### PR DESCRIPTION
## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

## Description

The goal of this change is to add the field `hasOverdueInvoices` to `Types::Customer::Object`.