### PR TITLE
fix: Compare terminated_at to timestamp for terminated subscription

### DIFF
--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -166,7 +166,10 @@ class Subscription < ApplicationRecord
   end
 
   def terminated_at?(timestamp)
-    terminated? && terminated_at <= timestamp
+    return false unless terminated?
+    return false if terminated_at.nil? || timestamp.nil?
+
+    terminated_at <= timestamp
   end
 end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -164,6 +164,10 @@ class Subscription < ApplicationRecord
 
     number_od_days.negative? ? 0 : number_od_days
   end
+
+  def terminated_at?(timestamp)
+    terminated? && terminated_at <= timestamp
+  end
 end
 
 # == Schema Information

--- a/app/services/invoices/create_invoice_subscription_service.rb
+++ b/app/services/invoices/create_invoice_subscription_service.rb
@@ -89,7 +89,7 @@ module Invoices
 
     def date_service(subscription)
       current_usage = invoicing_reason.to_sym == :progressive_billing
-      current_usage ||= subscription.terminated? && subscription.upgraded?
+      current_usage ||= subscription.terminated_at?(datetime) && subscription.upgraded?
 
       Subscriptions::DatesService.new_instance(subscription, datetime, current_usage:)
     end

--- a/app/services/subscriptions/dates_service.rb
+++ b/app/services/subscriptions/dates_service.rb
@@ -95,7 +95,7 @@ module Subscriptions
 
     def charges_to_datetime
       datetime = customer_timezone_shift(compute_charges_to_date, end_of_day: true)
-      datetime = subscription.terminated_at if subscription.terminated? && datetime > subscription.terminated_at
+      datetime = subscription.terminated_at if subscription.terminated_at?(datetime)
 
       datetime
     end
@@ -179,11 +179,11 @@ module Subscriptions
     def terminated_pay_in_arrear?
       # NOTE: In case of termination or upgrade when we are terminating old plan (paying in arrear),
       #       we should take to the beginning of the billing period
-      subscription.terminated? && plan.pay_in_arrear? && !subscription.downgraded?
+      subscription.terminated_at?(billing_at) && plan.pay_in_arrear? && !subscription.downgraded?
     end
 
     def terminated?
-      subscription.terminated? && !subscription.next_subscription
+      subscription.terminated_at?(billing_at) && !subscription.next_subscription
     end
 
     # NOTE: Handle leap years and anniversary date > 28

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -491,4 +491,27 @@ RSpec.describe Subscription, type: :model do
       end
     end
   end
+
+  describe '#terminated_at?' do
+    context 'when subscription is terminated before the timestamp' do
+      it 'returns true' do
+        subscription = build(:subscription, :terminated, terminated_at: 2.days.ago)
+        expect(subscription.terminated_at?(1.day.ago)).to be true
+      end
+    end
+
+    context 'when subscription is terminated after the timestamp' do
+      it 'returns false' do
+        subscription = build(:subscription, :terminated, terminated_at: 1.day.from_now)
+        expect(subscription.terminated_at?(2.days.ago)).to be false
+      end
+    end
+
+    context 'when subscription is not terminated' do
+      it 'returns false' do
+        subscription = build(:subscription)
+        expect(subscription.terminated_at?(1.day.ago)).to be false
+      end
+    end
+  end
 end

--- a/spec/services/invoices/calculate_fees_service_spec.rb
+++ b/spec/services/invoices/calculate_fees_service_spec.rb
@@ -1198,7 +1198,7 @@ RSpec.describe Invoices::CalculateFeesService, type: :service do
 
         let(:started_at) { DateTime.parse('07 Mar 2022') }
         let(:terminated_at) { DateTime.parse('17 Oct 2022 12:35:12') }
