### PR TITLE
Feat: anrok <> credit_notes model changes

### DIFF
--- a/app/models/credit_note.rb
+++ b/app/models/credit_note.rb
@@ -21,6 +21,7 @@ class CreditNote < ApplicationRecord
   has_many :applied_taxes, class_name: 'CreditNote::AppliedTax', dependent: :destroy
   has_many :taxes, through: :applied_taxes
   has_many :integration_resources, as: :syncable
+  has_many :error_details, as: :owner, dependent: :destroy
 
   has_one_attached :file
 

--- a/app/models/credit_note/applied_tax.rb
+++ b/app/models/credit_note/applied_tax.rb
@@ -33,9 +33,9 @@ end
 #
 # Indexes
 #
-#  index_credit_notes_taxes_on_credit_note_id             (credit_note_id)
-#  index_credit_notes_taxes_on_credit_note_id_and_tax_id  (credit_note_id,tax_id) UNIQUE
-#  index_credit_notes_taxes_on_tax_id                     (tax_id)
+#  index_credit_notes_taxes_on_credit_note_id               (credit_note_id)
+#  index_credit_notes_taxes_on_credit_note_id_and_tax_code  (credit_note_id,tax_code) UNIQUE
+#  index_credit_notes_taxes_on_tax_code                     (tax_code)
 #
 # Foreign Keys
 #

--- a/app/models/credit_note/applied_tax.rb
+++ b/app/models/credit_note/applied_tax.rb
@@ -36,6 +36,7 @@ end
 #  index_credit_notes_taxes_on_credit_note_id               (credit_note_id)
 #  index_credit_notes_taxes_on_credit_note_id_and_tax_code  (credit_note_id,tax_code) UNIQUE
 #  index_credit_notes_taxes_on_tax_code                     (tax_code)
+#  index_credit_notes_taxes_on_tax_id                       (tax_id)
 #
 # Foreign Keys
 #

--- a/app/models/credit_note/applied_tax.rb
+++ b/app/models/credit_note/applied_tax.rb
@@ -7,7 +7,7 @@ class CreditNote
     include PaperTrailTraceable
 
     belongs_to :credit_note
-    belongs_to :tax
+    belongs_to :tax, optional: true
 
     monetize :amount_cents
     monetize :base_amount_cents, with_model_currency: :amount_currency
@@ -29,7 +29,7 @@ end
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  credit_note_id    :uuid             not null
-#  tax_id            :uuid             not null
+#  tax_id            :uuid
 #
 # Indexes
 #

--- a/db/migrate/20240910093646_change_tax_id_null_on_credit_note_applied_taxes.rb
+++ b/db/migrate/20240910093646_change_tax_id_null_on_credit_note_applied_taxes.rb
@@ -1,0 +1,5 @@
+class ChangeTaxIdNullOnCreditNoteAppliedTaxes < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :credit_notes_taxes, :tax_id, true
+  end
+end

--- a/db/migrate/20240910093646_change_tax_id_null_on_credit_note_applied_taxes.rb
+++ b/db/migrate/20240910093646_change_tax_id_null_on_credit_note_applied_taxes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeTaxIdNullOnCreditNoteAppliedTaxes < ActiveRecord::Migration[7.1]
   def change
     change_column_null :credit_notes_taxes, :tax_id, true

--- a/db/migrate/20240910111203_update_indexes_for_credit_notes_taxes.rb
+++ b/db/migrate/20240910111203_update_indexes_for_credit_notes_taxes.rb
@@ -1,0 +1,11 @@
+class UpdateIndexesForCreditNotesTaxes < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :credit_notes_taxes, :tax_id, algorithm: :concurrently
+    remove_index :credit_notes_taxes, %i[credit_note_id tax_id], unique: true, algorithm: :concurrently
+
+    add_index :credit_notes_taxes, :tax_code, algorithm: :concurrently
+    add_index :credit_notes_taxes, %i[credit_note_id tax_code], unique: true, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240910111203_update_indexes_for_credit_notes_taxes.rb
+++ b/db/migrate/20240910111203_update_indexes_for_credit_notes_taxes.rb
@@ -2,7 +2,6 @@ class UpdateIndexesForCreditNotesTaxes < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
-    remove_index :credit_notes_taxes, :tax_id, algorithm: :concurrently
     remove_index :credit_notes_taxes, %i[credit_note_id tax_id], unique: true, algorithm: :concurrently
 
     add_index :credit_notes_taxes, :tax_code, algorithm: :concurrently

