### PR TITLE
Feat(invoice): Add finalize zero invoice to GraphQL

### DIFF
--- a/app/graphql/types/customers/create_customer_input.rb
+++ b/app/graphql/types/customers/create_customer_input.rb
@@ -41,6 +41,7 @@ module Types
       argument :integration_customers, [Types::IntegrationCustomers::Input], required: false
 
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false
+      argument :finalize_zero_amount_invoice, String, required: false
     end
   end
 end

--- a/app/graphql/types/customers/create_customer_input.rb
+++ b/app/graphql/types/customers/create_customer_input.rb
@@ -41,7 +41,7 @@ module Types
       argument :integration_customers, [Types::IntegrationCustomers::Input], required: false
 
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false
-      argument :finalize_zero_amount_invoice, String, required: false
+      argument :finalize_zero_amount_invoice, Types::Customers::FinalizeZeroAmountInvoiceEnum, required: false
     end
   end
 end

--- a/app/graphql/types/customers/finalize_zero_amount_invoice_enum.rb
+++ b/app/graphql/types/customers/finalize_zero_amount_invoice_enum.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Types
+  module Customers
+    class FinalizeZeroAmountInvoiceEnum < BaseEnum
+      Customer::FINALIZE_ZERO_AMOUNT_INVOICE_OPTIONS.each do |type|
+        value type
+      end
+    end
+  end
+end

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -83,7 +83,7 @@ module Types
         description 'Check if customer attributes are editable'
       end
 
-      field :finalize_zero_amount_invoice, String, null: true, description: 'Options for handling invoices with a zero total amount.'
+      field :finalize_zero_amount_invoice, Types::Customers::FinalizeZeroAmountInvoiceEnum, null: true, description: 'Options for handling invoices with a zero total amount.'
 
       def invoices
         object.invoices.visible.order(created_at: :desc)

--- a/app/graphql/types/customers/object.rb
+++ b/app/graphql/types/customers/object.rb
@@ -83,6 +83,8 @@ module Types
         description 'Check if customer attributes are editable'
       end
 
+      field :finalize_zero_amount_invoice, String, null: true, description: 'Options for handling invoices with a zero total amount.'
+
       def invoices
         object.invoices.visible.order(created_at: :desc)
       end

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -45,7 +45,7 @@ module Types
       argument :tax_codes, [String], required: false, permissions: %w[customer_settings:update:tax_rates customers:update]
 
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false
-      argument :finalize_zero_amount_invoice, String, required: false
+      argument :finalize_zero_amount_invoice, Types::Customers::FinalizeZeroAmountInvoiceEnum, required: false
     end
   end
 end

--- a/app/graphql/types/customers/update_customer_input.rb
+++ b/app/graphql/types/customers/update_customer_input.rb
@@ -45,6 +45,7 @@ module Types
       argument :tax_codes, [String], required: false, permissions: %w[customer_settings:update:tax_rates customers:update]
 
       argument :billing_configuration, Types::Customers::BillingConfigurationInput, required: false
+      argument :finalize_zero_amount_invoice, String, required: false
     end
   end
 end

--- a/app/graphql/types/invoices/status_type_enum.rb
+++ b/app/graphql/types/invoices/status_type_enum.rb
@@ -5,7 +5,7 @@ module Types
     class StatusTypeEnum < Types::BaseEnum
       graphql_name 'InvoiceStatusTypeEnum'
 
-      Invoice::VISIBLE_STATUS.keys.each do |type|
+      Invoice::STATUS.keys.each do |type|
         value type
       end
     end

--- a/app/graphql/types/organizations/current_organization_type.rb
+++ b/app/graphql/types/organizations/current_organization_type.rb
@@ -42,6 +42,7 @@ module Types
 
       field :billing_configuration, Types::Organizations::BillingConfiguration, permission: 'organization:invoices:view'
       field :email_settings, [Types::Organizations::EmailSettingsEnum], permission: 'organization:emails:view'
+      field :finalize_zero_amount_invoice, Boolean, null: false
       field :taxes, [Types::Taxes::Object], resolver: Resolvers::TaxesResolver, permission: 'organization:taxes:view'
 
       field :adyen_payment_providers, [Types::PaymentProviders::Adyen], permission: 'organization:integrations:view'

--- a/app/graphql/types/organizations/update_organization_input.rb
+++ b/app/graphql/types/organizations/update_organization_input.rb
@@ -31,6 +31,7 @@ module Types
 
       argument :billing_configuration, Types::Organizations::BillingConfigurationInput, required: false, permission: 'organization:invoices:view'
       argument :email_settings, [Types::Organizations::EmailSettingsEnum], required: false, permission: 'organization:emails:view'
