### PR TITLE
feat(customer-type): Whitelist new params in customer controller

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -94,6 +94,9 @@ module Api
         params.require(:customer).permit(
           :external_id,
           :name,
+          :firstname,
+          :lastname,
+          :customer_type,
           :country,
           :address_line1,
           :address_line2,

--- a/spec/requests/api/v1/customers_controller_spec.rb
+++ b/spec/requests/api/v1/customers_controller_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe Api::V1::CustomersController, type: :request do
     let(:create_params) do
       {
         external_id: SecureRandom.uuid,
-        name: 'Foo Bar',
+        name: 'Foo Bar Inc.',
+        firstname: 'Foo',
+        lastname: 'Bar',
+        customer_type: 'company',
         currency: 'EUR',
         timezone: 'America/New_York',
         external_salesforce_id: 'foobar'
@@ -25,6 +28,9 @@ RSpec.describe Api::V1::CustomersController, type: :request do
         expect(json[:customer][:lago_id]).to be_present
         expect(json[:customer][:external_id]).to eq(create_params[:external_id])
         expect(json[:customer][:name]).to eq(create_params[:name])
+        expect(json[:customer][:firstname]).to eq(create_params[:firstname])
+        expect(json[:customer][:lastname]).to eq(create_params[:lastname])
+        expect(json[:customer][:customer_type]).to eq(create_params[:customer_type])
         expect(json[:customer][:created_at]).to be_present
         expect(json[:customer][:currency]).to eq(create_params[:currency])
         expect(json[:customer][:external_salesforce_id]).to eq(create_params[:external_salesforce_id])


### PR DESCRIPTION
## Context
We currently only create Lago customers as **companies**, but there is a need to support both **companies** and **individuals**. This change is motivated by scenarios where customers may be a mix of B2B and B2C, and where external integrations require handling both **Contacts** and **Companies**.

To address this, we are introducing a new field, `customer_type`, to distinguish whether a customer is a **company** or an **individual**. Existing customers will remain unaffected with `customer_type` set to the default `nil`. 

## Description
In this PR we're white-listing the new fields `lastname`, `firstname` and `customer_type` in `CustomersController`.