### PR TITLE
fix(taxes): tax_error handling must target ValidationFailure

### DIFF
--- a/app/jobs/fees/create_pay_in_advance_job.rb
+++ b/app/jobs/fees/create_pay_in_advance_job.rb
@@ -9,9 +9,17 @@ module Fees
     def perform(charge:, event:, billing_at: nil)
       result = Fees::CreatePayInAdvanceService.call(charge:, event:, billing_at:)
 
-      return if !result.success? && result.error.messages.dig(:tax_error)
+      return if !result.success? && tax_error?(result)
 
       result.raise_if_error!
+    end
+
+    private
+
+    def tax_error?(result)
+      return false unless result.error.is_a?(BaseService::ValidationFailure)
+
+      result.error&.messages&.dig(:tax_error)
     end
   end
 end

--- a/app/jobs/invoices/create_pay_in_advance_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_charge_job.rb
@@ -13,7 +13,7 @@ module Invoices
       return if result.success?
       # NOTE: We don't want a dead job for failed invoice due to the tax reason.
       #       This invoice should be in failed status and can be retried.
-      return if result.error.messages.dig(:tax_error)
+      return if tax_error?(result)
 
       result.raise_if_error! if invoice || result.invoice.nil? || !result.invoice.generating?
 
@@ -24,6 +24,14 @@ module Invoices
         timestamp:,
         invoice: result.invoice
       )
+    end
+
+    private
+
+    def tax_error?(result)
+      return false unless result.error.is_a?(BaseService::ValidationFailure)
+
+      result.error&.messages&.dig(:tax_error)
     end
   end
 end

--- a/app/jobs/invoices/finalize_all_job.rb
+++ b/app/jobs/invoices/finalize_all_job.rb
@@ -12,6 +12,8 @@ module Invoices
     private
 
     def tax_error?(result)
+      return false unless result.error.is_a?(BaseService::ValidationFailure)
+
       result.error&.messages&.dig(:tax_error)
     end
   end


### PR DESCRIPTION
## Description

This PR fixes the following error in `BillSubscriptionJob`

```
NoMethodError
 undefined method `messages' for an instance of ActiveRecord::RecordNotUnique
```

The issue is related to the recent handling of `tax_error` that is checking for a `tax_error` error in the `error.messages`. `error.messages` only exists if the error is a `BaseService::ValidationFailure`