### PR TITLE
feat(dunning): Drop lago_invoice_ids from PSPs metadata payloads

### DIFF
--- a/app/services/payment_providers/adyen_service.rb
+++ b/app/services/payment_providers/adyen_service.rb
@@ -143,7 +143,6 @@ module PaymentProviders
       metadata = {
         payment_type:,
         lago_invoice_id: event.dig('additionalData', 'metadata.lago_invoice_id'),
-        lago_invoice_ids: event.dig('additionalData', 'metadata.lago_invoice_ids'),
         lago_payment_request_id: event.dig('additionalData', 'metadata.lago_payment_request_id'),
         lago_payable_type: event.dig('additionalData', 'metadata.lago_payable_type')
       }

--- a/app/services/payment_requests/payments/adyen_service.rb
+++ b/app/services/payment_requests/payments/adyen_service.rb
@@ -190,7 +190,6 @@ module PaymentRequests
           metadata: {
             lago_customer_id: customer.id,
             lago_payment_request_id: payable.id,
-            lago_invoice_ids: payable.invoice_ids,
             payment_type: "one-time"
           }
         }

--- a/app/services/payment_requests/payments/gocardless_service.rb
+++ b/app/services/payment_requests/payments/gocardless_service.rb
@@ -141,8 +141,7 @@ module PaymentRequests
             retry_if_possible: false,
             metadata: {
               lago_customer_id: customer.id,
-              lago_payment_request_id: payable.id,
-              lago_invoice_ids: payable.invoice_ids
+              lago_payment_request_id: payable.id
             },
             links: {
               mandate: mandate_id

--- a/app/services/payment_requests/payments/stripe_service.rb
+++ b/app/services/payment_requests/payments/stripe_service.rb
@@ -204,8 +204,7 @@ module PaymentRequests
           description:,
           metadata: {
             lago_customer_id: customer.id,
-            lago_payment_request_id: payable.id,
-            lago_invoice_ids: payable.invoice_ids
+            lago_payment_request_id: payable.id
           }
         }
       end
@@ -271,7 +270,6 @@ module PaymentRequests
             metadata: {
               lago_customer_id: customer.id,
               lago_payment_request_id: payable.id,
-              lago_invoice_ids: payable.invoice_ids,
               payment_type: "one-time"
             }
           }

--- a/spec/fixtures/adyen/webhook_authorisation_payment_response_invalid_payable.json
+++ b/spec/fixtures/adyen/webhook_authorisation_payment_response_invalid_payable.json
@@ -14,7 +14,6 @@
           "threeds2.cardEnrolled": "false",
           "recurringProcessingModel": "CardOnFile",
           "metadata.lago_payment_request_id": "ec82efeb-88bb-44f8-ba30-0d55b3fd583a",
