### PR TITLE
feat(customer_type): Gocardless add firstname and lastname

### DIFF
--- a/app/services/payment_provider_customers/gocardless_service.rb
+++ b/app/services/payment_provider_customers/gocardless_service.rb
@@ -70,12 +70,14 @@ module PaymentProviderCustomers
     end
 
     def create_gocardless_customer
-      client.customers.create(
-        params: {
-          email: customer.email&.strip&.split(',')&.first,
-          company_name: customer.name
-        }
-      )
+      customer_params = {
+        email: customer.email&.strip&.split(',')&.first,
+        company_name: customer.name.presence,
+        given_name: customer.firstname.presence,
+        family_name: customer.lastname.presence
+      }.compact
+
+      client.customers.create(customer_params)
     rescue GoCardlessPro::Error => e
       deliver_error_webhook(e)
 

--- a/spec/services/payment_provider_customers/gocardless_service_spec.rb
+++ b/spec/services/payment_provider_customers/gocardless_service_spec.rb
@@ -27,6 +27,20 @@ RSpec.describe PaymentProviderCustomers::GocardlessService, type: :service do
         .and_return(GoCardlessPro::Resources::Customer.new('id' => '123'))
     end
 
+    context 'when all customer details are present' do
+      it 'creates a customer with company_name, given_name, and family_name' do
+        expect(gocardless_customers_service).to receive(:create).with(
+          hash_including(
+            email: customer.email,
+            company_name: customer.name,
+            given_name: customer.firstname,
+            family_name: customer.lastname
+          )
+        )
+        gocardless_service.create
+      end
+    end
+
     it 'creates the gocardless customer' do
       result = gocardless_service.create
 

--- a/spec/services/payment_provider_customers/gocardless_service_spec.rb
+++ b/spec/services/payment_provider_customers/gocardless_service_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe PaymentProviderCustomers::GocardlessService, type: :service do
 
     context 'when all customer details are present' do
       it 'creates a customer with company_name, given_name, and family_name' do
-        expect(gocardless_customers_service).to receive(:create).with(
+        gocardless_service.create
+        expect(gocardless_customers_service).to have_received(:create).with(
           hash_including(
             email: customer.email,
             company_name: customer.name,
@@ -37,7 +38,6 @@ RSpec.describe PaymentProviderCustomers::GocardlessService, type: :service do
             family_name: customer.lastname
           )
         )
-        gocardless_service.create
       end
     end
 


### PR DESCRIPTION
## Context
We currently only create Lago customers as **companies**, but there is a need to support both **companies** and **individuals**. This change is motivated by scenarios where customers may be a mix of B2B and B2C, and where external integrations require handling both **Contacts** and **Companies**.

## Description
We currently only create GoCardless customers with a limited set of details. However, there is a need to ensure that **company name**, **first name**, and **last name** are included when available. 

the additional customer attributes to GoCardless, specifically:
- `given_name`: If the customer's first name is present, it will be sent.
- `family_name`: If the customer's last name is present, it will be sent.





