### PR TITLE
feat(ProgressiveBilling) - Only refresh LifeTimeUsage for premium integrations with progressive_billing enabled

### DIFF
--- a/app/jobs/clock/refresh_lifetime_usages_job.rb
+++ b/app/jobs/clock/refresh_lifetime_usages_job.rb
@@ -10,7 +10,7 @@ module Clock
     def perform
       return unless License.premium?
 
-      LifetimeUsage.needs_recalculation.find_each do |ltu|
+      LifetimeUsage.joins(:organization).merge(Organization.with_progressive_billing_support).needs_recalculation.find_each do |ltu|
         LifetimeUsages::RecalculateAndCheckJob.perform_later(ltu)
       end
     end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -76,6 +76,10 @@ class Organization < ApplicationRecord
 
   after_create :generate_document_number_prefix
 
+  INTEGRATIONS.each do |premium_integration|
+    scope "with_#{premium_integration}_support", -> { where("? = ANY(premium_integrations)", premium_integration) }
+  end
+
   def logo_url
     return if logo.blank?
 

--- a/app/services/credits/progressive_billing_service.rb
+++ b/app/services/credits/progressive_billing_service.rb
@@ -9,7 +9,6 @@ module Credits
 
     def call
       result.credits = []
-      return result unless should_create_progressive_billing_credit?
 
       invoice.invoice_subscriptions.each do |invoice_subscription|
         subscription = invoice_subscription.subscription
@@ -54,15 +53,6 @@ module Credits
     private
 
     attr_reader :invoice
-
-    def should_create_progressive_billing_credit?
-      invoice.invoice_subscriptions.any? do |invoice_subscription|
-        invoice_subscription.subscription.invoices.progressive_billing
-          .finalized
-          .where(created_at: invoice_subscription.charges_from_datetime...invoice_subscription.charges_to_datetime)
-          .exists?
-      end
-    end
 
     def apply_credit_to_fees(credit)
       invoice.fees.charge.reload.each do |fee|

--- a/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
+++ b/spec/jobs/clock/refresh_lifetime_usages_job_spec.rb
@@ -6,9 +6,10 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
   subject { described_class }
 
   describe '.perform' do
-    let(:lifetime_usage1) { create(:lifetime_usage, recalculate_invoiced_usage: true) }
-    let(:lifetime_usage2) { create(:lifetime_usage, recalculate_current_usage: true) }
-    let(:lifetime_usage3) { create(:lifetime_usage, recalculate_invoiced_usage: false, recalculate_current_usage: false) }
+    let(:organization) { create(:organization) }
+    let(:lifetime_usage1) { create(:lifetime_usage, organization:, recalculate_invoiced_usage: true) }
+    let(:lifetime_usage2) { create(:lifetime_usage, organization:, recalculate_current_usage: true) }
+    let(:lifetime_usage3) { create(:lifetime_usage, organization:, recalculate_invoiced_usage: false, recalculate_current_usage: false) }
 
     before do
       lifetime_usage1
@@ -25,7 +26,21 @@ describe Clock::RefreshLifetimeUsagesJob, job: true do
       end
     end
 
-    context 'when premium' do
+    context 'when only premium' do
+      around { |test| lago_premium!(&test) }
+
+      it "does not enqueue any job" do
+        described_class.perform_now
+
+        expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage1)
+        expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage2)
+        expect(LifetimeUsages::RecalculateAndCheckJob).not_to have_been_enqueued.with(lifetime_usage3)
+      end
+    end
+
+    context 'when premium & with the premium_integration enabled' do
+      let(:organization) { create(:organization, premium_integrations: ['progressive_billing']) }
+
       around { |test| lago_premium!(&test) }
 
       it "enqueues a job for every usage that needs to be recalculated" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -142,4 +142,21 @@ RSpec.describe Organization, type: :model do
       expect(organization.api_key).to be_present
     end
   end
+
+  describe 'Premium integrations scopes' do
+    it "returns the organization if the premium integration is enabled" do
+      Organization::INTEGRATIONS.each do |integration|
+        expect(described_class.send("with_#{integration}_support")).to be_empty
+        organization.update!(premium_integrations: [integration])
+        expect(described_class.send("with_#{integration}_support")).to eq([organization])
+        organization.update!(premium_integrations: [])
+      end
+    end
+
+    it "does not return the organization for another premium integration" do
+      organization.update!(premium_integrations: ['progressive_billing'])
+      expect(described_class.with_dunning_support).to be_empty
+      expect(described_class.with_progressive_billing_support).to eq([organization])
+    end
+  end
 end


### PR DESCRIPTION
## Description

Instead of refreshing all LifetimeUsage objects, we'll only check those that belong to an organization that has `progressive_billing` enabled.