### PR TITLE
misc: prevent applying taxes for current usage where it is not necessary

### DIFF
--- a/app/graphql/resolvers/customers/usage_resolver.rb
+++ b/app/graphql/resolvers/customers/usage_resolver.rb
@@ -15,7 +15,12 @@ module Resolvers
       type Types::Customers::Usage::Current, null: false
 
       def resolve(customer_id:, subscription_id:)
-        result = Invoices::CustomerUsageService.with_ids(context[:current_user], customer_id:, subscription_id:).call
+        result = Invoices::CustomerUsageService.with_ids(
+          context[:current_user],
+          customer_id:,
+          subscription_id:,
+          apply_taxes: false
+        ).call
 
         result.success? ? result.usage : result_error(result)
       end

--- a/app/services/lifetime_usages/calculate_service.rb
+++ b/app/services/lifetime_usages/calculate_service.rb
@@ -52,7 +52,8 @@ module LifetimeUsages
       result = Invoices::CustomerUsageService.call(
         nil, # current_user
         customer: subscription.customer,
-        subscription: subscription
+        subscription: subscription,
+        apply_taxes: false
       )
       result.usage.amount_cents
     end

--- a/spec/graphql/resolvers/customers/usage_resolver_spec.rb
+++ b/spec/graphql/resolvers/customers/usage_resolver_spec.rb
@@ -145,8 +145,8 @@ RSpec.describe Resolvers::Customers::UsageResolver, type: :graphql do
       expect(usage_response['currency']).to eq('EUR')
       expect(usage_response['issuingDate']).to eq(Time.zone.today.end_of_month.iso8601)
       expect(usage_response['amountCents']).to eq('405')
-      expect(usage_response['totalAmountCents']).to eq('486')
-      expect(usage_response['taxesAmountCents']).to eq('81')
+      expect(usage_response['totalAmountCents']).to eq('405')
+      expect(usage_response['taxesAmountCents']).to eq('0')
 
       charge_usage = usage_response['chargesUsage'].first
       expect(charge_usage['billableMetric']['name']).to eq(metric.name)


### PR DESCRIPTION
## Context

In current usage, taxes are relevant only in API context and in Ongoing Wallet Balance Job. In other cases, tax computation should be skipped.