### PR TITLE
feat(customer-type): Replace customer name with display_name in templates

### DIFF
--- a/app/views/templates/credit_note.slim
+++ b/app/views/templates/credit_note.slim
@@ -347,11 +347,7 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('credit_note.credit_to')
-          .body-2
-            - if customer.legal_name.present?
-              | #{customer.legal_name}
-            - else
-              | #{customer.name}
+          .body-2 = customer.display_name
           - if customer.legal_number.present?
             .body-2 #{customer.legal_number}
           .body-2 = customer.address_line1

--- a/app/views/templates/invoices/v1.slim
+++ b/app/views/templates/invoices/v1.slim
@@ -411,11 +411,7 @@ html
           .body-2 = organization.email
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2
-            - if customer.legal_name.present?
-              | #{customer.legal_name}
-            - else
-              | #{customer.name}
+          .body-2 = customer.display_name
           .body-2 = customer.address_line1
           .body-2 = customer.address_line2
           .body-2

--- a/app/views/templates/invoices/v2.slim
+++ b/app/views/templates/invoices/v2.slim
@@ -411,11 +411,7 @@ html
           .body-2 = organization.email
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2
-            - if customer.legal_name.present?
-              | #{customer.legal_name}
-            - else
-              | #{customer.name}
+          .body-2 = customer.display_name
           .body-2 = customer.address_line1
           .body-2 = customer.address_line2
           .body-2

--- a/app/views/templates/invoices/v3.slim
+++ b/app/views/templates/invoices/v3.slim
@@ -394,11 +394,7 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2
-            - if customer.legal_name.present?
-              | #{customer.legal_name}
-            - else
-              | #{customer.name}
+          .body-2 = customer.display_name
           - if customer.legal_number.present?
             .body-2 #{customer.legal_number}
           .body-2 = customer.address_line1

--- a/app/views/templates/invoices/v3/charge.slim
+++ b/app/views/templates/invoices/v3/charge.slim
@@ -388,11 +388,7 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2
-            - if customer.legal_name.present?
-              | #{customer.legal_name}
-            - else
-              | #{customer.name}
+          .body-2 = customer.display_name
           - if customer.legal_number.present?
             .body-2 #{customer.legal_number}
           .body-2 = customer.address_line1

--- a/app/views/templates/invoices/v3/one_off.slim
+++ b/app/views/templates/invoices/v3/one_off.slim
@@ -389,11 +389,7 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2
-            - if customer.legal_name.present?
-              | #{customer.legal_name}
-            - else
-              | #{customer.name}
+          .body-2 = customer.display_name
           - if customer.legal_number.present?
             .body-2 #{customer.legal_number}
           .body-2 = customer.address_line1

--- a/app/views/templates/invoices/v4.slim
+++ b/app/views/templates/invoices/v4.slim
@@ -423,11 +423,7 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2
-            - if customer.legal_name.present?
-              | #{customer.legal_name}
-            - else
-              | #{customer.name}
+          .body-2 = customer.display_name
           - if customer.legal_number.present?
             .body-2 #{customer.legal_number}
           .body-2 = customer.address_line1

--- a/app/views/templates/invoices/v4/charge.slim
+++ b/app/views/templates/invoices/v4/charge.slim
@@ -388,11 +388,7 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2
-            - if customer.legal_name.present?
-              | #{customer.legal_name}
-            - else
-              | #{customer.name}
+          .body-2 = customer.display_name
           - if customer.legal_number.present?
             .body-2 #{customer.legal_number}
           .body-2 = customer.address_line1

--- a/app/views/templates/invoices/v4/one_off.slim
+++ b/app/views/templates/invoices/v4/one_off.slim
@@ -391,11 +391,7 @@ html
             .body-2 = I18n.t('invoice.tax_identification_number', tax_identification_number: organization.tax_identification_number)
         .billing-information-column
           .body-1 = I18n.t('invoice.bill_to')
-          .body-2
-            - if customer.legal_name.present?
-              | #{customer.legal_name}
-            - else
-              | #{customer.name}
+          .body-2 = customer.display_name
           - if customer.legal_number.present?
             .body-2 #{customer.legal_number}
           .body-2 = customer.address_line1


### PR DESCRIPTION
## Context
We currently only create Lago customers as **companies**, but there is a need to support both **companies** and **individuals**. This change is motivated by scenarios where customers may be a mix of B2B and B2C, and where external integrations require handling both **Contacts** and **Companies**.

To address this, we are introducing a new field, `customer_type`, to distinguish whether a customer is a **company** or an **individual**. Existing customers will remain unaffected with `customer_type` set to the default `nil`. 

## Description
This PR modifies all the invoice/credit note templates so that they call `customer.display_name` method that handles the logic of what's displayed.