### PR TITLE
Feat(anrok<>credit_notes) refactor CreditNotes::AppliedTax to search taxes by tax_code

### DIFF
--- a/app/models/credit_note_item.rb
+++ b/app/models/credit_note_item.rb
@@ -9,7 +9,7 @@ class CreditNoteItem < ApplicationRecord
   validates :amount_cents, numericality: {greater_than_or_equal_to: 0}
 
   def applied_taxes
-    credit_note.applied_taxes.where(tax_id: fee.applied_taxes.select('fees_taxes.tax_id'))
+    credit_note.applied_taxes.where(tax_code: fee.applied_taxes.select('fees_taxes.tax_code'))
   end
 end
 

--- a/spec/factories/fee_applied_taxes.rb
+++ b/spec/factories/fee_applied_taxes.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :fee_applied_tax, class: 'Fee::AppliedTax' do
     fee
     tax
-    tax_code { "vat-#{SecureRandom.uuid}" }
+    tax_code { tax&.code.presence || "vat-#{SecureRandom.uuid}" }
     tax_description { 'French Standard VAT' }
     tax_name { 'VAT' }
     tax_rate { 20.0 }

--- a/spec/factories/fee_applied_taxes.rb
+++ b/spec/factories/fee_applied_taxes.rb
@@ -10,5 +10,15 @@ FactoryBot.define do
     tax_rate { 20.0 }
     amount_cents { 200 }
     amount_currency { 'EUR' }
+    transient do
+      provider_tax_breakdown_object { nil }
+    end
+
+    trait :with_provider_tax do
+      tax_description { provider_tax_breakdown_object.type }
+      tax_code { provider_tax_breakdown_object.name.parameterize(separator: '_') }
+      tax_name { provider_tax_breakdown_object.name }
+      tax_rate { provider_tax_breakdown_object.rate }
+    end
   end
 end

--- a/spec/factories/invoice_applied_taxes.rb
+++ b/spec/factories/invoice_applied_taxes.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
       tax_description { provider_tax_breakdown_object.type }
       tax_code { provider_tax_breakdown_object.name.parameterize(separator: '_') }
       tax_name { provider_tax_breakdown_object.name }
-      tax_rate {  provider_tax_breakdown_object.rate }
+      tax_rate { provider_tax_breakdown_object.rate }
     end
   end
 end

--- a/spec/factories/invoice_applied_taxes.rb
+++ b/spec/factories/invoice_applied_taxes.rb
@@ -10,5 +10,16 @@ FactoryBot.define do
     tax_rate { 20.0 }
     amount_cents { 200 }
     amount_currency { 'EUR' }
+
+    transient do
+      provider_tax_breakdown_object { nil }
+    end
+
+    trait :with_provider_tax do
+      tax_description { provider_tax_breakdown_object.type }
+      tax_code { provider_tax_breakdown_object.name.parameterize(separator: '_') }
+      tax_name { provider_tax_breakdown_object.name }
+      tax_rate {  provider_tax_breakdown_object.rate }
+    end
   end
 end

--- a/spec/factories/invoice_applied_taxes.rb
+++ b/spec/factories/invoice_applied_taxes.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :invoice_applied_tax, class: 'Invoice::AppliedTax' do
     invoice
     tax
-    tax_code { "vat-#{SecureRandom.uuid}" }
+    tax_code { tax&.code.presence || "vat-#{SecureRandom.uuid}" }
     tax_description { 'French Standard VAT' }
     tax_name { 'VAT' }
     tax_rate { 20.0 }

--- a/spec/mailers/payment_request_mailer_spec.rb
+++ b/spec/mailers/payment_request_mailer_spec.rb
@@ -5,8 +5,9 @@ require "rails_helper"
 RSpec.describe PaymentRequestMailer, type: :mailer do
   subject(:payment_request_mailer) { described_class }
 
-  let(:first_invoice) { create(:invoice, total_amount_cents: 1000) }
-  let(:second_invoice) { create(:invoice, total_amount_cents: 2000) }
+  let(:organization) { create(:organization, document_number_prefix: 'ORG-123B') }
+  let(:first_invoice) { create(:invoice, total_amount_cents: 1000, organization:) }
+  let(:second_invoice) { create(:invoice, total_amount_cents: 2000, organization:) }
   let(:payment_request) { create(:payment_request, invoices: [first_invoice, second_invoice]) }
 
   before do

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Credit, type: :model do
     it { is_expected.to belong_to(:applied_coupon).optional }
     it { is_expected.to belong_to(:credit_note).optional }
     it { is_expected.to belong_to(:progressive_billing_invoice).optional }
