### PR TITLE
feat(dunning): Include payment link to payment request email when available

### DIFF
--- a/app/mailers/payment_request_mailer.rb
+++ b/app/mailers/payment_request_mailer.rb
@@ -8,6 +8,7 @@ class PaymentRequestMailer < ApplicationMailer
     @organization = @payment_request.organization
     @customer = @payment_request.customer
     @invoices = @payment_request.invoices
+    @payment_url = ::PaymentRequests::Payments::GeneratePaymentUrlService.call(payable: @payment_request).payment_url
 
     I18n.with_locale(@customer.preferred_document_locale) do
       mail(

--- a/app/views/payment_request_mailer/requested.slim
+++ b/app/views/payment_request_mailer/requested.slim
@@ -1,41 +1,41 @@
-div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
-  = I18n.t('email.payment_request.requested.hello', customer_name: @customer.name)
-div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
-  = I18n.t('email.payment_request.requested.reminder_overdue_balance', organization_name: @organization.name)
-div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
-  = I18n.t('email.payment_request.requested.total_amount_due', amount: MoneyHelper.format(@payment_request.amount))
-div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
+div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
+  = I18n.t("email.payment_request.requested.hello", customer_name: @customer.name)
+div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
+  = I18n.t("email.payment_request.requested.reminder_overdue_balance", organization_name: @organization.name)
+div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
+  = I18n.t("email.payment_request.requested.total_amount_due", amount: MoneyHelper.format(@payment_request.amount))
+div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
   - if @customer.applicable_net_payment_term > 0
-    = I18n.t('email.payment_request.requested.payment_terms', count: @customer.applicable_net_payment_term)
+    = I18n.t("email.payment_request.requested.payment_terms", count: @customer.applicable_net_payment_term)
   - else
-    = I18n.t('email.payment_request.requested.upon_invoice_generation')
-div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
-  = I18n.t('email.payment_request.requested.already_paid')
-div style='margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;'
-  = I18n.t('email.payment_request.requested.thank_you')
+    = I18n.t("email.payment_request.requested.upon_invoice_generation")
+div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
+  = I18n.t("email.payment_request.requested.already_paid")
+div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
+  = I18n.t("email.payment_request.requested.thank_you")
 
-div style='padding-top: 32px;font-style: normal;font-weight: 400;font-size: 14px;line-height: 20px;color: #66758F;border-top: 1px solid #d9dee7;'
-  = I18n.t('email.payment_request.requested.remaining_amount')
-div style='margin-bottom: 16px;font-style: normal;font-weight: 700;font-size: 32px;line-height: 40px;color: #19212E;'
+div style="padding-top: 32px;font-style: normal;font-weight: 400;font-size: 14px;line-height: 20px;color: #66758F;border-top: 1px solid #d9dee7;"
+  = I18n.t("email.payment_request.requested.remaining_amount")
+div style="margin-bottom: 16px;font-style: normal;font-weight: 700;font-size: 32px;line-height: 40px;color: #19212E;"
   = MoneyHelper.format(@payment_request.amount)
 
 /! TODO: Do not display the button unless payment url is present
-table style='margin-bottom: 32px' width="100%" cellspacing="0" cellpadding="0"
-  tr
-    td
-      table cellspacing="0" cellpadding="0"
-        tr
-          td style="border-radius: 12px;" bgcolor="#006CFA"
-            a href="#" style="padding: 10px 16px;font-size: 16px; color: #ffffff;text-decoration: none;font-weight:bold;display: inline-block;font-weight: 400;font-style: normal;line-height: 24px;"
-              = I18n.t('email.payment_request.requested.pay_amount')
+- if @payment_url
+  table style="margin-bottom: 32px" width="100%" cellspacing="0" cellpadding="0"
+    tr
+      td
+        table cellspacing="0" cellpadding="0"
+          tr
+            td style="border-radius: 12px;" bgcolor="#006CFA"
+              = link_to I18n.t("email.payment_request.requested.pay_amount"), @payment_url, id: "payment_link", style: "padding: 10px 16px;font-size: 16px; color: #ffffff;text-decoration: none;font-weight:bold;display: inline-block;font-weight: 400;font-style: normal;line-height: 24px;"
 
 table style="width: 100%; border-collapse: collapse;"
   tr
   tr style="border-bottom: 1px solid #d9dee7;"
     td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: left; color: #66758F; white-space: nowrap; padding: 16px 0;"
-      = I18n.t('email.credit_note.created.invoice_number')
+      = I18n.t("email.credit_note.created.invoice_number")
     td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: right; color: #66758F; white-space: nowrap; padding: 16px 0;"
-      = I18n.t('invoice.amount')
+      = I18n.t("invoice.amount")
   - @invoices.each do |invoice|
     tr style="border-bottom: 1px solid #d9dee7;"
       td style="font-size: 14px; font-weight: 400; line-height: 20px; letter-spacing: 0em; text-align: left; padding-right: 16px; white-space: nowrap; padding: 16px 0;"

--- a/spec/mailers/payment_request_mailer_spec.rb
+++ b/spec/mailers/payment_request_mailer_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe PaymentRequestMailer, type: :mailer do
   end
 
   describe "#requested" do
+    let(:payment_url) { Faker::Internet.url }
+    let(:payment_url_result) do
+      BaseService::Result.new.tap do |result|
+        result.payment_url = payment_url
+      end
+    end
+
+    before do
+      allow(::PaymentRequests::Payments::GeneratePaymentUrlService)
+        .to receive(:call)
+        .and_return(payment_url_result)
+    end
+
     specify do
       mailer = payment_request_mailer.with(payment_request:).requested
 
@@ -30,6 +43,33 @@ RSpec.describe PaymentRequestMailer, type: :mailer do
       expect(mailer.reply_to).to eq([payment_request.organization.email])
       expect(mailer.body.encoded).to include(first_invoice.number)
       expect(mailer.body.encoded).to include(second_invoice.number)
+    end
+
+    it "calls the generate payment url service" do
+      mailer = payment_request_mailer.with(payment_request:).requested
+      parsed_body = Nokogiri::HTML(mailer.body.encoded)
+
+      expect(parsed_body.at_css("a#payment_link")["href"]).to eq(payment_url)
+      expect(mailer.body.encoded).to include("Pay balance")
+      expect(PaymentRequests::Payments::GeneratePaymentUrlService)
+        .to have_received(:call)
+        .with(payable: payment_request)
+    end
+
+    context "when no payment url is available" do
+      let(:payment_url_result) do
+        BaseService::Result.new.tap do |result|
+          result.single_validation_failure!(error_code: "invalid_payment_provider")
+        end
+      end
+
+      it "does not include the payment link" do
+        mailer = payment_request_mailer.with(payment_request:).requested
+        parsed_body = Nokogiri::HTML(mailer.body.encoded)
+
+        expect(parsed_body.css("a#payment_link")).not_to be_present
+        expect(mailer.body.encoded).not_to include("Pay balance")
+      end
     end
   end
 end


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

 ## Description

The goal of this change is to include the payment link within the payment request requested email to customers when the PSP is Stripe or Adyen and the link is available