-        let(:timestamp) { DateTime.parse('17 Oct 2022') }
+        let(:timestamp) { DateTime.parse('17 Oct 2022 15:00') }
 
         let(:subscription) do
           create(

--- a/spec/services/subscriptions/dates/monthly_service_spec.rb
+++ b/spec/services/subscriptions/dates/monthly_service_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       context 'when subscription is just terminated' do
         let(:billing_at) { DateTime.parse('10 Mar 2022') }
 
-        before { subscription.terminated! }
+        before { subscription.mark_as_terminated!('9 Mar 2022') }
 
         it 'returns the beginning of the month' do
           expect(result).to eq('2022-03-01 00:00:00 UTC')
@@ -101,7 +101,7 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       context 'when subscription is just terminated' do
         let(:billing_at) { DateTime.parse('10 Mar 2022') }
 
-        before { subscription.terminated! }
+        before { subscription.mark_as_terminated!('9 Mar 2022') }
 
         it 'returns the previous month day' do
           expect(result).to eq('2022-03-02 00:00:00 UTC')
@@ -125,11 +125,13 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
         end
 
         context 'when billing day on first month of the year' do
+          before { subscription.mark_as_terminated!('27 Jan 2022') }
+
           let(:billing_at) { DateTime.parse('28 Jan 2022') }
-          let(:subscription_at) { DateTime.parse('29 Mar 2021') }
+          let(:subscription_at) { DateTime.parse('27 Mar 2021') }
 
           it 'returns the previous month last day' do
-            expect(result).to eq('2021-12-29 00:00:00 UTC')
+            expect(result).to eq('2021-12-27 00:00:00 UTC')
           end
         end
       end
@@ -476,11 +478,9 @@ RSpec.describe Subscriptions::Dates::MonthlyService, type: :service do
       end
 
       context 'when subscription is terminated in the middle of a period' do
-        let(:terminated_at) { DateTime.parse('06 Mar 2022') }
+        let(:terminated_at) { DateTime.parse('1 Mar 2022') }
 
-        before do
-          subscription.update!(status: :terminated, terminated_at:)
-        end
+        before { subscription.mark_as_terminated!(terminated_at) }
 
         it 'returns the terminated date' do
           expect(result).to eq(subscription.terminated_at.utc.to_s)

--- a/spec/services/subscriptions/dates/quarterly_service_spec.rb
+++ b/spec/services/subscriptions/dates/quarterly_service_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       context 'when subscription is just terminated' do
         let(:billing_at) { DateTime.parse('10 Jul 2022') }
 
-        before { subscription.terminated! }
+        before { subscription.mark_as_terminated!('9 Jul 2022') }
 
         it 'returns the beginning of the quarter' do
           expect(result).to eq('2022-07-01 00:00:00 UTC')
@@ -116,7 +116,7 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
       context 'when subscription is just terminated' do
         let(:billing_at) { DateTime.parse('10 May 2022') }
 
-        before { subscription.terminated! }
+        before { subscription.mark_as_terminated!('9 May 2022') }
 
         it 'returns the correct day at the beginning of the quarter' do
           expect(result).to eq('2022-05-02 00:00:00 UTC')
@@ -143,8 +143,10 @@ RSpec.describe Subscriptions::Dates::QuarterlyService, type: :service do
           let(:billing_at) { DateTime.parse('27 Feb 2022') }
           let(:subscription_at) { DateTime.parse('28 Feb 2021') }
 
+          before { subscription.mark_as_terminated!('25 Feb 2022') }
+
           it 'returns the previous quarter last day' do
-            expect(result).to eq('2021-11-30 00:00:00 UTC')
+            expect(result).to eq('2021-11-28 00:00:00 UTC')
           end
         end
       end

--- a/spec/services/subscriptions/dates/weekly_service_spec.rb
+++ b/spec/services/subscriptions/dates/weekly_service_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       context 'when subscription is just terminated' do
         let(:billing_at) { DateTime.parse('10 Mar 2022') }
 
-        before { subscription.terminated! }
+        before { subscription.mark_as_terminated!('9 Mar 2022') }
 
         it 'returns the beginning of the week' do
           expect(result).to eq('2022-03-07 00:00:00 UTC')
@@ -100,7 +100,7 @@ RSpec.describe Subscriptions::Dates::WeeklyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        before { subscription.terminated! }
+        before { subscription.mark_as_terminated!('8 Mar 2022') }
 
         it 'returns the previous week day' do
           expect(result).to eq('2022-03-08 00:00:00 UTC')

--- a/spec/services/subscriptions/dates/yearly_service_spec.rb
+++ b/spec/services/subscriptions/dates/yearly_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       context 'when subscription is just terminated' do
         let(:billing_at) { DateTime.parse('10 Mar 2022') }
 
-        before { subscription.terminated! }
+        before { subscription.mark_as_terminated!('9 Mar 2022') }
 
         it 'returns the beginning of the year' do
           expect(result).to eq('2022-01-01 00:00:00 UTC')
@@ -108,7 +108,7 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when subscription is just terminated' do
-        before { subscription.terminated! }
+        before { subscription.mark_as_terminated!('1 Feb 2022') }
 
         it 'returns the previous year day' do
           expect(result).to eq('2022-02-02 00:00:00 UTC')
@@ -419,12 +419,10 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
         end
 
         context 'when subscription terminated in the middle of a period' do
-          let(:terminated_at) { DateTime.parse('10 Mar 2022') }
+          let(:terminated_at) { DateTime.parse('05 Mar 2022') }
           let(:billing_at) { DateTime.parse('07 Mar 2022') }
 
-          before do
-            subscription.update!(status: :terminated, terminated_at:)
-          end
+          before { subscription.mark_as_terminated!(terminated_at) }
 
           it 'returns the terminated_at date' do
             expect(result).to eq(subscription.terminated_at.utc.to_s)
@@ -452,11 +450,9 @@ RSpec.describe Subscriptions::Dates::YearlyService, type: :service do
       end
 
       context 'when subscription is terminated in the middle of a period' do
-        let(:terminated_at) { DateTime.parse('06 Mar 2022') }
+        let(:terminated_at) { DateTime.parse('6 Jan 2022') }
 
-        before do
-          subscription.update!(status: :terminated, terminated_at:)
-        end
+        before { subscription.mark_as_terminated!(terminated_at) }
 
         it 'returns the terminated date' do
           expect(result).to eq(subscription.terminated_at.utc.to_s)


### PR DESCRIPTION
## Issue

After terminating a subscription, when there are several draft invoices linked to the same subscription (i.e. several invoice subscriptions) and we refresh the oldest one, the corresponding invoice subscription is updated with the boundaries of the most recent invoice subscription.

## Objective

The goal of this PR is to check the termination date of the subscription and compare it with the given timestamp, in addition of checking if the subscription is terminated.