-    it { is_expected.to have_many(:error_details) }
   end
 
   describe 'invoice item' do

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Credit, type: :model do
     it { is_expected.to belong_to(:applied_coupon).optional }
     it { is_expected.to belong_to(:credit_note).optional }
     it { is_expected.to belong_to(:progressive_billing_invoice).optional }
+    it { is_expected.to have_many(:error_details) }
   end
 
   describe 'invoice item' do

--- a/spec/services/credit_notes/apply_taxes_service_spec.rb
+++ b/spec/services/credit_notes/apply_taxes_service_spec.rb
@@ -320,4 +320,21 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
     end
 
   end
+
+  context 'when no taxes are applied on the invoice' do
+    describe 'call' do
+      it 'succeeds' do
+        result = apply_service.call
+        expect(result).to be_success
+        aggregate_failures do
+          applied_taxes = result.applied_taxes
+          expect(applied_taxes.count).to eq(0)
+          expect(result.taxes_amount_cents.round).to eq(0)
+          expect(result.taxes_rate).to eq(0)
+          expect(result.coupons_adjustment_amount_cents.round).to eq(12)
+        end
+      end
+    end
+
+  end
 end

--- a/spec/services/credit_notes/apply_taxes_service_spec.rb
+++ b/spec/services/credit_notes/apply_taxes_service_spec.rb
@@ -46,46 +46,6 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
     )
   end
 
