### PR TITLE
feat: Add firstname and last name to queries

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -79,7 +79,7 @@ class Customer < ApplicationRecord
   validates :email, email: true, if: :email?
 
   def self.ransackable_attributes(_auth_object = nil)
-    %w[id name external_id email]
+    %w[id name firstname lastname external_id email]
   end
 
   def display_name

--- a/app/queries/customers_query.rb
+++ b/app/queries/customers_query.rb
@@ -22,6 +22,8 @@ class CustomersQuery < BaseQuery
     {
       m: 'or',
       name_cont: search_term,
+      firstname_cont: search_term,
+      lastname_cont: search_term,
       external_id_cont: search_term,
       email_cont: search_term
     }

--- a/app/queries/invoices_query.rb
+++ b/app/queries/invoices_query.rb
@@ -40,6 +40,8 @@ class InvoicesQuery < BaseQuery
 
     terms.merge(
       customer_name_cont: search_term,
+      customer_firstname_cont: search_term,
+      customer_lastname_cont: search_term,
       customer_external_id_cont: search_term,
       customer_email_cont: search_term
     )

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -88,16 +88,16 @@ RSpec.describe CustomersQuery, type: :query do
   end
 
   context 'when searching for lastname "Doe"' do
-    let(:search_term) { 'Doe' }
+    let(:search_term) { 'Johnson' }
 
     it 'returns only one customer' do
       returned_ids = result.customers.pluck(:id)
 
       aggregate_failures do
         expect(returned_ids.count).to eq(1)
-        expect(returned_ids).to include(customer_first.id)
+        expect(returned_ids).not_to include(customer_first.id)
         expect(returned_ids).not_to include(customer_second.id)
-        expect(returned_ids).not_to include(customer_third.id)
+        expect(returned_ids).to include(customer_third.id)
       end
     end
   end

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe CustomersQuery, type: :query do
     end
   end
 
-  context 'when searching for lastname "Doe"' do
+  context 'when searching for lastname "Johnson"' do
     let(:search_term) { 'Johnson' }
 
     it 'returns only one customer' do

--- a/spec/queries/customers_query_spec.rb
+++ b/spec/queries/customers_query_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe CustomersQuery, type: :query do
   let(:organization) { membership.organization }
 
   let(:customer_first) do
-    create(:customer, organization:, name: 'defgh', external_id: '11', email: '1@example.com')
+    create(:customer, organization:, name: 'defgh', firstname: 'John', lastname: 'Doe', external_id: '11', email: '1@example.com')
   end
   let(:customer_second) do
-    create(:customer, organization:, name: 'abcde', external_id: '22', email: '2@example.com')
+    create(:customer, organization:, name: 'abcde', firstname: 'Jane', lastname: 'Smith', external_id: '22', email: '2@example.com')
   end
   let(:customer_third) do
-    create(:customer, organization:, name: 'presuv', external_id: '33', email: '3@example.com')
+    create(:customer, organization:, name: 'presuv', firstname: 'Mary', lastname: 'Johnson', external_id: '33', email: '3@example.com')
   end
 
   before do
@@ -67,6 +67,36 @@ RSpec.describe CustomersQuery, type: :query do
         expect(returned_ids.count).to eq(2)
         expect(returned_ids).to include(customer_first.id)
         expect(returned_ids).to include(customer_second.id)
+        expect(returned_ids).not_to include(customer_third.id)
+      end
+    end
+  end
+
+  context 'when searching for firstname "Jane"' do
+    let(:search_term) { 'Jane' }
+
+    it 'returns only one customer' do
+      returned_ids = result.customers.pluck(:id)
+
+      aggregate_failures do
+        expect(returned_ids.count).to eq(1)
+        expect(returned_ids).to include(customer_second.id)
+        expect(returned_ids).not_to include(customer_first.id)
+        expect(returned_ids).not_to include(customer_third.id)
+      end
+    end
+  end
+
+  context 'when searching for lastname "Doe"' do
+    let(:search_term) { 'Doe' }
+
+    it 'returns only one customer' do
+      returned_ids = result.customers.pluck(:id)
+
+      aggregate_failures do
+        expect(returned_ids.count).to eq(1)
+        expect(returned_ids).to include(customer_first.id)
+        expect(returned_ids).not_to include(customer_second.id)
         expect(returned_ids).not_to include(customer_third.id)
       end
     end

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -495,7 +495,7 @@ RSpec.describe InvoicesQuery, type: :query do
   context 'when searching for lastname "SanchezLast"' do
     let(:search_term) { 'SanchezLast' }
 
