### PR TITLE
misc(cleanup) Fix billing service call & introduce rubocop ensuring code consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ require:
   - rubocop-rails
   - rubocop-thread_safety
   - rubocop-graphql
+  - ./lib/cops/service_call_cop.rb
 
 inherit_gem:
   standard: config/base.yml
@@ -13,9 +14,9 @@ AllCops:
   NewCops: disable
   DisplayStyleGuide: true
   Exclude:
-    - "bin/**/*"
-    - "db/schema.rb"
-    - "db/*_schema.rb"
+    - 'bin/**/*'
+    - 'db/schema.rb'
+    - 'db/*_schema.rb'
 
 # TODO: Enable when we have time to fix all the offenses
 Style/StringLiterals:
@@ -29,11 +30,11 @@ Performance/CaseWhenSplat:
   Enabled: true
 
 Rails/InverseOf:
-  Description: "Checks for associations where the inverse cannot be determined automatically."
+  Description: 'Checks for associations where the inverse cannot be determined automatically.'
   Enabled: false
 
 Rails/HttpStatus:
-  Description: "Enforces use of symbolic or numeric value to describe HTTP status."
+  Description: 'Enforces use of symbolic or numeric value to describe HTTP status.'
   Enabled: false
 
 Rails/HasManyOrHasOneDependent:
@@ -41,11 +42,11 @@ Rails/HasManyOrHasOneDependent:
   Enabled: false
 
 RSpec/ExampleLength:
-  Description: "Checks for long examples."
+  Description: 'Checks for long examples.'
   Enabled: false
 
 RSpec/MultipleExpectations:
-  Description: "Checks if examples contain too many expect calls."
+  Description: 'Checks if examples contain too many expect calls.'
   Enabled: false
 
 RSpec/MultipleMemoizedHelpers:
@@ -73,10 +74,10 @@ GraphQL/ExtractType:
 
 GraphQL/ExtractInputType:
   Exclude:
-    - "app/graphql/mutations/applied_coupons/create.rb"
-    - "app/graphql/mutations/credit_notes/create.rb"
-    - "app/graphql/mutations/invites/accept.rb"
-    - "app/graphql/mutations/plans/create.rb"
-    - "app/graphql/mutations/plans/update.rb"
-    - "app/graphql/mutations/register_user.rb"
-    - "app/graphql/mutations/wallet_transactions/create.rb"
+    - 'app/graphql/mutations/applied_coupons/create.rb'
+    - 'app/graphql/mutations/credit_notes/create.rb'
+    - 'app/graphql/mutations/invites/accept.rb'
+    - 'app/graphql/mutations/plans/create.rb'
+    - 'app/graphql/mutations/plans/update.rb'
+    - 'app/graphql/mutations/register_user.rb'
+    - 'app/graphql/mutations/wallet_transactions/create.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,11 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'simplecov', require: false
   gem 'webmock'
+  gem 'rubocop-rails'
+  gem 'rubocop-graphql', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rspec', require: false
+  gem 'rubocop-thread_safety', require: false
   gem 'awesome_print'
 end
 
@@ -119,13 +124,7 @@ group :development do
   gem 'coffee-rails'
   gem 'graphiql-rails', git: 'https://github.com/rmosolgo/graphiql-rails.git'
 
-  gem 'rubocop-graphql', require: false
-  gem 'rubocop-performance', require: false
-  gem 'rubocop-rails', require: false
-  gem 'rubocop-rspec', require: false
-  gem 'rubocop-thread_safety', require: false
   gem "standard", require: false
-
   gem 'annotate'
 
   gem 'sass-rails'

