### PR TITLE
feat(dunning): Fix Spanish translation for payment requested email

### DIFF
--- a/app/views/payment_request_mailer/requested.slim
+++ b/app/views/payment_request_mailer/requested.slim
@@ -5,10 +5,7 @@ div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16
 div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
   = I18n.t("email.payment_request.requested.total_amount_due", amount: MoneyHelper.format(@payment_request.amount))
 div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
-  - if @customer.applicable_net_payment_term > 0
     = I18n.t("email.payment_request.requested.payment_terms", count: @customer.applicable_net_payment_term)
-  - else
-    = I18n.t("email.payment_request.requested.upon_invoice_generation")
 div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"
   = I18n.t("email.payment_request.requested.already_paid")
 div style="margin-bottom: 32px;font-style: normal;font-weight: 400;font-size: 16px;line-height: 24px;color: #19212E;"

--- a/config/locales/en/email.yml
+++ b/config/locales/en/email.yml
@@ -45,6 +45,5 @@ en:
         subject: Your overdue balance from %{organization_name}
         thank_you: Thank you.
         total_amount_due: The total amount due is %{amount}.
-        upon_invoice_generation: Our contractually agreed payment terms require payment upon invoice generation.
     powered_by: Powered by
     questions: Questions? Contact us at

--- a/config/locales/es/email.yml
+++ b/config/locales/es/email.yml
@@ -20,19 +20,19 @@ es:
         invoice_number: Número de factura
         issue_date: Fecha de emisión
         subject: 'Tu factura de %{organization_name} #%{invoice_number}'
-      payment_request:
-        requested:
-          already_paid: Si ya ha realizado el pago, por favor ignore este correo electrónico.
-          hello: Hola %{customer_name},
-          pay_amount: Pagar el saldo
-          payment_terms:
-            one: Nuestros términos de pago acordados contractualmente son %{count} día.
-            other: Nuestros términos de pago acordados contractualmente son %{count} días.
-            zero: Nuestros términos de pago acordados contractualmente requieren el pago al generar la factura.
-          remaining_amount: Monto restante a pagar
-          reminder_overdue_balance: Este es un recordatorio del equipo financiero de %{organization_name} de que algunas facturas están vencidas.
-          subject: Su saldo vencido de %{organization_name}
-          thank_you: Gracias.
-          total_amount_due: El monto total adeudado es de %{amount}.
+    payment_request:
+      requested:
+        already_paid: Si ya ha realizado el pago, por favor ignore este correo electrónico.
+        hello: Hola %{customer_name},
+        pay_amount: Pagar el saldo
+        payment_terms:
+          one: Nuestros términos de pago acordados contractualmente son %{count} día.
+          other: Nuestros términos de pago acordados contractualmente son %{count} días.
+          zero: Nuestros términos de pago acordados contractualmente requieren el pago al generar la factura.
+        remaining_amount: Monto restante a pagar
+        reminder_overdue_balance: Este es un recordatorio del equipo financiero de %{organization_name} de que algunas facturas están vencidas.
+        subject: Su saldo vencido de %{organization_name}
+        thank_you: Gracias.
+        total_amount_due: El monto total adeudado es de %{amount}.
     powered_by_lago: Powered by
     questions: "¿Preguntas? Contáctanos en"


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

 ## Description

The goal of this change is to fix QA returns related to the Spanish translation for payment requested email.