-          "metadata.lago_invoice_ids": ["invoice_id_1", "invoice_id_2"],
           "metadata.lago_payable_type": "InvalidPayableTypeName"
         },
         "amount": {

--- a/spec/fixtures/adyen/webhook_authorisation_payment_response_payment_request.json
+++ b/spec/fixtures/adyen/webhook_authorisation_payment_response_payment_request.json
@@ -14,7 +14,6 @@
           "threeds2.cardEnrolled": "false",
           "recurringProcessingModel": "CardOnFile",
           "metadata.lago_payment_request_id": "ec82efeb-88bb-44f8-ba30-0d55b3fd583a",
-          "metadata.lago_invoice_ids": ["invoice_id_1", "invoice_id_2"],
           "metadata.lago_payable_type": "PaymentRequest"
         },
         "amount": {

--- a/spec/fixtures/stripe/charge_event_invalid_payable_type.json
+++ b/spec/fixtures/stripe/charge_event_invalid_payable_type.json
@@ -45,7 +45,6 @@
       "livemode": false,
       "metadata": {
         "lago_payment_request_id": "a587e552-36bc-4334-81f2-abcbf034ad3f",
-        "lago_invoice_ids": ["invoice_id_1", "invoice_id_2"],
         "lago_payable_type": "InvalidPayableTypeName"
       },
       "on_behalf_of": null,

--- a/spec/fixtures/stripe/charge_event_payment_request.json
+++ b/spec/fixtures/stripe/charge_event_payment_request.json
@@ -45,7 +45,6 @@
       "livemode": false,
       "metadata": {
         "lago_payment_request_id": "a587e552-36bc-4334-81f2-abcbf034ad3f",
-        "lago_invoice_ids": ["invoice_id_1", "invoice_id_2"],
         "lago_payable_type": "PaymentRequest"
       },
       "on_behalf_of": null,

--- a/spec/fixtures/stripe/payment_intent_event_invalid_payable_type.json
+++ b/spec/fixtures/stripe/payment_intent_event_invalid_payable_type.json
@@ -36,7 +36,6 @@
       "livemode": false,
       "metadata": {
         "lago_payment_request_id": "a587e552-36bc-4334-81f2-abcbf034ad3f",
-        "lago_invoice_ids": ["invoice_id_1", "invoice_id_2"],
         "lago_payable_type": "InvalidPayableTypeName"
       },
       "next_action": null,

--- a/spec/fixtures/stripe/payment_intent_event_payment_request.json
+++ b/spec/fixtures/stripe/payment_intent_event_payment_request.json
@@ -36,7 +36,6 @@
       "livemode": false,
       "metadata": {
         "lago_payment_request_id": "a587e552-36bc-4334-81f2-abcbf034ad3f",
-        "lago_invoice_ids": ["invoice_id_1", "invoice_id_2"],
         "lago_payable_type": "PaymentRequest"
       },
       "next_action": null,

--- a/spec/services/payment_providers/stripe_service_spec.rb
+++ b/spec/services/payment_providers/stripe_service_spec.rb
@@ -262,7 +262,6 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
             provider_payment_id: "pi_1JKS2Y2VYugoKSBzNHPFBNj9",
             status: "succeeded",
             metadata: {
-              lago_invoice_ids: %w[invoice_id_1 invoice_id_2],
               lago_payment_request_id: "a587e552-36bc-4334-81f2-abcbf034ad3f",
               lago_payable_type: "PaymentRequest"
             }
@@ -338,7 +337,6 @@ RSpec.describe PaymentProviders::StripeService, type: :service do
             provider_payment_id: 'pi_123456',
             status: "succeeded",
             metadata: {
-              lago_invoice_ids: %w[invoice_id_1 invoice_id_2],
               lago_payment_request_id: "a587e552-36bc-4334-81f2-abcbf034ad3f",
               lago_payable_type: "PaymentRequest"
             }

--- a/spec/services/payment_requests/payments/adyen_service_spec.rb
+++ b/spec/services/payment_requests/payments/adyen_service_spec.rb
@@ -314,7 +314,6 @@ RSpec.describe PaymentRequests::Payments::AdyenService, type: :service do
               merchantAccount: adyen_payment_provider.merchant_account,
               metadata: {
                 lago_customer_id: customer.id,
-                lago_invoice_ids: [invoice_1.id, invoice_2.id],
                 lago_payment_request_id: payment_request.id,
                 payment_type: "one-time"
               },

--- a/spec/services/payment_requests/payments/gocardless_service_spec.rb
+++ b/spec/services/payment_requests/payments/gocardless_service_spec.rb
@@ -103,7 +103,6 @@ RSpec.describe PaymentRequests::Payments::GocardlessService, type: :service do
             links: {mandate: "mandate_id"},
             metadata: {
               lago_customer_id: customer.id,
-              lago_invoice_ids: [invoice_1.id, invoice_2.id],
               lago_payment_request_id: payment_request.id
             },
             retry_if_possible: false

--- a/spec/services/payment_requests/payments/stripe_service_spec.rb
+++ b/spec/services/payment_requests/payments/stripe_service_spec.rb
@@ -115,8 +115,7 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
           description: "#{organization.name} - Overdue invoices",
           metadata: {
             lago_customer_id: customer.id,
-            lago_payment_request_id: payment_request.id,
-            lago_invoice_ids: payment_request.invoice_ids
+            lago_payment_request_id: payment_request.id
           }
         },
         hash_including(
@@ -403,7 +402,6 @@ RSpec.describe PaymentRequests::Payments::StripeService, type: :service do
               metadata: {
                 lago_customer_id: customer.id,
                 lago_payment_request_id: payment_request.id,
-                lago_invoice_ids: payment_request.invoice_ids,
                 payment_type: "one-time"
               }
             }


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

 ## Description

The goal of this change is to fix a QA return dropping the `Lago_invoices_id` attribute from PSPs payload as it is not needed for us and some PSPs like Stripe only supports string values, hence, a list of ids can not be passed within the metadata payload.