-    it 'returns four invoices for this customer' do
+    it 'returns the correct invoices for this customer' do
       returned_ids = result.invoices.pluck(:id)
 
       aggregate_failures do
@@ -510,10 +510,10 @@ RSpec.describe InvoicesQuery, type: :query do
     end
   end
 
-  context 'when searching for firstname "SanchezLast"' do
+  context 'when searching for firstname "MortyFirst"' do
     let(:search_term) { 'MortyFirst' }
 
-    it 'returns two invoices for this customer' do
+    it 'returns the correct invoices for this customer' do
       returned_ids = result.invoices.pluck(:id)
 
       aggregate_failures do

--- a/spec/queries/invoices_query_spec.rb
+++ b/spec/queries/invoices_query_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe InvoicesQuery, type: :query do
   let(:filters) { nil }
   let(:membership) { create(:membership) }
   let(:organization) { membership.organization }
-  let(:customer_first) { create(:customer, organization:, name: 'Rick Sanchez', email: 'pickle@hotmail.com') }
-  let(:customer_second) { create(:customer, organization:, name: 'Morty Smith', email: 'ilovejessica@gmail.com') }
+  let(:customer_first) { create(:customer, organization:, name: 'Rick Sanchez', firstname: 'RickFirst', lastname: 'SanchezLast', email: 'pickle@hotmail.com') }
+  let(:customer_second) { create(:customer, organization:, name: 'Morty Smith', firstname: 'MortyFirst', lastname: 'SmithLast', email: 'ilovejessica@gmail.com') }
   let(:invoice_first) do
     create(
       :invoice,
@@ -488,6 +488,42 @@ RSpec.describe InvoicesQuery, type: :query do
         expect(returned_ids).not_to include(invoice_second.id)
         expect(returned_ids).not_to include(invoice_third.id)
         expect(returned_ids).not_to include(invoice_fourth.id)
+      end
+    end
+  end
+
+  context 'when searching for lastname "SanchezLast"' do
+    let(:search_term) { 'SanchezLast' }
+
+    it 'returns four invoices for this customer' do
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(returned_ids.count).to eq(4)
+        expect(returned_ids).to include(invoice_first.id)
+        expect(returned_ids).not_to include(invoice_second.id)
+        expect(returned_ids).to include(invoice_third.id)
+        expect(returned_ids).not_to include(invoice_fourth.id)
+        expect(returned_ids).to include(invoice_fifth.id)
+        expect(returned_ids).to include(invoice_sixth.id)
+      end
+    end
+  end
+
+  context 'when searching for firstname "SanchezLast"' do
+    let(:search_term) { 'MortyFirst' }
+
+    it 'returns two invoices for this customer' do
+      returned_ids = result.invoices.pluck(:id)
+
+      aggregate_failures do
+        expect(returned_ids.count).to eq(2)
+        expect(returned_ids).not_to include(invoice_first.id)
+        expect(returned_ids).to include(invoice_second.id)
+        expect(returned_ids).not_to include(invoice_third.id)
+        expect(returned_ids).to include(invoice_fourth.id)
+        expect(returned_ids).not_to include(invoice_fifth.id)
+        expect(returned_ids).not_to include(invoice_sixth.id)
       end
     end
   end


### PR DESCRIPTION
## Context
We have enhanced the search functionality for both Customers and Invoices to allow searches by `firstname` and `lastname` fields, in addition to the existing name field. 