### PR TITLE
feat(customer-type): Update netsuite payload with new fields

### DIFF
--- a/spec/services/integrations/aggregator/contacts/create_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/create_service_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
             'isDynamic' => true,
             'columns' => {
               'companyname' => customer.name,
+              'isperson' => 'F',
               'subsidiary' => subsidiary_id,
               'custentity_lago_id' => customer.id,
               'custentity_lago_sf_id' => customer.external_salesforce_id,
@@ -181,6 +182,7 @@ RSpec.describe Integrations::Aggregator::Contacts::CreateService do
           'isDynamic' => true,
           'columns' => {
             'companyname' => customer.name,
+            'isperson' => 'F',
             'subsidiary' => subsidiary_id,
             'custentity_lago_id' => customer.id,
             'custentity_lago_sf_id' => customer.external_salesforce_id,

--- a/spec/services/integrations/aggregator/contacts/update_service_spec.rb
+++ b/spec/services/integrations/aggregator/contacts/update_service_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
             'recordId' => integration_customer.external_customer_id,
             'values' => {
               'companyname' => customer.name,
+              'isperson' => 'F',
               'subsidiary' => integration_customer.subsidiary_id,
               'custentity_lago_sf_id' => customer.external_salesforce_id,
               'custentity_lago_customer_link' => customer_link,
@@ -131,6 +132,7 @@ RSpec.describe Integrations::Aggregator::Contacts::UpdateService do
           'recordId' => integration_customer.external_customer_id,
           'values' => {
             'companyname' => customer.name,
+            'isperson' => 'F',
             'subsidiary' => integration_customer.subsidiary_id,
             'custentity_lago_sf_id' => customer.external_salesforce_id,
             'custentity_lago_customer_link' => customer_link,


### PR DESCRIPTION
## Context
We currently only create Lago customers as **companies**, but there is a need to support both **companies** and **individuals**. This change is motivated by scenarios where customers may be a mix of B2B and B2C, and where external integrations require handling both **Contacts** and **Companies**.

To address this, we are introducing a new field, `customer_type`, to distinguish whether a customer is a **company** or an **individual**. Existing customers will remain unaffected with `customer_type` set to the default `nil`. 

## Description
In this PR we're adding the new fields: `lastname`, `firstname` and `isperson` to both create and update netsuite payloads.