--- a/lib/cops/service_call_cop.rb
+++ b/lib/cops/service_call_cop.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ServiceCallCop < RuboCop::Cop::Cop
+  def_node_matcher :base_service_subclass?, <<~PATTERN
+    (const {nil? cbase} :BaseService)
+  PATTERN
+
+  def_node_matcher :call_method?, <<~PATTERN
+    (def :call ...)
+  PATTERN
+
+  MSG = "Subclasses of Baseservice should have #call without arguments"
+
+  def on_def(node)
+    return unless inherits_base_service?(node)
+    return unless call_method?(node)
+    return unless node.arguments?
+
+    add_offense(node)
+  end
+  alias_method :on_defs, :on_def
+
+  private
+
+  def inherits_base_service?(node)
+    node.each_ancestor(:class).any? { |class_node| base_service_subclass?(class_node.parent_class) }
+  end
+end

--- a/lib/cops/service_call_cop.rb
+++ b/lib/cops/service_call_cop.rb
@@ -1,28 +1,30 @@
 # frozen_string_literal: true
 
-class ServiceCallCop < RuboCop::Cop::Cop
-  def_node_matcher :base_service_subclass?, <<~PATTERN
-    (const {nil? cbase} :BaseService)
-  PATTERN
+module Cops
+  class ServiceCallCop < ::RuboCop::Cop::Cop
+    def_node_matcher :base_service_subclass?, <<~PATTERN
+      (const {nil? cbase} :BaseService)
+    PATTERN
 
-  def_node_matcher :call_method?, <<~PATTERN
-    (def :call ...)
-  PATTERN
+    def_node_matcher :call_method?, <<~PATTERN
+      (def :call ...)
+    PATTERN
 
-  MSG = "Subclasses of Baseservice should have #call without arguments"
+    MSG = "Subclasses of Baseservice should have #call without arguments"
 
-  def on_def(node)
-    return unless inherits_base_service?(node)
-    return unless call_method?(node)
-    return unless node.arguments?
+    def on_def(node)
+      return unless inherits_base_service?(node)
+      return unless call_method?(node)
+      return unless node.arguments?
 
-    add_offense(node)
-  end
-  alias_method :on_defs, :on_def
+      add_offense(node)
+    end
+    alias_method :on_defs, :on_def
 
-  private
+    private
 
-  def inherits_base_service?(node)
-    node.each_ancestor(:class).any? { |class_node| base_service_subclass?(class_node.parent_class) }
+    def inherits_base_service?(node)
+      node.each_ancestor(:class).any? { |class_node| base_service_subclass?(class_node.parent_class) }
+    end
   end
 end

--- a/spec/cop_helper.rb
+++ b/spec/cop_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rubocop'
+require 'rubocop/rspec/support'
+RSpec.configure do |config|
+  config.include RuboCop::RSpec::ExpectOffense
+end

--- a/spec/lib/cops/service_call_cop_spec.rb
+++ b/spec/lib/cops/service_call_cop_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'cop_helper'
+
+RSpec.describe Cops::ServiceCallCop, :config do
+  it 'registers an offense when defining call with arguments' do
+    expect_offense(<<~RUBY)
+      class X < BaseService
+        def call(args)
+        ^^^^^^^^^^^^^^ Subclasses of Baseservice should have #call without arguments
+          super
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when defining call with keyword arguments' do
+    expect_offense(<<~RUBY)
+      class X < BaseService
+        def call(arg:)
+        ^^^^^^^^^^^^^^ Subclasses of Baseservice should have #call without arguments
+          super
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when subclass of ::BaseService' do
+    expect_offense(<<~RUBY)
+      class X < ::BaseService
+        def call(arg:)
+        ^^^^^^^^^^^^^^ Subclasses of Baseservice should have #call without arguments
+          super
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when not a subclass of BaseService' do
+    expect_no_offenses(<<~RUBY)
+      class X
+        def call(arg:)
+          super
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
## Description

We've built several subclasses of BaseService that don't adhere to the common pattern of having an `initialize` method with arguments and a `call` method without arguments. In an effort to standardize this pattern, a rubocop is added that validates that the call method definition on subclasses of BaseService does not have any arguments.