### PR TITLE
Fix(permissions): Allow Finance Role to View and Update Organization’s Tax ID

### DIFF
--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -45,8 +45,8 @@ organization:
     view: true
     update: true
   taxes:
-    view: false
-    update: false
+    view: true
+    update: true
   emails:
     view: false
     update: false

--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -45,8 +45,8 @@ organization:
     view: true
     update: true
   taxes:
-    view: true
-    update: true
+    view: false
+    update: false
   emails:
     view: false
     update: false

--- a/app/graphql/types/organizations/current_organization_type.rb
+++ b/app/graphql/types/organizations/current_organization_type.rb
@@ -15,7 +15,7 @@ module Types
 
       field :legal_name, String
       field :legal_number, String
-      field :tax_identification_number, String, permission: 'organization:taxes:view'
+      field :tax_identification_number, String
 
       field :address_line1, String
       field :address_line2, String

--- a/app/graphql/types/organizations/update_organization_input.rb
+++ b/app/graphql/types/organizations/update_organization_input.rb
@@ -10,7 +10,7 @@ module Types
       argument :legal_name, String, required: false
       argument :legal_number, String, required: false
       argument :logo, String, required: false
-      argument :tax_identification_number, String, required: false, permission: 'organization:taxes:view'
+      argument :tax_identification_number, String, required: false
 
       argument :address_line1, String, required: false
       argument :address_line2, String, required: false

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
 
       aggregate_failures do
         expect(result_data['email']).to eq 'foo@bar2.com'
-        expect(result_data['taxIdentificationNumber']).to be_nil
+        expect(result_data['taxIdentificationNumber']).to eq 'tax007'
         expect(result_data['emailSettings']).to be_nil
       end
     end

--- a/spec/graphql/types/organizations/current_organization_type_spec.rb
+++ b/spec/graphql/types/organizations/current_organization_type_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Types::Organizations::CurrentOrganizationType do
   it { is_expected.to have_field(:legal_number).of_type('String') }
   it { is_expected.to have_field(:logo_url).of_type('String') }
   it { is_expected.to have_field(:name).of_type('String!') }
-  it { is_expected.to have_field(:tax_identification_number).of_type('String').with_permission('organization:taxes:view') }
+  it { is_expected.to have_field(:tax_identification_number).of_type('String') }
 
   it { is_expected.to have_field(:address_line1).of_type('String') }
   it { is_expected.to have_field(:address_line2).of_type('String') }

--- a/spec/graphql/types/organizations/update_organization_input_spec.rb
+++ b/spec/graphql/types/organizations/update_organization_input_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Types::Organizations::UpdateOrganizationInput do
   it { is_expected.to accept_argument(:legal_name).of_type('String') }
   it { is_expected.to accept_argument(:legal_number).of_type('String') }
   it { is_expected.to accept_argument(:logo).of_type('String') }
-  it { is_expected.to accept_argument(:tax_identification_number).of_type('String').with_permission('organization:taxes:view') }
+  it { is_expected.to accept_argument(:tax_identification_number).of_type('String') }
 
   it { is_expected.to accept_argument(:address_line1).of_type('String') }
   it { is_expected.to accept_argument(:address_line2).of_type('String') }


### PR DESCRIPTION
## Context

This PR addresses an issue where users with the “Finance” role were unable to view or update the organization.tax_identification_number despite the role having permissions to manage organization information according to the roles and permissions documentation.