--- a/db/migrate/20240910111203_update_indexes_for_credit_notes_taxes.rb
+++ b/db/migrate/20240910111203_update_indexes_for_credit_notes_taxes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UpdateIndexesForCreditNotesTaxes < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_06_170048) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_10_093646) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -360,7 +360,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_06_170048) do
 
   create_table "credit_notes_taxes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "credit_note_id", null: false
-    t.uuid "tax_id", null: false
+    t.uuid "tax_id"
     t.string "tax_description"
     t.string "tax_code", null: false
     t.string "tax_name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -373,6 +373,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_10_111203) do
     t.index ["credit_note_id", "tax_code"], name: "index_credit_notes_taxes_on_credit_note_id_and_tax_code", unique: true
     t.index ["credit_note_id"], name: "index_credit_notes_taxes_on_credit_note_id"
     t.index ["tax_code"], name: "index_credit_notes_taxes_on_tax_code"
+    t.index ["tax_id"], name: "index_credit_notes_taxes_on_tax_id"
   end
 
   create_table "credits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_10_093646) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_10_111203) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -370,9 +370,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_10_093646) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "base_amount_cents", default: 0, null: false
-    t.index ["credit_note_id", "tax_id"], name: "index_credit_notes_taxes_on_credit_note_id_and_tax_id", unique: true
+    t.index ["credit_note_id", "tax_code"], name: "index_credit_notes_taxes_on_credit_note_id_and_tax_code", unique: true
     t.index ["credit_note_id"], name: "index_credit_notes_taxes_on_credit_note_id"
-    t.index ["tax_id"], name: "index_credit_notes_taxes_on_tax_id"
+    t.index ["tax_code"], name: "index_credit_notes_taxes_on_tax_code"
   end
 
   create_table "credits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/credit_note/applied_tax_spec.rb
+++ b/spec/models/credit_note/applied_tax_spec.rb
@@ -5,5 +5,10 @@ require 'rails_helper'
 RSpec.describe CreditNote::AppliedTax, type: :model do
   subject(:applied_tax) { create(:credit_note_applied_tax) }
 
+  describe 'associations' do
+    it { is_expected.to belong_to(:credit_note) }
+    it { is_expected.to belong_to(:tax).optional }
+  end
+
   it_behaves_like 'paper_trail traceable'
 end

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CreditNote, type: :model do
   it_behaves_like 'paper_trail traceable'
 
   it { is_expected.to have_many(:integration_resources) }
+  it { is_expected.to have_many(:error_details) }
 
   describe 'sequential_id' do
     let(:invoice) { create(:invoice) }

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Credit, type: :model do
     it { is_expected.to belong_to(:applied_coupon).optional }
     it { is_expected.to belong_to(:credit_note).optional }
     it { is_expected.to belong_to(:progressive_billing_invoice).optional }
-    it { is_expected.to have_many(:error_details) }
   end
 
   describe 'invoice item' do

--- a/spec/models/credit_spec.rb
+++ b/spec/models/credit_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Credit, type: :model do
     it { is_expected.to belong_to(:applied_coupon).optional }
     it { is_expected.to belong_to(:credit_note).optional }
     it { is_expected.to belong_to(:progressive_billing_invoice).optional }
+    it { is_expected.to have_many(:error_details) }
   end
 
   describe 'invoice item' do


### PR DESCRIPTION
We need to adjust credit_note and credit_note::applied_tax to reflect the changes in processing taxes:
- applied_tax might not belong to a stored in lago tax, so tax_id becomes optional,
- during reporting we might receive some errors, so credit_note can have many :error_details