### PR TITLE
feat: Add customer type to services

### DIFF
--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -53,6 +53,9 @@ module Customers
         customer.net_payment_term = params[:net_payment_term] if params.key?(:net_payment_term)
         customer.external_salesforce_id = params[:external_salesforce_id] if params.key?(:external_salesforce_id)
         customer.finalize_zero_amount_invoice = params[:finalize_zero_amount_invoice] if params.key?(:finalize_zero_amount_invoice)
+        customer.firstname = params[:firstname] if params.key?(:firstname)
+        customer.lastname = params[:lastname] if params.key?(:lastname)
+        customer.customer_type = params[:customer_type] if params.key?(:customer_type)
         if params.key?(:tax_identification_number)
           customer.tax_identification_number = params[:tax_identification_number]
         end

--- a/app/services/customers/create_service.rb
+++ b/app/services/customers/create_service.rb
@@ -152,7 +152,10 @@ module Customers
         payment_provider_code: args[:payment_provider_code],
         currency: args[:currency],
         document_locale: billing_configuration[:document_locale],
-        tax_identification_number: args[:tax_identification_number]
+        tax_identification_number: args[:tax_identification_number],
+        firstname: args[:firstname],
+        lastname: args[:lastname],
+        customer_type: args[:customer_type]
       )
 
       if args.key?(:finalize_zero_amount_invoice)

--- a/app/services/customers/update_service.rb
+++ b/app/services/customers/update_service.rb
@@ -48,6 +48,9 @@ module Customers
         customer.shipping_zipcode = shipping_address[:zipcode] if shipping_address.key?(:zipcode)
         customer.shipping_state = shipping_address[:state] if shipping_address.key?(:state)
         customer.shipping_country = shipping_address[:country]&.upcase if shipping_address.key?(:country)
+        customer.firstname = args[:firstname] if args.key?(:firstname)
+        customer.lastname = args[:lastname] if args.key?(:lastname)
+        customer.customer_type = args[:customer_type] if args.key?(:customer_type)
 
         assign_premium_attributes(customer, args)
 

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -1004,6 +1004,8 @@ RSpec.describe Customers::CreateService, type: :service do
         {
           external_id: SecureRandom.uuid,
           name: 'Foo Bar',
+          firstname: 'First',
+          lastname: 'Last',
           organization_id: organization.id,
           timezone: 'Europe/Paris',
           invoice_grace_period: 2
@@ -1017,8 +1019,32 @@ RSpec.describe Customers::CreateService, type: :service do
           expect(result).to be_success
 
           customer = result.customer
+          expect(customer.firstname).to eq(create_args[:firstname])
+          expect(customer.lastname).to eq(create_args[:lastname])
+          expect(customer.customer_type).to be_nil
           expect(customer.timezone).to eq('Europe/Paris')
           expect(customer.invoice_grace_period).to eq(2)
+        end
+      end
+    end
+
+    context 'with customer_type' do
+      let(:create_args) do
+        {
+          external_id: SecureRandom.uuid,
+          name: 'Foo Bar',
+          customer_type: 'individual',
+          organization_id: organization.id
+        }
+      end
+
+      it 'creates customer with customer_type' do
+        result = customers_service.create(**create_args)
+
+        aggregate_failures do
+          expect(result).to be_success
+          customer = result.customer
+          expect(customer.customer_type).to eq(create_args[:customer_type])
         end
       end
     end

--- a/spec/services/customers/create_service_spec.rb
+++ b/spec/services/customers/create_service_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Customers::CreateService, type: :service do
         external_id:,
         name: 'Foo Bar',
         currency: 'EUR',
+        firstname: 'First',
+        lastname: 'Last',
         tax_identification_number: '123456789',
         billing_configuration: {
           document_locale: 'fr'
@@ -46,6 +48,9 @@ RSpec.describe Customers::CreateService, type: :service do
         expect(customer.organization_id).to eq(organization.id)
         expect(customer.external_id).to eq(create_args[:external_id])
         expect(customer.name).to eq(create_args[:name])
+        expect(customer.firstname).to eq(create_args[:firstname])
+        expect(customer.lastname).to eq(create_args[:lastname])
+        expect(customer.customer_type).to be_nil
         expect(customer.currency).to eq(create_args[:currency])
         expect(customer.tax_identification_number).to eq(create_args[:tax_identification_number])
         expect(customer.timezone).to be_nil
@@ -152,6 +157,30 @@ RSpec.describe Customers::CreateService, type: :service do
           customers = organization.customers.with_discarded
           expect(customers.count).to eq(2)
           expect(customers.pluck(:external_id).uniq).to eq([external_id])
+        end
+      end
+    end
+
+    context 'with customer_type' do
+      let(:create_args) do
+        {
+          external_id:,
+          name: 'Foo Bar',
+          currency: 'EUR',
+          customer_type: 'company'
+        }
+      end
+
+      it 'creates customer with correct customer_type' do
+        result = customers_service.create_from_api(
+          organization:,
+          params: create_args
+        )
+
+        aggregate_failures do
+          expect(result).to be_success
+          customer = result.customer
+          expect(customer.customer_type).to eq(create_args[:customer_type])
         end
       end
     end

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Customers::UpdateService, type: :service do
         expect(updated_customer.firstname).to eq(update_args[:firstname])
         expect(updated_customer.lastname).to eq(update_args[:lastname])
         expect(updated_customer.customer_type).to eq(update_args[:customer_type])
-        expect(updated_customer.tax_identification_number).to eq('2246')
+        expect(updated_customer.tax_identification_number).to eq(update_args[:tax_identification_number])
 
         shipping_address = update_args[:shipping_address]
         expect(updated_customer.shipping_city).to eq(shipping_address[:city])

--- a/spec/services/customers/update_service_spec.rb
+++ b/spec/services/customers/update_service_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe Customers::UpdateService, type: :service do
       {
         id: customer.id,
         name: 'Updated customer name',
+        firstname: 'Updated customer firstname',
+        lastname: 'Updated customer lastname',
+        customer_type: 'individual',
         tax_identification_number: '2246',
         net_payment_term: 8,
         external_id:,
@@ -34,7 +37,10 @@ RSpec.describe Customers::UpdateService, type: :service do
 
       updated_customer = result.customer
       aggregate_failures do
-        expect(updated_customer.name).to eq('Updated customer name')
+        expect(updated_customer.name).to eq(update_args[:name])
+        expect(updated_customer.firstname).to eq(update_args[:firstname])
+        expect(updated_customer.lastname).to eq(update_args[:lastname])
+        expect(updated_customer.customer_type).to eq(update_args[:customer_type])
         expect(updated_customer.tax_identification_number).to eq('2246')
 
         shipping_address = update_args[:shipping_address]


### PR DESCRIPTION
## Context
We currently only create Lago customers as **companies**, but there is a need to support both **companies** and **individuals**. This change is motivated by scenarios where customers may be a mix of B2B and B2C, and where external integrations require handling both **Contacts** and **Companies**.

To address this, we are introducing a new field, `customer_type`, to distinguish whether a customer is a **company** or an **individual**. Existing customers will remain unaffected with `customer_type` set to the default `nil`. 

## Description
In this PR we're adding the new model fields `lastname`, `firstname` and `customer_type` to  create and update customer services