### PR TITLE
fix(wallet): Add validation rule on rate_amount

### DIFF
--- a/app/models/wallet.rb
+++ b/app/models/wallet.rb
@@ -13,6 +13,8 @@ class Wallet < ApplicationRecord
   monetize :balance_cents, :ongoing_balance_cents, :ongoing_usage_balance_cents
   monetize :consumed_amount_cents
 
+  validates :rate_amount, numericality: {greater_than: 0}
+
   STATUSES = [
     :active,
     :terminated

--- a/spec/models/wallet_spec.rb
+++ b/spec/models/wallet_spec.rb
@@ -5,6 +5,10 @@ require 'rails_helper'
 RSpec.describe Wallet, type: :model do
   subject(:wallet) { build(:wallet) }
 
+  describe 'validations' do
+    it { is_expected.to validate_numericality_of(:rate_amount).is_greater_than(0) }
+  end
+
   describe 'currency=' do
     it 'assigns the currency to all amounts' do
       wallet.currency = 'CAD'


### PR DESCRIPTION
## Context

This PR adds a validation rule to `wallet#rate_amount` to make sure it will always be a positive value.

It will fixes the following dead job related to wallets with rate_amount = 0 

```
ActiveRecord::RecordInvalid

Validation failed: Ongoing balance is not a number, Ongoing usage balance is not a number (ActiveRecord::RecordInvalid)
```