### PR TITLE
feat(dunning): Add permission to analytics overdue balances

### DIFF
--- a/app/config/permissions/definition.yml
+++ b/app/config/permissions/definition.yml
@@ -1,5 +1,7 @@
 ---
 analytics:
+  overdue_balances:
+    view:
   view:
 billable_metrics:
   view:

--- a/app/config/permissions/role-finance.yml
+++ b/app/config/permissions/role-finance.yml
@@ -1,5 +1,7 @@
 ---
 analytics:
+  overdue_balances:
+    view: true
   view: true
 billable_metrics:
   view: false

--- a/app/config/permissions/role-manager.yml
+++ b/app/config/permissions/role-manager.yml
@@ -1,5 +1,7 @@
 ---
 analytics:
+  overdue_balances:
+    view: true
   view: false
 billable_metrics:
   view: false

--- a/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
+++ b/app/graphql/resolvers/analytics/overdue_balances_resolver.rb
@@ -6,7 +6,7 @@ module Resolvers
       include AuthenticableApiUser
       include RequiredOrganization
 
-      REQUIRED_PERMISSION = 'analytics:view'
+      REQUIRED_PERMISSION = 'analytics:overdue_balances:view'
 
       description 'Query overdue balances of an organization'
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -5574,6 +5574,7 @@ type Permissions {
   addonsDelete: Boolean!
   addonsUpdate: Boolean!
   addonsView: Boolean!
+  analyticsOverdueBalancesView: Boolean!
   analyticsView: Boolean!
   billableMetricsCreate: Boolean!
   billableMetricsDelete: Boolean!

--- a/schema.json
+++ b/schema.json
@@ -25955,6 +25955,24 @@
               ]
             },
             {
+              "name": "analyticsOverdueBalancesView",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "analyticsView",
               "description": null,
               "type": {

--- a/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
+++ b/spec/graphql/resolvers/analytics/overdue_balances_resolver_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Resolvers::Analytics::OverdueBalancesResolver, type: :graphql do
-  let(:required_permission) { 'analytics:view' }
+  let(:required_permission) { 'analytics:overdue_balances:view' }
   let(:query) do
     <<~GQL
       query($currency: CurrencyEnum, $externalCustomerId: String, $months: Int, $expireCache: Boolean) {
@@ -24,7 +24,7 @@ RSpec.describe Resolvers::Analytics::OverdueBalancesResolver, type: :graphql do
 
   it_behaves_like 'requires current user'
   it_behaves_like 'requires current organization'
-  it_behaves_like 'requires permission', 'analytics:view'
+  it_behaves_like 'requires permission', 'analytics:overdue_balances:view'
 
   it 'returns a list of overdue balances' do
     result = execute_graphql(


### PR DESCRIPTION
 ## Roadmap Task

👉 https://getlago.canny.io/feature-requests/p/send-reminders-for-overdue-invoices

 ## Context

We want to be able to manually request payment of the overdue balance and send emails for reminders.

 ## Description

The goal of this change is to fix QA returns related to the overdue balances permission.