### PR TITLE
bug - Order fees by created_at, id to ensure consistent ordering

### DIFF
--- a/app/queries/fees_query.rb
+++ b/app/queries/fees_query.rb
@@ -3,7 +3,7 @@
 class FeesQuery < BaseQuery
   def call
     fees = paginate(Fee.from_organization(organization))
-    fees = fees.order(created_at: :asc)
+    fees = fees.order(created_at: :asc, id: :asc)
 
     fees = with_external_subscription(fees) if filters.external_subscription_id
     fees = with_external_customer(fees) if filters.external_customer_id


### PR DESCRIPTION
Postgres does not guarantee that rows with the same created_at will always be returned in the same order. In order to guarantee a consistent ordering, we also have to order by id.