+      argument :finalize_zero_amount_invoice, Boolean, required: false
     end
   end
 end

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -52,6 +52,10 @@ module Customers
         customer.lastname = args[:lastname] if args.key?(:lastname)
         customer.customer_type = args[:customer_type] if args.key?(:customer_type)
 
+        if args.key?(:finalize_zero_amount_invoice)
+          customer.finalize_zero_amount_invoice = args[:finalize_zero_amount_invoice]
+        end
+
         assign_premium_attributes(customer, args)
 
         customer.payment_provider = args[:payment_provider] if args.key?(:payment_provider)

--- a/app/services/invoices/advance_charges_service.rb
+++ b/app/services/invoices/advance_charges_service.rb
@@ -20,11 +20,9 @@ module Invoices
 
       invoice = create_group_invoice
 
-      if invoice
+      unless invoice&.closed?
         SendWebhookJob.perform_later('invoice.created', invoice)
-
         Invoices::GeneratePdfAndNotifyJob.perform_later(invoice:, email: false)
-
         Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
         Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
         Utils::SegmentTrack.invoice_created(invoice)

--- a/app/services/invoices/create_pay_in_advance_charge_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_service.rb
@@ -47,13 +47,14 @@ module Invoices
         invoice.save!
       end
 
-      Utils::SegmentTrack.invoice_created(invoice)
-
-      deliver_webhooks
-      GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
-      Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-      Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
-      Invoices::Payments::CreateService.new(invoice).call
+      unless invoice.closed?
+        Utils::SegmentTrack.invoice_created(invoice)
+        deliver_webhooks
+        GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_email?)
+        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+        Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
+        Invoices::Payments::CreateService.new(invoice).call
+      end
 
       result
     rescue ActiveRecord::RecordInvalid => e

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -66,7 +66,7 @@ module Invoices
       if grace_period?
         SendWebhookJob.perform_later('invoice.drafted', invoice)
       else
-        unless invoice.closed # we dont need to send the webhooks if the invoice was closed ( skip 0 invoice setting )
+        unless invoice.closed? # we dont need to send the webhooks if the invoice was closed ( skip 0 invoice setting )
           SendWebhookJob.perform_later('invoice.created', invoice)
           GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_finalized_email?)
           Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?

--- a/app/services/invoices/subscription_service.rb
+++ b/app/services/invoices/subscription_service.rb
@@ -66,12 +66,14 @@ module Invoices
       if grace_period?
         SendWebhookJob.perform_later('invoice.drafted', invoice)
       else
-        SendWebhookJob.perform_later('invoice.created', invoice)
-        GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_finalized_email?)
-        Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
-        Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
-        Invoices::Payments::CreateService.new(invoice).call
-        Utils::SegmentTrack.invoice_created(invoice)
+        unless invoice.closed # we dont need to send the webhooks if the invoice was closed ( skip 0 invoice setting )
+          SendWebhookJob.perform_later('invoice.created', invoice)
+          GeneratePdfAndNotifyJob.perform_later(invoice:, email: should_deliver_finalized_email?)
+          Integrations::Aggregator::Invoices::CreateJob.perform_later(invoice:) if invoice.should_sync_invoice?
+          Integrations::Aggregator::SalesOrders::CreateJob.perform_later(invoice:) if invoice.should_sync_sales_order?
+          Invoices::Payments::CreateService.new(invoice).call
+          Utils::SegmentTrack.invoice_created(invoice)
+        end
       end
 
       result