-  let(:tax1) { create(:tax, organization:, rate: 12) }
-  let(:tax2) { create(:tax, organization:, rate: 8) }
-
-  let(:fee_applied_tax11) do
-    create(
-      :fee_applied_tax,
-      tax: tax1,
-      tax_code: tax1.code,
-      fee: fee1,
-      amount_cents: (fee1.sub_total_excluding_taxes_amount_cents * tax1.rate).fdiv(100)
-    )
-  end
-
-  let(:fee_applied_tax21) do
-    create(
-      :fee_applied_tax,
-      tax: tax1,
-      tax_code: tax1.code,
-      fee: fee2,
-      amount_cents: (fee2.sub_total_excluding_taxes_amount_cents * tax1.rate).fdiv(100)
-    )
-  end
-
-  let(:fee_applied_tax22) do
-    create(
-      :fee_applied_tax,
-      tax: tax2,
-      tax_code: tax2.code,
-      fee: fee2,
-      amount_cents: (fee2.sub_total_excluding_taxes_amount_cents * tax2.rate).fdiv(100)
-    )
-  end
-
-  let(:invoice_applied_taxes) {
-    [
-      create(:invoice_applied_tax, tax_code: tax1.code, tax_rate: tax1.rate, tax: tax1, invoice:),
-      create(:invoice_applied_tax, tax_code: tax2.code, tax_rate: tax2.rate, tax: tax2, invoice:)
-    ]
-  }
-
   let(:items) do
     [
       build(
@@ -107,51 +67,257 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
     ]
   end
 
-  before do
-    invoice_applied_taxes
-    fee_applied_tax11
-    fee_applied_tax21
-    fee_applied_tax22
-  end
+  context 'when local taxes are applied' do
+    let(:tax1) { create(:tax, organization:, rate: 12) }
+    let(:tax2) { create(:tax, organization:, rate: 8) }
 
-  describe 'call' do
-    it 'creates applied taxes' do
-      result = apply_service.call
+    let(:fee_applied_tax11) do
+      create(
+        :fee_applied_tax,
+        tax: tax1,
+        tax_code: tax1.code,
+        fee: fee1,
+        amount_cents: (fee1.sub_total_excluding_taxes_amount_cents * tax1.rate).fdiv(100)
+      )
+    end
 
-      aggregate_failures do
-        expect(result).to be_success
+    let(:fee_applied_tax21) do
+      create(
+        :fee_applied_tax,
+        tax: tax1,
+        tax_code: tax1.code,
+        fee: fee2,
+        amount_cents: (fee2.sub_total_excluding_taxes_amount_cents * tax1.rate).fdiv(100)
+      )
+    end
+
+    let(:fee_applied_tax22) do
+      create(
+        :fee_applied_tax,
+        tax: tax2,
+        tax_code: tax2.code,
+        fee: fee2,
+        amount_cents: (fee2.sub_total_excluding_taxes_amount_cents * tax2.rate).fdiv(100)
+      )
+    end
+
+    let(:invoice_applied_taxes) {
+      [
+        create(:invoice_applied_tax, tax_code: tax1.code, tax_rate: tax1.rate, tax: tax1, invoice:),
+        create(:invoice_applied_tax, tax_code: tax2.code, tax_rate: tax2.rate, tax: tax2, invoice:)
+      ]
+    }
+
+    before do
+      invoice_applied_taxes
+      fee_applied_tax11
+      fee_applied_tax21
+      fee_applied_tax22
+    end
+
+    describe 'call' do
+      it 'creates applied taxes' do
+        result = apply_service.call
 
         aggregate_failures do
-          applied_taxes = result.applied_taxes
-          expect(applied_taxes.count).to eq(2)
+          expect(result).to be_success
 
-          expect(applied_taxes[0]).to have_attributes(
-            credit_note: nil,
-            tax: tax1,
-            tax_description: tax1.description,
-            tax_code: tax1.code,
-            tax_name: tax1.name,
-            tax_rate: 12,
-            amount_currency: invoice.currency,
-            amount_cents: 7
-          )
+          aggregate_failures do
+            applied_taxes = result.applied_taxes
+            expect(applied_taxes.count).to eq(2)
 
-          expect(applied_taxes[1]).to have_attributes(
-            credit_note: nil,
-            tax: tax2,
-            tax_description: tax2.description,
-            tax_code: tax2.code,
-            tax_name: tax2.name,
-            tax_rate: 8,
-            amount_currency: invoice.currency,
-            amount_cents: 3
-          )
+            expect(applied_taxes[0]).to have_attributes(
+              credit_note: nil,
+              tax: tax1,
+              tax_description: tax1.description,
+              tax_code: tax1.code,
+              tax_name: tax1.name,
+              tax_rate: 12,
+              amount_currency: invoice.currency,
+              amount_cents: 7
+            )
 
-          expect(result.taxes_amount_cents.round).to eq(10)
-          expect(result.taxes_rate).to eq(17.71429)
-          expect(result.coupons_adjustment_amount_cents.round).to eq(12)
+            expect(applied_taxes[1]).to have_attributes(
+              credit_note: nil,
+              tax: tax2,
+              tax_description: tax2.description,
+              tax_code: tax2.code,
+              tax_name: tax2.name,
+              tax_rate: 8,
+              amount_currency: invoice.currency,
+              amount_cents: 3
+            )
+
+            expect(result.taxes_amount_cents.round).to eq(10)
+            expect(result.taxes_rate).to eq(17.71429)
+            expect(result.coupons_adjustment_amount_cents.round).to eq(12)
+          end
         end
       end
     end
+  end
+
+  context 'when taxes from tax provider are applied' do
+
+    let(:provider_tax_1) { OpenStruct.new(name: 'provider tax 1', type: 'providerTax1', rate: 12.0, code: 'provider_tax_1') }
+    let(:provider_tax_2) { OpenStruct.new(name: 'provider tax 2', type: 'providerTax2', rate: 8.0, code: 'provider_tax_2') }
+
+    let(:fee_applied_tax11) do
+      create(
+        :fee_applied_tax,
+        :with_provider_tax,
+        tax: nil,
+        provider_tax_breakdown_object: provider_tax_1,
+        fee: fee1
+      )
+    end
+
+    let(:fee_applied_tax21) do
+      create(
+        :fee_applied_tax,
+        :with_provider_tax,
+        tax: nil,
+        provider_tax_breakdown_object: provider_tax_1,
+        fee: fee2
+      )
+    end
+
+    let(:fee_applied_tax22) do
+      create(
+        :fee_applied_tax,
+        :with_provider_tax,
+        tax: nil,
+        provider_tax_breakdown_object: provider_tax_2,
+        fee: fee2,
+      )
+    end
+
+    let(:invoice_applied_taxes) {
+      [
+        create(:invoice_applied_tax, :with_provider_tax,  provider_tax_breakdown_object: provider_tax_1, tax: nil, invoice:),
+        create(:invoice_applied_tax, :with_provider_tax,  provider_tax_breakdown_object: provider_tax_2, tax: nil, invoice:)
+      ]
+    }
+
+    before do
+      invoice_applied_taxes
+      fee_applied_tax11
+      fee_applied_tax21
+      fee_applied_tax22
+    end
+
+    context 'when coupons are applied' do
+
+      describe 'call' do
+        it 'creates applied taxes' do
+          result = apply_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            aggregate_failures do
+              applied_taxes = result.applied_taxes
+              expect(applied_taxes.count).to eq(2)
+
+              expect(applied_taxes[0]).to have_attributes(
+                                            credit_note: nil,
+                                            tax: nil,
+                                            tax_description: provider_tax_1.type,
+                                            tax_code: provider_tax_1.code,
+                                            tax_name: provider_tax_1.name,
+                                            tax_rate: provider_tax_1.rate,
+                                            amount_currency: invoice.currency,
+                                            amount_cents: 7
+                                          )
+
+              expect(applied_taxes[1]).to have_attributes(
+                                            credit_note: nil,
+                                            tax: nil,
+                                            tax_description: provider_tax_2.type,
+                                            tax_code: provider_tax_2.code,
+                                            tax_name: provider_tax_2.name,
+                                            tax_rate: provider_tax_2.rate,
+                                            amount_currency: invoice.currency,
+                                            amount_cents: 3
+                                          )
+
+              expect(result.taxes_amount_cents.round).to eq(10)
+              expect(result.taxes_rate).to eq(17.71429)
+              expect(result.coupons_adjustment_amount_cents.round).to eq(12)
+            end
+          end
+        end
+      end
+    end
+
+    context 'plain fees without coupons' do
+      let(:fee1) do
+        create(
+          :fee,
+          invoice:,
+          amount_cents: 100,
+          taxes_amount_cents: 20,
+          taxes_rate: 20,
+          precise_coupons_amount_cents: 0
+        )
+      end
+
+      let(:fee2) do
+        create(
+          :fee,
+          invoice:,
+          amount_cents: 50,
+          taxes_amount_cents: 2,
+          taxes_rate: 10,
+          precise_coupons_amount_cents: 0
+        )
+      end
+
+      let(:provider_tax_1) { OpenStruct.new(name: 'provider tax 1', type: 'providerTax1', rate: 20.0, code: 'provider_tax_1') }
+      let(:provider_tax_2) { OpenStruct.new(name: 'provider tax 2', type: 'providerTax2', rate: 10.0, code: 'provider_tax_2') }
+
+
+      describe 'call' do
+        it 'creates applied taxes' do
+          result = apply_service.call
+
+          aggregate_failures do
+            expect(result).to be_success
+
+            aggregate_failures do
+              applied_taxes = result.applied_taxes
+              expect(applied_taxes.count).to eq(2)
+
+              expect(applied_taxes[0]).to have_attributes(
+                credit_note: nil,
+                tax: nil,
+                tax_description: provider_tax_1.type,
+                tax_code: provider_tax_1.code,
+                tax_name: provider_tax_1.name,
+                tax_rate: provider_tax_1.rate,
+                amount_currency: invoice.currency,
+                amount_cents: 14
+              )
+
+              expect(applied_taxes[1]).to have_attributes(
+                credit_note: nil,
+                tax: nil,
+                tax_description: provider_tax_2.type,
+                tax_code: provider_tax_2.code,
+                tax_name: provider_tax_2.name,
+                tax_rate: provider_tax_2.rate,
+                amount_currency: invoice.currency,
+                amount_cents: 5
+              )
+
+              expect(result.taxes_amount_cents.round).to eq(19)
+              expect(result.taxes_rate).to eq(27.14286)
+              expect(result.coupons_adjustment_amount_cents.round).to eq(0)
+            end
+          end
+        end
+      end
+    end
+
   end
 end

--- a/spec/services/credit_notes/apply_taxes_service_spec.rb
+++ b/spec/services/credit_notes/apply_taxes_service_spec.rb
@@ -49,32 +49,42 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
   let(:tax1) { create(:tax, organization:, rate: 12) }
   let(:tax2) { create(:tax, organization:, rate: 8) }
 
-  let(:applied_tax11) do
+  let(:fee_applied_tax11) do
     create(
       :fee_applied_tax,
       tax: tax1,
+      tax_code: tax1.code,
       fee: fee1,
       amount_cents: (fee1.sub_total_excluding_taxes_amount_cents * tax1.rate).fdiv(100)
     )
   end
 
-  let(:applied_tax21) do
+  let(:fee_applied_tax21) do
     create(
       :fee_applied_tax,
       tax: tax1,
+      tax_code: tax1.code,
       fee: fee2,
       amount_cents: (fee2.sub_total_excluding_taxes_amount_cents * tax1.rate).fdiv(100)
     )
   end
 
-  let(:applied_tax22) do
+  let(:fee_applied_tax22) do
     create(
       :fee_applied_tax,
       tax: tax2,
+      tax_code: tax2.code,
       fee: fee2,
       amount_cents: (fee2.sub_total_excluding_taxes_amount_cents * tax2.rate).fdiv(100)
     )
   end
+
+  let(:invoice_applied_taxes) {
+    [
+      create(:invoice_applied_tax, tax_code: tax1.code, tax_rate: tax1.rate, tax: tax1, invoice:),
+      create(:invoice_applied_tax, tax_code: tax2.code, tax_rate: tax2.rate, tax: tax2, invoice:)
+    ]
+  }
 
   let(:items) do
     [
@@ -98,9 +108,10 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
   end
 
   before do
-    applied_tax11
-    applied_tax21
-    applied_tax22
+    invoice_applied_taxes
+    fee_applied_tax11
+    fee_applied_tax21
+    fee_applied_tax22
   end
 
   describe 'call' do

--- a/spec/services/credit_notes/apply_taxes_service_spec.rb
+++ b/spec/services/credit_notes/apply_taxes_service_spec.rb
@@ -158,7 +158,6 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
   end
 
   context 'when taxes from tax provider are applied' do
-
     let(:provider_tax_1) { OpenStruct.new(name: 'provider tax 1', type: 'providerTax1', rate: 12.0, code: 'provider_tax_1') }
     let(:provider_tax_2) { OpenStruct.new(name: 'provider tax 2', type: 'providerTax2', rate: 8.0, code: 'provider_tax_2') }
 
@@ -188,14 +187,14 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
         :with_provider_tax,
         tax: nil,
         provider_tax_breakdown_object: provider_tax_2,
-        fee: fee2,
+        fee: fee2
       )
     end
 
     let(:invoice_applied_taxes) {
       [
-        create(:invoice_applied_tax, :with_provider_tax,  provider_tax_breakdown_object: provider_tax_1, tax: nil, invoice:),
-        create(:invoice_applied_tax, :with_provider_tax,  provider_tax_breakdown_object: provider_tax_2, tax: nil, invoice:)
+        create(:invoice_applied_tax, :with_provider_tax, provider_tax_breakdown_object: provider_tax_1, tax: nil, invoice:),
+        create(:invoice_applied_tax, :with_provider_tax, provider_tax_breakdown_object: provider_tax_2, tax: nil, invoice:)
       ]
     }
 
@@ -207,7 +206,6 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
     end
 
     context 'when coupons are applied' do
-
       describe 'call' do
         it 'creates applied taxes' do
           result = apply_service.call
@@ -220,26 +218,26 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
               expect(applied_taxes.count).to eq(2)
 
               expect(applied_taxes[0]).to have_attributes(
-                                            credit_note: nil,
-                                            tax: nil,
-                                            tax_description: provider_tax_1.type,
-                                            tax_code: provider_tax_1.code,
-                                            tax_name: provider_tax_1.name,
-                                            tax_rate: provider_tax_1.rate,
-                                            amount_currency: invoice.currency,
-                                            amount_cents: 7
-                                          )
+                credit_note: nil,
+                tax: nil,
+                tax_description: provider_tax_1.type,
+                tax_code: provider_tax_1.code,
+                tax_name: provider_tax_1.name,
+                tax_rate: provider_tax_1.rate,
+                amount_currency: invoice.currency,
+                amount_cents: 7
+              )
 
               expect(applied_taxes[1]).to have_attributes(
-                                            credit_note: nil,
-                                            tax: nil,
-                                            tax_description: provider_tax_2.type,
-                                            tax_code: provider_tax_2.code,
-                                            tax_name: provider_tax_2.name,
-                                            tax_rate: provider_tax_2.rate,
-                                            amount_currency: invoice.currency,
-                                            amount_cents: 3
-                                          )
+                credit_note: nil,
+                tax: nil,
+                tax_description: provider_tax_2.type,
+                tax_code: provider_tax_2.code,
+                tax_name: provider_tax_2.name,
+                tax_rate: provider_tax_2.rate,
+                amount_currency: invoice.currency,
+                amount_cents: 3
+              )
 
               expect(result.taxes_amount_cents.round).to eq(10)
               expect(result.taxes_rate).to eq(17.71429)
