### PR TITLE
misc: Fix some warning in specs

### DIFF
--- a/spec/services/invoices/finalize_open_credit_service_spec.rb
+++ b/spec/services/invoices/finalize_open_credit_service_spec.rb
@@ -9,8 +9,10 @@ RSpec.describe Invoices::FinalizeOpenCreditService, type: :service do
   let(:invoice) { create(:invoice, organization:, invoice_type: 'credit', status: :open, payment_due_date: 1.week.ago.to_date) }
 
   before do
-    allow(invoice).to receive(:should_sync_invoice?).and_return(true)
-    allow(invoice).to receive(:should_sync_sales_order?).and_return(true)
+    if invoice
+      allow(invoice).to receive(:should_sync_invoice?).and_return(true)
+      allow(invoice).to receive(:should_sync_sales_order?).and_return(true)
+    end
   end
 
   describe '.call' do


### PR DESCRIPTION
This PR fixes the following warning messages when running the specs:
```
WARNING: An expectation of `:should_sync_invoice?` was set on `nil`. To allow expectations on `nil` and suppress this message, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `true`. To disallow expectations on `nil`, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `false`. Called from /home/runner/work/lago-api/lago-api/spec/services/invoices/finalize_open_credit_service_spec.rb:12:in `block (2 levels) in <top (required)>'.

WARNING: An expectation of `:should_sync_sales_order?` was set on `nil`. To allow expectations on `nil` and suppress this message, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `true`. To disallow expectations on `nil`, set `RSpec::Mocks.configuration.allow_message_expectations_on_nil` to `false`. Called from /home/runner/work/lago-api/lago-api/spec/services/invoices/finalize_open_credit_service_spec.rb:13:in `block (2 levels) in <top (required)>'.
```