--- a/schema.graphql
+++ b/schema.graphql
@@ -4166,9 +4166,12 @@ enum InvoicePaymentStatusTypeEnum {
 }
 
 enum InvoiceStatusTypeEnum {
+  closed
   draft
   failed
   finalized
+  generating
+  open
   voided
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -1908,6 +1908,7 @@ input CreateCustomerInput {
   email: String
   externalId: String!
   externalSalesforceId: String
+  finalizeZeroAmountInvoice: FinalizeZeroAmountInvoiceEnum
   firstname: String
   integrationCustomers: [IntegrationCustomerInput!]
   invoiceGracePeriod: Int
@@ -3013,6 +3014,7 @@ type CurrentOrganization {
   email: String
   emailSettings: [EmailSettingsEnum!]
   euTaxManagement: Boolean!
+  finalizeZeroAmountInvoice: Boolean!
   gocardlessPaymentProviders: [GocardlessProvider!]
   id: ID!
   legalName: String
@@ -3078,6 +3080,11 @@ type Customer {
   email: String
   externalId: String!
   externalSalesforceId: String
+
+  """
+  Options for handling invoices with a zero total amount.
+  """
+  finalizeZeroAmountInvoice: FinalizeZeroAmountInvoiceEnum
   firstname: String
 
   """
@@ -3780,6 +3787,12 @@ input FinalizeInvoiceInput {
   """
   clientMutationId: String
   id: ID!
+}
+
+enum FinalizeZeroAmountInvoiceEnum {
+  finalize
+  inherit
+  skip
 }
 
 type FinalizedInvoiceCollection {
@@ -7440,6 +7453,7 @@ input UpdateCustomerInput {
   email: String
   externalId: String!
   externalSalesforceId: String
+  finalizeZeroAmountInvoice: FinalizeZeroAmountInvoiceEnum
   firstname: String
   id: ID!
   integrationCustomers: [IntegrationCustomerInput!]
@@ -7636,6 +7650,7 @@ input UpdateOrganizationInput {
   email: String
   emailSettings: [EmailSettingsEnum!]
   euTaxManagement: Boolean
+  finalizeZeroAmountInvoice: Boolean
   legalName: String
   legalNumber: String
   logo: String

--- a/schema.json
+++ b/schema.json
@@ -7392,6 +7392,18 @@
               "deprecationReason": null
             },
             {
+              "name": "finalizeZeroAmountInvoice",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "FinalizeZeroAmountInvoiceEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {
@@ -11478,6 +11490,24 @@
               ]
             },
             {
+              "name": "finalizeZeroAmountInvoice",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "gocardlessPaymentProviders",
               "description": null,
               "type": {
@@ -12242,6 +12272,20 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "finalizeZeroAmountInvoice",
+              "description": "Options for handling invoices with a zero total amount.",
+              "type": {
+                "kind": "ENUM",
+                "name": "FinalizeZeroAmountInvoiceEnum",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -16850,6 +16894,35 @@
             }
           ],
           "enumValues": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "FinalizeZeroAmountInvoiceEnum",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": null,
+          "enumValues": [
+            {
+              "name": "inherit",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "skip",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "finalize",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ]
         },
         {
           "kind": "OBJECT",
@@ -35671,6 +35744,18 @@
               "deprecationReason": null
             },
             {
+              "name": "finalizeZeroAmountInvoice",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "FinalizeZeroAmountInvoiceEnum",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {
@@ -36822,6 +36907,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "finalizeZeroAmountInvoice",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/schema.json
+++ b/schema.json
@@ -20102,6 +20102,24 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "generating",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "open",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "closed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ]
         },

--- a/spec/graphql/mutations/customers/create_spec.rb
+++ b/spec/graphql/mutations/customers/create_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           netPaymentTerm
           canEditAttributes
           invoiceGracePeriod
+          finalizeZeroAmountInvoice
           billingConfiguration { documentLocale }
           shippingAddress { addressLine1 city state }
           metadata { id, key, value, displayInInvoice }
@@ -76,6 +77,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
           taxIdentificationNumber: '123456789',
           currency: 'EUR',
           netPaymentTerm: 30,
+          finalizeZeroAmountInvoice: 'skip',
           providerCustomer: {
             providerCustomerId: 'cu_12345',
             providerPaymentMethods: ['card']
@@ -124,6 +126,7 @@ RSpec.describe Mutations::Customers::Create, type: :graphql do
       expect(result_data['shippingAddress']['city']).to eq('Paris')
       expect(result_data['shippingAddress']['state']).to eq('test state')
       expect(result_data['netPaymentTerm']).to eq(30)
+      expect(result_data['finalizeZeroAmountInvoice']).to eq('skip')
       expect(result_data['metadata'].count).to eq(1)
       expect(result_data['metadata'][0]['value']).to eq('John Doe')
       expect(result_data['taxes'][0]['code']).to eq(tax.code)

--- a/spec/graphql/mutations/customers/update_spec.rb
+++ b/spec/graphql/mutations/customers/update_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
           netPaymentTerm
           canEditAttributes
           invoiceGracePeriod
+          finalizeZeroAmountInvoice
           providerCustomer { id, providerCustomerId, providerPaymentMethods }
           billingConfiguration { id, documentLocale }
           metadata { id, key, value, displayInInvoice }
@@ -57,6 +58,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       paymentProvider: 'stripe',
       currency: 'USD',
       netPaymentTerm: 3,
+      finalizeZeroAmountInvoice: 'skip',
       providerCustomer: {
         providerCustomerId: 'cu_12345',
         providerPaymentMethods: %w[card sepa_debit]
@@ -119,6 +121,7 @@ RSpec.describe Mutations::Customers::Update, type: :graphql do
       expect(result_data['timezone']).to be_nil
       expect(result_data['netPaymentTerm']).to eq(3)
       expect(result_data['invoiceGracePeriod']).to be_nil
+      expect(result_data['finalizeZeroAmountInvoice']).to eq('skip')
       expect(result_data['providerCustomer']['id']).to be_present
       expect(result_data['providerCustomer']['providerCustomerId']).to eq('cu_12345')
       expect(result_data['providerCustomer']['providerPaymentMethods']).to eq(%w[card sepa_debit])

--- a/spec/graphql/mutations/organizations/update_spec.rb
+++ b/spec/graphql/mutations/organizations/update_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           euTaxManagement,
           documentNumbering
           documentNumberPrefix
+          finalizeZeroAmountInvoice
           billingConfiguration {
             invoiceFooter,
             invoiceGracePeriod,
@@ -62,6 +63,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
           euTaxManagement: true,
           webhookUrl: 'https://app.test.dev',
           documentNumberPrefix: 'ORG-2',
+          finalizeZeroAmountInvoice: false,
           billingConfiguration: {
             invoiceFooter: 'invoice footer',
             documentLocale: 'fr'
@@ -93,6 +95,7 @@ RSpec.describe Mutations::Organizations::Update, type: :graphql do
       expect(result_data['billingConfiguration']['documentLocale']).to eq('fr')
       expect(result_data['euTaxManagement']).to be_truthy
       expect(result_data['timezone']).to eq('TZ_UTC')
+      expect(result_data['finalizeZeroAmountInvoice']).to be false
     end
   end
 

--- a/spec/graphql/types/customers/create_customer_input_spec.rb
+++ b/spec/graphql/types/customers/create_customer_input_spec.rb
@@ -36,4 +36,5 @@ RSpec.describe Types::Customers::CreateCustomerInput do
   it { is_expected.to accept_argument(:provider_customer).of_type('ProviderCustomerInput') }
   it { is_expected.to accept_argument(:integration_customers).of_type('[IntegrationCustomerInput!]') }
   it { is_expected.to accept_argument(:billing_configuration).of_type('CustomerBillingConfigurationInput') }
+  it { is_expected.to accept_argument(:finalize_zero_amount_invoice).of_type('FinalizeZeroAmountInvoiceEnum') }
 end

--- a/spec/graphql/types/customers/object_spec.rb
+++ b/spec/graphql/types/customers/object_spec.rb
@@ -71,4 +71,5 @@ RSpec.describe Types::Customers::Object do
   it { is_expected.to have_field(:has_overdue_invoices).of_type('Boolean!') }
 
   it { is_expected.to have_field(:can_edit_attributes).of_type('Boolean!') }
+  it { is_expected.to have_field(:finalize_zero_amount_invoice).of_type('FinalizeZeroAmountInvoiceEnum') }
 end

--- a/spec/graphql/types/organizations/current_organization_type_spec.rb
+++ b/spec/graphql/types/organizations/current_organization_type_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe Types::Organizations::CurrentOrganizationType do
   it { is_expected.to have_field(:created_at).of_type('ISO8601DateTime!') }
   it { is_expected.to have_field(:updated_at).of_type('ISO8601DateTime!') }
 
+  it { is_expected.to have_field(:finalize_zero_amount_invoice).of_type('Boolean!') }
   it { is_expected.to have_field(:billing_configuration).of_type('OrganizationBillingConfiguration').with_permission('organization:invoices:view') }
   it { is_expected.to have_field(:email_settings).of_type('[EmailSettingsEnum!]').with_permission('organization:emails:view') }
   it { is_expected.to have_field(:taxes).of_type('[Tax!]').with_permission('organization:taxes:view') }

--- a/spec/graphql/types/organizations/update_organization_input_spec.rb
+++ b/spec/graphql/types/organizations/update_organization_input_spec.rb
@@ -29,4 +29,5 @@ RSpec.describe Types::Organizations::UpdateOrganizationInput do
 
   it { is_expected.to accept_argument(:billing_configuration).of_type('OrganizationBillingConfigurationInput').with_permission('organization:invoices:view') }
   it { is_expected.to accept_argument(:email_settings).of_type('[EmailSettingsEnum!]').with_permission('organization:emails:view') }
+  it { is_expected.to accept_argument(:finalize_zero_amount_invoice).of_type('Boolean') }
 end


### PR DESCRIPTION
## Context

This PR introduces a new field, finalize_zero_amount_invoice, to the Customer-related GraphQL types and input objects, as well as to the organization settings. This field is an enum type that provides options for handling invoices with a zero total amount. The enhancement allows users to specify how zero-amount invoices should be managed at both the organization and customer levels

its to enable what we did on this pr but on the frontend https://github.com/getlago/lago-api/pull/2462