@@ -250,7 +248,7 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
       end
     end
 
-    context 'plain fees without coupons' do
+    context 'when there are plain fees without coupons' do
       let(:fee1) do
         create(
           :fee,
@@ -275,7 +273,6 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
 
       let(:provider_tax_1) { OpenStruct.new(name: 'provider tax 1', type: 'providerTax1', rate: 20.0, code: 'provider_tax_1') }
       let(:provider_tax_2) { OpenStruct.new(name: 'provider tax 2', type: 'providerTax2', rate: 10.0, code: 'provider_tax_2') }
-
 
       describe 'call' do
         it 'creates applied taxes' do
@@ -318,7 +315,6 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
         end
       end
     end
-
   end
 
   context 'when no taxes are applied on the invoice' do
@@ -335,6 +331,5 @@ RSpec.describe CreditNotes::ApplyTaxesService, type: :service do
         end
       end
     end
-
   end
 end

--- a/spec/services/credit_notes/create_from_progressive_billing_invoice_spec.rb
+++ b/spec/services/credit_notes/create_from_progressive_billing_invoice_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe CreditNotes::CreateFromProgressiveBillingInvoice, type: :service 
 
   let(:fee1_applied_tax) { create(:fee_applied_tax, tax:, fee: fee1) }
   let(:fee2_applied_tax) { create(:fee_applied_tax, tax:, fee: fee2) }
+  let(:invoice_applied_tax) { create(:invoice_applied_tax, invoice: progressive_billing_invoice, tax: )}
 
   before do
     progressive_billing_invoice
@@ -53,6 +54,7 @@ RSpec.describe CreditNotes::CreateFromProgressiveBillingInvoice, type: :service 
     fee2
     fee1_applied_tax
     fee2_applied_tax
+    invoice_applied_tax
   end
 
   describe "#call" do
@@ -83,6 +85,9 @@ RSpec.describe CreditNotes::CreateFromProgressiveBillingInvoice, type: :service 
         expect(credit_fee1.amount_cents).to eq(80)
         credit_fee2 = credit_note.items.find { |i| i.fee == fee2 }
         expect(credit_fee2.amount_cents).to eq(20)
+        expect(credit_note.applied_taxes.length).to eq(1)
+        expect(credit_note.applied_taxes.first.tax_code).to eq(invoice_applied_tax.tax_code)
+        expect(credit_note.applied_taxes.first.tax_id).to eq(tax.id)
       end
     end
   end

--- a/spec/services/credit_notes/create_from_progressive_billing_invoice_spec.rb
+++ b/spec/services/credit_notes/create_from_progressive_billing_invoice_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe CreditNotes::CreateFromProgressiveBillingInvoice, type: :service 
 
   let(:fee1_applied_tax) { create(:fee_applied_tax, tax:, fee: fee1) }
   let(:fee2_applied_tax) { create(:fee_applied_tax, tax:, fee: fee2) }
-  let(:invoice_applied_tax) { create(:invoice_applied_tax, invoice: progressive_billing_invoice, tax: )}
+  let(:invoice_applied_tax) { create(:invoice_applied_tax, invoice: progressive_billing_invoice, tax:) }
 
   before do
     progressive_billing_invoice

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -59,9 +59,14 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
   end
 
   let(:tax) { create(:tax, organization:, rate: 20) }
+  let(:fee_applied_tax) { create(:fee_applied_tax, tax:, fee: subscription_fee) }
+  let(:invoice_applied_tax) { create(:invoice_applied_tax, invoice:, tax:)}
 
   describe '#call' do
-    before { create(:fee_applied_tax, tax:, fee: subscription_fee) }
+    before do
+      fee_applied_tax
+      invoice_applied_tax
+    end
 
     it 'creates a credit note' do
       result = create_service.call
@@ -79,6 +84,8 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
         expect(credit_note.balance_amount_cents).to eq(19)
         expect(credit_note.balance_amount_currency).to eq('EUR')
         expect(credit_note.reason).to eq('order_change')
+        expect(credit_note.applied_taxes.length).to eq(1)
+        expect(credit_note.applied_taxes.first.tax_code).to eq(invoice_applied_tax.tax_code)
 
         expect(credit_note.items.count).to eq(1)
       end

--- a/spec/services/credit_notes/create_from_termination_spec.rb
+++ b/spec/services/credit_notes/create_from_termination_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
 
   let(:tax) { create(:tax, organization:, rate: 20) }
   let(:fee_applied_tax) { create(:fee_applied_tax, tax:, fee: subscription_fee) }
-  let(:invoice_applied_tax) { create(:invoice_applied_tax, invoice:, tax:)}
+  let(:invoice_applied_tax) { create(:invoice_applied_tax, invoice:, tax:) }
 
   describe '#call' do
     before do
@@ -391,11 +391,11 @@ RSpec.describe CreditNotes::CreateFromTermination, type: :service do
             credit_note = result.credit_note
             expect(credit_note).to be_available
             expect(credit_note).to be_order_change
-            expect(credit_note.total_amount_cents).to eq(499)
+            expect(credit_note.total_amount_cents).to eq(599)
             expect(credit_note.total_amount_currency).to eq('EUR')
-            expect(credit_note.credit_amount_cents).to eq(499)
+            expect(credit_note.credit_amount_cents).to eq(599)
             expect(credit_note.credit_amount_currency).to eq('EUR')
-            expect(credit_note.balance_amount_cents).to eq(499)
+            expect(credit_note.balance_amount_cents).to eq(599)
             expect(credit_note.balance_amount_currency).to eq('EUR')
             expect(credit_note.reason).to eq('order_change')
 

--- a/spec/services/credit_notes/create_service_spec.rb
+++ b/spec/services/credit_notes/create_service_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe CreditNotes::CreateService, type: :service do
   before do
     create(:fee_applied_tax, tax:, fee: fee1)
     create(:fee_applied_tax, tax:, fee: fee2)
+    create(:invoice_applied_tax, tax:, invoice:) if invoice
   end
 
   describe '.call' do

--- a/spec/services/credit_notes/estimate_service_spec.rb
+++ b/spec/services/credit_notes/estimate_service_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe CreditNotes::EstimateService, type: :service do
   before do
     create(:fee_applied_tax, tax:, fee: fee1)
     create(:fee_applied_tax, tax:, fee: fee2)
+    create(:invoice_applied_tax, tax:, invoice:) if invoice
   end
 
   it 'estimates the credit and refund amount' do

--- a/spec/services/credit_notes/refresh_draft_service_spec.rb
+++ b/spec/services/credit_notes/refresh_draft_service_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe CreditNotes::RefreshDraftService, type: :service do
   describe '#call' do
     let(:status) { :draft }
     let(:fee) { create(:fee, invoice:, taxes_rate: 20, amount_cents: 100, precise_coupons_amount_cents: 20) }
-    let(:applied_tax) { create(:fee_applied_tax, tax:, fee:, amount_cents: 0) }
+    let(:fee_applied_tax) { create(:fee_applied_tax, tax:, fee:, amount_cents: 0) }
+    let(:invoice_applied_tax) { create(:invoice_applied_tax, tax:, invoice:) }
     let(:credit_note_item) { create(:credit_note_item, credit_note:, fee: create(:fee, invoice:, taxes_rate: 0)) }
     let(:credit_note) do
       create(
@@ -37,7 +38,8 @@ RSpec.describe CreditNotes::RefreshDraftService, type: :service do
     end
 
     before do
-      applied_tax
+      fee_applied_tax
+      invoice_applied_tax
       credit_note_item
     end
 


### PR DESCRIPTION
**Context**
When we apply taxes on credit_notes, we're applying taxes that are stored for invoice - Invoice::AppliedTax. (and then we select taxes applied on fees, related to the credit_note_items)

Previous taxes implementation suggested that we should have a tax, saved in the db, so when iterating through taxes we were using tax.id, but currently taxes received from tax provider don't have a corresponding tax in the db, but we have tax_code, identifying the tax. the same is with stored in the db taxes: within the organization the tax_code will not be repeated, so if we start looking for taxes by tax_code instead of tax.id, we won't break existing logic and will adapt it to the new applied taxes that do not have taxes, stored in the db.

**What was done:**
Updated algorythm of searching taxes to apply on credit note, to search them by tax_code instead of tax_id